### PR TITLE
[Release v3.29] AdminNetworkPolicy network cidr support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,13 @@ image:
 # using a local kind cluster.
 ###############################################################################
 E2E_FOCUS ?= "sig-network.*Conformance"
+ADMINPOLICY_SUPPORTED_FEATURES ?= "AdminNetworkPolicy"
 ADMINPOLICY_UNSUPPORTED_FEATURES ?= "BaselineAdminNetworkPolicy"
 e2e-test:
 	$(MAKE) -C e2e build
 	$(MAKE) -C node kind-k8st-setup
 	KUBECONFIG=$(KIND_KUBECONFIG) ./e2e/bin/k8s/e2e.test -ginkgo.focus=$(E2E_FOCUS)
-	KUBECONFIG=$(KIND_KUBECONFIG) ./e2e/bin/adminpolicy/e2e.test -exempt-features=$(ADMINPOLICY_UNSUPPORTED_FEATURES)
+	KUBECONFIG=$(KIND_KUBECONFIG) ./e2e/bin/adminpolicy/e2e.test -exempt-features=$(ADMINPOLICY_UNSUPPORTED_FEATURES) -supported-features=$(ADMINPOLICY_SUPPORTED_FEATURES)
 
 ###############################################################################
 # Release logic below

--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -7,7 +7,7 @@ LOCAL_CHECKS = goimports check-gen-files
 KIND_CONFIG = $(KIND_DIR)/kind-single.config
 
 NETPOL_TAG = v0.1.5
-NETPOL_CRD_URL = https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/refs/tags/$(NETPOL_TAG)/config/crd/standard
+NETPOL_CRD_URL = https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/refs/tags/$(NETPOL_TAG)/config/crd/experimental
 NETPOL_ANP_CRD = policy.networking.k8s.io_adminnetworkpolicies.yaml
 
 ###############################################################################

--- a/libcalico-go/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/libcalico-go/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -115,6 +115,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -216,6 +226,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -373,6 +474,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -617,6 +723,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/libcalico-go/lib/backend/k8s/conversion/adminnetworkpolicy_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/adminnetworkpolicy_test.go
@@ -528,7 +528,10 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					NamespaceSelector: "k10 == 'v10' && k20 == 'v20'",
 				},
 				Destination: apiv3.EntityRule{
-					Ports: []numorstring.Port{numorstring.SinglePort(80), {MinPort: 2000, MaxPort: 3000}},
+					Ports: []numorstring.Port{
+						numorstring.SinglePort(80),
+						{MinPort: 2000, MaxPort: 3000},
+					},
 				},
 			},
 		))
@@ -542,7 +545,10 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 				Source:   apiv3.EntityRule{},
 				Destination: apiv3.EntityRule{
 					NamespaceSelector: "k3 == 'v3' && k4 == 'v4'",
-					Ports:             []numorstring.Port{numorstring.SinglePort(80), {MinPort: 2000, MaxPort: 3000}},
+					Ports: []numorstring.Port{
+						numorstring.SinglePort(80),
+						{MinPort: 2000, MaxPort: 3000},
+					},
 				},
 			},
 		))
