### PR TITLE
[Release v3.28] BGP: Filter advertisement of routes related to local eBPF devices

### DIFF
--- a/confd/etc/calico/confd/templates/bird6_ipam.cfg.template
+++ b/confd/etc/calico/confd/templates/bird6_ipam.cfg.template
@@ -18,6 +18,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -26,6 +35,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 {{- $static_key := "/staticroutesv6"}}

--- a/confd/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/confd/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -18,6 +18,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -26,6 +35,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 {{- $static_key := "/staticroutes"}}

--- a/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/explicit_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/export_only/global_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step1/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_deletion/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/filter_names/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_names/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/filter_names/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/filter_names/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/explicit_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/import_only/global_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/match_interface/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_interface/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/match_interface/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_interface/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/match_operators/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_operators/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/match_operators/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_operators/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/match_source/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_source/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/match_source/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/match_source/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/explicit_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/multi_filter/global_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/node_mesh/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/node_mesh/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/explicit_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/single_filter/global_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/explicit_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v4_only/global_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/explicit_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/bgpfilter/v6_only/global_peer/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/global-external/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-external/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/global-external/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-external/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/global/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/selectors/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/selectors/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/specific_node/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/specific_node/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/explicit_peering/specific_node/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/specific_node/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ignored_interfaces/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/ignored_interfaces/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ignored_interfaces/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/ignored_interfaces/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/bgp-export/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/bgp-export/bird6_ipam.cfg
@@ -15,6 +15,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -23,6 +32,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/bgp-export/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/bgp-export/bird_ipam.cfg
@@ -15,6 +15,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -23,6 +32,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/communities/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/communities/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/communities/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/communities/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/hash/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/hash/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/hash/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/hash/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/ipip-always/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-always/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/ipip-always/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-always/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/ipip-off/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-off/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/ipip-off/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-off/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/password/step1/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step1/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/password/step1/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step1/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/password/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/password/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/password/step3/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step3/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/password/step3/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step3/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/restart-time/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/restart-time/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/static-routes/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password-deadlock/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password-deadlock/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password-deadlock/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password-deadlock/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step1/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step1/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step1/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step1/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step3/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step3/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step3/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step3/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step4/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step4/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step4/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step4/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step5/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step5/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step5/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step5/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step6/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step6/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/password/step6/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/password/step6/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/reachable_by/global_peers/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/reachable_by/global_peers/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/reachable_by/global_peers/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/reachable_by/global_peers/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/reachable_by/route_reflectors/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/reachable_by/route_reflectors/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/reachable_by/route_reflectors/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/reachable_by/route_reflectors/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step1/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step2/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/sourceaddr_gracefulrestart/step3/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ttl_security/explicit_node/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/ttl_security/explicit_node/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ttl_security/explicit_node/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/ttl_security/explicit_node/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ttl_security/global/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/ttl_security/global/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ttl_security/global/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/ttl_security/global/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ttl_security/peer_selector/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/ttl_security/peer_selector/bird6_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 

--- a/confd/tests/compiled_templates/ttl_security/peer_selector/bird_ipam.cfg
+++ b/confd/tests/compiled_templates/ttl_security/peer_selector/bird_ipam.cfg
@@ -14,6 +14,15 @@ function reject_tunnel_routes () {
   }
 }
 
+function reject_local_routes () {
+  # Don't export local routes learned via BPF as they should never leave the node.
+  if (defined(ifname)) then {
+     if (ifname ~ "bpf*.cali") then {
+        reject;
+     }
+  }
+}
+
 function calico_export_to_bgp_peers(bool internal_peer) {
   # filter code terminates when it calls `accept;` or `reject;`,
   # call reject_disabled_pools() first, then reject_tunnel_routes(),
@@ -22,6 +31,7 @@ function calico_export_to_bgp_peers(bool internal_peer) {
   if (internal_peer) then {
     reject_tunnel_routes();
   }
+  reject_local_routes();
   apply_communities();
   calico_aggr();
 


### PR DESCRIPTION
## Description
- Add new `reject_local_routes` function to bird configs to prevent readvertisement of kernel routes learned from `bpf*.cali` interfaces
- Resolves condition where all nodes in cluster will readvertise cluster-local routes learned via eBPF to BGP peers

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Cherry pick of https://github.com/projectcalico/calico/pull/9112

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
BGP: Prevent the advertisement of local kernel routes learned from eBPF interfaces (bpf*.cali) to peers.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
