### PR TITLE
Update to allowing building and publishing images in hashrelease

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -40,6 +40,8 @@ blocks:
       jobs:
         - name: Build and publish hashrelease
           commands:
+            - |
+              [[ ${SEMAPHORE_PIPELINE_PROMOTION} == "true" ]] && export BUILD_ARGS="--build-images" && export PUBLISH_ARGS="--skip-publish-images=false" || echo
             - make hashrelease
       prologue:
         commands:
@@ -47,5 +49,5 @@ blocks:
           - cd release
           - make build
       env_vars:
-        - name: IS_HASHRELEASE
-          value: "true"
+        - name: DEV_REGISTRIES
+          value: docker.io/calico

--- a/release/Makefile
+++ b/release/Makefile
@@ -26,8 +26,8 @@ ci: static-checks
 ###############################################################################
 .PHONY: hashrelease
 hashrelease: bin/release var-require-all-GITHUB_TOKEN
-	@bin/release hashrelease build
-	@bin/release hashrelease publish
+	@bin/release hashrelease build ${BUILD_ARGS}
+	@bin/release hashrelease publish ${PUBLISH_ARGS}
 
 ###############################################################################
 # Release

--- a/release/build/main.go
+++ b/release/build/main.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/projectcalico/calico/release/internal/config"
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/pinnedversion"
 	"github.com/projectcalico/calico/release/internal/registry"
@@ -336,8 +337,7 @@ func hashreleaseSubCommands(cfg *config.Config) []*cli.Command {
 			Aliases: []string{"gc"},
 			Action: func(c *cli.Context) error {
 				configureLogging("hashrelease-garbage-collect.log")
-				tasks.HashreleaseCleanRemote(cfg)
-				return nil
+				return hashreleaseserver.CleanOldHashreleases(&cfg.HashreleaseServerConfig)
 			},
 		},
 	}

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -52,6 +52,12 @@ type Hashrelease struct {
 	// Stream is the version the hashrelease is for (e.g master, v3.19)
 	Stream string
 
+	// ProductVersion is the product version in the hashrelease
+	ProductVersion string
+
+	// OperatorVersion is the operator version for the hashreleaseq
+	OperatorVersion string
+
 	// Source is the source of hashrelease content
 	Source string
 
@@ -62,8 +68,13 @@ type Hashrelease struct {
 	Latest bool
 }
 
-func (h Hashrelease) URL() string {
+func (h *Hashrelease) URL() string {
 	return fmt.Sprintf("https://%s.%s", h.Name, BaseDomain)
+}
+
+func (h *Hashrelease) AsLatest() *Hashrelease {
+	h.Latest = true
+	return h
 }
 
 func remoteDocsPath(user string) string {

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -197,63 +197,6 @@ func RetrievePinnedOperator(outputDir string) (registry.OperatorComponent, error
 	}, nil
 }
 
-// RetrievePinnedOperatorVersion retrieves the operator version from the pinned version file.
-func RetrievePinnedOperatorVersion(outputDir string) (string, error) {
-	operator, err := RetrievePinnedOperator(outputDir)
-	if err != nil {
-		return "", err
-	}
-	return operator.Version, nil
-}
-
-// RetrieveReleaseName retrieves the release name from the pinned version file.
-func RetrieveReleaseName(outputDir string) (string, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedversion PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return "", err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
-		return "", err
-	}
-	return pinnedversion[0].ReleaseName, nil
-}
-
-// RetrievePinnedProductVersion retrieves the product version from the pinned version file.
-func RetrievePinnedProductVersion(outputDir string) (string, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedversion PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return "", err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
-		return "", err
-	}
-	return pinnedversion[0].Title, nil
-}
-
-// RetrievePinnedVersionNote retrieves the note from the pinned version file.
-func RetrievePinnedVersionNote(outputDir string) (string, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedversion PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return "", err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
-		return "", err
-	}
-	return pinnedversion[0].Note, nil
-}
-
-// RetrievePinnedVersionHash retrieves the hash from the pinned version file.
-func RetrievePinnedVersionHash(outputDir string) (string, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedversion PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return "", err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
-		return "", err
-	}
-	return pinnedversion[0].Hash, nil
-}
-
 // RetrieveComponentsToValidate retrieves the components to validate from the pinned version file.
 func RetrieveComponentsToValidate(outputDir string) (map[string]registry.Component, error) {
 	pinnedVersionPath := pinnedVersionFilePath(outputDir)
@@ -283,4 +226,26 @@ func RetrieveComponentsToValidate(outputDir string) (map[string]registry.Compone
 		components[name] = component
 	}
 	return components, nil
+}
+
+func AsHashrelease(repoRootDir, tmpDir, srcDir string) (*hashreleaseserver.Hashrelease, error) {
+	productBranch, err := utils.GitBranch(repoRootDir)
+	if err != nil {
+		logrus.WithError(err).Errorf("Failed to get %s branch name", utils.ProductName)
+		return nil, err
+	}
+	pinnedVersion, err := RetrievePinnedVersion(tmpDir)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to get pinned version")
+	}
+	return &hashreleaseserver.Hashrelease{
+		Name:            pinnedVersion.ReleaseName,
+		Hash:            pinnedVersion.Hash,
+		Note:            pinnedVersion.Note,
+		Stream:          version.DeterminePublishStream(productBranch, pinnedVersion.Title),
+		ProductVersion:  pinnedVersion.Title,
+		OperatorVersion: pinnedVersion.TigeraOperator.Version,
+		Source:          srcDir,
+		Time:            time.Now(),
+	}, nil
 }

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -15,10 +15,13 @@
 package calico
 
 import (
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/version"
 )
 
 type Option func(*CalicoManager) error
