### PR TITLE
Use errors.New and fmt.Errorf from stdlib

### DIFF
--- a/apiserver/pkg/registry/projectcalico/authorizer/authorizer.go
+++ b/apiserver/pkg/registry/projectcalico/authorizer/authorizer.go
@@ -4,6 +4,7 @@ package authorizer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -11,7 +12,7 @@ import (
 
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sauth "k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/filters"
 )
@@ -152,7 +153,7 @@ func (a *authorizer) AuthorizeTierOperation(
 	// Request is forbidden.
 	reason := forbiddenMessage(attributes, "tier", tierName, decisionGetTier)
 	klog.V(4).Infof("Operation on Calico tiered policy is forbidden: %v", reason)
-	return errors.NewForbidden(calico.Resource(attributes.GetResource()), policyName, fmt.Errorf("%s", reason))
+	return k8serrors.NewForbidden(calico.Resource(attributes.GetResource()), policyName, errors.New(reason))
 }
 
 // forbiddenMessage crafts the appropriate forbidden message for our special hierarchically owned resource types. This

--- a/calicoctl/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/export.go
@@ -17,6 +17,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -190,7 +191,7 @@ Description:
 					errStr += "\n"
 				}
 			}
-			return fmt.Errorf("%s", errStr)
+			return errors.New(errStr)
 		}
 
 		for i, resource := range results.Resources {
@@ -379,7 +380,7 @@ Description:
 				errStr += "\n"
 			}
 		}
-		return fmt.Errorf("%s", errStr)
+		return errors.New(errStr)
 	}
 
 	// Denote separation between resources stored in YAML and the JSON IPAM resources.

--- a/calicoctl/calicoctl/commands/delete.go
+++ b/calicoctl/calicoctl/commands/delete.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -138,7 +139,7 @@ Description:
 				errStr += fmt.Sprintf("Failed to delete resource: %v\n", err)
 			}
 		}
-		return fmt.Errorf("%s", errStr)
+		return errors.New(errStr)
 	}
 
 	return nil

--- a/calicoctl/calicoctl/commands/get.go
+++ b/calicoctl/calicoctl/commands/get.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -209,7 +210,7 @@ Description:
 				errStr += "\n"
 			}
 		}
-		return fmt.Errorf("%s", errStr)
+		return errors.New(errStr)
 	}
 
 	return nil

--- a/calicoctl/calicoctl/commands/node/run.go
+++ b/calicoctl/calicoctl/commands/node/run.go
@@ -16,6 +16,7 @@ package node
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	gonet "net"
 	"os"
@@ -374,7 +375,7 @@ Description:
 		for _, line := range strings.Split(string(output), "/n") {
 			errStr += fmt.Sprintf(" | %s/n", line)
 		}
-		return fmt.Errorf("%s", errStr)
+		return errors.New(errStr)
 	}
 
 	// Create the command to follow the docker logs for the calico/node

--- a/calicoctl/calicoctl/commands/patch.go
+++ b/calicoctl/calicoctl/commands/patch.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -110,7 +111,7 @@ Description:
 		for _, err := range results.ResErrs {
 			errStr += fmt.Sprintf("Failed to patch '%s' resource: %v\n", results.SingleKind, err)
 		}
-		return fmt.Errorf("%s", errStr)
+		return errors.New(errStr)
 	}
 
 	return nil

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -155,7 +155,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 				// present both.
 				msg = fmt.Sprintf("%s: error=%s", msg, err)
 			}
