### PR TITLE
[BPF] disable conntrack bypass, exclude link-local

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -198,7 +198,7 @@ type Config struct {
 	BPFMapSizeConntrack                int               `config:"int;512000;non-zero"`
 	BPFMapSizeIPSets                   int               `config:"int;1048576;non-zero"`
 	BPFMapSizeIfState                  int               `config:"int;1000;non-zero"`
-	BPFHostConntrackBypass             bool              `config:"bool;true"`
+	BPFHostConntrackBypass             bool              `config:"bool;false"`
 	BPFEnforceRPF                      string            `config:"oneof(Disabled,Strict,Loose);Loose;non-zero"`
 	BPFPolicyDebugEnabled              bool              `config:"bool;true"`
 	BPFForceTrackPacketsFromIfaces     []string          `config:"iface-filter-slice;docker+"`

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5578,6 +5578,12 @@ func conntrackFlushWorkloadEntries(felixes []*infrastructure.Felix) func() {
 }
 
 func conntrackChecks(felixes []*infrastructure.Felix) []interface{} {
+	if felixes[0].ExpectedIPIPTunnelAddr != "" ||
+		felixes[0].ExpectedWireguardTunnelAddr != "" ||
+		felixes[0].ExpectedWireguardV6TunnelAddr != "" {
+		return nil
+	}
+
 	return []interface{}{
 		CheckWithInit(conntrackFlushWorkloadEntries(felixes)),
 		CheckWithFinalTest(conntrackCheck(felixes)),

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1207,6 +1207,25 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 			}
 		}
 
+		switch ipVersion {
+		case 4:
+			bpfUntrackedFlowRules = append(bpfUntrackedFlowRules,
+				generictables.Rule{
+					Match:   r.NewMatch().DestNet("169.254.0.0/16"),
+					Action:  r.Return(),
+					Comment: []string{"link-local"},
+				},
+			)
+		case 6:
+			bpfUntrackedFlowRules = append(bpfUntrackedFlowRules,
+				generictables.Rule{
+					Match:   r.NewMatch().DestNet("fe80::/10"),
+					Action:  r.Return(),
+					Comment: []string{"link-local"},
+				},
+			)
+		}
+
 		bpfUntrackedFlowRules = append(bpfUntrackedFlowRules,
 			generictables.Rule{
 				Match:   r.NewMatch().MarkMatchesWithMask(tcdefs.MarkSeenSkipFIB, tcdefs.MarkSeenSkipFIB),

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -1835,6 +1835,11 @@ var _ = Describe("Static", func() {
 	Describe("with BPF mode raw chains", func() {
 		staticBPFModeRawRules := []generictables.Rule{
 			{
+				Match:   Match().DestNet("169.254.0.0/16"),
+				Action:  ReturnAction{},
+				Comment: []string{"link-local"},
+			},
+			{
 				Match:   Match().MarkMatchesWithMask(0x1100000, 0x1100000),
 				Action:  ReturnAction{},
 				Comment: []string{"MarkSeenSkipFIB Mark"},


### PR DESCRIPTION
Given the fact that since kernel 5.9+ when FIB is enabled (always except if ipip is used) we always bypass iptables for forwarded traffic, we no longer have the confusing half-open conntrack entries because the first packet would sometimes go through host net stack and then the rest would bypass it. And since most deployments do not use kernels older than 5.9 it is not a common requirement to bypass conntrack. Therefore the default setting it not to do that. However, it is still possible to turn it on via bpfHostConntrackBypass. Some environments like MKE require this to be turned off to function correctly.

Also link-local addresses destinations should not be excluded.

fixes https://github.com/projectcalico/calico/issues/9157

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: disable conntrack bypass by default (not needed for kernels 5.9+), exclude link-local from the bypass
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
