### PR TITLE
Accept updates for NP/GNP without tier prefixed names

### DIFF
--- a/apiserver/pkg/registry/projectcalico/globalpolicy/strategy.go
+++ b/apiserver/pkg/registry/projectcalico/globalpolicy/strategy.go
@@ -17,6 +17,7 @@ package globalpolicy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,9 +44,34 @@ func (policyStrategy) NamespaceScoped() bool {
 }
 
 func (policyStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	obj.(*calico.GlobalNetworkPolicy).Name = canonicalizePolicyName(obj)
 }
 
 func (policyStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	obj.(*calico.GlobalNetworkPolicy).Name = canonicalizePolicyName(old)
+}
+
+func canonicalizePolicyName(obj runtime.Object) string {
+	// Policies without a tier prepended to their name should have the tier prepended.
+	// It's possible for a user to send a policy with one of two name formats:
+	//
+	// - "tier.policy"
+	// - "policy"
+	//
+	// The logic below handles canonicalizing the name to the former.
+	tier := "default"
+	if oldPolicy, ok := obj.(*calico.GlobalNetworkPolicy); ok && oldPolicy.Spec.Tier != "" {
+		tier = oldPolicy.Spec.Tier
+	}
+
+	policy := obj.(*calico.GlobalNetworkPolicy)
+	if len(strings.Split(policy.Name, ".")) == 1 {
+		// Tier is not included in the name - add it.
+		return tier + "." + policy.Name
+	}
+
+	// Name already includes the tier.
+	return policy.Name
 }
 
 func (policyStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/apiserver/pkg/registry/projectcalico/networkpolicy/strategy.go
+++ b/apiserver/pkg/registry/projectcalico/networkpolicy/strategy.go
@@ -17,6 +17,7 @@ package networkpolicy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,14 +44,39 @@ func (policyStrategy) NamespaceScoped() bool {
 }
 
 func (policyStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	obj.(*calico.NetworkPolicy).Name = canonicalizePolicyName(obj)
 }
 
 func (policyStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	obj.(*calico.NetworkPolicy).Name = canonicalizePolicyName(old)
+}
+
+func canonicalizePolicyName(obj runtime.Object) string {
+	// Policies without a tier prepended to their name should have the tier prepended.
+	// It's possible for a user to send a policy with one of two name formats:
+	//
+	// - "tier.policy"
+	// - "policy"
+	//
+	// The logic below handles canonicalizing the name to the former.
+	tier := "default"
+	if oldPolicy, ok := obj.(*calico.NetworkPolicy); ok && oldPolicy.Spec.Tier != "" {
+		tier = oldPolicy.Spec.Tier
+	}
+
+	policy := obj.(*calico.NetworkPolicy)
+	if len(strings.Split(policy.Name, ".")) == 1 {
+		// Tier is not included in the name - add it.
+		return tier + "." + policy.Name
+	}
+
+	// Name already includes the tier.
+	return policy.Name
 }
 
 func (policyStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	return field.ErrorList{}
-	//return validation.ValidatePolicy(obj.(*calico.Policy))
+	// return validation.ValidatePolicy(obj.(*calico.Policy))
 }
 
 func (policyStrategy) AllowCreateOnUpdate() bool {

--- a/apiserver/pkg/storage/calico/policy_storage.go
+++ b/apiserver/pkg/storage/calico/policy_storage.go
@@ -3,10 +3,9 @@
 package calico
 
 import (
+	"context"
 	"reflect"
 	"strings"
-
-	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
@@ -94,8 +93,7 @@ func NewNetworkPolicyStorage(opts Options) (registry.DryRunnableStorage, factory
 	return dryRunnableStorage, func() {}
 }
 
-type NetworkPolicyConverter struct {
-}
+type NetworkPolicyConverter struct{}
 
 func (rc NetworkPolicyConverter) convertToLibcalico(aapiObj runtime.Object) resourceObject {
 	aapiPolicy := aapiObj.(*v3.NetworkPolicy)

--- a/apiserver/pkg/storage/calico/resource.go
+++ b/apiserver/pkg/storage/calico/resource.go
@@ -4,13 +4,12 @@ package calico
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"reflect"
 	"strconv"
 	"time"
-
-	"context"
 
 	aapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"


### PR DESCRIPTION
## Description

We allow users to create policies with one of two name formats:

- tier.name
- name

However, the apiserver was rejecting Update() requests of the form "name", resulting in confusing behavior where 
create succeeded but an update for the same exact resource failed.

More confusing was that `calicoctl` accepted updates using "name" format.

The root cause was some additoinal validation on the name field present in the apiserver that got executed before the name canonicalization logic in
libcalico-go.

This PR introduces equivalent logic to canonicalize the name as "tier.name" in the apiserver.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
EE: https://github.com/tigera/calico-private/pull/7929

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
