### PR TITLE
Various fixes to (hash)release builder

### DIFF
--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -280,7 +280,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)-fips LATEST_IMAGE_TAG=latest-fips
 	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
-	$(MAKE) release-verify
 	touch $@
 
 ## Verifies the release artifacts produces by `make release-build` are correct.
@@ -305,7 +304,7 @@ release-verify-fips:
 	go tool nm .tmp/calico | grep '_Cfunc__goboringcrypto_' 1> /dev/null || echo "ERROR: Binary in image '$(IMAGE)' is missing expected goboring symbols"
 	rm -rf .tmp
 
-release-publish: release-prereqs .release-$(VERSION).published
+release-publish: release-prereqs release-verify .release-$(VERSION).published
 .release-$(VERSION).published:
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	$(MAKE) FIPS=true push-images-to-registries push-manifests IMAGETAG=$(VERSION)-fips RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
@@ -317,7 +316,7 @@ release-publish: release-prereqs .release-$(VERSION).published
 # WARNING: Only run this target if this release is the latest stable release. Do NOT
 # run this target for alpha / beta / release candidate builds, or patches to earlier Calico versions.
 ## Pushes `latest` release images. WARNING: Only run this for latest stable releases.
-release-publish-latest: release-prereqs
+release-publish-latest: release-prereqs release-verify
 	# Check latest versions match.
 	if ! docker run $(CNI_PLUGIN_IMAGE):latest-$(ARCH) calico -v | grep '^$(VERSION)$$'; then echo "Reported version:" `docker run $(CNI_PLUGIN_IMAGE):latest-$(ARCH) calico -v` "\nExpected version: $(VERSION)"; false; else echo "\nVersion check passed\n"; fi
 	if ! docker run quay.io/$(CNI_PLUGIN_IMAGE):latest-$(ARCH) calico -v | grep '^$(VERSION)$$'; then echo "Reported version:" `docker run quay.io/$(CNI_PLUGIN_IMAGE):latest-$(ARCH) calico -v` "\nExpected version: $(VERSION)"; false; else echo "\nVersion check passed\n"; fi

