### PR TITLE
Fix untracked policy mark clearance.

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -171,8 +171,8 @@ enum calico_skb_mark {
 	/* "BYPASS_FWD" is a special case of "BYPASS" used when a packet returns from one of our
 	 * VXLAN tunnels.  It tells the downstream program to forward the packet. */
 	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS  | 0x00300000,
-	/* Now unused mark */
-	CALI_SKB_MARK_free_to_use            = CALI_SKB_MARK_BYPASS  | 0x00500000,
+	/* Accepted by XDP untracked policy. */
+	CALI_SKB_MARK_BYPASS_XDP             = CALI_SKB_MARK_BYPASS  | 0x00500000,
 	CALI_SKB_MARK_BYPASS_MASK            = CALI_SKB_MARK_SEEN_MASK | 0x02700000,
 	/* The FALLTHROUGH bit is used by programs that are towards the host namespace to indicate
 	 * that the packet is not known in BPF conntrack. We have iptables rules to drop or allow

--- a/felix/bpf-gpl/metadata.h
+++ b/felix/bpf-gpl/metadata.h
@@ -81,7 +81,7 @@ static CALI_BPF_INLINE __u32 xdp2tc_get_metadata(struct __sk_buff *skb) {
 		goto no_metadata;
 	}
 
-	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "Received metadata from XDP: %d", metadata->flags);
+	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "Received metadata from XDP: 0x%x", metadata->flags);
 	goto metadata_ok;
 #else
 	struct cali_tc_ctx ctx = {

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -129,7 +129,7 @@ int calico_tc_main(struct __sk_buff *skb)
 		if (xdp2tc_get_metadata(skb) & CALI_META_ACCEPTED_BY_XDP) {
 			CALI_LOG_IF(CALI_LOG_LEVEL_INFO,
 					"Final result=ALLOW (%d). Accepted by XDP.", CALI_REASON_ACCEPTED_BY_XDP);
-			skb->mark = CALI_SKB_MARK_BYPASS;
+			skb->mark = CALI_SKB_MARK_BYPASS_XDP;
 			return TC_ACT_UNSPEC;
 		}
 	}

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -29,6 +29,7 @@ const (
 	MarkSeenFallThrough       = MarkSeen | 0x04000000
 	MarkSeenFallThroughMask   = MarkSeenMask | MarkSeenFallThrough
 	MarkSeenBypassForward     = MarkSeenBypass | 0x00300000
+	MarkSeenBypassXDP         = MarkSeenBypass | 0x00500000
 	MarkSeenBypassForwardMask = MarkSeenBypassMask | 0x00f00000
 	MarkSeenNATOutgoing       = MarkSeenBypass | 0x00800000
 	MarkSeenNATOutgoingMask   = MarkSeenBypassMask | 0x00f00000

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -206,17 +206,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			Expect(tc.Felixes[0].IPSetNames()).To(ContainElements(elems))
 		}
 
-		By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
+		By("Having only failsafe connectivity after removing host-0's egress rule")
 		// Since there's no conntrack, removing rules in one direction is enough to prevent
 		// connectivity in either direction.
-		host0Pol.Spec.Egress = []api.Rule{
-			{
-				Action: api.Deny,
-				Destination: api.EntityRule{
-					Selector: host0Selector,
-				},
-			},
-		}
+		host0Pol.Spec.Egress = []api.Rule{}
 		host0Pol, err := client.GlobalNetworkPolicies().Update(ctx, host0Pol, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1165,7 +1165,7 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 	rawRules = append(rawRules,
 		generictables.Rule{
 			// Return, i.e. no-op, if bypass mark is not set.
-			Match:   r.NewMatch().MarkMatchesWithMask(tcdefs.MarkSeenBypass, 0xffffffff),
+			Match:   r.NewMatch().MarkMatchesWithMask(tcdefs.MarkSeenBypassXDP, 0xffffffff),
 			Action:  r.GoTo(ChainRawBPFUntrackedPolicy),
 			Comment: []string{"Jump to target for packets with Bypass mark"},
 		},

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1262,7 +1262,7 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 		Rules: []generictables.Rule{
 			// At this point we know bypass mark is set, which means that the packet has
 			// been explicitly allowed by untracked ingress policy (XDP).  We should
-			// clear the mark so as not to affect any FROM_HOST processing.  (There
+			// clear the mark so as not to affect any FROM_HOST processing.  There
 			// shouldn't be any FROM_HOST processing, because untracked policy is only
 			// intended for traffic to/from the host.  But if the traffic is in fact
 			// forwarded and goes to or through another endpoint, it's better to enforce
@@ -1271,7 +1271,7 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 			// logic because no one else's iptables should have had a chance to execute
 			// yet.
 			{
-				Action: r.SetMark(0),
+				Action: r.SetMaskedMark(0, tcdefs.MarksMask),
 			},
 			// Now ensure that the packet is not tracked.
 			{


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Was using SetMark(0), which ends up using a mask of 0, so it is a no-op.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-10758

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
BPF: Fix that we'd fail to clear mark bits after applying do-not-track policy.  Use dedicated mark for XDP bypass traffic.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
