### PR TITLE
[release-v3.28] Auto pick #9137: fix applying and removing log filters

### DIFF
--- a/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
@@ -1068,6 +1068,10 @@ spec:
                                   If omitted, the API server Deployment will use its default value for nodeSelector.
                                   WARNING: Please note that this field will modify the default API server Deployment nodeSelector.
                                 type: object
+                              priorityClassName:
+                                description: PriorityClassName allows to specify a
+                                  PriorityClass resource to be used.
+                                type: string
                               tolerations:
                                 description: |-
                                   Tolerations is the API server pod's tolerations.

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -980,6 +980,7 @@ func (m *bpfEndpointManager) reclaimFilterIdx(name string, iface *bpfInterface) 
 		if err := m.jumpMapAlloc.Put(iface.dpState.filterIdx[attachHook], name); err != nil {
 			log.WithError(err).Errorf("Filter hook %s", attachHook)
 		}
+		iface.dpState.filterIdx[attachHook] = -1
 	}
 }
 
@@ -1018,6 +1019,7 @@ func (m *bpfEndpointManager) updateIfaceStateMap(name string, iface *bpfInterfac
 		if iface.dpState.v6Readiness != ifaceNotReady {
 			flags |= ifstate.FlgIPv6Ready
 		}
+
 		v := ifstate.NewValue(flags, name,
 			iface.dpState.v4.policyIdx[hook.XDP],
 			iface.dpState.v4.policyIdx[hook.Ingress],
@@ -1767,7 +1769,6 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface, masterIface string,
 	)
 
 	m.ifacesLock.Lock()
-	ifaceName := iface
 	m.withIface(iface, func(iface *bpfInterface) bool {
 		up = iface.info.ifaceIsUp()
 		state = iface.dpState
@@ -1777,10 +1778,6 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface, masterIface string,
 	if !up {
 		log.WithField("iface", iface).Debug("Ignoring interface that is down")
 		return state, nil
-	}
-
-	if err := m.dataIfaceStateFillJumps(ifaceName, xdpMode, &state); err != nil {
-		return state, err
 	}
 
 	hepIface := iface
@@ -1805,6 +1802,10 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface, masterIface string,
 	var xdpAP4, xdpAP6 *xdp.AttachPoint
 
 	tcAttachPoint := m.calculateTCAttachPoint(iface)
+	if err := m.dataIfaceStateFillJumps(tcAttachPoint, xdpMode, &state); err != nil {
+		return state, err
+	}
+
 	xdpAttachPoint := &xdp.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
 			Hook:     hook.XDP,
@@ -2135,12 +2136,12 @@ func (m *bpfEndpointManager) allocJumpIndicesForDataIface(ifaceName string, xdpM
 	return nil
 }
 
-func (m *bpfEndpointManager) wepStateFillJumps(ifaceName string, state *bpfInterfaceState) error {
+func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInterfaceState) error {
 	var err error
 
 	// Allocate indices for IPv4
 	if m.v4 != nil {
-		err = m.allocJumpIndicesForWEP(ifaceName, &state.v4)
+		err = m.allocJumpIndicesForWEP(ap.IfaceName(), &state.v4)
 		if err != nil {
 			return err
 		}
@@ -2148,58 +2149,79 @@ func (m *bpfEndpointManager) wepStateFillJumps(ifaceName string, state *bpfInter
 
 	// Allocate indices for IPv6
 	if m.v6 != nil {
-		err = m.allocJumpIndicesForWEP(ifaceName, &state.v6)
+		err = m.allocJumpIndicesForWEP(ap.IfaceName(), &state.v6)
 		if err != nil {
 			return err
 		}
 	}
 
-	if m.bpfLogLevel == "debug" {
+	if ap.LogLevel == "debug" {
 		if state.filterIdx[hook.Ingress] == -1 {
-			state.filterIdx[hook.Ingress], err = m.jumpMapAlloc.Get(ifaceName)
+			state.filterIdx[hook.Ingress], err = m.jumpMapAlloc.Get(ap.IfaceName())
 			if err != nil {
 				return err
 			}
 		}
 		if state.filterIdx[hook.Egress] == -1 {
-			state.filterIdx[hook.Egress], err = m.jumpMapAlloc.Get(ifaceName)
+			state.filterIdx[hook.Egress], err = m.jumpMapAlloc.Get(ap.IfaceName())
 			if err != nil {
 				return err
 			}
 		}
+	} else {
+		for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
+			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook]); err != nil {
+				log.WithError(err).Warn("Filter program may leak.")
+			}
+			if err := m.jumpMapAlloc.Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
+				log.WithError(err).Errorf("Filter hook %s", attachHook)
+			}
+			state.filterIdx[attachHook] = -1
+		}
 	}
+
 	return nil
 }
 
-func (m *bpfEndpointManager) dataIfaceStateFillJumps(ifaceName string, xdpMode XDPMode, state *bpfInterfaceState) error {
+func (m *bpfEndpointManager) dataIfaceStateFillJumps(ap *tc.AttachPoint, xdpMode XDPMode, state *bpfInterfaceState) error {
 	var err error
 
 	if m.v4 != nil {
-		err = m.allocJumpIndicesForDataIface(ifaceName, xdpMode, &state.v4)
+		err = m.allocJumpIndicesForDataIface(ap.IfaceName(), xdpMode, &state.v4)
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.v6 != nil {
-		err = m.allocJumpIndicesForDataIface(ifaceName, xdpMode, &state.v6)
+		err = m.allocJumpIndicesForDataIface(ap.IfaceName(), xdpMode, &state.v6)
 		if err != nil {
 			return err
 		}
 	}
 
-	if m.bpfLogLevel == "debug" {
+	if ap.LogLevel == "debug" {
 		if state.filterIdx[hook.Ingress] == -1 {
-			state.filterIdx[hook.Ingress], err = m.jumpMapAlloc.Get(ifaceName)
+			state.filterIdx[hook.Ingress], err = m.jumpMapAlloc.Get(ap.IfaceName())
 			if err != nil {
 				return err
 			}
 		}
 		if state.filterIdx[hook.Egress] == -1 {
-			state.filterIdx[hook.Egress], err = m.jumpMapAlloc.Get(ifaceName)
+			state.filterIdx[hook.Egress], err = m.jumpMapAlloc.Get(ap.IfaceName())
 			if err != nil {
 				return err
 			}
+		}
+	} else {
+		for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
+			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook]); err != nil {
+				log.WithError(err).Warn("Filter program may leak.")
+			}
+			if err := m.jumpMapAlloc.Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
+				log.WithError(err).Errorf("Filter hook %s", attachHook)
+			}
+			state.filterIdx[attachHook] = -1
 		}
 	}
 	return nil
@@ -2235,10 +2257,6 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		log.WithField("ifaceName", ifaceName).Debug(
 			"Ignoring request to program interface that is not present.")
 		return state, nil
-	}
-
-	if err := m.wepStateFillJumps(ifaceName, &state); err != nil {
-		return state, err
 	}
 
 	// Otherwise, the interface appears to be present but we may or may not have an endpoint from the
@@ -2291,6 +2309,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	}
 
 	ap := m.calculateTCAttachPoint(ifaceName)
