### PR TITLE
Attach xdp to slave devices of a bond (#9132)

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -330,9 +330,10 @@ type bpfEndpointManager struct {
 	updatePolicyProgramFn func(rules polprog.Rules, polDir string, ap attachPoint, ipFamily proto.IPVersion) error
 
 	// HEP processing.
-	hostIfaceToEpMap     map[string]proto.HostEndpoint
-	wildcardHostEndpoint proto.HostEndpoint
-	wildcardExists       bool
+	hostIfaceToEpMap        map[string]proto.HostEndpoint
+	wildcardHostEndpoint    proto.HostEndpoint
+	wildcardExists          bool
+	hostIfaceToSlaveDevices map[string]set.Set[string]
 
 	// UT-able BPF dataplane interface.
 	dp bpfDataplane
@@ -502,12 +503,13 @@ func newBPFEndpointManager(
 		// Note: the allocators only allocate a fraction of the map, the
 		// rest is reserved for sub-programs generated if a single program
 		// would be too large.
-		jumpMapAlloc:     newJumpMapAlloc(jump.TCMaxEntryPoints),
-		xdpJumpMapAlloc:  newJumpMapAlloc(jump.XDPMaxEntryPoints),
-		ruleRenderer:     iptablesRuleRenderer,
-		onStillAlive:     livenessCallback,
-		hostIfaceToEpMap: map[string]proto.HostEndpoint{},
-		opReporter:       opReporter,
+		jumpMapAlloc:            newJumpMapAlloc(jump.TCMaxEntryPoints),
+		xdpJumpMapAlloc:         newJumpMapAlloc(jump.XDPMaxEntryPoints),
+		ruleRenderer:            iptablesRuleRenderer,
+		onStillAlive:            livenessCallback,
+		hostIfaceToEpMap:        map[string]proto.HostEndpoint{},
+		hostIfaceToSlaveDevices: map[string]set.Set[string]{},
+		opReporter:              opReporter,
 		// ipv6Enabled Should be set to config.Ipv6Enabled, but for now it is better
 		// to set it to BPFIpv6Enabled which is a dedicated flag for development of IPv6.
 		// TODO: set ipv6Enabled to config.Ipv6Enabled when IPv6 support is complete
@@ -1116,7 +1118,14 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 	}
 
 	masterIfIndex := 0
+	prevMasterIfIndex := 0
 	curIfaceType := IfaceTypeUnknown
+	prevIfaceType := IfaceTypeUnknown
+	if val, ok := m.nameToIface[update.Name]; ok {
+		prevIfaceType = val.info.ifaceType
+		prevMasterIfIndex = val.info.masterIfIndex
+	}
+
 	if update.State != ifacemonitor.StateNotPresent && !m.isWorkloadIface(update.Name) {
 		// Determine the type of interface.
 		// These include host, bond, slave, ipip, wireguard, l3.
@@ -1132,10 +1141,6 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			curIfaceType = m.getIfaceTypeFromLink(link)
 			masterIfIndex = link.Attrs().MasterIndex
 		}
-		prevIfaceType := IfaceTypeUnknown
-		if val, ok := m.nameToIface[update.Name]; ok {
-			prevIfaceType = val.info.ifaceType
-		}
 		if prevIfaceType != curIfaceType {
 			if curIfaceType == IfaceTypeBondSlave {
 				// Remove the Tc program.
@@ -1147,6 +1152,47 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 						log.WithError(err).Warnf("Failed to detach old programs from now bonding device '%s'", update.Name)
 					}
 				}
+			} else if curIfaceType == IfaceTypeBond {
+				// create an entry in the hostIfaceToSlaveDevices
+				m.hostIfaceToSlaveDevices[update.Name] = set.New[string]()
+			}
+		}
+	}
+
+	// Manage bond slaves.
+	if !m.isWorkloadIface(update.Name) && curIfaceType != prevIfaceType {
+		if curIfaceType == IfaceTypeBondSlave {
+			/* Interface has been added to a bond.
+			 * Add this interface to the list of slave devices
+			 * of the master.
+			 */
+			netiface, err := m.dp.interfaceByIndex(masterIfIndex)
+			if err != nil {
+				log.WithError(err).Warn("Failed to get master interface name. Slave devices not updated")
+			} else {
+				if _, ok := m.hostIfaceToSlaveDevices[netiface.Name]; ok {
+					m.hostIfaceToSlaveDevices[netiface.Name].Add(update.Name)
+				}
+			}
+		} else {
+			/* Interface is either removed from the bond or deleted.
+			 * In such cases, remove the interface from the list of slave devices.
+			 */
+			if prevIfaceType == IfaceTypeBondSlave {
+				netiface, err := m.dp.interfaceByIndex(prevMasterIfIndex)
+				if err != nil {
+					log.WithError(err).Warn("Failed to get master interface name. Slave devices not updated")
+				} else {
+					if _, ok := m.hostIfaceToSlaveDevices[netiface.Name]; ok {
+						m.hostIfaceToSlaveDevices[netiface.Name].Discard(update.Name)
+					}
+				}
+			}
+			/* Interface is not a bond anymore. Remove the interface
+			 * from the map.
+			 */
+			if prevIfaceType == IfaceTypeBond {
+				delete(m.hostIfaceToSlaveDevices, update.Name)
 			}
 		}
 	}
