### PR TITLE
Allow disabling ValidatingAdmissionPolicy for clusters that don't hav…

### DIFF
--- a/apiserver/cmd/apiserver/apiserver.go
+++ b/apiserver/cmd/apiserver/apiserver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
 
 /*
 Copyright 2016 The Kubernetes Authors.
@@ -57,7 +57,7 @@ func main() {
 		logs.FlushLogs()
 	}
 
-	cmd, err := server.NewCommandStartCalicoServer(os.Stdout)
+	cmd, _, err := server.NewCommandStartCalicoServer(os.Stdout)
 	if err != nil {
 		klog.Errorf("Error creating server: %v", err)
 		logs.FlushLogs()

--- a/apiserver/cmd/apiserver/server/options.go
+++ b/apiserver/cmd/apiserver/server/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
 
 /*
 Copyright 2017 The Kubernetes Authors.
@@ -53,24 +53,24 @@ type CalicoServerOptions struct {
 	PrintSwagger    bool
 	SwaggerFilePath string
 
-	// Enable Admission Controller support.
-	EnableAdmissionController bool
+	// This Kubernetes feature was made default in k8s 1.30, but may not be enabled prior.
+	EnableValidatingAdmissionPolicy bool
 
 	StopCh <-chan struct{}
 }
 
-func (s *CalicoServerOptions) addFlags(flags *pflag.FlagSet) {
-	s.RecommendedOptions.AddFlags(flags)
+func (o *CalicoServerOptions) addFlags(flags *pflag.FlagSet) {
+	o.RecommendedOptions.AddFlags(flags)
 
-	flags.BoolVar(&s.EnableAdmissionController, "enable-admission-controller-support", s.EnableAdmissionController,
-		"If true, admission controller hooks will be enabled.")
-	flags.BoolVar(&s.PrintSwagger, "print-swagger", false,
+	flags.BoolVar(&o.PrintSwagger, "print-swagger", false,
 		"If true, prints swagger to stdout and exits.")
-	flags.StringVar(&s.SwaggerFilePath, "swagger-file-path", "./",
+	flags.StringVar(&o.SwaggerFilePath, "swagger-file-path", "./",
 		"If print-swagger is set true, then write swagger.json to location specified. Default is current directory.")
+	flags.BoolVar(&o.EnableValidatingAdmissionPolicy, "enable-validating-admission-policy", true,
+		"If true, establishes watches for ValidatingAdmissionPolicy at startup.")
 }
 
-func (o CalicoServerOptions) Validate(args []string) error {
+func (o *CalicoServerOptions) Validate(args []string) error {
 	errors := []error{}
 	errors = append(errors, o.RecommendedOptions.Validate()...)
 	return utilerrors.NewAggregate(errors)

--- a/apiserver/cmd/apiserver/server/run_server.go
+++ b/apiserver/cmd/apiserver/server/run_server.go
@@ -26,7 +26,9 @@ import (
 	"os"
 	gpath "path"
 
+	"k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/apiserver/pkg/apiserver"
@@ -40,6 +42,11 @@ func PrepareServer(opts *CalicoServerOptions) (*apiserver.ProjectCalicoServer, e
 		opts.StopCh = make(chan struct{})
 	}
 
+	klog.Infof("Enabling ValidatingAdmissionPolicy: %v", opts.EnableValidatingAdmissionPolicy)
+	if !opts.EnableValidatingAdmissionPolicy {
+		opts.RecommendedOptions.Admission = options.NewAdmissionOptions()
+		opts.RecommendedOptions.Admission.DisablePlugins = []string{validating.PluginName}
+	}
 	config, err := opts.Config()
 	if err != nil {
 		return nil, err

--- a/apiserver/cmd/apiserver/server/server.go
+++ b/apiserver/cmd/apiserver/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
 
 /*
 Copyright 2016 The Kubernetes Authors.
@@ -50,8 +50,8 @@ func logrusLevel() logrus.Level {
 	return logrus.ErrorLevel
 }
 
-// NewCommandStartMaster provides a CLI handler for 'start master' command
-func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, error) {
+// NewCommandStartCalicoServer provides a CLI handler for 'start master' command
+func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, *CalicoServerOptions, error) {
 	//	o := NewCalicoServerOptions(out, errOut)
 
 	// Create the command that runs the API server
@@ -91,5 +91,5 @@ func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, error) {
 		}
 	}
 
-	return cmd, nil
+	return cmd, opts, nil
 }

--- a/apiserver/cmd/apiserver/server/server_test.go
+++ b/apiserver/cmd/apiserver/server/server_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCATypeFlagParsing(t *testing.T) {
+	testCases := []struct {
+		args                                        []string
+		expectedmanagementClusterCAType             string
+		expectedEnableValidatingAdmissionController bool
+	}{
+		{[]string{}, "", true},
+		{[]string{"--enable-validating-admission-policy=true"}, "", true},
+		{[]string{"--enable-validating-admission-policy=false"}, "", false},
+	}
+
+	for _, testCase := range testCases {
+		cmd, opts, err := NewCommandStartCalicoServer(os.Stdout)
+		if err != nil {
+			t.Fatalf("Failed to create the server command: %v", err)
+		}
+
+		err = cmd.ParseFlags(testCase.args)
+		if err != nil {
+			t.Fatalf("Failed to parse flags from the server command: %v", err)
+		}
+
+		parsedEnableValidatingAdmissionController, err := cmd.Flags().GetBool("enable-validating-admission-policy")
+		if err != nil {
+			t.Fatalf("Failed to get enable-validating-admission-policy flag from the server command: %v", err)
+		}
+
+		if parsedEnableValidatingAdmissionController != testCase.expectedEnableValidatingAdmissionController || opts.EnableValidatingAdmissionPolicy != testCase.expectedEnableValidatingAdmissionController {
+			t.Fatalf(
+				"Parsed value %v for enable-validating-admission-policy flag, expected %v for args %v",
+				parsedEnableValidatingAdmissionController,
+				testCase.expectedEnableValidatingAdmissionController,
+				testCase.args,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Before this fix, apiserver would crash-loop on <1.30 with message:

```
W1203 21:29:57.602511       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.7/tools/cache/reflector.go:232: failed to list *v1.ValidatingAdmissionPolicy: the server could not find the requested resource
E1203 21:29:57.602562       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.7/tools/cache/reflector.go:232: Failed to watch *v1.ValidatingAdmissionPolicy: failed to list *v1.ValidatingAdmissionPolicy: the server could not find the requested resource
W1203 21:30:24.556236       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.7/tools/cache/reflector.go:232: failed to list *v1.ValidatingAdmissionPolicyBinding: the server could not find the requested resource
E1203 21:30:24.556293       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.7/tools/cache/reflector.go:232: Failed to watch *v1.ValidatingAdmissionPolicyBinding: failed to list *v1.ValidatingAdmissionPolicyBinding: the server could not find the requested resource
```

## Release Note

```release-note
Feature to enable/disable ValidatingAdmissionPolicy, so it can be disabled for clusters that don't have this API enabled (k8s <v1.30), preventing the server from crash-looping.
```