### PR TITLE
update semaphore secrets for nightly build

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -2,24 +2,24 @@ version: v1.0
 name: Publish hashrelease
 agent:
   machine:
-    type: f1-standard-2
+    type: f1-standard-4
     os_image: ubuntu2004
 execution_time_limit:
   hours: 4
 
 global_job_config:
   secrets:
+    - name: oss-release-secrets
     # Github SSH secret for pulling private repositories.
     - name: private-repo
     # Secret for GitHub API access.
     - name: marvin-github-token
     # Secret for pushing to the docs box.
     - name: docs-ssh
-    # Secret for pulling images from GCR.
-    - name: gcloud-registry-access
-    # Secret for the docker auth
-    - name: hashrelease-docker-auth
-    # Secret for Image Scanning Service
+    # Secret for images
+    - name: google-service-account-for-gce
+    - name: quay-robot-calico+semaphoreci
+    - name: docker
     - name: iss-image-scanning
     # Secrets for Slack notifications
     - name: releasebot-slack
@@ -27,12 +27,37 @@ global_job_config:
     commands:
       - chmod 0600 ~/.keys/*
       - ssh-add ~/.keys/*
-      - export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/keys/.registry-viewer-serviceaccount.json
-      - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-      - docker login
+      # For some reason, /mnt is 100 GB and has a qemu-nbd image file.
+      # Let's delete it and use it for our own purposes (building calico
+      # without running out of space)
+      - sudo killall qemu-nbd || true
+      - sudo rm -f /mnt/docker.qcow2
+      - sudo chown $(id -u):$(id -g) /mnt/
+      - mkdir calico
+      - sudo mount --bind /mnt calico
+      # Checkout the code and unshallow it.
+      # (this is going to throw an error because it can't remove
+      # the `calico` directory, which is a mount, but it will
+      # continue anyway)
       - checkout
-      # Unshallow the git repository to get latest tags
       - retry git fetch --quiet --unshallow
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Log in to container registries needed for release.
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      # Credentials for accessing gcloud, needed to push images to gcr
+      - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/gcr-credentials.json
+      - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      # Manually log in to GCR until we can test the gcr credentials helper
+      - cat ${GOOGLE_APPLICATION_CREDENTIALS} | docker login -u _json_key --password-stdin https://gcr.io
+      - cat ${GOOGLE_APPLICATION_CREDENTIALS} | docker login -u _json_key --password-stdin https://eu.gcr.io
+      - cat ${GOOGLE_APPLICATION_CREDENTIALS} | docker login -u _json_key --password-stdin https://asia.gcr.io
+      - cat ${GOOGLE_APPLICATION_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
 
 blocks:
   - name: Publish hashrelease


### PR DESCRIPTION
## Description

Fix [nightly hashrelease failing](https://tigera.semaphoreci.com/workflows/0a190c1a-0e7b-4ce9-b6ef-0576e4d7194b?pipeline_id=4f66c933-c442-41e3-820a-10344459ca4f) due to missing permissions for publishing images.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
