### PR TITLE
[BPF] print proper IPs in debug output

### DIFF
--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -11,6 +11,7 @@ CFLAGS +=  \
 	-Wall \
 	-Werror \
 	-fno-stack-protector \
+	-Wno-address-of-packed-member \
 	-O2 \
 	-target bpf \
 	-emit-llvm \

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -226,15 +226,29 @@ static CALI_BPF_INLINE __attribute__((noreturn)) void bpf_exit(int rc) {
 
 #ifdef IPVER6
 
+#ifdef BPF_CORE_SUPPORTED
+#define IPv "[%pI6]"
+#define debug_ip(ip) (&(ip))
+#else
 #define debug_ip(ip) (bpf_htonl((ip).d))
+#endif
 #define ip_is_dnf(ip) (true)
 
 #else
 
+#ifdef BPF_CORE_SUPPORTED
+#define IPv "%pI4"
+#define debug_ip(ip) (&(ip))
+#else
 #define debug_ip(ip) bpf_htonl(ip)
+#endif
 
 #define ip_is_dnf(ip) ((ip)->frag_off & bpf_htons(0x4000))
 #define ip_frag_no(ip) ((ip)->frag_off & bpf_htons(0x1fff))
+#endif
+
+#ifndef IPv
+#define IPv "%x"
 #endif
 
 static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -109,7 +109,7 @@ static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 
 		arpv = cali_arp_lookup_elem(&arpk);
 		if (!arpv) {
-			CALI_DEBUG("ARP lookup failed for %x dev %d\n",
+			CALI_DEBUG("ARP lookup failed for " IPv " dev %d\n",
 					debug_ip(state->ip_dst), iface);
 			goto skip_redir_ifindex;
 		}
@@ -308,7 +308,7 @@ cancel_fib:
 			struct arp_value *arpv = cali_arp_lookup_elem(&arpk);
 			if (!arpv) {
 				ctx->fwd.reason = CALI_REASON_NATIFACE;
-				CALI_DEBUG("ARP lookup failed for %x dev %d\n",
+				CALI_DEBUG("ARP lookup failed for " IPv " dev %d\n",
 						debug_ip(state->ip_dst), iface);
 				goto deny;
 			}

--- a/felix/bpf-gpl/list-ut-objs
+++ b/felix/bpf-gpl/list-ut-objs
@@ -10,8 +10,8 @@
 # WARNING: should be kept in sync with the combinations used in tests, in particular bpf_prog_test.go.
 
 emit_filename() {
-  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}.o"
-  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_v6.o"
+  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_co-re.o"
+  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_co-re_v6.o"
 }
 
 log_level=debug
@@ -38,5 +38,5 @@ done
 
 echo "bin/test_from_hep_fib_no_log_skb0x0.o"
 echo "bin/test_from_wep_fib_no_log.o"
-echo "bin/test_xdp_debug.o"
+echo "bin/test_xdp_debug_co-re.o"
 echo "bin/test_xdp_debug_co-re_v6.o"

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -102,7 +102,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 	bool csum_update = false;
 
 	if (!ip_equal(ip_src_from, ip_src_to)) {
-		CALI_DEBUG("L4 checksum update src IP from %x to %x\n",
+		CALI_DEBUG("L4 checksum update src IP from " IPv " to " IPv "\n",
 				debug_ip(ip_src_from), debug_ip(ip_src_to));
 
 		csum = bpf_csum_diff((__u32*)&ip_src_from, sizeof(ip_src_from), (__u32*)&ip_src_to, sizeof(ip_src_to), csum);
@@ -110,7 +110,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 		csum_update = true;
 	}
 	if (!ip_equal(ip_dst_from, ip_dst_to)) {
-		CALI_DEBUG("L4 checksum update dst IP from %x to %x\n",
+		CALI_DEBUG("L4 checksum update dst IP from " IPv " to " IPv "\n",
 				debug_ip(ip_dst_from), debug_ip(ip_dst_to));
 		csum = bpf_csum_diff((__u32*)&ip_dst_from, sizeof(ip_dst_from), (__u32*)&ip_dst_to, sizeof(ip_dst_to), csum);
 		CALI_DEBUG("bpf_l4_csum_diff(IP): 0x%x\n", csum);
@@ -158,7 +158,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 {
 	/* decap on host ep only if directly for the node */
-	CALI_DEBUG("VXLAN tunnel packet to %x (host IP=%x)\n",
+	CALI_DEBUG("VXLAN tunnel packet to " IPv " (host IP=" IPv ")\n",
 #ifdef IPVER6
 		bpf_ntohl(ip_hdr(ctx)->daddr.in6_u.u6_addr32[3]),
 #else
@@ -214,7 +214,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 	arpk.ip = ip_hdr(ctx)->saddr;
 #endif
 	cali_arp_update_elem(&arpk, eth_hdr(ctx), 0);
-	CALI_DEBUG("ARP update for ifindex %d ip %x\n", arpk.ifindex, debug_ip(arpk.ip));
+	CALI_DEBUG("ARP update for ifindex %d ip " IPv "\n", arpk.ifindex, debug_ip(arpk.ip));
 
 #ifdef IPVER6
 	ipv6hdr_ip_to_ipv6_addr_t(&ctx->state->tun_ip, &ip_hdr(ctx)->saddr);
@@ -234,7 +234,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 		goto deny;
 	}
 
-	CALI_DEBUG("vxlan decap origin %x\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("vxlan decap origin " IPv "\n", debug_ip(ctx->state->tun_ip));
 
 fall_through:
 	return 0;

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -44,16 +44,16 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 	switch (nat_key.protocol) {
 	case IPPROTO_UDP:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d udp\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d udp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	case IPPROTO_TCP:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d tcp\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d tcp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	case IPPROTO_ICMP:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d icmp\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d icmp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	default:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d other\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d other\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	}
 
@@ -169,7 +169,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 	if (affval) {
 		int timeo = (affinity_always_timeo ? : nat_lv1_val->affinity_timeo);
 		if (now - affval->ts <= timeo  * 1000000000ULL) {
-			CALI_DEBUG("NAT: using affinity backend %x:%d\n",
+			CALI_DEBUG("NAT: using affinity backend " IPv ":%d\n",
 					debug_ip(affval->nat_dest.addr), affval->nat_dest.port);
 			if (affinity_tmr_update) {
 				affval->ts = now;
@@ -177,9 +177,9 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 			return &affval->nat_dest;
 		}
-		CALI_DEBUG("NAT: affinity expired for %x:%d\n", debug_ip(*ip_dst), dport);
+		CALI_DEBUG("NAT: affinity expired for " IPv ":%d\n", debug_ip(*ip_dst), dport);
 	} else {
-		CALI_DEBUG("no previous affinity for %x:%d", debug_ip(*ip_dst), dport);
+		CALI_DEBUG("no previous affinity for " IPv ":%d", debug_ip(*ip_dst), dport);
 	}
 	/* To be k8s conformant, fall through to pick a random backend. */
 
@@ -196,7 +196,7 @@ skip_affinity:
 		return NULL;
 	}
 
-	CALI_DEBUG("NAT: backend selected %x:%d\n", debug_ip(nat_lv2_val->addr), nat_lv2_val->port);
+	CALI_DEBUG("NAT: backend selected " IPv ":%d\n", debug_ip(nat_lv2_val->addr), nat_lv2_val->port);
 
 	if (nat_lv1_val->affinity_timeo != 0 || affinity_always_timeo) {
 		int err;
@@ -205,7 +205,7 @@ skip_affinity:
 			.nat_dest = *nat_lv2_val,
 		};
 
-		CALI_DEBUG("NAT: updating affinity for client %x\n", debug_ip(*ip_src));
+		CALI_DEBUG("NAT: updating affinity for client " IPv "\n", debug_ip(*ip_src));
 		if ((err = cali_nat_aff_update_elem(&affkey, &val, BPF_ANY))) {
 			CALI_INFO("NAT: failed to update affinity table: %d\n", err);
 			/* we do carry on, we have a good nat_lv2_val */

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -65,7 +65,7 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 #endif
 
 	CALI_DEBUG("IP id=%d len=%d\n",bpf_ntohs(ip_hdr(ctx)->id), bpf_htons(ip_hdr(ctx)->tot_len));
-	CALI_DEBUG("IP s=%x d=%x\n", bpf_ntohl(ip_hdr(ctx)->saddr), bpf_ntohl(ip_hdr(ctx)->daddr));
+	CALI_DEBUG("IP s=" IPv " d=" IPv "\n", debug_ip(ip_hdr(ctx)->saddr), debug_ip(ip_hdr(ctx)->daddr));
 	// Drop malformed IP packets
 	if (ip_hdr(ctx)->ihl < 5) {
 		CALI_DEBUG("Drop malformed IP packets\n");

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -11,7 +11,7 @@
 
 static CALI_BPF_INLINE bool wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
-        CALI_DEBUG("Workload RPF check src=%x skb iface=%d.\n",
+        CALI_DEBUG("Workload RPF check src=" IPv " skb iface=%d.\n",
                         debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
         if (!r) {
                 CALI_INFO("Workload RPF fail: missing route.\n");
@@ -92,7 +92,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 				CALI_DEBUG("Host RPF check skb strict if %d\n", fib_params.ifindex);
 #endif
 #else
-				CALI_DEBUG("Host RPF check src=%x skb strict if %d\n",
+				CALI_DEBUG("Host RPF check src=" IPv " skb strict if %d\n",
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			} else {
@@ -102,7 +102,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 				CALI_DEBUG("Host RPF check skb loose if %d\n", fib_params.ifindex);
 #endif
 #else
-				CALI_DEBUG("Host RPF check src=%x skb loose if %d\n",
+				CALI_DEBUG("Host RPF check src=" IPv " skb loose if %d\n",
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			}
@@ -122,7 +122,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 	CALI_DEBUG("Host RPF check skb iface=%d\n", ctx->skb->ifindex);
 #endif
 #else
-	CALI_DEBUG("Host RPF check src=%x skb iface=%d\n",
+	CALI_DEBUG("Host RPF check src=" IPv " skb iface=%d\n",
 			debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
 #endif
 	CALI_DEBUG("Host RPF check rc %d result %d\n", rc, ret);

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -203,12 +203,12 @@ int calico_xdp_drop(struct xdp_md *xdp)
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);
-	CALI_DEBUG("src=%x dst=%x\n", debug_ip(ctx->state->ip_src),
+	CALI_DEBUG("src=" IPv " dst=" IPv "\n", debug_ip(ctx->state->ip_src),
 			debug_ip(ctx->state->ip_dst));
-	CALI_DEBUG("pre_nat=%x:%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
+	CALI_DEBUG("pre_nat=" IPv ":%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
 			ctx->state->pre_nat_dport);
-	CALI_DEBUG("post_nat=%x:%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
-	CALI_DEBUG("tun_ip=%x\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("post_nat=" IPv ":%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
+	CALI_DEBUG("tun_ip=" IPv "\n", debug_ip(ctx->state->tun_ip));
 	CALI_DEBUG("pol_rc=%d\n", ctx->state->pol_rc);
 	CALI_DEBUG("sport=%d\n", ctx->state->sport);
 	CALI_DEBUG("flags=0x%x\n", ctx->state->flags);

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -152,7 +152,7 @@ func initObjectFiles() {
 									fibEnabled,
 									dsr,
 									logLevel,
-									bpfutils.SupportsBTF(),
+									bpfutils.BTFEnabled,
 								)
 							}
 						}

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -372,13 +372,11 @@ func setupAndRun(logger testLogger, loglevel, section string, rules *polprog.Rul
 
 	if topts.objname != "" {
 		obj = topts.objname
-	} else if topts.ipv6 {
-		if topts.xdp {
-			obj += "_co-re_v6"
-		} else {
+	} else {
+		obj += "_co-re"
+		if topts.ipv6 {
 			obj += "_v6"
 		}
-
 	}
 
 	if topts.xdp {


### PR DESCRIPTION
## Description

    It is only available for co-re objects since the printk feature is
    available only since 5.13 so definitely available for kernels with co-re
    support since 5.17. And supporting it for older kernels would make the
    code very messy with little benefit.
    
    v4 output
    
    WEP-NAT1--------E: New packet at ifindex=1; mark=0
    
    WEP-NAT1--------E: IP id=0 len=58
    
    WEP-NAT1--------E: IP s=1.1.1.1 d=10.10.0.1
    
    WEP-NAT1--------E: IP ihl=28 bytes
    
    WEP-NAT1--------E: UDP; ports: s=1234 d=5678
    
    WEP-NAT1--------E: CT: lookup from 1.1.1.1:1234
    
    WEP-NAT1--------E: CT: lookup to   10.10.0.1:5678
    
    WEP-NAT1--------E: CT: Miss.
    
    WEP-NAT1--------E: CT: result: NEW.
    
    WEP-NAT1--------E: conntrack entry flags 0x0
    
    WEP-NAT1--------E: NAT: 1st level lookup addr=10.10.0.1 port=5678 udp
    
    of V6 version:
    
    IPv6 WEP-NAT1--------I: CT: lookup from [abcd:0000:0000:0000:0000:ffff:0808:0808]:666
    
    IPv6 WEP-NAT1--------I: CT: lookup to   [ff00:0000:0000:0000:0000:0000:0000:0001]:1234
    
    IPv6 WEP-NAT1--------I: CT: tun_ip:[0000:0000:0000:0000:0000:0000:0000:0000]
    
    IPv6 WEP-NAT1--------I: CT: Hit! NAT REV entry at ingress to connection opener: SNAT.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
