### PR TITLE
[Release v3.29] Fix panic in felix flushHostIPUpdates

### DIFF
--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -528,9 +528,13 @@ func (buf *EventSequencer) OnHostIPUpdate(hostname string, ip *net.IP) {
 
 func (buf *EventSequencer) flushHostIPUpdates() {
 	for hostname, hostIP := range buf.pendingHostIPUpdates {
+		hostAddr := ""
+		if hostIP != nil {
+			hostAddr = hostIP.IP.String()
+		}
 		buf.Callback(&proto.HostMetadataUpdate{
 			Hostname: hostname,
-			Ipv4Addr: hostIP.IP.String(),
+			Ipv4Addr: hostAddr,
 		})
 		buf.sentHostIPs.Add(hostname)
 		delete(buf.pendingHostIPUpdates, hostname)
@@ -566,9 +570,13 @@ func (buf *EventSequencer) OnHostIPv6Update(hostname string, ip *net.IP) {
 
 func (buf *EventSequencer) flushHostIPv6Updates() {
 	for hostname, hostIP := range buf.pendingHostIPv6Updates {
+		hostIPv6Addr := ""
+		if hostIP != nil {
+			hostIPv6Addr = hostIP.IP.String()
+		}
 		buf.Callback(&proto.HostMetadataV6Update{
 			Hostname: hostname,
-			Ipv6Addr: hostIP.IP.String(),
+			Ipv6Addr: hostIPv6Addr,
 		})
 		buf.sentHostIPv6s.Add(hostname)
 		delete(buf.pendingHostIPv6Updates, hostname)


### PR DESCRIPTION
## Description
Cherry pick of https://github.com/projectcalico/calico/pull/9466

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/9373

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a panic in Felix when accessing a nil address in flushing host addresses, i.e. flushHostIPUpdates function.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
