### PR TITLE
Fix: announcement of /32 and /128 entries for serviceExternalIPs

### DIFF
--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -27,6 +27,9 @@ const (
 
 	// Specific IP for loadbalancer IP test.
 	loadBalancerIP1 = "172.217.4.10"
+
+	// externalIP3 for single external IP test.
+	externalIP3 = "45.12.70.7"
 )
 
 func addEndpointSubset(ep *v1.Endpoints, nodename string) {
@@ -87,6 +90,23 @@ func buildSimpleService3() (svc *v1.Service, ep *v1.Endpoints) {
 			LoadBalancer: v1.LoadBalancerStatus{
 				Ingress: []v1.LoadBalancerIngress{{IP: loadBalancerIP1}},
 			},
+		},
+	}
+	ep = &v1.Endpoints{
+		ObjectMeta: meta,
+	}
+	return
+}
+
+func buildSimpleService4() (svc *v1.Service, ep *v1.Endpoints) {
+	meta := metav1.ObjectMeta{Namespace: "foo", Name: "ext"}
+	svc = &v1.Service{
+		ObjectMeta: meta,
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ClusterIP:             "127.0.0.11",
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			ExternalIPs:           []string{externalIP3},
 		},
 	}
 	ep = &v1.Endpoints{
@@ -230,29 +250,35 @@ var _ = Describe("RouteGenerator", func() {
 
 	Describe("resourceInformerHandlers", func() {
 		var (
-			svc, svc2, svc3 *v1.Service
-			ep, ep2, ep3    *v1.Endpoints
+			svc, svc2, svc3, svc4 *v1.Service
+			ep, ep2, ep3, ep4     *v1.Endpoints
 		)
 
 		BeforeEach(func() {
 			svc, ep = buildSimpleService()
 			svc2, ep2 = buildSimpleService2()
 			svc3, ep3 = buildSimpleService3()
+			svc4, ep4 = buildSimpleService4()
 
 			addEndpointSubset(ep, rg.nodeName)
 			addEndpointSubset(ep2, rg.nodeName)
 			addEndpointSubset(ep3, rg.nodeName)
+			addEndpointSubset(ep4, rg.nodeName)
 			err := rg.epIndexer.Add(ep)
 			Expect(err).NotTo(HaveOccurred())
 			err = rg.epIndexer.Add(ep2)
 			Expect(err).NotTo(HaveOccurred())
 			err = rg.epIndexer.Add(ep3)
 			Expect(err).NotTo(HaveOccurred())
+			err = rg.epIndexer.Add(ep4)
+			Expect(err).NotTo(HaveOccurred())
 			err = rg.svcIndexer.Add(svc)
 			Expect(err).NotTo(HaveOccurred())
 			err = rg.svcIndexer.Add(svc2)
 			Expect(err).NotTo(HaveOccurred())
 			err = rg.svcIndexer.Add(svc3)
+			Expect(err).NotTo(HaveOccurred())
+			err = rg.svcIndexer.Add(svc4)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -621,6 +647,59 @@ var _ = Describe("RouteGenerator", func() {
 				// Finally, remove BGPConfiguration. It should withdraw the route
 				// and delete the refcount entry.
 				rg.client.onLoadBalancerIPsUpdate([]string{})
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache).NotTo(HaveKey(key))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey(key))
+			})
+
+			// This test simulates a situation where BGPConfiguration has a /32 route that exactly matches
+			// externalIP of a LoadBalancer service with ExternalTrafficPolicy set to Local. The route should only be advertised
+			// when the Service is created, and not when the BGPConfiguration is created.
+			It("should handle /32 routes for externalIPs", func() {
+				// BeforeEach creates a service. Remove it before the test, since we want to start
+				// this test without the service in place. svc4 is a LoadBalancer service with external traffic
+				// policy of Local and an externalIP.
+				err := rg.epIndexer.Delete(ep4)
+				Expect(err).NotTo(HaveOccurred())
+				err = rg.svcIndexer.Delete(svc4)
+				Expect(err).NotTo(HaveOccurred())
+
+				// The key we expect to be used for the LB IP.
+				key := "/calico/staticroutes/" + externalIP3 + "-32"
+
+				// Trigger programming of valid routes from the route generator for any known services.
+				// We don't have a BGPConfiguration update or services yet, so we shouldn't receive any routes.
+				By("Resyncing routes at start of test")
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache[key]).To(Equal(""))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(0))
+
+				// Simulate an event from the syncer which sets the external IP range containing only the service's externalIP.
+				// We use a /32 route to trigger the situation under test.
+				externalIPRangeSingle := fmt.Sprintf("%s/32", externalIP3)
+				By("onExternalIPsUpdate to include /32 route")
+				rg.client.onExternalIPsUpdate([]string{externalIPRangeSingle})
+				rg.resyncKnownRoutes()
+
+				// No routes should be advertised yet.
+				Expect(rg.client.cache[key]).To(Equal(""))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(0))
+
+				// Now add the service.
+				err = rg.epIndexer.Add(ep4)
+				Expect(err).NotTo(HaveOccurred())
+				err = rg.svcIndexer.Add(svc4)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect that we advertise the /32 external IP from the Service.
+				By("Resyncing routes from route generator")
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache[key]).To(Equal(externalIP3 + "/32"))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
+
+				// Finally, remove BGPConfiguration. It should withdraw the route
+				// and delete the refcount entry.
+				rg.client.onExternalIPsUpdate([]string{})
 				rg.resyncKnownRoutes()
 				Expect(rg.client.cache).NotTo(HaveKey(key))
 				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey(key))


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Similar to https://github.com/projectcalico/calico/pull/6282 but for externalIP, I kind of ran into this and it would be great if externalIPs populated as single IP addresses stop advertising itself as global routes and only expose itself for services with externalTrafficPolicy as Cluster.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes https://github.com/projectcalico/calico/issues/7558

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/7558

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that single-IP entries on BGPConfiguration serviceExternalIPs were not advertised according to external traffic policy. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
