### PR TITLE
Add configuration for publishing a release in parts

### DIFF
--- a/release/build/main.go
+++ b/release/build/main.go
@@ -38,6 +38,11 @@ const (
 	skipValidationFlag = "skip-validation"
 	skipImageScanFlag  = "skip-image-scan"
 	publishBranchFlag  = "git-publish"
+
+	// Configuration flags for the release publish command.
+	publishImagesFlag    = "publish-images"
+	publishGitTag        = "publish-git-tag"
+	publishGithubRelease = "publish-github-release"
 )
 
 var (
@@ -303,6 +308,11 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 		{
 			Name:  "publish",
 			Usage: "Publish a pre-built Calico release",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: publishImagesFlag, Usage: "Publish container images to release registry", Value: true},
+				&cli.BoolFlag{Name: publishGitTag, Usage: "Publish tag to git repository", Value: true},
+				&cli.BoolFlag{Name: publishGithubRelease, Usage: "Publish release to Github", Value: true},
+			},
 			Action: func(c *cli.Context) error {
 				configureLogging("release-publish.log")
 				ver, operatorVer, err := version.VersionsFromManifests(cfg.RepoRootDir)
@@ -313,6 +323,7 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 					builder.WithRepoRoot(cfg.RepoRootDir),
 					builder.WithVersions(ver.FormattedString(), operatorVer.FormattedString()),
 					builder.WithOutputDir(filepath.Join(baseUploadDir, ver.FormattedString())),
+					builder.WithPublishOptions(c.Bool(publishImagesFlag), c.Bool(publishGitTag), c.Bool(publishGithubRelease)),
 				}
 				r := builder.NewReleaseBuilder(opts...)
 				return r.PublishRelease()

--- a/release/pkg/builder/builder.go
+++ b/release/pkg/builder/builder.go
@@ -53,6 +53,7 @@ func NewReleaseBuilder(opts ...Option) *ReleaseBuilder {
 		publishImages: true,
 		publishTag:    true,
 		publishGithub: true,
+		buildImages:   true,
 	}
 
 	// Run through provided options.
@@ -89,6 +90,9 @@ type ReleaseBuilder struct {
 
 	// isHashRelease is a flag to indicate that we should build a hashrelease.
 	isHashRelease bool
+
+	// buildImages controls whether we should build container images, or use ones already built by CI.
+	buildImages bool
 
 	// validate is a flag to indicate that we should skip pre-release validation.
 	validate bool
@@ -161,11 +165,13 @@ func (r *ReleaseBuilder) Build() error {
 				}
 			}
 		}()
+	}
 
-		// Build the container images for the release.
+	if r.buildImages {
+		// Build the container images for the release if configured to do so.
 		//
-		// Note: hashreleases don't currently build container images - instead, they use the images
-		// already published as part of CI.
+		// If skipped, we expect that the images for this version have already
+		// been published as part of CI.
 		if err = r.BuildContainerImages(ver); err != nil {
 			return err
 		}

--- a/release/pkg/builder/options.go
+++ b/release/pkg/builder/options.go
@@ -51,3 +51,12 @@ func WithOutputDir(outputDir string) Option {
 		return nil
 	}
 }
+
+func WithPublishOptions(images, tag, github bool) Option {
+	return func(r *ReleaseBuilder) error {
+		r.publishImages = images
+		r.publishTag = tag
+		r.publishGithub = github
+		return nil
+	}
+}

--- a/release/pkg/builder/options.go
+++ b/release/pkg/builder/options.go
@@ -60,3 +60,10 @@ func WithPublishOptions(images, tag, github bool) Option {
 		return nil
 	}
 }
+
+func WithBuildImages(buildImages bool) Option {
+	return func(r *ReleaseBuilder) error {
+		r.buildImages = buildImages
+		return nil
+	}
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

First step towards making various parts of the release / publish
configurable. 

Adding some default "true" options to disable publishing certain parts
of a release will be helpful for developers, or release team if they
need to update just one part of a release.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.