### PR TITLE
Use restricted namespace for calico-apiserver

### DIFF
--- a/manifests/ocp/00-namespace-calico-apiserver.yaml
+++ b/manifests/ocp/00-namespace-calico-apiserver.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     name: calico-apiserver
     security.openshift.io/scc.podSecurityLabelSync: "false"
-    pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
## Description

- the opensource calico-apiserver is now running as a non-root container, however the calico-apiserver namespace has privileged labels which is not necessary
- the calico-apiserver pods are happy with the restricted namespace label, so update the OCP templates

## Related issues/PRs

related operator change
https://github.com/tigera/operator/pull/3489

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Use restricted pod security standard on calico-apiserver namespace in manifests for OCP
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
