### PR TITLE
Switch to netlink.RouteListFilteredIter() API

### DIFF
--- a/felix/netlinkshim/netlink.go
+++ b/felix/netlinkshim/netlink.go
@@ -33,6 +33,7 @@ type Interface interface {
 	LinkSetMTU(link netlink.Link, mtu int) error
 	LinkSetUp(link netlink.Link) error
 	RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
+	RouteListFilteredIter(family int, filter *netlink.Route, filterMask uint64, f func(netlink.Route) (cont bool)) error
 	RouteAdd(route *netlink.Route) error
 	RouteReplace(route *netlink.Route) error
 	RouteDel(route *netlink.Route) error
@@ -117,6 +118,11 @@ func (r *RealNetlink) RouteListFiltered(family int, filter *netlink.Route, filte
 		}
 		return routes, err
 	}
+}
+
+func (r *RealNetlink) RouteListFilteredIter(family int, filter *netlink.Route, filterMask uint64, f func(netlink.Route) (cont bool)) error {
+	// Can't retry inline because that would confuse the callback function.
+	return r.nlHandle.RouteListFilteredIter(family, filter, filterMask, f)
 }
 
 func (r *RealNetlink) RouteAdd(route *netlink.Route) error {

--- a/felix/routetable/bench_test.go
+++ b/felix/routetable/bench_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routetable_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/procfs"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/projectcalico/calico/felix/dataplane/linux/dataplanedefs"
+	"github.com/projectcalico/calico/felix/fv/utils"
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/logutils"
+	mocknetlink "github.com/projectcalico/calico/felix/netlinkshim/mocknetlink"
+	. "github.com/projectcalico/calico/felix/routetable"
+	"github.com/projectcalico/calico/felix/routetable/ownershippol"
+)
+
+// Note: these benchmarks must be run as root, because they create a dummy
+// interface.
+
+func BenchmarkResync1024(b *testing.B) {
+	benchResyncNumRoutes(b, 1024)
+}
+func BenchmarkResync4096(b *testing.B) {
+	benchResyncNumRoutes(b, 4096)
+}
+func BenchmarkResync65536(b *testing.B) {
+	benchResyncNumRoutes(b, 65536)
+}
+
+func benchResyncNumRoutes(b *testing.B, numRoutes int) {
+	RegisterTestingT(b)
+
+	if os.Getuid() != 0 {
+		b.Fatal("This test must be run as root.")
+	}
+
+	logutils.ConfigureEarlyLogging()
+	logrus.SetLevel(logrus.WarnLevel)
+
+	ifaceName := fmt.Sprintf("testcali%04x", rand.Intn(65536))
+	utils.Run("ip", "link", "add", "name", ifaceName, "type", "dummy")
+	b.Cleanup(func() {
+		utils.Run("ip", "link", "del", "dev", ifaceName)
+	})
+	utils.Run("ip", "link", "set", "dev", ifaceName, "up")
+
+	sum := logutils.NewSummarizer("test")
+	mockDP := mocknetlink.New()
+	rt := New(
+		ownershippol.NewMainTable(
+			dataplanedefs.VXLANIfaceNameV4,
+			88,
+			[]string{"testcali"},
+			false,
+		),
+		4,
+		5*time.Second,
+		nil,
+		88,
+		false,
+		unix.RT_TABLE_MAIN,
+		sum,
+		mockDP,
+	)
+
+	n := 0
+outer:
+	for i := 0; i < 256; i++ {
+		for j := 0; j < 256; j++ {
+			rt.RouteUpdate(RouteClassLocalWorkload, ifaceName, Target{
+				CIDR: ip.MustParseCIDROrIP(fmt.Sprintf("10.0.%d.%d/32", i, j)),
+			})
+			n++
+			if n == numRoutes {
+				break outer
+			}
+		}
+	}
+	if n < numRoutes {
+		b.Fatalf("Only added %d routes", n)
+	}
+	err := rt.Apply()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+
+	proc, _ := procfs.NewProc(os.Getpid())
+	stat, _ := proc.Stat()
+	startCPU := stat.CPUTime()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rt.QueueResync()
+		err := rt.Apply()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	runtime.GC()
+	stat, _ = proc.Stat()
+	endCPU := stat.CPUTime()
+	b.ReportMetric((endCPU-startCPU)/float64(b.N)*1000000000, "ncpu/op")
+}