@@ -1322,8 +1368,9 @@ func (m *bpfEndpointManager) markEndpointsDirty(ids set.Set[any], kind string) {
 					}
 				}
 			} else {
-				log.Debugf("Mark host iface dirty, for host %v change", kind)
+				log.Debugf("Mark host iface dirty %v, for host %v change", id, kind)
 				m.dirtyIfaceNames.Add(id)
+				m.dirtyIfaceNames.AddSet(m.getBondSlaves(id))
 			}
 		}
 		return nil
@@ -1697,8 +1744,7 @@ func (m *bpfEndpointManager) reportHealth(ready bool, detail string) {
 	})
 }
 
-func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfaceState, error) {
-
+func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface, masterIface string, ifaceType IfaceType, attachXDPOnly bool) (bpfInterfaceState, error) {
 	var (
 		err   error
 		up    bool
@@ -1717,16 +1763,22 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfac
 		log.WithField("iface", iface).Debug("Ignoring interface that is down")
 		return state, nil
 	}
-	if err := m.dataIfaceStateFillJumps(ifaceName, &state); err != nil {
+	if err := m.dataIfaceStateFillJumps(ifaceName, attachXDPOnly, &state); err != nil {
 		return state, err
 	}
 
-	_, err = m.dp.ensureQdisc(iface)
-	if err != nil {
-		return state, err
+	hepIface := iface
+	if !attachXDPOnly {
+		_, err = m.dp.ensureQdisc(iface)
+		if err != nil {
+			return state, err
+		}
+	} else {
+		hepIface = masterIface
 	}
+
 	var hepPtr *proto.HostEndpoint
-	if hep, hepExists := m.hostIfaceToEpMap[iface]; hepExists {
+	if hep, hepExists := m.hostIfaceToEpMap[hepIface]; hepExists {
 		hepPtr = &hep
 	}
 
@@ -1751,12 +1803,12 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfac
 		go func() {
 			defer parallelWG.Done()
 			ingressAP6, egressAP6, xdpAP6, err6 = m.v6.applyPolicyToDataIface(iface, hepPtr, &state,
-				tcAttachPoint, xdpAttachPoint)
+				tcAttachPoint, xdpAttachPoint, ifaceType, attachXDPOnly)
 		}()
 	}
 	if m.v4 != nil {
 		ingressAP4, egressAP4, xdpAP4, err4 = m.v4.applyPolicyToDataIface(iface, hepPtr, &state,
-			tcAttachPoint, xdpAttachPoint)
+			tcAttachPoint, xdpAttachPoint, ifaceType, attachXDPOnly)
 	}
 
 	parallelWG.Wait()
@@ -1777,10 +1829,12 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfac
 	go func() {
 		defer parallelWG.Done()
 		xdpAP := mergeAttachPoints(xdpAP4, xdpAP6)
-		if hepPtr != nil && len(hepPtr.UntrackedTiers) == 1 && xdpAP != nil {
-			_, xdpErr = m.dp.ensureProgramAttached(xdpAP)
-		} else {
-			xdpErr = m.dp.ensureNoProgram(xdpAP)
+		if xdpAP != nil {
+			if hepPtr != nil && len(hepPtr.UntrackedTiers) == 1 {
+				_, xdpErr = m.dp.ensureProgramAttached(xdpAP)
+			} else {
+				xdpErr = m.dp.ensureNoProgram(xdpAP)
+			}
 		}
 	}()
 
@@ -1849,6 +1903,8 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 			}
 			return nil
 		}
+		attachXDPOnly := false
+		masterName := ""
 		m.ifacesLock.Lock()
 		val, ok := m.nameToIface[iface]
 		m.ifacesLock.Unlock()
@@ -1860,12 +1916,15 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 				masterIfa, err := m.dp.interfaceByIndex(val.info.masterIfIndex)
 				if err != nil {
 					log.Warnf("Failed to get master interface details for '%s'. Continuing to attach program", iface)
-				} else if !m.isDataIface(masterIfa.Name) {
-					log.Warnf("Master interface '%s' ignored. Add it to the bpfDataIfacePattern config", masterIfa.Name)
 				} else {
-					log.WithField("iface", iface).Debug(
-						"Ignoring bonding slave interface")
-					return set.RemoveItem
+					masterName = masterIfa.Name
+					if !m.isDataIface(masterIfa.Name) {
+						log.Warnf("Master interface '%s' ignored. Add it to the bpfDataIfacePattern config", masterIfa.Name)
+					} else {
+						log.WithField("iface", iface).Debug(
+							"Attaching xdp only")
+						attachXDPOnly = true
+					}
 				}
 			}
 		}
