### PR TITLE
Enhance bpf interface autodetection

### DIFF
--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -75,7 +75,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	host1 := createVethName("hostep1")
+	host1 := createHostIf("hostep1")
 	defer deleteLink(host1)
 
 	workload0 := createVethName("workloadep0")
@@ -278,7 +278,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(xdpProgs).To(HaveLen(0))
 	})
 
-	host2 := createVethName("hostep2")
+	host2 := createHostIf("hostep2")
 	defer deleteLink(host2)
 
 	t.Run("create another host interface without a host endpoint (no policy)", func(t *testing.T) {
@@ -848,7 +848,7 @@ func TestLogFilters(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	host1 := createVethName("hostep1")
+	host1 := createHostIf("hostep1")
 	defer deleteLink(host1)
 
 	workload0 := createVethName("workloadep0")

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -94,6 +94,18 @@ func createVethName(name string) netlink.Link {
 	return veth
 }
 
+func createHostIf(name string) netlink.Link {
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Flags = net.FlagUp
+	var hostIf netlink.Link = &netlink.Dummy{
+		LinkAttrs: la,
+	}
+	err := netlink.LinkAdd(hostIf)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create test hostIf: %q", name))
+	return hostIf
+}
+
 func deleteLink(veth netlink.Link) {
 	err := netlink.LinkDel(veth)
 	Expect(err).NotTo(HaveOccurred(), "failed to delete test veth")

--- a/felix/fv/bpf_attach_test.go
+++ b/felix/fv/bpf_attach_test.go
@@ -19,7 +19,6 @@ package fv_test
 import (
 	"encoding/json"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -133,7 +132,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		tc.Felixes[0].Exec("ip", "link", "set", "eth10", "master", "bond0")
 		tc.Felixes[0].Exec("ip", "link", "set", "eth20", "master", "bond0")
 		tc.Felixes[0].Exec("ifconfig", "bond0", "up")
-		time.Sleep(0 * time.Second)
 		Eventually(getBPFNet, "15s", "1s").Should(ContainElement("bond0"))
 		Eventually(getBPFNet, "15s", "1s").ShouldNot(ContainElements("eth10", "eth20"))
 		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond})

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5672,12 +5672,12 @@ func checkServiceRoute(felix *infrastructure.Felix, ip string) bool {
 	return false
 }
 
-func bpfCheckIfPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
+func checkIfPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool, ipFamily proto.IPVersion) bool {
 	startStr := fmt.Sprintf("Start of policy %s", polName)
 	endStr := fmt.Sprintf("End of policy %s", polName)
 	actionStr := fmt.Sprintf("Start of rule action:\"%s\"", action)
 	var policyDbg bpf.PolicyDebugInfo
-	out, err := felix.ExecOutput("cat", bpf.PolicyDebugJSONFileName(iface, hook, proto.IPVersion_IPV4))
+	out, err := felix.ExecOutput("cat", bpf.PolicyDebugJSONFileName(iface, hook, ipFamily))
 	if err != nil {
 		return false
 	}
@@ -5719,6 +5719,14 @@ func bpfCheckIfPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polNam
 	}
 
 	return (startOfPolicy && endOfPolicy && actionMatch)
+}
+
+func bpfCheckIfPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
+	return checkIfPolicyProgrammed(felix, iface, hook, polName, action, isWorkload, proto.IPVersion_IPV4)
+}
+
+func bpfCheckIfPolicyProgrammedV6(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
+	return checkIfPolicyProgrammed(felix, iface, hook, polName, action, isWorkload, proto.IPVersion_IPV6)
 }
 
 func bpfDumpPolicy(felix *infrastructure.Felix, iface, hook string) string {

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -379,6 +379,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 				ensureRightIFStateFlags(felix, ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, ifstate.FlgBondSlave, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgIPv6Ready | ifstate.FlgBond})
 				createHostEndpoint(felix, "bond0", []string{felix.IP, felix.IPv6}, client, ctx)
 			}
+
+			for _, felix := range tc.Felixes {
+				Eventually(func() bool {
+					return bpfCheckIfPolicyProgrammed(felix, "bond0", "egress", "default.allow-egress", "allow", false)
+				}, "5s", "200ms").Should(BeTrue())
+
+				Eventually(func() bool {
+					return bpfCheckIfPolicyProgrammedV6(felix, "bond0", "egress", "default.allow-egress", "allow", false)
+				}, "5s", "200ms").Should(BeTrue())
+
+			}
 		})
 
 		AfterEach(func() {

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -520,7 +520,9 @@ func (d *MockNetlinkDataplane) LinkAdd(link netlink.Link) error {
 		return AlreadyExistsError
 	}
 	attrs := *link.Attrs()
-	attrs.Index = 100 + d.NumLinkAddCalls
+	if attrs.Index == 0 {
+		attrs.Index = 100 + d.NumLinkAddCalls
+	}
 	d.NameToLink[link.Attrs().Name] = &MockLink{
 		LinkAttrs: attrs,
 		LinkType:  link.Type(),


### PR DESCRIPTION
## Description

This PR enhances the host interface auto-detection logic for the eBPF dataplane.
with the new approach, BPF endpoint manager builds a set of trees based on the netlink information of each host interface.

For example, if we have 2 interfaces in a bond and vlan on top of the bond, vlan interface is at the root of the tree, bond is at level 1 and physical interfaces are at the leaves. In the case of single standalone interfaces, each interface is a single node tree. Attaching Tc,XDP programs follows the below logic
1. If the interface is a root node, attach Tc.
2. If the interface is a leaf node, attach XDP.
3. If the interface is neither root nor leaf, it is ignored.

In the above process, XDP and Tc programs are removed from the interfaces when the interface moves down the tree.

```
bpftool net
xdp:
enp1s0f0np0(2) driver id 965
enp1s0f1np1(4) driver id 968

tc:
lo(1) clsact/ingress cali_tc_preambl:[804] id 804
lo(1) clsact/egress cali_tc_preambl:[805] id 805
bond0.1001(6) clsact/ingress cali_tc_preambl:[974] id 974
bond0.1001(6) clsact/egress cali_tc_preambl:[976] id 976
bpfout.cali(7) clsact/ingress cali_tc_preambl:[844] id 844
bpfout.cali(7) clsact/egress cali_tc_preambl:[843] id 843
cali662a7526402(9) clsact/ingress cali_tc_preambl:[894] id 894
cali662a7526402(9) clsact/egress cali_tc_preambl:[895] id 895
vxlan.calico(10) clsact/ingress cali_tc_preambl:[823] id 823
vxlan.calico(10) clsact/egress cali_tc_preambl:[822] id 822
cali596936e74c1(11) clsact/ingress cali_tc_preambl:[896] id 896
cali596936e74c1(11) clsact/egress cali_tc_preambl:[889] id 889
calie500d5708cd(12) clsact/ingress cali_tc_preambl:[890] id 890
calie500d5708cd(12) clsact/egress cali_tc_preambl:[891] id 891
```

xdp attached to physical interface and tc to bond.vlan

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: improved autodetection of device hierarchy like bonds and vlans. tc is attached to the root and xdp to the leaves.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
