### PR TITLE
Support for OpenStack Caracal release

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -737,6 +737,43 @@ blocks:
           - mkdir logs
           - sudo journalctl > logs/journalctl.txt
           - artifact push job --expire-in 1d logs
+
+- name: "OpenStack integration (Caracal)"
+  run:
+    when: "true or change_in(['/networking-calico/'])"
+  dependencies:
+    - Prerequisites
+  task:
+    agent:
+      machine:
+        type: f1-standard-2
+        os_image: ubuntu2004
+    prologue:
+      commands:
+        - cd networking-calico
+    jobs:
+      - name: "Unit and FV tests (tox) on Caracal"
+        commands:
+          - ../.semaphore/run-and-monitor tox.log make tox-caracal
+      - name: "Mainline ST (DevStack + Tempest) on Caracal"
+        commands:
+          # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
+          # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
+          # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
+          # or replace the existing version.  Happily we do know that, so let's do it upfront here.
+          - sudo apt-get remove -y python3-wrapt || true
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
+    epilogue:
+      on_fail:
+        commands:
+          - mkdir logs
+          - sudo journalctl > logs/journalctl.txt
+          - artifact push job --expire-in 1d logs
 - name: release tooling
   run:
     when: "true or change_in(['/*', '/release/'], {exclude: ['/**/.gitignore', '/**/*.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -771,7 +771,7 @@ blocks:
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
           - TEMPEST=true DEVSTACK_BRANCH=stable/2024.1 ./devstack/bootstrap.sh
     epilogue:
-      on_fail:
+      always:
         commands:
           - mkdir logs
           - sudo journalctl > logs/journalctl.txt

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -747,7 +747,7 @@ blocks:
     agent:
       machine:
         type: f1-standard-2
-        os_image: ubuntu2004
+        os_image: ubuntu2204
     prologue:
       commands:
         - cd networking-calico

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -767,6 +767,7 @@ blocks:
           - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
           - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
     epilogue:
       on_fail:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -754,6 +754,7 @@ blocks:
     jobs:
       - name: "Unit and FV tests (tox) on Caracal"
         commands:
+          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - ../.semaphore/run-and-monitor tox.log make tox-caracal
       - name: "Mainline ST (DevStack + Tempest) on Caracal"
         commands:
@@ -764,11 +765,11 @@ blocks:
           - sudo apt-get remove -y python3-wrapt || true
           - git checkout -b devstack-test
           - export LIBVIRT_TYPE=qemu
-          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
+          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
-          - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
+          - TEMPEST=true DEVSTACK_BRANCH=stable/2024.1 ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -771,7 +771,7 @@ blocks:
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
           - TEMPEST=true DEVSTACK_BRANCH=stable/2024.1 ./devstack/bootstrap.sh
     epilogue:
-      on_fail:
+      always:
         commands:
           - mkdir logs
           - sudo journalctl > logs/journalctl.txt

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -747,7 +747,7 @@ blocks:
     agent:
       machine:
         type: f1-standard-2
-        os_image: ubuntu2004
+        os_image: ubuntu2204
     prologue:
       commands:
         - cd networking-calico

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -767,6 +767,7 @@ blocks:
           - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
           - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
     epilogue:
       on_fail:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -737,6 +737,43 @@ blocks:
           - mkdir logs
           - sudo journalctl > logs/journalctl.txt
           - artifact push job --expire-in 1d logs
+
+- name: "OpenStack integration (Caracal)"
+  run:
+    when: "false or change_in(['/networking-calico/'])"
+  dependencies:
+    - Prerequisites
+  task:
+    agent:
+      machine:
+        type: f1-standard-2
+        os_image: ubuntu2004
+    prologue:
+      commands:
+        - cd networking-calico
+    jobs:
+      - name: "Unit and FV tests (tox) on Caracal"
+        commands:
+          - ../.semaphore/run-and-monitor tox.log make tox-caracal
+      - name: "Mainline ST (DevStack + Tempest) on Caracal"
+        commands:
+          # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
+          # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
+          # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
+          # or replace the existing version.  Happily we do know that, so let's do it upfront here.
+          - sudo apt-get remove -y python3-wrapt || true
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
+    epilogue:
+      on_fail:
+        commands:
+          - mkdir logs
+          - sudo journalctl > logs/journalctl.txt
+          - artifact push job --expire-in 1d logs
 - name: release tooling
   run:
     when: "false or change_in(['/*', '/release/'], {exclude: ['/**/.gitignore', '/**/*.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -754,6 +754,7 @@ blocks:
     jobs:
       - name: "Unit and FV tests (tox) on Caracal"
         commands:
