### PR TITLE
fix(charts/tigera-operator): openshift provider

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-configmap-calico-resources.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-configmap-calico-resources.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.installation.kubernetesProvider "openshift" }}
+{{- if eq (lower .Values.installation.kubernetesProvider) "openshift" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -251,7 +251,7 @@ rules:
     verbs:
       - list
       - watch
-{{- if eq .Values.installation.kubernetesProvider "openshift" }}
+{{- if eq (lower .Values.installation.kubernetesProvider) "openshift" }}
   # When running in OpenShift, we need to update networking config.
   - apiGroups:
       - config.openshift.io

--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -78,7 +78,7 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
-{{- if eq .Values.installation.kubernetesProvider "openshift" }}
+{{- if eq (lower .Values.installation.kubernetesProvider) "openshift" }}
         - name: calico-resources
           configMap:
             defaultMode: 0400

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -101,7 +101,7 @@ ${HELM} template --include-crds \
 	../charts/tigera-operator/ \
 	--output-dir ocp \
 	--no-hooks \
-	--set installation.kubernetesProvider=openshift \
+	--set installation.kubernetesProvider=OpenShift \
 	--set installation.enabled=false \
 	--set apiServer.enabled=false \
 	--set tigeraOperator.version=$OPERATOR_VERSION \


### PR DESCRIPTION
## Description

Fixes installation of calico tigera-operator when `installation.kubernetesProvider` is set to `OpenShift`.

Currently some resources are not created when `installation.kubernetesProvider` is set to `OpenShift` since the comparision is case sensitive. Since `installation.kubernetesProvider` values are limited to `["", EKS, GKE, AKS, OpenShift, DockerEnterprise, RKE2, TKG]` due to [Installation CRD schema](https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Provider) we need to adapt the conditional.

## Related issues/PRs

None

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Helm: Fix OpenShift provider
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
