### PR TITLE
Configure Certificate Rotation for the Kubelet

### DIFF
--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -58,6 +58,7 @@ $argList = @(`
     "--hairpin-mode=promiscuous-bridge",`
     "--cgroups-per-qos=false",`
     "--enforce-node-allocatable=""""",`
+    "--rotate-certificates=true",`
     "--kubeconfig=""c:\k\config"""`
 )
 


### PR DESCRIPTION
Almost a year ago, I used this script `install-calico-windows.ps1` to join a windows node to a k8s cluster.

Recently, I received a warning about an expired certificate from https://github.com/prometheus-operator/kube-prometheus : `KubeClientCertificateExpiration: Client certificate is about to expire`. 

I think this change will fix this problem.

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Configure kubelet certificate rotation on manually installed Calico for Windows.
```
