### PR TITLE
Add key-cert-provisioner to tested calico images

### DIFF
--- a/hack/postrelease/golang/tests/oss/github/calico/github_calico_test.go
+++ b/hack/postrelease/golang/tests/oss/github/calico/github_calico_test.go
@@ -36,7 +36,7 @@ var expectedCalicoAssets = []string{
 func TestMain(m *testing.M) {
 	failed := false
 	if calicoReleaseTag == "" {
-		fmt.Println("Missing CALICO_RELEASE variable!")
+		fmt.Println("Missing CALICO_VERSION variable!")
 		failed = true
 	}
 	if failed {

--- a/hack/postrelease/golang/tests/oss/helm/helm_test.go
+++ b/hack/postrelease/golang/tests/oss/helm/helm_test.go
@@ -15,7 +15,7 @@ var calicoReleaseTag = os.Getenv("CALICO_VERSION")
 func TestMain(m *testing.M) {
 	failed := false
 	if calicoReleaseTag == "" {
-		fmt.Println("Missing CALICO_RELEASE variable!")
+		fmt.Println("Missing CALICO_VERSION variable!")
 		failed = true
 	}
 	if failed {

--- a/hack/postrelease/golang/tests/oss/images/images_test.go
+++ b/hack/postrelease/golang/tests/oss/images/images_test.go
@@ -57,7 +57,7 @@ var (
 func TestMain(m *testing.M) {
 	failed := false
 	if calicoReleaseTag == "" {
-		fmt.Println("Missing CALICO_RELEASE variable!")
+		fmt.Println("Missing CALICO_VERSION variable!")
 		failed = true
 	}
 	if operatorReleaseVersion == "" {

--- a/hack/postrelease/golang/tests/oss/images/images_test.go
+++ b/hack/postrelease/golang/tests/oss/images/images_test.go
@@ -40,6 +40,7 @@ var expectedCalicoImages = []string{
 	// "pilot-webhook",
 	"pod2daemon-flexvol",
 	"csi",
+	"key-cert-provisioner",
 }
 
 var expectedWindowsImages = []string{

--- a/hack/postrelease/golang/tests/oss/openstack/openstack_test.go
+++ b/hack/postrelease/golang/tests/oss/openstack/openstack_test.go
@@ -15,7 +15,7 @@ var calicoReleaseTag = os.Getenv("CALICO_VERSION")
 func TestMain(m *testing.M) {
 	failed := false
 	if calicoReleaseTag == "" {
-		fmt.Println("Missing CALICO_RELEASE variable!")
+		fmt.Println("Missing CALICO_VERSION variable!")
 		failed = true
 	}
 	if failed {


### PR DESCRIPTION
- Add key-cert-provisioner to postrelease tests
- Fix incorrect reference to environment variable
