### PR TITLE
Restrict tigera-operator secret access to namespace only, retain get/…

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator-secrets.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator-secrets.yaml
@@ -1,0 +1,16 @@
+# Permissions required to manipulate operator secrets for a Calico cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tigera-operator-secrets
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update
+      - delete

--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -60,7 +60,6 @@ rules:
       - endpoints
       - events
       - configmaps
-      - secrets
       - serviceaccounts
     verbs:
       - create
@@ -73,6 +72,7 @@ rules:
       - ""
     resources:
       - resourcequotas
+      - secrets
     verbs:
       - list
       - get

--- a/charts/tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator-secrets.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator-secrets.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tigera-operator-secrets
+  namespace: {{.Release.Namespace}}
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{.Release.Namespace}}
+    namespace: {{.Release.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: tigera-operator-secrets
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/ocp/02-role-tigera-operator-secrets.yaml
+++ b/manifests/ocp/02-role-tigera-operator-secrets.yaml
@@ -1,0 +1,16 @@
+# Permissions required to manipulate operator secrets for a Calico cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tigera-operator-secrets
+  labels:
+    k8s-app: tigera-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update
+      - delete

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -60,7 +60,6 @@ rules:
       - endpoints
       - events
       - configmaps
-      - secrets
       - serviceaccounts
     verbs:
       - create
@@ -73,6 +72,7 @@ rules:
       - ""
     resources:
       - resourcequotas
+      - secrets
     verbs:
       - list
       - get

--- a/manifests/ocp/02-rolebinding-tigera-operator-secrets.yaml
+++ b/manifests/ocp/02-rolebinding-tigera-operator-secrets.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tigera-operator-secrets
+  namespace: tigera-operator
+  labels:
+    k8s-app: tigera-operator
+subjects:
+  - kind: ServiceAccount
+    name: tigera-operator
+    namespace: tigera-operator
+roleRef:
+  kind: ClusterRole
+  name: tigera-operator-secrets
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -17,6 +17,24 @@ metadata:
 imagePullSecrets:
   []
 ---
+# Source: tigera-operator/templates/tigera-operator/02-role-tigera-operator-secrets.yaml
+# Permissions required to manipulate operator secrets for a Calico cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tigera-operator-secrets
+  labels:
+    k8s-app: tigera-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update
+      - delete
+---
 # Source: tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
 # Permissions required when running the operator for a Calico cluster.
 apiVersion: rbac.authorization.k8s.io/v1
@@ -80,7 +98,6 @@ rules:
       - endpoints
       - events
       - configmaps
-      - secrets
       - serviceaccounts
     verbs:
       - create
@@ -93,6 +110,7 @@ rules:
       - ""
     resources:
       - resourcequotas
+      - secrets
     verbs:
       - list
       - get
@@ -385,6 +403,23 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: tigera-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator-secrets.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tigera-operator-secrets
+  namespace: tigera-operator
+  labels:
+    k8s-app: tigera-operator
+subjects:
+  - kind: ServiceAccount
+    name: tigera-operator
+    namespace: tigera-operator
+roleRef:
+  kind: ClusterRole
+  name: tigera-operator-secrets
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: tigera-operator/templates/tigera-operator/02-tigera-operator.yaml


### PR DESCRIPTION
…list/watch cluster-wide

https://github.com/tigera/operator/pull/3630
https://tigera.atlassian.net/browse/EV-5410


```
vara@vara:~/bzprofiles/Clusters/tc_os$ ts
NAME        AVAILABLE   PROGRESSING   DEGRADED   SINCE
apiserver   True        False         False      115s
calico      True        False         False      90s
ippools     True        False         False      23m
vara@vara:~/bzprofiles/Clusters/tc_os$ k get rolebinding -A |grep tigera-operator-secrets
calico-apiserver   tigera-operator-secrets                             ClusterRole/tigera-operator-secrets                   6m19s
calico-system      tigera-operator-secrets                             ClusterRole/tigera-operator-secrets                   3m13s
tigera-operator    tigera-operator-secrets                             ClusterRole/tigera-operator-secrets                   24m

```

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