+          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - ../.semaphore/run-and-monitor tox.log make tox-caracal
       - name: "Mainline ST (DevStack + Tempest) on Caracal"
         commands:
@@ -764,11 +765,11 @@ blocks:
           - sudo apt-get remove -y python3-wrapt || true
           - git checkout -b devstack-test
           - export LIBVIRT_TYPE=qemu
-          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
+          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
-          - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
+          - TEMPEST=true DEVSTACK_BRANCH=stable/2024.1 ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -52,6 +52,7 @@
     jobs:
       - name: "Unit and FV tests (tox) on Caracal"
         commands:
+          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - ../.semaphore/run-and-monitor tox.log make tox-caracal
       - name: "Mainline ST (DevStack + Tempest) on Caracal"
         commands:
@@ -62,11 +63,11 @@
           - sudo apt-get remove -y python3-wrapt || true
           - git checkout -b devstack-test
           - export LIBVIRT_TYPE=qemu
-          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
+          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
-          - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
+          - TEMPEST=true DEVSTACK_BRANCH=stable/2024.1 ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -35,3 +35,40 @@
           - mkdir logs
           - sudo journalctl > logs/journalctl.txt
           - artifact push job --expire-in 1d logs
+
+- name: "OpenStack integration (Caracal)"
+  run:
+    when: "${FORCE_RUN} or change_in(['/networking-calico/'])"
+  dependencies:
+    - Prerequisites
+  task:
+    agent:
+      machine:
+        type: f1-standard-2
+        os_image: ubuntu2004
+    prologue:
+      commands:
+        - cd networking-calico
+    jobs:
+      - name: "Unit and FV tests (tox) on Caracal"
+        commands:
+          - ../.semaphore/run-and-monitor tox.log make tox-caracal
+      - name: "Mainline ST (DevStack + Tempest) on Caracal"
+        commands:
+          # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
+          # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
+          # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
+          # or replace the existing version.  Happily we do know that, so let's do it upfront here.
+          - sudo apt-get remove -y python3-wrapt || true
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
+    epilogue:
+      on_fail:
+        commands:
+          - mkdir logs
+          - sudo journalctl > logs/journalctl.txt
+          - artifact push job --expire-in 1d logs

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -69,7 +69,7 @@
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
           - TEMPEST=true DEVSTACK_BRANCH=stable/2024.1 ./devstack/bootstrap.sh
     epilogue:
-      on_fail:
+      always:
         commands:
           - mkdir logs
           - sudo journalctl > logs/journalctl.txt

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -45,7 +45,7 @@
     agent:
       machine:
         type: f1-standard-2
