### PR TITLE
Add bounds checks for int conversions.

### DIFF
--- a/felix/config/param_types.go
+++ b/felix/config/param_types.go
@@ -132,6 +132,10 @@ func (p *IntParam) Parse(raw string) (interface{}, error) {
 		err = p.parseFailed(raw, "invalid int")
 		return nil, err
 	}
+	if value < math.MinInt || value > math.MaxInt {
+		err = p.parseFailed(raw, "value out of range for int type")
+		return nil, err
+	}
 	result := int(value)
 	if len(p.Ranges) == 1 {
 		if result < p.Ranges[0].Min {
@@ -812,10 +816,10 @@ func (c *ServerListParam) Parse(raw string) (result interface{}, err error) {
 				err = c.parseFailed(in, "invalid port '"+portStr+"': "+err.Error())
 				return
 			}
-			if port < 0 || port > 65535 {
-				err = c.parseFailed(in, "invalid port '"+portStr+"': should be between 0 and 65535")
-				return
-			}
+		}
+		if port < 0 || port > math.MaxUint16 {
+			err = c.parseFailed(in, fmt.Sprintf("invalid port %d: should be between 0 and 65535", port))
+			return
 		}
 		resultSlice = append(resultSlice, ServerPort{IP: val, Port: uint16(port)})
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add extra bounds checks in Felix's parameter parsing.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Tweak bounds checking in Felix parameter conversion to avoid false positives in static analysis.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
