### PR TITLE
Documentation Fix: 

### DIFF
--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1299,7 +1299,7 @@ spec:
                   with the calico-bpf command-line tool.
                 type: boolean
               bpfRedirectToPeer:
-                description: 'BPFRedirectToPeer controls which whether it is allowed
+                description: 'BPFRedirectToPeer controls whether it is allowed
                   to forward straight to the peer side of the workload devices. It
                   is allowed for any host L2 devices by default (L2Only), but it breaks
                   TCP dump on the host side of workload device as it bypasses it on


### PR DESCRIPTION
This change updates `calico.yaml` file and improves the first sentence for the bpfRedirectToPeer description.

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
