### PR TITLE
[release tool] update to get hashreleases working

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -11,18 +11,11 @@ global_job_config:
   secrets:
     - name: docs-ssh
     - name: marvin-github-token
-    - name: gcloud-registry-access
     - name: hashrelease-docker-auth
     - name: iss-image-scanning
     - name: releasebot-slack
   prologue:
     commands:
-      - chmod 0600 ~/.keys/*
-      - ssh-add ~/.keys/*
-      # Credentials for accessing gcloud, needed to push images to gcr
-      - export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/keys/.registry-viewer-serviceaccount.json
-      - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-      - docker login
       - checkout
 
 blocks:
@@ -35,10 +28,10 @@ blocks:
             - ./bin/release hashrelease publish
       prologue:
         commands:
-          - cache restore release-${SEMAPHORE_GIT_SHA}
           - cd release
+          - cache restore release-${SEMAPHORE_GIT_SHA}
       env_vars:
         - name: OPERATOR_BRANCH
           value: master
         - name: IS_HASHRELEASE
-          value: true
+          value: "true"

--- a/release/build/main.go
+++ b/release/build/main.go
@@ -76,16 +76,12 @@ func hashrelaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) []
 			Flags: []cli.Flag{
 				&cli.BoolFlag{Name: skipValidationFlag, Usage: "Skip pre-build validation", Value: false},
 			},
-			Before: func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				configureLogging()
 				if !c.Bool(skipValidationFlag) {
 					tasks.PreReleaseValidate(cfg)
 				}
 				tasks.PinnedVersion(cfg)
-				return nil
-			},
-			Action: func(c *cli.Context) error {
-				configureLogging()
 				tasks.OperatorHashreleaseBuild(runner, cfg)
 				tasks.HashreleaseBuild(cfg)
 				tasks.ReleaseNotes(cfg)
@@ -102,17 +98,14 @@ func hashrelaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) []
 				&cli.BoolFlag{Name: skipValidationFlag, Usage: "Skip pre-build validation", Value: false},
 				&cli.BoolFlag{Name: skipImageScanFlag, Usage: "Skip sending images to image scan service.\nIf pre-build validation is skipped, image scanning also gets skipped", Value: false},
 			},
-			Before: func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				configureLogging()
-				// Push the operator hashrelease first, as it is needed for the main hashrelease.
+				// Push the operator hashrelease first before validaion
+				// This is because validation checks all images exists and sends to Image Scan Service
 				tasks.OperatorHashreleasePush(runner, cfg)
 				if !c.Bool(skipValidationFlag) {
 					tasks.HashreleaseValidate(cfg, c.Bool(skipImageScanFlag))
 				}
-				return nil
-			},
-			Action: func(c *cli.Context) error {
-				configureLogging()
 				tasks.HashreleasePush(cfg)
 				return nil
 			},

--- a/release/build/main.go
+++ b/release/build/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/projectcalico/calico/release/internal/config"
 	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/pkg/tasks"
 
 	"github.com/sirupsen/logrus"
@@ -30,6 +32,7 @@ func configureLogging() {
 var globalFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:        "debug",
+		Aliases:     []string{"d"},
 		Usage:       "Enable verbose log output",
 		Value:       false,
 		Destination: &debug,
@@ -42,7 +45,7 @@ func main() {
 
 	app := &cli.App{
 		Name:     "release",
-		Usage:    "release is a tool for building Calico releases",
+		Usage:    fmt.Sprintf("a tool for building %s releases", utils.DisplayProductName()),
 		Flags:    globalFlags,
 		Commands: []*cli.Command{},
 	}

--- a/release/build/main.go
+++ b/release/build/main.go
@@ -101,6 +101,8 @@ func hashrelaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) []
 			},
 			Before: func(c *cli.Context) error {
 				configureLogging()
+				// Push the operator hashrelease first, as it is needed for the main hashrelease.
+				tasks.OperatorHashreleasePush(runner, cfg)
 				if !c.Bool(skipValidationFlag) {
 					tasks.HashreleaseValidate(cfg, c.Bool(skipImageScanFlag))
 				}
@@ -108,7 +110,6 @@ func hashrelaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) []
 			},
 			Action: func(c *cli.Context) error {
 				configureLogging()
-				tasks.OperatorHashreleasePush(runner, cfg)
 				tasks.HashreleasePush(cfg)
 				return nil
 			},

--- a/release/internal/config/config.go
+++ b/release/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
+	"github.com/projectcalico/calico/release/internal/operator"
 	"github.com/projectcalico/calico/release/internal/slack"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
@@ -29,15 +30,11 @@ type Config struct {
 	// RepoReleaseBranchPrefix is the suffix for the release tag
 	RepoReleaseBranchPrefix string `envconfig:"RELEASE_BRANCH_PREFIX" default:"release"`
 
-	// OperatorRepo is the repository for the operator
-	OperatorBranchName string `envconfig:"OPERATOR_BRANCH" default:"master"`
+	// OperatorConfig is the configuration for Tigera operator
+	OperatorConfig operator.Config
 
 	// ValidArchs are the OS architectures supported for multi-arch build
 	ValidArchs []string `envconfig:"VALID_ARCHES" default:"amd64,arm64,ppc64le,s390x"`
-
-	// Registry is the registry to publish images.
-	// This is only required if not on a release branch.
-	Registry string `envconfig:"REGISTRY"`
 
 	// DocsHost is the host for the hashrelease docs
 	DocsHost string `envconfig:"DOCS_HOST"`
@@ -104,6 +101,9 @@ func LoadConfig() *Config {
 	}
 	if config.OutputDir == "" {
 		config.OutputDir = filepath.Join(config.RepoRootDir, utils.ReleaseFolderName, "output")
+	}
+	if config.OperatorConfig.Dir == "" {
+		config.OperatorConfig.Dir = filepath.Join(config.TmpFolderPath(), "operator")
 	}
 	return config
 }

--- a/release/internal/hashrelease/pinnedversion.go
+++ b/release/internal/hashrelease/pinnedversion.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -132,9 +131,8 @@ func GeneratePinnedVersionFile(rootDir, operatorDir, releaseBranchPrefix, devTag
 		ReleaseBranch: parsedProductVersion.ReleaseBranch(releaseBranchPrefix),
 	}
 	if registry != "" {
-		data.Operator.Registry = registry
 		data.Registry = registry
-		data.Operator.Image = strings.ReplaceAll(operator.ImageName, "-", "/")
+		data.Operator.Registry, data.Operator.Image = operator.ImageInfo(registry)
 	}
 	logrus.WithField("file", pinnedVersionPath).Info("Generating pinned-version.yaml")
 	pinnedVersionFile, err := os.Create(pinnedVersionPath)

--- a/release/internal/hashrelease/pinnedversion.go
+++ b/release/internal/hashrelease/pinnedversion.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -48,14 +49,14 @@ func (c Component) String() string {
 
 // PinnedVersionData represents the data needed to generate the pinned version file.
 type PinnedVersionData struct {
-	ReleaseName   string
-	BaseDomain    string
-	CalicoVersion string
-	Operator      Component
-	Note          string
-	Hash          string
-	Registry      string
-	ReleaseBranch string
+	ReleaseName    string
+	BaseDomain     string
+	ProductVersion string
+	Operator       Component
+	Note           string
+	Hash           string
+	Registry       string
+	ReleaseBranch  string
 }
 
 // PinnedVersion represents an entry in pinned version file.
@@ -87,18 +88,18 @@ func GeneratePinnedVersionFile(rootDir, operatorDir, releaseBranchPrefix, devTag
 		logrus.WithField("file", pinnedVersionPath).Info("Pinned version file already exists")
 		return pinnedVersionPath, fmt.Errorf("pinned version file already exists")
 	}
-	calicoBranch, err := utils.GitBranch(rootDir)
+	productBranch, err := utils.GitBranch(rootDir)
 	if err != nil {
 		return "", err
 	}
 	// TODO: Validate this is a acceptable branch i.e. master or release-vX.Y
-	releaseName := fmt.Sprintf("%s-%s-%s", time.Now().Format("2006-01-02"), calicoBranch, RandomWord())
-	calicoVersion, err := utils.GitVersion(rootDir)
+	releaseName := fmt.Sprintf("%s-%s-%s", time.Now().Format("2006-01-02"), productBranch, RandomWord())
+	productVersion, err := utils.GitVersion(rootDir)
 	if err != nil {
 		return "", err
 	}
-	if !version.IsDevVersion(calicoVersion, devTagSuffix) {
-		return "", fmt.Errorf("calico version %s does not have dev tag %s", calicoVersion, devTagSuffix)
+	if !version.IsDevVersion(productVersion, devTagSuffix) {
+		return "", fmt.Errorf("%s version %s does not have dev tag %s", utils.ProductName, productVersion, devTagSuffix)
 	}
 	operatorBranch, err := operator.GitBranch(operatorDir)
 	if err != nil {
@@ -115,24 +116,25 @@ func GeneratePinnedVersionFile(rootDir, operatorDir, releaseBranchPrefix, devTag
 	if err != nil {
 		return "", err
 	}
-	productVersion := version.Version(calicoVersion)
+	parsedProductVersion := version.Version(productVersion)
 	data := &PinnedVersionData{
-		ReleaseName:   releaseName,
-		BaseDomain:    baseDomain,
-		CalicoVersion: calicoVersion,
+		ReleaseName:    releaseName,
+		BaseDomain:     baseDomain,
+		ProductVersion: productVersion,
 		Operator: Component{
 			Version:  operatorVersion + "-" + releaseName,
 			Image:    operator.ImageName,
 			Registry: operator.Registry,
 		},
-		Hash: calicoVersion + "-" + operatorVersion,
+		Hash: productVersion + "-" + operatorVersion,
 		Note: fmt.Sprintf("%s - generated at %s using %s release branch with %s operator branch",
-			releaseName, time.Now().Format(time.RFC1123), calicoBranch, operatorBranch),
-		ReleaseBranch: productVersion.ReleaseBranch(releaseBranchPrefix),
+			releaseName, time.Now().Format(time.RFC1123), productBranch, operatorBranch),
+		ReleaseBranch: parsedProductVersion.ReleaseBranch(releaseBranchPrefix),
 	}
 	if registry != "" {
 		data.Operator.Registry = registry
 		data.Registry = registry
+		data.Operator.Image = strings.ReplaceAll(operator.ImageName, "-", "/")
 	}
 	logrus.WithField("file", pinnedVersionPath).Info("Generating pinned-version.yaml")
 	pinnedVersionFile, err := os.Create(pinnedVersionPath)
@@ -205,8 +207,8 @@ func RetrieveReleaseName(outputDir string) (string, error) {
 	return pinnedversion[0].ReleaseName, nil
 }
 
-// RetrievePinnedCalicoVersion retrieves the calico version from the pinned version file.
-func RetrievePinnedCalicoVersion(outputDir string) (string, error) {
+// RetrievePinnedProductVersion retrieves the product version from the pinned version file.
+func RetrievePinnedProductVersion(outputDir string) (string, error) {
 	pinnedVersionPath := pinnedVersionFilePath(outputDir)
 	var pinnedversion PinnedVersionFile
 	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {

--- a/release/internal/hashrelease/templates/pinned-version.yaml.gotmpl
+++ b/release/internal/hashrelease/templates/pinned-version.yaml.gotmpl
@@ -1,4 +1,4 @@
-- title: {{.CalicoVersion}}
+- title: {{.ProductVersion}}
   manifests_url: https://{{.ReleaseName}}.{{.BaseDomain}}
   release_name: {{.ReleaseName}}
   note: {{.Note}}
@@ -9,38 +9,38 @@
     registry: {{.Operator.Registry}}
   components:
     calico:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     typha:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     calicoctl:
-      version:  {{.CalicoVersion}}
+      version:  {{.ProductVersion}}
     calico/node:
-      version:  {{.CalicoVersion}}
+      version:  {{.ProductVersion}}
     calico/cni:
-      version:  {{.CalicoVersion}}
+      version:  {{.ProductVersion}}
     calico/apiserver:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
       image: calico/apiserver
     calico/kube-controllers:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     calico/api:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     networking-calico:
       version: {{.ReleaseBranch}}
     flannel:
       version: v0.12.0
       registry: quay.io
     calico/dikastes:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     flexvol:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     key-cert-provisioner:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     calico/csi:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     csi-node-driver-registrar:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     calico/cni-windows:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}
     calico/node-windows:
-      version: {{.CalicoVersion}}
+      version: {{.ProductVersion}}

--- a/release/internal/operator/git.go
+++ b/release/internal/operator/git.go
@@ -8,28 +8,21 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
-const (
-	operatorRepo = "git@github.com:tigera/operator.git"
-)
-
-func Dir(dir string) string {
-	return filepath.Join(dir, "operator")
-}
-
 // Clone clones the operator repo into a path from the repoRootDir.
-func Clone(operatorDir, branchName string) error {
-	clonePath := filepath.Dir(operatorDir)
+func Clone(cfg Config) error {
+	targetDir := cfg.Dir
+	clonePath := filepath.Dir(targetDir)
 	if err := os.MkdirAll(clonePath, utils.DirPerms); err != nil {
 		return err
 	}
-	if _, err := os.Stat(operatorDir); !os.IsNotExist(err) {
-		_, err := command.GitInDir(operatorDir, "checkout", branchName)
+	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+		_, err := command.GitInDir(targetDir, "checkout", cfg.Branch)
 		if err == nil {
-			_, err = command.GitInDir(operatorDir, "pull")
+			_, err = command.GitInDir(targetDir, "pull")
 			return err
 		}
 	}
-	_, err := command.GitInDir(clonePath, "clone", operatorRepo, "--branch", branchName)
+	_, err := command.GitInDir(clonePath, "clone", cfg.Repo, "--branch", cfg.Branch)
 	return err
 }
 

--- a/release/internal/operator/operator.go
+++ b/release/internal/operator/operator.go
@@ -6,24 +6,27 @@ import (
 	"strings"
 
 	"github.com/projectcalico/calico/release/internal/command"
-	"github.com/projectcalico/calico/release/internal/registry"
 )
 
-const (
-	ImageName = "tigera/operator"
-	Registry  = registry.QuayRegistry
-)
+type Config struct {
+	// Repo is the repository for the operator
+	Repo string `envconfig:"OPERATOR_REPO" default:"git@github.com:tigera/operator.git"`
 
-// ImageInfo returns the registry and image name for the operator images.
-// When a registry is specified in the config, the image name is modified and the registry is used
-func ImageInfo(registryRpl string) (string, string) {
-	registry := Registry
-	imageName := ImageName
-	if registryRpl != "" {
-		registry = registryRpl
-		imageName = strings.ReplaceAll(imageName, "/", "-")
-	}
-	return registry, imageName
+	// Branch is the repository for the operator
+	Branch string `envconfig:"OPERATOR_BRANCH" default:"master"`
+
+	// Dir is the directory to clone the operator repository
+	Dir string `envconfig:"OPERATOR_DIR"`
+
+	// Image is the image for Tigera operator
+	Image string `envconfig:"OPERATOR_IMAGE" default:"tigera/operator"`
+
+	// Registry is the registry for Tigera operator
+	Registry string `envconfig:"OPERATOR_REGISTRY" default:"quay.io"`
+}
+
+func (c Config) String() string {
+	return fmt.Sprintf("Repo: %s, Branch: %s, Image: %s, Registry: %s", c.Repo, c.Branch, c.Image, c.Registry)
 }
 
 // GenVersions generates the versions for operator.

--- a/release/internal/operator/operator.go
+++ b/release/internal/operator/operator.go
@@ -14,6 +14,18 @@ const (
 	Registry  = registry.QuayRegistry
 )
 
+// ImageInfo returns the registry and image name for the operator images.
+// When a registry is specified in the config, the image name is modified and the registry is used
+func ImageInfo(registryRpl string) (string, string) {
+	registry := Registry
+	imageName := ImageName
+	if registryRpl != "" {
+		registry = registryRpl
+		imageName = strings.ReplaceAll(imageName, "/", "-")
+	}
+	return registry, imageName
+}
+
 // GenVersions generates the versions for operator.
 func GenVersions(componentsVersionPath, dir string) error {
 	env := os.Environ()

--- a/release/internal/outputs/calico.go
+++ b/release/internal/outputs/calico.go
@@ -12,10 +12,10 @@ import (
 )
 
 // ReleaseWindowsArchive generates the windows archive for the release.
-func ReleaseWindowsArchive(rootDir, calicoVersion, outDir string) error {
+func ReleaseWindowsArchive(rootDir, version, outDir string) error {
 	outDir = filepath.Join(outDir, "files", "windows")
 	env := os.Environ()
-	env = append(env, fmt.Sprintf("VERSION=%s", calicoVersion))
+	env = append(env, fmt.Sprintf("VERSION=%s", version))
 	if _, err := command.MakeInDir(filepath.Join(rootDir, "node"), []string{"release-windows-archive"}, env); err != nil {
 		logrus.WithError(err).Error("Failed to make release-windows-archive")
 		return err
@@ -23,7 +23,7 @@ func ReleaseWindowsArchive(rootDir, calicoVersion, outDir string) error {
 	if err := os.MkdirAll(outDir, utils.DirPerms); err != nil {
 		logrus.WithError(err).Error("Failed to create windows output directory")
 	}
-	fileName := fmt.Sprintf("calico-windows-%s.zip", calicoVersion)
+	fileName := fmt.Sprintf("calico-windows-%s.zip", version)
 	if err := utils.MoveFile(filepath.Join(rootDir, "node", "dist", fileName), filepath.Join(outDir, fileName)); err != nil {
 		logrus.WithError(err).Error("Failed to move generated windows archive to output directory")
 		return err
@@ -32,13 +32,13 @@ func ReleaseWindowsArchive(rootDir, calicoVersion, outDir string) error {
 }
 
 // HelmArchive generates the helm archive for the release.
-func HelmArchive(rootDir, calicoVersion, operatorVersion, outDir string) error {
+func HelmArchive(rootDir, version, operatorVersion, outDir string) error {
 	tigeraOperatorChartValuesFilePath := filepath.Join(rootDir, "charts", "tigera-operator", "values.yaml")
 	if _, err := command.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, operatorVersion), tigeraOperatorChartValuesFilePath}); err != nil {
 		logrus.WithError(err).Error("Failed to update operator version in values.yaml")
 		return err
 	}
-	if _, err := command.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, calicoVersion), tigeraOperatorChartValuesFilePath}); err != nil {
+	if _, err := command.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, version), tigeraOperatorChartValuesFilePath}); err != nil {
 		logrus.WithError(err).Error("Failed to update calicoctl version in values.yaml")
 		return err
 	}
@@ -59,9 +59,9 @@ func HelmArchive(rootDir, calicoVersion, operatorVersion, outDir string) error {
 }
 
 // Manifests generates the manifests for the release.
-func Manifests(rootDir, calicoVersion, operatorVersion, outDir string) error {
+func Manifests(rootDir, version, operatorVersion, outDir string) error {
 	env := os.Environ()
-	env = append(env, fmt.Sprintf("CALICO_VERSION=%s", calicoVersion))
+	env = append(env, fmt.Sprintf("CALICO_VERSION=%s", version))
 	env = append(env, fmt.Sprintf("OPERATOR_VERSION=%s", operatorVersion))
 	if _, err := command.MakeInDir(rootDir, []string{"gen-manifests"}, env); err != nil {
 		logrus.WithError(err).Error("Failed to make manifests")

--- a/release/internal/outputs/release.go
+++ b/release/internal/outputs/release.go
@@ -5,6 +5,6 @@ import (
 )
 
 // Metadata generates metadata for a release.
-func Metadata(repoRootDir, calicoVersion, operatorVersion string) error {
-	return command.Builder().BuildMetadataWithVersions(repoRootDir, calicoVersion, operatorVersion)
+func Metadata(repoRootDir, version, operatorVersion string) error {
+	return command.Builder().BuildMetadataWithVersions(repoRootDir, version, operatorVersion)
 }

--- a/release/internal/registry/image.go
+++ b/release/internal/registry/image.go
@@ -44,7 +44,7 @@ func (i ImageRef) Registry() Registry {
 	return GetRegistry(domain)
 }
 
-func (i ImageRef) IsPrivate() bool {
+func (i ImageRef) RequiresAuth() bool {
 	for _, img := range privateImages {
 		if i.Repository() == img {
 			return true
@@ -67,7 +67,7 @@ func ImageExists(img ImageRef) (bool, error) {
 	scope := fmt.Sprintf("repository:%s:pull", img.Repository())
 	var token string
 	var err error
-	if img.IsPrivate() {
+	if img.RequiresAuth() {
 		token, err = getBearerTokenWithDefaultAuth(registry, scope)
 	} else {
 		token, err = getBearerToken(registry, scope)

--- a/release/internal/slack/slack.go
+++ b/release/internal/slack/slack.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"text/template"
 
@@ -36,8 +35,8 @@ type MessageData struct {
 	// Product is the name of the product
 	Product string
 
-	// Branch is the branch of the release
-	Branch string
+	// Stream is the stream of the release
+	Stream string
 
 	// Version is the version of the release
 	Version string
@@ -106,24 +105,23 @@ func (m *Message) send(client *slack.Client, messageTemplateData string) error {
 	if err != nil {
 		return err
 	}
-	_, _, err = client.PostMessage(m.Config.Channel, slack.MsgOptionBlocks(message.BlockSet...))
+	_, _, err = client.PostMessage(m.Config.Channel, slack.MsgOptionBlocks(message...))
 	return err
 }
 
 // renderMessage renders the message from the template
-func (m *Message) renderMessage(templateData string) (slack.Blocks, error) {
+func (m *Message) renderMessage(templateData string) ([]slack.Block, error) {
 	tmpl, err := template.New("message").Parse(templateData)
-	empty := slack.Blocks{}
 	if err != nil {
-		return empty, err
+		return nil, err
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, m.Data); err != nil {
-		return empty, err
+		return nil, err
 	}
-	var message slack.Blocks
-	if err := json.Unmarshal(buf.Bytes(), &message); err != nil {
-		return empty, err
+	blocks := slack.Blocks{}
+	if err := blocks.UnmarshalJSON(buf.Bytes()); err != nil {
+		return nil, err
 	}
-	return message, nil
+	return blocks.BlockSet, nil
 }

--- a/release/internal/slack/slack.go
+++ b/release/internal/slack/slack.go
@@ -35,8 +35,8 @@ type MessageData struct {
 	// Product is the name of the product
 	Product string
 
-	// Stream is the stream of the release
-	Stream string
+	// Branch is the branch of the release
+	Branch string
 
 	// Version is the version of the release
 	Version string

--- a/release/internal/slack/templates/failure.json.gotmpl
+++ b/release/internal/slack/templates/failure.json.gotmpl
@@ -1,71 +1,85 @@
-{
-	"blocks": [
-		{
-			"type": "header",
-			"text": {
-				"type": "plain_text",
-				"text": ":warning: Failed to create {{.Product}} {{.Branch}} release"
-			}
-		},
-		{
-			"type": "section",
-			"text": {
-				"type": "mrkdwn",
-				"text": "*{{.ReleaseName}}*"
-			},
-			"accessory": {
-				"type": "button",
-				"text": {
-					"type": "plain_text",
-					"text": ":building_construction: Build Details",
-					"emoji": true
-				},
-				"value": "ci_link",
-				"url": "{{.CIURL}}"
-			}
-		},
-		{
-			"type": "context",
-			"elements": [
-				{
-					"type": "mrkdwn",
-					"text": "{{.Version}} | Operator {{.OperatorVersion}}"
-				}
-			]
-		},
-		{
-			"type": "divider"
-		},
-		{
-			"type": "section",
-			"text": {
-				"type": "plain_text",
-				"text": "See the list of unavailable images and versions below :arrow_heading_down:",
-				"emoji": true
-			}
-		},
-		{
-			"type": "section",
-			"fields": [
-				{
-					"type": "mrkdwn",
-					"text": "*Images*"
-				},
-				{
-					"type": "mrkdwn",
-					"text": "*Version*"
-				}
-				{{- range .FailedImages }},
-        {
-					"type": "plain_text",
-					"text": "{{.Image}}"
-				},
-				{
-					"type": "plain_text",
-					"text": "{{.Version}}"
-				}
-        {{- end }}
-			]
-		}
-	]
-}
+[
+  {
+    "type": "header",
+    "text": {
+      "type": "plain_text",
+      "text": ":warning: Failed to create {{.Product}} {{.Stream}} release"
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "*{{.ReleaseName}}*"
+    }
+    {{- if .CIURL}},
+    "accessory": {
+      "type": "button",
+      "text": {
+        "type": "plain_text",
+        "text": ":building_construction: Build Details",
+        "emoji": true
+      },
+      "value": "ci_link",
+      "url": "{{.CIURL}}"
+    }
+    {{- end }}
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "mrkdwn",
+        "text": "{{.Version}}\nOperator {{.OperatorVersion}}"
+      }
+    ]
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "plain_text",
+      "text": "See the list of unavailable images and versions below :arrow_heading_down:",
+      "emoji": true
+    }
+  },
+  {
+    "type": "section",
+    "fields": [
+      {
+        "type": "mrkdwn",
+        "text": "*Images*"
+      },
+      {
+        "type": "mrkdwn",
+        "text": "*Version*"
+      }
+      {{- range .FailedImages }},
+      {
+        "type": "plain_text",
+        "text": "{{.Image}}"
+      },
+      {
+        "type": "plain_text",
+        "text": "{{.Version}}"
+      }
+      {{- end }}
+    ]
+  }
+  {{- if not .CIURL }},
+  {
+    "type": "divider"
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "plain_text",
+        "text": "This release was not built by CI."
+      }
+    ]
+  }
+  {{- end }}
+]

--- a/release/internal/slack/templates/failure.json.gotmpl
+++ b/release/internal/slack/templates/failure.json.gotmpl
@@ -3,7 +3,7 @@
     "type": "header",
     "text": {
       "type": "plain_text",
-      "text": ":warning: Failed to create {{.Product}} {{.Stream}} release"
+      "text": ":warning: Failed to create {{.Product}} {{.Branch}} release"
     }
   },
   {

--- a/release/internal/slack/templates/success.json.gotmpl
+++ b/release/internal/slack/templates/success.json.gotmpl
@@ -1,101 +1,99 @@
-{
-	"blocks": [
-		{
-			"type": "header",
-			"text": {
-				"type": "plain_text",
-				"text": ":loud_sound: New {{.Product}} {{.Branch}} release"
-			}
-		},
-		{
-			"type": "section",
-			"text": {
-				"type": "mrkdwn",
-				"text": "*<{{.DocsURL}}|{{.ReleaseName}}>*"
-			}
-		},
-		{
-			"type": "context",
-			"elements": [
-				{
-					"type": "mrkdwn",
-					"text": "{{.Version}} | Operator {{.OperatorVersion}}"
-				}
-			]
-		},
-		{
-			"type": "actions",
-			"elements": [
-				{
-					"type": "button",
-					"text": {
-						"type": "plain_text",
-						"text": ":book: Docs",
-						"emoji": true
-					},
-					"value": "docs_link",
-					"url": "{{.DocsURL}}"
-				},
-				{
-					"type": "button",
-					"text": {
-						"type": "plain_text",
-						"text": ":page_with_curl: Manifests",
-						"emoji": true
-					},
-					"value": "manifests_link",
-					"url": "{{.DocsURL}}/manifests"
-				}
-        {{- if .ImageScanResultURL }},
-				{
-					"type": "button",
-					"text": {
-						"type": "plain_text",
-						"text": ":mag: Images Scan Result",
-						"emoji": true
-					},
-					"value": "image_scan_link",
-					"url": "{{.ImageScanResultURL}}"
-				}
-        {{- end }}
-        {{- if .CIURL }},
-				{
-					"type": "button",
-					"text": {
-						"type": "plain_text",
-						"text": ":building_construction: Build Details",
-						"emoji": true
-					},
-					"value": "ci_link",
-					"url": "{{.CIURL}}"
-				}
-        {{- end }}
-			]
-		}
-    {{- if not .ImageScanResultURL }},
-		{
-			"type": "context",
-			"elements": [
-				{
-					"type": "mrkdwn",
-					"text": ":warning: Image scan results are not available for this release."
-				}
-			]
-		}
-    {{- end }}
-    {{- if not .CIURL }},
-		{
-			"type": "divider"
-		},
-		{
-			"type": "context",
-			"elements": [
-				{
-					"type": "plain_text",
-					"text": "This release was not built by CI."
-				}
-			]
-		}
-    {{- end }}
-	]
-}
+[
+  {
+    "type": "header",
+    "text": {
+      "type": "plain_text",
+      "text": ":loud_sound: New {{.Product}} {{.Stream}} release"
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "*<{{.DocsURL}}|{{.ReleaseName}}>*"
+    }
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "mrkdwn",
+        "text": "{{.Version}} | Operator {{.OperatorVersion}}"
+      }
+    ]
+  },
+  {
+    "type": "actions",
+    "elements": [
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": ":book: Docs",
+          "emoji": true
+        },
+        "value": "docs_link",
+        "url": "{{.DocsURL}}"
+      },
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": ":page_with_curl: Manifests",
+          "emoji": true
+        },
+        "value": "manifests_link",
+        "url": "{{.DocsURL}}/manifests"
+      }
+      {{- if .ImageScanResultURL }},
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": ":mag: Images Scan Result",
+          "emoji": true
+        },
+        "value": "image_scan_link",
+        "url": "{{.ImageScanResultURL}}"
+      }
+      {{- end }}
+      {{- if .CIURL }},
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": ":building_construction: Build Details",
+          "emoji": true
+        },
+        "value": "ci_link",
+        "url": "{{.CIURL}}"
+      }
+      {{- end }}
+    ]
+  }
+  {{- if not .ImageScanResultURL }},
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "mrkdwn",
+        "text": ":warning: Image scan results are not available for this release."
+      }
+    ]
+  }
+  {{- end }}
+  {{- if not .CIURL }},
+  {
+    "type": "divider"
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "plain_text",
+        "text": "This release was not built by CI."
+      }
+    ]
+  }
+  {{- end }}
+]

--- a/release/internal/slack/templates/success.json.gotmpl
+++ b/release/internal/slack/templates/success.json.gotmpl
@@ -3,7 +3,7 @@
     "type": "header",
     "text": {
       "type": "plain_text",
-      "text": ":loud_sound: New {{.Product}} {{.Stream}} release"
+      "text": ":loud_sound: New {{.Product}} {{.Branch}} release"
     }
   },
   {

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -37,14 +37,15 @@ func PinnedVersion(cfg *config.Config) {
 	if err := os.MkdirAll(outputDir, utils.DirPerms); err != nil {
 		logrus.WithError(err).Fatal("Failed to create output directory")
 	}
-	operatorDir := operator.Dir(cfg.TmpFolderPath())
-	if err := operator.Clone(operatorDir, cfg.OperatorBranchName); err != nil {
+	operatorConfig := cfg.OperatorConfig
+	if err := operator.Clone(operatorConfig); err != nil {
 		logrus.WithFields(logrus.Fields{
-			"directory":       outputDir,
-			"operator branch": cfg.OperatorBranchName,
+			"directory":  outputDir,
+			"repository": operatorConfig.Repo,
+			"branch":     operatorConfig.Branch,
 		}).WithError(err).Fatal("Failed to clone operator repository")
 	}
-	pinnedVersionFilePath, err := hashrelease.GeneratePinnedVersionFile(cfg.RepoRootDir, operatorDir, cfg.RepoReleaseBranchPrefix, cfg.DevTagSuffix, cfg.Registry, outputDir)
+	pinnedVersionFilePath, err := hashrelease.GeneratePinnedVersionFile(cfg.RepoRootDir, cfg.RepoReleaseBranchPrefix, cfg.DevTagSuffix, operatorConfig, outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to generate pinned-version.yaml")
 	}

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -60,7 +60,7 @@ func HashreleaseBuild(cfg *config.Config) {
 	if err := os.MkdirAll(hashreleaseOutputDir, utils.DirPerms); err != nil {
 		logrus.WithError(err).Fatal("Failed to create hashrelease directory")
 	}
-	releaseVersion, err := hashrelease.RetrievePinnedCalicoVersion(outputDir)
+	releaseVersion, err := hashrelease.RetrievePinnedProductVersion(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get candidate name")
 	}
@@ -108,11 +108,15 @@ func HashreleaseValidate(cfg *config.Config, sendImagestoISS bool) {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get release name")
 	}
-	calicoVersion, err := hashrelease.RetrievePinnedCalicoVersion(outputDir)
+	productBranch, err := utils.GitBranch(cfg.RepoRootDir)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to get %s branch name", utils.ProductName)
+	}
+	productVersion, err := hashrelease.RetrievePinnedProductVersion(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get candidate name")
 	}
-	productVersion := version.Version(calicoVersion)
+	parsedProductVersion := version.Version(productVersion)
 	operatorVersion, err := hashrelease.RetrievePinnedOperatorVersion(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get operator version")
@@ -156,8 +160,8 @@ func HashreleaseValidate(cfg *config.Config, sendImagestoISS bool) {
 				Data: slack.MessageData{
 					ReleaseName:     name,
 					Product:         utils.DisplayProductName(),
-					Stream:          productVersion.Stream(),
-					Version:         calicoVersion,
+					Branch:          productBranch,
+					Version:         productVersion,
 					OperatorVersion: operatorVersion,
 					CIURL:           ciURL,
 					FailedImages:    failedImages,
@@ -176,7 +180,7 @@ func HashreleaseValidate(cfg *config.Config, sendImagestoISS bool) {
 			imageList = append(imageList, component.String())
 		}
 		imageScanner := imagescanner.New(cfg.ImageScannerConfig)
-		err := imageScanner.Scan(imageList, productVersion.Stream(), false, cfg.OutputDir)
+		err := imageScanner.Scan(imageList, parsedProductVersion.Stream(), false, cfg.OutputDir)
 		if err != nil {
 			// Error is logged and ignored as this is not considered a fatal error
 			logrus.WithError(err).Error("Failed to scan images")
@@ -196,11 +200,14 @@ func HashreleasePush(cfg *config.Config) {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get pinned version note")
 	}
-	calicoVersion, err := hashrelease.RetrievePinnedCalicoVersion(outputDir)
+	productBranch, err := utils.GitBranch(cfg.RepoRootDir)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to get %s branch name", utils.ProductName)
+	}
+	productVersion, err := hashrelease.RetrievePinnedProductVersion(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get candidate name")
 	}
-	productVersion := version.Version(calicoVersion)
 	operatorVersion, err := hashrelease.RetrievePinnedOperatorVersion(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get operator version")
@@ -209,9 +216,8 @@ func HashreleasePush(cfg *config.Config) {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get release hash")
 	}
-	releaseVersion := version.Version(calicoVersion)
 	logrus.WithField("note", note).Info("Publishing hashrelease")
-	if err := hashrelease.PublishHashrelease(name, releaseHash, note, releaseVersion.Stream(), cfg.HashreleaseDir(), sshConfig); err != nil {
+	if err := hashrelease.PublishHashrelease(name, releaseHash, note, productBranch, cfg.HashreleaseDir(), sshConfig); err != nil {
 		logrus.WithError(err).Fatal("Failed to publish hashrelease")
 	}
 	scanResultURL := imagescanner.RetrieveResultURL(cfg.OutputDir)
@@ -220,8 +226,8 @@ func HashreleasePush(cfg *config.Config) {
 		Data: slack.MessageData{
 			ReleaseName:        name,
 			Product:            utils.DisplayProductName(),
-			Stream:             productVersion.Stream(),
-			Version:            calicoVersion,
+			Branch:             productBranch,
+			Version:            productVersion,
 			OperatorVersion:    operatorVersion,
 			DocsURL:            hashrelease.URL(name),
 			CIURL:              ciURL(),

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -44,7 +44,7 @@ func PinnedVersion(cfg *config.Config) {
 			"operator branch": cfg.OperatorBranchName,
 		}).WithError(err).Fatal("Failed to clone operator repository")
 	}
-	pinnedVersionFilePath, err := hashrelease.GeneratePinnedVersionFile(cfg.RepoRootDir, operatorDir, cfg.DevTagSuffix, cfg.Registry, outputDir)
+	pinnedVersionFilePath, err := hashrelease.GeneratePinnedVersionFile(cfg.RepoRootDir, operatorDir, cfg.RepoReleaseBranchPrefix, cfg.DevTagSuffix, cfg.Registry, outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to generate pinned-version.yaml")
 	}
@@ -156,7 +156,7 @@ func HashreleaseValidate(cfg *config.Config, sendImagestoISS bool) {
 				Data: slack.MessageData{
 					ReleaseName:     name,
 					Product:         utils.DisplayProductName(),
-					Branch:          productVersion.ReleaseBranch(cfg.RepoReleaseBranchPrefix),
+					Stream:          productVersion.Stream(),
 					Version:         calicoVersion,
 					OperatorVersion: operatorVersion,
 					CIURL:           ciURL,
@@ -220,7 +220,7 @@ func HashreleasePush(cfg *config.Config) {
 		Data: slack.MessageData{
 			ReleaseName:        name,
 			Product:            utils.DisplayProductName(),
-			Branch:             productVersion.ReleaseBranch(cfg.RepoReleaseBranchPrefix),
+			Stream:             productVersion.Stream(),
 			Version:            calicoVersion,
 			OperatorVersion:    operatorVersion,
 			DocsURL:            hashrelease.URL(name),

--- a/release/pkg/tasks/operator.go
+++ b/release/pkg/tasks/operator.go
@@ -15,12 +15,12 @@ import (
 // As images are build with the latest tag, they are re-tagged with the hashrelease version
 func OperatorHashreleaseBuild(runner *registry.DockerRunner, cfg *config.Config) {
 	outputDir := cfg.OutputDir
-	operatorDir := operator.Dir(cfg.TmpFolderPath())
+	operatorDir := cfg.OperatorConfig.Dir
 	componentsVersionPath, err := hashrelease.GenerateComponentsVersionFile(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to generate components.yaml")
 	}
-	operatorVersion, err := hashrelease.RetrievePinnedOperatorVersion(outputDir)
+	operatorComponent, err := hashrelease.RetrievePinnedOperator(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get operator version")
 	}
@@ -28,17 +28,17 @@ func OperatorHashreleaseBuild(runner *registry.DockerRunner, cfg *config.Config)
 		logrus.WithError(err).Fatal("Failed to generate versions")
 	}
 	logrus.Infof("Building operator images for %v", cfg.ValidArchs)
-	if err := operator.ImageAll(cfg.ValidArchs, operatorVersion, operatorDir); err != nil {
+	if err := operator.ImageAll(cfg.ValidArchs, operatorComponent.Version, operatorDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to build images")
 	}
 	logrus.Info("Building operator init image")
-	if err := operator.InitImage(operatorVersion, operatorDir); err != nil {
+	operatorInitImage := operatorComponent.InitImage()
+	if err := operator.InitImage(operatorInitImage.Version, operatorDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to init images")
 	}
-	registry, imageName := operator.ImageInfo(cfg.Registry)
 	for _, arch := range cfg.ValidArchs {
-		currentTag := fmt.Sprintf("%s:latest-%s", operator.ImageName, arch)
-		newTag := fmt.Sprintf("%s/%s:%s-%s", registry, imageName, operatorVersion, arch)
+		currentTag := fmt.Sprintf("%s:latest-%s", operatorComponent.Image, arch)
+		newTag := fmt.Sprintf("%s-%s", operatorComponent.String(), arch)
 		logrus.WithFields(logrus.Fields{
 			"current tag": currentTag,
 			"new tag":     newTag,
@@ -48,8 +48,8 @@ func OperatorHashreleaseBuild(runner *registry.DockerRunner, cfg *config.Config)
 		}
 	}
 	logrus.Info("Re-tag operator init image")
-	currentTag := fmt.Sprintf("%s-init:latest", operator.ImageName)
-	newTag := fmt.Sprintf("%s/%s-init:%s", registry, imageName, operatorVersion)
+	currentTag := fmt.Sprintf("%s:latest", operatorInitImage.Image)
+	newTag := operatorComponent.InitImage().String()
 	if err := runner.TagImage(currentTag, newTag); err != nil {
 		logrus.WithError(err).Fatal("Failed to tag operator init image")
 	}
@@ -61,26 +61,25 @@ func OperatorHashreleaseBuild(runner *registry.DockerRunner, cfg *config.Config)
 // pushing the operator images to the registry,
 // then pushing a manifest list of the operator images to the registry.
 func OperatorHashreleasePush(runner *registry.DockerRunner, cfg *config.Config) {
-	operatorVersion, err := hashrelease.RetrievePinnedOperatorVersion(cfg.OutputDir)
-	registry, imageName := operator.ImageInfo(cfg.Registry)
+	operatorComponent, err := hashrelease.RetrievePinnedOperator(cfg.OutputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get operator version")
 	}
 	var imageList []string
 	for _, arch := range cfg.ValidArchs {
-		imgName := fmt.Sprintf("%s/%s:%s-%s", registry, imageName, operatorVersion, arch)
+		imgName := fmt.Sprintf("%s-%s", operatorComponent.String(), arch)
 		if err := runner.PushImage(imgName); err != nil {
 			logrus.WithField("image", imgName).WithError(err).Fatal("Failed to push operator image")
 		}
 		logrus.WithField("image", imgName).Info("Pushed operator image")
 		imageList = append(imageList, imgName)
 	}
-	manifestListName := fmt.Sprintf("%s/%s:%s", registry, imageName, operatorVersion)
+	manifestListName := operatorComponent.String()
 	if err = runner.ManifestPush(manifestListName, imageList); err != nil {
 		logrus.WithField("manifest", manifestListName).WithError(err).Fatal("Failed to push operator manifest")
 	}
-	imgName := fmt.Sprintf("%s/%s-init:%s", registry, imageName, operatorVersion)
-	if err := runner.PushImage(imgName); err != nil {
-		logrus.WithField("image", imgName).WithError(err).Fatal("Failed to push operator init image")
+	initImage := operatorComponent.InitImage()
+	if err := runner.PushImage(initImage.String()); err != nil {
+		logrus.WithField("image", initImage).WithError(err).Fatal("Failed to push operator init image")
 	}
 }

--- a/release/pkg/tasks/release.go
+++ b/release/pkg/tasks/release.go
@@ -34,10 +34,7 @@ func PreReleaseValidate(cfg *config.Config) {
 	match := fmt.Sprintf(`^(%s|%s-v\d+\.\d+(?:-\d+)?)$`, utils.DefaultBranch, cfg.RepoReleaseBranchPrefix)
 	re := regexp.MustCompile(match)
 	if !re.MatchString(releaseBranch) {
-		if cfg.Registry == "" {
-			logrus.Fatal("Not on a release branch and no registry specified")
-		}
-		logrus.Warnf("Not on a release branch, images will be pushed to %s", cfg.Registry)
+		logrus.WithField("branch", releaseBranch).Fatal("Not on a release branch")
 	}
 	dirty, err := utils.GitIsDirty(cfg.RepoRootDir)
 	if err != nil {
@@ -47,6 +44,6 @@ func PreReleaseValidate(cfg *config.Config) {
 	}
 	logrus.WithFields(logrus.Fields{
 		"releaseBranch":  releaseBranch,
-		"operatorBranch": cfg.OperatorBranchName,
+		"operatorConfig": cfg.OperatorConfig,
 	}).Info("Pre-release validation complete, ready to release")
 }


### PR DESCRIPTION
## Description

This add some tweaks to get the hashrelease process working from promotion:

- Update the hashrelease semaphore file to a working state
- Update slack messaging
- Push operator before validations
- Fix image validation for windows images

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