@@ -1874,7 +1933,7 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 		wg.Add(1)
 		go func(ifaceName string) {
 			defer wg.Done()
-			state, err := m.doApplyPolicyToDataIface(ifaceName)
+			state, err := m.doApplyPolicyToDataIface(ifaceName, masterName, val.info.ifaceType, attachXDPOnly)
 			m.ifacesLock.Lock()
 			m.withIface(ifaceName, func(bpfIface *bpfInterface) bool {
 				bpfIface.dpState = state
@@ -2029,19 +2088,21 @@ func (m *bpfEndpointManager) allocJumpIndicesForWEP(ifaceName string, idx *bpfIn
 	return nil
 }
 
-func (m *bpfEndpointManager) allocJumpIndicesForDataIface(ifaceName string, idx *bpfInterfaceJumpIndices) error {
+func (m *bpfEndpointManager) allocJumpIndicesForDataIface(ifaceName string, attachXDPOnly bool, idx *bpfInterfaceJumpIndices) error {
 	var err error
-	if idx.policyIdx[hook.Ingress] == -1 {
-		idx.policyIdx[hook.Ingress], err = m.jumpMapAlloc.Get(ifaceName)
-		if err != nil {
-			return err
+	if !attachXDPOnly {
+		if idx.policyIdx[hook.Ingress] == -1 {
+			idx.policyIdx[hook.Ingress], err = m.jumpMapAlloc.Get(ifaceName)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if idx.policyIdx[hook.Egress] == -1 {
-		idx.policyIdx[hook.Egress], err = m.jumpMapAlloc.Get(ifaceName)
-		if err != nil {
-			return err
+		if idx.policyIdx[hook.Egress] == -1 {
+			idx.policyIdx[hook.Egress], err = m.jumpMapAlloc.Get(ifaceName)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -2091,18 +2152,18 @@ func (m *bpfEndpointManager) wepStateFillJumps(ifaceName string, state *bpfInter
 	return nil
 }
 
-func (m *bpfEndpointManager) dataIfaceStateFillJumps(ifaceName string, state *bpfInterfaceState) error {
+func (m *bpfEndpointManager) dataIfaceStateFillJumps(ifaceName string, attachXDPOnly bool, state *bpfInterfaceState) error {
 	var err error
 
 	if m.v4 != nil {
-		err = m.allocJumpIndicesForDataIface(ifaceName, &state.v4)
+		err = m.allocJumpIndicesForDataIface(ifaceName, attachXDPOnly, &state.v4)
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.v6 != nil {
-		err = m.allocJumpIndicesForDataIface(ifaceName, &state.v6)
+		err = m.allocJumpIndicesForDataIface(ifaceName, attachXDPOnly, &state.v6)
 		if err != nil {
 			return err
 		}
@@ -2563,6 +2624,8 @@ func (d *bpfEndpointManagerDataplane) applyPolicyToDataIface(
 	state *bpfInterfaceState,
 	ap *tc.AttachPoint,
 	apxdp *xdp.AttachPoint,
+	ifaceType IfaceType,
+	attachXDPOnly bool,
 ) (*tc.AttachPoint, *tc.AttachPoint, *xdp.AttachPoint, error) {
 
 	ingressAttachPoint := *ap
@@ -2574,20 +2637,24 @@ func (d *bpfEndpointManagerDataplane) applyPolicyToDataIface(
 	var xdpAP *xdp.AttachPoint
 	var ingressErr, egressErr, xdpErr error
 
-	parallelWG.Add(2)
-	go func() {
-		defer parallelWG.Done()
-		ingressAP, ingressErr = d.attachDataIfaceProgram(ifaceName, ep, PolDirnIngress, state, &ingressAttachPoint)
-	}()
+	if ifaceType != IfaceTypeBond {
+		parallelWG.Add(1)
+		go func() {
+			defer parallelWG.Done()
+			xdpAP, xdpErr = d.attachXDPProgram(&xdpAttachPoint, ep, state)
+		}()
+	}
 
-	go func() {
-		defer parallelWG.Done()
-		xdpAP, xdpErr = d.attachXDPProgram(&xdpAttachPoint, ep, state)
-	}()
+	if !attachXDPOnly {
+		parallelWG.Add(1)
+		go func() {
+			defer parallelWG.Done()
+			ingressAP, ingressErr = d.attachDataIfaceProgram(ifaceName, ep, PolDirnIngress, state, &ingressAttachPoint)
+		}()
 
-	egressAP, egressErr = d.attachDataIfaceProgram(ifaceName, ep, PolDirnEgress, state, &egressAttachPoint)
+		egressAP, egressErr = d.attachDataIfaceProgram(ifaceName, ep, PolDirnEgress, state, &egressAttachPoint)
+	}
 	parallelWG.Wait()
-
 	return ingressAP, egressAP, xdpAP, errors.Join(ingressErr, egressErr, xdpErr)
 }
 
@@ -3111,6 +3178,7 @@ func (m *bpfEndpointManager) OnHEPUpdate(hostIfaceToEpMap map[string]proto.HostE
 				delete(m.hostIfaceToEpMap, ifaceName)
 			}
 			m.dirtyIfaceNames.Add(ifaceName)
+			m.dirtyIfaceNames.AddSet(m.getBondSlaves(ifaceName))
 		}
 		delete(hostIfaceToEpMap, ifaceName)
 	}
@@ -3125,6 +3193,7 @@ func (m *bpfEndpointManager) OnHEPUpdate(hostIfaceToEpMap map[string]proto.HostE
 		m.addHEPToIndexes(ifaceName, &newEp)
 		m.hostIfaceToEpMap[ifaceName] = newEp
 		m.dirtyIfaceNames.Add(ifaceName)
+		m.dirtyIfaceNames.AddSet(m.getBondSlaves(ifaceName))
 	}
 }
 
@@ -4107,6 +4176,13 @@ func (m *bpfEndpointManager) getIfaceTypeFromLink(link netlink.Link) IfaceType {
 		}
 	}
 	return IfaceTypeData
+}
+
+func (m *bpfEndpointManager) getBondSlaves(masterIfName string) set.Set[string] {
+	if val, ok := m.hostIfaceToSlaveDevices[masterIfName]; ok {
+		return val
+	}
+	return set.New[string]()
 }
 
 func newJumpMapAlloc(entryPoints int) *jumpMapAlloc {

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -830,6 +830,41 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				genIfaceUpdate("eth11", ifacemonitor.StateNotPresent, 21)()
 				genIfaceUpdate("foo0", ifacemonitor.StateNotPresent, 11)()
 			})
+
+			It("should attach XDP to slave devices", func() {
+				By("adding untracked policy")
+				genUntracked("default", "untracked1")()
+				newHEP := hostEp
+				newHEP.UntrackedTiers = []*proto.TierInfo{{
+					Name:            "default",
+					IngressPolicies: []string{"untracked1"},
+				}}
+				genHEPUpdate("bond0", newHEP)()
+				err := bpfEpMgr.CompleteDeferredWork()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(dp.programAttached("bond0:ingress")).To(BeTrue())
+				Expect(dp.programAttached("bond0:egress")).To(BeTrue())
+				Expect(dp.programAttached("bond0:xdp")).To(BeFalse())
+				checkIfState(10, "bond0", ifstate.FlgIPv4Ready|ifstate.FlgBond)
+
+				Expect(dp.programAttached("eth10:ingress")).To(BeFalse())
+				Expect(dp.programAttached("eth10:egress")).To(BeFalse())
+				Expect(dp.programAttached("eth20:ingress")).To(BeFalse())
+				Expect(dp.programAttached("eth20:egress")).To(BeFalse())
+				Expect(dp.programAttached("eth10:xdp")).To(BeTrue())
+				Expect(dp.programAttached("eth20:xdp")).To(BeTrue())
+
+				By("removing the untracked policy")
+				genHEPUpdate("bond0", hostEp)()
+				err = bpfEpMgr.CompleteDeferredWork()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dp.programAttached("bond0:ingress")).To(BeTrue())
+				Expect(dp.programAttached("bond0:egress")).To(BeTrue())
+				Expect(dp.programAttached("eth10:xdp")).To(BeFalse())
+				Expect(dp.programAttached("eth20:xdp")).To(BeFalse())
+
+			})
 		})
 	})
 

--- a/felix/fv/bpf_attach_test.go
+++ b/felix/fv/bpf_attach_test.go
@@ -124,7 +124,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		tc.Felixes[0].Exec("ifconfig", "eth20", "up")
 
 		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("eth10", "eth20"))
-		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP, "eth20": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, map[string]uint32{"eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP, "eth20": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
 
 		By("Creating a bond interface and eth10, eth20 to the bond")
 		tc.Felixes[0].Exec("ip", "link", "add", "bond0", "type", "bond", "mode", "802.3ad")
@@ -136,20 +136,20 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		time.Sleep(0 * time.Second)
 		Eventually(getBPFNet, "15s", "1s").Should(ContainElement("bond0"))
 		Eventually(getBPFNet, "15s", "1s").ShouldNot(ContainElements("eth10", "eth20"))
-		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond})
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond})
 
 		By("Removing eth10 from bond")
 		tc.Felixes[0].Exec("ip", "link", "set", "eth10", "nomaster")
 		tc.Felixes[0].Exec("ifconfig", "eth10", "up")
 		Eventually(getBPFNet, "15s", "1s").ShouldNot(ContainElement("eth20"))
 		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("bond0", "eth10"))
-		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond, "eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond, "eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
 
 		By("Removing eth20 from bond")
 		tc.Felixes[0].Exec("ip", "link", "set", "eth20", "nomaster")
 		tc.Felixes[0].Exec("ifconfig", "eth20", "up")
 		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("bond0", "eth10", "eth20"))
