### PR TITLE
Add sempahore auto go-build workflow

### DIFF
--- a/.semaphore/update-go-build-pins.yml
+++ b/.semaphore/update-go-build-pins.yml
@@ -1,0 +1,25 @@
+version: v1.0
+name: Trigger calico/go-build update
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+
+execution_time_limit:
+  minutes: 30
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+
+blocks:
+  - name: Auto calico/go-build update
+    task:
+      secrets:
+        - name: marvin-github-token
+      jobs:
+        - name: Auto calico/go-build update
+          commands:
+            - CONFIRM=true make git-config
+            - CONFIRM=true GITHUB_TOKEN=${MARVIN_GITHUB_TOKEN} make trigger-auto-pin-update-process

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,8 @@ endif
 		python:3 \
 		bash -c '/usr/local/bin/python release/get-contributors.py >> /code/AUTHORS.md'
 
+update-pins: update-go-build-pin
+
 ###############################################################################
 # Post-release validation
 ###############################################################################


### PR DESCRIPTION
## Description

This change adds a semaphore workflow to trigger calico/go-build pin update. We improved calico/go-build to trigger this workflow when there is a new release tag pushed to the go-build repository.

## Related issues/PRs

Requires changes from https://github.com/projectcalico/go-build/pull/611.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
