### PR TITLE
Add documentation for Wireguard Threaded NAPI

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -827,7 +827,12 @@ type FelixConfigurationSpec struct {
 
 	// WireguardEnabledV6 controls whether Wireguard is enabled for IPv6 (encapsulating IPv6 traffic over an IPv6 underlay network). [Default: false]
 	WireguardEnabledV6 *bool `json:"wireguardEnabledV6,omitempty"`
-	// WireguardThreadingEnabled controls whether Wireguard has NAPI threading enabled. [Default: false]
+	// WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+	// This increases the maximum number of packets a Wireguard interface can process.
+	// Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+	// There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+	// that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+	// Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
 	WireguardThreadingEnabled *bool `json:"wireguardThreadingEnabled,omitempty"`
 	// WireguardListeningPort controls the listening port used by IPv4 Wireguard. [Default: 51820]
 	WireguardListeningPort *int `json:"wireguardListeningPort,omitempty" validate:"omitempty,gt=0,lte=65535"`

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -3366,7 +3366,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 					},
 					"wireguardThreadingEnabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "WireguardThreadingEnabled controls whether Wireguard has NAPI threading enabled. [Default: false]",
+							Description: "WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false] This increases the maximum number of packets a Wireguard interface can process. Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core. There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed. Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -4362,8 +4362,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Controls whether Wireguard has NAPI threading enabled.",
-          "DescriptionHTML": "<p>Controls whether Wireguard has NAPI threading enabled.</p>",
+          "Description": "Controls whether Wireguard has Threaded NAPI enabled. \nThis increases the maximum number of packets a Wireguard interface can process.\nConsider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.\nThere is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting\nthat may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.\nWorkaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.",
+          "DescriptionHTML": "<p>Controls whether Wireguard has Threaded NAPI enabled. \nThis increases the maximum number of packets a Wireguard interface can process.\nConsider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated <code>softirq</code> CPU core.\nThere is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting\nthat may cause NAPI to get stuck holding the global <code>rtnl_mutex</code> when a peer is removed.\nWorkaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.</p>",
           "UserEditable": true,
           "GoType": "*bool"
         }

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -2398,7 +2398,12 @@ Controls the priority value to use for the Wireguard routing rule.
 
 ### `WireguardThreadingEnabled` (config file) / `wireguardThreadingEnabled` (YAML)
 
-Controls whether Wireguard has NAPI threading enabled.
+Controls whether Wireguard has Threaded NAPI enabled. 
+This increases the maximum number of packets a Wireguard interface can process.
+Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
 
 | Detail |   |
 | --- | --- |

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -1129,8 +1129,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -2141,8 +2141,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -2151,8 +2151,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -2152,8 +2152,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -2136,8 +2136,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -2136,8 +2136,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -2153,8 +2153,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2046,8 +2046,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -2136,8 +2136,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-

--- a/manifests/ocp/crd.projectcalico.org_felixconfigurations.yaml
+++ b/manifests/ocp/crd.projectcalico.org_felixconfigurations.yaml
@@ -1073,7 +1073,15 @@ spec:
                 type: integer
               wireguardThreadingEnabled:
                 description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                  has Threaded NAPI enabled. [Default: false] This increases the maximum
+                  number of packets a Wireguard interface can process. Consider threaded
+                  NAPI only if you have high packets per second workloads that are
+                  causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/)
+                  with this setting that may cause NAPI to get stuck holding the global
+                  `rtnl_mutex` when a peer is removed. Workaround: Make sure your
+                  Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6)
+                  to unwedge NAPI.'
                 type: boolean
               workloadSourceSpoofing:
                 description: WorkloadSourceSpoofing controls whether pods can use

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -20672,8 +20672,13 @@ spec:
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
               wireguardThreadingEnabled:
-                description: 'WireguardThreadingEnabled controls whether Wireguard
-                  has NAPI threading enabled. [Default: false]'
+                description: |-
+                  WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                  This increases the maximum number of packets a Wireguard interface can process.
+                  Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                  There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                  that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                  Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
                 type: boolean
               workloadSourceSpoofing:
                 description: |-


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Type: Documentation
Why: Document the caveats to using Wireguard Threaded NAPI. This was a better spot than in the docs repo.
How: I edited the code comment and ran `make generate`.
Affects: CRDs, OpenAPI and autogenerated docs


## Related issues/PRs

documents https://github.com/projectcalico/calico/pull/9260

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
N/A
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
