### PR TITLE
[Prototype] Fix for PATCH without tier prefix

### DIFF
--- a/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
@@ -128,7 +128,8 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, val rest.Validate
 }
 
 func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc,
-	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions,
+) (runtime.Object, bool, error) {
 	tierName, _ := util.GetTierFromPolicyName(name)
 	err := r.authorizer.AuthorizeTierOperation(ctx, name, tierName)
 	if err != nil {
@@ -145,7 +146,6 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 	if err != nil {
 		return nil, err
 	}
-
 	return r.Store.Get(ctx, name, options)
 }
 

--- a/apiserver/pkg/registry/projectcalico/networkpolicy/strategy.go
+++ b/apiserver/pkg/registry/projectcalico/networkpolicy/strategy.go
@@ -47,7 +47,10 @@ func (policyStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) 
 }
 
 func (policyStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
-	obj.(*calico.NetworkPolicy).Name = canonicalizePolicyName(old)
+	// Canonicalize the old object's name as well to make sure it's consistent.
+	// This typically shouldn't be needed for update requests, but is necessary in PATCH
+	// requests because we may need to strip the tier earlier in the pipeline to pass earlier validation.
+	old.(*calico.NetworkPolicy).Name = canonicalizePolicyName(old)
 }
 
 func canonicalizePolicyName(obj runtime.Object) string {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This is one attempt at fixing https://github.com/projectcalico/calico/issues/9437

Basically, we try the update as provided. If it fails, then we retry it removing the "tier" from the object. This allows us to call applyPatch on an object without the tier prefix, which passes the name validation.

Once it passes the applyPatch name validation, it continues on to PrepareForUpdate, at which point we need to re-canonicalize the objects to include the tier prefix on them for storage...

I am not sure this is a viable solution - we need to think about what happens if there actually are policies in different tiers and someone tries to send a PATCH. I think it might just be OK, because in the second case you would need to specify the tier name (it's only for default that this is really a problem?)

At a minimum, for this change to go in we'd want to also:

- Only apply this logic for policies in the default tier
- Only apply this logic if we get the precise error back that we expect in the mismatched tier case.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