-		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP, "eth20": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, map[string]uint32{"eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP, "eth20": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
 
 		By("Creating a bond interface which does match BPFDataIfacePattern")
 		tc.Felixes[0].Exec("ip", "link", "add", "foo0", "type", "bond", "mode", "802.3ad")

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -265,8 +265,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 		if !ipv6Dataplane {
 			JustBeforeEach(func() {
 				tc.TriggerDelayedStart()
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, nil)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready, ifstate.FlgHEP, nil)
 			})
 			It("should drop ipv6 packets at workload interface and allow ipv6 packets at host interface when in IPv4 only mode", func() {
 				// IPv4 connectivity must work.
@@ -357,8 +357,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 
 				tc.TriggerDelayedStart()
 
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, nil)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgHEP, nil)
 				cc.ExpectSome(w[0][1], w[0][0])
 				cc.ExpectSome(w[1][0], w[0][0])
 				cc.ExpectSome(w[1][1], w[0][0])
@@ -390,7 +390,7 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 				_, err = k8sClient.CoreV1().Nodes().UpdateStatus(context.Background(), node, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgHEP, nil)
 				cc.ExpectSome(w[0][1], w[0][0])
 				cc.ExpectSome(w[1][0], w[0][0])
 				cc.ExpectSome(w[1][1], w[0][0])
