### PR TITLE
short names for cnp and gnp

### DIFF
--- a/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
@@ -104,7 +104,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), []string{}}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {

--- a/apiserver/pkg/registry/projectcalico/kubecontrollersconfig/storage.go
+++ b/apiserver/pkg/registry/projectcalico/kubecontrollersconfig/storage.go
@@ -33,6 +33,7 @@ import (
 // rest implements a RESTStorage for API services against etcd
 type REST struct {
 	*genericregistry.Store
+	shortNames []string
 }
 
 // EmptyObject returns an empty instance
@@ -47,7 +48,8 @@ func NewList() runtime.Object {
 
 // StatusREST implements the REST endpoint for changing the status of a deployment
 type StatusREST struct {
-	store *genericregistry.Store
+	store      *genericregistry.Store
+	shortNames []string
 }
 
 func (r *StatusREST) New() runtime.Object {
@@ -123,5 +125,5 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, *StatusREST, e
 	statusStore := *store
 	statusStore.UpdateStrategy = NewStatusStrategy(strategy)
 
-	return &REST{store}, &StatusREST{&statusStore}, nil
+	return &REST{store, opts.ShortNames}, &StatusREST{&statusStore, opts.ShortNames}, nil
 }

--- a/apiserver/pkg/registry/projectcalico/kubecontrollersconfig/storage.go
+++ b/apiserver/pkg/registry/projectcalico/kubecontrollersconfig/storage.go
@@ -127,3 +127,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, *StatusREST, e
 
 	return &REST{store, opts.ShortNames}, &StatusREST{&statusStore, opts.ShortNames}, nil
 }
+
+func (r *REST) ShortNames() []string {
+	return r.shortNames
+}

--- a/apiserver/pkg/registry/projectcalico/networkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/networkpolicy/storage.go
@@ -103,7 +103,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), []string{}}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {


### PR DESCRIPTION
## Description
Change to enable short names for calico network policy, global network policy and kube controllers config

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
