### PR TITLE
Check operator CRDs as part of ci preflight checks

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -47,7 +47,5 @@ blocks:
           - cd release
           - make build
       env_vars:
-        - name: OPERATOR_BRANCH
-          value: master
         - name: IS_HASHRELEASE
           value: "true"

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ check-language:
 
 generate:
 	$(MAKE) gen-semaphore-yaml
+	$(MAKE) get-operator-crds
 	$(MAKE) -C api gen-files
 	$(MAKE) -C libcalico-go gen-files
 	$(MAKE) -C felix gen-files
@@ -61,12 +62,15 @@ gen-manifests: bin/helm
 		CALICO_VERSION=$(CALICO_VERSION) \
 		./generate.sh
 
-# Get operator CRDs from the operator repo, OPERATOR_BRANCH_NAME must be set
-get-operator-crds: var-require-all-OPERATOR_BRANCH_NAME
+# Get operator CRDs from the operator repo, OPERATOR_BRANCH must be set
+get-operator-crds: var-require-all-OPERATOR_BRANCH
+	@echo ================================================================
+	@echo === Pulling new operator CRDs from branch $(OPERATOR_BRANCH) ===
+	@echo ================================================================
 	cd ./charts/tigera-operator/crds/ && \
-	for file in operator.tigera.io_*.yaml; do echo "downloading $$file from operator repo" && curl -fsSL https://raw.githubusercontent.com/tigera/operator/${OPERATOR_BRANCH_NAME}/pkg/crds/operator/$${file%_crd.yaml}.yaml -o $${file}; done
+	for file in operator.tigera.io_*.yaml; do echo "downloading $$file from operator repo" && curl -fsSL https://raw.githubusercontent.com/tigera/operator/$(OPERATOR_BRANCH)/pkg/crds/operator/$${file%_crd.yaml}.yaml -o $${file}; done
 	cd ./manifests/ocp/ && \
-	for file in operator.tigera.io_*.yaml; do echo "downloading $$file from operator repo" && curl -fsSL https://raw.githubusercontent.com/tigera/operator/${OPERATOR_BRANCH_NAME}/pkg/crds/operator/$${file%_crd.yaml}.yaml -o $${file}; done
+	for file in operator.tigera.io_*.yaml; do echo "downloading $$file from operator repo" && curl -fsSL https://raw.githubusercontent.com/tigera/operator/$(OPERATOR_BRANCH)/pkg/crds/operator/$${file%_crd.yaml}.yaml -o $${file}; done
 
 gen-semaphore-yaml:
 	cd .semaphore && ./generate-semaphore-yaml.sh

--- a/metadata.mk
+++ b/metadata.mk
@@ -46,3 +46,6 @@ WINDOWS_VERSIONS ?= 1809 ltsc2022
 # whenever the cni-plugin image is created.
 CNI_VERSION=master
 FLANNEL_VERSION=main
+
+# The operator branch corresponding to this branch.
+OPERATOR_BRANCH=master

--- a/release/RELEASING.md
+++ b/release/RELEASING.md
@@ -103,6 +103,7 @@ When starting development on a new minor release, the first step is to create a 
 
    - charts/calico/values.yaml
    - charts/tigera-operator/values.yaml
+   - metadata.mk (OPERATOR_BRANCH)
 
    Then, run manifest generation
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/8883

This PR will fail CI if the operator CRDs are not in sync.

This is potentially annoying, as it means we may need to push some
unrelated changes into PRs to get CI working. But I think it is worth
the friction to avoid these getting out of sync.

We have encountered release problems in the past where we shipped
operator CRDs that were out of date.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.