@@ -405,8 +405,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 				tc.TriggerDelayedStart()
 				externalClient := infrastructure.RunExtClient("ext-client")
 				_ = externalClient
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgHEP, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgHEP, nil)
 
 				tcpdump := externalClient.AttachTCPDump("any")
 				tcpdump.SetLogEnabled(true)
@@ -552,9 +552,9 @@ func removeIPv6Address(k8sClient *kubernetes.Clientset, felix *infrastructure.Fe
 	felix.Exec("ip", "-6", "addr", "del", felix.Container.IPv6+"/64", "dev", "eth0")
 }
 
-func ensureRightIFStateFlags(felix *infrastructure.Felix, ready uint32, additionalInterfaces map[string]uint32) {
+func ensureRightIFStateFlags(felix *infrastructure.Felix, ready uint32, hostIfType uint32, additionalInterfaces map[string]uint32) {
 	expectedIfacesToFlags := map[string]uint32{
-		"eth0": ifstate.FlgHEP | ready,
+		"eth0": hostIfType | ready,
 	}
 
 	if additionalInterfaces != nil {

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -19,6 +19,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/projectcalico/calico/felix/fv/connectivity"
@@ -47,6 +48,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 		client         client.Interface
 		cc             *Checker
 		externalClient *containers.Container
+		ctx            context.Context
+		cancel         context.CancelFunc
 	)
 
 	BeforeEach(func() {
@@ -155,6 +158,100 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 		cc.CheckConnectivityOffset(1)
 	}
 
+	testDonotTrackPolicy := func(iface string) {
+		// This test covers both normal connectivity and failsafe connectivity.  We combine the
+		// tests because we rely on the changes of normal connectivity at each step to make sure
+		// that the policy has actually flowed through to the dataplane.
+
+		By("having only failsafe connectivity to start with")
+		expectFailSafeOnlyConnectivity()
+
+		if BPFMode() {
+			expectFailSafeOnlyConnectivity(ExpectWithIPVersion(6))
+			By("Having no Linux IP sets")
+			Consistently(tc.Felixes[0].IPSetNames, "2s", "1s").Should(BeEmpty())
+		}
+
+		host0Selector := fmt.Sprintf("name == '%s-%s'", iface, tc.Felixes[0].Name)
+		host1Selector := fmt.Sprintf("name == '%s-%s'", iface, tc.Felixes[1].Name)
+
+		By("Having connectivity after installing bidirectional policies")
+		host0Pol := createDonotTrackPolicy("host-0-pol", host0Selector, host1Selector, client, ctx)
+		_ = createDonotTrackPolicy("host-1-pol", host1Selector, host0Selector, client, ctx)
+
+		if iface == "bond0" {
+			Consistently(xdpProgramAttached(tc.Felixes[0], "bond0"), "2s", "1s").Should(BeFalse())
+			Consistently(xdpProgramAttached(tc.Felixes[1], "bond0"), "2s", "1s").Should(BeFalse())
+			Eventually(xdpProgramAttached(tc.Felixes[0], "eth0"), "10s", "1s").Should(BeTrue())
+			Eventually(xdpProgramAttached(tc.Felixes[1], "eth0"), "10s", "1s").Should(BeTrue())
+		}
+
+		expectFullConnectivity()
+		if BPFMode() {
+			expectFullConnectivity(ExpectWithIPVersion(6))
+			By("Having a Linux IP set for the egress policy")
+
+			elems := []string{
+				utils.IPSetNameForSelector(4, host1Selector),
+				utils.IPSetNameForSelector(6, host1Selector),
+			}
+			Expect(tc.Felixes[0].IPSetNames()).To(ContainElements(elems))
+		}
+
+		By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
+		// Since there's no conntrack, removing rules in one direction is enough to prevent
+		// connectivity in either direction.
+		host0Pol.Spec.Egress = []api.Rule{
+			{
+				Action: api.Deny,
+				Destination: api.EntityRule{
+					Selector: host0Selector,
+				},
+			},
+		}
+		host0Pol, err := client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectFailSafeOnlyConnectivityWithHost0()
+		if BPFMode() {
+			expectFailSafeOnlyConnectivityWithHost0(ExpectWithIPVersion(6))
+		}
+
+		By("Having full connectivity after putting them back")
+		host0Pol.Spec.Egress = []api.Rule{
+			{
+				Action: api.Allow,
+				Destination: api.EntityRule{
+					Selector: host1Selector,
+				},
+			},
+		}
+		host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectFullConnectivity()
+		if BPFMode() {
+			expectFullConnectivity(ExpectWithIPVersion(6))
+		}
+
+		By("Having only failsafe connectivity after replacing host-0's ingress rules with Deny")
+		host0Pol.Spec.Ingress = []api.Rule{
+			{
+				Action: api.Deny,
+				Destination: api.EntityRule{
+					Selector: host0Selector,
+				},
+			},
+		}
+		host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectFailSafeOnlyConnectivityWithHost0()
+		if BPFMode() {
+			expectFailSafeOnlyConnectivityWithHost0(ExpectWithIPVersion(6))
+		}
+	}
+
 	It("before adding policy, should have connectivity between hosts", func() {
 		expectFullConnectivity()
 		if BPFMode() {
@@ -163,11 +260,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 	})
 
 	Context("after adding host endpoints", func() {
-		var (
-			ctx    context.Context
-			cancel context.CancelFunc
-		)
-
 		BeforeEach(func() {
 			// Make sure our new host endpoints don't cut felix off from the datastore.
 			err := infra.AddAllowToDatastore("host-endpoint=='true'")
@@ -176,21 +268,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			ctx, cancel = context.WithTimeout(context.Background(), 50*time.Second)
 
 			for _, f := range tc.Felixes {
-				hep := api.NewHostEndpoint()
-				hep.Name = "eth0-" + f.Name
-				hep.Labels = map[string]string{
-					"name":          hep.Name,
-					"host-endpoint": "true",
-				}
-				hep.Spec.Node = f.Hostname
-				hep.Spec.InterfaceName = "eth0"
-				hep.Spec.ExpectedIPs = []string{f.IP, f.IPv6}
-				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				createHostEndpoint(f, "eth0", []string{f.IP, f.IPv6}, client, ctx)
 			}
 			if BPFMode() {
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgHEP, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgHEP, nil)
 			}
 		})
 
@@ -198,137 +280,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			cancel()
 		})
 
-		checkUntrackedPol := func() {
-			// This test covers both normal connectivity and failsafe connectivity.  We combine the
-			// tests because we rely on the changes of normal connectivity at each step to make sure
-			// that the policy has actually flowed through to the dataplane.
-
-			By("having only failsafe connectivity to start with")
-			expectFailSafeOnlyConnectivity()
-
-			if BPFMode() {
-				expectFailSafeOnlyConnectivity(ExpectWithIPVersion(6))
-				By("Having no Linux IP sets")
-				Consistently(tc.Felixes[0].IPSetNames, "2s", "1s").Should(BeEmpty())
-			}
-
-			host0Selector := fmt.Sprintf("name == 'eth0-%s'", tc.Felixes[0].Name)
-			host1Selector := fmt.Sprintf("name == 'eth0-%s'", tc.Felixes[1].Name)
-
-			By("Having connectivity after installing bidirectional policies")
-			host0Pol := api.NewGlobalNetworkPolicy()
-			host0Pol.Name = "host-0-pol"
-			host0Pol.Spec.Selector = host0Selector
-			host0Pol.Spec.DoNotTrack = true
-			host0Pol.Spec.ApplyOnForward = true
-			host0Pol.Spec.Ingress = []api.Rule{
-				{
-					Action: api.Allow,
-					Source: api.EntityRule{
-						Selector: host1Selector,
-					},
-				},
-			}
-			host0Pol.Spec.Egress = []api.Rule{
-				{
-					Action: api.Allow,
-					Destination: api.EntityRule{
-						Selector: host1Selector,
-					},
-				},
-			}
-			host0Pol, err := client.GlobalNetworkPolicies().Create(ctx, host0Pol, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			host1Pol := api.NewGlobalNetworkPolicy()
-			host1Pol.Name = "host-1-pol"
-			host1Pol.Spec.Selector = host1Selector
-			host1Pol.Spec.DoNotTrack = true
-			host1Pol.Spec.ApplyOnForward = true
-			host1Pol.Spec.Ingress = []api.Rule{
-				{
-					Action: api.Allow,
-					Source: api.EntityRule{
-						Selector: host0Selector,
-					},
-				},
-			}
-			host1Pol.Spec.Egress = []api.Rule{
-				{
-					Action: api.Allow,
-					Destination: api.EntityRule{
-						Selector: host0Selector,
-					},
-				},
-			}
-			host1Pol, err = client.GlobalNetworkPolicies().Create(ctx, host1Pol, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			expectFullConnectivity()
-			if BPFMode() {
-				expectFullConnectivity(ExpectWithIPVersion(6))
-				By("Having a Linux IP set for the egress policy")
-				Expect(tc.Felixes[0].IPSetNames()).To(ContainElements(
-					utils.IPSetNameForSelector(4, host1Selector),
-					utils.IPSetNameForSelector(6, host1Selector),
-				))
-			}
-
-			By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
-			// Since there's no conntrack, removing rules in one direction is enough to prevent
-			// connectivity in either direction.
-			host0Pol.Spec.Egress = []api.Rule{
-				{
-					Action: api.Deny,
-					Destination: api.EntityRule{
-						Selector: host0Selector,
-					},
-				},
-			}
-			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			expectFailSafeOnlyConnectivityWithHost0()
-			if BPFMode() {
-				expectFailSafeOnlyConnectivityWithHost0(ExpectWithIPVersion(6))
-			}
-
-			By("Having full connectivity after putting them back")
-			host0Pol.Spec.Egress = []api.Rule{
-				{
-					Action: api.Allow,
-					Destination: api.EntityRule{
-						Selector: host1Selector,
-					},
-				},
-			}
-			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			expectFullConnectivity()
-			if BPFMode() {
-				expectFullConnectivity(ExpectWithIPVersion(6))
-			}
-
-			By("Having only failsafe connectivity after replacing host-0's ingress rules with Deny")
-			host0Pol.Spec.Ingress = []api.Rule{
-				{
-					Action: api.Deny,
-					Destination: api.EntityRule{
-						Selector: host0Selector,
-					},
-				},
-			}
-			host0Pol, err = client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			expectFailSafeOnlyConnectivityWithHost0()
-			if BPFMode() {
-				expectFailSafeOnlyConnectivityWithHost0(ExpectWithIPVersion(6))
-			}
-		}
-
-		It("should implement untracked policy correctly", checkUntrackedPol)
+		It("should implement untracked policy correctly", func() {
+			testDonotTrackPolicy("eth0")
+		})
 
 		if BPFMode() {
 			Describe("with a custom map size", func() {
@@ -349,8 +303,125 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 					})
 				})
 
-				It("should implement untracked policy correctly", checkUntrackedPol)
+				It("should implement untracked policy correctly", func() {
+					testDonotTrackPolicy("eth0")
+				})
 			})
 		}
 	})
