### PR TITLE
Bump flannel to v0.24.4

### DIFF
--- a/charts/calico/values.yaml
+++ b/charts/calico/values.yaml
@@ -14,7 +14,7 @@ kubeControllers:
   image: docker.io/calico/kube-controllers
 flannel:
   image: docker.io/flannel/flannel
-  tag: v0.24.3
+  tag: v0.24.4
 flannelMigration:
   image: docker.io/calico/flannel-migration
 dikastes:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -610,7 +610,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: docker.io/flannel/flannel:v0.24.3
+          image: docker.io/flannel/flannel:v0.24.4
           imagePullPolicy: IfNotPresent
           env:
             # The location of the etcd cluster.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -5157,7 +5157,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: docker.io/flannel/flannel:v0.24.3
+          image: docker.io/flannel/flannel:v0.24.4
           imagePullPolicy: IfNotPresent
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:


### PR DESCRIPTION
## Description

Flannel `v0.24.3` has a bug where it creates ipv6 masking rules when ipvs6 is disabled. This will cause kube-flannel to constantly log the following. This issue was resolved in flannel `v0.24.4`.

* https://github.com/flannel-io/flannel/releases/tag/v0.24.3

```bash
kubectl -n kube-system logs -c kube-flannel canal-vvt9q
...
I0903 21:56:26.989480       1 iptables.go:503] Some iptables rules are missing; deleting and recreating rules
E0903 21:56:27.030919       1 iptables.go:440] Failed to ensure iptables rules: error setting up rules: failed to apply partial iptables-restore unable to run iptables-restore (, ): exit status 4
I0903 21:56:32.048045       1 iptables.go:503] Some iptables rules are missing; deleting and recreating rules
E0903 21:56:32.238407       1 iptables.go:440] Failed to ensure iptables rules: error setting up rules: failed to apply partial iptables-restore unable to run iptables-restore (, ): exit status 4

```

```release-note
Update flannel to version v0.24.4
```

## Related issues/PRs

fixes: 
- https://github.com/flannel-io/flannel/issues/1906
- https://github.com/flannel-io/flannel/issues/1913
