### PR TITLE
[release-v3.29] Auto pick #9452: support for policy rules Log action

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1230,6 +1230,7 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 	}
 
 	update_rule_counters(ctx);
+	skb_log(ctx, true);
 
 	ctx->fwd = calico_tc_skb_accepted(ctx);
 	return forward_or_drop(ctx);
@@ -1942,6 +1943,7 @@ int calico_tc_skb_drop(struct __sk_buff *skb)
 	CALI_DEBUG("Entering calico_tc_skb_drop\n");
 
 	update_rule_counters(ctx);
+	skb_log(ctx, false);
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -149,6 +149,8 @@ enum cali_state_flags {
 	CALI_ST_CT_NP_REMOTE	  = 0x100,
 	/* CALI_ST_NAT_EXCLUDE is set when there is a NAT hit, but we don't want to resolve (such as node local DNS). */
 	CALI_ST_NAT_EXCLUDE       = 0x200,
+	/* CALI_ST_LOG_PACKET is set by policy program if a log rule was hit. */
+	CALI_ST_LOG_PACKET        = 0x400,
 };
 
 struct fwd {

--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -419,6 +419,10 @@ func (b *Block) AndImm64(dst Reg, imm int32) {
 	b.add(AndImm64, dst, 0, 0, imm, "")
 }
 
+func (b *Block) OrImm64(dst Reg, imm int32) {
+	b.add(OrImm64, dst, 0, 0, imm, "")
+}
+
 func (b *Block) ShiftRImm64(dst Reg, imm int32) {
 	b.add(ShiftRImm64, dst, 0, 0, imm, "")
 }

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -163,6 +163,7 @@ var (
 	// Bits in the state flags field.
 	FlagDestIsHost uint64 = 1 << 2
 	FlagSrcIsHost  uint64 = 1 << 3
+	FlagLogPacket  uint64 = 1 << 10
 )
 
 type Rule struct {
@@ -484,6 +485,7 @@ func (p *Builder) writeTiers(tiers []Tier, destLeg matchLeg, allowLabel string) 
 	actionLabels := map[string]string{
 		"allow": allowLabel,
 		"deny":  "deny",
+		"log":   "log",
 	}
 	for _, tier := range tiers {
 		endOfTierLabel := fmt.Sprint("end_of_tier_", p.tierID)
@@ -533,10 +535,6 @@ func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string
 		}
 		p.b.AddCommentF("Rule MatchID: %d", rule.MatchID)
 		action := strings.ToLower(rule.Action)
-		if action == "log" {
-			log.Debug("Skipping log rule.  Not supported in BPF mode.")
-			continue
-		}
 		p.writeRule(rule, actionLabels[action], destLeg)
 		log.Debugf("End of rule %d", ruleIdx)
 		p.b.AddCommentF("End of rule %s", rule.RuleId)
@@ -741,14 +739,20 @@ func (p *Builder) writeStartOfRule() {
 }
 
 func (p *Builder) writeEndOfRule(rule Rule, actionLabel string) {
-	// If all the match criteria are met, we fall through to the end of the rule
-	// so all that's left to do is to jump to the relevant action.
-	// TODO log and log-and-xxx actions
-	if p.policyDebugEnabled {
-		p.writeRecordRuleHit(rule, actionLabel)
-	}
+	if actionLabel == "log" {
+		p.b.Load64(R1, R9, stateOffFlags)
+		p.b.OrImm64(R1, int32(FlagLogPacket))
+		p.b.Store64(R9, R1, stateOffFlags)
+	} else {
+		// If all the match criteria are met, we fall through to the end of the rule
+		// so all that's left to do is to jump to the relevant action.
+		// TODO log and log-and-xxx actions
+		if p.policyDebugEnabled {
+			p.writeRecordRuleHit(rule, actionLabel)
+		}
 
-	p.b.Jump(actionLabel)
+		p.b.Jump(actionLabel)
+	}
 
 	p.b.LabelNextInsn(p.endOfRuleLabel())
 }

--- a/felix/bpf/polprog/pol_prog_builder_test.go
+++ b/felix/bpf/polprog/pol_prog_builder_test.go
@@ -81,33 +81,6 @@ func TestPolicySanityCheck(t *testing.T) {
 	}
 }
 
-func TestLogActionIgnored(t *testing.T) {
-	RegisterTestingT(t)
-	alloc := idalloc.New()
-
-	pg := NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
-	insns, err := pg.Instructions(Rules{
-		Tiers: []Tier{{
-			Name: "default",
-			Policies: []Policy{{
-				Name: "test policy",
-				Rules: []Rule{{Rule: &proto.Rule{
-					Action: "Log",
-				}}},
-			}},
-		}}})
-	Expect(err).NotTo(HaveOccurred())
-
-	pg = NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
-	noOpInsns, err := pg.Instructions(Rules{
-		Tiers: []Tier{{
-			Name:     "default",
-			Policies: []Policy{},
-		}}})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(noOpInsns).To(Equal(insns))
-}
-
 func TestPolicyDump(t *testing.T) {
 	RegisterTestingT(t)
 	alloc := idalloc.New()

--- a/felix/bpf/ut/log_test.go
+++ b/felix/bpf/ut/log_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/polprog"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+func TestLog(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetBPFMaps()
+	bpfIfaceName = "LOG"
+	defer func() { bpfIfaceName = "" }()
+
+	hostIP = node1ip
+
+	_, iphdr, _, _, pktBytes, _ := testPacketUDPDefault()
+
+	resetRTMap(rtMap)
+	beV4CIDR := ip.CIDRFromNetIP(iphdr.SrcIP).(ip.V4CIDR)
+	bertKey := routes.NewKey(beV4CIDR).AsBytes()
+	bertVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	err := rtMap.Update(bertKey, bertVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	rules := &polprog.Rules{
+		Tiers: []polprog.Tier{{
+			Name: "base tier",
+			Policies: []polprog.Policy{
+				{
+					Name: "log icmp",
+					Rules: []polprog.Rule{
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 1}},
+								DstNet:   []string{"8.8.8.8/32"},
+								Action:   "Allow",
+							},
+						},
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 1}},
+								Action:   "Log", // Denied by default deny when not matching any rule
+							},
+						},
+					},
+				},
+				{
+					Name: "log tcp allow",
+					Rules: []polprog.Rule{
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+								Action:   "Log",
+							},
+						},
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+								Action:   "Allow",
+							},
+						},
+					},
+				},
+				{
+					Name: "log udp deny",
+					Rules: []polprog.Rule{
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 17}},
+								Action:   "Log",
+							},
+						},
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 17}},
+								Action:   "Deny",
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	pktIPHdr := *ipv4Default
+	pktIPHdr.Protocol = layers.IPProtocolTCP
+
+	pktTCPHdr := &layers.TCP{
+		SrcPort:    layers.TCPPort(12345),
+		DstPort:    layers.TCPPort(321),
+		SYN:        true,
+		DataOffset: 5,
+	}
+
+	_, _, _, _, pktBytes, _ = testPacketV4(nil, &pktIPHdr, pktTCPHdr,
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 11, 22, 33, 44, 55, 66, 77, 88, 99, 0})
+
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	pktBytes = makeICMPErrorFrom(ipv4Default.SrcIP, &pktIPHdr, pktTCPHdr, 0, 0)
+
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	pktIPHdr2 := pktIPHdr
+	pktIPHdr2.SrcIP = net.ParseIP("8.8.8.8")
+	pktBytes = makeICMPErrorFrom(ipv4Default.SrcIP, &pktIPHdr2, pktTCPHdr, 0, 0)
+
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -600,8 +600,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				pol := api.NewGlobalNetworkPolicy()
 				pol.Namespace = "fv"
 				pol.Name = "policy-1"