+
+	Context("after adding eth0 to a bond interface", func() {
+		if !BPFMode() {
+			return
+		}
+
+		BeforeEach(func() {
+			// Make sure our new host endpoints don't cut felix off from the datastore.
+			err := infra.AddAllowToDatastore("host-endpoint=='true'")
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel = context.WithTimeout(context.Background(), 50*time.Second)
+			for _, felix := range tc.Felixes {
+				// recreate those after moving the IP.
+				defaultRoute, err := felix.ExecOutput("ip", "route", "show", "default")
+				Expect(err).NotTo(HaveOccurred())
+				lines := strings.Split(strings.Trim(defaultRoute, "\n "), "\n")
+				Expect(lines).To(HaveLen(1))
+				defaultRouteArgs := strings.Split(strings.Replace(lines[0], "eth0", "bond0", -1), " ")
+
+				// Assuming the subnet route will be "proto kernel" and that will be the only such route.
+				subnetRoute, err := felix.ExecOutput("ip", "route", "show", "proto", "kernel")
+				Expect(err).NotTo(HaveOccurred())
+				lines = strings.Split(strings.Trim(subnetRoute, "\n "), "\n")
+				Expect(lines).To(HaveLen(1), "expected only one proto kernel route, has docker's routing set-up changed?")
+				subnetArgs := strings.Split(strings.Replace(lines[0], "eth0", "bond0", -1), " ")
+
+				//Move IPv6
+				defaultRoute6, err := felix.ExecOutput("ip", "-6", "route", "show", "default")
+				Expect(err).NotTo(HaveOccurred())
+				lines = strings.Split(strings.Trim(defaultRoute6, "\n "), "\n")
+				Expect(lines).To(HaveLen(1))
+				defaultRoute6Args := strings.Split(strings.Replace(lines[0], "eth0", "bond0", -1), " ")
+
+				// Assuming the subnet route will be "proto kernel" and that will be the only such route.
+				subnetRoute6, err := felix.ExecOutput("ip", "-6", "route", "show", "proto", "kernel")
+				Expect(err).NotTo(HaveOccurred())
+				lines = strings.Split(strings.Trim(subnetRoute6, "\n "), "\n")
+				subnet6Args := strings.Split(strings.Replace(lines[0], "eth0", "bond0", -1), " ")
+
+				felix.Exec("ip", "addr", "del", felix.IP, "dev", "eth0")
+				ip6WithSubnet := felix.IPv6 + "/" + felix.GetIPv6Prefix()
+				felix.Exec("ip", "-6", "addr", "del", ip6WithSubnet, "dev", "eth0")
+
+				felix.Exec("ip", "link", "add", "dev", "bond0", "type", "bond")
+				felix.Exec("ip", "link", "set", "dev", "eth0", "down")
+				felix.Exec("ip", "link", "set", "dev", "eth0", "master", "bond0")
+				felix.Exec("ip", "link", "set", "dev", "eth0", "up")
+				felix.Exec("ip", "link", "set", "dev", "bond0", "up")
+
+				ipWithSubnet := felix.IP + "/" + felix.GetIPPrefix()
+				felix.Exec("ip", "addr", "add", ipWithSubnet, "dev", "bond0")
+				felix.Exec(append([]string{"ip", "r", "add"}, defaultRouteArgs...)...)
+				felix.Exec(append([]string{"ip", "r", "replace"}, subnetArgs...)...)
+
+				felix.Exec("ip", "-6", "addr", "add", ip6WithSubnet, "dev", "bond0")
+				felix.Exec(append([]string{"ip", "-6", "r", "add"}, defaultRoute6Args...)...)
+				felix.Exec(append([]string{"ip", "-6", "r", "replace"}, subnet6Args...)...)
+
+				ensureRightIFStateFlags(felix, ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgBondSlave, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgIPv6Ready | ifstate.FlgBond})
+				createHostEndpoint(felix, "bond0", []string{felix.IP, felix.IPv6}, client, ctx)
+			}
+		})
+
+		AfterEach(func() {
+			cancel()
+		})
+		It("should implement untracked policy correctly", func() {
+			testDonotTrackPolicy("bond0")
+		})
+
+	})
+
 })
