### PR TITLE
[BPF] fixed routing from outside the cluster in EKS with aws-cni

### DIFF
--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -356,6 +356,12 @@ skip_fib:
 		if (ctx->state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL) {
 			CALI_DEBUG("To host marked with FLAG_EXT_LOCAL");
 			ctx->fwd.mark |= EXT_TO_SVC_MARK;
+			if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK) {
+				/* needs to go via normal routing unless we have access
+				 * to BPF_FIB_LOOKUP_MARK in kernel 6.10+
+				 */
+				rc = TC_ACT_UNSPEC;
+			}
 		}
 
 		if (CALI_F_NAT_IF) {


### PR DESCRIPTION
With aws-cni external traffic needs to be marked see [1], but fib_lookup for returning traffic does not consider that mark. Hence the returning traffic, if not routed by Linux, would go to a wrong host iface. This can be fixed with BPF_FIB_LOOKUP_MARK in kernels 6.10+

[1] https://github.com/projectcalico/felix/commit/a662ef7aed985e05e84076f00059a844c6d3e847

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixed routing from outside the cluster in EKS with aws-cni
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
