### PR TITLE
fix creating release notes for release

### DIFF
--- a/release/internal/outputs/releasenotes.go
+++ b/release/internal/outputs/releasenotes.go
@@ -161,13 +161,13 @@ func outputReleaseNotes(issueDataList []*ReleaseNoteIssueData, outputFilePath st
 		logrus.WithError(err).Errorf("Failed to create release notes folder %s", dir)
 		return err
 	}
-	logrus.WithField("template", releaseNoteTemplate).Info("Parsing release note template")
+	logrus.WithField("template", releaseNoteTemplate).Debug("Parsing release note template")
 	tmpl, err := template.New("release-note").Parse(releaseNoteTemplate)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to parse release note template")
 		return err
 	}
-	logrus.Info("Generating release notes")
+	logrus.Debug("Generating release notes from template")
 	date := time.Now().Format("02 Jan 2006")
 	data := &ReleaseNoteData{
 		Date:         date,
@@ -196,7 +196,7 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 		logrus.Warn("No directory is set, using current directory")
 		outputDir = "."
 	}
-
+	logrus.Infof("Generating release notes for %s", ver.FormattedString())
 	milestone := ver.Milestone()
 	githubClient := github.NewTokenClient(context.Background(), githubToken)
 	releaseNoteDataList := []*ReleaseNoteIssueData{}

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -114,7 +114,7 @@ func DetermineReleaseVersion(v Version, devTagSuffix string) (Version, error) {
 	if HasDevTag(v, devTagSuffix) {
 		// This is the first release from this branch - we can simply extract the version from
 		// the dev tag.
-		return New(strings.Split(gitVersion, devTagSuffix)[0]), nil
+		return New(strings.Split(gitVersion, "-"+devTagSuffix)[0]), nil
 	} else {
 		// This is a patch release - we need to parse the previous, and
 		// bump the patch version.


### PR DESCRIPTION
## Description

This fixes the current failure with generating release notes. Also updated the logs

```
time="2024-10-23T16:43:25-07:00" level=info msg="Running git command" cmd="/usr/bin/git describe --tags --always --long --abbrev=12 --dirty" dir=.
time="2024-10-23T16:43:25-07:00" level=info msg="Current git describe" out=v3.30.0-0.dev-113-g6281d1b3224b
time="2024-10-23T16:43:25-07:00" level=fatal msg="Failed to parse version" error="Invalid Semantic Version" version=v3.30.0-
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
