### PR TITLE
[release tool] rework sending notifications

### DIFF
--- a/release/build/main.go
+++ b/release/build/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
+	"github.com/projectcalico/calico/release/pkg/errors"
 	"github.com/projectcalico/calico/release/pkg/manager/branch"
 	"github.com/projectcalico/calico/release/pkg/manager/calico"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
@@ -143,6 +144,11 @@ func main() {
 
 	// Run the app.
 	if err := app.Run(os.Args); err != nil {
+		if cfg.CI.IsCI {
+			if err := tasks.Notify(err, cfg); err != nil {
+				logrus.WithError(err).Error("Error sending notification")
+			}
+		}
 		logrus.WithError(err).Fatal("Error running task")
 	}
 }
@@ -218,9 +224,7 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 				}
 
 				// Check if the hashrelease has already been published.
-				if published, err := tasks.HashreleasePublished(cfg, data.Hash); err != nil {
-					return err
-				} else if published {
+				if published := hashreleaseserver.HasHashrelease(data.Hash, &cfg.HashreleaseServerConfig); published {
 					// On CI, we want it to fail if the hashrelease has already been published.
 					// However, on local builds, we just log a warning and continue.
 					if cfg.CI.IsCI {
@@ -271,13 +275,9 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 					return err
 				}
 
-				// For real releases, release notes are generated prior to building the release.
-				// For hash releases, generate a set of release notes and add them to the hashrelease directory.
-				releaseVersion, err := version.DetermineReleaseVersion(versions.ProductVersion, cfg.DevTagSuffix)
-				if err != nil {
-					return fmt.Errorf("failed to determine release version: %v", err)
-				}
-				if _, err := outputs.ReleaseNotes(config.DefaultOrg, cfg.GithubToken, cfg.RepoRootDir, filepath.Join(dir, releaseNotesDir), releaseVersion); err != nil {
+				// For real releases, release notes are generated prior to building the release. For hash releases,
+				// generate a set of release notes and add them to the hashrelease directory.
+				if _, err := outputs.ReleaseNotes(config.DefaultOrg, cfg.GithubToken, cfg.RepoRootDir, filepath.Join(dir, releaseNotesDir), versions.ProductVersion); err != nil {
 					return err
 				}
 
@@ -317,17 +317,14 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 				// Extract the pinned version as a hashrelease.
 				hashrel, err := pinnedversion.LoadHashrelease(cfg.RepoRootDir, cfg.TmpFolderPath(), dir)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to get retrieve pinnedversion as hashrelease: %w", err)
 				}
-				if c.Bool(latestFlag) {
-					hashrel.Latest = true
-				}
-
-				// Check if the hashrelease has already been published.
-				if published, err := tasks.HashreleasePublished(cfg, hashrel.Hash); err != nil {
-					return err
-				} else if published {
-					return fmt.Errorf("%s hashrelease (%s) has already been published", hashrel.Name, hashrel.Hash)
+				if hashreleaseserver.HasHashrelease(hashrel.Hash, &cfg.HashreleaseServerConfig) {
+					return errors.ErrHashreleaseAlreadyExists{
+						ReleaseName: hashrel.Name,
+						Hash:        hashrel.Hash,
+						Stream:      hashrel.Stream(),
+					}
 				}
 
 				// Push the operator hashrelease first before validaion
@@ -345,10 +342,7 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.IsHashRelease(),
-					calico.WithVersions(&version.Data{
-						ProductVersion:  version.New(hashrel.ProductVersion),
-						OperatorVersion: version.New(hashrel.OperatorVersion),
-					}),
+					calico.WithVersions(&hashrel.Versions),
 					calico.WithGithubOrg(c.String(orgFlag)),
 					calico.WithRepoName(c.String(repoFlag)),
 					calico.WithRepoRemote(cfg.GitRemote),
@@ -366,14 +360,7 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 				if err := r.PublishRelease(); err != nil {
 					return err
 				}
-
-				// Send a slack message to notify that the hashrelease has been published.
-				if !c.Bool(skipPublishHashreleaseFlag) {
-					if err := tasks.HashreleaseSlackMessage(cfg, hashrel); err != nil {
-						return err
-					}
-				}
-				return nil
+				return tasks.AnnouceHashrelease(*hashrel, cfg)
 			},
 		},
 

--- a/release/internal/hashreleaseserver/hashrelease.go
+++ b/release/internal/hashreleaseserver/hashrelease.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashreleaseserver
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/version"
+	"github.com/projectcalico/calico/release/pkg/errors"
+)
+
+type Hashrelease struct {
+	// Name is the name of the hashrelease.
+	// When publishing a hashrelease, this is the name of the folder in the server.
+	// When getting a hashrelease, this is the full path of the hashrelease folder.
+	Name string
+
+	// Hash is the hash of the hashrelease
+	Hash string
+
+	// Note is the info about the hashrelease
+	Note string
+
+	// Branch is the branch the hashrelease is built from
+	Branch string
+
+	Versions version.Data
+
+	// Source is the source of hashrelease content
+	Source string
+
+	// Time is the modified time of the hashrelease
+	Time time.Time
+
+	// Latest is if the hashrelease is the latest for the stream
+	Latest bool
+
+	// Components is the components of the hashrelease
+	Components map[string]registry.Component
+}
+
+func (h Hashrelease) Stream() string {
+	return version.DeterminePublishStream(h.Branch, h.Versions.ProductVersion.FormattedString())
+}
+
+func (h Hashrelease) URL() string {
+	return fmt.Sprintf("https://%s.%s", h.Name, BaseDomain)
+}
+
+func (h Hashrelease) Valid() ([]string, error) {
+	componentsToValidate := make(map[string]registry.Component)
+	for name, component := range h.Components {
+		// Skip components that do not produce images.
+		if name == "calico" || name == "calico/api" || name == "networking-calico" {
+			continue
+		}
+		img := registry.ImageMap[name]
+		if img != "" {
+			component.Image = img
+		} else if component.Image == "" {
+			component.Image = name
+		}
+		componentsToValidate[name] = component
+	}
+	results := make(map[string]imageCheckResult, len(componentsToValidate))
+	ch := make(chan imageCheckResult)
+	imageList := []string{}
+	for name, component := range componentsToValidate {
+		imageList = append(imageList, component.String())
+		go imgExists(name, component, ch)
+	}
+	for range componentsToValidate {
+		res := <-ch
+		results[res.name] = res
+	}
+	invalidImages := []registry.Component{}
+	for name, r := range results {
+		logrus.WithFields(logrus.Fields{
+			"image":  r.image,
+			"exists": r.exists,
+		}).Info("Validating image")
+		if r.err != nil || !r.exists {
+			logrus.WithError(r.err).WithField("image", name).Error("Error checking image")
+			invalidImages = append(invalidImages, componentsToValidate[name])
+		} else {
+			logrus.WithField("image", name).Debug("Image exists")
+		}
+	}
+	if len(invalidImages) > 0 {
+		return imageList, errors.ErrInvalidImages{
+			ReleaseName:  h.Name,
+			Stream:       h.Stream(),
+			Versions:     h.Versions,
+			FailedImages: invalidImages,
+		}
+	}
+	return imageList, nil
+}
+
+type imageCheckResult struct {
+	name   string
+	image  string
+	exists bool
+	err    error
+}
+
+func imgExists(name string, component registry.Component, ch chan imageCheckResult) {
+	r := imageCheckResult{
+		name:  name,
+		image: component.String(),
+	}
+	r.exists, r.err = registry.ImageExists(component.ImageRef())
+	ch <- r
+}

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -35,41 +35,6 @@ const (
 	BaseDomain = "docs.eng.tigera.net"
 )
 
