### PR TITLE
Add default tier to win dataplane

### DIFF
--- a/felix/dataplane/windows/endpoint_mgr.go
+++ b/felix/dataplane/windows/endpoint_mgr.go
@@ -26,10 +26,13 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	"github.com/projectcalico/calico/felix/dataplane/windows/hns"
 
 	"github.com/projectcalico/calico/felix/dataplane/windows/policysets"
 	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
@@ -356,43 +359,39 @@ func (m *endpointManager) CompleteDeferredWork() error {
 			//
 			// Also note whether the default tier has policies or not. If the
 			// default tier does not have policies in a direction, then a profile should be added for that direction.
-			var ingressPolNames, egressPolNames [][]string
 			var defaultTierIngressAppliesToEP bool
 			var defaultTierEgressAppliesToEP bool
+			var ingressRules, egressRules [][]*hns.ACLPolicy
 			for _, t := range workload.Tiers {
 				log.Debugf("windows workload %v, tiers: %v", workload.Name, t.Name)
+				endOfTierDrop := (t.DefaultAction != string(v3.Pass))
 				if len(t.IngressPolicies) > 0 {
-					if t.Name == "default" {
+					if t.Name == names.DefaultTierName {
 						defaultTierIngressAppliesToEP = true
 					}
-					ingressPolNames = append(ingressPolNames, prependAll(policysets.PolicyNamePrefix, t.IngressPolicies))
+					policyNames := prependAll(policysets.PolicyNamePrefix, t.IngressPolicies)
+					ingressRules = append(ingressRules, m.policysetsDataplane.GetPolicySetRules(policyNames, true, endOfTierDrop))
 				}
 				if len(t.EgressPolicies) > 0 {
-					if t.Name == "default" {
+					if t.Name == names.DefaultTierName {
 						defaultTierEgressAppliesToEP = true
 					}
-					egressPolNames = append(egressPolNames, prependAll(policysets.PolicyNamePrefix, t.EgressPolicies))
+					policyNames := prependAll(policysets.PolicyNamePrefix, t.EgressPolicies)
+					egressRules = append(egressRules, m.policysetsDataplane.GetPolicySetRules(policyNames, false, endOfTierDrop))
 				}
 			}
 			log.Debugf("default tier has ingress policies: %v, egress policies: %v", defaultTierIngressAppliesToEP, defaultTierEgressAppliesToEP)
 
 			// If _no_ policies apply at all, then we fall through to the profiles.  Otherwise, there's no way to get
 			// from policies to profiles.
-			if len(ingressPolNames) == 0 || !defaultTierIngressAppliesToEP {
-				ingressPolNames = append(ingressPolNames, prependAll(policysets.ProfileNamePrefix, workload.ProfileIds))
+			if len(ingressRules) == 0 || !defaultTierIngressAppliesToEP {
+				policyNames := prependAll(policysets.ProfileNamePrefix, workload.ProfileIds)
+				ingressRules = append(ingressRules, m.policysetsDataplane.GetPolicySetRules(policyNames, true, true))
 			}
 
-			if len(egressPolNames) == 0 || !defaultTierEgressAppliesToEP {
-				egressPolNames = append(egressPolNames, prependAll(policysets.ProfileNamePrefix, workload.ProfileIds))
-			}
-
-			// Expand the policies into rules.
-			var ingressRules, egressRules [][]*hns.ACLPolicy
-			for _, t := range ingressPolNames {
-				ingressRules = append(ingressRules, m.policysetsDataplane.GetPolicySetRules(t, true))
-			}
-			for _, t := range egressPolNames {
-				egressRules = append(egressRules, m.policysetsDataplane.GetPolicySetRules(t, false))
+			if len(egressRules) == 0 || !defaultTierEgressAppliesToEP {
+				policyNames := prependAll(policysets.ProfileNamePrefix, workload.ProfileIds)
+				egressRules = append(egressRules, m.policysetsDataplane.GetPolicySetRules(policyNames, false, true))
 			}
 
 			// Flatten any tiers.

--- a/felix/dataplane/windows/policy_mgr_test.go
+++ b/felix/dataplane/windows/policy_mgr_test.go
@@ -36,7 +36,7 @@ func TestPolicyManager(t *testing.T) {
 	ps := policysets.NewPolicySets(&h, []policysets.IPSetCache{&ipsc}, mockReader(""))
 	policyMgr := newPolicyManager(ps)
 
-	//Apply policy update
+	// Apply policy update
 	policyMgr.OnUpdate(&proto.ActivePolicyUpdate{
 		Id: &proto.PolicyID{Name: "pol1", Tier: "tier1"},
 		Policy: &proto.Policy{
@@ -49,33 +49,64 @@ func TestPolicyManager(t *testing.T) {
 		},
 	})
 
-	//assertion for ingress rules
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true)).To(Equal([]*hns.ACLPolicy{
+	// assertion for ingress rules
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		//policy-pol1 deny rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for ingress rules update for policy-pol1")
 
-	//assertion for egress rules
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false)).To(Equal([]*hns.ACLPolicy{
+	// assertion for ingress rules with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		//policy-pol1 deny rule should be present
+		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000},
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned for ingress rules update for policy-pol1")
+
+	// assertion for egress rules
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		//policy-pol1 allow rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for egress rules update for policy-pol1")
 
-	//remove policy here
+	// assertion for egress rules with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, false)).To(Equal([]*hns.ACLPolicy{
+		//policy-pol1 allow rule should be present
+		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000},
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned for egress rules update for policy-pol1")
+
+	// remove policy here
 	policyMgr.OnUpdate(&proto.ActivePolicyRemove{
 		Id: &proto.PolicyID{Name: "pol1", Tier: "tier1"},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true)).To(Equal([]*hns.ACLPolicy{
-		// Default deny rule.
+	// default ingress rule
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
 
-	//Apply profile update
+	// default ingress rule with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+
+	// default egress rule
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, true)).To(Equal([]*hns.ACLPolicy{
+		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+
+	// default egress rule with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, false)).To(Equal([]*hns.ACLPolicy{
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+
+	// Apply profile update
 	policyMgr.OnUpdate(&proto.ActiveProfileUpdate{
 		Id: &proto.ProfileID{Name: "prof1"},
 		Profile: &proto.Profile{
@@ -88,32 +119,66 @@ func TestPolicyManager(t *testing.T) {
 		},
 	})
 
-	//assertion for ingress rules
-	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, true)).To(Equal([]*hns.ACLPolicy{
+	// assertion for ingress rules
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		//profile-prof1 deny rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for ingress rules update for profile-prof1")
 
-	//assertion for egress rules
-	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, false)).To(Equal([]*hns.ACLPolicy{
+	// assertion for ingress rules with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		//profile-prof1 deny rule should be present
+		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000},
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned for ingress rules update for profile-prof1")
+
+	// assertion for egress rules
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		//profile-pol1 allow rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for egress rules update for profile-prof1")
 
-	//remove profile update
+	// assertion for egress rules
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, false, false)).To(Equal([]*hns.ACLPolicy{
+		//profile-pol1 allow rule should be present
+		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000},
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned for egress rules update for profile-prof1")
+
+	// remove profile update
 	policyMgr.OnUpdate(&proto.ActiveProfileRemove{
 		Id: &proto.ProfileID{Name: "prof1"},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, true)).To(Equal([]*hns.ACLPolicy{
+	// default ingress rule
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned after ActiveProfileRemove event for profile-prof1")
 
+	// default ingress rule with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned after ActiveProfileRemove event for profile-prof1")
+
+	// default egress rule
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, false, true)).To(Equal([]*hns.ACLPolicy{
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned after ActiveProfileRemove event for profile-prof1")
+
+	// default egress rule with endOfTierDrop disabled
+	Expect(ps.GetPolicySetRules([]string{"profile-prof1"}, false, false)).To(Equal([]*hns.ACLPolicy{
+		// Default deny rule.
+		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned after ActiveProfileRemove event for profile-prof1")
 }
 
 type mockHNS struct {

--- a/felix/dataplane/windows/policysets/policyset_defs.go
+++ b/felix/dataplane/windows/policysets/policyset_defs.go
@@ -70,7 +70,7 @@ type PolicySetsDataplane interface {
 	AddOrReplacePolicySet(setId string, policy interface{})
 	RemovePolicySet(setId string)
 	NewRule(isInbound bool, priority uint16) *hns.ACLPolicy
-	GetPolicySetRules(setIds []string, isInbound bool) (rules []*hns.ACLPolicy)
+	GetPolicySetRules(setIds []string, isInbound, endOfTierDrop bool) (rules []*hns.ACLPolicy)
 	ProcessIpSetUpdate(ipSetId string) []string
 	NewHostRule(bool) *hns.ACLPolicy
 }

--- a/felix/dataplane/windows/policysets/policysets.go
+++ b/felix/dataplane/windows/policysets/policysets.go
@@ -114,7 +114,7 @@ func (s *PolicySets) RemovePolicySet(setId string) {
 // GetPolicySetRules receives a list of Policy set ids and it computes the complete
 // set of resultant HNS rules that are needed to enforce all of the Policy sets for the
 // specified direction.
-func (s *PolicySets) GetPolicySetRules(setIds []string, isInbound bool) (rules []*hns.ACLPolicy) {
+func (s *PolicySets) GetPolicySetRules(setIds []string, isInbound, endOfTierDrop bool) (rules []*hns.ACLPolicy) {
 	// Rules from the first set will receive the default rule priority
 	currentPriority := PolicyRuleBasePriority
 
@@ -171,10 +171,13 @@ func (s *PolicySets) GetPolicySetRules(setIds []string, isInbound bool) (rules [
 		}
 	}
 
-	// Apply a default block rule for this direction at the end of the policy
+	// Apply a default block or pass rule for this direction at the end of the policy
 	currentPriority++
-	rules = append(rules, s.NewRule(isInbound, currentPriority))
-
+	endOfTierRule := s.NewRule(isInbound, currentPriority)
+	if !endOfTierDrop {
+		endOfTierRule.Action = ActionPass
+	}
+	rules = append(rules, endOfTierRule)
 	return
 }
 

--- a/felix/dataplane/windows/policysets/policysets_test.go
+++ b/felix/dataplane/windows/policysets/policysets_test.go
@@ -43,7 +43,7 @@ func TestRuleRenderingWithStaticRules(t *testing.T) {
 	ps := NewPolicySets(&h, []IPSetCache{&ipsc}, mockReader(staticRules))
 
 	// Unknown policy should result in default drop.
-	Expect(ps.GetPolicySetRules([]string{"unknown"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"unknown"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// Static inbound rule.
 		{Type: hns.ACL, Id: "MyPlatform-block-client", Protocol: 17, Action: hns.Allow, Direction: hns.In,
 			RuleType: hns.Host, Priority: 300, RemoteAddresses: "10.0.0.2/32", RemotePorts: "90"},
@@ -57,15 +57,30 @@ func TestRuleRenderingWithStaticRules(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"empty"}, true)).To(Equal([]*hns.ACLPolicy{
+	// Unknown policy should result in default pass with endOfTierDrop disabled.
+	Expect(ps.GetPolicySetRules([]string{"unknown"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		// Static inbound rule.
 		{Type: hns.ACL, Id: "MyPlatform-block-client", Protocol: 17, Action: hns.Allow, Direction: hns.In,
 			RuleType: hns.Host, Priority: 300, RemoteAddresses: "10.0.0.2/32", RemotePorts: "90"},
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	}), "unexpected rules returned for unknown policy")
+
+	// Empty policy should return no rules (apart from the default drop).
+	ps.AddOrReplacePolicySet("empty", &proto.Policy{
+		InboundRules:  []*proto.Rule{},
+		OutboundRules: []*proto.Rule{},
+	})
+
+	Expect(ps.GetPolicySetRules([]string{"empty"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		// Static inbound rule.
+		{Type: hns.ACL, Id: "MyPlatform-block-client", Protocol: 17, Action: hns.Allow, Direction: hns.In,
+			RuleType: hns.Host, Priority: 300, RemoteAddresses: "10.0.0.2/32", RemotePorts: "90"},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for empty policy")
 
-	Expect(ps.GetPolicySetRules([]string{"empty"}, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"empty"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		// Static outbound rule.
 		{Type: hns.ACL, Id: "MyPlatform-block-server", Protocol: 6, Action: hns.Block, Direction: hns.Out,
 			RuleType: hns.Switch, Priority: 200, RemoteAddresses: "10.0.0.1/32", RemotePorts: "80"},
@@ -109,7 +124,7 @@ func TestRuleRenderingWithStaticRules(t *testing.T) {
 		},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"basic"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"basic"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// Static inbound rule.
 		{Type: hns.ACL, Id: "MyPlatform-block-client", Protocol: 17, Action: hns.Allow, Direction: hns.In,
 			RuleType: hns.Host, Priority: 300, RemoteAddresses: "10.0.0.2/32", RemotePorts: "90"},
@@ -146,7 +161,7 @@ func TestRuleRenderingWithStaticRules(t *testing.T) {
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1002},
 	}), "unexpected rules returned for basic policy")
 
-	Expect(ps.GetPolicySetRules([]string{"basic"}, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"basic"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		// Static outbound rule.
 		{Type: hns.ACL, Id: "MyPlatform-block-server", Protocol: 6, Action: hns.Block, Direction: hns.Out,
 			RuleType: hns.Switch, Priority: 200, RemoteAddresses: "10.0.0.1/32", RemotePorts: "80"},
@@ -179,7 +194,7 @@ func TestRuleRendering(t *testing.T) {
 	ps := NewPolicySets(&h, []IPSetCache{&ipsc}, mockReader(""))
 
 	// Unknown policy should result in default drop.
-	Expect(ps.GetPolicySetRules([]string{"unknown"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"unknown"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for unknown policy")
@@ -190,9 +205,9 @@ func TestRuleRendering(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"empty"}, true)).To(Equal([]*hns.ACLPolicy{
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	Expect(ps.GetPolicySetRules([]string{"empty"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for empty policy")
 
 	// Tests of basic policy matches: CIDRs, protocol, ports.
@@ -225,7 +240,7 @@ func TestRuleRendering(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"basic"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"basic"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch,
 			Priority:        1000,
@@ -255,8 +270,8 @@ func TestRuleRendering(t *testing.T) {
 			Id:             "basic-rule-4-0",
 			LocalAddresses: "11.0.0.0/24",
 		},
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1002},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1002},
 	}), "unexpected rules returned for basic policy")
 
 	// Tests for Profile
@@ -266,7 +281,7 @@ func TestRuleRendering(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"empty-profile"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"empty-profile"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for empty profile")
@@ -282,7 +297,7 @@ func TestRuleRendering(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"rule-with-profile"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"rule-with-profile"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
 			Id: "rule-with-profile-rule-1-0",
@@ -323,9 +338,9 @@ func TestRuleRendering(t *testing.T) {
 	})
 
 	// We expect the rules to be skipped as there isn't any ip of type Ipv4
-	Expect(ps.GetPolicySetRules([]string{"mixed-cidr"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"mixed-cidr"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for mixed-cidr")
 
 	//Outbound policy with SrcNet
@@ -340,7 +355,7 @@ func TestRuleRendering(t *testing.T) {
 		},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"out-srcnet"}, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"out-srcnet"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
 			Id:             "out-srcnet-rule-1-0",
@@ -383,7 +398,7 @@ func TestIpPortRuleRendering(t *testing.T) {
 		InboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"basic"}, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"basic"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch,
 			Priority:        1000,
@@ -436,7 +451,7 @@ func TestIpPortRuleRenderingMultiPort(t *testing.T) {
 	})
 
 	// Should combine the first two endpoints since they share a protocol / port.
-	Expect(ps.GetPolicySetRules([]string{"basic"}, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"basic"}, false, false)).To(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch,
 			Priority:        1000,
@@ -453,8 +468,8 @@ func TestIpPortRuleRenderingMultiPort(t *testing.T) {
 			RemoteAddresses: "10.0.0.2",
 			RemotePorts:     "80",
 		},
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for IP+port policy")
 }
 
@@ -487,7 +502,7 @@ func TestIpPortRuleRenderingEmptyIPSet(t *testing.T) {
 	})
 
 	// Should only have the default rules.
-	Expect(ps.GetPolicySetRules([]string{"basic"}, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"basic"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for IP+port policy")
@@ -527,11 +542,11 @@ func TestNegativeTestCases(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"ipset-that-does-not-exist"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"ipset-that-does-not-exist"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		// Rules should be skipped
 		// Only the Default rules should exist.
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for ipset-that-does-not-exist")
 
 	//Negative test: Unsupported protocol
@@ -546,7 +561,7 @@ func TestNegativeTestCases(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"unsupported-protocol"}, true)).NotTo(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"unsupported-protocol"}, true, true)).NotTo(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch,
 			Priority: 1000,
@@ -570,7 +585,7 @@ func TestNegativeTestCases(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"unsupported-ip-version"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"unsupported-ip-version"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		//The rule with IP v6 should be skipped
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
@@ -589,10 +604,10 @@ func TestNegativeTestCases(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"named-port"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"named-port"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		//The rule with named port should be skipped
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rule with named port")
 
 	//Negative test: ICMP type
@@ -607,7 +622,7 @@ func TestNegativeTestCases(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"icmp-type"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"icmp-type"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		//The rule with ICMP type should be skipped
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
@@ -625,7 +640,7 @@ func TestNegativeTestCases(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"negative-match"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"negative-match"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		//The rule with negative match should be skipped
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
@@ -636,9 +651,9 @@ func TestNegativeTestCases(t *testing.T) {
 		Name: "abc",
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"invalid-arg"}, true)).To(Equal([]*hns.ACLPolicy{
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+	Expect(ps.GetPolicySetRules([]string{"invalid-arg"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned when invalid argument is passed to addOrReplacePolicySet function")
 
 	//Negative test for protoRuleToHnsRules
@@ -969,7 +984,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 	})
 
 	//check multi ips hns rules should be created using ipsets
-	Expect(ps.GetPolicySetRules([]string{"selector"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"selector"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
 			Id: "selector-rule-1-0", RemoteAddresses: "10.0.0.1,10.0.0.2,10.0.0.2,10.0.0.3",
@@ -978,8 +993,8 @@ func TestMultiIpPortChunks(t *testing.T) {
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
 			Id: "selector-rule-2-0", LocalAddresses: "10.1.0.1,10.1.0.2",
 		},
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for selector multi ips policy")
 
 	// Source and dest IP sets should be converted into hns rule with multi ips.
@@ -995,7 +1010,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"selector-ipsets"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"selector-ipsets"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// We expect the source/dest IP sets to be expressed as the cross product.
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
@@ -1036,7 +1051,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"selector-cidr"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"selector-cidr"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		// Intersection with first CIDR, picks up some IPs from each IP set.
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
@@ -1055,8 +1070,8 @@ func TestMultiIpPortChunks(t *testing.T) {
 		},
 		// Rule 4 becomes a no-op since intersection is empty.
 
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for selector CIDR filtering policy")
 
 	//Complete coverage of IPSetUpdate
@@ -1073,7 +1088,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 	//Updates the policies those use ipset a
 	ps.ProcessIpSetUpdate("a")
 
-	Expect(ps.GetPolicySetRules([]string{"selector-ipsets"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"selector-ipsets"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// We expect the policy to reflect the updated ipset
 		{
 			Type: hns.ACL, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000, Protocol: 256,
@@ -1095,7 +1110,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"ipset-update"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"ipset-update"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// Rule should be skipped
 		// Only the Default rules should exist.
 		// Default deny rule.
@@ -1126,7 +1141,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"ipset-update"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"ipset-update"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		//We expect the ipset updates would reflect in the rule
 		{
 			Type:            hns.ACL,
@@ -1138,8 +1153,8 @@ func TestMultiIpPortChunks(t *testing.T) {
 			RuleType:        hns.Switch,
 			Priority:        1000,
 		},
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "unexpected rules returned for ipset-update")
 
 	//Test where ProcessIpSetUpdate() receives an ipset-Id that doesn't have any policies linked
@@ -1165,7 +1180,7 @@ func TestMultiIpPortChunks(t *testing.T) {
 		OutboundRules: []*proto.Rule{},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"no-overlapping"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"no-overlapping"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		// We expect the rules to be skipped as no overlapping exist
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
@@ -1195,7 +1210,7 @@ func TestPolicyOrdering(t *testing.T) {
 		InboundRules: []*proto.Rule{{Action: "Deny"}},
 	})
 
-	Expect(ps.GetPolicySetRules([]string{"allow", "deny"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"allow", "deny"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000,
 			Id: "allow--0"},
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001,
@@ -1204,7 +1219,7 @@ func TestPolicyOrdering(t *testing.T) {
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1002},
 	}), "incorrect rules returned for allow,deny")
 
-	Expect(ps.GetPolicySetRules([]string{"allow", "allow"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"allow", "allow"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000,
 			Id: "allow--0"},
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1000,
@@ -1213,13 +1228,13 @@ func TestPolicyOrdering(t *testing.T) {
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
 	}), "incorrect rules returned for allow,allow")
 
-	Expect(ps.GetPolicySetRules([]string{"deny", "allow"}, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"deny", "allow"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000,
 			Id: "deny--0"},
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.In, RuleType: hns.Switch, Priority: 1001,
 			Id: "allow--0"},
-		// Default deny rule.
-		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1002},
+		// Default pass rule.
+		{Type: hns.ACL, Protocol: 256, Action: ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1002},
 	}), "incorrect rules returned for deny,allow")
 }
 

--- a/felix/fv/winfv/policy_test.go
+++ b/felix/fv/winfv/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -163,8 +163,46 @@ var _ = Describe("Windows policy test", func() {
 
 			// Create a policy allowing to the nginx-b service.
 			client := newClient()
+
+			By("creating tier1 and a network policy in it")
+			tier1 := v3.NewTier()
+			tier1.Name = "tier1"
+			order := float64(10)
+			tier1.Spec.Order = &order
+			_, err := client.Tiers().Create(context.Background(), tier1, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				_, err = client.Tiers().Delete(context.Background(), tier1.Name, options.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			p1 := v3.NetworkPolicy{}
+			p1.Name = fmt.Sprintf("%v.allow-nginx-x", tier1.Name)
+			p1.Namespace = "demo"
+			p1.Spec.Tier = tier1.Name
+			p1.Spec.Selector = "all()"
+			p1.Spec.Egress = []v3.Rule{
+				{
+					Action: v3.Allow,
+					Destination: v3.EntityRule{
+						Services: &v3.ServiceMatch{
+							Name:      "nginx-x",
+							Namespace: "demo",
+						},
+					},
+				},
+			}
+			_, err = client.NetworkPolicies().Create(context.Background(), &p1, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				_, err = client.NetworkPolicies().Delete(context.Background(), "demo", p1.Name, options.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("creating a network policy to allow traffic")
 			p := v3.NetworkPolicy{}
 			p.Name = "allow-nginx-b"
+
 			p.Namespace = "demo"
 			p.Spec.Selector = "all()"
 			p.Spec.Egress = []v3.Rule{
@@ -178,13 +216,26 @@ var _ = Describe("Windows policy test", func() {
 					},
 				},
 			}
-			_, err := client.NetworkPolicies().Create(context.Background(), &p, options.SetOptions{})
+			_, err = client.NetworkPolicies().Create(context.Background(), &p, options.SetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				_, err = client.NetworkPolicies().Delete(context.Background(), "demo", "allow-nginx-b", options.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
+			By("asserting destination is not reachable")
+			// Assert nginx-b is not reachable.
+			kubectlExecWithErrors(fmt.Sprintf(`-t porter -- powershell -Command 'Invoke-WebRequest -UseBasicParsing -TimeoutSec 5 %v'`, nginxB))
+
+			By("updating tier1 default action to pass")
+			tier1, err = client.Tiers().Get(context.Background(), tier1.Name, options.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			passAction := v3.Pass
+			tier1.Spec.DefaultAction = &passAction
+			_, err = client.Tiers().Update(context.Background(), tier1, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("asserting destination is now reachable")
 			// Assert that it's now reachable.
 			kubectlExec(fmt.Sprintf(`-t porter -- powershell -Command 'Invoke-WebRequest -UseBasicParsing -TimeoutSec 5 %v'`, nginxB))
 		})


### PR DESCRIPTION
## Description

Add support for tier's default action to windows dataplane.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Original PR: https://github.com/projectcalico/calico/pull/9085

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