+
+func createHostEndpoint(f *infrastructure.Felix, iface string,
+	expectedIPs []string, client client.Interface, ctx context.Context) {
+	hep := api.NewHostEndpoint()
+	hep.Name = iface + "-" + f.Name
+	hep.Labels = map[string]string{
+		"name":          hep.Name,
+		"host-endpoint": "true",
+	}
+	hep.Spec.Node = f.Hostname
+	hep.Spec.InterfaceName = iface
+	hep.Spec.ExpectedIPs = expectedIPs
+	_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createDonotTrackPolicy(name, selector, dstSelector string, client client.Interface, ctx context.Context) *api.GlobalNetworkPolicy {
+	pol := api.NewGlobalNetworkPolicy()
+	pol.Name = name
+	pol.Spec.Selector = selector
+	pol.Spec.DoNotTrack = true
+	pol.Spec.ApplyOnForward = true
+	pol.Spec.Ingress = []api.Rule{
+		{
+			Action: api.Allow,
+			Source: api.EntityRule{
+				Selector: dstSelector,
+			},
+		},
+	}
+	pol.Spec.Egress = []api.Rule{
+		{
+			Action: api.Allow,
+			Destination: api.EntityRule{
+				Selector: dstSelector,
+			},
+		},
+	}
+	pol, err := client.GlobalNetworkPolicies().Create(ctx, pol, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	return pol
+}

--- a/felix/fv/xdp_test.go
+++ b/felix/fv/xdp_test.go
@@ -180,23 +180,6 @@ func xdpTest(getInfra infrastructure.InfraFactory, proto string) {
 		expectNoConnectivity(cc)
 	})
 
-	xdpProgramID := func(felix *infrastructure.Felix, iface string) int {
-		out, err := felix.ExecCombinedOutput("ip", "link", "show", "dev", iface)
-		Expect(err).NotTo(HaveOccurred())
-		r := regexp.MustCompile(`prog/xdp id (\d+)`)
-		matches := r.FindStringSubmatch(out)
-		if len(matches) == 0 {
-			return 0
-		}
-		id, err := strconv.Atoi(matches[1])
-		Expect(err).NotTo(HaveOccurred())
-		return id
-	}
-
-	xdpProgramAttached := func(felix *infrastructure.Felix, iface string) bool {
-		return xdpProgramID(felix, iface) != 0
-	}
-
 	xdpProgramAttachedServerEth0 := func() bool {
 		return xdpProgramAttached(tc.Felixes[srvr], "eth0")
 	}
@@ -526,4 +509,21 @@ func xdpTest(getInfra infrastructure.InfraFactory, proto string) {
 			})
 		})
 	})
+}
+
+func xdpProgramID(felix *infrastructure.Felix, iface string) int {
+	out, err := felix.ExecCombinedOutput("ip", "link", "show", "dev", iface)
+	Expect(err).NotTo(HaveOccurred())
+	r := regexp.MustCompile(`prog/xdp id (\d+)`)
+	matches := r.FindStringSubmatch(out)
+	if len(matches) == 0 {
+		return 0
+	}
+	id, err := strconv.Atoi(matches[1])
+	Expect(err).NotTo(HaveOccurred())
+	return id
+}
+
+func xdpProgramAttached(felix *infrastructure.Felix, iface string) bool {
+	return xdpProgramID(felix, iface) != 0
 }


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/projectcalico/calico/pull/9132


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf - Attach XDP to bond slave devices.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