-			err = fmt.Errorf("%s", msg)
+			err = errors.New(msg)
 		}
 		if err != nil {
 			logrus.WithError(err).Error("Final result of CNI ADD was an error.")
@@ -572,7 +572,7 @@ func cmdDel(args *skel.CmdArgs) (err error) {
 				// present both.
 				msg = fmt.Sprintf("%s: error=%s", msg, err)
 			}
-			err = fmt.Errorf("%s", msg)
+			err = errors.New(msg)
 		}
 		if err != nil {
 			logrus.WithError(err).Error("Final result of CNI DEL was an error.")

--- a/felix/aws/ec2_test.go
+++ b/felix/aws/ec2_test.go
@@ -162,7 +162,7 @@ var _ = Describe("AWS Tests", func() {
 		Expect(errMsg).To(Equal(fmt.Sprintf("%s: %s", fakeCode, fakeMsg)))
 
 		fakeMsg = "fake non-aws error"
-		err := fmt.Errorf("%s", fakeMsg)
+		err := errors.New(fakeMsg)
 		errMsg = convertError(err)
 		Expect(errMsg).To(Equal(fakeMsg))
 	})
@@ -181,7 +181,7 @@ var _ = Describe("AWS Tests", func() {
 		Expect(retriable(awsErr)).To(BeFalse())
 
 		fakeMsg = "non-aws error"
-		err := fmt.Errorf("%s", fakeMsg)
+		err := errors.New(fakeMsg)
 		Expect(retriable(err)).To(BeFalse())
 	})
 

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -525,7 +525,7 @@ func getMapStructGeneral(mapDesc []string) (*mapInfo, error) {
 		return nil, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
 	}
 	if m.Err != "" {
-		return nil, fmt.Errorf("%s", m.Err)
+		return nil, errors.New(m.Err)
 	}
 	return &m, nil
 }
@@ -1051,7 +1051,7 @@ func (b *BPFLib) GetXDPTag(ifName string) (string, error) {
 		return "", fmt.Errorf("cannot parse json output: %v\n%s", err, output)
 	}
 	if p.Err != "" {
-		return "", fmt.Errorf("%s", p.Err)
+		return "", errors.New(p.Err)
 	}
 
 	return p.Tag, nil
@@ -1141,7 +1141,7 @@ func (b *BPFLib) GetMapsFromXDP(ifName string) ([]int, error) {
 		return nil, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
 	}
 	if p.Err != "" {
-		return nil, fmt.Errorf("%s", p.Err)
+		return nil, errors.New(p.Err)
 	}
 
 	return p.MapIds, nil
@@ -1666,7 +1666,7 @@ func (b *BPFLib) getSockMapID(progID int) (int, error) {
 		return -1, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
 	}
 	if p.Err != "" {
-		return -1, fmt.Errorf("%s", p.Err)
+		return -1, errors.New(p.Err)
 	}
 
 	for _, mapID := range p.MapIds {
@@ -1717,7 +1717,7 @@ func clearSockmap(mapArgs []string) error {
 		}
 
 		if e.Err != "" {
-			return fmt.Errorf("%s", e.Err)
+			return errors.New(e.Err)
 		}
 
 		keyArgs := jsonKeyToArgs(e.NextKey)

--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -288,7 +288,7 @@ func ShowMapCmd(m Map) ([]string, error) {
 		}, nil
 	}
 
-	return nil, errors.Errorf("unrecognized map type %T", m)
+	return nil, fmt.Errorf("unrecognized map type %T", m)
 }
 
 // DumpMapCmd returns the command that can be used to dump a map or an error
@@ -305,7 +305,7 @@ func DumpMapCmd(m Map) ([]string, error) {
 		}, nil
 	}
 
-	return nil, errors.Errorf("unrecognized map type %T", m)
+	return nil, fmt.Errorf("unrecognized map type %T", m)
 }
 
 func MapDeleteKeyCmd(m Map, key []byte) ([]string, error) {
@@ -330,7 +330,7 @@ func MapDeleteKeyCmd(m Map, key []byte) ([]string, error) {
 		return cmd, nil
 	}
 
-	return nil, errors.Errorf("unrecognized map type %T", m)
+	return nil, fmt.Errorf("unrecognized map type %T", m)
 }
 
 var ErrNotSupported = fmt.Errorf("prog_array iteration not supported")
@@ -377,7 +377,7 @@ func (b *PinnedMap) Iter(f IterCallback) error {
 			if err == ErrIterationFinished {
 				return nil
 			}
-			return errors.Errorf("iterating the map failed: %s", err)
+			return fmt.Errorf("iterating the map failed: %s", err)
 		}
 
 		action = f(k, v)
