### PR TITLE
Fix handling of duplicate MACs in VXLAN FDB

### DIFF
--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -325,9 +325,9 @@ func (c *DataplaneView[K, V]) ReplaceAllIter(iter func(func(k K, v V)) error) er
 	c.inDataplaneAndDesired = newInDPDesired
 	c.inDataplaneNotDesired = newInDPNotDesired
 	c.logCtx.WithFields(logrus.Fields{
-		"totalNumInDP":          len(c.inDataplaneAndDesired),
-		"desiredUpdates":        len(c.desiredUpdates),
-		"inDataplaneNotDesired": len(c.inDataplaneNotDesired),
+		"totalInDataplane":        len(c.inDataplaneAndDesired) + len(c.inDataplaneNotDesired),
+		"pendingCreatesOrUpdates": len(c.desiredUpdates),
+		"pendingDeletions":        len(c.inDataplaneNotDesired),
 	}).Debug("Updated dataplane state.")
 
 	return nil

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -921,18 +921,35 @@ func (d *MockNetlinkDataplane) AddNeighs(family int, neighs ...netlink.Neigh) {
 	if d.NeighsByFamily[family] == nil {
 		d.NeighsByFamily[family] = map[NeighKey]*netlink.Neigh{}
 	}
-	addNeighs(d.NeighsByFamily[family], neighs)
+	addNeighs(family, d.NeighsByFamily[family], neighs)
 }
 
-func addNeighs(neighMap map[NeighKey]*netlink.Neigh, neighs []netlink.Neigh) {
+func addNeighs(family int, neighMap map[NeighKey]*netlink.Neigh, neighs []netlink.Neigh) {
 	for _, neigh := range neighs {
 		neigh := neigh
-		nk := NeighKey{
-			LinkIndex: neigh.LinkIndex,
-			MAC:       neigh.HardwareAddr.String(),
-			IP:        ip.FromNetIP(neigh.IP),
-		}
+		nk := NeighKeyForFamily(family, neigh.LinkIndex, neigh.HardwareAddr, ip.FromNetIP(neigh.IP))
 		neighMap[nk] = &neigh
+	}
+}
+
+// NeighKeyForFamily returns an appropriate NeighKey for the given family.
+// Different families are keyed in different ways by the kernel.  ARP/NDP
+// entries are keyed on IP address, but FDB entries are keyed on MAC address
+// instead.
+func NeighKeyForFamily(family int, ifaceIdx int, mac net.HardwareAddr, ipAddr ip.Addr) NeighKey {
+	switch family {
+	case unix.AF_INET, unix.AF_INET6:
+		return NeighKey{
+			LinkIndex: ifaceIdx,
+			IP:        ipAddr,
+		}
+	case unix.AF_BRIDGE:
+		return NeighKey{
+			LinkIndex: ifaceIdx,
+			MAC:       mac.String(),
+		}
+	default:
+		panic(fmt.Sprintf("unsupported family %d", family))
 	}
 }
 
@@ -942,7 +959,7 @@ func (d *MockNetlinkDataplane) ExpectNeighs(family int, neighs ...netlink.Neigh)
 		return
 	}
 	nm := map[NeighKey]*netlink.Neigh{}
-	addNeighs(nm, neighs)
+	addNeighs(family, nm, neighs)
 	ExpectWithOffset(1, d.NeighsByFamily[family]).To(Equal(nm))
 }
 
@@ -965,11 +982,8 @@ func (d *MockNetlinkDataplane) NeighAdd(neigh *netlink.Neigh) error {
 	if neigh.LinkIndex == 0 {
 		return unix.EINVAL
 	}
-	nk := NeighKey{
-		LinkIndex: neigh.LinkIndex,
-		MAC:       neigh.HardwareAddr.String(),
-		IP:        ip.FromNetIP(neigh.IP),
-	}
+
+	nk := NeighKeyForFamily(family, neigh.LinkIndex, neigh.HardwareAddr, ip.FromNetIP(neigh.IP))
 
 	if _, ok := d.NeighsByFamily[family][nk]; ok {
 		return unix.EEXIST
@@ -1027,11 +1041,8 @@ func (d *MockNetlinkDataplane) NeighSet(neigh *netlink.Neigh) error {
 	if neigh.LinkIndex == 0 {
 		return unix.EINVAL
 	}
-	nk := NeighKey{
-		LinkIndex: neigh.LinkIndex,
-		MAC:       neigh.HardwareAddr.String(),
-		IP:        ip.FromNetIP(neigh.IP),
-	}
+
+	nk := NeighKeyForFamily(family, neigh.LinkIndex, neigh.HardwareAddr, ip.FromNetIP(neigh.IP))
 
 	d.NeighsByFamily[family][nk] = neigh
 	return nil
@@ -1059,11 +1070,8 @@ func (d *MockNetlinkDataplane) NeighDel(neigh *netlink.Neigh) error {
 	if neigh.LinkIndex == 0 {
 		return unix.EINVAL
 	}
-	nk := NeighKey{
-		LinkIndex: neigh.LinkIndex,
-		MAC:       neigh.HardwareAddr.String(),
-		IP:        ip.FromNetIP(neigh.IP),
-	}
+
+	nk := NeighKeyForFamily(family, neigh.LinkIndex, neigh.HardwareAddr, ip.FromNetIP(neigh.IP))
 
 	if _, ok := d.NeighsByFamily[family][nk]; !ok {
 		return unix.ENOENT


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fix that the VXLAN FDB would fail to clean up stale ARP entries if they had the same MAC address as an entry that it was trying to create.  The internal data structure was indexed on MAC address, preventing it from "seeing" the second entry so it would try to clean up the _desired_ entry instead and then add it back again at the next resync.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes #9450
CORE-10865

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that in-use VXLAN ARP entries could be repeatedly cleaned up and then re-added if they shared a MAC address with an stale entry that was supposed to be cleaned up.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.

