### PR TITLE
supports custom ipFamilies

### DIFF
--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -212,11 +212,12 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		// Check for calico IPAM specific annotations and set them if needed.
 		if conf.IPAM.Type == "calico-ipam" {
 
-			var v4pools, v6pools string
+			var v4pools, v6pools, ipFamilies string
 
 			// Sets  the Namespace annotation for IP pools as default
 			v4pools = annotNS["cni.projectcalico.org/ipv4pools"]
 			v6pools = annotNS["cni.projectcalico.org/ipv6pools"]
+			ipFamilies = annotNS["cni.projectcalico.org/ipFamilies"]
 
 			// Gets the POD annotation for IP Pools and overwrites Namespace annotation if it exists
 			v4poolpod := annot["cni.projectcalico.org/ipv4pools"]
@@ -227,13 +228,17 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 			if len(v6poolpod) != 0 {
 				v6pools = v6poolpod
 			}
+			ipFamiliesPod := annot["cni.projectcalico.org/ipFamilies"]
+			if len(ipFamiliesPod) != 0 {
+				ipFamilies = ipFamiliesPod
+			}
 
-			if len(v4pools) != 0 || len(v6pools) != 0 {
+			if len(v4pools) != 0 || len(v6pools) != 0 || len(ipFamilies) != 0 {
 				var stdinData map[string]interface{}
 				if err := json.Unmarshal(args.StdinData, &stdinData); err != nil {
 					return nil, err
 				}
-				var v4PoolSlice, v6PoolSlice []string
+				var v4PoolSlice, v6PoolSlice, ipFamilieSlice []string
 
 				if len(v4pools) > 0 {
 					if err := json.Unmarshal([]byte(v4pools), &v4PoolSlice); err != nil {
@@ -258,6 +263,36 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 					}
 					stdinData["ipam"].(map[string]interface{})["ipv6_pools"] = v6PoolSlice
 					logger.WithField("ipv6_pools", v6pools).Debug("Setting IPv6 Pools")
+				}
+
+				if len(ipFamilies) > 0 {
+					if err := json.Unmarshal([]byte(ipFamilies), &ipFamilieSlice); err != nil {
+						logger.WithField("IPFamilies", ipFamilies).Error("Error parsing IPFamilies")
+						return nil, err
+					}
+
+					assignV4 := "false"
+					assignV6 := "false"
+					for _, ipFamily := range ipFamilieSlice {
+						switch ipFamily {
+						case "IPv4":
+							assignV4 = "true"
+						case "IPv6":
+							assignV6 = "true"
+						default:
+							logger.WithField("IPFamilies", ipFamilies).Error("Error parsing ipFamilies")
+							return nil, fmt.Errorf("error parsing ipFamilies: %s", ipFamilies)
+						}
+					}
+
+					if _, ok := stdinData["ipam"].(map[string]interface{}); !ok {
+						return nil, errors.New("data on stdin was of unexpected type")
+					}
+
+					stdinData["ipam"].(map[string]interface{})["assign_ipv4"] = &assignV4
+					stdinData["ipam"].(map[string]interface{})["assign_ipv6"] = &assignV6
+					logger.WithField("assign_ipv4", assignV4).Debug("Setting assignV4")
+					logger.WithField("assign_ipv6", assignV6).Debug("Setting assignV6")
 				}
 
 				newData, err := json.Marshal(stdinData)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

After enabling Calico dual-stack networking (IPv4/IPv6) in a Kubernetes cluster, while all newly created Pods will receive both IPv4 and IPv6 addresses, Calico's configuration prevents the cluster from supporting IPv4-only or IPv6-only single-stack modes. This means that even legacy applications using only IPv4 require a restart to obtain dual-stack addresses, even though they don't need IPv6. Enabling dual-stack in a long-running single-stack cluster can therefore introduce several issues:

- Unnecessary Restarts: Forcing a restart on legacy applications that don't require IPv6 increases unnecessary operational burden and potential downtime.

- Increased IP Address Management Complexity: Even if legacy applications restart and obtain IPv6 addresses, these addresses are wasted if the application doesn't support or use IPv6. This adds complexity to IP address management.

Ideally, we'd like Calico to still allow existing Pods to use IPv4-only or IPv6-only single-stack modes after enabling dual-stack.

~~This can be achieved by adding a `cni.projectcalico.org/ipFamilies` annotation, ~~supporting values `ipv4Only`, `ipv6Only`, and `dualStack`~~ supporting values `IPv4`, `IPv6`.~~

This is configured using the `cni.projectcalico.org/ipFamilies` annotation. This annotation must be set to a JSON array. Valid values are: `["IPv4"]` for IPv4-only addressing, `["IPv6"]` for IPv6-only addressing, and `["IPv4", "IPv6"]` (or `["IPv6", "IPv4"]`) for dual-stack addressing. If a value other than these three is set, the annotation parsing will fail, and Pod creation will fail. If the annotation is not set, the existing ipam configuration from the CNI configuration file will be used.

Support for this annotation should be provided at both the `namespace` and `Pod` levels, with Pod-level annotations taking precedence over namespace-level annotations.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
https://github.com/projectcalico/calico/issues/9491

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Support for a new cni.projectcalico.org/ipFamilies annotation to configure which IP families to use on a per-pod or per-Namespace basis.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