+
+type PublishOptions func(*CalicoManager) error
 
 func WithRepoRoot(root string) Option {
 	return func(r *CalicoManager) error {
@@ -63,11 +66,41 @@ func WithOutputDir(outputDir string) Option {
 	}
 }
 
-func WithPublishOptions(images, tag, github bool) Option {
+func WithPublishOptions(opt ...PublishOptions) Option {
 	return func(r *CalicoManager) error {
-		r.publishImages = images
-		r.publishTag = tag
-		r.publishGithub = github
+		for _, opt := range opt {
+			if err := opt(r); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func PublishImages() PublishOptions {
+	return func(r *CalicoManager) error {
+		r.publishImages = true
+		return nil
+	}
+}
+
+func PublishGitTag() PublishOptions {
+	return func(r *CalicoManager) error {
+		r.publishTag = true
+		return nil
+	}
+}
+
+func PublishGithubRelease() PublishOptions {
+	return func(r *CalicoManager) error {
+		r.publishGithub = true
+		return nil
+	}
+}
+
+func PublishHashrelease() PublishOptions {
+	return func(r *CalicoManager) error {
+		r.publishHashrelease = true
 		return nil
 	}
 }
@@ -117,6 +150,14 @@ func WithRepoName(name string) Option {
 func WithReleaseBranchPrefix(prefix string) Option {
 	return func(r *CalicoManager) error {
 		r.releaseBranchPrefix = prefix
+		return nil
+	}
+}
+
+func WithHashrelease(hashrelease hashreleaseserver.Hashrelease, cfg hashreleaseserver.Config) Option {
+	return func(r *CalicoManager) error {
+		r.hashrelease = hashrelease
+		r.hashreleaseConfig = cfg
 		return nil
 	}
 }

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -51,27 +51,23 @@ func imgExists(name string, component registry.Component, ch chan imageExistsRes
 // HashreleaseValidate validates the images in the hashrelease.
 // These images are checked to ensure they exist in the registry
 // as they should have been pushed in the standard build process.
-func HashreleaseValidate(cfg *config.Config, skipISS bool) {
+func HashreleaseValidate(cfg *config.Config, skipISS bool) error {
 	tmpDir := cfg.TmpFolderPath()
-	name, err := pinnedversion.RetrieveReleaseName(tmpDir)
+	pinned, err := pinnedversion.RetrievePinnedVersion(tmpDir)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get release name")
+		logrus.WithError(err).Error("Failed to get release name")
+		return err
 	}
 	productBranch, err := utils.GitBranch(cfg.RepoRootDir)
 	if err != nil {
-		logrus.WithError(err).Fatalf("Failed to get %s branch name", utils.ProductName)
+		logrus.WithError(err).Errorf("Failed to get %s branch name", utils.ProductName)
+		return err
 	}
-	productVersion, err := pinnedversion.RetrievePinnedProductVersion(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get candidate name")
-	}
-	operatorVersion, err := pinnedversion.RetrievePinnedOperatorVersion(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get operator version")
-	}
+	productVersion := pinned.Title
+	productStream := version.DeterminePublishStream(productBranch, productVersion)
 	images, err := pinnedversion.RetrieveComponentsToValidate(tmpDir)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get pinned version")
+		logrus.WithError(err).Error("Failed to get pinned version")
 	}
 	results := make(map[string]imageExistsResult, len(images))
 
@@ -105,11 +101,11 @@ func HashreleaseValidate(cfg *config.Config, skipISS bool) {
 			slackMsg := slack.Message{
 				Config: cfg.SlackConfig,
 				Data: slack.MessageData{
-					ReleaseName:     name,
+					ReleaseName:     pinned.ReleaseName,
 					Product:         utils.DisplayProductName(),
-					Stream:          version.DeterminePublishStream(productBranch, productVersion),
+					Stream:          productStream,
 					Version:         productVersion,
-					OperatorVersion: operatorVersion,
+					OperatorVersion: pinned.TigeraOperator.Version,
 					CIURL:           cfg.CI.URL(),
 					FailedImages:    failedImages,
 				},
@@ -119,7 +115,8 @@ func HashreleaseValidate(cfg *config.Config, skipISS bool) {
 			}
 		}
 		logrus.WithField("images", strings.Join(failedImageNames, ", ")).
-			Fatalf("Failed to validate %d images, see above for details", failedCount)
+			Errorf("Failed to validate %d images, see above for details", failedCount)
+		return fmt.Errorf("failed to validate %d images", failedCount)
 	}
 	if !skipISS {
 		logrus.Info("Sending images to ISS")
@@ -128,12 +125,13 @@ func HashreleaseValidate(cfg *config.Config, skipISS bool) {
 			imageList = append(imageList, component.String())
 		}
 		imageScanner := imagescanner.New(cfg.ImageScannerConfig)
-		err := imageScanner.Scan(imageList, version.DeterminePublishStream(productBranch, productVersion), false, cfg.OutputDir)
+		err := imageScanner.Scan(imageList, productStream, false, cfg.OutputDir)
 		if err != nil {
 			// Error is logged and ignored as this is not considered a fatal error
 			logrus.WithError(err).Error("Failed to scan images")
 		}
 	}
+	return nil
 }
 
 // HashreleasePublished checks if the hashrelease has already been published.
@@ -152,54 +150,20 @@ func HashreleasePublished(cfg *config.Config, hash string) (bool, error) {
 	return hashreleaseserver.HasHashrelease(hash, &cfg.HashreleaseServerConfig), nil
 }
 
-// HashreleaseValidate publishes the hashrelease
-func HashreleasePush(cfg *config.Config, path string, setLatest bool) {
-	tmpDir := cfg.TmpFolderPath()
-	name, err := pinnedversion.RetrieveReleaseName(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get release name")
-	}
-	note, err := pinnedversion.RetrievePinnedVersionNote(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get pinned version note")
-	}
-	productBranch, err := utils.GitBranch(cfg.RepoRootDir)
-	if err != nil {
-		logrus.WithError(err).Fatalf("Failed to get %s branch name", utils.ProductName)
-	}
-	productVersion, err := pinnedversion.RetrievePinnedProductVersion(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get candidate name")
-	}
-	operatorVersion, err := pinnedversion.RetrievePinnedOperatorVersion(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get operator version")
-	}
-	releaseHash, err := pinnedversion.RetrievePinnedVersionHash(tmpDir)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get release hash")
-	}
-	hashrel := hashreleaseserver.Hashrelease{
-		Name:   name,
-		Hash:   releaseHash,
-		Note:   note,
-		Stream: version.DeterminePublishStream(productBranch, productVersion),
-		Source: path,
-		Latest: setLatest,
-	}
-	logrus.WithField("note", note).Info("Publishing hashrelease")
-	if err := hashreleaseserver.PublishHashrelease(hashrel, &cfg.HashreleaseServerConfig); err != nil {
-		logrus.WithError(err).Fatal("Failed to publish hashrelease")
-	}
+// HashreleaseSlackMessage sends a slack message to notify that a hashrelease has been published.
+func HashreleaseSlackMessage(cfg *config.Config, hashrel *hashreleaseserver.Hashrelease) error {
 	scanResultURL := imagescanner.RetrieveResultURL(cfg.OutputDir)
+	if scanResultURL == "" {
+		logrus.Warn("No image scan result URL found")
+	}
 	slackMsg := slack.Message{
 		Config: cfg.SlackConfig,
 		Data: slack.MessageData{
-			ReleaseName:        name,
+			ReleaseName:        hashrel.Name,
 			Product:            utils.DisplayProductName(),
-			Stream:             version.DeterminePublishStream(productBranch, productVersion),
-			Version:            productVersion,
-			OperatorVersion:    operatorVersion,
+			Stream:             hashrel.Stream,
+			Version:            hashrel.ProductVersion,
+			OperatorVersion:    hashrel.OperatorVersion,
 			DocsURL:            hashrel.URL(),
 			CIURL:              cfg.CI.URL(),
 			ImageScanResultURL: scanResultURL,
@@ -209,9 +173,10 @@ func HashreleasePush(cfg *config.Config, path string, setLatest bool) {
 		logrus.WithError(err).Error("Failed to send slack message")
 	}
 	logrus.WithFields(logrus.Fields{
-		"name": name,
+		"name": hashrel.Name,
 		"URL":  hashrel.URL(),
-	}).Info("Published hashrelease")
+	}).Info("Sent hashrelease publish notification to slack")
+	return nil
 }
 
 // ReformatHashrelease modifies the generated release output to match

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -214,14 +214,6 @@ func HashreleasePush(cfg *config.Config, path string, setLatest bool) {
 	}).Info("Published hashrelease")
 }
 
-// HashreleaseCleanRemote cleans up old hashreleases on the docs host
-func HashreleaseCleanRemote(cfg *config.Config) {
-	logrus.Info("Cleaning up old hashreleases")
-	if err := hashreleaseserver.CleanOldHashreleases(&cfg.HashreleaseServerConfig); err != nil {
-		logrus.WithError(err).Fatal("Failed to delete old hashreleases")
-	}
-}
-
 // ReformatHashrelease modifies the generated release output to match
 // the "legacy" format our CI tooling expects. This should be temporary until
 // we can update the tooling to expect the new format.


### PR DESCRIPTION
## Description

This allows building and publishing images in hashreleases.

Semaphore allows the ability to distinguish how a workflow is started using [`SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE`](https://docs.semaphoreci.com/reference/env-vars#workflow-triggered-by-schedule) environment variable.

This allow cleans up some of the hashrelease tasks and move into calico manager or build/main.go

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
