### PR TITLE
Felix test-workload: call cni-plugin DoNetworking

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -283,7 +283,7 @@ blocks:
           - .semaphore/run-and-monitor e2e-test.log make e2e-test
 - name: "Felix: Build"
   run:
-    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/hack/test/certs/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/hack/test/certs/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:
@@ -412,7 +412,7 @@ blocks:
 
 - name: "Felix: FV Tests"
   run:
-    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - "Felix: Build"
   task:
@@ -478,7 +478,7 @@ blocks:
 
 - name: "Felix: BPF UT/FV tests on new kernel"
   run:
-    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:
@@ -511,7 +511,7 @@ blocks:
 
 - name: "Felix: BPF UT/FV tests on new kernel (nftables)"
   run:
-    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -283,7 +283,7 @@ blocks:
           - .semaphore/run-and-monitor e2e-test.log make e2e-test
 - name: "Felix: Build"
   run:
-    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/hack/test/certs/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/hack/test/certs/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:
@@ -412,7 +412,7 @@ blocks:
 
 - name: "Felix: FV Tests"
   run:
-    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - "Felix: Build"
   task:
@@ -478,7 +478,7 @@ blocks:
 
 - name: "Felix: BPF UT/FV tests on new kernel"
   run:
-    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:
@@ -511,7 +511,7 @@ blocks:
 
 - name: "Felix: BPF UT/FV tests on new kernel (nftables)"
   run:
-    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -1,6 +1,6 @@
 - name: "Felix: Build"
   run:
-    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/hack/test/certs/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/hack/test/certs/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:
@@ -129,7 +129,7 @@
 
 - name: "Felix: FV Tests"
   run:
-    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - "Felix: Build"
   task:
@@ -195,7 +195,7 @@
 
 - name: "Felix: BPF UT/FV tests on new kernel"
   run:
-    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:
@@ -228,7 +228,7 @@
 
 - name: "Felix: BPF UT/FV tests on new kernel (nftables)"
   run:
-    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/', '/cni-plugin/pkg/dataplane/linux/dataplane_linux.go'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:

--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -54,9 +54,6 @@ func NewLinuxDataplane(conf types.NetConf, logger *logrus.Entry) *linuxDataplane
 // DoNetworking sets up the network for the container's netns.  It creates the
 // veth pair with one end in the host network namespace and the other in the
 // container's network namespace.  It also sets up addresses and routes.
