### PR TITLE
Remove the `ctl` component from OpenShift certification [v3.29]

### DIFF
--- a/hack/certification/certify.sh
+++ b/hack/certification/certify.sh
@@ -56,7 +56,6 @@ declare -A calico_image_project=(
     ["node-driver-registrar"]="64c01702093679e0f47fa153"
     ["flannel-migration-controller"]="5e619bec2c5f183d03415978"
     ["dikastes"]="5e619e432f3c1acdd05f6240"
-    ["ctl"]="5f1781b1421fb18d530fad40"
 )
 
 declare -A operator_image_project=(


### PR DESCRIPTION
We no longer attempt to certify calicoctl for OpenShift; remove it from the certification script to prevent unnecessarily test failures. Cherry-pick of #9424.