### PR TITLE
[release tool] halt hash release process early if already published

### DIFF
--- a/release/build/main.go
+++ b/release/build/main.go
@@ -138,8 +138,11 @@ func hashreleaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) [
 					tasks.PreReleaseValidate(cfg)
 				}
 
-				// Create the pinned-version.yaml file and extract the versions.
-				ver, operatorVer := tasks.PinnedVersion(cfg)
+				// Create the pinned-version.yaml file and extract the versions and hash.
+				ver, operatorVer, hash := tasks.PinnedVersion(cfg)
+
+				// Check if the hashrelease has already been published.
+				tasks.CheckIfHashReleasePublished(cfg, hash)
 
 				// Build the operator.
 				tasks.OperatorHashreleaseBuild(runner, cfg)


### PR DESCRIPTION
## Description

This make the process exist early so we do not end up with dangling (_soemwhat_ duplicate) operator images or taking up time building the release

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
