### PR TITLE
Add log prefix annotation to rules

### DIFF
--- a/felix/iptables/actions.go
+++ b/felix/iptables/actions.go
@@ -21,6 +21,8 @@ import (
 	"github.com/projectcalico/calico/felix/generictables"
 )
 
+var shellUnsafe = regexp.MustCompile(`[^\w @%+=:,./-]`)
+
 func Actions() generictables.ActionFactory {
 	return &actionFactory{}
 }
@@ -189,7 +191,7 @@ type LogAction struct {
 }
 
 func (g LogAction) ToFragment(features *environment.Features) string {
-	return fmt.Sprintf(`--jump LOG --log-prefix "%s: " --log-level 5`, g.Prefix)
+	return fmt.Sprintf(`--jump LOG --log-prefix "%s: " --log-level 5`, escapeLogPrefix(g.Prefix))
 }
 
 func (g LogAction) String() string {
@@ -374,4 +376,10 @@ func (c SetConnMarkAction) ToFragment(features *environment.Features) string {
 
 func (c SetConnMarkAction) String() string {
 	return fmt.Sprintf("SetConnMarkWithMask:%#x/%#x", c.Mark, c.Mask)
+}
+
+// escapeLogPrefix replaces anything other than "safe" shell characters with an
+// underscore (_) and truncates to 27 characters.
+func escapeLogPrefix(s string) string {
+	return shellUnsafe.ReplaceAllString(s, "_")[:27]
 }

--- a/felix/nftables/actions.go
+++ b/felix/nftables/actions.go
@@ -24,6 +24,8 @@ import (
 	"github.com/projectcalico/calico/felix/generictables"
 )
 
+var shellUnsafe = regexp.MustCompile(`[^\w @%+=:,./-]`)
+
 type namespaceable interface {
 	Namespace(string) generictables.Action
 }
@@ -229,7 +231,7 @@ type LogAction struct {
 }
 
 func (g LogAction) ToFragment(features *environment.Features) string {
-	return fmt.Sprintf(`log prefix %s level info`, g.Prefix)
+	return fmt.Sprintf(`log prefix "%s" level info`, escapeLogPrefix(g.Prefix))
 }
 
 func (g LogAction) String() string {
@@ -405,4 +407,11 @@ func (c SetConnMarkAction) ToFragment(features *environment.Features) string {
 
 func (c SetConnMarkAction) String() string {
 	return fmt.Sprintf("SetConnMarkWithMask:%#x/%#x", c.Mark, c.Mask)
+}
+
+
+// escapeLogPrefix replaces anything other than "safe" shell characters with an
+// underscore (_).
+func escapeLogPrefix(s string) string {
+	return shellUnsafe.ReplaceAllString(s, "_")
 }

--- a/felix/rules/policy.go
+++ b/felix/rules/policy.go
@@ -544,7 +544,11 @@ func (r *DefaultRuleRenderer) CalculateActions(pRule *proto.Rule, ipVersion uint
 		actions = append(actions, r.IptablesFilterDenyAction())
 	case "log":
 		// This rule should log.
-		actions = append(actions, r.Log(r.LogPrefix))
+		prefix, ok := pRule.Metadata.Annotations["projectcalico.org/LogPrefix"]
+		if ! ok {
+			prefix = r.LogPrefix
+		}
+		actions = append(actions, r.Log(prefix))
 	default:
 		log.WithField("action", pRule.Action).Panic("Unknown rule action")
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

New feature: This enabled rules to set their own log prefixes, overriding the global setting.

This makes different logging rules distinguishable.

Testing is not done yet, hence draft status.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