-type Hashrelease struct {
-	// Name is the name of the hashrelease.
-	// When publishing a hashrelease, this is the name of the folder in the server.
-	// When getting a hashrelease, this is the full path of the hashrelease folder.
-	Name string
-
-	// Hash is the hash of the hashrelease
-	Hash string
-
-	// Note is the info about the hashrelease
-	Note string
-
-	// Stream is the version the hashrelease is for (e.g master, v3.19)
-	Stream string
-
-	// ProductVersion is the product version in the hashrelease
-	ProductVersion string
-
-	// OperatorVersion is the operator version for the hashreleaseq
-	OperatorVersion string
-
-	// Source is the source of hashrelease content
-	Source string
-
-	// Time is the modified time of the hashrelease
-	Time time.Time
-
-	// Latest is if the hashrelease is the latest for the stream
-	Latest bool
-}
-
-func (h *Hashrelease) URL() string {
-	return fmt.Sprintf("https://%s.%s", h.Name, BaseDomain)
-}
-
 func RemoteDocsPath(user string) string {
 	path := "files"
 	if user != "root" {
@@ -92,8 +57,8 @@ func HasHashrelease(hash string, cfg *Config) bool {
 
 // SetHashreleaseAsLatest sets the hashrelease as the latest for the stream
 func SetHashreleaseAsLatest(rel Hashrelease, cfg *Config) error {
-	logrus.Debugf("Updating latest hashrelease for %s stream to %s", rel.Stream, rel.Name)
-	if _, err := runSSHCommand(cfg, fmt.Sprintf(`echo "%s/" > %s/latest-os/%s.txt && echo %s >> %s`, rel.URL(), RemoteDocsPath(cfg.User), rel.Stream, rel.Name, remoteReleasesLibraryPath(cfg.User))); err != nil {
+	logrus.Debugf("Updating latest hashrelease for %s stream to %s", rel.Stream(), rel.Name)
+	if _, err := runSSHCommand(cfg, fmt.Sprintf(`echo "%s/" > %s/latest-os/%s.txt && echo %s >> %s`, rel.URL(), RemoteDocsPath(cfg.User), rel.Stream(), rel.Name, remoteReleasesLibraryPath(cfg.User))); err != nil {
 		logrus.WithError(err).Error("Failed to update latest hashrelease and hashrelease library")
 		return err
 	}

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -197,6 +197,18 @@ func RetrievePinnedOperator(outputDir string) (registry.OperatorComponent, error
 	}, nil
 }
 
+// RetrievePinnedProductVersion retrieves the product version from the pinned version file.
+func RetrievePinnedProductVersion(outputDir string) (string, error) {
+	pinnedVersionPath := pinnedVersionFilePath(outputDir)
+	var pinnedversion PinnedVersionFile
+	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
+		return "", err
+	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
+		return "", err
+	}
+	return pinnedversion[0].Title, nil
+}
+
 // RetrieveComponentsToValidate retrieves the components to validate from the pinned version file.
 func RetrieveComponentsToValidate(outputDir string) (map[string]registry.Component, error) {
 	pinnedVersionPath := pinnedVersionFilePath(outputDir)
@@ -229,23 +241,19 @@ func RetrieveComponentsToValidate(outputDir string) (map[string]registry.Compone
 }
 
 func LoadHashrelease(repoRootDir, tmpDir, srcDir string) (*hashreleaseserver.Hashrelease, error) {
-	productBranch, err := utils.GitBranch(repoRootDir)
-	if err != nil {
-		logrus.WithError(err).Errorf("Failed to get %s branch name", utils.ProductName)
-		return nil, err
-	}
 	pinnedVersion, err := RetrievePinnedVersion(tmpDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get pinned version")
 	}
 	return &hashreleaseserver.Hashrelease{
-		Name:            pinnedVersion.ReleaseName,
-		Hash:            pinnedVersion.Hash,
-		Note:            pinnedVersion.Note,
-		Stream:          version.DeterminePublishStream(productBranch, pinnedVersion.Title),
-		ProductVersion:  pinnedVersion.Title,
-		OperatorVersion: pinnedVersion.TigeraOperator.Version,
-		Source:          srcDir,
-		Time:            time.Now(),
+		Name: pinnedVersion.ReleaseName,
+		Hash: pinnedVersion.Hash,
+		Note: pinnedVersion.Note,
+		Versions: version.Data{
+			ProductVersion:  version.New(pinnedVersion.Title),
+			OperatorVersion: version.New(pinnedVersion.TigeraOperator.Version),
+		},
+		Source: srcDir,
+		Time:   time.Now(),
 	}, nil
 }

--- a/release/internal/slack/templates/failed-images.json.gotmpl
+++ b/release/internal/slack/templates/failed-images.json.gotmpl
@@ -1,0 +1,85 @@
+[
+  {
+    "type": "header",
+    "text": {
+      "type": "plain_text",
+      "text": ":warning: Failed to create {{.Product}} {{.Stream}} {{.ReleaseType}}"
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "*{{.ReleaseName}}*"
+    }
+    {{- if .CIURL}},
+    "accessory": {
+      "type": "button",
+      "text": {
+        "type": "plain_text",
+        "text": ":building_construction: Build Details",
+        "emoji": true
+      },
+      "value": "ci_link",
+      "url": "{{.CIURL}}"
+    }
+    {{- end }}
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "mrkdwn",
+        "text": "Version:{{.Versions.ProductVersion}}\nOperator {{.Versions.OperatorVersion}}"
+      }
+    ]
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "plain_text",
+      "text": "See the list of unavailable images and versions below :arrow_heading_down:",
+      "emoji": true
+    }
+  },
+  {
+    "type": "section",
+    "fields": [
+      {
+        "type": "mrkdwn",
+        "text": "*Images*"
+      },
+      {
+        "type": "mrkdwn",
+        "text": "*Version*"
+      }
+      {{- range $component := .FailedImages }},
+      {
+        "type": "plain_text",
+        "text": "{{$component.Image}}"
+      },
+      {
+        "type": "plain_text",
+        "text": "{{$component.Version}}"
+      }
+      {{- end }}
+    ]
+  }
+  {{- if not .CIURL }},
+  {
+    "type": "divider"
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "plain_text",
+        "text": "This release was not built by CI."
+      }
+    ]
+  }
+  {{- end }}
+]

