### PR TITLE
[release tool] hashrelease: fix sending images to ISS

### DIFF
--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -71,7 +71,7 @@ func imgExists(name string, component hashrelease.Component, ch chan imageExists
 // HashreleaseValidate validates the images in the hashrelease.
 // These images are checked to ensure they exist in the registry
 // as they should have been pushed in the standard build process.
-func HashreleaseValidate(cfg *config.Config, sendImagestoISS bool) {
+func HashreleaseValidate(cfg *config.Config, skipISS bool) {
 	tmpDir := cfg.TmpFolderPath()
 	name, err := hashrelease.RetrieveReleaseName(tmpDir)
 	if err != nil {
@@ -143,7 +143,8 @@ func HashreleaseValidate(cfg *config.Config, sendImagestoISS bool) {
 		logrus.WithField("images", strings.Join(failedImageNames, ", ")).
 			Fatalf("Failed to validate %d images, see above for details", failedCount)
 	}
-	if sendImagestoISS {
+	if !skipISS {
+		logrus.Info("Sending images to ISS")
 		imageList := []string{}
 		for _, component := range images {
 			imageList = append(imageList, component.String())


### PR DESCRIPTION
## Description

This fixes sending image scan to ISS. The skip flag was misinterpreted and scans were not getting sent.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