-				pol.Spec.Ingress = []api.Rule{{Action: "Allow"}}
-				pol.Spec.Egress = []api.Rule{{Action: "Allow"}}
+				if true || testOpts.bpfLogLevel == "info" {
+					pol.Spec.Ingress = []api.Rule{{Action: "Log"}, {Action: "Allow"}}
+					pol.Spec.Egress = []api.Rule{{Action: "Log"}, {Action: "Allow"}}
+				} else {
+					pol.Spec.Ingress = []api.Rule{{Action: "Allow"}}
+					pol.Spec.Egress = []api.Rule{{Action: "Allow"}}
+				}
 				pol.Spec.Selector = "all()"
 
 				pol = createPolicy(pol)


### PR DESCRIPTION
Cherry pick of #9452 on release-v3.29.

#9452: support for policy rules Log action

# Original PR Body below

It is sometimes nice to see whether packets are dropped and which packets are dropped (or accepted) and where. Whenever a packet matches ANY rule with a Log action, the verdict with packet details will be logged to the trace pipe regardless of the bpfLogLevel setting or bpfLogFilters filtering.

```
cali8d1e69e5f89-E: policy ALLOWED proto 17 src 10.65.0.3:46519 dest 172.18.0.6:8055
cali8d1e69e5f89-E: policy ALLOWED proto 6 src 10.65.0.3:36185 dest 10.65.0.2:8055
cali866cd63afec-I: policy ALLOWED proto 6 src 10.65.0.3:36185 dest 10.65.0.2:8055
cali866cd63afec-E: policy ALLOWED proto 6 src 10.65.0.2:43553 dest 10.65.0.3:8055
cali8d1e69e5f89-I: policy DENIED  proto 6 src 10.65.0.2:43553 dest 10.65.0.3:8055
cali8d1e69e5f89-E: policy ALLOWED proto 6 src 10.65.0.3:46519 dest 172.18.0.6:8055
```
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: support for log action in policy rules
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.