### PR TITLE
Add Felix GPL source to published node images

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -64,7 +64,7 @@ THIRD_PARTY_DEPS_MIRROR=https://storage.googleapis.com/public-calico-third-party
 # Versions and location of dependencies used in the build.
 BIRD_IMAGE ?= calico/bird:$(BIRD_VERSION)-$(ARCH)
 BIRD_SOURCE=filesystem/included-source/bird-$(BIRD_VERSION).tar.gz
-FELIX_GPL_SOURCE=filesystem/included-source/felix-ebpf-gpl.tar.gz
+FELIX_GPL_SOURCE=filesystem/included-source/felix-ebpf-gpl.tar.xz
 INCLUDED_SOURCE=$(BIRD_SOURCE) $(FELIX_GPL_SOURCE)
 
 # Versions and locations of dependencies used in tests.
@@ -278,11 +278,11 @@ $(BIRD_SOURCE): .bird-source.created
 	touch $@
 
 # include GPL felix code in the image.
-$(FELIX_GPL_SOURCE):
+$(FELIX_GPL_SOURCE): .felix-gpl-source.created
 .felix-gpl-source.created: $(shell find ../felix/bpf-gpl -type f)
 	rm -rf filesystem/included-source/felix*
 	mkdir -p filesystem/included-source/
-	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'tar cf $(FELIX_GPL_SOURCE) ../felix/bpf-gpl;'
+	tar cf $(FELIX_GPL_SOURCE) ../felix/bpf-gpl --use-compress-program="xz -T0"
 	touch $@
 
 ###############################################################################


### PR DESCRIPTION
This PR adds back the GPL Felix source code to the published `calico/node` images; while the source was always available from Github, this will make it easier for end-users to find the source code that corresponds specifically to the version of Calico they're using.