@@ -459,7 +459,7 @@ func (b *PinnedMap) updateDeltaEntries() error {
 			if err == ErrIterationFinished {
 				break
 			}
-			return errors.Errorf("iterating the old map failed: %s", err)
+			return fmt.Errorf("iterating the old map failed: %s", err)
 		}
 		if numEntriesCopied == b.MaxEntries {
 			return fmt.Errorf("new map cannot hold all the data from the old map %s.", b.GetName())
@@ -508,7 +508,7 @@ func (b *PinnedMap) copyFromOldMap() error {
 			if err == ErrIterationFinished {
 				return nil
 			}
-			return errors.Errorf("iterating the old map failed: %s", err)
+			return fmt.Errorf("iterating the old map failed: %s", err)
 		}
 
 		if numEntriesCopied == b.MaxEntries {

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -18,6 +18,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -120,11 +121,11 @@ type stoppableRunner interface {
 func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option) (ProxyFrontend, error) {
 
 	if k8s == nil {
-		return nil, errors.Errorf("no k8s client")
+		return nil, errors.New("no k8s client")
 	}
 
 	if dp == nil {
-		return nil, errors.Errorf("no dataplane syncer")
+		return nil, errors.New("no dataplane syncer")
 	}
 
 	p := &proxy{
@@ -168,12 +169,12 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 
 	noProxyName, err := labels.NewRequirement(apis.LabelServiceProxyName, selection.DoesNotExist, nil)
 	if err != nil {
-		return nil, errors.Errorf("noProxyName selector: %s", err)
+		return nil, fmt.Errorf("noProxyName selector: %s", err)
 	}
 
 	noHeadlessEndpoints, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
 	if err != nil {
-		return nil, errors.Errorf("noHeadlessEndpoints selector: %s", err)
+		return nil, fmt.Errorf("noHeadlessEndpoints selector: %s", err)
 	}
 
 	labelSelector := labels.NewSelector()

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -25,15 +25,15 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
 	v1 "k8s.io/api/core/v1"
 	k8sp "k8s.io/kubernetes/pkg/proxy"
-
-	"github.com/projectcalico/calico/felix/cachingmap"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/cachingmap"
 	"github.com/projectcalico/calico/felix/ip"
 )
 
@@ -455,7 +455,7 @@ func (s *Syncer) applyExpandedNP(sname k8sp.ServicePortName, sinfo k8sp.ServiceP
 	si.port = nport
 
 	if err := s.applySvc(skey, si, eps); err != nil {
-		return errors.Errorf("apply NodePortRemote for %s node %s", sname, node)
+		return fmt.Errorf("apply NodePortRemote for %s node %s", sname, node)
 	}
 
 	return nil
@@ -531,7 +531,7 @@ func (s *Syncer) applyDerived(
 	svc, ok := s.newSvcMap[getSvcKey(sname, "")]
 	if !ok {
 		// this should not happen
-		return errors.Errorf("no ClusterIP for derived service type %d", t)
+		return fmt.Errorf("no ClusterIP for derived service type %d", t)
 	}
 
 	var skey svcKey
@@ -960,7 +960,7 @@ func ProtoV1ToInt(p v1.Protocol) (uint8, error) {
 		return 132, nil
 	}
 
-	return 0, errors.Errorf("unknown protocol %q", p)
+	return 0, fmt.Errorf("unknown protocol %q", p)
 }
 
 // ProtoV1ToIntPanic translates k8s v1.Protocol to its IANA number and panics if
@@ -1213,7 +1213,7 @@ func (s *Syncer) cleanupSticky() error {
 		return maps.IterNone
 	})
 	if err != nil {
-		return errors.Errorf("NAT affinity map iterator failed: %s", err)
+		return fmt.Errorf("NAT affinity map iterator failed: %s", err)
 	}
 	return nil
 }

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -15,26 +15,25 @@
 package proxy_test
 
 import (
+	"fmt"
 	"net"
 	"sync"
 	"time"
 
-	"github.com/projectcalico/calico/felix/bpf/maps"
-	"github.com/projectcalico/calico/felix/bpf/nat"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	k8sp "k8s.io/kubernetes/pkg/proxy"
-
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8sp "k8s.io/kubernetes/pkg/proxy"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/mock"
+	"github.com/projectcalico/calico/felix/bpf/nat"
 	proxy "github.com/projectcalico/calico/felix/bpf/proxy"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/ip"
@@ -1328,11 +1327,11 @@ func (m *mockNATMap) Update(k, v []byte) error {
 
 	ks := len(nat.FrontendKey{})
 	if len(k) != ks {
-		return errors.Errorf("expected key size %d got %d", ks, len(k))
+		return fmt.Errorf("expected key size %d got %d", ks, len(k))
 	}
 	vs := len(nat.FrontendValue{})
 	if len(v) != vs {
-		return errors.Errorf("expected value size %d got %d", vs, len(v))
+		return fmt.Errorf("expected value size %d got %d", vs, len(v))
 	}
 
 	var key nat.FrontendKey
@@ -1360,7 +1359,7 @@ func (m *mockNATMap) Delete(k []byte) error {
 
 	ks := len(nat.FrontendKey{})
 	if len(k) != ks {
-		return errors.Errorf("expected key size %d got %d", ks, len(k))
+		return fmt.Errorf("expected key size %d got %d", ks, len(k))
 	}
 
 	var key nat.FrontendKey
@@ -1421,11 +1420,11 @@ func (m *mockNATBackendMap) Update(k, v []byte) error {
 
 	ks := len(nat.BackendKey{})
 	if len(k) != ks {
-		return errors.Errorf("expected key size %d got %d", ks, len(k))
+		return fmt.Errorf("expected key size %d got %d", ks, len(k))
 	}
 	vs := len(nat.BackendValue{})
 	if len(v) != vs {
-		return errors.Errorf("expected value size %d got %d", vs, len(v))
+		return fmt.Errorf("expected value size %d got %d", vs, len(v))
 	}
 
 	var key nat.BackendKey
@@ -1453,7 +1452,7 @@ func (m *mockNATBackendMap) Delete(k []byte) error {
 
 	ks := len(nat.BackendKey{})
 	if len(k) != ks {
-		return errors.Errorf("expected key size %d got %d", ks, len(k))
+		return fmt.Errorf("expected key size %d got %d", ks, len(k))
 	}
 
 	var key nat.BackendKey
@@ -1506,11 +1505,11 @@ func (m *mockAffinityMap) Update(k, v []byte) error {
 
 	ks := len(nat.AffinityKey{})
 	if len(k) != ks {
-		return errors.Errorf("expected key size %d got %d", ks, len(k))
+		return fmt.Errorf("expected key size %d got %d", ks, len(k))
 	}
 	vs := len(nat.AffinityValue{})
 	if len(v) != vs {
-		return errors.Errorf("expected value size %d got %d", vs, len(v))
+		return fmt.Errorf("expected value size %d got %d", vs, len(v))
 	}
 
 	var key nat.AffinityKey
@@ -1534,7 +1533,7 @@ func (m *mockAffinityMap) Delete(k []byte) error {
 
 	ks := len(nat.AffinityKey{})
 	if len(k) != ks {
-		return errors.Errorf("expected key size %d got %d", ks, len(k))
+		return fmt.Errorf("expected key size %d got %d", ks, len(k))
 	}
 
 	var key nat.AffinityKey

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -997,12 +997,12 @@ func bpftoolProgRunN(progName string, dataIn, ctxIn []byte, N int) (bpfRunResult
 	ctxOutFname := tempDir + "/ctx_out"
 
 	if err := os.WriteFile(dataInFname, dataIn, 0644); err != nil {
-		return res, errors.Errorf("failed to write input data in file: %s", err)
+		return res, fmt.Errorf("failed to write input data in file: %s", err)
 	}
 
 	if ctxIn != nil {
 		if err := os.WriteFile(ctxInFname, ctxIn, 0644); err != nil {
-			return res, errors.Errorf("failed to write input ctx in file: %s", err)
+			return res, fmt.Errorf("failed to write input ctx in file: %s", err)
 		}
 	}
 
@@ -1020,18 +1020,18 @@ func bpftoolProgRunN(progName string, dataIn, ctxIn []byte, N int) (bpfRunResult
 	}
 
 	if err := json.Unmarshal(out, &res); err != nil {
-		return res, errors.Errorf("failed to unmarshall json: %s", err)
+		return res, fmt.Errorf("failed to unmarshall json: %s", err)
 	}
 
 	res.dataOut, err = os.ReadFile(dataOutFname)
 	if err != nil {
-		return res, errors.Errorf("failed to read output data from file: %s", err)
+		return res, fmt.Errorf("failed to read output data from file: %s", err)
 	}
 
 	if ctxIn != nil {
 		ctxOut, err := os.ReadFile(ctxOutFname)
 		if err != nil {
-			return res, errors.Errorf("failed to read output ctx from file: %s", err)
+			return res, fmt.Errorf("failed to read output ctx from file: %s", err)
 		}
 		skbMark = binary.LittleEndian.Uint32(ctxOut[2*4 : 3*4])
 	}
@@ -1614,7 +1614,7 @@ func (pkt *Packet) handleL4() error {
 		pkt.l4Protocol = layers.IPProtocolICMPv6
 		pkt.layers = append(pkt.layers, pkt.icmpv6)
 	default:
-		return errors.Errorf("unrecognized l4 layer type %t", pkt.l4)
+		return fmt.Errorf("unrecognized l4 layer type %t", pkt.l4)
 	}
 	return nil
 }
@@ -1705,7 +1705,7 @@ func (pkt *Packet) handleL3() error {
 		pkt.ipv6.Length = uint16(pkt.length)
 		pkt.layers = append(pkt.layers, pkt.ipv6)
 	default:
-		return errors.Errorf("unrecognized l3 layer type %t", pkt.l3)
+		return fmt.Errorf("unrecognized l3 layer type %t", pkt.l3)
 	}
 	return nil
 }

--- a/felix/cmd/calico-bpf/commands/conntrack.go
+++ b/felix/cmd/calico-bpf/commands/conntrack.go
@@ -32,7 +32,6 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/maps"
 
 	"github.com/docopt/docopt-go"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -321,12 +320,12 @@ func newConntrackRemoveCmd() *cobra.Command {
 func (cmd *conntrackRemoveCmd) Args(c *cobra.Command, args []string) error {
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	switch proto := strings.ToLower(args[0]); proto {
@@ -335,17 +334,17 @@ func (cmd *conntrackRemoveCmd) Args(c *cobra.Command, args []string) error {
 	case "tcp":
 		cmd.proto = 6
 	default:
-		return errors.Errorf("unknown protocol %s", proto)
+		return fmt.Errorf("unknown protocol %s", proto)
 	}
 
 	cmd.ip1 = net.ParseIP(cmd.IP1)
 	if cmd.ip1 == nil {
-		return errors.Errorf("ip1: %q is not an ip", cmd.IP1)
+		return fmt.Errorf("ip1: %q is not an ip", cmd.IP1)
 	}
 
 	cmd.ip2 = net.ParseIP(cmd.IP2)
 	if cmd.ip2 == nil {
-		return errors.Errorf("ip2: %q is not an ip", cmd.IP2)
+		return fmt.Errorf("ip2: %q is not an ip", cmd.IP2)
 	}
 
 	return nil
@@ -435,12 +434,12 @@ func newConntrackCreateCmd() *cobra.Command {
 func (cmd *conntrackCreateCmd) Args(c *cobra.Command, args []string) error {
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 	return nil
 }
@@ -488,12 +487,12 @@ func newConntrackWriteCmd() *cobra.Command {
 func (cmd *conntrackWriteCmd) Args(c *cobra.Command, args []string) error {
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	cmd.key, err = base64.StdEncoding.DecodeString(cmd.Key)
@@ -501,11 +500,11 @@ func (cmd *conntrackWriteCmd) Args(c *cobra.Command, args []string) error {
 		switch cmd.version {
 		case "2":
 			if len(cmd.key) != len(v2.Key{}) {
-				return errors.Errorf("failed to decode key: %s", err)
+				return fmt.Errorf("failed to decode key: %s", err)
 			}
 		default:
 			if len(cmd.key) != len(conntrack.Key{}) {
-				return errors.Errorf("failed to decode key: %s", err)
+				return fmt.Errorf("failed to decode key: %s", err)
 			}
 		}
 	}
@@ -515,11 +514,11 @@ func (cmd *conntrackWriteCmd) Args(c *cobra.Command, args []string) error {
 		switch cmd.version {
 		case "2":
 			if len(cmd.val) != len(v2.Value{}) {
-				return errors.Errorf("failed to decode val: %s", err)
+				return fmt.Errorf("failed to decode val: %s", err)
 			}
 		default:
 			if len(cmd.val) != len(conntrack.Value{}) {
-				return errors.Errorf("failed to decode val: %s", err)
+				return fmt.Errorf("failed to decode val: %s", err)
 			}
 		}
 	}

--- a/felix/cmd/calico-bpf/commands/ifstate.go
+++ b/felix/cmd/calico-bpf/commands/ifstate.go
@@ -15,12 +15,12 @@
 package commands
 
 import (
-	"github.com/projectcalico/calico/felix/bpf/ifstate"
-	"github.com/projectcalico/calico/felix/bpf/maps"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
 func init() {

--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -15,12 +15,12 @@
 package commands
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
 	"github.com/docopt/docopt-go"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -197,17 +197,17 @@ func (cmd *natFrontend) checkArgsCommon() error {
 	case "tcp":
 		cmd.proto = 6
 	default:
-		return errors.Errorf("unknown protocol %s", proto)
+		return fmt.Errorf("unknown protocol %s", proto)
 	}
 
 	cmd.ip = net.ParseIP(cmd.IP)
 	if cmd.ip == nil {
-		return errors.Errorf("ip: %q is not an ip", cmd.IP)
+		return fmt.Errorf("ip: %q is not an ip", cmd.IP)
 	}
 
 	port, err := strconv.ParseUint(cmd.Port, 0, 16)
 	if err != nil {
-		return errors.Errorf("port: %q is not 16-bit uint", cmd.Port)
+		return fmt.Errorf("port: %q is not 16-bit uint", cmd.Port)
 	}
 	cmd.port = uint16(port)
 
@@ -219,12 +219,12 @@ func (cmd *natFrontend) ArgsSet(c *cobra.Command, args []string) error {
 
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	if err := cmd.checkArgsCommon(); err != nil {
@@ -233,13 +233,13 @@ func (cmd *natFrontend) ArgsSet(c *cobra.Command, args []string) error {
 
 	id, err := strconv.ParseUint(cmd.ID, 0, 32)
 	if err != nil {
-		return errors.Errorf("id: %q is not 32-bit uint", cmd.ID)
+		return fmt.Errorf("id: %q is not 32-bit uint", cmd.ID)
 	}
 	cmd.id = uint32(id)
 
 	count, err := strconv.ParseUint(cmd.Count, 0, 16)
 	if err != nil {
-		return errors.Errorf("count: %q is not 32-bit uint", cmd.Count)
+		return fmt.Errorf("count: %q is not 32-bit uint", cmd.Count)
 	}
 	cmd.count = uint32(count)
 
@@ -281,12 +281,12 @@ func (cmd *natFrontend) ArgsDel(c *cobra.Command, args []string) error {
 
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	return cmd.checkArgsCommon()
@@ -337,13 +337,13 @@ func newNatSetBackend() *cobra.Command {
 func (cmd *natBackend) checkArgsCommon() error {
 	id, err := strconv.ParseUint(cmd.ID, 0, 32)
 	if err != nil {
-		return errors.Errorf("id: %q is not 32-bit uint", cmd.ID)
+		return fmt.Errorf("id: %q is not 32-bit uint", cmd.ID)
 	}
 	cmd.id = uint32(id)
 
 	idx, err := strconv.ParseUint(cmd.Idx, 0, 32)
 	if err != nil {
-		return errors.Errorf("idx: %q is not 32-bit uint", cmd.Idx)
+		return fmt.Errorf("idx: %q is not 32-bit uint", cmd.Idx)
 	}
 	cmd.idx = uint32(idx)
 
@@ -355,22 +355,22 @@ func (cmd *natBackend) ArgsSet(c *cobra.Command, args []string) error {
 
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	cmd.ip = net.ParseIP(cmd.IP)
 	if cmd.ip == nil {
-		return errors.Errorf("ip: %q is not an ip", cmd.IP)
+		return fmt.Errorf("ip: %q is not an ip", cmd.IP)
 	}
 
 	port, err := strconv.ParseUint(cmd.Port, 0, 16)
 	if err != nil {
-		return errors.Errorf("port: %q is not 16-bit uint", cmd.Port)
+		return fmt.Errorf("port: %q is not 16-bit uint", cmd.Port)
 	}
 	cmd.port = uint16(port)
 
@@ -412,12 +412,12 @@ func (cmd *natBackend) ArgsDel(c *cobra.Command, args []string) error {
 
 	a, err := docopt.ParseArgs(makeDocUsage(c), args, "")
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	err = a.Bind(cmd)
 	if err != nil {
-		return errors.New(err.Error())
+		return err
 	}
 
 	return cmd.checkArgsCommon()

--- a/felix/environment/versionparse.go
+++ b/felix/environment/versionparse.go
@@ -15,6 +15,7 @@
 package environment
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -112,7 +113,7 @@ func GetVersionFromString(s string) (*Version, error) {
 	if len(matches) == 0 {
 		msg := "Failed to parse kernel version string"
 		log.WithField("rawVersion", s).Warn(msg)
-		return nil, fmt.Errorf("%s", msg)
+		return nil, errors.New(msg)
 	}
 	parsedVersion, err := NewVersion(matches[1])
 	log.WithField("version", parsedVersion).Debug("Parsed kernel version")

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	api "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"

--- a/felix/vxlanfdb/vxlan_fdb.go
+++ b/felix/vxlanfdb/vxlan_fdb.go
@@ -15,12 +15,12 @@
 package vxlanfdb
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"slices"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -16,19 +16,21 @@ package node_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"reflect"
 	"time"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/sirupsen/logrus"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -39,7 +41,6 @@ import (
 	backend "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
-	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -881,7 +882,7 @@ func expectLabels(c client.Interface, labels map[string]string, node string) err
 	if !reflect.DeepEqual(cn.Labels, labels) {
 		s := fmt.Sprintf("Labels do not match.\n\nExpected: %#v\n  Actual: %#v\n", labels, cn.Labels)
 		logrus.Warn(s)
-		return fmt.Errorf("%s", s)
+		return errors.New(s)
 	}
 	return nil
 }
@@ -900,7 +901,7 @@ func assertNumBlocks(bc backend.Client, num int) error {
 func assertIPsWithHandle(c ipam.Interface, handle string, num int) error {
 	ips, err := c.IPsByHandle(context.Background(), handle)
 	if err != nil {
-		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
+		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
 			return fmt.Errorf("error querying ips for handle %s: %s", handle, err)
 		}
 	}

--- a/kube-controllers/tests/testutils/node_controller_utils.go
+++ b/kube-controllers/tests/testutils/node_controller_utils.go
@@ -19,6 +19,7 @@ package testutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -34,7 +35,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	v3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
-	"github.com/projectcalico/calico/libcalico-go/lib/errors"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
@@ -96,7 +97,7 @@ func ExpectNodeLabels(c client.Interface, labels map[string]string, node string)
 	if !reflect.DeepEqual(cn.Labels, labels) {
 		s := fmt.Sprintf("Labels do not match.\n\nExpected: %#v\n  Actual: %#v\n", labels, cn.Labels)
 		logrus.Warn(s)
-		return fmt.Errorf("%s", s)
+		return errors.New(s)
 	}
 	return nil
 }
@@ -117,19 +118,19 @@ func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[s
 	if !reflect.DeepEqual(hep.Labels, expectedLabels) {
 		s := fmt.Sprintf("labels do not match.\n\nExpected: %#v\n  Actual: %#v\n", expectedLabels, hep.Labels)
 		logrus.Warn(s)
-		return fmt.Errorf("%s", s)
+		return errors.New(s)
 	}
 
 	if !reflect.DeepEqual(hep.Spec.ExpectedIPs, expectedIPs) {
 		s := fmt.Sprintf("expectedIPs do not match.\n\nExpected: %#v\n  Actual: %#v\n", expectedIPs, hep.Spec.ExpectedIPs)
 		logrus.Warn(s)
-		return fmt.Errorf("%s", s)
+		return errors.New(s)
 	}
 
 	if !reflect.DeepEqual(hep.Spec.Profiles, expectedProfiles) {
 		s := fmt.Sprintf("profiles do not match.\n\nExpected: %#v\n  Actual: %#v\n", expectedProfiles, hep.Spec.Profiles)
 		logrus.Warn(s)
-		return fmt.Errorf("%s", s)
+		return errors.New(s)
 	}
 
 	return nil
@@ -139,7 +140,7 @@ func ExpectHostendpointDeleted(c client.Interface, name string) error {
 	hep, err := c.HostEndpoints().Get(context.Background(), name, options.GetOptions{})
 	if err != nil {
 		// We are done if the hep does not exist.
-		if _, ok := err.(errors.ErrorResourceDoesNotExist); ok {
+		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
 			return nil
 		}
 		return err
@@ -200,7 +201,7 @@ func UpdateCalicoNode(c client.Interface, name string, update func(n *v3.Node)) 
 		_, err = c.Nodes().Update(context.Background(), cn, options.SetOptions{})
 		if err == nil {
 			return nil
-		} else if _, ok := err.(errors.ErrorResourceUpdateConflict); !ok {
+		} else if _, ok := err.(cerrors.ErrorResourceUpdateConflict); !ok {
 			return err
 		}
 	}

--- a/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
@@ -190,7 +190,7 @@ func (c *ipamHandleClient) Get(ctx context.Context, key model.Key, revision stri
 		if _, err := c.DeleteKVP(ctx, v1kvp); err != nil {
 			return nil, err
 		}
-		return nil, cerrors.ErrorResourceDoesNotExist{Err: errors.New("Resource was deleted"), Identifier: key}
+		return nil, cerrors.ErrorResourceDoesNotExist{Err: errors.New("resource was deleted"), Identifier: key}
 	}
 
 	return v1kvp, nil

--- a/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
@@ -16,7 +16,7 @@ package resources
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -190,7 +190,7 @@ func (c *ipamHandleClient) Get(ctx context.Context, key model.Key, revision stri
 		if _, err := c.DeleteKVP(ctx, v1kvp); err != nil {
 			return nil, err
 		}
-		return nil, cerrors.ErrorResourceDoesNotExist{Err: fmt.Errorf("%s", "Resource was deleted"), Identifier: key}
+		return nil, cerrors.ErrorResourceDoesNotExist{Err: errors.New("Resource was deleted"), Identifier: key}
 	}
 
 	return v1kvp, nil

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
@@ -15,6 +15,7 @@
 package updateprocessors_test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -356,5 +357,5 @@ func assertBlockAffinityUpdate(kvps []*model.KVPair, expected *model.KVPair) {
 
 	}
 	e += "]"
-	Expect(fmt.Errorf("%s", e)).NotTo(HaveOccurred())
+	Expect(errors.New(e)).NotTo(HaveOccurred())
 }

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
@@ -15,6 +15,7 @@
 package updateprocessors_test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -611,5 +612,5 @@ func assertBlockUpdate(kvps []*model.KVPair, expected *model.KVPair) {
 
 	}
 	e += "]"
-	Expect(fmt.Errorf("%s", e)).NotTo(HaveOccurred())
+	Expect(errors.New(e)).NotTo(HaveOccurred())
 }

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
@@ -16,14 +16,16 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes"
 
 	log "github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/kubernetes"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -381,7 +383,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						if len(failed) != 0 || len(success) != 16 {
 							s := fmt.Sprintf("%s failed to claim affinity for %v, succeeded on %v", testhost, failed, success)
 							log.WithError(err).Error(s)
-							testErr = fmt.Errorf("%s", s)
+							testErr = errors.New(s)
 						}
 					}()
 				}

--- a/release/internal/registry/dockerrunner.go
+++ b/release/internal/registry/dockerrunner.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 
@@ -143,7 +143,7 @@ func (d *DockerRunner) PushImage(img string) error {
 		}
 		if errorMessage.Error != "" {
 			logrus.WithField("error", errorMessage).Error("failed to push image")
-			return fmt.Errorf("%s", errorMessage.Error)
+			return errors.New(errorMessage.Error)
 		}
 	}
 	logrus.WithField("image", img).Debug("Image pushed")


### PR DESCRIPTION
## Description

This change cleans up errors imports in favor of `errors.New` and `fmt.Errorf` from Go stdlib.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
