### PR TITLE
Add setNodeNetworkUnavailable option for calico node

### DIFF
--- a/node/cmd/calico-node/main.go
+++ b/node/cmd/calico-node/main.go
@@ -53,6 +53,7 @@ var monitorAddrs = flagSet.Bool("monitor-addresses", false, "Monitor change in n
 var runAllocateTunnelAddrs = flagSet.Bool("allocate-tunnel-addrs", false, "Configure tunnel addresses for this node")
 var allocateTunnelAddrsRunOnce = flagSet.Bool("allocate-tunnel-addrs-run-once", false, "Run allocate-tunnel-addrs in oneshot mode")
 var monitorToken = flagSet.Bool("monitor-token", false, "Watch for Kubernetes token changes, update CNI config")
+var setNodeNetworkUnavailable = flagSet.Bool("set-node-network-unavailable", true, "Set nodeNetworkUnavailable after calico startup")
 
 // Options for liveness checks.
 var felixLive = flagSet.Bool("felix-live", false, "Run felix liveness checks")
@@ -135,7 +136,7 @@ func main() {
 		nodeinit.Run(*bestEffort)
 	} else if *runStartup {
 		logrus.SetFormatter(&logutils.Formatter{Component: "startup"})
-		startup.Run()
+		startup.Run(*setNodeNetworkUnavailable)
 	} else if *runShutdown {
 		logrus.SetFormatter(&logutils.Formatter{Component: "shutdown"})
 		shutdown.Run()

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -84,7 +84,7 @@ var (
 //   - Configuring the node resource with IP/AS information provided in the
 //     environment, or autodetected.
 //   - Creating default IP Pools for quick-start use
-func Run() {
+func Run(setNodeNetworkUnavailable bool) {
 	// Check $CALICO_STARTUP_LOGLEVEL to capture early log statements
 	ConfigureLogging()
 
@@ -222,10 +222,12 @@ func Run() {
 	// node condition will trigger node-controller updating node taints.
 	if os.Getenv("CALICO_NETWORKING_BACKEND") != "none" {
 		if clientset != nil {
-			err := utils.SetNodeNetworkUnavailableCondition(*clientset, k8sNodeName, false, 30*time.Second)
-			if err != nil {
-				log.WithError(err).Error("Unable to set NetworkUnavailable to False")
-				utils.Terminate()
+			if setNodeNetworkUnavailable {
+				err := utils.SetNodeNetworkUnavailableCondition(*clientset, k8sNodeName, false, 30*time.Second)
+				if err != nil {
+					log.WithError(err).Error("Unable to set NetworkUnavailable to False")
+					utils.Terminate()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

New feature, add an option `setNodeNetworkUnavailable`, default is true, control the behavior after calico-node is ready
and the calico node to set `NodeNetworkUnavailable = false` or not.
Some times, in our cluster, we have noticed that the node is ready and `NodeNetworkUnavailable = false`. but our network is not ready to accept the requests, so we want to add this option to control this.
And we also can find the options in other network projects like flannel or cilium.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add setNodeNetworkUnavailable option for calico node
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
