### PR TITLE
Add RUN_AS_ROOT Docker args to cni-plugin commands.

### DIFF
--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -154,6 +154,7 @@ CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildvers
 
 $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth &: $(CONTAINERNETWORKING_PLUGINS_CLONED)
 	docker run \
+		$(EXTRA_DOCKER_ARGS) \
 		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/containernetworking/plugins --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \
@@ -171,6 +172,7 @@ $(FLANNEL_CNI_PLUGIN_CLONED):
 
 $(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
 	docker run \
+		$(EXTRA_DOCKER_ARGS) \
 		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \


### PR DESCRIPTION
## Description


Hi, developer from the GKE Networking team here hoping to fix a minor bug. GKE builds the cni-plugin image as root and therefore has UID=0. When UID=0, we get the following error:
```
docker run \
	-v /workspace/louhi_ws/go/src/github.com/projectcalico/calico/cni-plugin/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
	-e LOCAL_USER_ID=0 -w /go/src/github.com/flannel-io/cni-plugin --rm calico/go-build:v0.91 \
	/bin/sh -xe -c ' \
		ARCH=amd64 VERSION=v1.2.0-flannel2-go1.22.7 make build_linux'
Starting with UID: 0
useradd: UID 0 is not unique
su-exec: getpwnam(user): Success
make: *** [Makefile:173: bin/amd64/flannel] Error 1
make: Leaving directory '/workspace/louhi_ws/go/src/github.com/projectcalico/calico/cni-plugin'
 "gcr.io/louhi-prod-1/addon-builder" failed: step exited with non-zero status: 2
```

`RUN_AS_ROOT='true'` is added to the `EXTRA_DOCKER_ARGS`  when UID=0 in lib.Makefile: https://github.com/projectcalico/calico/blob/master/lib.Makefile#L235-L238 

We added the `EXTRA_DOCKER_ARGS` to the Makefile rules installing the CNI binaries without issue internally and the change passes all GKE e2e testing. We'd like to upstream this change to avoid having to carry it internally indefinitely.


## Release Note

```release-note
Add RUN_AS_ROOT Docker args to cni-plugin commands.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
