### PR TITLE
generate docs for felixconfiguration from Api and code

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -445,6 +445,10 @@ stop-grafana:
 	@-docker rm -f k8sfv-grafana
 	sleep 2
 
+bin/docs-parser: $(SRC_FILES)
+	@echo Building calico-bpf...
+	$(call build_cgo_binary, "$(PACKAGE_NAME)/utils/docs-parser", $@)
+
 bin/calico-bpf: $(SRC_FILES)
 	@echo Building calico-bpf...
 	$(call build_cgo_binary, "$(PACKAGE_NAME)/cmd/calico-bpf", $@)

--- a/felix/utils/docs-parser/main.go
+++ b/felix/utils/docs-parser/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type docField struct {
+	Name     string
+	comment  string
+	Doc      string
+	DefaultV string
+}
+
+func main() {
+	if len(os.Args) != 5 {
+		fmt.Fprintf(os.Stderr, "Usage docs-parser <doc_file> <type> <def_file> <type>\n")
+		return
+	}
+
+	fname := os.Args[1]
+	tname := os.Args[2]
+	fset := token.NewFileSet()
+
+	astF, err := parser.ParseFile(fset, fname, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse the source file: %s\n", err)
+		return
+	}
+
+	pkg, err := doc.NewFromFiles(fset, []*ast.File{astF}, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate docs from source file: %s\n", err)
+		return
+	}
+
+	var dt *doc.Type
+
+	for _, t := range pkg.Types {
+		if t.Name == tname {
+			dt = t
+			break
+		}
+	}
+
+	if dt == nil {
+		fmt.Fprintf(os.Stderr, "Source file does not contain type: %s\n", tname)
+		return
+	}
+
+	fields := make(map[string]docField)
+	defRegexp := regexp.MustCompile(`(.*)\s*\[[dD]efault:\s*(.*)\]`)
+
+	ast.Inspect(dt.Decl, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.Field:
+			f := docField{
+				Name:    x.Names[0].Name,
+				comment: x.Doc.Text(),
+			}
+
+			c := ""
+			lines := strings.Split(f.comment, "\n")
+			for i, l := range lines {
+				if len(l) > 0 && l[0] != '+' {
+					if i > 0 {
+						c += " "
+					}
+					c += l
+				}
+			}
+
+			m := defRegexp.FindStringSubmatch(c)
+			if len(m) == 3 {
+				f.Doc = m[1]
+				f.DefaultV = m[2]
+			} else {
+				f.Doc = c
+			}
+
+			fields[x.Names[0].Name] = f
+		}
+
+		return true
+	})
+
+	fname = os.Args[3]
+	tname = os.Args[4]
+	fset = token.NewFileSet()
+
+	astF, err = parser.ParseFile(fset, fname, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse the source file: %s\n", err)
+		return
+	}
+
+	pkg, err = doc.NewFromFiles(fset, []*ast.File{astF}, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate docs from source file: %s\n", err)
+		return
+	}
+
+	dt = nil
+	for _, t := range pkg.Types {
+		if t.Name == tname {
+			dt = t
+			break
+		}
+	}
+
+	if dt == nil {
+		fmt.Fprintf(os.Stderr, "Source file does not contain type: %s\n", tname)
+		return
+	}
+
+	tagRegexp := regexp.MustCompile(`.config:"[^;]*;([^;"]+)`)
+
+	ast.Inspect(dt.Decl, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.Field:
+			name := x.Names[0].Name
+			f, ok := fields[name]
+			if !ok {
+				return true
+			}
+			if x.Tag == nil {
+				return true
+			}
+
+			tag := x.Tag.Value
+			m := tagRegexp.FindStringSubmatch(tag)
+			if len(m) > 0 {
+				f.DefaultV = m[1]
+				fields[name] = f
+			}
+		}
+
+		return true
+	})
+
+	list := make([]docField, 0, len(fields))
+
+	for _, f := range fields {
+		list = append(list, f)
+	}
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+
+	jsonData, err := json.MarshalIndent(list, "", "    ")
+
+	fmt.Println(string(jsonData))
+}


### PR DESCRIPTION
usage:

bin/docs-parser ../api/pkg/apis/projectcalico/v3/felixconfig.go FelixConfigurationSpec config/config_params.go Config > docs.json

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
