### PR TITLE
Fix that node deletion controller didn't sync at startup

### DIFF
--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -40,9 +40,7 @@ const (
 	hepCreatedLabelValue  = "calico-kube-controllers"
 )
 
-var (
-	retrySleepTime = 100 * time.Millisecond
-)
+var retrySleepTime = 100 * time.Millisecond
 
 // NodeController implements the Controller interface.  It is responsible for monitoring
 // kubernetes nodes and responding to delete events by removing them from the Calico datastore.
@@ -67,7 +65,8 @@ func NewNodeController(ctx context.Context,
 	k8sClientset *kubernetes.Clientset,
 	calicoClient client.Interface,
 	cfg config.NodeControllerConfig,
-	nodeInformer, podInformer cache.SharedIndexInformer) controller.Controller {
+	nodeInformer, podInformer cache.SharedIndexInformer,
+) controller.Controller {
 	nc := &NodeController{
 		ctx:          ctx,
 		calicoClient: calicoClient,
@@ -102,7 +101,8 @@ func NewNodeController(ctx context.Context,
 			for _, f := range nodeDeletionFuncs {
 				f()
 			}
-		}}
+		},
+	}
 
 	// Create the Auto HostEndpoint sub-controller and register it to receive data.
 	// We always launch this controller, even if auto-HEPs are disabled, since the controller

--- a/kube-controllers/pkg/controllers/node/node_deleter.go
+++ b/kube-controllers/pkg/controllers/node/node_deleter.go
@@ -71,12 +71,9 @@ func (c *nodeDeleter) onStatusUpdate(s bapi.SyncStatus) {
 }
 
 func (c *nodeDeleter) run() {
-	for {
-		select {
-		case <-c.syncChan:
-			if err := c.deleteStaleNodes(); err != nil {
-				log.WithError(err).Warn("Error deleting any stale nodes")
-			}
+	for range c.syncChan {
+		if err := c.deleteStaleNodes(); err != nil {
+			log.WithError(err).Warn("Error deleting any stale nodes")
 		}
 	}
 }

--- a/kube-controllers/pkg/controllers/node/node_deleter.go
+++ b/kube-controllers/pkg/controllers/node/node_deleter.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
 
+	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
@@ -31,29 +32,52 @@ import (
 // NewNodeDeletionController creates a new controller responsible for garbage collection Calico node objects
 // in etcd mode when their corresponding Kubernetes node is deleted.
 func NewNodeDeletionController(client client.Interface, cs *kubernetes.Clientset) *nodeDeleter {
-	return &nodeDeleter{
+	d := &nodeDeleter{
 		clientset: cs,
 		client:    client,
 		rl:        workqueue.DefaultControllerRateLimiter(),
+		syncChan:  make(chan struct{}),
 	}
+	go d.run()
+	return d
 }
 
 type nodeDeleter struct {
 	rl        workqueue.RateLimiter
 	clientset *kubernetes.Clientset
 	client    client.Interface
+	syncChan  chan struct{}
 }
 
 func (c *nodeDeleter) RegisterWith(f *DataFeed) {
-	// No-op - we only care about Kubernetes node deletion events.
+	// We use status updates to do a "start of day" sync. This controller doens't
+	// actually use the syncer feed, but we do key off syncer updates at start of day to
+	// trigger an initial sync. This helps catch scenarios where nodes may have been deleted
+	// while the controller was not running / being rescheduled.
+	f.RegisterForSyncStatus(c.onStatusUpdate)
 }
 
 func (c *nodeDeleter) OnKubernetesNodeDeleted() {
 	// When a Kubernetes node is deleted, trigger a sync.
 	log.Debug("Kubernetes node deletion event")
-	err := c.deleteStaleNodes()
-	if err != nil {
-		log.WithError(err).Warn("Error deleting any stale nodes")
+	c.syncChan <- struct{}{}
+}
+
+func (c *nodeDeleter) onStatusUpdate(s bapi.SyncStatus) {
+	if s == bapi.InSync {
+		log.Info("Sync status is now in sync, checking for stale nodes")
+		c.syncChan <- struct{}{}
+	}
+}
+
+func (c *nodeDeleter) run() {
+	for {
+		select {
+		case <-c.syncChan:
+			if err := c.deleteStaleNodes(); err != nil {
+				log.WithError(err).Warn("Error deleting any stale nodes")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/9182

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
[etcd mode] Fix issue where Calico nodes failed to decommission if calico-kube-controllers was running on the terminated node.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.