### PR TITLE
fix: docs for upgrades to include CRD upgrade notes

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -79,7 +79,7 @@ ownership of the helm resources to the new chart location.
 1. Upgrade CRDs:
 
    ```bash
-   kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/projectcalico/calico/{{site.data.versions[0].title}}/manifests/operator-crds.yaml
+   kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.5/manifests/operator-crds.yaml
    ```
 
 1. Run the helm upgrade:

--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -76,6 +76,12 @@ ownership of the helm resources to the new chart location.
 
 ## All other upgrades
 
+1. Upgrade CRDs:
+
+   ```bash
+   kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/projectcalico/calico/{{site.data.versions[0].title}}/manifests/operator-crds.yaml
+   ```
+
 1. Run the helm upgrade:
 
    ```bash


### PR DESCRIPTION
## Description

Documentation updates. 

Artifacthub's README.md upgrade steps did not match what was on: https://docs.tigera.io/calico/latest/operations/upgrading/kubernetes-upgrade#all-other-upgrades this PR is to bring them into sync.


## Related issues/PRs
N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note



```release-note
Update docs to include upgrade instructions for CRDs and for v1.28+
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.



