### PR TITLE
Felix: Multi-path support for RouteTable.

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -658,6 +658,17 @@ func (t *mockRouteTable) RouteUpdate(routeClass routetable.RouteClass, ifaceName
 
 func (t *mockRouteTable) OnIfaceStateChanged(string, int, ifacemonitor.State) {}
 func (t *mockRouteTable) QueueResync()                                        {}
+func (t *mockRouteTable) QueueResyncIface(ifaceName string)                   {}
+
+func (t *mockRouteTable) Index() int {
+	return t.index
+}
+
+func (t *mockRouteTable) ReadRoutesFromKernel(ifaceName string) ([]routetable.Target, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (t *mockRouteTable) Apply() error {
 	return nil
 }

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -390,6 +390,10 @@ func (d *MockNetlinkDataplane) AddIface(idx int, name string, up bool, running b
 	d.NameToLink[name] = link
 	d.SetIface(name, up, running)
 	return link.copy()
+}
+
+func (d *MockNetlinkDataplane) DelIface(name string) {
+	delete(d.NameToLink, name)
 }
 
 func (d *MockNetlinkDataplane) SetIface(name string, up bool, running bool) {

--- a/felix/routetable/dataplane_shims.go
+++ b/felix/routetable/dataplane_shims.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/routetable/defs.go
+++ b/felix/routetable/defs.go
@@ -66,12 +66,13 @@ var (
 )
 
 type Target struct {
-	Type     TargetType
-	CIDR     ip.CIDR
-	GW       ip.Addr
-	Src      ip.Addr
-	DestMAC  net.HardwareAddr
-	Protocol netlink.RouteProtocol
+	Type      TargetType
+	CIDR      ip.CIDR
+	GW        ip.Addr
+	Src       ip.Addr
+	DestMAC   net.HardwareAddr
+	Protocol  netlink.RouteProtocol
+	MultiPath []NextHop
 }
 
 func (t Target) Equal(t2 Target) bool {
@@ -127,6 +128,11 @@ func (t Target) Flags() netlink.NextHopFlag {
 	default:
 		return 0
 	}
+}
+
+type NextHop struct {
+	Gw        ip.Addr
+	IfaceName string
 }
 
 type TargetType string

--- a/felix/routetable/dummy_table.go
+++ b/felix/routetable/dummy_table.go
@@ -14,6 +14,9 @@ func (_ *DummyTable) OnIfaceStateChanged(_ string, _ int, _ ifacemonitor.State) 
 func (_ *DummyTable) QueueResync() {
 }
 
+func (_ *DummyTable) QueueResyncIface(string) {
+}
+
 func (_ *DummyTable) Apply() error {
 	return nil
 }
@@ -25,4 +28,15 @@ func (_ *DummyTable) RouteRemove(routeClass RouteClass, ifaceName string, cidr i
 }
 
 func (_ *DummyTable) RouteUpdate(routeClass RouteClass, ifaceName string, target Target) {
+}
+
+func (_ *DummyTable) Index() int {
+	return 0
+}
+
+func (_ *DummyTable) ReadRoutesFromKernel(ifaceName string) ([]Target, error) {
+	return nil, nil
+}
+
+func (_ *DummyTable) SetRemoveExternalRoutes(b bool) {
 }

--- a/felix/routetable/interface.go
+++ b/felix/routetable/interface.go
@@ -33,6 +33,9 @@ type Interface interface {
 	SetRoutes(routeClass RouteClass, ifaceName string, targets []Target)
 	RouteRemove(routeClass RouteClass, ifaceName string, cidr ip.CIDR)
 	RouteUpdate(routeClass RouteClass, ifaceName string, target Target)
+	Index() int
+	QueueResyncIface(ifaceName string)
+	ReadRoutesFromKernel(ifaceName string) ([]Target, error)
 }
 
 // ClassView wraps a RouteTable with a simplified API that removes the need to
@@ -71,6 +74,18 @@ func (cv *ClassView) RouteRemove(ifaceName string, cidr ip.CIDR) {
 
 func (cv *ClassView) RouteUpdate(ifaceName string, target Target) {
 	cv.routeTable.RouteUpdate(cv.class, ifaceName, target)
+}
+
+func (cv *ClassView) Index() int {
+	return cv.routeTable.Index()
+}
+
+func (cv *ClassView) QueueResyncIface(ifaceName string) {
+	cv.routeTable.QueueResyncIface(ifaceName)
+}
+
+func (cv *ClassView) ReadRoutesFromKernel(ifaceName string) ([]Target, error) {
+	return cv.routeTable.ReadRoutesFromKernel(ifaceName)
 }
 
 var _ SyncerInterface = (*ClassView)(nil)


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Upstream basic multi-path support to the RouteTable. Keep code in sync with Enterprise version.  Feature is currently unused.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

#8418 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
