### PR TITLE
[release-v3.29] Auto pick #9264: Dump ipset IDs in bpf policy dump

### DIFF
--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -899,32 +899,29 @@ func (p *Builder) writeCIDRSMatch(negate bool, leg matchLeg, cidrs []string) {
 
 func (p *Builder) printIPSetIDs(r Rule) string {
 	str := ""
-	concatIDs := func(ipSets []string) string {
-		idString := ""
-		for idx, ipSetID := range ipSets {
+	joinIDs := func(ipSets []string) string {
+		idString := []string{}
+		for _, ipSetID := range ipSets {
 			id := p.ipSetIDProvider.GetNoAlloc(ipSetID)
 			if id != 0 {
-				idString = idString + fmt.Sprintf("0x%x", id)
-				if idx < len(r.SrcIpSetIds)-1 {
-					idString = idString + ","
-				}
+				idString = append(idString, fmt.Sprintf("0x%x", id))
 			}
 		}
-		return idString
+		return strings.Join(idString[:], ",")
 	}
-	srcIDString := concatIDs(r.SrcIpSetIds)
+	srcIDString := joinIDs(r.SrcIpSetIds)
 	if srcIDString != "" {
 		str = str + fmt.Sprintf("src_ip_set_ids:<%s> ", srcIDString)
 	}
-	notSrcIDString := concatIDs(r.NotSrcIpSetIds)
+	notSrcIDString := joinIDs(r.NotSrcIpSetIds)
 	if notSrcIDString != "" {
 		str = str + fmt.Sprintf("not_src_ip_set_ids:<%s> ", notSrcIDString)
 	}
-	dstIDString := concatIDs(r.DstIpSetIds)
+	dstIDString := joinIDs(r.DstIpSetIds)
 	if dstIDString != "" {
 		str = str + fmt.Sprintf("dst_ip_set_ids:<%s> ", dstIDString)
 	}
-	notDstIDString := concatIDs(r.NotDstIpSetIds)
+	notDstIDString := joinIDs(r.NotDstIpSetIds)
 	if notDstIDString != "" {
 		str = str + fmt.Sprintf("not_dst_ip_set_ids:<%s> ", notDstIDString)
 	}

--- a/felix/cmd/calico-bpf/commands/policy_debug.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug.go
@@ -153,7 +153,7 @@ func dumpPolicyInfo(cmd *cobra.Command, iface string, h hook.Hook, m counters.Po
 			if strings.Contains(comment, "Rule MatchID") {
 				matchId := getRuleMatchID(comment)
 				cmd.Printf("// count = %d\n", m[matchId])
-			} else if verboseFlagSet || strings.Contains(comment, "Start of policy") || strings.Contains(comment, "Start of rule") {
+			} else if verboseFlagSet || strings.Contains(comment, "Start of policy") || strings.Contains(comment, "Start of rule") || strings.Contains(comment, "IPSets") {
 				cmd.Printf("// %s\n", comment)
 			}
 		}


### PR DESCRIPTION
Cherry pick of #9264 on release-v3.29.

#9264: Dump ipset IDs in bpf policy dump

# Original PR Body below

## Description

At present, ```calico-node -bpf policy dump <interface><hook>``` dumps only the stringID of the IPSets. It will be better to dump the 64bit ID as well so that its easy to correlate with ```calico-node -bpf ipsets dump```.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.