### PR TITLE
felix/ifacemonitor: use `regexp.MatchString` to reduce allocs

### DIFF
--- a/felix/config/param_types.go
+++ b/felix/config/param_types.go
@@ -236,7 +236,7 @@ func (p *RegexpPatternListParam) Parse(raw string) (interface{}, error) {
 	// Split into individual elements, then validate each one and compile to regexp
 	tokens := strings.Split(raw, p.Delimiter)
 	for _, t := range tokens {
-		if p.RegexpElemRegexp.Match([]byte(t)) {
+		if p.RegexpElemRegexp.MatchString(t) {
 			// Need to remove the start and end symbols that wrap the actual regexp
 			// Note: There's a coupling here with the assumed pattern in RegexpElemRegexp
 			// i.e. that each value is wrapped by a single char symbol on either side
@@ -246,7 +246,7 @@ func (p *RegexpPatternListParam) Parse(raw string) (interface{}, error) {
 				return nil, p.parseFailed(raw, p.Msg)
 			}
 			result = append(result, compiledRegexp)
-		} else if p.NonRegexpElemRegexp.Match([]byte(t)) {
+		} else if p.NonRegexpElemRegexp.MatchString(t) {
 			compiledRegexp, compileErr := regexp.Compile("^" + regexp.QuoteMeta(t) + "$")
 			if compileErr != nil {
 				return nil, p.parseFailed(raw, p.Msg)

--- a/felix/ifacemonitor/iface_monitor.go
+++ b/felix/ifacemonitor/iface_monitor.go
@@ -189,7 +189,7 @@ func (m *InterfaceMonitor) MonitorInterfaces() {
 
 func (m *InterfaceMonitor) isExcludedInterface(ifName string) bool {
 	for _, nameExp := range m.InterfaceExcludes {
-		if nameExp.Match([]byte(ifName)) {
+		if nameExp.MatchString(ifName) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description

`(*Regexp).Match` have a string-based equivalent `(*Regexp).MatchString`. We should use the string version to avoid unnecessary `[]byte` conversions.
Benchmark:

```go
var regex = regexp.MustCompile("^kube-ipvs.*")

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := regex.Match([]byte("kube-ipvs1")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := regex.MatchString("kube-ipvs1"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/projectcalico/calico/felix/ifacemonitor
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 2828719	       436.5 ns/op	      16 B/op	       1 allocs/op
BenchmarkMatchString-16    	 3547651	       336.4 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 0.0% of statements
ok  	github.com/projectcalico/calico/felix/ifacemonitor	3.244s
```

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