--- a/release/README.md
+++ b/release/README.md
@@ -15,4 +15,25 @@ make build
 ./bin/release --help
 ```
 
-By default, it builds hash release. For actual releases, set `IS_HASHRELEASE=false`
+## Developer Guide
+
+### Building and publishing a test release
+
+This section describes how to build a test release using the locally checked out code, and publish that release to your own GitHub repository and container registry.
+
+### Building a local release
+
+Build the release, providing your own registry to use for the images. For example:
+
+```
+ARCHES=amd64 ./bin/release hashrelease build --skip-validation --build-images --dev-registry <YOUR REGISTRY>
+```
+
+This may take some time, but will produce a full set of release images as well as an operator image based on the locally checked out commit. Artifacts can be found
+in `_output/hashrelease`.
+
+### Publishing the release
+
+This section outlines how to publish a test release to your own image registry.
+
+TODO

--- a/release/build/main.go
+++ b/release/build/main.go
@@ -23,7 +23,6 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/projectcalico/calico/release/internal/config"
-	"github.com/projectcalico/calico/release/internal/hashrelease"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
@@ -39,6 +38,8 @@ const (
 	skipImageScanFlag  = "skip-image-scan"
 	publishBranchFlag  = "git-publish"
 	buildImagesFlag    = "build-images"
+
+	imageRegistryFlag = "dev-registry"
 
 	// Configuration flags for the release publish command.
 	skipPublishImagesFlag    = "skip-publish-images"
@@ -141,6 +142,7 @@ func hashreleaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) [
 			Flags: []cli.Flag{
 				&cli.BoolFlag{Name: skipValidationFlag, Usage: "Skip pre-build validation", Value: false},
 				&cli.BoolFlag{Name: buildImagesFlag, Usage: "Build images from local codebase. If false, will use images from CI instead.", Value: false},
+				&cli.StringFlag{Name: imageRegistryFlag, Usage: "Specify image registry to use, for development", Value: ""},
 			},
 			Action: func(c *cli.Context) error {
 				configureLogging("hashrelease-build.log")
@@ -166,7 +168,13 @@ func hashreleaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) [
 					builder.WithOutputDir(dir),
 					builder.WithBuildImages(c.Bool(buildImagesFlag)),
 					builder.WithPreReleaseValidation(!c.Bool(skipValidationFlag)),
+					builder.WithGithubOrg(cfg.Organization),
+					builder.WithArchitectures(cfg.Arches),
 				}
+				if reg := c.String(imageRegistryFlag); reg != "" {
+					opts = append(opts, builder.WithImageRegistries([]string{reg}))
+				}
+
 				r := builder.NewReleaseBuilder(opts...)
 				if err := r.Build(); err != nil {
 					return err
@@ -175,39 +183,9 @@ func hashreleaseSubCommands(cfg *config.Config, runner *registry.DockerRunner) [
 				// For real releases, release notes are generated prior to building the release. For hash releases,
 				// generate a set of release notes and add them to the hashrelease directory.
 				tasks.ReleaseNotes(cfg, filepath.Join(dir, releaseNotesDir), version.New(ver))
-				return nil
-			},
-			After: func(c *cli.Context) error {
-				// We use an After() function to modify the generated release output to match
-				// the "legacy" format our CI tooling expects. This should be temporary until
-				// we can update the tooling to expect the new format.
-				// Specifically, we need to do two things:
-				// - Copy the windows zip file to files/windows/calico-windows-<ver>.zip
-				// - Copy tigera-operator-<ver>.tgz to tigera-operator.tgz
-				logrus.Info("Modifying hashrelease output to match legacy format")
-				pinned, err := hashrelease.RetrievePinnedVersion(cfg.TmpFolderPath())
-				if err != nil {
-					return err
-				}
-				ver := pinned.Components["calico"].Version
 
-				// Copy the windows zip file to files/windows/calico-windows-<ver>.zip
-				if err := os.MkdirAll(filepath.Join(dir, "files", "windows"), 0o755); err != nil {
-					return err
-				}
-				windowsZip := filepath.Join(dir, fmt.Sprintf("calico-windows-%s.zip", ver))
-				windowsZipDst := filepath.Join(dir, "files", "windows", fmt.Sprintf("calico-windows-%s.zip", ver))
-				if err := utils.CopyFile(windowsZip, windowsZipDst); err != nil {
-					return err
-				}
-
-				// Copy the operator tarball to tigera-operator.tgz
-				operatorTarball := filepath.Join(dir, fmt.Sprintf("tigera-operator-%s.tgz", ver))
-				operatorTarballDst := filepath.Join(dir, "tigera-operator.tgz")
-				if err := utils.CopyFile(operatorTarball, operatorTarballDst); err != nil {
-					return err
-				}
-				return nil
+				// Adjsut the formatting of the generated outputs to match the legacy hashrelease format.
+				return tasks.ReformatHashrelease(cfg, dir)
 			},
 		},
 
@@ -280,6 +258,7 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 			Usage: "Build an official Calico release",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{Name: skipValidationFlag, Usage: "Skip pre-build validation", Value: false},
+				&cli.StringFlag{Name: imageRegistryFlag, Usage: "Specify image registry to use, for development", Value: ""},
 			},
 			Action: func(c *cli.Context) error {
 				configureLogging("release-build.log")
@@ -299,9 +278,14 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 					builder.WithRepoRoot(cfg.RepoRootDir),
 					builder.WithVersions(ver.FormattedString(), operatorVer.FormattedString()),
 					builder.WithOutputDir(filepath.Join(baseUploadDir, ver.FormattedString())),
+					builder.WithArchitectures(cfg.Arches),
+					builder.WithGithubOrg(cfg.Organization),
 				}
 				if c.Bool(skipValidationFlag) {
 					opts = append(opts, builder.WithPreReleaseValidation(false))
+				}
+				if reg := c.String(imageRegistryFlag); reg != "" {
+					opts = append(opts, builder.WithImageRegistries([]string{reg}))
 				}
 				r := builder.NewReleaseBuilder(opts...)
 				return r.Build()
@@ -316,6 +300,7 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 				&cli.BoolFlag{Name: skipPublishImagesFlag, Usage: "Skip publishing of container images to registry", Value: false},
 				&cli.BoolFlag{Name: skipPublishGitTag, Usage: "Skip publishing of tag to git repository", Value: false},
 				&cli.BoolFlag{Name: skipPublishGithubRelease, Usage: "Skip publishing of release to Github", Value: false},
+				&cli.StringFlag{Name: imageRegistryFlag, Usage: "Specify image registry to use, for development", Value: ""},
 			},
 			Action: func(c *cli.Context) error {
 				configureLogging("release-publish.log")
@@ -328,6 +313,10 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 					builder.WithVersions(ver.FormattedString(), operatorVer.FormattedString()),
 					builder.WithOutputDir(filepath.Join(baseUploadDir, ver.FormattedString())),
 					builder.WithPublishOptions(!c.Bool(skipPublishImagesFlag), !c.Bool(skipPublishGitTag), !c.Bool(skipPublishGithubRelease)),
+					builder.WithGithubOrg(cfg.Organization),
+				}
+				if reg := c.String(imageRegistryFlag); reg != "" {
+					opts = append(opts, builder.WithImageRegistries([]string{reg}))
 				}
 				r := builder.NewReleaseBuilder(opts...)
 				return r.PublishRelease()

--- a/release/internal/config/config.go
+++ b/release/internal/config/config.go
@@ -29,8 +29,8 @@ type Config struct {
 	// OperatorConfig is the configuration for Tigera operator
 	OperatorConfig operator.Config
 
-	// ValidArchs are the OS architectures supported for multi-arch build
-	ValidArchs []string `envconfig:"VALID_ARCHES" default:"amd64,arm64,ppc64le,s390x"`
+	// Arches are the OS architectures supported for multi-arch build
+	Arches []string `envconfig:"ARCHES" default:"amd64,arm64,ppc64le,s390x"`
 
 	// DocsHost is the host for the hashrelease docs
 	DocsHost string `envconfig:"DOCS_HOST"`

--- a/release/internal/hashrelease/pinnedversion.go
+++ b/release/internal/hashrelease/pinnedversion.go
@@ -94,14 +94,12 @@ func operatorComponentsFilePath(outputDir string) string {
 // GeneratePinnedVersionFile generates the pinned version file.
 func GeneratePinnedVersionFile(rootDir, releaseBranchPrefix, devTagSuffix string, operatorConfig operator.Config, outputDir string) (string, *PinnedVersionData, error) {
 	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	if _, err := os.Stat(pinnedVersionPath); err == nil {
-		logrus.WithField("file", pinnedVersionPath).Info("Pinned version file already exists")
-		return pinnedVersionPath, nil, fmt.Errorf("pinned version file already exists")
-	}
+
 	productBranch, err := utils.GitBranch(rootDir)
 	if err != nil {
 		return "", nil, err
 	}
+
 	productVersion := version.GitVersion()
 	releaseName := fmt.Sprintf("%s-%s-%s", time.Now().Format("2006-01-02"), version.DeterminePublishStream(productBranch, string(productVersion)), RandomWord())
 	operatorBranch, err := operator.GitBranch(operatorConfig.Dir)

--- a/release/pkg/builder/options.go
+++ b/release/pkg/builder/options.go
@@ -67,3 +67,24 @@ func WithBuildImages(buildImages bool) Option {
 		return nil
 	}
 }
+
+func WithImageRegistries(registries []string) Option {
+	return func(r *ReleaseBuilder) error {
+		r.imageRegistries = registries
+		return nil
+	}
+}
+
+func WithArchitectures(architectures []string) Option {
+	return func(r *ReleaseBuilder) error {
+		r.architectures = architectures
+		return nil
+	}
+}
+
+func WithGithubOrg(org string) Option {
+	return func(r *ReleaseBuilder) error {
+		r.githubOrg = org
+		return nil
+	}
+}

--- a/release/pkg/tasks/operator.go
+++ b/release/pkg/tasks/operator.go
@@ -27,8 +27,8 @@ func OperatorHashreleaseBuild(runner *registry.DockerRunner, cfg *config.Config)
 	if err := operator.GenVersions(componentsVersionPath, operatorDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to generate versions")
 	}
-	logrus.Infof("Building operator images for %v", cfg.ValidArchs)
-	if err := operator.ImageAll(cfg.ValidArchs, operatorComponent.Version, operatorDir); err != nil {
+	logrus.Infof("Building operator images for %v", cfg.Arches)
+	if err := operator.ImageAll(cfg.Arches, operatorComponent.Version, operatorDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to build images")
 	}
 	logrus.Info("Building operator init image")
@@ -36,7 +36,7 @@ func OperatorHashreleaseBuild(runner *registry.DockerRunner, cfg *config.Config)
 	if err := operator.InitImage(operatorInitImage.Version, operatorDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to init images")
 	}
-	for _, arch := range cfg.ValidArchs {
+	for _, arch := range cfg.Arches {
 		currentTag := fmt.Sprintf("%s:latest-%s", operatorComponent.Image, arch)
 		newTag := fmt.Sprintf("%s-%s", operatorComponent.String(), arch)
 		logrus.WithFields(logrus.Fields{
@@ -66,7 +66,7 @@ func OperatorHashreleasePush(runner *registry.DockerRunner, cfg *config.Config) 
 		logrus.WithError(err).Fatal("Failed to get operator version")
 	}
 	var imageList []string
-	for _, arch := range cfg.ValidArchs {
+	for _, arch := range cfg.Arches {
 		imgName := fmt.Sprintf("%s-%s", operatorComponent.String(), arch)
 		if err := runner.PushImage(imgName); err != nil {
 			logrus.WithField("image", imgName).WithError(err).Fatal("Failed to push operator image")


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Fix cni-plugin release-verify to follow the same pattern as other directories.
- Add developer guide for building local releases.
- Add option to specify custom image registry.
- Rename cfg.ValidArches to match underlying implementation (VALIDARCHES is sematnically different)
- Don't error out if pinned_version.yaml already exists (make it easier to develop)
- Fix `make release-windows` being run in the wrong directory (IMPORTANT, NEEDS CHERRY PICK)
- Move hashrelease form-factor adjustment out of After() since we don't want it to run if the build fails. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.