### PR TITLE
Update yamllint workflow configuration [v3.27]

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -17,12 +17,13 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - '.semaphore/**/*.yml'
       - '.semaphore/**/*.yml.tpl'
+      - '.semaphore/.yamllint.yml'
 
 jobs:
   lintSemaphoreYaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: yaml-lint
         uses: ibiqlik/action-yamllint@v3
         with:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           file_or_dir: .semaphore/**/*.yml .semaphore/**/*.yml.tpl
           config_file: .semaphore/.yamllint.yml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: yamllint-logfile

--- a/.semaphore/.yamllint.yml
+++ b/.semaphore/.yamllint.yml
@@ -1,8 +1,8 @@
 extends: default
 
 rules:
-  line-length:
-    max: 130
-    level: warning
+  line-length: disable
+  document-start: disable
+  empty-lines: disable
   indentation:
     indent-sequences: whatever

--- a/.semaphore/.yamllint.yml
+++ b/.semaphore/.yamllint.yml
@@ -2,7 +2,7 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 130
     level: warning
   indentation:
     indent-sequences: whatever

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -686,4 +686,3 @@ after_pipeline:
       - name: Reports
         commands:
           - test-results gen-pipeline-report --force
-

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -686,3 +686,4 @@ after_pipeline:
       - name: Reports
         commands:
           - test-results gen-pipeline-report --force
+


### PR DESCRIPTION
A few updates to the `yamllint` workflow:

* Update `actions/checkout` and `actions/upload-artifact` to v4 (deprecations)
* Trigger `yamllint` workflow on `yamllint` configuration change (not just yaml file change)
* Disable `line-length`, `document-start`, and `empty-lines` checks