### PR TITLE
log csidriver root error when failing to retrieve pod info

### DIFF
--- a/pod2daemon/csidriver/driver/node.go
+++ b/pod2daemon/csidriver/driver/node.go
@@ -106,8 +106,8 @@ func (ns *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnp
 	// Inspect the file stored at /var/run/nodeagent/creds/volumeID for the pod info
 	podInfo, err := ns.retrievePodInfoFromFile(req.VolumeId)
 	if err != nil {
-		log.Error("Unable to retrieve pod info")
-		return nil, status.Error(codes.Internal, "Unable to retrieve pod info")
+		log.WithError(err).Error("Unable to retrieve pod info")
+		return nil, status.Errorf(codes.Internal, "Unable to retrieve pod info: %s", err)
 	}
 
 	// Unmount the relevant directories at the TargetPath


### PR DESCRIPTION
## Description

log csidriver root error when failing to retrieve pod info

## Related issues/PRs

CI-1590 / CORE-10679


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
