### PR TITLE
add validating changed pipeline files

### DIFF
--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -5,3 +5,12 @@
       - name: Pre-flight checks
         commands:
           - make ci-preflight-checks
+- name: Pipeline Validator
+  dependencies: []
+  run:
+    when: "change_in(['/.semaphore', '/**/.semaphore'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  task:
+    jobs:
+      - name: Validate Semaphore pipeline
+        commands:
+          - make ci-pipeline-check

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,16 @@ ci-preflight-checks:
 	$(MAKE) generate
 	$(MAKE) check-dirty
 
+ci-pipeline-check:
+	$(eval CHANGED_YAML_FILES = $(shell git diff --name-only $$SEMAPHORE_GIT_COMMIT_RANGE | grep -E '.*.semaphore.*\.ya?ml$$' | while read file; do if git show HEAD:$$file > /dev/null 2>&1; then echo "$$file"; fi; done | paste -sd ","))
+ifeq ($(CHANGED_YAML_FILES), "")
+	$(info No semaphore yaml files changed, skipping semvalidator)
+else
+	$(DOCKER_RUN) -w /go/src/github.com/projectcalico/calico $(GO_BUILD_IMAGE):master \
+	semvalidator -org-url $$SEMAPHORE_ORGANIZATION_URL -token $$SEMAPHORE_API_TOKEN  \
+	-skip-dirs semaphore.yml.d -files $(CHANGED_YAML_FILES)
+endif
+
 check-dockerfiles:
 	./hack/check-dockerfiles.sh
 


### PR DESCRIPTION
## Description

This allows validating semaphore pipeline files when changed.

## Related issues/PRs

- blocked by https://github.com/projectcalico/go-build/pull/596

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
