### PR TITLE
[release-v3.29] Auto pick #9416: Fix vxlan cross-subnet routes in pure V6 env

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -35,7 +35,7 @@ import (
 	"github.com/projectcalico/calico/felix/proto"
 )
 
-// L3RouteResolver is responsible for indexing (currently only IPv4 versions of):
+// L3RouteResolver is responsible for indexing :
 //
 // - IPAM blocks
 // - IP pools
@@ -46,7 +46,7 @@ import (
 // - The relevant destination CIDR.
 // - The IP pool type that contains the CIDR (or none).
 // - Other metadata about the containing IP pool.
-// - Whether this (/32) CIDR is a host or not.
+// - Whether this (/32) CIDR is a host or not. (or /128 for IPv6)
 // - For workload CIDRs, the IP and name of the host that contains the workload.
 //
 // The BPF dataplane use the above to form a map of IP space so it can look up whether a particular

--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -171,7 +171,7 @@ func (i l3rrNodeInfo) AddressesAsCIDRs() []ip.CIDR {
 	return cidrs
 }
 
-func NewL3RouteResolver(hostname string, callbacks PipelineCallbacks, useNodeResourceUpdates bool, routeSource string) *L3RouteResolver {
+func NewL3RouteResolver(hostname string, callbacks routeCallbacks, useNodeResourceUpdates bool, routeSource string) *L3RouteResolver {
 	logrus.Info("Creating L3 route resolver")
 	l3rr := &L3RouteResolver{
 		myNodeName: hostname,
@@ -832,10 +832,13 @@ func (c *L3RouteResolver) flush() {
 			}
 		}
 
+		var ipFamily int
+
 		if rt.DstNodeName != "" {
 			dstNodeInfo, exists := c.nodeNameToNodeInfo[rt.DstNodeName]
 			if exists {
-				switch cidr.Version() {
+				ipFamily = int(cidr.Version())
+				switch ipFamily {
 				case 4:
 					if dstNodeInfo.V4Addr != emptyV4Addr {
 						rt.DstNodeIp = dstNodeInfo.V4Addr.String()
@@ -849,7 +852,7 @@ func (c *L3RouteResolver) flush() {
 				}
 			}
 		}
-		rt.SameSubnet = poolAllowsCrossSubnet && c.nodeInOurSubnet(rt.DstNodeName)
+		rt.SameSubnet = poolAllowsCrossSubnet && c.nodeInOurSubnet(rt.DstNodeName, ipFamily)
 
 		if rt.Dst != emptyV4Addr.AsCIDR().String() && rt.Dst != emptyV6Addr.AsCIDR().String() {
 			// Skip sending a route for an empty CIDR
@@ -864,7 +867,7 @@ func (c *L3RouteResolver) flush() {
 
 // nodeInOurSubnet returns true if the IP of the given node is known and it's in our subnet.
 // Return false if either the remote IP or our subnet is not known.
-func (c *L3RouteResolver) nodeInOurSubnet(name string) bool {
+func (c *L3RouteResolver) nodeInOurSubnet(name string, ipFamily int) bool {
 	localNodeInfo, exists := c.nodeNameToNodeInfo[c.myNodeName]
 	if !exists {
 		return false
@@ -875,10 +878,14 @@ func (c *L3RouteResolver) nodeInOurSubnet(name string) bool {
 		return false
 	}
 
-	sameV4 := localNodeInfo.V4CIDR.ContainsV4(nodeInfo.V4Addr)
-	sameV6 := localNodeInfo.V6CIDR != ip.V6CIDR{} && nodeInfo.V6Addr != ip.V6Addr{} && localNodeInfo.V6CIDR.ContainsV6(nodeInfo.V6Addr)
+	switch ipFamily {
+	case 4:
+		return localNodeInfo.V4CIDR != ip.V4CIDR{} && localNodeInfo.V4CIDR.ContainsV4(nodeInfo.V4Addr)
+	case 6:
+		return localNodeInfo.V6CIDR != ip.V6CIDR{} && localNodeInfo.V6CIDR.ContainsV6(nodeInfo.V6Addr)
+	}
 
-	return sameV4 || sameV6
+	return false
 }
 
 func (c *L3RouteResolver) maybeReportLive() {

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -19,16 +19,22 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/encap"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 var _ = Describe("L3RouteResolver", func() {
 	Describe("L3RouteResolver UTs", func() {
 		var l3RR *L3RouteResolver
-		var eventBuf *EventSequencer
+		var eventBuf rtEventsMock
 
 		BeforeEach(func() {
-			eventBuf = NewEventSequencer(nil)
+			eventBuf = make(rtEventsMock, 100)
 			l3RR = NewL3RouteResolver("test-hostname", eventBuf, true, "CalicoIPAM")
+			l3RR.OnAlive = func() {}
 		})
 
 		It("onNodeUpdate should add entries to the correct IP version tries", func() {
@@ -54,6 +60,86 @@ var _ = Describe("L3RouteResolver", func() {
 			cidrV6, _ := ip.CIDRFromString("dead:beef::1/128")
 			expectedV6T.Update(cidrV6, ri)
 			Expect(l3RR.trie.v6T).To(Equal(expectedV6T))
+		})
+
+		It("should add crossSubnet routes in pure V6 env", func() {
+			cidr, _ := ip.CIDRFromString("dead:beef::/122")
+			ipnet := net.IPNet{IPNet: cidr.ToIPNet()}
+			v1Pool := model.IPPool{
+				CIDR:      ipnet,
+				VXLANMode: encap.CrossSubnet,
+			}
+
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: v1Pool.CIDR},
+					Value: &v1Pool,
+				},
+			})
+
+			cidr, _ = ip.CIDRFromString("abcd:eeee::/32")
+			nodeInfo := &l3rrNodeInfo{
+				V6Addr:      ip.FromString("abcd:eeee::1").(ip.V6Addr),
+				V6CIDR:      cidr.(ip.V6CIDR),
+				VXLANV6Addr: ip.FromString("abcd:0000::1").(ip.V6Addr),
+			}
+
+			l3RR.onNodeUpdate("test-hostname", nodeInfo)
+
+			cidr, _ = ip.CIDRFromString("abcd:ffff::/32")
+			nodeInfo = &l3rrNodeInfo{
+				V6Addr:      ip.FromString("abcd:ffff::1").(ip.V6Addr),
+				V6CIDR:      cidr.(ip.V6CIDR),
+				VXLANV6Addr: ip.FromString("abcd:0001::1").(ip.V6Addr),
+			}
+
+			l3RR.onNodeUpdate("nodeName1", nodeInfo)
+
+			cidr, _ = ip.CIDRFromString("dead:beef::1/122")
+
+			l3RR.OnWorkloadUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.WorkloadEndpointKey{
+						Hostname:   "test-hostname",
+						WorkloadID: "w1",
+						EndpointID: "ep1",
+					},
+					Value: &model.WorkloadEndpoint{
+						Name:     "w1",
+						IPv6Nets: []net.IPNet{{IPNet: cidr.ToIPNet()}},
+					},
+				},
+			})
+
+			// drain all route updates
+		drainLoop:
+			for {
+				select {
+				case <-eventBuf:
+				default:
+					break drainLoop
+				}
+			}
+
+			cidr, _ = ip.CIDRFromString("dead:beef::2/122")
+
+			l3RR.OnWorkloadUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.WorkloadEndpointKey{
+						Hostname:   "nodeName1",
+						WorkloadID: "w2",
+						EndpointID: "ep2",
+					},
+					Value: &model.WorkloadEndpoint{
+						Name:     "w2",
+						IPv6Nets: []net.IPNet{{IPNet: cidr.ToIPNet()}},
+					},
+				},
+			})
+
+			rt := (<-eventBuf).(*proto.RouteUpdate)
+			Expect(rt.Type).To(Equal(proto.RouteType_REMOTE_WORKLOAD))
+			Expect(rt.SameSubnet).NotTo(BeTrue())
 		})
 	})
 	Describe("l3rrNodeInfo UTs", func() {
@@ -90,3 +176,13 @@ var _ = Describe("L3RouteResolver", func() {
 		})
 	})
 })
+
+type rtEventsMock chan any
+
+func (m rtEventsMock) OnRouteUpdate(update *proto.RouteUpdate) {
+	m <- update
+}
+
+func (m rtEventsMock) OnRouteRemove(dst string) {
+	m <- dst
+}

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -49,6 +49,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 	}
 	for _, testConfig := range []testConf{
 		{api.VXLANModeCrossSubnet, "CalicoIPAM", true, true},
+		{api.VXLANModeCrossSubnet, "CalicoIPAM", false, true},
 		{api.VXLANModeCrossSubnet, "WorkloadIPs", false, true},
 		{api.VXLANModeCrossSubnet, "CalicoIPAM", true, false},
 		{api.VXLANModeCrossSubnet, "WorkloadIPs", false, false},
@@ -85,6 +86,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 				}
 
 				topologyOptions = createBaseTopologyOptions(vxlanMode, enableIPv6, routeSource, brokenXSum)
+				topologyOptions.FelixLogSeverity = "Debug"
 				tc, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
 
 				w, w6, hostW, hostW6 = setupWorkloads(infra, tc, topologyOptions, client, enableIPv6)
@@ -105,6 +107,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						felix.Exec("ipset", "list")
 						felix.Exec("ip", "r")
 						felix.Exec("ip", "a")
+						if enableIPv6 {
+							felix.Exec("ip", "-6", "route")
+						}
 					}
 				}
 


### PR DESCRIPTION
Cherry pick of #9416 on release-v3.29.

#9416: Fix vxlan cross-subnet routes in pure V6 env

# Original PR Body below

In a pure V6 env, nodes do not have v4 addresses and thus testing localNodeInfo.V4CIDR.ContainsV4(nodeInfo.V4Addr) is always true and sameV4 || sameV6 would also always evaluate to true.

It is better to evaluate  nodeInOurSubnet separately for each IP family.

fixes https://github.com/projectcalico/calico/issues/9403

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix missing routes when vxlan mode is cross-subnet and the environment is purely V6 (no V4 host addresses)
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.