### PR TITLE
[BPF] packets to host must have MarkSeenSkipFIB

### DIFF
--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1169,15 +1169,15 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 			Action:  r.GoTo(ChainRawBPFUntrackedPolicy),
 			Comment: []string{"Jump to target for packets with Bypass mark"},
 		},
+		generictables.Rule{
+			Match:   r.NewMatch().DestAddrType(generictables.AddrTypeLocal),
+			Action:  r.SetMaskedMark(tcdefs.MarkSeenSkipFIB, tcdefs.MarkSeenSkipFIB),
+			Comment: []string{"Mark traffic towards the host - it is TRACKed"},
+		},
 	)
 
 	if bypassHostConntrack {
 		rawRules = append(rawRules,
-			generictables.Rule{
-				Match:   r.NewMatch().DestAddrType(generictables.AddrTypeLocal),
-				Action:  r.SetMaskedMark(tcdefs.MarkSeenSkipFIB, tcdefs.MarkSeenSkipFIB),
-				Comment: []string{"Mark traffic towards the host - it is TRACKed"},
-			},
 			generictables.Rule{
 				Match:   r.NewMatch().NotDestAddrType(generictables.AddrTypeLocal),
 				Action:  r.GoTo(ChainRawUntrackedFlows),


### PR DESCRIPTION
Regardless of whether we bypass conntrack or not, that mark must be on so that returning traffic from a pod (if the traffic was redirected) does not do FIB and skip iptables.

refs https://github.com/projectcalico/calico/issues/6522

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: when bpfConntrackBypass is disabled, ensure that iptables rules, which allow 3rd party iptables rules work for traffic originally for the host, are in place.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