-//
-// Note: this method is also used by the Felix FV test-workload to create
-// a simulated workload.
 func (d *linuxDataplane) DoNetworking(
 	ctx context.Context,
 	calicoClient calicoclient.Interface,
@@ -68,27 +65,63 @@ func (d *linuxDataplane) DoNetworking(
 	annotations map[string]string,
 ) (hostVethName, contVethMAC string, err error) {
 	hostVethName = desiredVethName
-	contVethName := args.IfName
-	var hasIPv4, hasIPv6 bool
-
 	d.logger.Infof("Setting the host side veth name to %s", hostVethName)
 
 	hostNlHandle, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create host netlink handle: %v", err)
 	}
-
 	defer hostNlHandle.Close()
 
+	contVethMAC, err = d.DoWorkloadNetnsSetUp(
+		hostNlHandle,
+		args.Netns,
+		result.IPs, // Note: DoWorkloadNetnsSetUp updates CIDR masks.
+		args.IfName,
+		hostVethName,
+		routes,
+		annotations,
+	)
+	if err != nil {
+		return "", "", err
+	}
+
+	hostVeth, err := hostNlHandle.LinkByName(hostVethName)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to lookup %q: %v", hostVethName, err)
+	}
+
+	// Add the routes to host veth in the host namespace.
+	err = SetupRoutes(hostNlHandle, hostVeth, result)
+	if err != nil {
+		return "", "", fmt.Errorf("error adding host side routes for interface: %s, error: %s", hostVeth.Attrs().Name, err)
+	}
+
+	return hostVethName, contVethMAC, err
+}
+
+// DoWorkloadNetnsSetUp only sets up the veth and the in-netns routes.
+//
+// Note: this method is also used by the Felix FV test-workload to create
+// a simulated workload.
+func (d *linuxDataplane) DoWorkloadNetnsSetUp(
+	hostNlHandle *netlink.Handle,
+	netnsPath string,
+	ipAddrs []*cniv1.IPConfig,
+	contVethName string,
+	hostVethName string,
+	routes []*net.IPNet,
+	annotations map[string]string,
+) (contVethMAC string, err error) {
 	// Clean up if hostVeth exists.
 	if oldHostVeth, err := hostNlHandle.LinkByName(hostVethName); err == nil {
 		if err = hostNlHandle.LinkDel(oldHostVeth); err != nil {
-			return "", "", fmt.Errorf("failed to delete old hostVeth %v: %v", hostVethName, err)
+			return "", fmt.Errorf("failed to delete old hostVeth %v: %v", hostVethName, err)
 		}
 		d.logger.Infof("Cleaning old hostVeth: %v", hostVethName)
 	}
 
-	err = ns.WithNetNSPath(args.Netns, func(hostNS ns.NetNS) error {
+	err = ns.WithNetNSPath(netnsPath, func(hostNS ns.NetNS) error {
 		la := netlink.NewLinkAttrs()
 		la.Name = contVethName
 		la.MTU = d.mtu
@@ -122,7 +155,8 @@ func (d *linuxDataplane) DoNetworking(
 		}
 
 		// Figure out whether we have IPv4 and/or IPv6 addresses.
-		for _, addr := range result.IPs {
+		var hasIPv4, hasIPv6 bool
+		for _, addr := range ipAddrs {
 			if addr.Address.IP.To4() != nil {
 				hasIPv4 = true
 				addr.Address.Mask = net.CIDRMask(32, 32)
@@ -290,7 +324,7 @@ func (d *linuxDataplane) DoNetworking(
 		}
 
 		// Now add the IPs to the container side of the veth.
-		for _, addr := range result.IPs {
+		for _, addr := range ipAddrs {
 			if err = netlink.AddrAdd(contVeth, &netlink.Addr{IPNet: &addr.Address}); err != nil {
 				return fmt.Errorf("failed to add IP addr to %q: %v", contVeth, err)
 			}
@@ -305,21 +339,10 @@ func (d *linuxDataplane) DoNetworking(
 
 	if err != nil {
 		d.logger.Errorf("Error creating veth: %s", err)
-		return "", "", err
+		return "", err
 	}
 
-	hostVeth, err := hostNlHandle.LinkByName(hostVethName)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to lookup %q: %v", hostVethName, err)
-	}
-
-	// Add the routes to host veth in the host namespace.
-	err = SetupRoutes(hostNlHandle, hostVeth, result)
-	if err != nil {
-		return "", "", fmt.Errorf("error adding host side routes for interface: %s, error: %s", hostVeth.Attrs().Name, err)
-	}
-
-	return hostVethName, contVethMAC, err
+	return
 }
 
 func disableDAD(contVethName string) error {

--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -51,6 +51,12 @@ func NewLinuxDataplane(conf types.NetConf, logger *logrus.Entry) *linuxDataplane
 	}
 }
 
+// DoNetworking sets up the network for the container's netns.  It creates the
+// veth pair with one end in the host network namespace and the other in the
+// container's network namespace.  It also sets up addresses and routes.
+//
+// Note: this method is also used by the Felix FV test-workload to create
+// a simulated workload.
 func (d *linuxDataplane) DoNetworking(
 	ctx context.Context,
 	calicoClient calicoclient.Interface,

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -466,13 +466,12 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 					ensureBPFProgramsAttachedOffsetWithIPVersion(1, f, false, true, "eth0")
 				}
 
-				felixReady := func(f *infrastructure.Felix) int {
-					return healthStatus("["+f.IPv6+"]", "9099", "readiness")
-				}
-
 				for _, f := range tc.Felixes {
-					Eventually(felixReady(f), "10s", "330ms").Should(BeGood())
-					Consistently(felixReady(f), "10s", "1s").Should(BeGood())
+					felixReady := func() int {
+						return healthStatus("["+f.IPv6+"]", "9099", "readiness")
+					}
+					Eventually(felixReady, "10s", "330ms").Should(BeGood())
+					Consistently(felixReady, "10s", "1s").Should(BeGood())
 				}
 
 				cc.Expect(None, w[0][1], w[0][0])
@@ -502,13 +501,12 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 					ensureBPFProgramsAttachedOffsetWithIPVersion(1, f, true, false, "eth0")
 				}
 
-				felixReady := func(f *infrastructure.Felix) int {
-					return healthStatus(f.IP, "9099", "readiness")
-				}
-
 				for _, f := range tc.Felixes {
-					Eventually(felixReady(f), "10s", "330ms").Should(BeGood())
-					Consistently(felixReady(f), "10s", "1s").Should(BeGood())
+					felixReady := func() int {
+						return healthStatus(f.IP, "9099", "readiness")
+					}
+					Eventually(felixReady, "10s", "330ms").Should(BeGood())
+					Consistently(felixReady, "10s", "1s").Should(BeGood())
 				}
 
 				cc.Expect(None, w[0][1], w[0][0], ExpectWithIPVersion(6))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1236,12 +1236,11 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			Expect(err).NotTo(HaveOccurred())
 			if !options.TestManagesBPF {
 				ensureAllNodesBPFProgramsAttached(tc.Felixes)
-				felixReady := func(f *infrastructure.Felix) int {
-					return healthStatus(containerIP(f.Container), "9099", "readiness")
-				}
-
 				for _, f := range tc.Felixes {
-					Eventually(felixReady(f), "10s", "500ms").Should(BeGood())
+					felixReady := func() int {
+						return healthStatus(containerIP(f.Container), "9099", "readiness")
+					}
+					Eventually(felixReady, "10s", "500ms").Should(BeGood())
 				}
 			}
 		}

--- a/felix/fv/health_test.go
+++ b/felix/fv/health_test.go
@@ -355,7 +355,7 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 		})
 
 		It("typha should not report live", func() {
-			Consistently(typhaLiveness(), "10s", "1s").ShouldNot(BeGood())
+			Consistently(typhaLiveness, "10s", "1s").ShouldNot(BeGood())
 		})
 	})
 

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -40,6 +40,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/cgroup"
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/utils"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 const usage = `test-workload, test workload for Felix FV testing.
@@ -52,6 +53,7 @@ Usage:
 
 func main() {
 	log.SetLevel(log.DebugLevel)
+	logutils.ConfigureFormatter("test-workload")
 
 	// If we've been told to, move into this felix's cgroup.
 	cgroup.MaybeMoveToFelixCgroupv2()

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -16,29 +16,30 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
-	"golang.org/x/sys/unix"
-
-	"github.com/projectcalico/calico/felix/fv/cgroup"
-	"github.com/projectcalico/calico/felix/fv/connectivity"
-	"github.com/projectcalico/calico/felix/fv/utils"
-
+	"github.com/containernetworking/cni/pkg/skel"
+	cniv1 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	nsutils "github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/docopt/docopt-go"
 	"github.com/ishidawataru/sctp"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+
+	"github.com/projectcalico/calico/cni-plugin/pkg/dataplane/linux"
+	"github.com/projectcalico/calico/cni-plugin/pkg/types"
+	"github.com/projectcalico/calico/felix/fv/cgroup"
+	"github.com/projectcalico/calico/felix/fv/connectivity"
+	"github.com/projectcalico/calico/felix/fv/utils"
 )
 
 const usage = `test-workload, test workload for Felix FV testing.
@@ -46,7 +47,7 @@ const usage = `test-workload, test workload for Felix FV testing.
 If <interface-name> is "", the workload will start in the current namespace.
 
 Usage:
-  test-workload [--protocol=<protocol>] [--namespace-path=<path>] [--sidecar-iptables] [--up-lo] [--mtu=<mtu>] [--listen-any-ip] <interface-name> <ip-address> <ports>
+  test-workload [--protocol=<protocol>] [--namespace-path=<path>] [--sidecar-iptables] [--mtu=<mtu>] [--listen-any-ip] <interface-name> <ip-address> <ports>
 `
 
 func main() {
@@ -69,7 +70,6 @@ func main() {
 		nsPath = arg.(string)
 	}
 	sidecarIptables := arguments["--sidecar-iptables"].(bool)
-	upLo := arguments["--up-lo"].(bool)
 	mtu := 1450
 	if arg, ok := arguments["--mtu"]; ok && arg != nil {
 		mtu, err = strconv.Atoi(arg.(string))
@@ -115,179 +115,75 @@ func main() {
 				log.WithError(err).Panic("Giving up after multiple retries")
 			}
 		}
-		log.WithField("namespace", namespace).Debug("Created namespace")
+		log.WithField("namespace", namespace.Path()).Debug("Created namespace")
 
-		peerName := "w" + interfaceName
-		if len(peerName) > 11 {
-			peerName = peerName[:11]
+		conf := types.NetConf{
+			MTU:       mtu,
+			NumQueues: 1,
 		}
-		// Create a veth pair.
-		la := netlink.NewLinkAttrs()
-		la.Name = interfaceName
-		la.MTU = mtu
-		veth := &netlink.Veth{
-			LinkAttrs: la,
-			PeerName:  peerName,
+		dp := linux.NewLinuxDataplane(conf, log.WithField("ns", namespace.Path()))
+		hostVethName := interfaceName
+		args := skel.CmdArgs{
+			IfName: "eth0",
+			Netns:  namespace.Path(),
 		}
-		err = netlink.LinkAdd(veth)
-		panicIfError(err)
-		log.WithField("veth", veth).Debug("Created veth pair")
-
-		err := netlink.LinkSetUp(veth)
-		panicIfError(err)
-
-		peerVeth, err := netlink.LinkByName(veth.PeerName)
-		panicIfError(err)
-
-		// Need to set the peer up in order to get an IPv6 address.
-		err = netlink.LinkSetUp(peerVeth)
-		panicIfError(err)
-
-		var hostIPv6Addr net.IP
-
+		var addrs []*cniv1.IPConfig
+		if ipv4Addr != "" {
+			addrs = append(addrs, &cniv1.IPConfig{
+				Address: net.IPNet{
+					IP:   net.ParseIP(ipv4Addr),
+					Mask: net.CIDRMask(32, 32),
+				},
+			})
+		}
 		if ipv6Addr != "" {
-			attempts := 0
-			for {
-				// No need to add a dummy next hop route as the host veth device will already have an IPv6
-				// link local address that can be used as a next hop.
-				// Just fetch the address of the host end of the veth and use it as the next hop.
-				addresses, err := netlink.AddrList(veth, netlink.FAMILY_V6)
-				if err != nil && !errors.Is(err, unix.EINTR) {
-					log.WithError(err).Panic("Error listing IPv6 addresses for the host side of the veth pair")
-				}
-
-				if len(addresses) < 1 {
-					attempts++
-					if attempts > 30 {
-						log.WithError(err).Panic("Giving up waiting for IPv6 addresses after multiple retries")
-					}
-
-					time.Sleep(100 * time.Millisecond)
-					continue
-				}
-
-				hostIPv6Addr = addresses[0].IP
-				break
-			}
+			addrs = append(addrs, &cniv1.IPConfig{
+				Address: net.IPNet{
+					IP:   net.ParseIP(ipv6Addr),
+					Mask: net.CIDRMask(128, 128),
+				},
+			})
 		}
-
-		// Move the workload end of the pair into the namespace, and set it up.
-		workloadIf, err := netlink.LinkByName(veth.PeerName)
-		log.WithField("workloadIf", workloadIf).Debug("Workload end")
+		result := cniv1.Result{
+			IPs: addrs,
+		}
+		_, v4Default, err := net.ParseCIDR("0.0.0.0/0")
 		panicIfError(err)
-		err = netlink.LinkSetNsFd(workloadIf, int(namespace.Fd()))
+		_, v6Default, err := net.ParseCIDR("::/0")
 		panicIfError(err)
-		err = namespace.Do(func(_ ns.NetNS) (err error) {
-			err = utils.RunCommand("ip", "link", "set", veth.PeerName, "name", "eth0")
-			if err != nil {
-				return
-			}
-			err = utils.RunCommand("ip", "link", "set", "eth0", "up")
-			if err != nil {
-				return
-			}
-
-			err = utils.RunCommand("ip", "link", "set", "dev", "lo", "up")
-			if err != nil {
-				log.WithError(err).Info("Failed to set dev lo up")
-			}
-
-			if ipv6Addr != "" {
-				// Make sure ipv6 is enabled in the container/pod network namespace.
-				// Without these sysctls enabled, interfaces will come up but they won't get a link local IPv6 address,
-				// which is required to add the default IPv6 route.
-				if err = writeProcSys("/proc/sys/net/ipv6/conf/all/disable_ipv6", "0"); err != nil {
-					log.WithError(err).Error("Failed to enable IPv6.")
-					return
-				}
-
-				if err = writeProcSys("/proc/sys/net/ipv6/conf/default/disable_ipv6", "0"); err != nil {
-					log.WithError(err).Error("Failed to enable IPv6 by default.")
-					return
-				}
-
-				if err = writeProcSys("/proc/sys/net/ipv6/conf/lo/disable_ipv6", "0"); err != nil {
-					log.WithError(err).Error("Failed to enable IPv6 on the loopback interface.")
-					return
-				}
-
-				err = utils.RunCommand("ip", "-6", "addr", "add", ipv6Addr+"/128", "dev", "eth0")
-				if err != nil {
-					log.WithField("ipAddress", ipv6Addr+"/128").WithError(err).Error("Failed to add IPv6 addr to eth0.")
-					return
-				}
-				err = utils.RunCommand("ip", "-6", "route", "add", "default", "via", hostIPv6Addr.String(), "dev", "eth0")
-				if err != nil {
-					log.WithField("hostIP", hostIPv6Addr.String()).WithError(err).Info("Failed to add IPv6 route to eth0.")
-					return
-				}
-
-				// Output the routing table to the log for diagnostic purposes.
-				err = utils.RunCommand("ip", "-6", "route")
-				if err != nil {
-					log.WithError(err).Info("Failed to output IPv6 routes.")
-				}
-				err = utils.RunCommand("ip", "-6", "addr")
-				if err != nil {
-					log.WithError(err).Info("Failed to output IPv6 addresses.")
-				}
-			}
-			if ipv4Addr != "" {
-				err = utils.RunCommand("ip", "addr", "add", ipv4Addr+"/32", "dev", "eth0")
-				if err != nil {
-					log.WithField("ipAddress", ipv4Addr+"/32").WithError(err).Error("Failed to add IPv4 addr to eth0.")
-					return
-				}
-				err = utils.RunCommand("ip", "route", "add", "169.254.169.254/32", "dev", "eth0")
-				if err != nil {
-					log.WithField("hostIP", hostIPv6Addr.String()).WithError(err).Info("Failed to add IPv4 route to eth0.")
-					return
-				}
-				err = utils.RunCommand("ip", "route", "add", "default", "via", "169.254.169.254", "dev", "eth0")
-				if err != nil {
-					log.WithField("hostIP", hostIPv6Addr.String()).WithError(err).Info("Failed to add default route to eth0.")
-					return
-				}
-
-				// Output the routing table to the log for diagnostic purposes.
-				err = utils.RunCommand("ip", "route")
-				if err != nil {
-					log.WithError(err).Info("Failed to output IPv4 routes.")
-					return
-				}
-				err = utils.RunCommand("ip", "addr")
-				if err != nil {
-					log.WithError(err).Info("Failed to output IPv4 addresses.")
-					return
-				}
-			}
-			return
-		})
-		panicIfError(err)
-
-		// Set the host end up too.
-		hostIf, err := netlink.LinkByName(veth.LinkAttrs.Name)
-		log.WithField("hostIf", hostIf).Debug("Host end")
-		panicIfError(err)
-		err = netlink.LinkSetUp(hostIf)
+		routes := []*net.IPNet{
+			v4Default,
+			v6Default, // Only used if we end up adding a v6 address.
+		}
+		_, _, err = dp.DoNetworking(
+			context.TODO(),
+			nil,
+			&args,
+			&result,
+			hostVethName,
+			routes,
+			nil,
+			nil,
+		)
 		panicIfError(err)
 	} else {
 		namespace, err = ns.GetCurrentNS()
 		panicIfError(err)
 	}
 
-	// Print out the namespace path, so that test code can pick it up and execute subsequent
-	// operations in the same namespace - which (in the context of this FV framework)
-	// effectively means _as_ this workload.
-	fmt.Println(namespace.Path())
-
 	// Now listen on the specified ports in the workload namespace.
 	err = namespace.Do(func(_ ns.NetNS) error {
-		if upLo {
-			if err := utils.RunCommand("ip", "link", "set", "lo", "up"); err != nil {
-				return fmt.Errorf("failed to bring loopback up: %v", err)
+		if interfaceName != "" {
+			lo, err := netlink.LinkByName("lo")
+			if err != nil {
+				return fmt.Errorf("failed to look up 'lo' inside netns: %w", err)
+			}
+			err = netlink.LinkSetUp(lo)
+			if err != nil {
+				return fmt.Errorf("failed bring 'lo' up inside netns: %w", err)
 			}
 		}
+
 		if sidecarIptables {
 			if err := doSidecarIptablesSetup(); err != nil {
 				return fmt.Errorf("failed to setup sidecar-like iptables: %v", err)
@@ -309,6 +205,11 @@ func main() {
 				break
 			}
 		}
+
+		// Print out the namespace path, so that test code can pick it up and execute subsequent
+		// operations in the same namespace - which (in the context of this FV framework)
+		// effectively means _as_ this workload.
+		fmt.Println(namespace.Path())
 
 		handleRequest := func(conn net.Conn) {
 			log.WithFields(log.Fields{
@@ -542,22 +443,6 @@ func panicIfError(err error) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-// writeProcSys takes the sysctl path and a string value to set i.e. "0" or "1" and sets the sysctl.
-func writeProcSys(path, value string) error {
-	f, err := os.OpenFile(path, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	n, err := f.Write([]byte(value))
-	if err == nil && n < len(value) {
-		err = io.ErrShortWrite
-	}
-	if err1 := f.Close(); err == nil {
-		err = err1
-	}
-	return err
 }
 
 // doSidecarIptablesSetup generates some iptables rules to redirect a

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -600,7 +600,6 @@ func startSideService(w *Workload) (*SideService, error) {
 	}
 	testWorkloadShArgs = append(testWorkloadShArgs,
 		"--sidecar-iptables",
-		"--up-lo",
 		fmt.Sprintf("'--namespace-path=%s'", w.namespacePath),
 		"''", // interface name, not important
 		"127.0.0.1",

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -278,7 +278,7 @@ func (w *Workload) Start() error {
 				log.WithError(err).Info("End of workload stderr")
 				return
 			}
-			log.Infof("Workload %s stderr: %s", w.Name, strings.TrimSpace(string(line)))
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%v[stderr] %v\n", w.Name, line)
 		}
 	}()
 
@@ -296,6 +296,7 @@ func (w *Workload) Start() error {
 		defer errDone.Wait()
 		return fmt.Errorf("reading from stdout failed: %w", err)
 	}
+	log.WithField("workload", w.Name).Infof("Workload namespace path: %s", namespacePath)
 
 	w.namespacePath = strings.TrimSpace(namespacePath)
 
@@ -306,7 +307,7 @@ func (w *Workload) Start() error {
 				log.WithError(err).Info("End of workload stdout")
 				return
 			}
-			log.Infof("Workload %s stdout: %s", w.Name, strings.TrimSpace(string(line)))
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%v[stdout] %v\n", w.Name, line)
 		}
 	}()
 

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -278,7 +278,7 @@ func (w *Workload) Start() error {
 				log.WithError(err).Info("End of workload stderr")
 				return
 			}
-			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%v[stderr] %v\n", w.Name, line)
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%v[stderr] %v", w.Name, line)
 		}
 	}()
 
@@ -307,7 +307,7 @@ func (w *Workload) Start() error {
 				log.WithError(err).Info("End of workload stdout")
 				return
 			}
-			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%v[stdout] %v\n", w.Name, line)
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%v[stdout] %v", w.Name, line)
 		}
 	}()
 


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
`test-workload` was setting up the netns in a different order to the CNI plugin, resulting in the interface flapping down->up->down->up.  To avoid that, call through to the real CNI code.  This has the bonus of giving that code more of a workout, and the disadvantage that it ties Felix tests to a bit of CNI-plugin internal code.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
