### PR TITLE
[release tool] Fix errors in hashrelease promotion

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -31,6 +31,8 @@ global_job_config:
       - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       - docker login
       - checkout
+      # Unshallow the git repository to get latest tags
+      - retry git fetch --quiet --unshallow
 
 blocks:
   - name: Publish hashrelease
@@ -42,8 +44,9 @@ blocks:
             - ./bin/release hashrelease publish
       prologue:
         commands:
+          - export GITHUB_TOKEN=${MARVIN_GITHUB_TOKEN}
           - cd release
-          - cache restore release-${SEMAPHORE_GIT_SHA}
+          - make build
       env_vars:
         - name: OPERATOR_BRANCH
           value: master

--- a/release/internal/hashrelease/hashrelease.go
+++ b/release/internal/hashrelease/hashrelease.go
@@ -15,9 +15,6 @@ import (
 )
 
 const (
-	// remoteReleasesPath is the path to the hashrelease folder in the server
-	remoteReleasesPath = "/home/core/disk/docs-preview/files"
-
 	// maxHashreleasesToKeep is the number of hashreleases to keep in the server
 	maxHashreleasesToKeep = 400
 
@@ -39,32 +36,34 @@ func URL(name string) string {
 	return fmt.Sprintf("https://%s.%s", name, baseDomain)
 }
 
-func remoteReleasesLibraryPath() string {
-	return filepath.Join(remoteReleasesPath, "all-releases")
+func remoteDocsPath(user string) string {
+	path := "files"
+	if user != "root" {
+		path = filepath.Join("home", "core", "disk", "docs-preview", path)
+	}
+	return "/" + path
 }
 
-// hasHashrelease checks if a hashrelease exists in the server
-func hasHashrelease(releaseHash string, sshConfig *command.SSHConfig) bool {
-	if out, err := command.RunSSHCommand(sshConfig, fmt.Sprintf("cat %s | grep %s", remoteReleasesLibraryPath(), releaseHash)); err == nil {
+func remoteReleasesLibraryPath(user string) string {
+	return filepath.Join(remoteDocsPath(user), "all-releases")
+}
+
+// Exists checks if a hashrelease exists in the server
+func Exists(releaseHash string, sshConfig *command.SSHConfig) bool {
+	if out, err := command.RunSSHCommand(sshConfig, fmt.Sprintf("cat %s | grep %s", remoteReleasesLibraryPath(sshConfig.User), releaseHash)); err == nil {
 		return strings.Contains(out, releaseHash)
 	}
 	return false
 }
 
-// PublishHashrelease publishes a hashrelease to the server
-func PublishHashrelease(name, hash, note, stream, dir string, sshConfig *command.SSHConfig) error {
-	if hasHashrelease(hash, sshConfig) {
-		logrus.WithFields(logrus.Fields{
-			"hash": hash,
-			"note": note,
-		}).Warn("Hashrelease already exists, skipping publish")
-		return nil
-	}
-	if _, err := command.Run("rsync", []string{"--stats", "-az", "--delete", fmt.Sprintf(`-e 'ssh %s'`, sshConfig.Args()), dir, fmt.Sprintf("%s:%s/%s", sshConfig.HostString(), remoteReleasesPath, name)}); err != nil {
+// Publish publishes a hashrelease to the server
+func Publish(name, hash, note, stream, dir string, sshConfig *command.SSHConfig) error {
+	dir = dir + "/"
+	if _, err := command.Run("rsync", []string{"--stats", "-az", "--delete", fmt.Sprintf(`-e 'ssh %s'`, sshConfig.Args()), dir, fmt.Sprintf("%s:%s/%s", sshConfig.HostString(), remoteDocsPath(sshConfig.User), name)}); err != nil {
 		logrus.WithError(err).Error("Failed to publish hashrelease")
 		return err
 	}
-	if _, err := command.RunSSHCommand(sshConfig, fmt.Sprintf(`echo "%s" > %s/latest-os/%s.txt && echo %s >> %s`, URL(name), remoteReleasesPath, stream, name, remoteReleasesLibraryPath())); err != nil {
+	if _, err := command.RunSSHCommand(sshConfig, fmt.Sprintf(`echo "%s" > %s/latest-os/%s.txt && echo %s >> %s`, URL(name), remoteDocsPath(sshConfig.User), stream, name, remoteReleasesLibraryPath(sshConfig.User))); err != nil {
 		logrus.WithError(err).Error("Failed to update latest hashrelease and hashrelease library")
 		return err
 	}
@@ -73,7 +72,7 @@ func PublishHashrelease(name, hash, note, stream, dir string, sshConfig *command
 
 // listHashreleases lists all hashreleases in the server
 func listHashreleases(sshConfig *command.SSHConfig) ([]hashrelease, error) {
-	cmd := fmt.Sprintf("ls -lt --time-style=+'%%Y-%%m-%%d %%H:%%M:%%S' %s", remoteReleasesPath)
+	cmd := fmt.Sprintf("ls -lt --time-style=+'%%Y-%%m-%%d %%H:%%M:%%S' %s", remoteDocsPath(sshConfig.User))
 	out, err := command.RunSSHCommand(sshConfig, cmd)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get list of hashreleases")
@@ -99,7 +98,7 @@ func listHashreleases(sshConfig *command.SSHConfig) ([]hashrelease, error) {
 		}
 		if re.MatchString(name) {
 			folders = append(folders, hashrelease{
-				Name: filepath.Join(remoteReleasesPath, name),
+				Name: filepath.Join(remoteDocsPath(sshConfig.User), name),
 				Time: time,
 			})
 		}
@@ -111,7 +110,7 @@ func listHashreleases(sshConfig *command.SSHConfig) ([]hashrelease, error) {
 }
 
 func getHashreleaseLibrary(sshConfig *command.SSHConfig) (string, error) {
-	out, err := command.RunSSHCommand(sshConfig, fmt.Sprintf("cat %s", remoteReleasesLibraryPath()))
+	out, err := command.RunSSHCommand(sshConfig, fmt.Sprintf("cat %s", remoteReleasesLibraryPath(sshConfig.User)))
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get hashrelease library")
 		return "", err
@@ -135,16 +134,16 @@ func cleanHashreleaseLibrary(sshConfig *command.SSHConfig, hashreleaseNames []st
 		}
 	}
 
-	if _, err := command.RunSSHCommand(sshConfig, fmt.Sprintf("echo \"%s\" > %s", strings.Join(newLibrary, "\n"), remoteReleasesLibraryPath())); err != nil {
+	if _, err := command.RunSSHCommand(sshConfig, fmt.Sprintf("echo \"%s\" > %s", strings.Join(newLibrary, "\n"), remoteReleasesLibraryPath(sshConfig.User))); err != nil {
 		logrus.WithError(err).Error("Failed to update hashrelease library")
 		return err
 	}
 	return nil
 }
 
-// DeleteOldHashreleases deletes old hashreleases from the server.
+// DeleteOld deletes old hashreleases from the server.
 // The limit parameter specifies the number of hashreleases to keep
-func DeleteOldHashreleases(sshConfig *command.SSHConfig) error {
+func DeleteOld(sshConfig *command.SSHConfig) error {
 	folders, err := listHashreleases(sshConfig)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to list hashreleases")

--- a/release/internal/imagescanner/scanner.go
+++ b/release/internal/imagescanner/scanner.go
@@ -136,6 +136,10 @@ func writeScanResultToFile(resp *http.Response, outputDir string) error {
 // RetrieveResultURL retrieves the URL to the image scan result from the scan result file.
 func RetrieveResultURL(outputDir string) string {
 	outputFilePath := filepath.Join(outputDir, scanResultFileName)
+	if _, err := os.Stat(outputFilePath); os.IsNotExist(err) {
+		logrus.WithError(err).Error("Image scan result file does not exist")
+		return ""
+	}
 	var result map[string]interface{}
 	resultData, err := os.ReadFile(outputFilePath)
 	if err != nil {

--- a/release/internal/slack/slack.go
+++ b/release/internal/slack/slack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 
 	"github.com/projectcalico/calico/release/internal/hashrelease"
@@ -105,6 +106,10 @@ func (m *Message) send(client *slack.Client, messageTemplateData string) error {
 	if err != nil {
 		return err
 	}
+	logrus.WithFields(logrus.Fields{
+		"channel": m.Config.Channel,
+		"message": message,
+	}).Debug("Sending message to Slack")
 	_, _, err = client.PostMessage(m.Config.Channel, slack.MsgOptionBlocks(message...))
 	return err
 }

--- a/release/internal/slack/templates/failure.json.gotmpl
+++ b/release/internal/slack/templates/failure.json.gotmpl
@@ -56,14 +56,14 @@
         "type": "mrkdwn",
         "text": "*Version*"
       }
-      {{- range .FailedImages }},
+      {{- range $component := .FailedImages }},
       {
         "type": "plain_text",
-        "text": "{{.Image}}"
+        "text": "{{$component.Image}}"
       },
       {
         "type": "plain_text",
-        "text": "{{.Version}}"
+        "text": "{{$component.Version}}"
       }
       {{- end }}
     ]

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -217,8 +217,12 @@ func HashreleasePush(cfg *config.Config) {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get release hash")
 	}
+	if hashrelease.Exists(releaseHash, sshConfig) {
+		logrus.WithField("hashrelease", releaseHash).Warn("Hashrelease already exists")
+		return
+	}
 	logrus.WithField("note", note).Info("Publishing hashrelease")
-	if err := hashrelease.PublishHashrelease(name, releaseHash, note, productBranch, cfg.HashreleaseDir(), sshConfig); err != nil {
+	if err := hashrelease.Publish(name, releaseHash, note, productBranch, cfg.HashreleaseDir(), sshConfig); err != nil {
 		logrus.WithError(err).Fatal("Failed to publish hashrelease")
 	}
 	scanResultURL := imagescanner.RetrieveResultURL(cfg.OutputDir)
@@ -244,7 +248,7 @@ func HashreleasePush(cfg *config.Config) {
 func HashreleaseCleanRemote(cfg *config.Config) {
 	sshConfig := command.NewSSHConfig(cfg.DocsHost, cfg.DocsUser, cfg.DocsKey, cfg.DocsPort)
 	logrus.Info("Cleaning up old hashreleases")
-	if err := hashrelease.DeleteOldHashreleases(sshConfig); err != nil {
+	if err := hashrelease.DeleteOld(sshConfig); err != nil {
 		logrus.WithError(err).Fatal("Failed to delete old hashreleases")
 	}
 }


### PR DESCRIPTION
## Description

- pipeline
  - export GITHUB_TOKEN
  - unshallow the git repo to access latest tags
  - build the release binary
- docs server
  - fix path for files based on root or not
  - expose checking if hashrelease exists
  - fn naming updates
- image scanner
  - check if result file exists before attempting to open
- slack
  - add debug log for messages
  - update failure message template to access failed images

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