@@ -1405,13 +1411,16 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 	})
 
 	It("should replace an unsupported AdminNeworkPolicy rule with Deny action with a deny-all one", func() {
-		ports := []adminpolicy.AdminNetworkPolicyPort{{
-			PortNumber: &adminpolicy.Port{Port: 80},
-		}}
-
-		badPorts := []adminpolicy.AdminNetworkPolicyPort{{
-			PortRange: &adminpolicy.PortRange{Start: 40, End: 20, Protocol: kapiv1.ProtocolUDP},
-		}}
+		ports := []adminpolicy.AdminNetworkPolicyPort{
+			{
+				PortNumber: &adminpolicy.Port{Port: 80},
+			},
+		}
+		badPorts := []adminpolicy.AdminNetworkPolicyPort{
+			{
+				PortRange: &adminpolicy.PortRange{Start: 40, End: 20, Protocol: kapiv1.ProtocolUDP},
+			},
+		}
 		anp := adminpolicy.AdminNetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test.policy",
@@ -1542,9 +1551,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 
 		Expect(gnp.Spec.Egress).To(HaveLen(2))
 		Expect(gnp.Spec.Egress[0].Destination.NamespaceSelector).To(BeZero())
-		Expect(gnp.Spec.Egress[0]).To(Equal(apiv3.Rule{
-			Action: apiv3.Deny,
-		}))
+		Expect(gnp.Spec.Egress[0]).To(Equal(apiv3.Rule{Action: apiv3.Deny}))
 
 		Expect(gnp.Spec.Egress[1].Destination.NamespaceSelector).To(Equal("k4 == 'v4'"))
 		Expect(gnp.Spec.Egress[1].Destination.Selector).To(BeZero())
@@ -1554,5 +1561,382 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 		Expect(len(gnp.Spec.Types)).To(Equal(2))
 		Expect(gnp.Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
 		Expect(gnp.Spec.Types[1]).To(Equal(apiv3.PolicyTypeEgress))
+	})
+
+	It("should parse a k8s AdminNetworkPolicy with a Networks peer", func() {
+		anp := adminpolicy.AdminNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test.policy",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+			Spec: adminpolicy.AdminNetworkPolicySpec{
+				Priority: 200,
+				Subject: adminpolicy.AdminNetworkPolicySubject{
+					Namespaces: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label":  "value",
+							"label2": "value2",
+						},
+					},
+				},
+				Ingress: []adminpolicy.AdminNetworkPolicyIngressRule{
+					{
+						Name:   "A random ingress rule",
+						Action: "Pass",
+						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k": "v",
+									},
+								},
+							},
+						},
+					},
+				},
+				Egress: []adminpolicy.AdminNetworkPolicyEgressRule{
+					{
+						Name:   "A random egress rule",
+						Action: "Deny",
+						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k3": "v3",
+									},
+								},
+							},
+							{
+								Networks: []adminpolicy.CIDR{"10.10.10.0/24", "1.1.1.1/32"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Convert the policy
+		gnp := convertToGNP(&anp, float64(200.0), nil)
+
+		Expect(gnp.Spec.Ingress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata:    k8sAdminNetworkPolicyToCalicoMetadata("A random ingress rule"),
+				Action:      "Pass",
+				Protocol:    nil, // We only default to TCP when ports exist
+				Source:      apiv3.EntityRule{NamespaceSelector: "k == 'v'"},
+				Destination: apiv3.EntityRule{},
+			},
+		))
+		Expect(gnp.Spec.Egress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata:    k8sAdminNetworkPolicyToCalicoMetadata("A random egress rule"),
+				Action:      "Deny",
+				Protocol:    nil, // We only default to TCP when ports exist
+				Source:      apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{NamespaceSelector: "k3 == 'v3'"},
+			},
+			apiv3.Rule{
+				Metadata:    k8sAdminNetworkPolicyToCalicoMetadata("A random egress rule"),
+				Action:      "Deny",
+				Protocol:    nil, // We only default to TCP when ports exist
+				Source:      apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{Nets: []string{"10.10.10.0/24", "1.1.1.1/32"}},
+			},
+		))
+	})
+
+	It("should parse a k8s AdminNetworkPolicy with an any address Network peer", func() {
+		anp := adminpolicy.AdminNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test.policy",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+			Spec: adminpolicy.AdminNetworkPolicySpec{
+				Priority: 200,
+				Subject: adminpolicy.AdminNetworkPolicySubject{
+					Namespaces: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label":  "value",
+							"label2": "value2",
+						},
+					},
+				},
+				Ingress: []adminpolicy.AdminNetworkPolicyIngressRule{
+					{
+						Name:   "A random ingress rule",
+						Action: "Pass",
+						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k": "v",
+									},
+								},
+							},
+						},
+					},
+				},
+				Egress: []adminpolicy.AdminNetworkPolicyEgressRule{
+					{
+						Name:   "A random egress rule",
+						Action: "Deny",
+						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k3": "v3",
+									},
+								},
+							},
+							{
+								Networks: []adminpolicy.CIDR{"0.0.0.0/0", "::/0"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Convert the policy
+		gnp := convertToGNP(&anp, float64(200.0), nil)
+
+		Expect(gnp.Spec.Ingress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata:    k8sAdminNetworkPolicyToCalicoMetadata("A random ingress rule"),
+				Action:      "Pass",
+				Protocol:    nil, // We only default to TCP when ports exist
+				Source:      apiv3.EntityRule{NamespaceSelector: "k == 'v'"},
+				Destination: apiv3.EntityRule{},
+			},
+		))
+		Expect(gnp.Spec.Egress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata:    k8sAdminNetworkPolicyToCalicoMetadata("A random egress rule"),
+				Action:      "Deny",
+				Protocol:    nil, // We only default to TCP when ports exist
+				Source:      apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{NamespaceSelector: "k3 == 'v3'"},
+			},
+			apiv3.Rule{
+				Metadata:    k8sAdminNetworkPolicyToCalicoMetadata("A random egress rule"),
+				Action:      "Deny",
+				Protocol:    nil, // We only default to TCP when ports exist
+				Source:      apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{Nets: []string{"0.0.0.0/0", "::/0"}},
+			},
+		))
+	})
+
+	It("should parse a k8s AdminNetworkPolicy with a Networks peer and ports", func() {
+		ports := []adminpolicy.AdminNetworkPolicyPort{
+			{
+				PortNumber: &adminpolicy.Port{Port: 80},
+			},
+		}
+		anp := adminpolicy.AdminNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test.policy",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+			Spec: adminpolicy.AdminNetworkPolicySpec{
+				Priority: 200,
+				Subject: adminpolicy.AdminNetworkPolicySubject{
+					Namespaces: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label":  "value",
+							"label2": "value2",
+						},
+					},
+				},
+				Ingress: []adminpolicy.AdminNetworkPolicyIngressRule{
+					{
+						Name:   "A random ingress rule",
+						Action: "Pass",
+						Ports:  &ports,
+						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k": "v",
+									},
+								},
+							},
+						},
+					},
+				},
+				Egress: []adminpolicy.AdminNetworkPolicyEgressRule{
+					{
+						Name:   "A random egress rule",
+						Action: "Deny",
+						Ports:  &ports,
+						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k3": "v3",
+									},
+								},
+							},
+							{
+								Networks: []adminpolicy.CIDR{"10.10.10.0/24", "1.1.1.1/32"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Convert the policy
+		gnp := convertToGNP(&anp, float64(200.0), nil)
+
+		protocolTCP := numorstring.ProtocolFromString(numorstring.ProtocolTCP)
+		Expect(gnp.Spec.Ingress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata: k8sAdminNetworkPolicyToCalicoMetadata("A random ingress rule"),
+				Action:   "Pass",
+				Protocol: &protocolTCP,
+				Source:   apiv3.EntityRule{NamespaceSelector: "k == 'v'"},
+				Destination: apiv3.EntityRule{
+					Ports: []numorstring.Port{
+						numorstring.SinglePort(80),
+					},
+				},
+			},
+		))
+		Expect(gnp.Spec.Egress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata: k8sAdminNetworkPolicyToCalicoMetadata("A random egress rule"),
+				Action:   "Deny",
+				Protocol: &protocolTCP,
+				Source:   apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{
+					NamespaceSelector: "k3 == 'v3'",
+					Ports: []numorstring.Port{
+						numorstring.SinglePort(80),
+					},
+				},
+			},
+			apiv3.Rule{
+				Metadata: k8sAdminNetworkPolicyToCalicoMetadata("A random egress rule"),
+				Action:   "Deny",
+				Protocol: &protocolTCP,
+				Source:   apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{
+					Nets: []string{"10.10.10.0/24", "1.1.1.1/32"},
+					Ports: []numorstring.Port{
+						numorstring.SinglePort(80),
+					},
+				},
+			},
+		))
+	})
+
+	It("should parse a k8s AdminNetworkPolicy with an invalid networks peer", func() {
+		ports := []adminpolicy.AdminNetworkPolicyPort{
+			{
+				PortNumber: &adminpolicy.Port{Port: 80},
+			},
+		}
+		anp := adminpolicy.AdminNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test.policy",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+			Spec: adminpolicy.AdminNetworkPolicySpec{
+				Priority: 200,
+				Subject: adminpolicy.AdminNetworkPolicySubject{
+					Namespaces: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label":  "value",
+							"label2": "value2",
+						},
+					},
+				},
+				Ingress: []adminpolicy.AdminNetworkPolicyIngressRule{
+					{
+						Name:   "A random ingress rule",
+						Action: "Pass",
+						Ports:  &ports,
+						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k": "v",
+									},
+								},
+							},
+						},
+					},
+				},
+				Egress: []adminpolicy.AdminNetworkPolicyEgressRule{
+					{
+						Name:   "A random egress rule",
+						Action: "Deny",
+						Ports:  &ports,
+						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k3": "v3",
+									},
+								},
+							},
+							{
+								Networks: []adminpolicy.CIDR{"10.10.10.0/24", "1.1.1.1/66"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		expectedErr := cerrors.ErrorAdminPolicyConversion{
+			PolicyName: "test.policy",
+			Rules: []cerrors.ErrorAdminPolicyConversionRule{
+				{
+					IngressRule: nil,
+					EgressRule: &adminpolicy.AdminNetworkPolicyEgressRule{
+						Name:   "A random egress rule",
+						Action: "Deny",
+						Ports:  &ports,
+						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels:      map[string]string{"k3": "v3"},
+									MatchExpressions: nil,
+								},
+							},
+							{
+								Networks: []adminpolicy.CIDR{"10.10.10.0/24", "1.1.1.1/66"},
+							},
+						},
+					},
+					Reason: "k8s rule couldn't be converted: invalid CIDR in ANP rule: invalid CIDR address: 1.1.1.1/66",
+				},
+			},
+		}
+
+		// Convert the policy
+		gnp := convertToGNP(&anp, float64(200.0), &expectedErr)
+
+		protocolTCP := numorstring.ProtocolFromString(numorstring.ProtocolTCP)
+		Expect(gnp.Spec.Ingress).To(ConsistOf(
+			apiv3.Rule{
+				Metadata: k8sAdminNetworkPolicyToCalicoMetadata("A random ingress rule"),
+				Action:   "Pass",
+				Protocol: &protocolTCP,
+				Source:   apiv3.EntityRule{NamespaceSelector: "k == 'v'"},
+				Destination: apiv3.EntityRule{
+					Ports: []numorstring.Port{
+						numorstring.SinglePort(80),
+					},
+				},
+			},
+		))
+		Expect(gnp.Spec.Egress).To(ConsistOf(
+			apiv3.Rule{
+				Action: "Deny", // The invalid rule is replaced with a deny-all rule.
+			},
+		))
 	})
 })

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -4640,7 +4640,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4751,6 +4751,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4852,6 +4862,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5009,6 +5110,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5253,6 +5359,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4650,7 +4650,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4761,6 +4761,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4862,6 +4872,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5019,6 +5120,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5263,6 +5369,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4651,7 +4651,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4762,6 +4762,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4863,6 +4873,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5020,6 +5121,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5264,6 +5370,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -4635,7 +4635,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4746,6 +4746,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4847,6 +4857,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5004,6 +5105,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5248,6 +5354,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4635,7 +4635,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4746,6 +4746,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4847,6 +4857,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5004,6 +5105,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5248,6 +5354,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4652,7 +4652,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4763,6 +4763,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4864,6 +4874,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5021,6 +5122,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5265,6 +5371,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -4545,7 +4545,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4656,6 +4656,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4757,6 +4767,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -4914,6 +5015,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5158,6 +5264,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -4635,7 +4635,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4746,6 +4746,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4847,6 +4857,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -5004,6 +5105,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5248,6 +5354,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/ocp/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/manifests/ocp/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -115,6 +115,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -216,6 +226,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -373,6 +474,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -617,6 +723,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -21074,7 +21074,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -21185,6 +21185,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -21286,6 +21296,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -21443,6 +21544,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -21687,6 +21793,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -4570,7 +4570,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
     policy.networking.k8s.io/bundle-version: v0.1.1
-    policy.networking.k8s.io/channel: standard
+    policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:
@@ -4681,6 +4681,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.
@@ -4782,6 +4792,97 @@ spec:
 
 
                               Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -4939,6 +5040,11 @@ spec:
                   - action
                   - to
                   type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
                 maxItems: 100
                 type: array
               ingress:
@@ -5183,6 +5289,16 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
                           portNumber:
                             description: |-
                               Port selects a port on a pod(s) based on number.


### PR DESCRIPTION
## Description
Add support for AdminNetworkPolicy egress network CIDRs.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Cherry pick of https://github.com/projectcalico/calico/pull/9276

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add support for AdminNetworkPolicy egress network CIDRs.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