--- a/felix/routetable/conntrack_owner_tracker.go
+++ b/felix/routetable/conntrack_owner_tracker.go
@@ -99,8 +99,12 @@ var _ RouteOwnershipTracker = (*ConntrackCleanupManager)(nil)
 
 func NewConntrackCleanupManager(ipVersion uint8, conntrack conntrackIface) *ConntrackCleanupManager {
 	return &ConntrackCleanupManager{
-		ipVersion:      ipVersion,
-		addrOwners:     deltatracker.New[ip.Addr, conntrackOwner](),
+		ipVersion: ipVersion,
+		addrOwners: deltatracker.New[ip.Addr, conntrackOwner](
+			deltatracker.WithValuesEqualFn[ip.Addr, conntrackOwner](func(a, b conntrackOwner) bool {
+				return a == b
+			}),
+		),
 		addrsToCleanUp: set.New[ip.Addr](),
 		perIPDoneChans: map[ip.Addr]chan struct{}{},
 		cleanupDoneC:   make(chan ip.Addr),

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -940,7 +940,7 @@ func (r *RouteTable) doFullResync(nl netlinkshim.Interface) error {
 	routeFilterFlags := netlink.RT_FILTER_TABLE
 
 	var err error
-	seenKeys := set.New[kernelRouteKey]()
+	seenKeys := set.NewSize[kernelRouteKey](r.kernelRoutes.Dataplane().Len())
 	for attempt := 0; attempt < routeListFilterAttempts; attempt++ {
 		// Using the Iter version here saves allocating a large slice of netlink.Route,
 		// which we immediately discard.

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -43,6 +43,10 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
+const (
+	routeListFilterAttempts = 5
+)
+
 var (
 	ipV6LinkLocalCIDR = ip.MustParseCIDROrIP("fe80::/64")
 
@@ -930,29 +934,41 @@ func (r *RouteTable) doFullResync(nl netlinkshim.Interface) error {
 		Table: r.tableIndex,
 	}
 	routeFilterFlags := netlink.RT_FILTER_TABLE
-	allRoutes, err := nl.RouteListFiltered(r.netlinkFamily, routeFilter, routeFilterFlags)
+
+	var err error
+	seenKeys := set.New[kernelRouteKey]()
+	for attempt := 0; attempt < routeListFilterAttempts; attempt++ {
+		// Using the Iter version here saves allocating a large slice of netlink.Route,
+		// which we immediately discard.
+		err = nl.RouteListFilteredIter(r.netlinkFamily, routeFilter, routeFilterFlags, func(route netlink.Route) bool {
+			r.onIfaceSeen(route.LinkIndex)
+			kernKey, kernRoute, ok := r.netlinkRouteToKernelRoute(route)
+			if !ok {
+				// Not a route that we're managing.
+				return true
+			}
+			r.kernelRoutes.Dataplane().Set(kernKey, kernRoute)
+			seenKeys.Add(kernKey)
+			r.livenessCallback()
+			return true
+		})
+		if errors.Is(err, unix.EINTR) {
+			// Expected error if the routes got updated in kernel mid-dump.
+			log.WithError(err).Debug("Interrupted while listing routes.")
+			seenKeys.Clear()
+			continue
+		}
+		break
+	}
+
 	if errors.Is(err, unix.ENOENT) {
 		// In strict mode, get this if the routing table doesn't exist; it'll be auto-created
 		// when we add the first route so just treat it as empty.
 		log.WithError(err).Debug("Routing table doesn't exist (yet). Treating as empty.")
-		allRoutes = nil
 		err = nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to list all routes for resync: %w", err)
-	}
-
-	seenKeys := set.New[kernelRouteKey]()
-	for _, route := range allRoutes {
-		r.onIfaceSeen(route.LinkIndex)
-		kernKey, kernRoute, ok := r.netlinkRouteToKernelRoute(route)
-		if !ok {
-			// Not a route that we're managing.
-			continue
-		}
-		r.kernelRoutes.Dataplane().Set(kernKey, kernRoute)
-		seenKeys.Add(kernKey)
-		r.livenessCallback()
 	}
 
 	r.kernelRoutes.Dataplane().Iter(func(kernKey kernelRouteKey, kernRoute kernelRoute) {
@@ -1019,13 +1035,36 @@ func (r *RouteTable) resyncIface(nl netlinkshim.Interface, ifaceName string) err
 		LinkIndex: ifIndex,
 	}
 	routeFilterFlags := netlink.RT_FILTER_OIF | netlink.RT_FILTER_TABLE
-	netlinkRoutes, err := nl.RouteListFiltered(r.netlinkFamily, routeFilter, routeFilterFlags)
+
+	seenRoutes := set.New[kernelRouteKey]()
+	for attempt := 0; attempt < routeListFilterAttempts; attempt++ {
+		// Using the Iter version here saves allocating a large slice of netlink.Route,
+		// which we immediately discard.
+		err = nl.RouteListFilteredIter(r.netlinkFamily, routeFilter, routeFilterFlags, func(route netlink.Route) bool {
+			kernKey, kernRoute, ok := r.netlinkRouteToKernelRoute(route)
+			if !ok {
+				// Not a route that we're managing, so we don't want it to
+				// be a candidate for us to delete.
+				return true
+			}
+			r.kernelRoutes.Dataplane().Set(kernKey, kernRoute)
+			seenRoutes.Add(kernKey)
+			return true
+		})
+		if errors.Is(err, unix.EINTR) {
+			// Expected error if the routes got updated in kernel mid-dump.
+			log.WithError(err).Debug("Interrupted while listing routes.")
+			seenRoutes.Clear()
+			continue
+		}
+		break
+	}
+
 	if errors.Is(err, unix.ENOENT) {
 		// In strict mode, get this if the routing table doesn't exist; it'll be auto-created
 		// when we add the first route so just treat it as empty.
 		log.WithError(err).Debug("Routing table doesn't exist (yet). Treating as empty.")
 		err = nil
-		netlinkRoutes = nil
 	}
 	if err != nil {
 		// Filter the error so that we don't spam errors if the interface is being torn
@@ -1046,25 +1085,12 @@ func (r *RouteTable) resyncIface(nl netlinkshim.Interface, ifaceName string) err
 		}
 	}
 
-	// Loaded the routes, now update our tracker.  First index the data
-	// we loaded.
-	kernRoutes := map[kernelRouteKey]kernelRoute{}
-	for _, nlRoute := range netlinkRoutes {
-		kernKey, kernRoute, ok := r.netlinkRouteToKernelRoute(nlRoute)
-		if !ok {
-			// Not a route that we're managing, so we don't want it to
-			// be a candidate for us to delete.
-			continue
-		}
-		kernRoutes[kernKey] = kernRoute
-	}
-	// Then look for routes that the tracker says are there but are actually
-	// missing.
+	// Look for routes that the tracker says are there but are actually missing.
 	for _, ifaceToRoutes := range r.ifaceToRoutes {
 		for cidr := range ifaceToRoutes[ifaceName] {
 			kernKey := r.routeKeyForCIDR(cidr)
-			if _, ok := kernRoutes[kernKey]; ok {
-				// Route still there; handled below.
+			if seenRoutes.Contains(kernKey) {
+				// Route still there; handled above.
 				continue
 			}
 			desKernRoute, ok := r.kernelRoutes.Desired().Get(kernKey)
@@ -1075,10 +1101,6 @@ func (r *RouteTable) resyncIface(nl netlinkshim.Interface, ifaceName string) err
 			}
 			r.kernelRoutes.Dataplane().Delete(kernKey)
 		}
-	}
-	// Update tracker with the routes that we did see.
-	for kk, kr := range kernRoutes {
-		r.kernelRoutes.Dataplane().Set(kk, kr)
 	}
 	partialResyncTimeSummary.Observe(r.time.Since(startTime).Seconds())
 

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -308,8 +308,12 @@ func New(
 		ifaceToRoutes: map[RouteClass]map[string]map[ip.CIDR]Target{},
 		cidrToIfaces:  map[RouteClass]map[ip.CIDR]set.Set[string]{},
 
-		kernelRoutes: deltatracker.New[kernelRouteKey, kernelRoute](),
-		pendingARPs:  map[string]map[ip.Addr]net.HardwareAddr{},
+		kernelRoutes: deltatracker.New[kernelRouteKey, kernelRoute](
+			deltatracker.WithValuesEqualFn[kernelRouteKey, kernelRoute](func(a, b kernelRoute) bool {
+				return a == b
+			}),
+		),
+		pendingARPs: map[string]map[ip.Addr]net.HardwareAddr{},
 
 		ifaceIndexToGraceInfo: map[int]graceInfo{},
 		ifaceNameToIndex:      map[string]int{},

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -1381,6 +1381,7 @@ var _ = Describe("RouteTable", func() {
 			mocknetlink.FailNextLinkByName,
 			mocknetlink.FailNextRouteDel,
 			mocknetlink.FailNextRouteList,
+			mocknetlink.FailNextRouteListEINTR,
 		} {
 			failure := failure
 			It(fmt.Sprintf("with a %v failure it should ignore Down updates", failure), func() {

--- a/felix/vxlanfdb/vxlan_fdb.go
+++ b/felix/vxlanfdb/vxlan_fdb.go
@@ -17,6 +17,7 @@ package vxlanfdb
 import (
 	"fmt"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -111,9 +112,13 @@ func New(
 		log.WithField("family", family).Panic("Unknown family")
 	}
 	f := VXLANFDB{
-		family:     family,
-		ifaceName:  ifaceName,
-		arpEntries: deltatracker.New[string, ipMACMapping](),
+		family:    family,
+		ifaceName: ifaceName,
+		arpEntries: deltatracker.New[string, ipMACMapping](
+			deltatracker.WithValuesEqualFn[string, ipMACMapping](func(a, b ipMACMapping) bool {
+				return a.IP == b.IP && slices.Equal(a.MAC, b.MAC)
+			}),
+		),
 		fdbEntries: deltatracker.New[string, ipMACMapping](),
 		logCxt: log.WithFields(log.Fields{
 			"iface":  ifaceName,

--- a/libcalico-go/lib/set/set.go
+++ b/libcalico-go/lib/set/set.go
@@ -25,6 +25,10 @@ func New[T comparable]() Typed[T] {
 	return make(Typed[T])
 }
 
+func NewSize[T comparable](size int) Typed[T] {
+	return make(Typed[T], size)
+}
+
 // Empty returns a read-only set with no members.  Calls to Add etc. panic.
 func Empty[T comparable]() Typed[T] {
 	return (Typed[T])(nil)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Optimise RouteTable resync methods:
* Add benchmark for resync with various numbers of routes. 
* Switch to netlink.RouteListFilteredIter() API, which avoids a series of large slice allocations.
* Use benchmark to find more wins:

  * Use  deltatracker.WithValuesEqualFn, DeepEquals is the default and it was much slower.
  * Pre-allocate the seenKeys set, saves the expense of copying it multiple times as it grows.
  * Copy the netlink Route once per loop to a scratch variable to avoid escape to the heap.

Overall, significantly reduces allocations from when there are many routes to resync and significantly increases performance.

Benchmarks for resyncing 64k routes; 50% reduction in resync time; 80% saving in bytes allocated; GC-included CPU usage down by 60%.
```
v3.28:

BenchmarkResync65536-12    	       7	 156498055 ns/op	 242857143 ncpu/op	203556697 B/op	  790473 allocs/op

master:

BenchmarkResync65536-12    	       7	 143550698 ns/op	 270000000 ncpu/op	208147700 B/op	  724999 allocs/op

This PR: 

BenchmarkResync65536-12    	      13	  84051862 ns/op	 108461538 ncpu/op	36912350 B/op	  526080 allocs/op
```
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Follow on from #8979 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix's route resync logic has been optimised; it now uses 50% less CPU time and 80% less memory.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