--- a/release/internal/slack/templates/failure.json.gotmpl
+++ b/release/internal/slack/templates/failure.json.gotmpl
@@ -3,16 +3,30 @@
     "type": "header",
     "text": {
       "type": "plain_text",
-      "text": ":warning: Failed to create {{.Product}} {{.Stream}} release"
+      "text": ":boom: {{.Product}} {{.Stream}}{{ if .ReleaseType }} {{.ReleaseType}}{{end}} failure"
     }
+  },
+  {{ if .Versions -}}
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "mrkdwn",
+        "text": "Version:{{.Versions.ProductVersion}}\nOperator {{.Versions.OperatorVersion}}"
+      }
+    ]
+  },
+  {{- end}}
+  {
+    "type": "divider"
   },
   {
     "type": "section",
     "text": {
       "type": "mrkdwn",
-      "text": "*{{.ReleaseName}}*"
+      "text": "{{.Error}}"
     }
-    {{- if .CIURL}},
+    {{- if .CIURL }},
     "accessory": {
       "type": "button",
       "text": {
@@ -24,49 +38,6 @@
       "url": "{{.CIURL}}"
     }
     {{- end }}
-  },
-  {
-    "type": "context",
-    "elements": [
-      {
-        "type": "mrkdwn",
-        "text": "{{.Version}}\nOperator {{.OperatorVersion}}"
-      }
-    ]
-  },
-  {
-    "type": "divider"
-  },
-  {
-    "type": "section",
-    "text": {
-      "type": "plain_text",
-      "text": "See the list of unavailable images and versions below :arrow_heading_down:",
-      "emoji": true
-    }
-  },
-  {
-    "type": "section",
-    "fields": [
-      {
-        "type": "mrkdwn",
-        "text": "*Images*"
-      },
-      {
-        "type": "mrkdwn",
-        "text": "*Version*"
-      }
-      {{- range $component := .FailedImages }},
-      {
-        "type": "plain_text",
-        "text": "{{$component.Image}}"
-      },
-      {
-        "type": "plain_text",
-        "text": "{{$component.Version}}"
-      }
-      {{- end }}
-    ]
   }
   {{- if not .CIURL }},
   {

--- a/release/internal/slack/templates/success.json.gotmpl
+++ b/release/internal/slack/templates/success.json.gotmpl
@@ -3,7 +3,7 @@
     "type": "header",
     "text": {
       "type": "plain_text",
-      "text": ":loud_sound: New {{.Product}} {{.Stream}} release"
+      "text": ":loud_sound: New {{.Product}} {{.Stream}} {{.ReleaseType}}"
     }
   },
   {
@@ -18,7 +18,7 @@
     "elements": [
       {
         "type": "mrkdwn",
-        "text": "Version:{{.Version}}\nOperator {{.OperatorVersion}}"
+        "text": "Version:{{.Versions.ProductVersion}}\nOperator {{.Versions.OperatorVersion}}"
       }
     ]
   },

--- a/release/internal/utils/config.go
+++ b/release/internal/utils/config.go
@@ -27,6 +27,20 @@ const (
 	ProductCode = "os"
 )
 
+type ReleaseType string
+
+func (r ReleaseType) String() string {
+	return string(r)
+}
+
+const (
+	// ReleaseTypeHashrelease is the release type for hashrelease.
+	ReleaseTypeHashrelease ReleaseType = "hashrelease"
+
+	// ReleaseTypeRelease is the release type for release.
+	ReleaseTypeRelease ReleaseType = "release"
+)
+
 // DisplayProductName returns the product name in title case.
 func DisplayProductName() string {
 	return cases.Title(language.English).String(ProductName)

--- a/release/pkg/errors/errors.go
+++ b/release/pkg/errors/errors.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/internal/version"
+)
+
+type ErrInvalidImages struct {
+	ReleaseName  string
+	Stream       string
+	Versions     version.Data
+	FailedImages []registry.Component
+}
+
+func (e ErrInvalidImages) Error() string {
+	return fmt.Sprintf("%s hashrelease has %d invalid images: %v", e.ReleaseName, len(e.FailedImages), e.FailedImages)
+}
+
+func (e ErrInvalidImages) Unwrap() error {
+	return fmt.Errorf("invalid images: %v", e.FailedImages)
+}
+
+type ErrHashreleaseAlreadyExists struct {
+	ReleaseName string
+	Hash        string
+	Stream      string
+	Versions    version.Data
+}
+
+func (e ErrHashreleaseAlreadyExists) Error() string {
+	return fmt.Sprintf("hashrelease %s (%s) already exists", e.ReleaseName, e.Hash)
+}
+
+func (e ErrHashreleaseAlreadyExists) Unwrap() error {
+	return fmt.Errorf("hashrelease %s (%s) already exists", e.ReleaseName, e.Hash)
+}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -595,7 +595,7 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 			imageList = append(imageList, component.String())
 		}
 		imageScanner := imagescanner.New(r.imageScanningConfig)