-        os_image: ubuntu2004
+        os_image: ubuntu2204
     prologue:
       commands:
         - cd networking-calico

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -65,6 +65,7 @@
           - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/caracal
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
           - TEMPEST=true DEVSTACK_BRANCH=stable/caracal ./devstack/bootstrap.sh
     epilogue:
       on_fail:

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -12,5 +12,4 @@ tox:
 
 tox-%:
 	curl -L $${UPPER_CONSTRAINTS_FILE:-https://releases.openstack.org/constraints/upper/$*} -o upper-constraints-$*.txt
-	sed -i '/etcd3gw/d' upper-constraints-$*.txt
 	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-$*.txt

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -11,6 +11,6 @@ tox:
 	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT --rm networking-calico-test tox
 
 tox-%:
-	curl -L https://releases.openstack.org/constraints/upper/% -o upper-constraints-%.txt
-	sed -i '/etcd3gw/d' upper-constraints-%.txt
-	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-%.txt
+	curl -L https://releases.openstack.org/constraints/upper/$* -o upper-constraints-$*.txt
+	sed -i '/etcd3gw/d' upper-constraints-$*.txt
+	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-$*.txt

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -11,6 +11,6 @@ tox:
 	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT --rm networking-calico-test tox
 
 tox-%:
-	curl -L https://releases.openstack.org/constraints/upper/$* -o upper-constraints-$*.txt
+	curl -L $${UPPER_CONSTRAINTS_FILE:-https://releases.openstack.org/constraints/upper/$*} -o upper-constraints-$*.txt
 	sed -i '/etcd3gw/d' upper-constraints-$*.txt
 	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-$*.txt

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -10,12 +10,7 @@ tox:
 	docker build -t networking-calico-test .
 	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT --rm networking-calico-test tox
 
-tox-ussuri:
-	curl -L https://releases.openstack.org/constraints/upper/ussuri -o upper-constraints-ussuri.txt
-	sed -i '/etcd3gw/d' upper-constraints-ussuri.txt
-	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-ussuri.txt
-
-tox-yoga:
-	curl -L https://releases.openstack.org/constraints/upper/yoga -o upper-constraints-yoga.txt
-	sed -i '/etcd3gw/d' upper-constraints-yoga.txt
-	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-yoga.txt
+tox-%:
+	curl -L https://releases.openstack.org/constraints/upper/% -o upper-constraints-%.txt
+	sed -i '/etcd3gw/d' upper-constraints-%.txt
+	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-%.txt

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -172,6 +172,10 @@ cd ..
 sudo mkdir -p /opt/stack
 sudo mv devstack /opt/stack
 sudo chown -R stack:stack /opt/stack
+ls -ld /home/
+ls -la /home/
+ls -la /home/semaphore/
+ls -la /home/semaphore/calico
 
 # Stack!
 sudo -u stack -H -E bash -x <<'EOF'

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -175,6 +175,7 @@ sudo chown -R stack:stack /opt/stack
 
 # Stack!
 sudo -u stack -H -E bash -x <<'EOF'
+ls -la /home/semaphore/calico
 ls -ld /opt/stack
 ls -la /opt/stack
 cd /opt/stack/devstack

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -177,6 +177,11 @@ ls -la /home/
 ls -la /home/semaphore/
 ls -la /home/semaphore/calico
 
+# Allow the stack user to read /home/semaphore.  In the ubuntu2204 image on Semaphore,
+# /home/semaphore permissions are "drwxr-x---", which it means it can't be read by users outside the
+# "semaphore" group.
+sudo adduser stack semaphore
+
 # Stack!
 sudo -u stack -H -E bash -x <<'EOF'
 ls -la /home/semaphore/calico

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -177,6 +177,7 @@ ls -la /opt/stack
 # Stack!
 sudo -u stack -H -E bash -x <<'EOF'
 cd /opt/stack/devstack
+export FORCE=yes
 ./stack.sh
 EOF
 

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -135,6 +135,10 @@ LOG_COLOR=False
 
 TEMPEST_BRANCH=29.1.0
 
+# Setting to prevent DevStack from configuring a value of dhcp_client that old Tempest code does not
+# support.
+SCENARIO_IMAGE_TYPE=ignore
+
 # We clone from GitHub because we commonly used to hit GnuTLS errors when git cloning OpenStack
 # repos from opendev.org (which is the default server), for example:
 #

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -172,10 +172,11 @@ cd ..
 sudo mkdir -p /opt/stack
 sudo mv devstack /opt/stack
 sudo chown -R stack:stack /opt/stack
-ls -la /opt/stack
 
 # Stack!
 sudo -u stack -H -E bash -x <<'EOF'
+ls -ld /opt/stack
+ls -la /opt/stack
 cd /opt/stack/devstack
 export FORCE=yes
 ./stack.sh

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -138,7 +138,7 @@ EOF
 		    sudo mkdir /var/log/neutron || true
 		    sudo chown `whoami` /var/log/neutron
 		    run_process calico-dhcp \
-		      "/usr/local/bin/calico-dhcp-agent --config-file $NEUTRON_CONF"
+		      "${DEVSTACK_VENV:-/usr/local}/bin/calico-dhcp-agent --config-file $NEUTRON_CONF"
 
 		    ;;
 

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -120,6 +120,11 @@ class FakePlugin(object):
 
     get_networks = None
 
+    # New method required sometime between Yoga and Caracal releases - see
+    # https://github.com/projectcalico/calico/issues/9216 for discussion.
+    def get_ports(self, port_filters):
+        return None
+
 
 def empty_network(network_id=NETWORK_ID):
     """Construct and return an empty network model."""

--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -32,9 +32,13 @@ class DnsmasqRouted(dhcp.Dnsmasq):
     """Dnsmasq DHCP driver for routed virtual interfaces."""
 
     def __init__(self, conf, network, process_monitor,
-                 version=None, plugin=None):
-        super(DnsmasqRouted, self).__init__(conf, network, process_monitor,
-                                            version, plugin)
+                 version=None, plugin=None, *args):
+        if args:
+            super(DnsmasqRouted, self).__init__(conf, network, process_monitor,
+                                                version, plugin, *args)
+        else:
+            super(DnsmasqRouted, self).__init__(conf, network, process_monitor,
+                                                version, plugin)
         self.device_manager = CalicoDeviceManager(self.conf, plugin)
 
     # Frozen copy of Dnsmasq::_build_cmdline_callback from

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -891,7 +891,10 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         :return: context manager for use with with:.
         """
         session = context.session
-        conn_url = str(session.connection().engine.url).lower()
+        if getattr(session, 'bind', None):
+            conn_url = str(session.bind.url).lower()
+        else:
+            conn_url = str(session.connection().engine.url).lower()
         if (conn_url.startswith("mysql:") or
                 conn_url.startswith("mysql+mysqldb:")):
             # Neutron is using the mysqldb driver for accessing the database.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2014, 2015 Metaswitch Networks
 # Copyright (c) 2013 OpenStack Foundation
-# Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018 Tigera, Inc. All rights reserved.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -36,8 +36,6 @@ import eventlet
 from eventlet.queue import PriorityQueue
 from eventlet.semaphore import Semaphore
 from neutron.agent import rpc as agent_rpc
-
-from neutron_lib.db import api as db_api
 
 try:
     from neutron_lib.agent import topics
@@ -543,7 +541,6 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             # Actually do the update.
             self._try_to_update_port_status(admin_context, port_status_key)
 
-    @db_api.CONTEXT_WRITER
     def _try_to_update_port_status(self, admin_context, port_status_key):
         """Attempts to update the given port status.
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2014, 2015 Metaswitch Networks
 # Copyright (c) 2013 OpenStack Foundation
-# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -36,6 +36,8 @@ import eventlet
 from eventlet.queue import PriorityQueue
 from eventlet.semaphore import Semaphore
 from neutron.agent import rpc as agent_rpc
+
+from neutron_lib.db import api as db_api
 
 try:
     from neutron_lib.agent import topics
@@ -541,6 +543,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             # Actually do the update.
             self._try_to_update_port_status(admin_context, port_status_key)
 
+    @db_api.CONTEXT_WRITER
     def _try_to_update_port_status(self, admin_context, port_status_key):
         """Attempts to update the given port status.
 

--- a/networking-calico/requirements.txt
+++ b/networking-calico/requirements.txt
@@ -5,4 +5,4 @@
 Babel>=2.9.1 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw==1.0.1 # Apache-2.0
+etcd3gw==2.4.0 # Apache-2.0

--- a/networking-calico/requirements.txt
+++ b/networking-calico/requirements.txt
@@ -5,4 +5,8 @@
 Babel>=2.9.1 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw==2.4.0 # Apache-2.0
+
+# Don't specify the etcd3gw version here, because since the Yoga release we want to use the same
+# version as specified in OpenStack's constraints.  For Yoga that is etcd3gw 1.0.1.  For Caracal it
+# is etcd3gw 2.4.0.
+etcd3gw

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -17,7 +17,7 @@ testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 extras # Needed for latest testrepository
 
-etcd3gw==1.0.1 # Apache-2.0
+etcd3gw==2.4.0 # Apache-2.0
 neutron
 neutron-lib
 mock>=3.0.0 # BSD

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -17,7 +17,10 @@ testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 extras # Needed for latest testrepository
 
-etcd3gw==2.4.0 # Apache-2.0
+# Don't specify the etcd3gw version here, because since the Yoga release we want to use the same
+# version as specified in OpenStack's constraints.  For Yoga that is etcd3gw 1.0.1.  For Caracal it
+# is etcd3gw 2.4.0.
+etcd3gw
 neutron
 neutron-lib
 mock>=3.0.0 # BSD

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -15,6 +15,7 @@ oslotest>=3.2.0 # Apache-2.0
 testrepository>=0.0.18 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
+extras # Needed for latest testrepository
 
 etcd3gw==1.0.1 # Apache-2.0
 neutron


### PR DESCRIPTION
Update Calico's OpenStack integration code to work with the OpenStack Caracal release, and also with Ubuntu Jammy.  Note that Caracal itself requires Jammy (in order to have libvirt >= 7.0.0).

## Related issues/PRs

Fixes https://github.com/projectcalico/calico/issues/9216

Fixes https://github.com/projectcalico/calico/issues/9238

## Release Note

```release-note
Update Calico's OpenStack integration code to work with the OpenStack Caracal release, and also with Ubuntu Jammy.
```