### PR TITLE
Use gcp n4 machine and the latest ubuntu image

### DIFF
--- a/.semaphore/vms/create-test-vm
+++ b/.semaphore/vms/create-test-vm
@@ -28,11 +28,11 @@ gcloud auth activate-service-account --key-file=$gcp_secret_key
 function create-vm() {
   gcloud --quiet compute instances create "${vm_name}" \
            --zone=${zone} \
-           --machine-type=n1-standard-4 \
-           --image=ubuntu-2004-focal-v20211102 \
+           --machine-type=n4-standard-4 \
+           --image=ubuntu-2004-focal-v20241115 \
            --image-project=ubuntu-os-cloud \
            --boot-disk-size=$disk_size \
-           --boot-disk-type=pd-standard && \
+           --boot-disk-type=hyperdisk-balanced && \
   ssh_cmd="gcloud --quiet compute ssh --zone=${zone} ubuntu@${vm_name}"
   for ssh_try in $(seq 1 10); do
     echo "Trying to SSH in: $ssh_try"

--- a/felix/.semaphore/create-test-vm
+++ b/felix/.semaphore/create-test-vm
@@ -27,11 +27,11 @@ gcloud auth activate-service-account --key-file=$HOME/secrets/secret.google-serv
 function create-vm() {
   gcloud --quiet compute instances create "${vm_name}" \
            --zone=${zone} \
-           --machine-type=n1-standard-4 \
-           --image=ubuntu-2204-jammy-v20240228 \
+           --machine-type=n4-standard-4 \
+           --image=ubuntu-2204-jammy-v20241119 \
            --image-project=ubuntu-os-cloud \
            --boot-disk-size=20GB \
-           --boot-disk-type=pd-standard && \
+           --boot-disk-type=hyperdisk-balanced && \
   for ssh_try in $(seq 1 10); do
     echo "Trying to SSH in: $ssh_try"
     gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- echo "Success" && break


### PR DESCRIPTION
## Description

This change switches the GCP test VM type for BPF UT/FVs from n1 to n4. We noticed a much shorter run after this change and the cost remains roughly the same (or a little bit less).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
