### PR TITLE
[release-v3.28] Auto pick #9192: traffic from host should return through host

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -938,6 +938,22 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						cc.ResetExpectations()
 					}
 				})
+
+				It("should respond back to host is the original traffic came from the host", func() {
+					if testOpts.ipv6 {
+						return
+					}
+
+					By("Setting up istio-like rules that SNAT host as link-local IP")
+
+					tc.Felixes[0].Exec("iptables", "-t", "nat", "-A", "POSTROUTING", "-d", w[0].IP, "-j",
+						"SNAT", "--to-source", "169.254.7.127")
+
+					By("Testing connectivity from host to pod")
+
+					cc.Expect(Some, hostW, w[0], ExpectWithSrcIPs("169.254.7.127"))
+					cc.CheckConnectivity()
+				})
 			}
 
 			if testOpts.nonProtoTests {


### PR DESCRIPTION
Cherry pick of #9192 on release-v3.28.

#9192: traffic from host should return through host

# Original PR Body below

Anything that has not been seen bofore arriving on the WEP is clearly from the host and so we should return any responses through the host as well.

This also effectively disables conntrack bypass for traffic that is returning from a workload to a pod. This allow returning traffic to go through iptables rules that previously could have affected inbound traffic - similar rules like the ones inject by Istion in ambient mode.

fixes https://github.com/projectcalico/calico/issues/9157

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Fix for Istion ambient mode - traffic that arrives from host should go back through host and not skip iptables
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.