### PR TITLE
[Release v3.29] Improve robustness of data store initialisation when creating tiers

### DIFF
--- a/charts/calico/templates/calico-node-rbac.yaml
+++ b/charts/calico/templates/calico-node-rbac.yaml
@@ -115,6 +115,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/libcalico-go/lib/clientv3/client.go
+++ b/libcalico-go/lib/clientv3/client.go
@@ -249,12 +249,14 @@ func (c client) EnsureInitialized(ctx context.Context, calicoVersion, clusterTyp
 		errs = append(errs, err)
 	}
 
-	if err := c.ensureDefaultTierExists(ctx); err != nil {
+	err := c.ensureTierExists(ctx, names.DefaultTierName, v3.Deny, v3.DefaultTierOrder)
+	if err != nil {
 		log.WithError(err).Info("Unable to initialize default Tier")
 		errs = append(errs, err)
 	}
 
-	if err := c.ensureAdminNetworkPolicyTierExists(ctx); err != nil {
+	err = c.ensureTierExists(ctx, names.AdminNetworkPolicyTierName, v3.Pass, v3.AdminNetworkPolicyTierOrder)
+	if err != nil {
 		log.WithError(err).Info("Unable to initialize adminnetworkpolicy Tier")
 		errs = append(errs, err)
 	}
@@ -395,43 +397,30 @@ func (c client) ensureClusterInformation(ctx context.Context, calicoVersion, clu
 	return nil
 }
 
-// ensureDefaultTierExists ensures that the "default" Tier exits in the datastore.
-// This is done by trying to create the default tier. If it doesn't exists, it
-// is created.  A error is returned if there is any error other than when the
-// default tier resource already exists.
-func (c client) ensureDefaultTierExists(ctx context.Context) error {
-	order := v3.DefaultTierOrder
-	defaultTier := v3.NewTier()
-	defaultTier.ObjectMeta = metav1.ObjectMeta{Name: names.DefaultTierName}
-	defaultTier.Spec = v3.TierSpec{
-		Order: &order,
-	}
-	if _, err := c.Tiers().Create(ctx, defaultTier, options.SetOptions{}); err != nil {
-		if _, ok := err.(cerrors.ErrorResourceAlreadyExists); !ok {
-			return err
-		}
-	}
-	return nil
-}
-
-// ensureAdminNetworkPolicyTierExists ensures that the "adminnetworkpolicy" Tier exits in the datastore.
-// This is done by trying to create the adminnetworkpolicy tier. If it doesn't exists, it
-// is created.  A error is returned if there is any error other than when the
-// tier resource already exists.
-func (c client) ensureAdminNetworkPolicyTierExists(ctx context.Context) error {
-	order := v3.AdminNetworkPolicyTierOrder
-	actionPass := v3.Pass
-	anpTier := v3.NewTier()
-	anpTier.ObjectMeta = metav1.ObjectMeta{Name: names.AdminNetworkPolicyTierName}
-	anpTier.Spec = v3.TierSpec{
+// ensureTierExists ensures that a desired Tier exits in the datastore.
+// This is done by first trying to get the tier. If it doesn't exist, it
+// is created. A error is returned if there is any error other than when the
+// tier resource already exists, or when creating tiers is not allowed.
+func (c client) ensureTierExists(ctx context.Context, name string, defaultAction v3.Action, order float64) error {
+	tier := v3.NewTier()
+	tier.ObjectMeta = metav1.ObjectMeta{Name: name}
+	tier.Spec = v3.TierSpec{
 		Order:         &order,
-		DefaultAction: &actionPass,
+		DefaultAction: &defaultAction,
 	}
-	if _, err := c.Tiers().Create(ctx, anpTier, options.SetOptions{}); err != nil {
-		if _, ok := err.(cerrors.ErrorResourceAlreadyExists); !ok {
+	if _, err := c.Tiers().Create(ctx, tier, options.SetOptions{}); err != nil {
+		switch err.(type) {
+		case cerrors.ErrorResourceAlreadyExists:
+			log.WithError(err).Infof("Tier %v already exists.", name)
+			return nil
+		case cerrors.ErrorConnectionUnauthorized:
+			log.WithError(err).Warnf("Unauthorized to create tier %v.", name)
+			return nil
+		default:
 			return err
 		}
 	}
+	log.Infof("Tier %v is now available.", name)
 	return nil
 }
 

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -5924,6 +5924,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -5934,6 +5934,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -5935,6 +5935,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5919,6 +5919,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -5919,6 +5919,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -5937,6 +5937,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -5919,6 +5919,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/node/Makefile
+++ b/node/Makefile
@@ -288,7 +288,7 @@ $(FELIX_GPL_SOURCE): .felix-gpl-source.created
 ###############################################################################
 # FV Tests
 ###############################################################################
-K8ST_IMAGE_TARS=calico-node.tar calico-apiserver.tar calico-cni.tar pod2daemon.tar calicoctl.tar kube-controllers.tar
+K8ST_IMAGE_TARS=calico-node.tar calico-typha.tar calico-apiserver.tar calico-cni.tar pod2daemon.tar calicoctl.tar kube-controllers.tar
 
 ifeq ($(SEMAPHORE_GIT_REF_TYPE), pull-request)
 # Determine the tests to run using the test spider tool, which emits a list of impacted packages.
@@ -339,6 +339,10 @@ test_image: .calico_test.created
 
 calico-node.tar: $(NODE_CONTAINER_CREATED)
 	docker save --output $@ $(NODE_IMAGE):latest-$(ARCH)
+
+calico-typha.tar: ../go.mod $(shell find ../typha -name '*.go') $(shell find ../libcalico-go -name '*.go')
+	make -C ../typha image
+	docker save --output $@ calico/typha:latest-$(ARCH)
 
 calico-apiserver.tar: ../go.mod $(shell find ../apiserver -name '*.go') $(shell find ../libcalico-go -name '*.go')
 	make -C ../apiserver image

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016,2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1091,7 +1091,7 @@ func ensureDefaultConfig(ctx context.Context, cfg *apiconfig.CalicoAPIConfig, c 
 	}
 
 	if err := c.EnsureInitialized(ctx, VERSION, clusterType); err != nil {
-		return nil
+		return err
 	}
 
 	// By default we set the global reporting interval to 0 - this is

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -15,6 +15,22 @@ spec:
     matchLabels:
       k8s-app: calico-kube-controllers
 ---
+# Source: calico/templates/calico-typha.yaml
+# This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
+---
 # Source: calico/templates/calico-kube-controllers.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -44,8 +60,8 @@ metadata:
   name: calico-config
   namespace: kube-system
 data:
-  # Typha is disabled.
-  typha_service_name: "none"
+  # You must set a non-zero value for Typha replicas below.
+  typha_service_name: "calico-typha"
   # Configure the backend to use.
   calico_backend: "bird"
 
@@ -284,6 +300,12 @@ rules:
       - get
       - list
       - watch
+   # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
   # Calico must create and update some CRDs on startup.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
@@ -426,6 +448,26 @@ subjects:
 - kind: ServiceAccount
   name: calico-cni-plugin
   namespace: kube-system
+---
+# Source: calico/templates/calico-typha.yaml
+# This manifest creates a Service, which will be backed by Calico's Typha daemon.
+# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  ports:
+    - port: 5473
+      protocol: TCP
+      targetPort: calico-typha
+      name: calico-typha
+  selector:
+    k8s-app: calico-typha
 ---
 # Source: calico/templates/calico-node.yaml
 # This manifest installs the calico-node container, as well
@@ -584,6 +626,12 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
+            # Typha support: controlled by the ConfigMap.
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: typha_service_name
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -821,3 +869,128 @@ spec:
             periodSeconds: 10
           securityContext:
             runAsNonRoot: true
+---
+# Source: calico/templates/calico-typha.yaml
+# This manifest creates a Deployment of Typha to back the above service.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  # Number of Typha replicas. To enable Typha, set this to a non-zero value *and* set the
+  # typha_service_name variable in the calico-config ConfigMap above.
+  #
+  # We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is essential
+  # (when using the Kubernetes datastore). Use one replica for every 100-200 nodes. In
+  # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
+  strategy:
+    rollingUpdate:
+      # 100% surge allows a complete up-level set of typha instances to start and become ready,
+      # which in turn allows all the back-level typha instances to start shutting down. This
+      # means that connections tend to bounce directly from a back-level instance to an up-level
+      # instance.
+      maxSurge: 100%
+      # In case the cluster is unable to schedule extra surge instances, allow at most one instance
+      # to shut down to make room. You can set this to 0 if you're sure there'll always be enough room to
+      # schedule extra typha instances during an upgrade (because setting it to 0 blocks shutdown until
+      # up-level typha instances are online and ready).
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-typha
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      # Typha supports graceful shut down, disconnecting clients slowly during the grace period.
+      # The TYPHA_SHUTDOWNTIMEOUTSECS env var should be kept in sync with this value.
+      terminationGracePeriodSeconds: 300
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        # Make sure Typha can get scheduled on any nodes. 
+        - effect: NoSchedule 
+          operator: Exists 
+        - effect: NoExecute 
+          operator: Exists           
+      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # as a host-networked pod.
+      serviceAccountName: calico-node
+      priorityClassName: system-cluster-critical
+      # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
+      securityContext:
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - image: docker.io/calico/typha:latest-amd64
+        imagePullPolicy: Never
+        name: calico-typha
+        ports:
+        - containerPort: 5473
+          name: calico-typha
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+            name: kubernetes-services-endpoint
+            optional: true
+        env:
+          # Enable "info" logging by default. Can be set to "debug" to increase verbosity.
+          - name: TYPHA_LOGSEVERITYSCREEN
+            value: "info"
+          # Disable logging to file and syslog since those don't make sense in Kubernetes.
+          - name: TYPHA_LOGFILEPATH
+            value: "none"
+          - name: TYPHA_LOGSEVERITYSYS
+            value: "none"
+          # Monitor the Kubernetes API to find the number of running instances and rebalance
+          # connections.
+          - name: TYPHA_CONNECTIONREBALANCINGMODE
+            value: "kubernetes"
+          - name: TYPHA_DATASTORETYPE
+            value: "kubernetes"
+          - name: TYPHA_HEALTHENABLED
+            value: "true"
+          # Set this to the same value as terminationGracePeriodSeconds; it tells Typha how much time
+          # it has to shut down.
+          - name: TYPHA_SHUTDOWNTIMEOUTSECS
+            value: "300"
+          # Uncomment these lines to enable prometheus metrics. Since Typha is host-networked,
+          # this opens a port on the host, which may need to be secured.
+          #- name: TYPHA_PROMETHEUSMETRICSENABLED
+          #  value: "true"
+          #- name: TYPHA_PROMETHEUSMETRICSPORT
+          #  value: "9093"
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9098
+            host: localhost
+          periodSeconds: 30
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9098
+            host: localhost
+          periodSeconds: 10
+          timeoutSeconds: 10

--- a/node/tests/k8st/infra/values.yaml
+++ b/node/tests/k8st/infra/values.yaml
@@ -29,6 +29,8 @@ includeCRDs: false
 datastore: kubernetes
 network: calico
 ipam: calico-ipam
+typha:
+  enabled: true
 mtu: "1440"
 imagePullPolicy: Never
 etcd:

--- a/node/tests/k8st/load_images_on_kind_cluster.sh
+++ b/node/tests/k8st/load_images_on_kind_cluster.sh
@@ -3,18 +3,20 @@
 function load_image() {
     local node=$1
     docker cp ./calico-node.tar ${node}:/calico-node.tar
+    docker cp ./calico-typha.tar ${node}:/calico-typha.tar
     docker cp ./calico-apiserver.tar ${node}:/calico-apiserver.tar
     docker cp ./calicoctl.tar ${node}:/calicoctl.tar
     docker cp ./calico-cni.tar ${node}:/calico-cni.tar
     docker cp ./pod2daemon.tar ${node}:/pod2daemon.tar
     docker cp ./kube-controllers.tar ${node}:/kube-controllers.tar
     docker exec -t ${node} ctr -n=k8s.io images import /calico-node.tar
+    docker exec -t ${node} ctr -n=k8s.io images import /calico-typha.tar
     docker exec -t ${node} ctr -n=k8s.io images import /calico-apiserver.tar
     docker exec -t ${node} ctr -n=k8s.io images import /calicoctl.tar
     docker exec -t ${node} ctr -n=k8s.io images import /calico-cni.tar
     docker exec -t ${node} ctr -n=k8s.io images import /pod2daemon.tar
     docker exec -t ${node} ctr -n=k8s.io images import /kube-controllers.tar
-    docker exec -t ${node} rm /calico-node.tar /calicoctl.tar /calico-cni.tar /pod2daemon.tar /kube-controllers.tar /calico-apiserver.tar
+    docker exec -t ${node} rm /calico-node.tar /calico-typha.tar /calicoctl.tar /calico-cni.tar /pod2daemon.tar /kube-controllers.tar /calico-apiserver.tar
 }
 
 load_image kind-control-plane


### PR DESCRIPTION
## Description

Make sure initialising data store is not stopped because of the failure in creating `default` and `adminnetworkpolicy` tiers. Calico node and typha do not have `create` permission, and as such attempts to create those tiers result in `unauthorised` errors which in the end result in:
- Typha not starting up, like this GH issues: 
 https://github.com/projectcalico/calico/issues/9442
 https://github.com/projectcalico/calico/issues/9444
- Node not to create `felixConfig` which results in other deployment errors.

This PR fixes the issue in two ways:
- Detect and log `unathorised` error during attempts to create those tiers. Then, ignore the error as other components like calico-kube-controller would eventually create them.
- Add `create` permission to calico node and typha permission to calico manifests. This is similar to operator approach like https://github.com/tigera/operator/blob/1f9a7a9afbadd33d2c216e033360ccbd540a4421/pkg/render/node.go#L482.

The PR also enables deploying typha as part of kind cluster. Having it enabled, would have allowed detecting the issue earlier.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR 
- links to issues that this PR addresses
-->

## Related issues/PRs
GH issue: https://github.com/projectcalico/calico/issues/9442 https://github.com/projectcalico/calico/issues/9444
Cherry pick of https://github.com/projectcalico/calico/pull/9446

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Do not fail data store initialisation when unauthorised error happen while creating default and adminnetworkpolicy tiers. Those tiers eventually get created by another component. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
