### PR TITLE
[BPF] do not build objects for loglevel=info

### DIFF
--- a/felix/bpf-gpl/calculate-flags
+++ b/felix/bpf-gpl/calculate-flags
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Project Calico BPF dataplane build scripts.
-# Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+# Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-filename=$1 # Example: from_wep_host_drop_fib_info.o
+filename=$1 # Example: from_wep_host_drop_fib_debug.o
 args=()
 
 if [[ "${filename}" =~ .*co-re.* ]]; then
@@ -12,8 +12,6 @@ if [[ "${filename}" =~ .*co-re.* ]]; then
 fi
 if [[ "${filename}" =~ .*debug.* ]]; then
   args+=("-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_DEBUG")
-elif [[ "${filename}" =~ .*info.* ]]; then
-  args+=("-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_INFO")
 elif [[ "${filename}" =~ .*no_log.* ]]; then
   args+=("-DCALI_LOG_LEVEL=CALI_LOG_LEVEL_OFF")
 else

--- a/felix/bpf-gpl/list-objs
+++ b/felix/bpf-gpl/list-objs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Project Calico BPF dataplane build scripts.
-# Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+# Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 # Generate the cross-product of all the compile options, excluding some cases that don't make sense.
@@ -19,7 +19,7 @@ emit_filename() {
   fi
 }
 
-for log_level in debug info no_log; do
+for log_level in debug no_log; do
   echo "bin/connect_time_${log_level}_v4.o"
   echo "bin/connect_time_${log_level}_v6.o"
   echo "bin/connect_time_${log_level}_v46.o"

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -113,7 +113,7 @@ var objectFiles = make(map[AttachType]string)
 
 func initObjectFiles() {
 	for _, family := range []int{4, 6} {
-		for _, logLevel := range []string{"off", "info", "debug"} {
+		for _, logLevel := range []string{"off", "debug"} {
 			for _, epToHostDrop := range []bool{false, true} {
 				epToHostDrop := epToHostDrop
 				for _, fibEnabled := range []bool{false, true} {
@@ -163,7 +163,7 @@ func initObjectFiles() {
 	}
 
 	for _, family := range []int{4, 6} {
-		for _, logLevel := range []string{"off", "info", "debug"} {
+		for _, logLevel := range []string{"off", "debug"} {
 			l := strings.ToLower(logLevel)
 			if l == "off" {
 				l = "no_log"

--- a/felix/dataplane/linux/endpoint_mgr.go
+++ b/felix/dataplane/linux/endpoint_mgr.go
@@ -208,7 +208,6 @@ type endpointManager struct {
 	callbacks              endpointManagerCallbacks
 	bpfEnabled             bool
 	bpfEndpointManager     hepListener
-	bpfLogLevel            string
 }
 
 type EndpointStatusUpdateCallback func(ipVersion uint8, id interface{}, status string)
@@ -230,7 +229,6 @@ func newEndpointManager(
 	bpfEnabled bool,
 	bpfEndpointManager hepListener,
 	callbacks *common.Callbacks,
-	bpfLogLevel string,
 	floatingIPsEnabled bool,
 	nft bool,
 ) *endpointManager {
@@ -251,7 +249,6 @@ func newEndpointManager(
 		bpfEnabled,
 		bpfEndpointManager,
 		callbacks,
-		bpfLogLevel,
 		floatingIPsEnabled,
 		nft,
 	)
@@ -274,7 +271,6 @@ func newEndpointManagerWithShims(
 	bpfEnabled bool,
 	bpfEndpointManager hepListener,
 	callbacks *common.Callbacks,
-	bpfLogLevel string,
 	floatingIPsEnabled bool,
 	nft bool,
 ) *endpointManager {
@@ -355,7 +351,6 @@ func newEndpointManagerWithShims(
 
 		OnEndpointStatusUpdate: onWorkloadEndpointStatusUpdate,
 		callbacks:              newEndpointManagerCallbacks(callbacks, ipVersion),
-		bpfLogLevel:            bpfLogLevel,
 	}
 }
 

--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -787,7 +787,6 @@ func endpointManagerTests(ipVersion uint8) func() {
 				false,
 				hepListener,
 				common.NewCallbacks(),
-				"info",
 				true,
 				false,
 			)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -380,6 +380,10 @@ const (
 )
 
 func NewIntDataplaneDriver(config Config) *InternalDataplane {
+	if config.BPFLogLevel == "info" {
+		config.BPFLogLevel = "off"
+	}
+
 	log.WithField("config", config).Info("Creating internal dataplane driver.")
 	ruleRenderer := config.RuleRendererOverride
 	if ruleRenderer == nil {
@@ -911,7 +915,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		config.BPFEnabled,
 		bpfEndpointManager,
 		callbacks,
-		config.BPFLogLevel,
 		config.FloatingIPsEnabled,
 		config.RulesConfig.NFTables,
 	)
@@ -1045,7 +1048,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			config.BPFEnabled,
 			nil,
 			callbacks,
-			config.BPFLogLevel,
 			config.FloatingIPsEnabled,
 			config.RulesConfig.NFTables,
 		))


### PR DESCRIPTION
That level is not really used, just make it behave like if it was loglevel=off adn save us time for building images and space for shipping them. We may resurect that level in the future, but it does not provide any useful information now.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
