### PR TITLE
add env var to disable tunnel in calico node

### DIFF
--- a/node/filesystem/etc/rc.local
+++ b/node/filesystem/etc/rc.local
@@ -20,8 +20,11 @@ fi
 NODENAME=$(cat /var/lib/calico/nodename)
 export NODENAME
 
-# If possible pre-allocate any tunnel addresses.
-calico-node -allocate-tunnel-addrs -allocate-tunnel-addrs-run-once || exit 1
+if [ -z "$CALICO_DISABLE_TUNNEL" ]; then
+  # If possible pre-allocate any tunnel addresses.
+  calico-node -allocate-tunnel-addrs -allocate-tunnel-addrs-run-once || exit 1
+fi
+
 
 # Create a directly to put enabled service files
 mkdir /etc/service/enabled
@@ -41,8 +44,12 @@ if [ "$CALICO_NETWORKING_BACKEND" != "none" ]; then
   cp -a /etc/service/available/monitor-addresses  /etc/service/enabled/
 fi
 
-# Enable the allocate tunnel IP service
-cp -a /etc/service/available/allocate-tunnel-addrs  /etc/service/enabled/
+# Allow tunnel to be disabled,for example, when only calico bgp mode is used
+if [ -z "$CALICO_DISABLE_TUNNEL" ]; then
+  # Enable the allocate tunnel IP service
+  cp -a /etc/service/available/allocate-tunnel-addrs  /etc/service/enabled/
+fi
+
 
 # Enable the node status reporter service
 cp -a /etc/service/available/node-status-reporter  /etc/service/enabled/


### PR DESCRIPTION
## Description
When the env var CALICO_DISABLE_TUNNEL is set, the process allocate-tunnel-addrs is not started.

In our environment, we only use BGP, didn't use tunnel, we found when create/delete/update a IPPool, all calico-node will get and update node many times, it will make k8s apiserver load very high.Even if the Typha component is deployed, these problems cannot be alleviated.
We have also noticed that there is already an environment variable `CALICO_DISABLE_FELIX` that has a similar function.
So add an another environment variable `CALICO_DISABLE_TUNNEL` that can control whether to start the process allocate-tunnel-addrs  or not.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Fixs #9394 

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
