### PR TITLE
Use distinct UIDs for projectcalico.org/v3 APIs (#8586)

### DIFF
--- a/kube-controllers/pkg/converter/namespace_converter_test.go
+++ b/kube-controllers/pkg/converter/namespace_converter_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 var _ = Describe("Namespace conversion tests", func() {
-
 	nsConverter := converter.NewNamespaceConverter()
 
 	It("should parse a Namespace to a Profile", func() {
@@ -40,6 +39,7 @@ var _ = Describe("Namespace conversion tests", func() {
 					"roger":       "rabbit",
 				},
 				Annotations: map[string]string{},
+				UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 			},
 			Spec: k8sapi.NamespaceSpec{},
 		}
@@ -79,6 +79,7 @@ var _ = Describe("Namespace conversion tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "default",
 				Annotations: map[string]string{},
+				UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 			},
 			Spec: k8sapi.NamespaceSpec{},
 		}
@@ -120,6 +121,7 @@ var _ = Describe("Namespace conversion tests", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "default",
 					Annotations: map[string]string{},
+					UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 				},
 				Spec: k8sapi.NamespaceSpec{},
 			},
@@ -178,6 +180,5 @@ var _ = Describe("Namespace conversion tests", func() {
 			Expect(ns).To(Equal(""))
 			Expect(name).To(Equal("kns.default"))
 		})
-
 	})
 })

--- a/kube-controllers/pkg/converter/serviceaccount_converter_test.go
+++ b/kube-controllers/pkg/converter/serviceaccount_converter_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 var _ = Describe("ServiceAccount conversion tests", func() {
-
 	saConverter := converter.NewServiceAccountConverter()
 
 	It("should parse a Service Account to a Profile", func() {
@@ -40,6 +39,7 @@ var _ = Describe("ServiceAccount conversion tests", func() {
 					"roger":       "rabbit",
 				},
 				Annotations: map[string]string{},
+				UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 			},
 		}
 
@@ -73,6 +73,7 @@ var _ = Describe("ServiceAccount conversion tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "serviceaccount",
 				Annotations: map[string]string{},
+				UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 			},
 		}
 		p, err := saConverter.Convert(&sa)
@@ -107,6 +108,7 @@ var _ = Describe("ServiceAccount conversion tests", func() {
 				Name:        "serviceaccount",
 				Namespace:   "foo",
 				Annotations: map[string]string{},
+				UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 			},
 		}
 		p, err := saConverter.Convert(&sa)
@@ -142,6 +144,7 @@ var _ = Describe("ServiceAccount conversion tests", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "serviceaccount",
 					Annotations: map[string]string{},
+					UID:         "aa844ac0-87c8-440a-b270-307cdba8fd25",
 				},
 			},
 		}
@@ -199,6 +202,5 @@ var _ = Describe("ServiceAccount conversion tests", func() {
 			Expect(sa).To(Equal(""))
 			Expect(name).To(Equal("ksa.default.serviceaccount"))
 		})
-
 	})
 })

