### PR TITLE
[release tool] update docker credentials helper for gcloud

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1344,15 +1344,15 @@ help:
 ###############################################################################
 
 # When running on semaphore, just copy the docker config, otherwise run
-# 'docker-credential-gcr configure-docker' as well.
+# 'docker-credential-gcloud configure-docker' as well.
 ifdef SEMAPHORE
 DOCKER_CREDENTIAL_CMD = cp /root/.docker/config.json_host /root/.docker/config.json
 else
 DOCKER_CREDENTIAL_CMD = cp /root/.docker/config.json_host /root/.docker/config.json && \
-						docker-credential-gcr configure-docker
+						docker-credential-gcloud configure-docker
 endif
 
-# This needs the $(WINDOWS_DIST)/bin/docker-credential-gcr binary in $PATH and
+# This needs the $(WINDOWS_DIST)/bin/docker-credential-gcloud binary in $PATH and
 # also the local ~/.config/gcloud dir to be able to push to gcr.io.  It mounts
 # $(DOCKER_CONFIG) and copies it so that it can be written to on the container,
 # but not have any effect on the host config.
@@ -1442,17 +1442,17 @@ setup-windows-builder: clean-windows-builder
 
 $(WINDOWS_DIST)/$(WINDOWS_IMAGE)-$(GIT_VERSION)-%.tar: windows-sub-image-$*
 
-DOCKER_CREDENTIAL_VERSION="2.1.18"
+
 DOCKER_CREDENTIAL_OS="linux"
 DOCKER_CREDENTIAL_ARCH="amd64"
-$(WINDOWS_DIST)/bin/docker-credential-gcr:
+$(WINDOWS_DIST)/bin/docker-credential-gcloud:
 	-mkdir -p $(WINDOWS_DIST)/bin
-	curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v$(DOCKER_CREDENTIAL_VERSION)/docker-credential-gcr_$(DOCKER_CREDENTIAL_OS)_$(DOCKER_CREDENTIAL_ARCH)-$(DOCKER_CREDENTIAL_VERSION).tar.gz" \
-	| tar xz --to-stdout docker-credential-gcr \
-	| tee $(WINDOWS_DIST)/bin/docker-credential-gcr > /dev/null && chmod +x $(WINDOWS_DIST)/bin/docker-credential-gcr
+	curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcloud/releases/download/v$(DOCKER_CREDENTIAL_GCLOUD_VERSION)/docker-credential-gcloud_$(DOCKER_CREDENTIAL_OS)_$(DOCKER_CREDENTIAL_ARCH)-$(DOCKER_CREDENTIAL_GCLOUD_VERSION).tar.gz" \
+	| tar xz --to-stdout docker-credential-gcloud \
+	| tee $(WINDOWS_DIST)/bin/docker-credential-gcloud > /dev/null && chmod +x $(WINDOWS_DIST)/bin/docker-credential-gcloud
 
-.PHONY: docker-credential-gcr-binary
-docker-credential-gcr-binary: var-require-all-WINDOWS_DIST-DOCKER_CREDENTIAL_VERSION-DOCKER_CREDENTIAL_OS-DOCKER_CREDENTIAL_ARCH $(WINDOWS_DIST)/bin/docker-credential-gcr
+.PHONY: docker-credential-gcloud-binary
+docker-credential-gcloud-binary: var-require-all-WINDOWS_DIST-DOCKER_CREDENTIAL_GCLOUD_VERSION-DOCKER_CREDENTIAL_OS-DOCKER_CREDENTIAL_ARCH $(WINDOWS_DIST)/bin/docker-credential-gcloud
 
 # NOTE: WINDOWS_IMAGE_REQS must be defined with the requirements to build the windows
 # image. These must be added as reqs to 'image-windows' (originally defined in
@@ -1476,7 +1476,7 @@ image-windows: setup-windows-builder var-require-all-WINDOWS_VERSIONS
 		$(MAKE) windows-sub-image-$${version}; \
 	done;
 
-release-windows-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-IMAGETAG-DEV_REGISTRIES image-windows docker-credential-gcr-binary
+release-windows-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-IMAGETAG-DEV_REGISTRIES image-windows docker-credential-gcloud-binary
 	for registry in $(DEV_REGISTRIES); do \
 		echo Pushing Windows images to $${registry}; \
 		all_images=""; \

--- a/metadata.mk
+++ b/metadata.mk
@@ -45,6 +45,8 @@ DEV_REGISTRIES ?= calico
 # The directory for windows image tarballs
 WINDOWS_DIST = dist/windows
 
+DOCKER_CREDENTIAL_GCLOUD_VERSION=2.1.26
+
 # FIXME: Use WINDOWS_HPC_VERSION and remove WINDOWS_VERSIONS when containerd v1.6 is EOL'd
 # The Windows HPC container version used as base for Calico Windows images
 WINDOWS_HPC_VERSION ?= v1.0.0


### PR DESCRIPTION
## Description

docker-credential-gcr has been replaced with docker-credential-gcloud.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
