### PR TITLE
add release branch prefix

### DIFF
--- a/release/build/main.go
+++ b/release/build/main.go
@@ -220,6 +220,7 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 				// Build the operator
 				operatorOpts := []operator.Option{
 					operator.WithOperatorDirectory(cfg.Operator.Dir),
+					operator.WithReleaseBranchPrefix(cfg.RepoReleaseBranchPrefix),
 					operator.IsHashRelease(),
 					operator.WithArchitectures(cfg.Arches),
 					operator.WithValidate(!c.Bool(skipValidationFlag)),
@@ -235,6 +236,7 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 				// to build a Calico release.
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithReleaseBranchPrefix(cfg.RepoReleaseBranchPrefix),
 					calico.IsHashRelease(),
 					calico.WithVersions(versions),
 					calico.WithOutputDir(dir),
@@ -371,6 +373,7 @@ func releaseSubCommands(cfg *config.Config) []*cli.Command {
 				// Configure the builder.
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithReleaseBranchPrefix(cfg.RepoReleaseBranchPrefix),
 					calico.WithVersions(&version.Data{
 						ProductVersion:  ver,
 						OperatorVersion: operatorVer,


### PR DESCRIPTION
## Description

Getting this error in release-v3.29 hashrelease build

```sh
FATA[0007] Error running task                            error="not on a release branch"
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
