### PR TITLE
Ignore empty CIDRs in BGPConfiguration

### DIFF
--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1266,9 +1266,13 @@ func (c *client) getServiceExternalIPsKVPair(v3res *apiv3.BGPConfiguration, key 
 	if v3res != nil && v3res.Spec.ServiceExternalIPs != nil && len(v3res.Spec.ServiceExternalIPs) != 0 {
 		// We wrap each Service external IP in a ServiceExternalIPBlock struct to
 		// achieve the desired API structure, unpack that.
-		ipCidrs := make([]string, len(v3res.Spec.ServiceExternalIPs))
-		for i, ipBlock := range v3res.Spec.ServiceExternalIPs {
-			ipCidrs[i] = ipBlock.CIDR
+		ipCidrs := make([]string, 0, len(v3res.Spec.ServiceExternalIPs))
+		for _, ipBlock := range v3res.Spec.ServiceExternalIPs {
+			if ipBlock.CIDR == "" {
+				// The CRD allows CIDR to be optional so we just ignore empty CIDRs.
+				continue
+			}
+			ipCidrs = append(ipCidrs, ipBlock.CIDR)
 		}
 		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(svcExternalIPKey, strings.Join(ipCidrs, ",")))
 	} else {
@@ -1281,9 +1285,13 @@ func (c *client) getServiceLoadBalancerIPsKVPair(v3res *apiv3.BGPConfiguration, 
 	svcLoadBalancerIPKey := getBGPConfigKey("svc_loadbalancer_ips", key)
 
 	if v3res != nil && v3res.Spec.ServiceLoadBalancerIPs != nil && len(v3res.Spec.ServiceLoadBalancerIPs) != 0 {
-		ipCidrs := make([]string, len(v3res.Spec.ServiceLoadBalancerIPs))
-		for i, ipBlock := range v3res.Spec.ServiceLoadBalancerIPs {
-			ipCidrs[i] = ipBlock.CIDR
+		ipCidrs := make([]string, 0, len(v3res.Spec.ServiceLoadBalancerIPs))
+		for _, ipBlock := range v3res.Spec.ServiceLoadBalancerIPs {
+			if ipBlock.CIDR == "" {
+				// The CRD allows CIDR to be optional so we just ignore empty CIDRs.
+				continue
+			}
+			ipCidrs = append(ipCidrs, ipBlock.CIDR)
 		}
 		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(svcLoadBalancerIPKey, strings.Join(ipCidrs, ",")))
 	} else {
@@ -1304,9 +1312,13 @@ func (c *client) getServiceClusterIPsKVPair(v3res *apiv3.BGPConfiguration, key i
 		if v3res != nil && v3res.Spec.ServiceClusterIPs != nil && len(v3res.Spec.ServiceClusterIPs) != 0 {
 			// We wrap each Service Cluster IP in a ServiceClusterIPBlock to
 			// achieve the desired API structure. This unpacks that.
-			ipCidrs := make([]string, len(v3res.Spec.ServiceClusterIPs))
-			for i, ipBlock := range v3res.Spec.ServiceClusterIPs {
-				ipCidrs[i] = ipBlock.CIDR
+			ipCidrs := make([]string, 0, len(v3res.Spec.ServiceClusterIPs))
+			for _, ipBlock := range v3res.Spec.ServiceClusterIPs {
+				if ipBlock.CIDR == "" {
+					// The CRD allows CIDR to be optional so we just ignore empty CIDRs.
+					continue
+				}
+				ipCidrs = append(ipCidrs, ipBlock.CIDR)
 			}
 			c.updateCache(api.UpdateTypeKVUpdated, getKVPair(svcInternalIPKey, strings.Join(ipCidrs, ",")))
 		} else {

--- a/confd/tests/mock_data/calicoctl/mesh/static-routes/input.yaml
+++ b/confd/tests/mock_data/calicoctl/mesh/static-routes/input.yaml
@@ -5,9 +5,11 @@ metadata:
 spec:
   serviceClusterIPs:
   - cidr: 10.101.0.0/16
+  - {}
   - cidr: fd00:96::/112
   serviceLoadBalancerIPs:
   - cidr: 80.15.0.0/24
+  - {}
 
 ---
 

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -968,12 +968,27 @@ func (buf *EventSequencer) OnGlobalBGPConfigUpdate(cfg *v3.BGPConfiguration) {
 	buf.pendingGlobalBGPConfig = &proto.GlobalBGPConfigUpdate{}
 	if cfg != nil {
 		for _, block := range cfg.Spec.ServiceClusterIPs {
+			if block.CIDR == "" {
+				// When we defined the CRD we allowed this field to be optional
+				// for extensibility, ignore empty CIDRs.
+				continue
+			}
 			buf.pendingGlobalBGPConfig.ServiceClusterCidrs = append(buf.pendingGlobalBGPConfig.ServiceClusterCidrs, block.CIDR)
 		}
 		for _, block := range cfg.Spec.ServiceExternalIPs {
+			if block.CIDR == "" {
+				// When we defined the CRD we allowed this field to be optional
+				// for extensibility, ignore empty CIDRs.
+				continue
+			}
 			buf.pendingGlobalBGPConfig.ServiceExternalCidrs = append(buf.pendingGlobalBGPConfig.ServiceExternalCidrs, block.CIDR)
 		}
 		for _, block := range cfg.Spec.ServiceLoadBalancerIPs {
+			if block.CIDR == "" {
+				// When we defined the CRD we allowed this field to be optional
+				// for extensibility, ignore empty CIDRs.
+				continue
+			}
 			buf.pendingGlobalBGPConfig.ServiceLoadbalancerCidrs = append(buf.pendingGlobalBGPConfig.ServiceLoadbalancerCidrs, block.CIDR)
 		}
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The validation for BGPConfiguration is a bit loose and it allows for CIDRs to be omitted.  Handle that gracefully on the read side.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CI-1626
CORE-10663

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ignore empty CIDRs specified in the BGPConfiguration.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