-		err := imageScanner.Scan(imageList, r.hashrelease.Stream, false, r.tmpDir)
+		err := imageScanner.Scan(imageList, r.hashrelease.Stream(), false, r.tmpDir)
 		if err != nil {
 			// Error is logged and ignored as this is not considered a fatal error
 			logrus.WithError(err).Error("Failed to scan images")

--- a/release/pkg/tasks/notifications.go
+++ b/release/pkg/tasks/notifications.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"errors"
+
+	"github.com/projectcalico/calico/release/internal/config"
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
+	"github.com/projectcalico/calico/release/internal/imagescanner"
+	"github.com/projectcalico/calico/release/internal/slack"
+	"github.com/projectcalico/calico/release/internal/utils"
+	"github.com/projectcalico/calico/release/internal/version"
+	errrs "github.com/projectcalico/calico/release/pkg/errors"
+)
+
+// Notify sends a notification based on the error
+func Notify(err error, cfg *config.Config) error {
+	var m slack.Message
+	var errInvalidImages errrs.ErrInvalidImages
+	var errHashreleaseAlreadyExists errrs.ErrHashreleaseAlreadyExists
+	if errors.As(err, &errInvalidImages) {
+		m = slack.FailedImagesMessage{
+			Data: slack.FailedImagesMessageData{
+				BaseMessageData: slack.BaseMessageData{
+					ReleaseName: errInvalidImages.ReleaseName,
+					Product:     utils.ProductName,
+					Stream:      errInvalidImages.Stream,
+					ReleaseType: utils.ReleaseTypeHashrelease,
+					CIURL:       cfg.CI.URL(),
+					Versions:    errInvalidImages.Versions,
+				},
+				FailedImages: errInvalidImages.FailedImages,
+			},
+		}
+	} else if errors.As(err, &errHashreleaseAlreadyExists) {
+		m = slack.FailureMessage{
+			Data: slack.FailureMessageData{
+				BaseMessageData: slack.BaseMessageData{
+					ReleaseName: errHashreleaseAlreadyExists.ReleaseName,
+					Product:     utils.ProductName,
+					Stream:      errHashreleaseAlreadyExists.Stream,
+					ReleaseType: utils.ReleaseTypeHashrelease,
+					CIURL:       cfg.CI.URL(),
+					Versions:    errHashreleaseAlreadyExists.Versions,
+				},
+				Error: errHashreleaseAlreadyExists.Error(),
+			},
+		}
+	} else {
+		// attempt to get the branch and version to determine the stream
+		branch, _ := utils.GitBranch(cfg.RepoRootDir)
+		ver := version.GitVersion()
+		m = slack.FailureMessage{
+			Data: slack.FailureMessageData{
+				BaseMessageData: slack.BaseMessageData{
+					Product: utils.ProductName,
+					Stream:  version.DeterminePublishStream(branch, ver.FormattedString()),
+					CIURL:   cfg.CI.URL(),
+				},
+				Error: err.Error(),
+			},
+		}
+	}
+	return m.Send(cfg.SlackConfig)
+}
+
+// AnnouceHashrelease sends a notification to announce a release
+func AnnouceHashrelease(hashrelease hashreleaseserver.Hashrelease, cfg *config.Config) error {
+	m := slack.SuccessMessage{
+		Data: slack.SuccessMessageData{
+			BaseMessageData: slack.BaseMessageData{
+				ReleaseName: hashrelease.Name,
+				Product:     utils.ProductName,
+				Stream:      hashrelease.Stream(),
+				ReleaseType: utils.ReleaseTypeHashrelease,
+				CIURL:       cfg.CI.URL(),
+				Versions:    hashrelease.Versions,
+			},
+			DocsURL:            hashrelease.URL(),
+			ImageScanResultURL: imagescanner.RetrieveResultURL(cfg.OutputDir),
+		},
+	}
+	return m.Send(cfg.SlackConfig)
+}


### PR DESCRIPTION
## Description

This allows getting notification on failures (_mainly in CI_ ). 

Some new errors are defined to provide context in notifications. 

As only hashrelease was sending notifications previously, that has contextual errors defined with ability to add more if needed overtime

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
