### PR TITLE
Add release-build and release-publish targets to key-cert-provisioner

### DIFF
--- a/key-cert-provisioner/Makefile
+++ b/key-cert-provisioner/Makefile
@@ -108,9 +108,3 @@ release-publish: release-prereqs .release-$(VERSION).published
 .release-$(VERSION).published:
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	touch $@
-
-## Pushes a github release and release artifacts produced by `make release-build`.
-release-publish: release-prereqs .release-ksp-$(VERSION).published
-.release-ksp-$(VERSION).published:
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	touch $@

--- a/key-cert-provisioner/Makefile
+++ b/key-cert-provisioner/Makefile
@@ -55,11 +55,9 @@ $(BINDIR)/test-signer-$(ARCH):
 # BUILD IMAGE
 ###############################################################################
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
 
 SIGNER_CREATED=.signer.created-$(ARCH)
 
@@ -93,3 +91,26 @@ clean:
 	-docker image rm -f $$(docker images $(KEY_CERT_PROVISIONER_IMAGE) -a -q)
 	-docker image rm -f $$(docker images $(TEST_SIGNER_IMAGE) -a -q)
 
+###############################################################################
+# Release
+###############################################################################
+## Produces a clean build of release artifacts at the specified version.
+release-build: .release-$(VERSION).created
+.release-$(VERSION).created:
+	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
+	# Generate the `latest` images.
+	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
+	touch $@
+
+## Pushes a github release and release artifacts produced by `make release-build`.
+release-publish: release-prereqs .release-$(VERSION).published
+.release-$(VERSION).published:
+	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+	touch $@
+
+## Pushes a github release and release artifacts produced by `make release-build`.
+release-publish: release-prereqs .release-ksp-$(VERSION).published
+.release-ksp-$(VERSION).published:
+	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+	touch $@


### PR DESCRIPTION
We've added key-cert-provisioner to release publishing, but it doesn't include the actual release targets we need to build and publish key-cert-provisioner images. This PR adds those images.