### PR TITLE
[BPF]Fix memory leak when there is a pod churn

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1233,6 +1233,8 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			iface.info.isUP = false
 			m.updateIfaceStateMap(update.Name, iface)
 			iface.info.ifIndex = 0
+			iface.info.masterIfIndex = 0
+			iface.info.ifaceType = 0
 		}
 		return true // Force interface to be marked dirty in case we missed a transition during a resync.
 	})
@@ -4131,6 +4133,10 @@ func (m *bpfEndpointManager) getIfaceLink(name string) (netlink.Link, error) {
 		return nil, err
 	}
 	return link, nil
+}
+
+func (m *bpfEndpointManager) getNumEPs() int {
+	return len(m.nameToIface)
 }
 
 func (m *bpfEndpointManager) getIfaceTypeFromLink(link netlink.Link) IfaceType {


### PR DESCRIPTION
## Description

When there is a workload update, we add an entry to the nameToIface map. When there is a workload remove, we set the interface info to 0 and delete the entry. In 3.28, new fields were added to interface info, which were not reset to 0 on workload remove. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed memory leak in BPF endpoint manager.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
