### PR TITLE
Fix formatting of felix protobuf file

### DIFF
--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -5320,7 +5320,7 @@ func (m *ConfigUpdate) MarshalTo(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	if len(m.Config) > 0 {
-		for k := range m.Config {
+		for k, _ := range m.Config {
 			dAtA[i] = 0xa
 			i++
 			v := m.Config[k]
@@ -5337,7 +5337,7 @@ func (m *ConfigUpdate) MarshalTo(dAtA []byte) (int, error) {
 		}
 	}
 	if len(m.SourceToRawConfig) > 0 {
-		for k := range m.SourceToRawConfig {
+		for k, _ := range m.SourceToRawConfig {
 			dAtA[i] = 0x12
 			i++
 			v := m.SourceToRawConfig[k]
@@ -5394,7 +5394,7 @@ func (m *RawConfig) MarshalTo(dAtA []byte) (int, error) {
 		i += copy(dAtA[i:], m.Source)
 	}
 	if len(m.Config) > 0 {
-		for k := range m.Config {
+		for k, _ := range m.Config {
 			dAtA[i] = 0x12
 			i++
 			v := m.Config[k]
@@ -6502,7 +6502,7 @@ func (m *RuleMetadata) MarshalTo(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	if len(m.Annotations) > 0 {
-		for k := range m.Annotations {
+		for k, _ := range m.Annotations {
 			dAtA[i] = 0xa
 			i++
 			v := m.Annotations[k]
@@ -6821,7 +6821,7 @@ func (m *WorkloadEndpoint) MarshalTo(dAtA []byte) (int, error) {
 		}
 	}
 	if len(m.Annotations) > 0 {
-		for k := range m.Annotations {
+		for k, _ := range m.Annotations {
 			dAtA[i] = 0x5a
 			i++
 			v := m.Annotations[k]
@@ -7438,7 +7438,7 @@ func (m *HostMetadataV4V6Update) MarshalTo(dAtA []byte) (int, error) {
 		i += copy(dAtA[i:], m.Asnumber)
 	}
 	if len(m.Labels) > 0 {
-		for k := range m.Labels {
+		for k, _ := range m.Labels {
 			dAtA[i] = 0x2a
 			i++
 			v := m.Labels[k]
@@ -7785,7 +7785,7 @@ func (m *ServiceAccountUpdate) MarshalTo(dAtA []byte) (int, error) {
 		i += n79
 	}
 	if len(m.Labels) > 0 {
-		for k := range m.Labels {
+		for k, _ := range m.Labels {
 			dAtA[i] = 0x12
 			i++
 			v := m.Labels[k]
@@ -7888,7 +7888,7 @@ func (m *NamespaceUpdate) MarshalTo(dAtA []byte) (int, error) {
 		i += n81
 	}
 	if len(m.Labels) > 0 {
-		for k := range m.Labels {
+		for k, _ := range m.Labels {
 			dAtA[i] = 0x12
 			i++
 			v := m.Labels[k]

--- a/hack/banned-regexps-exceptions.txt
+++ b/hack/banned-regexps-exceptions.txt
@@ -1,3 +1,5 @@
 _v1_blacklist
 _%s_%s_blacklist
 google.golang.org/grpc/internal/binarylog
+pod2daemon/node-driver-registrar/vendor/
+

--- a/hack/check-dockerfiles.sh
+++ b/hack/check-dockerfiles.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-problems="$(find -name '*Dockerfile*' | xargs grep --with-filename '^ADD ')"
+problems="$(find -name '*Dockerfile*' | \
+            grep -v -e containernetworking-plugins -e flannel-cni-plugin | \
+            xargs grep --with-filename '^ADD ')"
 
 if [ "$problems" ]; then
   echo "Some Dockerfiles use ADD instead of COPY"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Think this got out of sync due to merging changes to the formatter.

Exclude some external files so that `make ci-preflight-checks` can be run on a local checkout.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
