### PR TITLE
Fix RunBPFProgram duration reporting.

### DIFF
--- a/felix/bpf/bpf_syscall.go
+++ b/felix/bpf/bpf_syscall.go
@@ -151,7 +151,7 @@ func RunBPFProgram(fd ProgFD, dataIn []byte, repeat int) (pr ProgResult, err err
 
 	pr.RC = int32(C.bpf_attr_prog_run_retval(bpfAttr))
 	dataOutSize := C.bpf_attr_prog_run_data_out_size(bpfAttr)
-	pr.Duration = time.Duration(C.bpf_attr_prog_run_data_out_size(bpfAttr))
+	pr.Duration = time.Duration(C.bpf_attr_prog_run_duration(bpfAttr))
 	pr.DataOut = C.GoBytes(cDataOut, C.int(dataOutSize))
 	return
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fix that we were reading the wrong attributed from the struct.  We were reporting the output size as the length.  I don't think there was any impact; we don't seem to be using that field right now.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
