### PR TITLE
Work around interaction between BPF and IPForward.

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -453,7 +453,8 @@ type FelixConfigurationSpec struct {
 
 	// IPForwarding controls whether Felix sets the host sysctls to enable IP forwarding.  IP forwarding is required
 	// when using Calico for workload networking.  This should only be disabled on hosts where Calico is used for
-	// host protection.  [Default: Enabled]
+	// host protection. In BPF mode, due to a kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+	// must be disabled. [Default: Enabled]
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	IPForwarding string `json:"ipForwarding,omitempty"`
 

--- a/api/pkg/openapi/openapi_generated.go
+++ b/api/pkg/openapi/openapi_generated.go
@@ -2795,7 +2795,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 					},
 					"ipForwarding": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IPForwarding controls whether Felix sets the host sysctls to enable IP forwarding.  IP forwarding is required when using Calico for workload networking.  This should only be disabled on hosts where Calico is used for host protection.  [Default: Enabled]",
+							Description: "IPForwarding controls whether Felix sets the host sysctls to enable IP forwarding.  IP forwarding is required when using Calico for workload networking.  This should only be disabled on hosts where Calico is used for host protection. In BPF mode, due to a kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF must be disabled. [Default: Enabled]",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -373,6 +373,18 @@ configRetry:
 		}
 	}
 
+	if configParams.BPFEnabled && configParams.IPForwarding == "Disabled" && configParams.BPFEnforceRPF != "Disabled" {
+		// BPF mode requires IP forwarding to be enabled because the BPF RPF
+		// check fails if it is disabled.  Seems to be an incorrect check in
+		// the kernel.  FIB lookups can only be done for interfaces that have
+		// forwarding enabled.
+		log.Warning("In BPF mode, either IPForwarding must be enabled or BPFEnforceRPF must be disabled. Forcing IPForwarding to 'Enabled'.")
+		_, err := configParams.OverrideParam("IPForwarding", "Enabled")
+		if err != nil {
+			log.WithError(err).Panic("Bug: failed to override config parameter")
+		}
+	}
+
 	// Set any watchdog timeout overrides before we initialise components.
 	health.SetGlobalTimeoutOverrides(configParams.HealthTimeoutOverrides)
 

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -532,7 +532,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1528,7 +1528,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1538,7 +1538,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1539,7 +1539,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1523,7 +1523,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1523,7 +1523,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1540,7 +1540,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1433,7 +1433,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1523,7 +1523,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/ocp/crd.projectcalico.org_felixconfigurations.yaml
+++ b/manifests/ocp/crd.projectcalico.org_felixconfigurations.yaml
@@ -532,7 +532,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -17962,7 +17962,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -1445,7 +1445,9 @@ spec:
                 description: 'IPForwarding controls whether Felix sets the host sysctls
                   to enable IP forwarding.  IP forwarding is required when using Calico
                   for workload networking.  This should only be disabled on hosts
-                  where Calico is used for host protection.  [Default: Enabled]'
+                  where Calico is used for host protection. In BPF mode, due to a
+                  kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                  must be disabled. [Default: Enabled]'
                 enum:
                 - Enabled
                 - Disabled


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The kernel refuses to do a FIB lookup for an interface with forwarding disabled (even though that should make sense for an output lookup). To avoid dropping all traffic to the host:

- Require that either IPForward is enabled or RPF is disabled.
- Force-enable IPForward if RPF is enabled.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

#9313 

#Option to disable

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