--- a/libcalico-go/lib/backend/k8s/conversion/conversion.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion.go
@@ -16,12 +16,15 @@ package conversion
 
 import (
 	"fmt"
+	"math/bits"
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	discovery "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -36,9 +39,7 @@ import (
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
-var (
-	protoTCP = kapiv1.ProtocolTCP
-)
+var protoTCP = kapiv1.ProtocolTCP
 
 type selectorType int8
 
@@ -99,13 +100,18 @@ func (c converter) NamespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, erro
 	// based on name within the namespaceSelector.
 	labels[NamespaceLabelPrefix+NameLabel] = ns.Name
 
+	uid, err := ConvertUID(ns.UID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create the profile object.
 	name := NamespaceProfileNamePrefix + ns.Name
 	profile := apiv3.NewProfile()
 	profile.ObjectMeta = metav1.ObjectMeta{
 		Name:              name,
 		CreationTimestamp: ns.CreationTimestamp,
-		UID:               ns.UID,
+		UID:               uid,
 	}
 	profile.Spec = apiv3.ProfileSpec{
 		Ingress:       []apiv3.Rule{{Action: apiv3.Allow}},
@@ -315,12 +321,12 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 			egress = true
 		}
 	}
-	types := []apiv3.PolicyType{}
+	policyTypes := []apiv3.PolicyType{}
 	if ingress {
-		types = append(types, apiv3.PolicyTypeIngress)
+		policyTypes = append(policyTypes, apiv3.PolicyTypeIngress)
 	}
 	if egress {
-		types = append(types, apiv3.PolicyTypeEgress)
+		policyTypes = append(policyTypes, apiv3.PolicyTypeEgress)
 	} else if len(egressRules) > 0 {
 		// Egress was introduced at the same time as policyTypes.  It shouldn't be possible to
 		// receive a NetworkPolicy with an egress rule but without "Egress" specified in its types,
@@ -331,8 +337,17 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 	// If no types were specified in the policy, then we're running on a cluster that doesn't
 	// include support for that field in the API.  In that case, the correct behavior is for the policy
 	// to apply to only ingress traffic.
-	if len(types) == 0 {
-		types = append(types, apiv3.PolicyTypeIngress)
+	if len(policyTypes) == 0 {
+		policyTypes = append(policyTypes, apiv3.PolicyTypeIngress)
+	}
+
+	var uid types.UID
+	var err error
+	if np.UID != "" {
+		uid, err = ConvertUID(np.UID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create the NetworkPolicy.
@@ -341,7 +356,7 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		Name:              policyName,
 		Namespace:         np.Namespace,
 		CreationTimestamp: np.CreationTimestamp,
-		UID:               np.UID,
+		UID:               uid,
 		ResourceVersion:   np.ResourceVersion,
 	}
 	policy.Spec = apiv3.NetworkPolicySpec{
@@ -349,7 +364,7 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		Selector: c.k8sSelectorToCalico(&np.Spec.PodSelector, SelectorPod),
 		Ingress:  ingressRules,
 		Egress:   egressRules,
-		Types:    types,
+		Types:    policyTypes,
 	}
 
 	// Build the KVPair.
@@ -731,12 +746,17 @@ func (c converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 	// based on name within the serviceAccountSelector.
 	labels[ServiceAccountLabelPrefix+NameLabel] = sa.Name
 
+	uid, err := ConvertUID(sa.UID)
+	if err != nil {
+		return nil, err
+	}
+
 	name := serviceAccountNameToProfileName(sa.Name, sa.Namespace)
 	profile := apiv3.NewProfile()
 	profile.ObjectMeta = metav1.ObjectMeta{
 		Name:              name,
 		CreationTimestamp: sa.CreationTimestamp,
-		UID:               sa.UID,
+		UID:               uid,
 	}
 	profile.Spec.LabelsToApply = labels
 
@@ -754,7 +774,6 @@ func (c converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 
 // ProfileNameToServiceAccount extracts the ServiceAccount name from the given Profile name.
 func (c converter) ProfileNameToServiceAccount(profileName string) (ns, sa string, err error) {
-
 	// Profile objects backed by ServiceAccounts have form "ksa.<namespace>.<sa_name>"
 	if !strings.HasPrefix(profileName, ServiceAccountProfileNamePrefix) {
 		// This is not backed by a Kubernetes ServiceAccount.
@@ -808,4 +827,41 @@ func stringsToIPNets(ipStrings []string) ([]*cnet.IPNet, error) {
 		podIPNets = append(podIPNets, ipNet)
 	}
 	return podIPNets, nil
+}
+
+// ConvertUID converts a UID to a new UID in a deterministic way. This is useful when we want to generate a new UID
+// for a resource that is derived from another resource, but we don't want to use the same UID in order to
+// ensure that the new resource is treated as unique. This is important, as two objects with the same UID causes
+// confusion in the Kubernetes garbage collection logic.
+func ConvertUID(uid types.UID) (types.UID, error) {
+	parsed, err := uuid.Parse(string(uid))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse UID for resource: %s", err)
+	}
+	reversed, err := reverseUID(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to reverse UID for resource: %s", err)
+	}
+	return types.UID(reversed.String()), nil
+}
+
+func reverseUID(uid uuid.UUID) (uuid.UUID, error) {
+	// v4 UUIDs used by Kubernetes use bits in the 7th byte to indicate the version and
+	// bits in the 9th byte to indicate the variant. Reverse the bits in the surrounding bytes but leave these intact.
+	nuid := make([]byte, len(uid))
+	copy(nuid, uid[:])
+
+	// Reverse the bits in the first 6 bytes.
+	for ii := range uid[:6] {
+		nuid[ii] = byte(bits.Reverse(uint(uid[ii])) >> 56)
+	}
+
+	// Reverse the bits in the 8th byte.
+	nuid[7] = byte(bits.Reverse(uint(uid[7])) >> 56)
+
+	// Reverse the bits in the remaining bytes.
+	for ii := range uid[9:] {
+		nuid[ii+9] = byte(bits.Reverse(uint(uid[ii+9])) >> 56)
+	}
+	return uuid.FromBytes(nuid)
 }

--- a/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -32,6 +33,7 @@ import (
 	kapiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -1175,6 +1177,49 @@ var _ = Describe("Test Pod conversion", func() {
 	})
 })
 
+var _ = Describe("Test UID conversion", func() {
+	It("should parse a UID to a Calico ID", func() {
+		By("Converting a UID")
+		original := types.UID("30316465-6365-4463-ad63-3564622d3638")
+		converted, err := ConvertUID(original)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(converted)).To(Equal("0c8c26a6-c6a6-44c6-adc6-ac2646b46c1c"))
+
+		By("Parsing it as a valid UID")
+		parsed, err := uuid.Parse(string(converted))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking the version bits are correct")
+		Expect(parsed[6] >> 4).To(Equal(byte(0x4))) // Version 4
+
+		By("Converting it back")
+		convertedBack, err := ConvertUID(converted)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(convertedBack).To(Equal(original))
+	})
+
+	It("should error on an invalid UID", func() {
+		_, err := ConvertUID("not-a-uid")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should always maintain the v4 version metadata bits, and convert back", func() {
+		for i := 0; i < 100000; i++ {
+			original := types.UID(uuid.New().String())
+			converted, err := ConvertUID(original)
+			Expect(err).NotTo(HaveOccurred())
+
+			parsed, err := uuid.Parse(string(converted))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parsed[6] >> 4).To(Equal(byte(0x4))) // Version 4
+
+			convertedBack, err := ConvertUID(converted)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(convertedBack).To(Equal(original))
+		}
+	})
+})
+
 var _ = Describe("Test NetworkPolicy conversion", func() {
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
@@ -1186,6 +1231,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1259,6 +1305,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1307,6 +1354,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1359,6 +1407,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1424,6 +1473,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1528,6 +1578,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1676,6 +1727,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1710,6 +1762,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -1754,6 +1807,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1824,6 +1878,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1901,6 +1956,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -1987,6 +2043,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2019,6 +2076,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2069,6 +2127,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2115,6 +2174,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2162,6 +2222,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2218,6 +2279,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2260,6 +2322,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2308,6 +2371,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2355,6 +2419,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2403,6 +2468,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2449,6 +2515,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2496,6 +2563,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2549,6 +2617,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2677,6 +2746,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -2750,6 +2820,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2815,6 +2886,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2848,6 +2920,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -2920,6 +2993,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -3005,6 +3079,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -3036,6 +3111,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -3077,6 +3153,7 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
@@ -3130,6 +3207,7 @@ var _ = Describe("Test Namespace conversion", func() {
 					"roger": "rabbit",
 				},
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3162,6 +3240,7 @@ var _ = Describe("Test Namespace conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "default",
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3192,6 +3271,7 @@ var _ = Describe("Test Namespace conversion", func() {
 				Annotations: map[string]string{
 					"net.beta.kubernetes.io/network-policy": "{\"ingress\": {\"isolation\": \"DefaultDeny\"}}",
 				},
+				UID: types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3217,6 +3297,7 @@ var _ = Describe("Test Namespace conversion", func() {
 				Annotations: map[string]string{
 					"net.beta.kubernetes.io/network-policy": "invalidJSON",
 				},
+				UID: types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3227,6 +3308,23 @@ var _ = Describe("Test Namespace conversion", func() {
 		})
 	})
 
+	It("should generate a deterministic UID for a Namespace Profile", func() {
+		ns := kapiv1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+			Spec: kapiv1.NamespaceSpec{},
+		}
+
+		p, err := c.NamespaceToProfile(&ns)
+		Expect(err).NotTo(HaveOccurred())
+		p2, err := c.NamespaceToProfile(&ns)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.UID).To(Equal(p2.UID))
+		Expect(p.UID).NotTo(Equal(ns.UID))
+	})
+
 	It("should handle a valid but not DefaultDeny annotation", func() {
 		ns := kapiv1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -3234,6 +3332,7 @@ var _ = Describe("Test Namespace conversion", func() {
 				Annotations: map[string]string{
 					"net.beta.kubernetes.io/network-policy": "{}",
 				},
+				UID: types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3272,6 +3371,7 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 					"roger": "rabbit",
 				},
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 		}
 
@@ -3294,12 +3394,29 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 		Expect(labels["pcsa.roger"]).To(Equal("rabbit"))
 	})
 
+	It("should generate a deterministic UID for a ServiceAccount Profile", func() {
+		sa := kapiv1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sa-test",
+				Namespace: "test",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+		}
+		p, err := c.ServiceAccountToProfile(&sa)
+		Expect(err).NotTo(HaveOccurred())
+		p2, err := c.ServiceAccountToProfile(&sa)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.UID).To(Equal(p2.UID))
+		Expect(p.UID).NotTo(Equal(sa.UID))
+	})
+
 	It("should parse a ServiceAccount in Namespace to a Profile", func() {
 		sa := kapiv1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "sa-test",
 				Namespace:   "test",
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 		}
 
@@ -3314,6 +3431,7 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 		sa := kapiv1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "sa-test",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 		}
 

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -996,7 +996,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		})
 	})
 
-	It("should handle a CRUD of Network Sets", func() {
+	It("should handle CRUD of Network Sets", func() {
 		kvp1 := &model.KVPair{
 			Key: model.ResourceKey{
 				Name:      "test-syncer-netset1",
@@ -1961,12 +1961,14 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 
 	It("should support listing block affinities", func() {
 		var nodename string
+
 		By("Listing all Nodes to find a suitable Node name", func() {
 			nodes, err := c.List(ctx, model.ResourceListOptions{Kind: libapiv3.KindNode}, "")
 			Expect(err).NotTo(HaveOccurred())
 			kvp := *nodes.KVPairs[0]
 			nodename = kvp.Key.(model.ResourceKey).Name
 		})
+
 		By("Creating an affinity for that node", func() {
 			cidr := net.MustParseCIDR("10.0.0.0/26")
 			kvp := model.KVPair{
@@ -1979,6 +1981,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			_, err := c.Create(ctx, &kvp)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		By("Creating an affinity for a different node", func() {
 			cidr := net.MustParseCIDR("10.0.1.0/26")
 			kvp := model.KVPair{
@@ -1991,11 +1994,13 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			_, err := c.Create(ctx, &kvp)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		By("Listing all BlockAffinity for all Nodes", func() {
 			objs, err := c.List(ctx, model.BlockAffinityListOptions{}, "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(objs.KVPairs)).To(Equal(2))
 		})
+
 		By("Listing all BlockAffinity for a specific Node", func() {
 			objs, err := c.List(ctx, model.BlockAffinityListOptions{Host: nodename}, "")
 			Expect(err).NotTo(HaveOccurred())
@@ -2060,6 +2065,13 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			updFC, err = c.Update(ctx, updFC)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updFC.Value.(*apiv3.FelixConfiguration).Spec.InterfacePrefix).To(Equal("someotherprefix-"))
+		})
+
+		By("updating an existing object with a bad UID in the precondition", func() {
+			updFC.Value.(*apiv3.FelixConfiguration).Spec.InterfacePrefix = "someevenothererprefix-"
+			updFC.Value.(*apiv3.FelixConfiguration).ObjectMeta.UID = types.UID("19e9c0f4-501d-429f-b581-8954440883f4")
+			_, err = c.Update(ctx, updFC)
+			Expect(err).To(HaveOccurred())
 		})
 
 		By("getting the updated object", func() {

--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -140,10 +140,13 @@ func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.Da
 				},
 			})
 
+			uid, err := conversion.ConvertUID(ns.UID)
+			Expect(err).NotTo(HaveOccurred())
+
 			// And expect a v3 profile for each namespace.
 			prof := apiv3.Profile{
 				TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
-				ObjectMeta: metav1.ObjectMeta{Name: name, UID: ns.UID, CreationTimestamp: ns.CreationTimestamp},
+				ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid, CreationTimestamp: ns.CreationTimestamp},
 				Spec: apiv3.ProfileSpec{
 					LabelsToApply: map[string]string{
 						"pcns.projectcalico.org/name":      ns.Name,
@@ -181,10 +184,13 @@ func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.Da
 					},
 				})
 
+				uid, err := conversion.ConvertUID(sa.UID)
+				Expect(err).NotTo(HaveOccurred())
+
 				//  We also expect one v3 Profile to be present for each ServiceAccount.
 				prof := apiv3.Profile{
 					TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
-					ObjectMeta: metav1.ObjectMeta{Name: name, UID: sa.UID, CreationTimestamp: sa.CreationTimestamp},
+					ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid, CreationTimestamp: sa.CreationTimestamp},
 					Spec: apiv3.ProfileSpec{
 						LabelsToApply: map[string]string{
 							"pcsa.projectcalico.org/name": sa.Name,

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -24,6 +24,7 @@ import (
 	kapiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -148,7 +149,6 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 			v1Key := model.PolicyKey{Name: ns2 + "/all-sa-selector"}
 			Expect(kvps).To(Equal([]*model.KVPair{{Key: v1Key, Value: &policy, Revision: testRev}}))
 		})
-
 	})
 })
 
@@ -156,58 +156,64 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 //
 // np1 is a NetworkPolicy with a single Egress rule, which contains ports only,
 // and no selectors.
-var protocol = kapiv1.ProtocolTCP
-var port = intstr.FromInt(80)
-var np1 = networkingv1.NetworkPolicy{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "test.policy",
-		Namespace: "default",
-	},
-	Spec: networkingv1.NetworkPolicySpec{
-		PodSelector: metav1.LabelSelector{},
-		Egress: []networkingv1.NetworkPolicyEgressRule{
-			{
-				Ports: []networkingv1.NetworkPolicyPort{
+var (
+	protocol = kapiv1.ProtocolTCP
+	port     = intstr.FromInt(80)
+	np1      = networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test.policy",
+			Namespace: "default",
+			UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &protocol,
+							Port:     &port,
+						},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+)
+
+// expected1 is the expected v1 KVPair representation of np1 from above.
+var (
+	tcp       = numorstring.ProtocolFromStringV1("tcp")
+	expected1 = []*model.KVPair{
+		{
+			Key: model.PolicyKey{Name: "default/knp.default.test.policy"},
+			Value: &model.Policy{
+				Namespace:      "default",
+				Order:          &testDefaultPolicyOrder,
+				Selector:       "(projectcalico.org/orchestrator == 'k8s') && projectcalico.org/namespace == 'default'",
+				Types:          []string{"egress"},
+				ApplyOnForward: true,
+				OutboundRules: []model.Rule{
 					{
-						Protocol: &protocol,
-						Port:     &port,
+						Action:      "allow",
+						Protocol:    &tcp,
+						SrcSelector: "",
+						DstSelector: "",
+						DstPorts:    []numorstring.Port{port80},
 					},
 				},
 			},
 		},
-		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
-	},
-}
-
-// expected1 is the expected v1 KVPair representation of np1 from above.
-var tcp = numorstring.ProtocolFromStringV1("tcp")
-var expected1 = []*model.KVPair{
-	{
-		Key: model.PolicyKey{Name: "default/knp.default.test.policy"},
-		Value: &model.Policy{
-			Namespace:      "default",
-			Order:          &testDefaultPolicyOrder,
-			Selector:       "(projectcalico.org/orchestrator == 'k8s') && projectcalico.org/namespace == 'default'",
-			Types:          []string{"egress"},
-			ApplyOnForward: true,
-			OutboundRules: []model.Rule{
-				{
-					Action:      "allow",
-					Protocol:    &tcp,
-					SrcSelector: "",
-					DstSelector: "",
-					DstPorts:    []numorstring.Port{port80},
-				},
-			},
-		},
-	},
-}
+	}
+)
 
 // np2 is a NeteworkPolicy with a single Ingress rule which allows from all namespaces.
 var np2 = networkingv1.NetworkPolicy{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "test.policy",
 		Namespace: "default",
+		UID:       types.UID("41cb1fde-57e7-42c1-a73b-0acaf38c7737"),
 	},
 	Spec: networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{},
@@ -223,6 +229,7 @@ var np2 = networkingv1.NetworkPolicy{
 		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 	},
 }
+
 var expected2 = []*model.KVPair{
 	{
 		Key: model.PolicyKey{Name: "default/knp.default.test.policy"},
@@ -269,7 +276,6 @@ var _ = Describe("Test the Kubernetes NetworkPolicy end-to-end conversion and up
 })
 
 var _ = Describe("Test end-to-end pod and network policy processing", func() {
-
 	// Define processors to use in the test.
 	npProcessor := updateprocessors.NewNetworkPolicyUpdateProcessor()
 	wepProcessor := updateprocessors.NewWorkloadEndpointUpdateProcessor()
@@ -504,5 +510,4 @@ var _ = Describe("Test end-to-end pod and network policy processing", func() {
 		matches := s.Evaluate(wep.Labels)
 		Expect(matches).To(BeTrue(), fmt.Sprintf("%s does not match %+v", np.Selector, wep.Labels))
 	})
-
 })

--- a/libcalico-go/lib/clientv3/bgpconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/bgpconfig_e2e_test.go
@@ -15,6 +15,7 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -22,8 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
@@ -37,7 +36,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	nameDefault := "default"
 	name1 := "bgpconfig-1"
@@ -126,7 +124,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 
 			By("Updating the BGPConfiguration before it is created")
 			_, outError := c.BGPConfigurations().Update(ctx, &apiv3.BGPConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: nameDefault, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-workload-bgpconfig"},
+				ObjectMeta: metav1.ObjectMeta{Name: nameDefault, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       specDefault1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -207,7 +205,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPConfiguration tests", testutils.Datas
 
 			By("Attempting to update the BGPConfiguration without a Creation Timestamp")
 			res, outError = c.BGPConfigurations().Update(ctx, &apiv3.BGPConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-bgpconfig"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       specInfo,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/bgpfilter_e2e_test.go
+++ b/libcalico-go/lib/clientv3/bgpfilter_e2e_test.go
@@ -15,6 +15,7 @@
 package clientv3_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -22,8 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -100,7 +99,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPFilter tests", testutils.DatastoreAll
 
 					By("Updating the BGPFilter before it is created")
 					_, outError := c.BGPFilter().Update(ctx, &apiv3.BGPFilter{
-						ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-BGPFilter"},
+						ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 						Spec:       spec1,
 					}, options.SetOptions{})
 					Expect(outError).To(HaveOccurred())
@@ -186,7 +185,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPFilter tests", testutils.DatastoreAll
 
 					By("Attempting to update the BGPFilter without a Creation Timestamp")
 					res, outError = c.BGPFilter().Update(ctx, &apiv3.BGPFilter{
-						ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-BGPFilter"},
+						ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 						Spec:       spec1,
 					}, options.SetOptions{})
 					Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/bgppeer_e2e_test.go
+++ b/libcalico-go/lib/clientv3/bgppeer_e2e_test.go
@@ -15,6 +15,7 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -22,8 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
@@ -37,7 +36,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "bgppeer-1"
 	name2 := "bgppeer-2"
@@ -54,7 +52,8 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 		Password: &apiv3.BGPPassword{
 			SecretKeyRef: &k8sv1.SecretKeySelector{
 				LocalObjectReference: k8sv1.LocalObjectReference{
-					Name: "bgp-passwords"},
+					Name: "bgp-passwords",
+				},
 				Key: "p2",
 			},
 		},
@@ -102,7 +101,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 
 			By("Updating the BGPPeer before it is created")
 			_, outError := c.BGPPeers().Update(ctx, &apiv3.BGPPeer{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-bgppeer"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -183,7 +182,7 @@ var _ = testutils.E2eDatastoreDescribe("BGPPeer tests", testutils.DatastoreAll, 
 
 			By("Attempting to update the BGPPeer without a Creation Timestamp")
 			res, outError = c.BGPPeers().Update(ctx, &apiv3.BGPPeer{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-bgppeer"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/blockaffinity_e2e_test.go
+++ b/libcalico-go/lib/clientv3/blockaffinity_e2e_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("Block affinity tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "affinity-1"
 	name2 := "affinity-2"
@@ -70,7 +69,7 @@ var _ = testutils.E2eDatastoreDescribe("Block affinity tests", testutils.Datasto
 		func(name1, name2 string, spec1, spec2 libapiv3.BlockAffinitySpec) {
 			By("Updating the block affinity before it is created")
 			_, outError := c.BlockAffinities().Update(ctx, &libapiv3.BlockAffinity{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-affinity"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -157,7 +156,7 @@ var _ = testutils.E2eDatastoreDescribe("Block affinity tests", testutils.Datasto
 
 			By("Attempting to update the BlockAffinity without a Creation Timestamp")
 			res, outError = c.BlockAffinities().Update(ctx, &libapiv3.BlockAffinity{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-affinity"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/caliconodestatus_e2e_test.go
+++ b/libcalico-go/lib/clientv3/caliconodestatus_e2e_test.go
@@ -15,14 +15,13 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -35,7 +34,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "caliconodestatus-1"
 	name2 := "caliconodestatus-2"
@@ -201,7 +199,7 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 
 			By("Updating the CalicoNodeStatus before it is created")
 			_, outError := c.CalicoNodeStatus().Update(ctx, &apiv3.CalicoNodeStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-caliconodestatus"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 				Status:     status1,
 			}, options.SetOptions{})
@@ -292,7 +290,7 @@ var _ = testutils.E2eDatastoreDescribe("CalicoNodeStatus tests", testutils.Datas
 
 			By("Attempting to update the CalicoNodeStatus without a Creation Timestamp")
 			res, outError = c.CalicoNodeStatus().Update(ctx, &apiv3.CalicoNodeStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-caliconodestatus"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 				Status:     status1,
 			}, options.SetOptions{})

--- a/libcalico-go/lib/clientv3/clusterinfo_e2e_test.go
+++ b/libcalico-go/lib/clientv3/clusterinfo_e2e_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name := "default"
 	readyTrue := true
@@ -218,7 +217,7 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 		func(name string, spec1, spec2 apiv3.ClusterInformationSpec) {
 			By("Updating the ClusterInformation before it is created")
 			_, outError := c.ClusterInformation().Update(ctx, &apiv3.ClusterInformation{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-clusterinfo"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -285,7 +284,7 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 
 			By("Attempting to update the ClusterInformation without a Creation Timestamp")
 			res, outError = c.ClusterInformation().Update(ctx, &apiv3.ClusterInformation{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: "test-fail-clusterinfo"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -364,7 +363,6 @@ var _ = testutils.E2eDatastoreDescribe("ClusterInformation tests", testutils.Dat
 			outList, outError = c.ClusterInformation().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
-
 		},
 
 		// Test 1: Pass two fully populated ClusterInformationSpecs and expect the series of operations to succeed.

--- a/libcalico-go/lib/clientv3/globalnetworkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/globalnetworkpolicy_e2e_test.go
@@ -15,14 +15,13 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -41,7 +40,6 @@ var (
 )
 
 var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	order1 := 99.999
 	order2 := 22.222
@@ -83,7 +81,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 
 			By("Updating the GlobalNetworkPolicy before it is created")
 			_, outError := c.GlobalNetworkPolicies().Update(ctx, &apiv3.GlobalNetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-globalnetworkpolicy"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -175,7 +173,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 
 			By("Attempting to update the GlobalNetworkPolicy without a Creation Timestamp")
 			res, outError = c.GlobalNetworkPolicies().Update(ctx, &apiv3.GlobalNetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-globalnetworkpolicy"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/globalnetworkset_e2e_test.go
+++ b/libcalico-go/lib/clientv3/globalnetworkset_e2e_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "networkset-1"
 	name2 := "networkset-2"
@@ -63,7 +62,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 
 			By("Updating the GlobalNetworkSet before it is created")
 			_, outError := c.GlobalNetworkSets().Update(ctx, &apiv3.GlobalNetworkSet{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-globalNetworkSet"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -144,7 +143,7 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkSet tests", testutils.Datas
 
 			By("Attempting to update the GlobalNetworkSet without a Creation Timestamp")
 			res, outError = c.GlobalNetworkSets().Update(ctx, &apiv3.GlobalNetworkSet{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-globalNetworkSet"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/hostendpoint_e2e_test.go
+++ b/libcalico-go/lib/clientv3/hostendpoint_e2e_test.go
@@ -15,14 +15,13 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
@@ -36,7 +35,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "hep-1"
 	name2 := "hep-2"
@@ -84,7 +82,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 
 			By("Updating the HostEndpoint before it is created")
 			_, outError := c.HostEndpoints().Update(ctx, &apiv3.HostEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-hostendpoint"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -164,7 +162,7 @@ var _ = testutils.E2eDatastoreDescribe("HostEndpoint tests", testutils.Datastore
 
 			By("Attempting to update the HostEndpoint without a Creation Timestamp")
 			res, outError = c.HostEndpoints().Update(ctx, &apiv3.HostEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-hostendpoint"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
@@ -65,7 +65,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 		func(name string, spec1, spec2 libapiv3.IPAMConfigSpec) {
 			By("Updating the IPAMConfig before it is created")
 			_, outError := c.IPAMConfig().Update(ctx, &libapiv3.IPAMConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-ipamconfig"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 
 			By("Attempting to update the IPAMConfig without a Creation Timestamp")
 			res, outError = c.IPAMConfig().Update(ctx, &libapiv3.IPAMConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: "test-fail-ipamconfig"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/ippool_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ippool_e2e_test.go
@@ -124,7 +124,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 
 			By("Updating the IPPool before it is created")
 			_, outError := c.IPPools().Update(ctx, &apiv3.IPPool{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-ippool"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -211,7 +211,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 
 			By("Attempting to update the IPPool without a Creation Timestamp")
 			res, outError = c.IPPools().Update(ctx, &apiv3.IPPool{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-ippool"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/ippool_kdd_conversion_test.go
+++ b/libcalico-go/lib/clientv3/ippool_kdd_conversion_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", testutils.DatastoreK8s, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "ippool-1"
 	name2 := "ippool-2"
@@ -254,7 +253,8 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 
 			By("Updating the IPPool from the API client with the non-writable v1 IPIP field")
 			_, outError = c.IPPools().Update(ctx, &apiv3.IPPool{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "555", CreationTimestamp: metav1.Now(), UID: "a-rabbit-ate-my-carrot"},
+				// R.I.P: 'a-rabbit-ate-my-carrot' is no longer a valid UID according to Calico.
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "555", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       kvp.Value.(*apiv3.IPPool).Spec,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -381,8 +381,6 @@ var _ = testutils.E2eDatastoreDescribe("IPPool KDD v1 to v3 migration tests", te
 				},
 			})
 			testWatcher2.Stop()
-
 		})
 	})
-
 })

--- a/libcalico-go/lib/clientv3/kubecontrollersconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/kubecontrollersconfig_e2e_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name := "default"
 	port := 9094
@@ -133,7 +132,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 		func(name string, spec1, spec2 apiv3.KubeControllersConfigurationSpec, status1, status2 apiv3.KubeControllersConfigurationStatus) {
 			By("Updating the KubeControllersConfiguration before it is created")
 			_, outError := c.KubeControllersConfiguration().Update(ctx, &apiv3.KubeControllersConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-kubecontrollersconfig"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -200,7 +199,7 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 
 			By("Attempting to update the KubeControllersConfiguration without a Creation Timestamp")
 			res, outError = c.KubeControllersConfiguration().Update(ctx, &apiv3.KubeControllersConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: "test-fail-kubecontrollersconfig"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -302,7 +301,6 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			outList, outError = c.KubeControllersConfiguration().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(0))
-
 		},
 
 		// Test 1: Pass two fully populated KubeControllersConfigurationSpecs and expect the series of operations to succeed.

--- a/libcalico-go/lib/clientv3/networkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/networkpolicy_e2e_test.go
@@ -15,6 +15,7 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -23,8 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -36,8 +35,10 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/watch"
 )
 
-var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
+// UID to use in tests, since our code expects valid UIDs.
+const uid = "41cb1fde-57e7-42c1-a73b-0acaf38c7737"
 
+var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 	ctx := context.Background()
 	order1 := 99.999
 	order2 := 22.222
@@ -80,7 +81,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 			By("Updating the NetworkPolicy before it is created")
 			rv := "1234"
 			_, outError := c.NetworkPolicies().Update(ctx, &apiv3.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: rv, CreationTimestamp: metav1.Now(), UID: "test-fail-networkpolicy"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: rv, CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -170,7 +171,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 
 			By("Attempting to update the NetworkPolicy without a Creation Timestamp")
 			res, outError = c.NetworkPolicies().Update(ctx, &apiv3.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: rv, UID: "test-fail-networkpolicy"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: rv, UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/networkset_e2e_test.go
+++ b/libcalico-go/lib/clientv3/networkset_e2e_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("NetworkSet tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "networkset-1"
 	name2 := "networkset-2"
@@ -66,7 +65,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkSet tests", testutils.DatastoreAl
 
 			By("Updating the NetworkSet before it is created")
 			_, outError := c.NetworkSets().Update(ctx, &apiv3.NetworkSet{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-networkSet"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -148,7 +147,7 @@ var _ = testutils.E2eDatastoreDescribe("NetworkSet tests", testutils.DatastoreAl
 
 			By("Attempting to update the NetworkSet without a Creation Timestamp")
 			res, outError = c.NetworkSets().Update(ctx, &apiv3.NetworkSet{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", UID: "test-fail-networkSet"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/node_e2e_test.go
+++ b/libcalico-go/lib/clientv3/node_e2e_test.go
@@ -15,6 +15,8 @@
 package clientv3_test
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -22,10 +24,6 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
-
-	"fmt"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -187,7 +185,6 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (kdd)", testutils.DatastoreK8
 })
 
 var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "node-1"
 	name2 := "node-2"
@@ -430,7 +427,6 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.Datastor
 			Expect(hep).ShouldNot(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 	})
 
 	DescribeTable("Node e2e CRUD tests",
@@ -444,7 +440,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.Datastor
 
 			By("Updating the Node before it is created")
 			_, outError := c.Nodes().Update(ctx, &libapiv3.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-node"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -525,7 +521,7 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.Datastor
 
 			By("Attempting to update the Node without a Creation Timestamp")
 			res, outError = c.Nodes().Update(ctx, &libapiv3.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-workload-endpoint"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -650,7 +646,6 @@ var _ = testutils.E2eDatastoreDescribe("Node tests (etcdv3)", testutils.Datastor
 			res, outError = c.Nodes().Get(ctx, name1, options.GetOptions{})
 			Expect(outError).ToNot(HaveOccurred())
 			Expect(res).To(MatchResourceWithStatus(libapiv3.KindNode, testutils.ExpectNoNamespace, name1, spec1, status))
-
 		},
 
 		// Test 1: Pass two fully populated NodeSpecs and expect the series of operations to succeed.

--- a/libcalico-go/lib/clientv3/profile_e2e_test.go
+++ b/libcalico-go/lib/clientv3/profile_e2e_test.go
@@ -15,14 +15,13 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -36,7 +35,6 @@ import (
 )
 
 var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	name1 := "profile-1"
 	name2 := "profile-2"
@@ -74,7 +72,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 
 			By("Updating the Profile before it is created")
 			_, outError = c.Profiles().Update(ctx, &apiv3.Profile{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-profile"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -157,7 +155,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 
 			By("Attempting to update the Profile without a Creation Timestamp")
 			res, outError = c.Profiles().Update(ctx, &apiv3.Profile{
-				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: "test-fail-profile"},
+				ObjectMeta: metav1.ObjectMeta{Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -307,7 +305,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			// Fill in some fields to pass validation.
 			res.ResourceVersion = "fakerv"
 			res.CreationTimestamp = metav1.Now()
-			res.UID = "uid"
+			res.UID = uid
 
 			_, outError = c.Profiles().Update(ctx, res, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/clientv3/workloadendpoint_e2e_test.go
+++ b/libcalico-go/lib/clientv3/workloadendpoint_e2e_test.go
@@ -15,14 +15,13 @@
 package clientv3_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"context"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
@@ -38,7 +37,6 @@ import (
 
 // These tests are not run on KDD since the WEP resource is not a creatable resource.
 var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.DatastoreEtcdV3, func(config apiconfig.CalicoAPIConfig) {
-
 	ctx := context.Background()
 	namespace1 := "namespace-1"
 	namespace2 := "namespace-2"
@@ -105,7 +103,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 
 			By("Updating the WorkloadEndpoint before it is created")
 			_, outError := c.WorkloadEndpoints().Update(ctx, &libapiv3.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: "test-fail-workload-endpoint"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1_1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -118,7 +116,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 
 			By("Attempting to create a new WorkloadEndpoint with name1/spec1_1 and a non-empty ResourceVersion")
 			_, outError = c.WorkloadEndpoints().Create(ctx, &libapiv3.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "12345", CreationTimestamp: metav1.Now(), UID: "test-fail-workload-endpoint"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "12345", CreationTimestamp: metav1.Now(), UID: uid},
 				Spec:       spec1_1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
@@ -212,7 +210,7 @@ var _ = testutils.E2eDatastoreDescribe("WorkloadEndpoint tests", testutils.Datas
 
 			By("Attempting to update the WorkloadEndpoint without a Creation Timestamp")
 			res, outError = c.WorkloadEndpoints().Update(ctx, &libapiv3.WorkloadEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", UID: "test-fail-workload-endpoint"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace1, Name: name1, ResourceVersion: "1234", UID: uid},
 				Spec:       spec1_1,
 			}, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())

--- a/libcalico-go/lib/options/delete.go
+++ b/libcalico-go/lib/options/delete.go
@@ -26,7 +26,6 @@ type DeleteOptions struct {
 	// +optional
 	ResourceVersion string
 
-	// If non-nil and supported by the backend (only KDD WorkloadEndpoints at the time of writing),
-	// only delete the resource if its UID matches.
+	// If non-nil and supported by the backend, only delete the resource if its UID matches.
 	UID *types.UID
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Pick of https://github.com/projectcalico/calico/pull/8586



## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix bug that inhibited garbage collection of Namespaces and ServiceAccounts with OwnerReferences.
```

```release-note
Fix that projectcalico.org/v3 resources with OwnerReferences were unable to be garbage collected due to non-unique UIDs.

Breaking change: On upgrade, the UID of projectcalico.org/v3 resources will change. It is recommended that you restart any controllers that may care about this after upgrading Calico, including the kube-controller-manager.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.