+
+	if err := m.wepStateFillJumps(ap, &state); err != nil {
+		return state, err
+	}
 
 	if m.v6 != nil {
 		wg.Add(1)
@@ -2802,7 +2824,11 @@ func (polDirection PolDirection) Inverse() PolDirection {
 }
 
 func (m *bpfEndpointManager) apLogFilter(ap *tc.AttachPoint, iface string) (string, string) {
-	if m.logFilters == nil {
+	if len(m.logFilters) == 0 {
+		return m.bpfLogLevel, ""
+	}
+
+	if m.bpfLogLevel != "debug" {
 		return m.bpfLogLevel, ""
 	}
 
@@ -2810,21 +2836,26 @@ func (m *bpfEndpointManager) apLogFilter(ap *tc.AttachPoint, iface string) (stri
 	if !ok {
 		if ap.Type == tcdefs.EpTypeWorkload {
 			if exp, ok := m.logFilters["weps"]; ok {
+				log.WithField("iface", iface).Debugf("Log filter for weps: %s", exp)
 				return m.bpfLogLevel, exp
 			}
 		}
 		if ap.Type == tcdefs.EpTypeHost {
 			if exp, ok := m.logFilters["heps"]; ok {
+				log.WithField("iface", iface).Debugf("Log filter for heps: %s", exp)
 				return m.bpfLogLevel, exp
 			}
 		}
 		if exp, ok := m.logFilters["all"]; ok {
+			log.WithField("iface", iface).Debugf("Log filter for all: %s", exp)
 			return m.bpfLogLevel, exp
 		}
 
+		log.WithField("iface", iface).Debug("No log filter")
 		return "off", ""
 	}
 
+	log.WithField("iface", iface).Debugf("Log filter:  %s", exp)
 	return m.bpfLogLevel, exp
 }
 

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -1427,6 +1427,10 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		}
 
 		It("should reclaim indexes for active interfaces", func() {
+
+			bpfEpMgr.bpfLogLevel = "debug"
+			bpfEpMgr.logFilters = map[string]string{"all": "tcp"}
+
 			for i := 0; i < 8; i++ {
 				_ = jumpMap.Update(jump.Key(i), jump.Value(uint32(1000+i)))
 				_ = jumpMap.Update(jump.Key(i+jump.TCMaxEntryPoints), jump.Value(uint32(1000+i)))
@@ -1468,17 +1472,17 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				123: value123.String(),
 			}))
 
-			// Expect clean-up deletions but no value changes due to mocking.
-			Expect(dumpJumpMap(jumpMap)).To(Equal(map[int]int{
-				0:     1000,
-				2:     1002,
-				3:     1003,
-				4:     1004,
-				10000: 1000,
-				10002: 1002,
-				10003: 1003,
-				10004: 1004,
-			}))
+			// Expect clean-up deletions.
+			jmps := dumpJumpMap(jumpMap)
+			Expect(jmps).To(HaveLen(8))
+			Expect(jmps).To(HaveKey(0)) /* filters reloaded to reflect current expressions */
+			Expect(jmps).To(HaveKey(2))
+			Expect(jmps).To(HaveKey(3))
+			Expect(jmps).To(HaveKey(4))
+			Expect(jmps).To(HaveKeyWithValue(10000, 1000))
+			Expect(jmps).To(HaveKeyWithValue(10002, 1002))
+			Expect(jmps).To(HaveKeyWithValue(10003, 1003))
+			Expect(jmps).To(HaveKeyWithValue(10004, 1004))
 			Expect(dumpJumpMap(xdpJumpMap)).To(Equal(map[int]int{
 				1: 2001,
 			}))
@@ -1821,6 +1825,9 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			newBpfEpMgr(true)
 		})
 		It("should clean up jump map entries for missing interfaces", func() {
+			bpfEpMgr.bpfLogLevel = "debug"
+			bpfEpMgr.logFilters = map[string]string{"all": "tcp"}
+
 			for i := 0; i < 17; i++ {
 				_ = jumpMap.Update(jump.Key(i), jump.Value(uint32(1000+i)))
 				_ = jumpMap.Update(jump.Key(i+jump.TCMaxEntryPoints), jump.Value(uint32(1000+i)))
@@ -1885,6 +1892,9 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		}
 
 		It("should reclaim indexes for active interfaces", func() {
+			bpfEpMgr.bpfLogLevel = "debug"
+			bpfEpMgr.logFilters = map[string]string{"all": "tcp"}
+
 			for i := 0; i < 8; i++ {
 				_ = jumpMap.Update(jump.Key(i), jump.Value(uint32(1000+i)))
 				_ = jumpMap.Update(jump.Key(i+jump.TCMaxEntryPoints), jump.Value(uint32(1000+i)))
@@ -1927,13 +1937,14 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				123: value123.String(),
 			}))
 
-			// Expect clean-up deletions but no value changes due to mocking.
-			Expect(dumpJumpMap(jumpMap)).To(Equal(map[int]int{
-				2:     1002,
-				3:     1003,
-				10002: 1002,
-				10003: 1003,
-			}))
+			// Expect clean-up deletions.
+			jmps := dumpJumpMap(jumpMap)
+			Expect(jmps).To(HaveLen(5))
+			Expect(jmps).To(HaveKey(2)) /* filters reloaded to reflect current expressions */
+			Expect(jmps).To(HaveKey(3))
+			Expect(jmps).To(HaveKey(4))
+			Expect(jmps).To(HaveKeyWithValue(10002, 1002))
+			Expect(jmps).To(HaveKeyWithValue(10003, 1003))
 			Expect(dumpJumpMap(xdpJumpMap)).To(Equal(map[int]int{
 				1: 2001,
 			}))

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -1071,6 +1071,10 @@ spec:
                                   If omitted, the API server Deployment will use its default value for nodeSelector.
                                   WARNING: Please note that this field will modify the default API server Deployment nodeSelector.
                                 type: object
+                              priorityClassName:
+                                description: PriorityClassName allows to specify a
+                                  PriorityClass resource to be used.
+                                type: string
                               tolerations:
                                 description: |-
                                   Tolerations is the API server pod's tolerations.

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -5431,6 +5431,10 @@ spec:
                                   If omitted, the API server Deployment will use its default value for nodeSelector.
                                   WARNING: Please note that this field will modify the default API server Deployment nodeSelector.
                                 type: object
+                              priorityClassName:
+                                description: PriorityClassName allows to specify a
+                                  PriorityClass resource to be used.
+                                type: string
                               tolerations:
                                 description: |-
                                   Tolerations is the API server pod's tolerations.


### PR DESCRIPTION
Cherry pick of #9137 on release-v3.28.

#9137: fix applying and removing log filters

# Original PR Body below

* do not apply an empty filter (matches all) if there is no filter for that device
* do not apply any filters if there the mode is not debug
* do not pre-allocate filter jumps indexes before deciding whether we will apply filters (hence do not take up space if no filter is applied)
* clean up state when a filter is removed. Do not incorrectly program the index in tc program config if there is no filter left.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix applying and removing log filters
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.