### PR TITLE
Replace invalid ANP rules with pass action to deny-all

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/adminnetworkpolicy_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/adminnetworkpolicy_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 				Ingress: []adminpolicy.AdminNetworkPolicyIngressRule{
 					{
 						Name:   "A random ingress rule",
-						Action: "Pass",
+						Action: "Allow",
 						Ports:  &badPorts,
 						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
 							{
@@ -422,7 +422,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					},
 					{
 						Name:   "A random ingress rule 2",
-						Action: "Allow",
+						Action: "Pass",
 						Ports:  &goodPorts,
 						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
 							{
@@ -454,7 +454,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					},
 					{
 						Name:   "A random egress rule 2",
-						Action: "Pass",
+						Action: "Allow",
 						Ports:  &badPorts,
 						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
 							{
@@ -478,7 +478,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					EgressRule: nil,
 					IngressRule: &adminpolicy.AdminNetworkPolicyIngressRule{
 						Name:   "A random ingress rule",
-						Action: "Pass",
+						Action: "Allow",
 						Ports:  &badPorts,
 						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
 							{
@@ -496,7 +496,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					IngressRule: nil,
 					EgressRule: &adminpolicy.AdminNetworkPolicyEgressRule{
 						Name:   "A random egress rule 2",
-						Action: "Pass",
+						Action: "Allow",
 						Ports:  &badPorts,
 						To: []adminpolicy.AdminNetworkPolicyEgressPeer{
 							{
@@ -522,7 +522,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 		Expect(gnp.Spec.Ingress).To(ConsistOf(
 			apiv3.Rule{
 				Metadata: k8sAdminNetworkPolicyToCalicoMetadata("A random ingress rule 2"),
-				Action:   "Allow",
+				Action:   "Pass",
 				Protocol: &protoTCP, // Defaulted to TCP.
 				Source: apiv3.EntityRule{
 					NamespaceSelector: "k10 == 'v10' && k20 == 'v20'",
@@ -1205,9 +1205,12 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 		Expect(gnp.Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && label == 'value'"))
 		Expect(gnp.Spec.NamespaceSelector).To(Equal("all()"))
 
-		// There should be no rules.
+		Expect(gnp.Spec.Egress).To(HaveLen(1))
+		Expect(gnp.Spec.Egress[0].Destination.NamespaceSelector).To(BeZero())
+		Expect(gnp.Spec.Egress[0]).To(Equal(apiv3.Rule{Action: apiv3.Deny}))
+
+		// There should be no ingress rules.
 		Expect(gnp.Spec.Ingress).To(HaveLen(0))
-		Expect(gnp.Spec.Egress).To(HaveLen(0))
 	})
 
 	It("should parse an AdminNetworkPolicy with a rule with empty namespaceSelector", func() {
@@ -1440,7 +1443,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					{
 						Name:   "A random ingress rule",
 						Action: "Pass",
-						Ports:  &ports,
+						Ports:  &badPorts,
 						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
 							{
 								Namespaces: &metav1.LabelSelector{
@@ -1453,7 +1456,7 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 					},
 					{
 						Name:   "A random ingress rule 2",
-						Action: "Pass",
+						Action: "Allow",
 						Ports:  &badPorts,
 						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
 							{
@@ -1505,8 +1508,26 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 				{
 					EgressRule: nil,
 					IngressRule: &adminpolicy.AdminNetworkPolicyIngressRule{
-						Name:   "A random ingress rule 2",
+						Name:   "A random ingress rule",
 						Action: "Pass",
+						Ports:  &badPorts,
+						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
+							{
+								Namespaces: &metav1.LabelSelector{
+									MatchLabels:      map[string]string{"k": "v"},
+									MatchExpressions: nil,
+								},
+								Pods: nil,
+							},
+						},
+					},
+					Reason: "k8s rule couldn't be converted: failed to parse k8s port: minimum port number (40) is greater than maximum port number (20) in port range",
+				},
+				{
+					EgressRule: nil,
+					IngressRule: &adminpolicy.AdminNetworkPolicyIngressRule{
+						Name:   "A random ingress rule 2",
+						Action: "Allow",
 						Ports:  &badPorts,
 						From: []adminpolicy.AdminNetworkPolicyIngressPeer{
 							{
@@ -1546,8 +1567,8 @@ var _ = Describe("Test AdminNetworkPolicy conversion", func() {
 		Expect(gnp.Spec.NamespaceSelector).To(Equal("label == 'value' && label2 == 'value2'"))
 
 		Expect(len(gnp.Spec.Ingress)).To(Equal(1))
-		Expect(gnp.Spec.Ingress[0].Source.NamespaceSelector).To(Equal("k == 'v'"))
-		Expect(gnp.Spec.Ingress[0].Destination.Ports).To(Equal([]numorstring.Port{numorstring.SinglePort(80)}))
+		Expect(gnp.Spec.Egress[0].Destination.NamespaceSelector).To(BeZero())
+		Expect(gnp.Spec.Egress[0]).To(Equal(apiv3.Rule{Action: apiv3.Deny}))
 
 		Expect(gnp.Spec.Egress).To(HaveLen(2))
 		Expect(gnp.Spec.Egress[0].Destination.NamespaceSelector).To(BeZero())

--- a/libcalico-go/lib/backend/k8s/conversion/conversion.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion.go
@@ -378,7 +378,8 @@ func (c converter) K8sAdminNetworkPolicyToCalico(anp *adminpolicy.AdminNetworkPo
 }
 
 func k8sANPHandleFailedRules(action adminpolicy.AdminNetworkPolicyRuleAction) *apiv3.Rule {
-	if action == adminpolicy.AdminNetworkPolicyRuleActionDeny {
+	if action == adminpolicy.AdminNetworkPolicyRuleActionDeny ||
+		action == adminpolicy.AdminNetworkPolicyRuleActionPass {
 		logrus.Warn("replacing failed rule with a deny-all one.")
 		return &apiv3.Rule{
 			Action: apiv3.Deny,


### PR DESCRIPTION
## Description

Replace an invalid ANP rule with `Pass` action, with a deny-all to fail closed.

AdminNetworkPolicy specification states the implementations should fail closed. As such, Calico handles unsupported or invalid rules as the following:
- Rules with `deny` action, are converted to a deny-all. 
- Rules with `pass` action, are converted to a deny-all. Mainly to not unintentionally hit another permissive rule. 
- Rules with `allow` action, are skipped.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
