### PR TITLE
[release tool] add making draft releases public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,13 @@ release/bin/release: $(shell find ./release -type f -name '*.go')
 bin/ghr:
 	$(DOCKER_RUN) -e GOBIN=/go/src/$(PACKAGE_NAME)/bin/ $(CALICO_BUILD) go install github.com/tcnksm/ghr@$(GHR_VERSION)
 
+# Install GitHub CLI
+bin/gh:
+	curl -sSL -o bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
+	tar -zxvf bin/gh.tgz -C bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh --strip-components=2
+	chmod +x $@
+	rm bin/gh.tgz
+
 # Build a release.
 release: release/bin/release
 	@release/bin/release release build
@@ -128,6 +135,9 @@ release: release/bin/release
 # Publish an already built release.
 release-publish: release/bin/release bin/ghr
 	@release/bin/release release publish
+
+release-public: bin/gh release/bin/release
+	@release/bin/release release public
 
 # Create a release branch.
 create-release-branch: release/bin/release

--- a/metadata.mk
+++ b/metadata.mk
@@ -19,6 +19,7 @@ KIND_VERSION=v0.24.0
 PROTOC_VER=v0.1
 UBI_VERSION=8.10
 GHR_VERSION=v0.17.0
+GITHUB_CLI_VERSION=2.26.0
 
 # Configuration for Semaphore/Github integration.
 ORGANIZATION = projectcalico

--- a/release/pkg/manager/operator/options.go
+++ b/release/pkg/manager/operator/options.go
@@ -23,6 +23,13 @@ func WithOperatorDirectory(root string) Option {
 	}
 }
 
+func WithCalicoDirectory(dir string) Option {
+	return func(o *OperatorManager) error {
+		o.calicoDir = dir
+		return nil
+	}
+}
+
 func WithRepoRemote(remote string) Option {
 	return func(o *OperatorManager) error {
 		o.remote = remote


### PR DESCRIPTION
## Description

Now that projectcalico/calico and tigera/operator create releases as draft first, this adds a command to allow making the draft release public.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
