### PR TITLE
[release-v3.29] Auto pick #9378: use bpfutils.BTFEnabled instead of SupportsBTF() #9452: support for policy rules Log action #9460: remove TestLogActionIgnored - no longer true

### DIFF
--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -11,6 +11,7 @@ CFLAGS +=  \
 	-Wall \
 	-Werror \
 	-fno-stack-protector \
+	-Wno-address-of-packed-member \
 	-O2 \
 	-target bpf \
 	-emit-llvm \

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -226,15 +226,29 @@ static CALI_BPF_INLINE __attribute__((noreturn)) void bpf_exit(int rc) {
 
 #ifdef IPVER6
 
+#ifdef BPF_CORE_SUPPORTED
+#define IPv "[%pI6]"
+#define debug_ip(ip) (&(ip))
+#else
 #define debug_ip(ip) (bpf_htonl((ip).d))
+#endif
 #define ip_is_dnf(ip) (true)
 
 #else
 
+#ifdef BPF_CORE_SUPPORTED
+#define IPv "%pI4"
+#define debug_ip(ip) (&(ip))
+#else
 #define debug_ip(ip) bpf_htonl(ip)
+#endif
 
 #define ip_is_dnf(ip) ((ip)->frag_off & bpf_htons(0x4000))
 #define ip_frag_no(ip) ((ip)->frag_off & bpf_htons(0x1fff))
+#endif
+
+#ifndef IPv
+#define IPv "%x"
 #endif
 
 static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -227,7 +227,7 @@ static CALI_BPF_INLINE __attribute__((noreturn)) void bpf_exit(int rc) {
 #ifdef IPVER6
 
 #ifdef BPF_CORE_SUPPORTED
-#define IPv "[%pI6]"
+#define IP_FMT "[%pI6]"
 #define debug_ip(ip) (&(ip))
 #else
 #define debug_ip(ip) (bpf_htonl((ip).d))
@@ -237,7 +237,7 @@ static CALI_BPF_INLINE __attribute__((noreturn)) void bpf_exit(int rc) {
 #else
 
 #ifdef BPF_CORE_SUPPORTED
-#define IPv "%pI4"
+#define IP_FMT "%pI4"
 #define debug_ip(ip) (&(ip))
 #else
 #define debug_ip(ip) bpf_htonl(ip)
@@ -247,8 +247,8 @@ static CALI_BPF_INLINE __attribute__((noreturn)) void bpf_exit(int rc) {
 #define ip_frag_no(ip) ((ip)->frag_off & bpf_htons(0x1fff))
 #endif
 
-#ifndef IPv
-#define IPv "%x"
+#ifndef IP_FMT
+#define IP_FMT "%x"
 #endif
 
 static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)

--- a/felix/bpf-gpl/connect_balancer.c
+++ b/felix/bpf-gpl/connect_balancer.c
@@ -56,7 +56,7 @@ int calico_recvmsg_v4(struct bpf_sock_addr *ctx)
 		goto out;
 	}
 
-	CALI_DEBUG("recvmsg_v4 %x:%d\n", bpf_ntohl(ctx->user_ip4), ctx_port_to_host(ctx->user_port));
+	CALI_DEBUG("recvmsg_v4 " IP_FMT" :%d\n", debug_ip(ctx->user_ip4), ctx_port_to_host(ctx->user_port));
 
 	if (ctx->type != SOCK_DGRAM) {
 		CALI_INFO("unexpected sock type %d\n", ctx->type);
@@ -64,7 +64,7 @@ int calico_recvmsg_v4(struct bpf_sock_addr *ctx)
 	}
 
 	__u64 cookie = bpf_get_socket_cookie(ctx);
-	CALI_DEBUG("Lookup: ip=%x port=%d(BE) cookie=%x\n",ctx->user_ip4, ctx->user_port, cookie);
+	CALI_DEBUG("Lookup: ip=" IP_FMT " port=%d(BE) cookie=%x\n",debug_ip(ctx->user_ip4), ctx->user_port, cookie);
 	struct sendrec_key key = {
 		.ip	= ctx->user_ip4,
 		.port	= ctx->user_port,
@@ -86,8 +86,8 @@ int calico_recvmsg_v4(struct bpf_sock_addr *ctx)
 
 	ctx->user_ip4 = revnat->ip;
 	ctx->user_port = revnat->port;
-	CALI_DEBUG("recvmsg_v4 rev nat to %x:%d\n",
-			bpf_ntohl(ctx->user_ip4), ctx_port_to_host(ctx->user_port));
+	CALI_DEBUG("recvmsg_v4 rev nat to " IP_FMT ":%d\n",
+			debug_ip(ctx->user_ip4), ctx_port_to_host(ctx->user_port));
 
 out:
 	return 1;

--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -44,12 +44,16 @@ int calico_connect_v46(struct bpf_sock_addr *ctx)
 	int ret = 1;
 	__be32 ipv4;
 
+#ifdef BPF_CORE_SUPPORTED
+	CALI_DEBUG("connect_v46 %pI6\n", ctx->user_ip6);
+#else
 	CALI_DEBUG("connect_v46 ip[0-1] %x%x\n",
 			ctx->user_ip6[0],
 			ctx->user_ip6[1]);
 	CALI_DEBUG("connect_v46 ip[2-3] %x%x\n",
 			ctx->user_ip6[2],
 			ctx->user_ip6[3]);
+#endif
 
 	if (is_ipv4_as_ipv6(ctx->user_ip6)) {
 		goto v4;
@@ -80,12 +84,16 @@ int calico_sendmsg_v46(struct bpf_sock_addr *ctx)
 
 	__be32 ipv4;
 
+#ifdef BPF_CORE_SUPPORTED
+	CALI_DEBUG("sendmsg_v46 %pI6\n", ctx->user_ip6);
+#else
 	CALI_DEBUG("sendmsg_v46 ip[0-1] %x%x\n",
 			ctx->user_ip6[0],
 			ctx->user_ip6[1]);
 	CALI_DEBUG("sendmsg_v46 ip[2-3] %x%x\n",
 			ctx->user_ip6[2],
 			ctx->user_ip6[3]);
+#endif
 
 	if (is_ipv4_as_ipv6(ctx->user_ip6)) {
 		goto v4;
@@ -96,7 +104,7 @@ int calico_sendmsg_v46(struct bpf_sock_addr *ctx)
 
 v4:
 	ipv4 = ctx->user_ip6[3];
-	CALI_DEBUG("sendmsg_v46 %x:%d\n", bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+	CALI_DEBUG("sendmsg_v46 " IP_FMT ":%d\n", debug_ip(ipv4), ctx_port_to_host(ctx->user_port));
 
 	if (ctx->type != SOCK_DGRAM) {
 		CALI_INFO("unexpected sock type %d\n", ctx->type);
@@ -117,12 +125,16 @@ int calico_recvmsg_v46(struct bpf_sock_addr *ctx)
 
 	__be32 ipv4;
 
+#ifdef BPF_CORE_SUPPORTED
+	CALI_DEBUG("recvmsg_v46 %pI6\n", ctx->user_ip6);
+#else
 	CALI_DEBUG("recvmsg_v46 ip[0-1] %x%x\n",
 			ctx->user_ip6[0],
 			ctx->user_ip6[1]);
 	CALI_DEBUG("recvmsg_v46 ip[2-3] %x%x\n",
 			ctx->user_ip6[2],
 			ctx->user_ip6[3]);
+#endif
 
 	if (is_ipv4_as_ipv6(ctx->user_ip6)) {
 		goto v4;
@@ -150,8 +162,8 @@ v4:
 	struct sendrec_val *revnat = cali_srmsg_lookup_elem(&key);
 
 	if (revnat == NULL) {
-		CALI_DEBUG("revnat miss for %x:%d\n",
-				bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+		CALI_DEBUG("revnat miss for " IP_FMT ":%d\n",
+				debug_ip(ipv4), ctx_port_to_host(ctx->user_port));
 		/* we are past policy and the packet was allowed. Either the
 		 * mapping does not exist anymore and if the app cares, it
 		 * should check the addresses. It is more likely a packet sent
@@ -162,8 +174,8 @@ v4:
 
 	ctx->user_ip6[3] = revnat->ip;
 	ctx->user_port = revnat->port;
-	CALI_DEBUG("recvmsg_v46 v4 rev nat to %x:%d\n",
-			bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+	CALI_DEBUG("recvmsg_v46 v4 rev nat to " IP_FMT ":%d\n",
+			debug_ip(ipv4), ctx_port_to_host(ctx->user_port));
 
 out:
 	return 1;

--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -69,8 +69,8 @@ static CALI_BPF_INLINE void fill_ct_key(struct calico_ct_key *k, bool sltd, __u8
 
 static CALI_BPF_INLINE void dump_ct_key(struct cali_tc_ctx *ctx, struct calico_ct_key *k)
 {
-	CALI_VERB("CT-ALL   key A=" IPv ":%d proto=%d\n", debug_ip(k->addr_a), k->port_a, (int)k->protocol);
-	CALI_VERB("CT-ALL   key B=" IPv ":%d size=%d\n", debug_ip(k->addr_b), k->port_b, (int)sizeof(struct calico_ct_key));
+	CALI_VERB("CT-ALL   key A=" IP_FMT ":%d proto=%d\n", debug_ip(k->addr_a), k->port_a, (int)k->protocol);
+	CALI_VERB("CT-ALL   key B=" IP_FMT ":%d size=%d\n", debug_ip(k->addr_b), k->port_b, (int)sizeof(struct calico_ct_key));
 }
 
 static CALI_BPF_INLINE int calico_ct_v4_create_tracking(struct cali_tc_ctx *ctx,
@@ -148,20 +148,20 @@ create:
 
 	ct_value.orig_sip = ct_ctx->orig_src;
 	ct_value.orig_sport = ct_ctx->orig_sport;
-	CALI_DEBUG("CT-ALL SNAT orig " IPv ":%d\n", debug_ip(ct_ctx->orig_src),  ct_ctx->orig_sport);
+	CALI_DEBUG("CT-ALL SNAT orig " IP_FMT ":%d\n", debug_ip(ct_ctx->orig_src),  ct_ctx->orig_sport);
 
 
 	if (ct_ctx->type == CALI_CT_TYPE_NAT_REV && !ip_void(ct_ctx->tun_ip)) {
 		if (ct_ctx->flags & CALI_CT_FLAG_NP_FWD) {
-			CALI_DEBUG("CT-ALL nat tunneled to " IPv "\n", debug_ip(ct_ctx->tun_ip));
+			CALI_DEBUG("CT-ALL nat tunneled to " IP_FMT "\n", debug_ip(ct_ctx->tun_ip));
 		} else {
 			struct cali_rt *rt = cali_rt_lookup(&ct_ctx->tun_ip);
 			if (!rt || !cali_rt_is_host(rt)) {
-				CALI_DEBUG("CT-ALL nat tunnel IP not a host " IPv "\n", debug_ip(ct_ctx->tun_ip));
+				CALI_DEBUG("CT-ALL nat tunnel IP not a host " IP_FMT "\n", debug_ip(ct_ctx->tun_ip));
 				err = -1;
 				goto out;
 			}
-			CALI_DEBUG("CT-ALL nat tunneled from " IPv "\n", debug_ip(ct_ctx->tun_ip));
+			CALI_DEBUG("CT-ALL nat tunneled from " IP_FMT "\n", debug_ip(ct_ctx->tun_ip));
 		}
 		ct_value.tun_ip = ct_ctx->tun_ip;
 	}
@@ -232,7 +232,7 @@ create:
 	if (CALI_F_HEP && err == -17 /* EEXIST */) {
 		int i;
 
-		CALI_DEBUG("Source collision for " IPv ":%d\n", debug_ip(ct_ctx->src), sport);
+		CALI_DEBUG("Source collision for " IP_FMT ":%d\n", debug_ip(ct_ctx->src), sport);
 
 		ct_value.orig_sport = sport;
 
@@ -255,7 +255,7 @@ create:
 		}
 
 		if (i == PSNAT_RETRIES) {
-			CALI_INFO("Source collision unresolved " IPv ":%d\n",
+			CALI_INFO("Source collision unresolved " IP_FMT ":%d\n",
 					debug_ip(ct_ctx->src), ct_value.orig_sport);
 			err = -17; /* EEXIST */
 		}
@@ -288,7 +288,7 @@ static CALI_BPF_INLINE int calico_ct_create_nat_fwd(struct cali_tc_ctx *ctx,
 	__u64 now = bpf_ktime_get_ns();
 
 	CALI_DEBUG("CT-%d Creating FWD entry at %llu.\n", ct_ctx->proto, now);
-	CALI_DEBUG("FWD " IPv " -> " IPv "\n", debug_ip(ip_src), debug_ip(ip_dst));
+	CALI_DEBUG("FWD " IP_FMT " -> " IP_FMT "\n", debug_ip(ip_src), debug_ip(ip_dst));
 	struct calico_ct_value ct_value = {
 		.type = CALI_CT_TYPE_NAT_FWD,
 		.last_seen = now,
@@ -591,8 +591,8 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 	struct tcphdr *tcp_header = STATE->ip_proto == IPPROTO_TCP ? tcp_hdr(ctx) : NULL;
 	bool related = false;
 
-	CALI_CT_DEBUG("lookup from " IPv ":%d\n", debug_ip(STATE->ip_src), STATE->sport);
-	CALI_CT_DEBUG("lookup to   " IPv ":%d\n", debug_ip(STATE->ip_dst), STATE->dport);
+	CALI_CT_DEBUG("lookup from " IP_FMT ":%d\n", debug_ip(STATE->ip_src), STATE->sport);
+	CALI_CT_DEBUG("lookup to   " IP_FMT ":%d\n", debug_ip(STATE->ip_dst), STATE->dport);
 	if (tcp_header) {
 		CALI_CT_VERB("packet seq = %u\n", bpf_ntohl(tcp_header->seq));
 		CALI_CT_VERB("packet ack_seq = %u\n", bpf_ntohl(tcp_header->ack_seq));
@@ -636,8 +636,8 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 			/* skb_icmp_err_unpack updates the ct_ctx with the details of the inner packet;
 			 * look for a conntrack entry for the inner packet...
 			 */
-			CALI_CT_DEBUG("related lookup from " IPv ":%d\n", debug_ip(ct_ctx->src), ct_ctx->sport);
-			CALI_CT_DEBUG("related lookup to   " IPv ":%d\n", debug_ip(ct_ctx->dst), ct_ctx->dport);
+			CALI_CT_DEBUG("related lookup from " IP_FMT ":%d\n", debug_ip(ct_ctx->src), ct_ctx->sport);
+			CALI_CT_DEBUG("related lookup to   " IP_FMT ":%d\n", debug_ip(ct_ctx->dst), ct_ctx->dport);
 			related = true;
 			tcp_header = STATE->ip_proto == IPPROTO_TCP ? tcp_hdr(ctx) : NULL;
 
@@ -754,10 +754,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		}
 
 		result.tun_ip = tracking_v->tun_ip;
-		CALI_CT_DEBUG("fwd tun_ip:" IPv "\n", debug_ip(tracking_v->tun_ip));
+		CALI_CT_DEBUG("fwd tun_ip:" IP_FMT "\n", debug_ip(tracking_v->tun_ip));
 		// flags are in the tracking entry
 		result.flags = ct_value_get_flags(tracking_v);
-		CALI_CT_DEBUG("result.flags " IPv "\n", result.flags);
+		CALI_CT_DEBUG("result.flags " IP_FMT "\n", result.flags);
 
 		if (ct_ctx->proto == IPPROTO_ICMP_46) {
 			result.rc =	CALI_CT_ESTABLISHED_DNAT;
@@ -778,7 +778,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		 */
 		if (CALI_F_FROM_HEP && !ip_void(ctx->state->tun_ip) && !ip_void(result.tun_ip) &&
 				!ip_equal(result.tun_ip, ctx->state->tun_ip)) {
-			CALI_CT_DEBUG("tunnel src changed from " IPv " to " IPv "\n",
+			CALI_CT_DEBUG("tunnel src changed from " IP_FMT " to " IP_FMT "\n",
 					debug_ip(result.tun_ip), debug_ip(ctx->state->tun_ip));
 			ct_result_set_flag(result.rc, CT_RES_TUN_SRC_CHANGED);
 		}
@@ -802,7 +802,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		}
 
 		result.tun_ip = v->tun_ip;
-		CALI_CT_DEBUG("tun_ip:" IPv "\n", debug_ip(v->tun_ip));
+		CALI_CT_DEBUG("tun_ip:" IP_FMT "\n", debug_ip(v->tun_ip));
 
 		result.flags = ct_value_get_flags(v);
 
@@ -921,7 +921,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 	}
 
 	if (ret_from_tun) {
-		CALI_DEBUG("Packet returned from tunnel " IPv "\n", debug_ip(ctx->state->tun_ip));
+		CALI_DEBUG("Packet returned from tunnel " IP_FMT "\n", debug_ip(ctx->state->tun_ip));
 	} else if (CALI_F_TO_HOST || (skb_from_host(ctx->skb) && result.flags & CALI_CT_FLAG_HOST_PSNAT)) {
 		/* Source of the packet is the endpoint, so check the src approval flag. */
 		if (CALI_F_LO || src_to_dst->approved) {

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -109,7 +109,7 @@ static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 
 		arpv = cali_arp_lookup_elem(&arpk);
 		if (!arpv) {
-			CALI_DEBUG("ARP lookup failed for %x dev %d\n",
+			CALI_DEBUG("ARP lookup failed for " IPv " dev %d\n",
 					debug_ip(state->ip_dst), iface);
 			goto skip_redir_ifindex;
 		}
@@ -308,7 +308,7 @@ cancel_fib:
 			struct arp_value *arpv = cali_arp_lookup_elem(&arpk);
 			if (!arpv) {
 				ctx->fwd.reason = CALI_REASON_NATIFACE;
-				CALI_DEBUG("ARP lookup failed for %x dev %d\n",
+				CALI_DEBUG("ARP lookup failed for " IPv " dev %d\n",
 						debug_ip(state->ip_dst), iface);
 				goto deny;
 			}

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -109,7 +109,7 @@ static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 
 		arpv = cali_arp_lookup_elem(&arpk);
 		if (!arpv) {
-			CALI_DEBUG("ARP lookup failed for " IPv " dev %d\n",
+			CALI_DEBUG("ARP lookup failed for " IP_FMT " dev %d\n",
 					debug_ip(state->ip_dst), iface);
 			goto skip_redir_ifindex;
 		}
@@ -308,7 +308,7 @@ cancel_fib:
 			struct arp_value *arpv = cali_arp_lookup_elem(&arpk);
 			if (!arpv) {
 				ctx->fwd.reason = CALI_REASON_NATIFACE;
-				CALI_DEBUG("ARP lookup failed for " IPv " dev %d\n",
+				CALI_DEBUG("ARP lookup failed for " IP_FMT " dev %d\n",
 						debug_ip(state->ip_dst), iface);
 				goto deny;
 			}

--- a/felix/bpf-gpl/list-ut-objs
+++ b/felix/bpf-gpl/list-ut-objs
@@ -10,8 +10,8 @@
 # WARNING: should be kept in sync with the combinations used in tests, in particular bpf_prog_test.go.
 
 emit_filename() {
-  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}.o"
-  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_v6.o"
+  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_co-re.o"
+  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_co-re_v6.o"
 }
 
 log_level=debug
@@ -38,5 +38,5 @@ done
 
 echo "bin/test_from_hep_fib_no_log_skb0x0.o"
 echo "bin/test_from_wep_fib_no_log.o"
-echo "bin/test_xdp_debug.o"
+echo "bin/test_xdp_debug_co-re.o"
 echo "bin/test_xdp_debug_co-re_v6.o"

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -102,7 +102,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 	bool csum_update = false;
 
 	if (!ip_equal(ip_src_from, ip_src_to)) {
-		CALI_DEBUG("L4 checksum update src IP from %x to %x\n",
+		CALI_DEBUG("L4 checksum update src IP from " IPv " to " IPv "\n",
 				debug_ip(ip_src_from), debug_ip(ip_src_to));
 
 		csum = bpf_csum_diff((__u32*)&ip_src_from, sizeof(ip_src_from), (__u32*)&ip_src_to, sizeof(ip_src_to), csum);
@@ -110,7 +110,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 		csum_update = true;
 	}
 	if (!ip_equal(ip_dst_from, ip_dst_to)) {
-		CALI_DEBUG("L4 checksum update dst IP from %x to %x\n",
+		CALI_DEBUG("L4 checksum update dst IP from " IPv " to " IPv "\n",
 				debug_ip(ip_dst_from), debug_ip(ip_dst_to));
 		csum = bpf_csum_diff((__u32*)&ip_dst_from, sizeof(ip_dst_from), (__u32*)&ip_dst_to, sizeof(ip_dst_to), csum);
 		CALI_DEBUG("bpf_l4_csum_diff(IP): 0x%x\n", csum);
@@ -158,7 +158,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 {
 	/* decap on host ep only if directly for the node */
-	CALI_DEBUG("VXLAN tunnel packet to %x (host IP=%x)\n",
+	CALI_DEBUG("VXLAN tunnel packet to " IPv " (host IP=" IPv ")\n",
 #ifdef IPVER6
 		bpf_ntohl(ip_hdr(ctx)->daddr.in6_u.u6_addr32[3]),
 #else
@@ -214,7 +214,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 	arpk.ip = ip_hdr(ctx)->saddr;
 #endif
 	cali_arp_update_elem(&arpk, eth_hdr(ctx), 0);
-	CALI_DEBUG("ARP update for ifindex %d ip %x\n", arpk.ifindex, debug_ip(arpk.ip));
+	CALI_DEBUG("ARP update for ifindex %d ip " IPv "\n", arpk.ifindex, debug_ip(arpk.ip));
 
 #ifdef IPVER6
 	ipv6hdr_ip_to_ipv6_addr_t(&ctx->state->tun_ip, &ip_hdr(ctx)->saddr);
@@ -234,7 +234,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 		goto deny;
 	}
 
-	CALI_DEBUG("vxlan decap origin %x\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("vxlan decap origin " IPv "\n", debug_ip(ctx->state->tun_ip));
 
 fall_through:
 	return 0;

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -102,7 +102,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 	bool csum_update = false;
 
 	if (!ip_equal(ip_src_from, ip_src_to)) {
-		CALI_DEBUG("L4 checksum update src IP from " IPv " to " IPv "\n",
+		CALI_DEBUG("L4 checksum update src IP from " IP_FMT " to " IP_FMT "\n",
 				debug_ip(ip_src_from), debug_ip(ip_src_to));
 
 		csum = bpf_csum_diff((__u32*)&ip_src_from, sizeof(ip_src_from), (__u32*)&ip_src_to, sizeof(ip_src_to), csum);
@@ -110,7 +110,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 		csum_update = true;
 	}
 	if (!ip_equal(ip_dst_from, ip_dst_to)) {
-		CALI_DEBUG("L4 checksum update dst IP from " IPv " to " IPv "\n",
+		CALI_DEBUG("L4 checksum update dst IP from " IP_FMT " to " IP_FMT "\n",
 				debug_ip(ip_dst_from), debug_ip(ip_dst_to));
 		csum = bpf_csum_diff((__u32*)&ip_dst_from, sizeof(ip_dst_from), (__u32*)&ip_dst_to, sizeof(ip_dst_to), csum);
 		CALI_DEBUG("bpf_l4_csum_diff(IP): 0x%x\n", csum);
@@ -158,7 +158,7 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 {
 	/* decap on host ep only if directly for the node */
-	CALI_DEBUG("VXLAN tunnel packet to " IPv " (host IP=" IPv ")\n",
+	CALI_DEBUG("VXLAN tunnel packet to " IP_FMT " (host IP=" IP_FMT ")\n",
 #ifdef IPVER6
 		bpf_ntohl(ip_hdr(ctx)->daddr.in6_u.u6_addr32[3]),
 #else
@@ -214,7 +214,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 	arpk.ip = ip_hdr(ctx)->saddr;
 #endif
 	cali_arp_update_elem(&arpk, eth_hdr(ctx), 0);
-	CALI_DEBUG("ARP update for ifindex %d ip " IPv "\n", arpk.ifindex, debug_ip(arpk.ip));
+	CALI_DEBUG("ARP update for ifindex %d ip " IP_FMT "\n", arpk.ifindex, debug_ip(arpk.ip));
 
 #ifdef IPVER6
 	ipv6hdr_ip_to_ipv6_addr_t(&ctx->state->tun_ip, &ip_hdr(ctx)->saddr);
@@ -234,7 +234,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx)
 		goto deny;
 	}
 
-	CALI_DEBUG("vxlan decap origin " IPv "\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("vxlan decap origin " IP_FMT "\n", debug_ip(ctx->state->tun_ip));
 
 fall_through:
 	return 0;

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -44,16 +44,16 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 	switch (nat_key.protocol) {
 	case IPPROTO_UDP:
-		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d udp\n", debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IP_FMT " port=%d udp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	case IPPROTO_TCP:
-		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d tcp\n", debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IP_FMT " port=%d tcp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	case IPPROTO_ICMP:
-		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d icmp\n", debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IP_FMT " port=%d icmp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	default:
-		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d other\n", debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IP_FMT " port=%d other\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	}
 
@@ -169,7 +169,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 	if (affval) {
 		int timeo = (affinity_always_timeo ? : nat_lv1_val->affinity_timeo);
 		if (now - affval->ts <= timeo  * 1000000000ULL) {
-			CALI_DEBUG("NAT: using affinity backend " IPv ":%d\n",
+			CALI_DEBUG("NAT: using affinity backend " IP_FMT ":%d\n",
 					debug_ip(affval->nat_dest.addr), affval->nat_dest.port);
 			if (affinity_tmr_update) {
 				affval->ts = now;
@@ -177,9 +177,9 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 			return &affval->nat_dest;
 		}
-		CALI_DEBUG("NAT: affinity expired for " IPv ":%d\n", debug_ip(*ip_dst), dport);
+		CALI_DEBUG("NAT: affinity expired for " IP_FMT ":%d\n", debug_ip(*ip_dst), dport);
 	} else {
-		CALI_DEBUG("no previous affinity for " IPv ":%d", debug_ip(*ip_dst), dport);
+		CALI_DEBUG("no previous affinity for " IP_FMT ":%d", debug_ip(*ip_dst), dport);
 	}
 	/* To be k8s conformant, fall through to pick a random backend. */
 
@@ -196,7 +196,7 @@ skip_affinity:
 		return NULL;
 	}
 
-	CALI_DEBUG("NAT: backend selected " IPv ":%d\n", debug_ip(nat_lv2_val->addr), nat_lv2_val->port);
+	CALI_DEBUG("NAT: backend selected " IP_FMT ":%d\n", debug_ip(nat_lv2_val->addr), nat_lv2_val->port);
 
 	if (nat_lv1_val->affinity_timeo != 0 || affinity_always_timeo) {
 		int err;
@@ -205,7 +205,7 @@ skip_affinity:
 			.nat_dest = *nat_lv2_val,
 		};
 
-		CALI_DEBUG("NAT: updating affinity for client " IPv "\n", debug_ip(*ip_src));
+		CALI_DEBUG("NAT: updating affinity for client " IP_FMT "\n", debug_ip(*ip_src));
 		if ((err = cali_nat_aff_update_elem(&affkey, &val, BPF_ANY))) {
 			CALI_INFO("NAT: failed to update affinity table: %d\n", err);
 			/* we do carry on, we have a good nat_lv2_val */

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -44,16 +44,16 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 	switch (nat_key.protocol) {
 	case IPPROTO_UDP:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d udp\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d udp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	case IPPROTO_TCP:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d tcp\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d tcp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	case IPPROTO_ICMP:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d icmp\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d icmp\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	default:
-		CALI_DEBUG("NAT: 1st level lookup addr=%x port=%d other\n", (int)debug_ip(nat_key.addr), (int)dport);
+		CALI_DEBUG("NAT: 1st level lookup addr=" IPv " port=%d other\n", debug_ip(nat_key.addr), (int)dport);
 		break;
 	}
 
@@ -169,7 +169,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 	if (affval) {
 		int timeo = (affinity_always_timeo ? : nat_lv1_val->affinity_timeo);
 		if (now - affval->ts <= timeo  * 1000000000ULL) {
-			CALI_DEBUG("NAT: using affinity backend %x:%d\n",
+			CALI_DEBUG("NAT: using affinity backend " IPv ":%d\n",
 					debug_ip(affval->nat_dest.addr), affval->nat_dest.port);
 			if (affinity_tmr_update) {
 				affval->ts = now;
@@ -177,9 +177,9 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 
 			return &affval->nat_dest;
 		}
-		CALI_DEBUG("NAT: affinity expired for %x:%d\n", debug_ip(*ip_dst), dport);
+		CALI_DEBUG("NAT: affinity expired for " IPv ":%d\n", debug_ip(*ip_dst), dport);
 	} else {
-		CALI_DEBUG("no previous affinity for %x:%d", debug_ip(*ip_dst), dport);
+		CALI_DEBUG("no previous affinity for " IPv ":%d", debug_ip(*ip_dst), dport);
 	}
 	/* To be k8s conformant, fall through to pick a random backend. */
 
@@ -196,7 +196,7 @@ skip_affinity:
 		return NULL;
 	}
 
-	CALI_DEBUG("NAT: backend selected %x:%d\n", debug_ip(nat_lv2_val->addr), nat_lv2_val->port);
+	CALI_DEBUG("NAT: backend selected " IPv ":%d\n", debug_ip(nat_lv2_val->addr), nat_lv2_val->port);
 
 	if (nat_lv1_val->affinity_timeo != 0 || affinity_always_timeo) {
 		int err;
@@ -205,7 +205,7 @@ skip_affinity:
 			.nat_dest = *nat_lv2_val,
 		};
 
-		CALI_DEBUG("NAT: updating affinity for client %x\n", debug_ip(*ip_src));
+		CALI_DEBUG("NAT: updating affinity for client " IPv "\n", debug_ip(*ip_src));
 		if ((err = cali_nat_aff_update_elem(&affkey, &val, BPF_ANY))) {
 			CALI_INFO("NAT: failed to update affinity table: %d\n", err);
 			/* we do carry on, we have a good nat_lv2_val */

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -65,7 +65,7 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 #endif
 
 	CALI_DEBUG("IP id=%d len=%d\n",bpf_ntohs(ip_hdr(ctx)->id), bpf_htons(ip_hdr(ctx)->tot_len));
-	CALI_DEBUG("IP s=%x d=%x\n", bpf_ntohl(ip_hdr(ctx)->saddr), bpf_ntohl(ip_hdr(ctx)->daddr));
+	CALI_DEBUG("IP s=" IPv " d=" IPv "\n", debug_ip(ip_hdr(ctx)->saddr), debug_ip(ip_hdr(ctx)->daddr));
 	// Drop malformed IP packets
 	if (ip_hdr(ctx)->ihl < 5) {
 		CALI_DEBUG("Drop malformed IP packets\n");

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -65,7 +65,7 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 #endif
 
 	CALI_DEBUG("IP id=%d len=%d\n",bpf_ntohs(ip_hdr(ctx)->id), bpf_htons(ip_hdr(ctx)->tot_len));
-	CALI_DEBUG("IP s=" IPv " d=" IPv "\n", debug_ip(ip_hdr(ctx)->saddr), debug_ip(ip_hdr(ctx)->daddr));
+	CALI_DEBUG("IP s=" IP_FMT " d=" IP_FMT "\n", debug_ip(ip_hdr(ctx)->saddr), debug_ip(ip_hdr(ctx)->daddr));
 	// Drop malformed IP packets
 	if (ip_hdr(ctx)->ihl < 5) {
 		CALI_DEBUG("Drop malformed IP packets\n");

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -11,7 +11,7 @@
 
 static CALI_BPF_INLINE bool wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
-        CALI_DEBUG("Workload RPF check src=%x skb iface=%d.\n",
+        CALI_DEBUG("Workload RPF check src=" IPv " skb iface=%d.\n",
                         debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
         if (!r) {
                 CALI_INFO("Workload RPF fail: missing route.\n");
@@ -92,7 +92,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 				CALI_DEBUG("Host RPF check skb strict if %d\n", fib_params.ifindex);
 #endif
 #else
-				CALI_DEBUG("Host RPF check src=%x skb strict if %d\n",
+				CALI_DEBUG("Host RPF check src=" IPv " skb strict if %d\n",
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			} else {
@@ -102,7 +102,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 				CALI_DEBUG("Host RPF check skb loose if %d\n", fib_params.ifindex);
 #endif
 #else
-				CALI_DEBUG("Host RPF check src=%x skb loose if %d\n",
+				CALI_DEBUG("Host RPF check src=" IPv " skb loose if %d\n",
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			}
@@ -122,7 +122,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 	CALI_DEBUG("Host RPF check skb iface=%d\n", ctx->skb->ifindex);
 #endif
 #else
-	CALI_DEBUG("Host RPF check src=%x skb iface=%d\n",
+	CALI_DEBUG("Host RPF check src=" IPv " skb iface=%d\n",
 			debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
 #endif
 	CALI_DEBUG("Host RPF check rc %d result %d\n", rc, ret);

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -11,7 +11,7 @@
 
 static CALI_BPF_INLINE bool wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
-        CALI_DEBUG("Workload RPF check src=" IPv " skb iface=%d.\n",
+        CALI_DEBUG("Workload RPF check src=" IP_FMT " skb iface=%d.\n",
                         debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
         if (!r) {
                 CALI_INFO("Workload RPF fail: missing route.\n");
@@ -92,7 +92,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 				CALI_DEBUG("Host RPF check skb strict if %d\n", fib_params.ifindex);
 #endif
 #else
-				CALI_DEBUG("Host RPF check src=" IPv " skb strict if %d\n",
+				CALI_DEBUG("Host RPF check src=" IP_FMT " skb strict if %d\n",
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			} else {
@@ -102,7 +102,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 				CALI_DEBUG("Host RPF check skb loose if %d\n", fib_params.ifindex);
 #endif
 #else
-				CALI_DEBUG("Host RPF check src=" IPv " skb loose if %d\n",
+				CALI_DEBUG("Host RPF check src=" IP_FMT " skb loose if %d\n",
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			}
@@ -122,7 +122,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 	CALI_DEBUG("Host RPF check skb iface=%d\n", ctx->skb->ifindex);
 #endif
 #else
-	CALI_DEBUG("Host RPF check src=" IPv " skb iface=%d\n",
+	CALI_DEBUG("Host RPF check src=" IP_FMT " skb iface=%d\n",
 			debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
 #endif
 	CALI_DEBUG("Host RPF check rc %d result %d\n", rc, ret);

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -199,9 +199,9 @@ static CALI_BPF_INLINE void skb_log(struct cali_tc_ctx *ctx, bool accepted)
 		}
 #endif
 		if (accepted) {
-			bpf_log("ALLOWED");
+			CALI_LOG("ALLOWED");
 		} else {
-			bpf_log("DENIED");
+			CALI_LOG("DENIED");
 		}
 	}
 }

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1230,6 +1230,7 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 	}
 
 	update_rule_counters(ctx);
+	skb_log(ctx, true);
 
 	ctx->fwd = calico_tc_skb_accepted(ctx);
 	return forward_or_drop(ctx);
@@ -1942,6 +1943,7 @@ int calico_tc_skb_drop(struct __sk_buff *skb)
 	CALI_DEBUG("Entering calico_tc_skb_drop\n");
 
 	update_rule_counters(ctx);
+	skb_log(ctx, false);
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -475,10 +475,10 @@ syn_force_policy:
 		}
 		/* If 3rd party CNI is used and dest is outside cluster. See commit fc711b192f for details. */
 		if (!(r->flags & CALI_RT_IN_POOL)) {
-			CALI_DEBUG("Source " IPv " not in IP pool\n", debug_ip(ctx->state->ip_src));
+			CALI_DEBUG("Source " IP_FMT " not in IP pool\n", debug_ip(ctx->state->ip_src));
 			r = cali_rt_lookup(&ctx->state->post_nat_ip_dst);
 			if (!r || !(r->flags & (CALI_RT_WORKLOAD | CALI_RT_HOST))) {
-				CALI_DEBUG("Outside cluster dest " IPv "\n", debug_ip(ctx->state->post_nat_ip_dst));
+				CALI_DEBUG("Outside cluster dest " IP_FMT "\n", debug_ip(ctx->state->post_nat_ip_dst));
 				ctx->state->flags |= CALI_ST_SKIP_FIB;
 			}
 		}
@@ -543,7 +543,7 @@ syn_force_policy:
 		dest_rt = cali_rt_lookup(&ctx->state->post_nat_ip_dst);
 	}
 	if (!dest_rt) {
-		CALI_DEBUG("No route for post DNAT dest " IPv "\n", debug_ip(ctx->state->post_nat_ip_dst));
+		CALI_DEBUG("No route for post DNAT dest " IP_FMT "\n", debug_ip(ctx->state->post_nat_ip_dst));
 		if (CALI_F_FROM_HEP) {
 			/* Disable FIB, let the packet go through the host after it is
 			 * policed. It is ingress into the system and we do not know what
@@ -604,7 +604,7 @@ syn_force_policy:
 	}
 
 	if (CALI_F_TO_HEP && ctx->nat_dest && !skb_seen(ctx->skb) && !(ctx->state->flags & CALI_ST_HOST_PSNAT)) {
-		CALI_DEBUG("Host accesses nodeport backend " IPv ":%d\n",
+		CALI_DEBUG("Host accesses nodeport backend " IP_FMT ":%d\n",
 			   debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
 		CALI_DEBUG("Host accesses nodeport state->flags 0x%x\n", ctx->state->flags);
 		if (cali_rt_flags_local_workload(dest_rt->flags)) {
@@ -725,7 +725,7 @@ static CALI_BPF_INLINE enum do_nat_res do_nat(struct cali_tc_ctx *ctx,
 		 */
 		*is_dnat = !ip_equal(STATE->ip_dst, STATE->post_nat_ip_dst) || STATE->dport != STATE->post_nat_dport;
 
-		CALI_DEBUG("CT: DNAT to " IPv ":%d\n",
+		CALI_DEBUG("CT: DNAT to " IP_FMT ":%d\n",
 				debug_ip(STATE->post_nat_ip_dst), STATE->post_nat_dport);
 
 		encap_needed = dnat_should_encap();
@@ -746,7 +746,7 @@ static CALI_BPF_INLINE enum do_nat_res do_nat(struct cali_tc_ctx *ctx,
 					deny_reason(ctx, CALI_REASON_RT_UNKNOWN);
 					goto deny;
 				}
-				CALI_DEBUG("rt found for " IPv " local %d\n",
+				CALI_DEBUG("rt found for " IP_FMT " local %d\n",
 						debug_ip(STATE->post_nat_ip_dst), !!cali_rt_is_local(rt));
 
 				encap_needed = !cali_rt_is_local(rt);
@@ -798,7 +798,7 @@ static CALI_BPF_INLINE enum do_nat_res do_nat(struct cali_tc_ctx *ctx,
 			STATE->ct_result.nat_sport = ct_ctx_nat->sport;
 		} else {
 			if (encap_needed && ct_result_np_node(STATE->ct_result)) {
-				CALI_DEBUG("CT says encap to node " IPv "\n", debug_ip(STATE->ct_result.tun_ip));
+				CALI_DEBUG("CT says encap to node " IP_FMT "\n", debug_ip(STATE->ct_result.tun_ip));
 				STATE->ip_dst = STATE->ct_result.tun_ip;
 			} else {
 				encap_needed = false;
@@ -927,7 +927,7 @@ static CALI_BPF_INLINE enum do_nat_res do_nat(struct cali_tc_ctx *ctx,
 		goto allow;
 
 	case CALI_CT_ESTABLISHED_SNAT:
-		CALI_DEBUG("CT: SNAT from " IPv ":%d\n",
+		CALI_DEBUG("CT: SNAT from " IP_FMT ":%d\n",
 				debug_ip(STATE->ct_result.nat_ip), STATE->ct_result.nat_port);
 
 		if (dnat_return_should_encap() && !ip_void(STATE->ct_result.tun_ip)) {
@@ -1001,7 +1001,7 @@ static CALI_BPF_INLINE enum do_nat_res do_nat(struct cali_tc_ctx *ctx,
 
 #ifndef IPVER6
 		if (!inner_icmp) {
-			CALI_VERB("L3 checksum update (csum is at %d) port from " IPv " to " IPv "\n",
+			CALI_VERB("L3 checksum update (csum is at %d) port from " IP_FMT " to " IP_FMT "\n",
 					l3_csum_off, STATE->ip_src, STATE->ct_result.nat_ip);
 
 			if (bpf_l3_csum_replace(ctx->skb, l3_csum_off,
@@ -1075,7 +1075,7 @@ nat_encap:
 
 		arpv = cali_arp_lookup_elem(&arpk);
 		if (!arpv) {
-			CALI_DEBUG("ARP lookup failed for " IPv " dev %d at HEP\n",
+			CALI_DEBUG("ARP lookup failed for " IP_FMT " dev %d at HEP\n",
 					debug_ip(STATE->ip_dst), arpk.ifindex);
 			/* Don't drop it yet, we might get lucky and the MAC is correct */
 		} else {
@@ -1152,7 +1152,7 @@ allow:
 
 		if (r && cali_rt_flags_local_workload(r->flags)) {
 			state->ct_result.ifindex_fwd = r->if_index;
-			CALI_DEBUG("NP local WL " IPv ":%d on HEP\n",
+			CALI_DEBUG("NP local WL " IP_FMT ":%d on HEP\n",
 					debug_ip(state->post_nat_ip_dst), state->post_nat_dport);
 			ctx->state->flags |= CALI_ST_CT_NP_LOOP;
 			fib = true; /* Enforce FIB since we want to redirect */
@@ -1160,7 +1160,7 @@ allow:
 			/* If there is no route, treat it as a remote NP BE */
 			if (CALI_F_LO || CALI_F_MAIN) {
 				state->ct_result.ifindex_fwd = NATIN_IFACE  ;
-				CALI_DEBUG("NP remote WL " IPv ":%d on LO or main HEP\n",
+				CALI_DEBUG("NP remote WL " IP_FMT ":%d on LO or main HEP\n",
 						debug_ip(state->post_nat_ip_dst), state->post_nat_dport);
 				ctx->state->flags |= CALI_ST_CT_NP_LOOP;
 			}
@@ -1357,7 +1357,7 @@ int calico_tc_skb_new_flow_entrypoint(struct __sk_buff *skb)
 	 * and save the information in conntrack.
 	 */
 	if (CALI_F_FROM_HEP && CALI_F_DSR && (GLOBAL_FLAGS & CALI_GLOBALS_NO_DSR_CIDRS)) {
-		CALI_DEBUG("state->tun_ip = " IPv "\n", debug_ip(state->tun_ip));
+		CALI_DEBUG("state->tun_ip = " IP_FMT "\n", debug_ip(state->tun_ip));
 		if (!ip_void(state->tun_ip) && cali_rt_lookup_flags(&state->ip_src) & CALI_RT_NO_DSR) {
 			ct_ctx_nat->flags |= CALI_CT_FLAG_NP_NO_DSR;
 			CALI_DEBUG("CALI_CT_FLAG_NP_NO_DSR\n");
@@ -1400,7 +1400,7 @@ int calico_tc_skb_new_flow_entrypoint(struct __sk_buff *skb)
 	if ((CALI_F_TO_HOST && CALI_F_NAT_IF) || (CALI_F_TO_HEP && (CALI_F_LO || CALI_F_MAIN))) {
 		struct cali_rt *r = cali_rt_lookup(&state->post_nat_ip_dst);
 		if (r && cali_rt_flags_remote_workload(r->flags) && cali_rt_is_tunneled(r)) {
-			CALI_DEBUG("remote wl " IPv " tunneled via " IPv "\n",
+			CALI_DEBUG("remote wl " IP_FMT " tunneled via " IP_FMT "\n",
 					debug_ip(state->post_nat_ip_dst), debug_ip(HOST_TUNNEL_IP));
 			ct_ctx_nat->src = HOST_TUNNEL_IP;
 			/* This would be the place to set a new source port if we
@@ -1466,9 +1466,9 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	bool is_dnat = false;
 	enum do_nat_res nat_res = NAT_ALLOW;
 
-	CALI_DEBUG("src=" IPv " dst=" IPv "\n", debug_ip(state->ip_src), debug_ip(state->ip_dst));
-	CALI_DEBUG("post_nat=" IPv ":%d\n", debug_ip(state->post_nat_ip_dst), state->post_nat_dport);
-	CALI_DEBUG("tun_ip=" IPv "\n", debug_ip(state->tun_ip));
+	CALI_DEBUG("src=" IP_FMT " dst=" IP_FMT "\n", debug_ip(state->ip_src), debug_ip(state->ip_dst));
+	CALI_DEBUG("post_nat=" IP_FMT ":%d\n", debug_ip(state->post_nat_ip_dst), state->post_nat_dport);
+	CALI_DEBUG("tun_ip=" IP_FMT "\n", debug_ip(state->tun_ip));
 	CALI_DEBUG("pol_rc=%d\n", state->pol_rc);
 	CALI_DEBUG("sport=%d\n", state->sport);
 	CALI_DEBUG("dport=%d\n", state->dport);
@@ -1543,14 +1543,14 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				if (outer_ip_nat) {
 					addr = &STATE->ip_src;
 					ip_hdr_set_ip(ctx, saddr, state->ct_result.nat_ip);
-					CALI_DEBUG("ICMP related: outer IP SNAT to " IPv "\n",
+					CALI_DEBUG("ICMP related: outer IP SNAT to " IP_FMT "\n",
 							debug_ip(state->ct_result.nat_ip));
 				}
 			} else if (ct_rc == CALI_CT_ESTABLISHED_DNAT) {
 				outer_ip_nat = true;
 				addr = &STATE->ip_dst;
 				ip_hdr_set_ip(ctx, daddr, state->ct_result.nat_ip);
-				CALI_DEBUG("ICMP related: outer IP DNAT to " IPv "\n",
+				CALI_DEBUG("ICMP related: outer IP DNAT to " IP_FMT "\n",
 						debug_ip(state->ct_result.nat_ip));
 			}
 
@@ -1945,12 +1945,12 @@ int calico_tc_skb_drop(struct __sk_buff *skb)
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);
-	CALI_DEBUG("src=" IPv " dst=" IPv "\n", debug_ip(ctx->state->ip_src),
+	CALI_DEBUG("src=" IP_FMT " dst=" IP_FMT "\n", debug_ip(ctx->state->ip_src),
 			debug_ip(ctx->state->ip_dst));
-	CALI_DEBUG("pre_nat=" IPv ":%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
+	CALI_DEBUG("pre_nat=" IP_FMT ":%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
 			ctx->state->pre_nat_dport);
-	CALI_DEBUG("post_nat=" IPv ":%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
-	CALI_DEBUG("tun_ip=" IPv "\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("post_nat=" IP_FMT ":%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
+	CALI_DEBUG("tun_ip=" IP_FMT "\n", debug_ip(ctx->state->tun_ip));
 	CALI_DEBUG("pol_rc=%d\n", ctx->state->pol_rc);
 	CALI_DEBUG("sport=%d\n", ctx->state->sport);
 	CALI_DEBUG("flags=0x%x\n", ctx->state->flags);
@@ -1980,7 +1980,7 @@ int calico_tc_skb_drop(struct __sk_buff *skb)
 			 * new flow detected - should happen exactly once in a blue moon ;-) )
 			 * but would be good to know about for issue debugging.
 			 */
-			CALI_INFO("Allowing WG " IPv " <-> " IPv " despite blocked by policy - known hosts.\n",
+			CALI_INFO("Allowing WG " IP_FMT " <-> " IP_FMT " despite blocked by policy - known hosts.\n",
 					debug_ip(ctx->state->ip_src), debug_ip(ctx->state->ip_dst));
 			goto allow;
 		}

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -149,6 +149,8 @@ enum cali_state_flags {
 	CALI_ST_CT_NP_REMOTE	  = 0x100,
 	/* CALI_ST_NAT_EXCLUDE is set when there is a NAT hit, but we don't want to resolve (such as node local DNS). */
 	CALI_ST_NAT_EXCLUDE       = 0x200,
+	/* CALI_ST_LOG_PACKET is set by policy program if a log rule was hit. */
+	CALI_ST_LOG_PACKET        = 0x400,
 };
 
 struct fwd {

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -203,12 +203,12 @@ int calico_xdp_drop(struct xdp_md *xdp)
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);
-	CALI_DEBUG("src=" IPv " dst=" IPv "\n", debug_ip(ctx->state->ip_src),
+	CALI_DEBUG("src=" IP_FMT " dst=" IP_FMT "\n", debug_ip(ctx->state->ip_src),
 			debug_ip(ctx->state->ip_dst));
-	CALI_DEBUG("pre_nat=" IPv ":%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
+	CALI_DEBUG("pre_nat=" IP_FMT ":%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
 			ctx->state->pre_nat_dport);
-	CALI_DEBUG("post_nat=" IPv ":%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
-	CALI_DEBUG("tun_ip=" IPv "\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("post_nat=" IP_FMT ":%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
+	CALI_DEBUG("tun_ip=" IP_FMT "\n", debug_ip(ctx->state->tun_ip));
 	CALI_DEBUG("pol_rc=%d\n", ctx->state->pol_rc);
 	CALI_DEBUG("sport=%d\n", ctx->state->sport);
 	CALI_DEBUG("flags=0x%x\n", ctx->state->flags);

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -203,12 +203,12 @@ int calico_xdp_drop(struct xdp_md *xdp)
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);
-	CALI_DEBUG("src=%x dst=%x\n", debug_ip(ctx->state->ip_src),
+	CALI_DEBUG("src=" IPv " dst=" IPv "\n", debug_ip(ctx->state->ip_src),
 			debug_ip(ctx->state->ip_dst));
-	CALI_DEBUG("pre_nat=%x:%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
+	CALI_DEBUG("pre_nat=" IPv ":%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
 			ctx->state->pre_nat_dport);
-	CALI_DEBUG("post_nat=%x:%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
-	CALI_DEBUG("tun_ip=%x\n", debug_ip(ctx->state->tun_ip));
+	CALI_DEBUG("post_nat=" IPv ":%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
+	CALI_DEBUG("tun_ip=" IPv "\n", debug_ip(ctx->state->tun_ip));
 	CALI_DEBUG("pol_rc=%d\n", ctx->state->pol_rc);
 	CALI_DEBUG("sport=%d\n", ctx->state->sport);
 	CALI_DEBUG("flags=0x%x\n", ctx->state->flags);

--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -419,6 +419,10 @@ func (b *Block) AndImm64(dst Reg, imm int32) {
 	b.add(AndImm64, dst, 0, 0, imm, "")
 }
 
+func (b *Block) OrImm64(dst Reg, imm int32) {
+	b.add(OrImm64, dst, 0, 0, imm, "")
+}
+
 func (b *Block) ShiftRImm64(dst Reg, imm int32) {
 	b.add(ShiftRImm64, dst, 0, 0, imm, "")
 }

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -152,7 +152,7 @@ func initObjectFiles() {
 									fibEnabled,
 									dsr,
 									logLevel,
-									bpfutils.SupportsBTF(),
+									bpfutils.BTFEnabled,
 								)
 							}
 						}

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -163,6 +163,7 @@ var (
 	// Bits in the state flags field.
 	FlagDestIsHost uint64 = 1 << 2
 	FlagSrcIsHost  uint64 = 1 << 3
+	FlagLogPacket  uint64 = 1 << 10
 )
 
 type Rule struct {
@@ -484,6 +485,7 @@ func (p *Builder) writeTiers(tiers []Tier, destLeg matchLeg, allowLabel string) 
 	actionLabels := map[string]string{
 		"allow": allowLabel,
 		"deny":  "deny",
+		"log":   "log",
 	}
 	for _, tier := range tiers {
 		endOfTierLabel := fmt.Sprint("end_of_tier_", p.tierID)
@@ -533,10 +535,6 @@ func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string
 		}
 		p.b.AddCommentF("Rule MatchID: %d", rule.MatchID)
 		action := strings.ToLower(rule.Action)
-		if action == "log" {
-			log.Debug("Skipping log rule.  Not supported in BPF mode.")
-			continue
-		}
 		p.writeRule(rule, actionLabels[action], destLeg)
 		log.Debugf("End of rule %d", ruleIdx)
 		p.b.AddCommentF("End of rule %s", rule.RuleId)
@@ -741,14 +739,20 @@ func (p *Builder) writeStartOfRule() {
 }
 
 func (p *Builder) writeEndOfRule(rule Rule, actionLabel string) {
-	// If all the match criteria are met, we fall through to the end of the rule
-	// so all that's left to do is to jump to the relevant action.
-	// TODO log and log-and-xxx actions
-	if p.policyDebugEnabled {
-		p.writeRecordRuleHit(rule, actionLabel)
-	}
+	if actionLabel == "log" {
+		p.b.Load64(R1, R9, stateOffFlags)
+		p.b.OrImm64(R1, int32(FlagLogPacket))
+		p.b.Store64(R9, R1, stateOffFlags)
+	} else {
+		// If all the match criteria are met, we fall through to the end of the rule
+		// so all that's left to do is to jump to the relevant action.
+		// TODO log and log-and-xxx actions
+		if p.policyDebugEnabled {
+			p.writeRecordRuleHit(rule, actionLabel)
+		}
 
-	p.b.Jump(actionLabel)
+		p.b.Jump(actionLabel)
+	}
 
 	p.b.LabelNextInsn(p.endOfRuleLabel())
 }

--- a/felix/bpf/polprog/pol_prog_builder_test.go
+++ b/felix/bpf/polprog/pol_prog_builder_test.go
@@ -81,33 +81,6 @@ func TestPolicySanityCheck(t *testing.T) {
 	}
 }
 
-func TestLogActionIgnored(t *testing.T) {
-	RegisterTestingT(t)
-	alloc := idalloc.New()
-
-	pg := NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
-	insns, err := pg.Instructions(Rules{
-		Tiers: []Tier{{
-			Name: "default",
-			Policies: []Policy{{
-				Name: "test policy",
-				Rules: []Rule{{Rule: &proto.Rule{
-					Action: "Log",
-				}}},
-			}},
-		}}})
-	Expect(err).NotTo(HaveOccurred())
-
-	pg = NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
-	noOpInsns, err := pg.Instructions(Rules{
-		Tiers: []Tier{{
-			Name:     "default",
-			Policies: []Policy{},
-		}}})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(noOpInsns).To(Equal(insns))
-}
-
 func TestPolicyDump(t *testing.T) {
 	RegisterTestingT(t)
 	alloc := idalloc.New()

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -372,13 +372,11 @@ func setupAndRun(logger testLogger, loglevel, section string, rules *polprog.Rul
 
 	if topts.objname != "" {
 		obj = topts.objname
-	} else if topts.ipv6 {
-		if topts.xdp {
-			obj += "_co-re_v6"
-		} else {
+	} else {
+		obj += "_co-re"
+		if topts.ipv6 {
 			obj += "_v6"
 		}
-
 	}
 
 	if topts.xdp {

--- a/felix/bpf/ut/log_test.go
+++ b/felix/bpf/ut/log_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/polprog"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+func TestLog(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetBPFMaps()
+	bpfIfaceName = "LOG"
+	defer func() { bpfIfaceName = "" }()
+
+	hostIP = node1ip
+
+	_, iphdr, _, _, pktBytes, _ := testPacketUDPDefault()
+
+	resetRTMap(rtMap)
+	beV4CIDR := ip.CIDRFromNetIP(iphdr.SrcIP).(ip.V4CIDR)
+	bertKey := routes.NewKey(beV4CIDR).AsBytes()
+	bertVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	err := rtMap.Update(bertKey, bertVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	rules := &polprog.Rules{
+		Tiers: []polprog.Tier{{
+			Name: "base tier",
+			Policies: []polprog.Policy{
+				{
+					Name: "log icmp",
+					Rules: []polprog.Rule{
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 1}},
+								DstNet:   []string{"8.8.8.8/32"},
+								Action:   "Allow",
+							},
+						},
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 1}},
+								Action:   "Log", // Denied by default deny when not matching any rule
+							},
+						},
+					},
+				},
+				{
+					Name: "log tcp allow",
+					Rules: []polprog.Rule{
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+								Action:   "Log",
+							},
+						},
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+								Action:   "Allow",
+							},
+						},
+					},
+				},
+				{
+					Name: "log udp deny",
+					Rules: []polprog.Rule{
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 17}},
+								Action:   "Log",
+							},
+						},
+						{
+							Rule: &proto.Rule{
+								Protocol: &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 17}},
+								Action:   "Deny",
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	pktIPHdr := *ipv4Default
+	pktIPHdr.Protocol = layers.IPProtocolTCP
+
+	pktTCPHdr := &layers.TCP{
+		SrcPort:    layers.TCPPort(12345),
+		DstPort:    layers.TCPPort(321),
+		SYN:        true,
+		DataOffset: 5,
+	}
+
+	_, _, _, _, pktBytes, _ = testPacketV4(nil, &pktIPHdr, pktTCPHdr,
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 11, 22, 33, 44, 55, 66, 77, 88, 99, 0})
+
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+
+	pktBytes = makeICMPErrorFrom(ipv4Default.SrcIP, &pktIPHdr, pktTCPHdr, 0, 0)
+
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	})
+
+	pktIPHdr2 := pktIPHdr
+	pktIPHdr2.SrcIP = net.ParseIP("8.8.8.8")
+	pktBytes = makeICMPErrorFrom(ipv4Default.SrcIP, &pktIPHdr2, pktTCPHdr, 0, 0)
+
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_workload_ep", rules, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -600,8 +600,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				pol := api.NewGlobalNetworkPolicy()
 				pol.Namespace = "fv"
 				pol.Name = "policy-1"
-				pol.Spec.Ingress = []api.Rule{{Action: "Allow"}}
-				pol.Spec.Egress = []api.Rule{{Action: "Allow"}}
+				if true || testOpts.bpfLogLevel == "info" {
+					pol.Spec.Ingress = []api.Rule{{Action: "Log"}, {Action: "Allow"}}
+					pol.Spec.Egress = []api.Rule{{Action: "Log"}, {Action: "Allow"}}
+				} else {
+					pol.Spec.Ingress = []api.Rule{{Action: "Allow"}}
+					pol.Spec.Egress = []api.Rule{{Action: "Allow"}}
+				}
 				pol.Spec.Selector = "all()"
 
 				pol = createPolicy(pol)


### PR DESCRIPTION
Cherry pick of #9378 #9452 #9460 on release-v3.29.

#9378: use bpfutils.BTFEnabled instead of SupportsBTF()
#9452: support for policy rules Log action
#9460: remove TestLogActionIgnored - no longer true

# Original PR Body below

## Description

    It is only available for co-re objects since the printk feature is
    available only since 5.13 so definitely available for kernels with co-re
    support since 5.17. And supporting it for older kernels would make the
    code very messy with little benefit.
    
    v4 output
    
    WEP-NAT1--------E: New packet at ifindex=1; mark=0
    
    WEP-NAT1--------E: IP id=0 len=58
    
    WEP-NAT1--------E: IP s=1.1.1.1 d=10.10.0.1
    
    WEP-NAT1--------E: IP ihl=28 bytes
    
    WEP-NAT1--------E: UDP; ports: s=1234 d=5678
    
    WEP-NAT1--------E: CT: lookup from 1.1.1.1:1234
    
    WEP-NAT1--------E: CT: lookup to   10.10.0.1:5678
    
    WEP-NAT1--------E: CT: Miss.
    
    WEP-NAT1--------E: CT: result: NEW.
    
    WEP-NAT1--------E: conntrack entry flags 0x0
    
    WEP-NAT1--------E: NAT: 1st level lookup addr=10.10.0.1 port=5678 udp
    
    or V6 version:
    
    IPv6 WEP-NAT1--------I: CT: lookup from [abcd:0000:0000:0000:0000:ffff:0808:0808]:666
    
    IPv6 WEP-NAT1--------I: CT: lookup to   [ff00:0000:0000:0000:0000:0000:0000:0001]:1234
    
    IPv6 WEP-NAT1--------I: CT: tun_ip:[0000:0000:0000:0000:0000:0000:0000:0000]
    
    IPv6 WEP-NAT1--------I: CT: Hit! NAT REV entry at ingress to connection opener: SNAT.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: real IPs in bpf debug output with co-re enabled kernels
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.