### PR TITLE
add an implement for calicoctl version --client

### DIFF
--- a/calicoctl/calicoctl/commands/version.go
+++ b/calicoctl/calicoctl/commands/version.go
@@ -46,7 +46,7 @@ func init() {
 
 func Version(args []string) error {
 	doc := `Usage:
-  <BINARY_NAME> version [--config=<CONFIG>] [--poll=<POLL>] [--allow-version-mismatch]
+  <BINARY_NAME> version [--config=<CONFIG>] [--poll=<POLL>] [--allow-version-mismatch] [--client]
 
 Options:
   -h --help                    Show this screen.
@@ -56,6 +56,8 @@ Options:
      --poll=<POLL>             Poll for changes to the cluster information at a frequency specified using POLL duration
                                (e.g. 1s, 10m, 2h etc.). A value of 0 (the default) disables polling.
      --allow-version-mismatch  Allow client and cluster versions mismatch.
+     --client                  Display the client version only.
+ }
 
 Description:
   Display the version of <BINARY_NAME>.
@@ -85,6 +87,10 @@ Description:
 
 	fmt.Println("Client Version:   ", VERSION)
 	fmt.Println("Git commit:       ", GIT_REVISION)
+
+	if clientOnly := argutils.ArgBoolOrFalse(parsedArgs, "--client"); clientOnly {
+		return nil
+	}
 
 	// Load the client config and connect.
 	cf := parsedArgs["--config"].(string)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

add an implement for calicoctl version --client

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

fixes https://github.com/projectcalico/calico/issues/9244

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added support for calicoctl version --client
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
