### PR TITLE
Reduce memory used to store inactive policies/profiles

### DIFF
--- a/felix/calc/active_rules_calculator.go
+++ b/felix/calc/active_rules_calculator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/projectcalico/calico/felix/multidict"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/packedmap"
 	"github.com/projectcalico/calico/libcalico-go/lib/selector"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
@@ -59,9 +60,15 @@ type PolicyMatchListener interface {
 // mapped to IP sets by the RuleScanner.
 type ActiveRulesCalculator struct {
 	// Caches of all known tiers/policies/profiles.
-	allTiers        map[string]*model.Tier
-	allPolicies     map[model.PolicyKey]*model.Policy
-	allProfileRules map[string]*model.ProfileRules
+	allTiers    map[string]*model.Tier
+	// We need to cache all the policies, and the policy Rule struct is very
+	// sparse (which makes it very wasteful). The packed map stores the policies
+	// in compressed format to save a lot of RAM.
+	allPolicies *packedmap.PackedMap[model.PolicyKey, *model.Policy]
+	// Similarly, profiles are sparse and wasteful, and in Kubernetes datastore
+	// mode, they're actually all identical(!) so we do the extra step of
+	// de-duping them.
+	allProfileRules *packedmap.DedupingPackedMap[string, *model.ProfileRules]
 
 	// Caches for ALP policies for stat collector.
 	allALPPolicies set.Set[model.PolicyKey]
@@ -92,8 +99,8 @@ type ActiveRulesCalculator struct {
 func NewActiveRulesCalculator() *ActiveRulesCalculator {
 	arc := &ActiveRulesCalculator{
 		// Caches of all known policies/profiles and tiers.
-		allPolicies:     make(map[model.PolicyKey]*model.Policy),
-		allProfileRules: make(map[string]*model.ProfileRules),
+		allPolicies:     packedmap.New[model.PolicyKey, *model.Policy](),
+		allProfileRules: packedmap.NewDeduping[string, *model.ProfileRules](),
 		allTiers:        make(map[string]*model.Tier),
 
 		allALPPolicies: set.New[model.PolicyKey](),
@@ -162,11 +169,12 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 	case model.ProfileRulesKey:
 		if update.Value != nil {
 			rules := update.Value.(*model.ProfileRules)
-			if reflect.DeepEqual(arc.allProfileRules[key.Name], rules) {
+			oldRules, _ := arc.allProfileRules.Get(key.Name)
+			if reflect.DeepEqual(oldRules, rules) {
 				log.WithField("key", update.Key).Debug("No-op profile change; ignoring.")
 				return
 			}
-			arc.allProfileRules[key.Name] = rules
+			arc.allProfileRules.Set(key.Name, rules)
 			if arc.profileIDToEndpointKeys.ContainsKey(key.Name) {
 				log.Debugf("Profile rules updated while active: %v", key.Name)
 				arc.sendProfileUpdate(key.Name)
@@ -174,7 +182,7 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 				log.Debugf("Profile rules updated while inactive: %v", key.Name)
 			}
 		} else {
-			delete(arc.allProfileRules, key.Name)
+			arc.allProfileRules.Delete(key.Name)
 			if arc.profileIDToEndpointKeys.ContainsKey(key.Name) {
 				log.Debug("Profile rules deleted while active, telling listener/felix")
 				arc.sendProfileUpdate(key.Name)
@@ -185,7 +193,7 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 		// Update the tier/policy/profile counts.
 		arc.updateStats()
 	case model.PolicyKey:
-		oldPolicy := arc.allPolicies[key]
+		oldPolicy, _ := arc.allPolicies.Get(key)
 		oldPolicyWasForceProgrammed := policyForceProgrammed(oldPolicy)
 		if update.Value != nil {
 			log.Debugf("Updating ARC for policy %v", key)
@@ -194,7 +202,7 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 				log.WithField("key", update.Key).Debug("No-op policy change; ignoring.")
 				return
 			}
-			arc.allPolicies[key] = policy
+			arc.allPolicies.Set(key, policy)
 
 			// If the policy transitions to be force-programmed, simulate
 			// a match with a dummy endpoint key.
@@ -237,7 +245,7 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 			}
 		} else {
 			log.Debugf("Removing policy %v from ARC", key)
-			delete(arc.allPolicies, key)
+			arc.allPolicies.Delete(key)
 			if oldPolicyWasForceProgrammed {
 				log.Debugf("Policy %v being deleted, was force-programmed.", key)
 				arc.onMatchStopped(key, forceProgrammedDummyKey)
@@ -288,7 +296,7 @@ func (arc *ActiveRulesCalculator) updateStats() {
 	if arc.OnPolicyCountsChanged == nil {
 		return
 	}
-	arc.OnPolicyCountsChanged(len(arc.allTiers), len(arc.allPolicies), len(arc.allProfileRules), arc.allALPPolicies.Len())
+	arc.OnPolicyCountsChanged(len(arc.allTiers), arc.allPolicies.Len(), arc.allProfileRules.Len(), arc.allALPPolicies.Len())
 }
 
 func (arc *ActiveRulesCalculator) OnStatusUpdate(status api.SyncStatus) {
@@ -379,7 +387,7 @@ var (
 
 func (arc *ActiveRulesCalculator) sendProfileUpdate(profileID string) {
 	active := arc.profileIDToEndpointKeys.ContainsKey(profileID)
-	rules, known := arc.allProfileRules[profileID]
+	rules, known := arc.allProfileRules.Get(profileID)
 	log.Debugf("Sending profile update for profile %v (known: %v, active: %v)",
 		profileID, known, active)
 	key := model.ProfileRulesKey{ProfileKey: model.ProfileKey{Name: profileID}}
@@ -411,7 +419,7 @@ func (arc *ActiveRulesCalculator) sendProfileUpdate(profileID string) {
 }
 
 func (arc *ActiveRulesCalculator) sendPolicyUpdate(policyKey model.PolicyKey) {
-	policy, known := arc.allPolicies[policyKey]
+	policy, known := arc.allPolicies.Get(policyKey)
 	active := arc.policyIDToEndpointKeys.ContainsKey(policyKey)
 	log.Debugf("Sending policy update for policy %v (known: %v, active: %v)",
 		policyKey, known, active)

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -1173,12 +1173,12 @@ func tierInfoToProtoTierInfo(filteredTiers []TierInfo) (normalTiers, untrackedTi
 			forwardTierInfo := &proto.TierInfo{Name: ti.Name, DefaultAction: string(ti.DefaultAction)}
 			normalTierInfo := &proto.TierInfo{Name: ti.Name, DefaultAction: string(ti.DefaultAction)}
 			for _, pol := range ti.OrderedPolicies {
-				if pol.Value.DoNotTrack {
+				if pol.Value.DoNotTrack() {
 					addPolicyToTierInfo(&pol, untrackedTierInfo, true)
-				} else if pol.Value.PreDNAT {
+				} else if pol.Value.PreDNAT() {
 					addPolicyToTierInfo(&pol, preDNATTierInfo, false)
 				} else {
-					if pol.Value.ApplyOnForward {
+					if pol.Value.ApplyOnForward() {
 						addPolicyToTierInfo(&pol, forwardTierInfo, true)
 					}
 					addPolicyToTierInfo(&pol, normalTierInfo, true)

--- a/felix/calc/policy_resolver.go
+++ b/felix/calc/policy_resolver.go
@@ -52,9 +52,9 @@ func init() {
 type PolicyResolver struct {
 	policyIDToEndpointIDs multidict.Multidict[model.PolicyKey, any]
 	endpointIDToPolicyIDs multidict.Multidict[any, model.PolicyKey]
-	allPolicies           map[model.PolicyKey]policyMetadata
+	allPolicies           map[model.PolicyKey]policyMetadata // Only storing metadata for lower occupancy.
 	sortedTierData        []*TierInfo
-	endpoints             map[model.Key]interface{}
+	endpoints             map[model.Key]interface{} // Local WEPs/HEPs only.
 	dirtyEndpoints        set.Set[any] /* FIXME model.WorkloadEndpointKey or model.HostEndpointKey */
 	policySorter          *PolicySorter
 	Callbacks             []PolicyResolverCallbacks

--- a/felix/calc/policy_resolver.go
+++ b/felix/calc/policy_resolver.go
@@ -52,7 +52,7 @@ func init() {
 type PolicyResolver struct {
 	policyIDToEndpointIDs multidict.Multidict[model.PolicyKey, any]
 	endpointIDToPolicyIDs multidict.Multidict[any, model.PolicyKey]
-	allPolicies           map[model.PolicyKey]*model.Policy
+	allPolicies           map[model.PolicyKey]policyMetadata
 	sortedTierData        []*TierInfo
 	endpoints             map[model.Key]interface{}
 	dirtyEndpoints        set.Set[any] /* FIXME model.WorkloadEndpointKey or model.HostEndpointKey */
@@ -69,7 +69,7 @@ func NewPolicyResolver() *PolicyResolver {
 	return &PolicyResolver{
 		policyIDToEndpointIDs: multidict.New[model.PolicyKey, any](),
 		endpointIDToPolicyIDs: multidict.New[any, model.PolicyKey](),
-		allPolicies:           map[model.PolicyKey]*model.Policy{},
+		allPolicies:           map[model.PolicyKey]policyMetadata{},
 		endpoints:             make(map[model.Key]interface{}),
 		dirtyEndpoints:        set.New[any](),
 		policySorter:          NewPolicySorter(),
@@ -105,7 +105,7 @@ func (pr *PolicyResolver) OnUpdate(update api.Update) (filterOut bool) {
 			delete(pr.allPolicies, key)
 		} else {
 			policy := update.Value.(*model.Policy)
-			pr.allPolicies[key] = policy
+			pr.allPolicies[key] = extractPolicyMetadata(policy)
 		}
 		if !pr.policyIDToEndpointIDs.ContainsKey(key) {
 			return
@@ -148,7 +148,7 @@ func (pr *PolicyResolver) OnPolicyMatch(policyKey model.PolicyKey, endpointKey m
 	// If it's first time the policy become matched, add it to the tier
 	if !pr.policySorter.HasPolicy(policyKey) {
 		policy := pr.allPolicies[policyKey]
-		pr.policySorter.UpdatePolicy(policyKey, policy)
+		pr.policySorter.UpdatePolicy(policyKey, &policy)
 	}
 	pr.policyIDToEndpointIDs.Put(policyKey, endpointKey)
 	pr.endpointIDToPolicyIDs.Put(endpointKey, policyKey)

--- a/felix/calc/policy_resolver.go
+++ b/felix/calc/policy_resolver.go
@@ -55,7 +55,7 @@ type PolicyResolver struct {
 	allPolicies           map[model.PolicyKey]policyMetadata // Only storing metadata for lower occupancy.
 	sortedTierData        []*TierInfo
 	endpoints             map[model.Key]interface{} // Local WEPs/HEPs only.
-	dirtyEndpoints        set.Set[any] /* FIXME model.WorkloadEndpointKey or model.HostEndpointKey */
+	dirtyEndpoints        set.Set[any]              /* FIXME model.WorkloadEndpointKey or model.HostEndpointKey */
 	policySorter          *PolicySorter
 	Callbacks             []PolicyResolverCallbacks
 	InSync                bool

--- a/felix/calc/policy_resolver_test.go
+++ b/felix/calc/policy_resolver_test.go
@@ -99,7 +99,7 @@ func TestPolicyResolver_OnPolicyMatch(t *testing.T) {
 		Name: "test-policy",
 	}
 
-	pol := model.Policy{}
+	pol := extractPolicyMetadata(&model.Policy{})
 
 	endpointKey := model.WorkloadEndpointKey{
 		Hostname: "test-workload-ep",
@@ -109,7 +109,7 @@ func TestPolicyResolver_OnPolicyMatch(t *testing.T) {
 	}
 	pr.endpoints[endpointKey] = wep
 
-	pr.allPolicies[polKey] = &pol
+	pr.allPolicies[polKey] = pol
 
 	// Haven't sent any matches so should get nothing out.
 	pr.Flush()
@@ -166,7 +166,7 @@ func TestPolicyResolver_OnPolicyMatchStopped(t *testing.T) {
 		Name: "test-policy",
 	}
 
-	pol := model.Policy{}
+	pol := policyMetadata{}
 
 	endpointKey := model.WorkloadEndpointKey{
 		Hostname: "test-workload-ep",

--- a/libcalico-go/lib/packedmap/packedmap.go
+++ b/libcalico-go/lib/packedmap/packedmap.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packedmap
+
+import (
+	"encoding/json"
+	"unique"
+
+	"github.com/golang/snappy"
+)
+
+// PackedMap is a map that stores values as compressed JSON strings. It requires
+// that the value type is serializable to JSON.
+type PackedMap[K comparable, V any] struct {
+	m map[K]string
+}
+
+func New[K comparable, V any]() *PackedMap[K, V] {
+	return &PackedMap[K, V]{
+		m: make(map[K]string),
+	}
+}
+
+func (pm PackedMap[K, V]) Set(key K, val V) {
+	value := encode(val)
+	pm.m[key] = value
+}
+
+func (pm PackedMap[K, V]) Get(key K) (val V, ok bool) {
+	packed, ok := pm.m[key]
+	if !ok {
+		return
+	}
+	val = decode[V](packed)
+	return
+}
+
+func (pm PackedMap[K, V]) Delete(key K) {
+	delete(pm.m, key)
+}
+
+func (pm PackedMap[K, V]) Len() int {
+	return len(pm.m)
+}
+
+// DedupingPackedMap is a variant of PackedMap that also dedupes its values
+// so that the same value is only stored once.  This has an additional CPU
+// cost but can save memory if the same value is stored many times.
+type DedupingPackedMap[K comparable, V any] struct {
+	m map[K]unique.Handle[string]
+}
+
+func NewDeduping[K comparable, V any]() *DedupingPackedMap[K, V] {
+	return &DedupingPackedMap[K, V]{
+		m: make(map[K]unique.Handle[string]),
+	}
+}
+
+func (pm DedupingPackedMap[K, V]) Set(key K, val V) {
+	value := encode(val)
+	pm.m[key] = unique.Make(value)
+}
+
+func (pm DedupingPackedMap[K, V]) Get(key K) (val V, ok bool) {
+	packed, ok := pm.m[key]
+	if !ok {
+		return
+	}
+	val = decode[V](packed.Value())
+	return
+}
+
+func (pm DedupingPackedMap[K, V]) Delete(key K) {
+	delete(pm.m, key)
+}
+
+func (pm DedupingPackedMap[K, V]) Len() int {
+	return len(pm.m)
+}
+
+func encode[V any](val V) string {
+	buf, err := json.Marshal(val)
+	if err != nil {
+		panic(err)
+	}
+	var arr [1024 * 16]byte
+	packed := snappy.Encode(arr[:], buf)
+	value := string(packed)
+	return value
+}
+
+func decode[V any](packed string) V {
+	var arr [1024 * 16]byte
+	buf, err := snappy.Decode(arr[:], []byte(packed))
+	if err != nil {
+		panic(err)
+	}
+	var val V
+	err = json.Unmarshal(buf, &val)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}

--- a/libcalico-go/lib/packedmap/packedmap_test.go
+++ b/libcalico-go/lib/packedmap/packedmap_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packedmap
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/json"
+)
+
+type exampleStruct struct {
+	Field1 string         `json:"field_one,omitempty"`
+	Field2 bool           `json:"field_two,omitempty"`
+	Field3 map[string]int `json:"field_three,omitemepty"`
+}
+
+func TestCompressedJSON(t *testing.T) {
+	// Create a new map.
+	m := MakeCompressedJSON[string, exampleStruct]()
+
+	// Add some entries.
+	empty := exampleStruct{}
+	m.Set("empty", empty)
+	simple := exampleStruct{Field1: "hello", Field2: true}
+	m.Set("simple", simple)
+	fullyLoaded := exampleStruct{
+		Field1: "world",
+		Field2: false,
+		Field3: map[string]int{"aaaaaaaaaaaaa": 1, "bbbbbbbbbbbbb": 2},
+	}
+	m.Set("fullyLoaded", fullyLoaded)
+
+	if m.Len() != 3 {
+		t.Errorf("Expected 3 entries")
+	}
+
+	// Check the entries.
+	if v, ok := m.Get("empty"); !ok || !reflect.DeepEqual(v, empty) {
+		t.Errorf("Expected empty entry")
+	}
+	if v, ok := m.Get("simple"); !ok || !reflect.DeepEqual(v, simple) {
+		t.Errorf("Expected simple entry")
+	}
+	if v, ok := m.Get("fullyLoaded"); !ok || !reflect.DeepEqual(v, fullyLoaded) {
+		t.Errorf("Expected fullyLoaded entry")
+	}
+	if _, ok := m.Get("missing"); ok {
+		t.Errorf("Expected missing entry")
+	}
+
+	// Check deletion.
+	m.Delete("simple")
+	if m.Len() != 2 {
+		t.Errorf("Expected 2 entries after deletion")
+	}
+
+	// Check compression is working.
+	rawJSON, err := json.Marshal(fullyLoaded)
+	if err != nil {
+		t.Errorf("Failed to marshal JSON: %v", err)
+	}
+	if len(rawJSON) <= len(m.m["fullyLoaded"]) {
+		// The test JSON isn't too long but there's enough redundancy for snappy to make savings.
+		t.Errorf("Expected compression")
+	}
+}
+
+func TestDedupe(t *testing.T) {
+	// Create a new map.
+	m := MakeDedupedCompressedJSON[string, exampleStruct]()
+
+	// Add some entries.
+	fullyLoaded := exampleStruct{
+		Field1: "world",
+		Field2: false,
+		Field3: map[string]int{"aaaaaaaaaaaaa": 1, "bbbbbbbbbbbbb": 2},
+	}
+	m.Set("fullyLoaded", fullyLoaded)
+	m.Set("fullyLoadedCopy", fullyLoaded)
+
+	if m.Len() != 2 {
+		t.Errorf("Expected 3 entries")
+	}
+
+	// Check the entries.
+	if v, ok := m.Get("fullyLoaded"); !ok || !reflect.DeepEqual(v, fullyLoaded) {
+		t.Errorf("Expected fullyLoaded entry")
+	}
+	if v, ok := m.Get("fullyLoadedCopy"); !ok || !reflect.DeepEqual(v, fullyLoaded) {
+		t.Errorf("Expected fullyLoaded entry")
+	}
+
+	// Check dedupe is working.
+	h1 := m.m["fullyLoaded"]
+	h2 := m.m["fullyLoadedCopy"]
+	if h1 != h2 {
+		t.Errorf("Expected dedupe")
+	}
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The `Rule` struct that is used in policies and profiles has grown very large over time.  With allocation overheads, policies end up using approximately 1KB per rule!

We were previously storing pointers to the policies in two places.  We need to change both in order to realise any savings:

- The active rules calculator needs the full policy struct to be available when it determines that a policy is active.
- The policy resolver/policy sorter only need to know the name and order of the policy.

We tackle them in two different ways:

- In the active rules calculator, store inactive policies in a compressed format; first encoding them as JSON, then compressing with "snappy" (a fast compression algorithm).  The data is already marked up for JSON serialisation (as used by Typha to serialise the stream to Felix) so this should be very safe.  Unpack the policies on demand. Notes:

  - Unpacks should happen rarely, only when a policy goes from inactive to active.
  - We could optimise the storage of active policies in future by changing from a sparse struct to something like a slice of match criteria.  But using the encoding we already had seemed like an easy win.

- In the policy resolver, avoid storing the whole policy and extract the needed metadata in a compact struct.  Since we're transforming the data anyway, map policy order "default" to float `+Inf`.  This sorts exactly as desired and avoids awkward special case logic.

I measured the saving using 1,000 namespaces, each with one k8s NetworkPolicy that allowed DNS traffic (UDP and TCP to a handful of CIDRs), traffic within the namespace and traffic from an external namespace.  (This was a policy supplied by a user who was running into occupancy problems with 10s of thousands of namespaces.)

* Before the changes, each namespace+policy used ~25KiB (heap inuse space).
* After the changes, that's down to 7.2KiB.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now compresses network policies and namespaces in memory, reducing RAM usage in clusters with many policies/namespaces that are not active on a given node.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
