### PR TITLE
[release-v3.28] Auto pick #9144: Handle bond slave updates before bond device update.

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -485,6 +485,25 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		Expect(name).To(Equal(vv.IfName()))
 	}
 
+	getPolicyIdx := func(idx int, name, hook string) int {
+		k := ifstate.NewKey(uint32(idx))
+		vb, err := ifStateMap.Get(k.AsBytes())
+		if err != nil {
+			Fail(fmt.Sprintf("Ifstate does not have key %s", k), 1)
+		}
+		vv := ifstate.ValueFromBytes(vb)
+		Expect(name).To(Equal(vv.IfName()))
+		switch hook {
+		case "ingress":
+			return vv.IngressPolicyV4()
+		case "egress":
+			return vv.EgressPolicyV4()
+		case "xdp":
+			return vv.XDPPolicyV4()
+		}
+		return -1
+	}
+
 	genIfaceUpdate := func(name string, state ifacemonitor.State, index int) func() {
 		return func() {
 			bpfEpMgr.OnUpdate(&ifaceStateUpdate{Name: name, State: state, Index: index})
@@ -763,6 +782,13 @@ var _ = Describe("BPF Endpoint Manager", func() {
 						Flags: net.FlagUp,
 					}, nil
 				}
+				if ifindex == 12 {
+					return &net.Interface{
+						Name:  "bond1",
+						Index: 12,
+						Flags: net.FlagUp,
+					}, nil
+				}
 				return nil, errors.New("no such network interface")
 			}
 
@@ -785,12 +811,42 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				Expect(dp.programAttached("bond0:ingress")).To(BeTrue())
 				Expect(dp.programAttached("bond0:egress")).To(BeTrue())
 				checkIfState(10, "bond0", ifstate.FlgIPv4Ready|ifstate.FlgBond)
+				xdpID := getPolicyIdx(10, "bond0", "xdp")
+				Expect(xdpID).To(Equal(-1))
 			})
 			It("should not attach to bond slaves", func() {
 				Expect(dp.programAttached("eth10:ingress")).To(BeFalse())
 				Expect(dp.programAttached("eth10:egress")).To(BeFalse())
 				Expect(dp.programAttached("eth20:ingress")).To(BeFalse())
 				Expect(dp.programAttached("eth20:egress")).To(BeFalse())
+			})
+
+			It("should attach xdp to slave interfaces when the slave interface update is received first", func() {
+				err := dp.createBondSlaves("eth11", 21, 12)
+				Expect(err).NotTo(HaveOccurred())
+				err = dp.createBondSlaves("eth21", 31, 12)
+				Expect(err).NotTo(HaveOccurred())
+				err = dp.createIface("bond1", 12, "bond")
+				Expect(err).NotTo(HaveOccurred())
+
+				genIfaceUpdate("eth11", ifacemonitor.StateUp, 21)()
+				genIfaceUpdate("eth21", ifacemonitor.StateUp, 31)()
+				genIfaceUpdate("bond1", ifacemonitor.StateUp, 12)()
+				genUntracked("default", "untracked1")()
+				newHEP := hostEp
+				newHEP.UntrackedTiers = []*proto.TierInfo{{
+					Name:            "default",
+					IngressPolicies: []string{"untracked1"},
+				}}
+				genHEPUpdate("bond1", newHEP)()
+				err = bpfEpMgr.CompleteDeferredWork()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dp.programAttached("eth11:ingress")).To(BeFalse())
+				Expect(dp.programAttached("eth11:egress")).To(BeFalse())
+				Expect(dp.programAttached("eth21:ingress")).To(BeFalse())
+				Expect(dp.programAttached("eth21:egress")).To(BeFalse())
+				Expect(dp.programAttached("eth11:xdp")).To(BeTrue())
+				Expect(dp.programAttached("eth21:xdp")).To(BeTrue())
 			})
 
 			It("should attach to interfaces when it is removed from bond", func() {


### PR DESCRIPTION
Cherry pick of #9144 on release-v3.28.

#9144: Handle bond slave updates before bond device update.

# Original PR Body below

## Description

This PR fixes
1. Don't  allocate XDP index for bond devices.
2. Handle slave device updates properly if it comes before bond device update. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.