### PR TITLE
Watch bookmarks.

### DIFF
--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -221,6 +221,34 @@ type WatchEvent struct {
 	Error error
 }
 
+func (w WatchEvent) String() string {
+	switch w.Type {
+	case WatchAdded:
+		if w.New == nil {
+			break // Malformed event, but still want to be able to print it!
+		}
+		return fmt.Sprintf("Added:%v@%v", w.New.Key, w.New.Revision)
+	case WatchModified:
+		if w.New == nil {
+			break
+		}
+		return fmt.Sprintf("Modified:%v@%v", w.New.Key, w.New.Revision)
+	case WatchDeleted:
+		if w.Old == nil {
+			break
+		}
+		return fmt.Sprintf("Deleted:%v@%v", w.Old.Key, w.Old.Revision)
+	case WatchBookmark:
+		if w.New == nil {
+			break
+		}
+		return fmt.Sprintf("Bookmark:%v", w.New.Revision)
+	case WatchError:
+		return fmt.Sprintf("Error:%v", w.Error)
+	}
+	return fmt.Sprintf("WatchEvent{Type: %s, Old: %v, New: %v, Error: %v}", w.Type, w.Old, w.New, w.Error)
+}
+
 // FakeWatcher is inspired by apimachinery (watch) FakeWatcher
 type FakeWatcher struct {
 	result  chan WatchEvent

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -126,7 +126,8 @@ type Client interface {
 }
 
 type WatchOptions struct {
-	Revision string
+	Revision            string
+	AllowWatchBookmarks bool
 }
 
 type Syncer interface {
@@ -200,6 +201,7 @@ const (
 	WatchModified WatchEventType = "MODIFIED"
 	WatchDeleted  WatchEventType = "DELETED"
 	WatchError    WatchEventType = "ERROR"
+	WatchBookmark WatchEventType = "BOOKMARK"
 )
 
 // Event represents a single event to a watched resource.

--- a/libcalico-go/lib/backend/k8s/resources/profile.go
+++ b/libcalico-go/lib/backend/k8s/resources/profile.go
@@ -484,7 +484,7 @@ func (pw *profileWatcher) processProfileEvents() {
 				}
 				oma.GetObjectMeta().SetResourceVersion(pw.JoinProfileRevisions(pw.k8sNSRev, pw.k8sSARev))
 			}
-		} else if e.Error == nil {
+		} else if e.Error == nil && e.Type != api.WatchBookmark {
 			log.WithField("event", e).Warning("Event without error or value")
 		}
 

--- a/libcalico-go/lib/backend/k8s/resources/profile.go
+++ b/libcalico-go/lib/backend/k8s/resources/profile.go
@@ -457,6 +457,13 @@ func (pw *profileWatcher) processProfileEvents() {
 		switch e.Type {
 		case api.WatchModified, api.WatchAdded:
 			value = e.New.Value
+		case api.WatchBookmark:
+			if isNsEvent {
+				pw.k8sNSRev = e.New.Revision
+			} else {
+				pw.k8sSARev = e.New.Revision
+			}
+			e.New.Revision = pw.JoinProfileRevisions(pw.k8sNSRev, pw.k8sSARev)
 		case api.WatchDeleted:
 			value = e.Old.Value
 		}

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -325,7 +325,8 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 
 func watchOptionsToK8sListOptions(wo api.WatchOptions) metav1.ListOptions {
 	return metav1.ListOptions{
-		ResourceVersion: wo.Revision,
-		Watch:           true,
+		ResourceVersion:     wo.Revision,
+		Watch:               true,
+		AllowWatchBookmarks: wo.AllowWatchBookmarks,
 	}
 }

--- a/libcalico-go/lib/backend/k8s/resources/watcher.go
+++ b/libcalico-go/lib/backend/k8s/resources/watcher.go
@@ -166,7 +166,17 @@ func (crw *k8sWatcherConverter) convertEvent(kevent kwatch.Event) []*api.WatchEv
 		}
 
 		return crw.buildEventsFromKVPs(kvps, kevent.Type)
-
+	case kwatch.Bookmark:
+		// For bookmarks we send an empty KVPair with the current resource
+		// version only.
+		k8sRes := kevent.Object.(Resource)
+		revision := k8sRes.GetObjectMeta().GetResourceVersion()
+		return []*api.WatchEvent{{
+			Type: api.WatchBookmark,
+			New: &model.KVPair{
+				Revision: revision,
+			},
+		}}
 	default:
 		return []*api.WatchEvent{{
 			Type:  api.WatchError,

--- a/libcalico-go/lib/backend/k8s/resources/watcher_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/watcher_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Resources watcher ", func() {
 
 		It("should return error WatchEvent with unexpected kwatch event type", func() {
 			events := kwc.convertEvent(kwatch.Event{
-				Type: kwatch.Bookmark,
+				Type: "GARBAGE",
 			})
 			Expect(events).To(HaveLen(1))
 			Expect(events[0].Type).To(Equal(api.WatchError))

--- a/libcalico-go/lib/backend/watchersyncer/reflector_ports.go
+++ b/libcalico-go/lib/backend/watchersyncer/reflector_ports.go
@@ -1,0 +1,54 @@
+// Extracted from on Kubernetes reflector.go, Copyright 2014 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchersyncer
+
+import (
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Copied from client-go's reflector.go
+func isTooLargeResourceVersionError(err error) bool {
+	if apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge) {
+		return true
+	}
+	// In Kubernetes 1.17.0-1.18.5, the api server doesn't set the error status cause to
+	// metav1.CauseTypeResourceVersionTooLarge to indicate that the requested minimum resource
+	// version is larger than the largest currently available resource version. To ensure backward
+	// compatibility with these server versions we also need to detect the error based on the content
+	// of the error message field.
+	if !apierrors.IsTimeout(err) {
+		return false
+	}
+	apierr, ok := err.(apierrors.APIStatus)
+	if !ok || apierr == nil || apierr.Status().Details == nil {
+		return false
+	}
+	for _, cause := range apierr.Status().Details.Causes {
+		// Matches the message returned by api server 1.17.0-1.18.5 for this error condition
+		if cause.Message == "Too large resource version" {
+			return true
+		}
+	}
+
+	// Matches the message returned by api server before 1.17.0
+	if strings.Contains(apierr.Status().Message, "Too large resource version") {
+		return true
+	}
+
+	return false
+}

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -17,6 +17,7 @@ package watchersyncer
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -73,7 +74,7 @@ type cacheEntry struct {
 // Create a new watcherCache.
 func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- interface{}) *watcherCache {
 	return &watcherCache{
-		logger:               logrus.WithField("ListRoot", model.ListOptionsToDefaultPathRoot(resourceType.ListInterface)),
+		logger:               logrus.WithField("ListRoot", listRootForLog(resourceType.ListInterface)),
 		client:               client,
 		resourceType:         resourceType,
 		results:              results,
@@ -83,32 +84,51 @@ func newWatcherCache(client api.Client, resourceType ResourceType, results chan<
 	}
 }
 
+func listRootForLog(listInterface model.ListInterface) string {
+	root := model.ListOptionsToDefaultPathRoot(listInterface)
+	root = strings.Replace(root, "/calico/resources/v3/projectcalico.org/", ".../v3/pc.org/", 1)
+	root = strings.Replace(root, "/calico/", ".../", 1)
+	return root
+}
+
 // run creates the watcher and loops indefinitely reading from the watcher.
 func (wc *watcherCache) run(ctx context.Context) {
-	wc.logger.Debug("Watcher cache starting, start initial sync processing")
-	wc.resyncAndCreateWatcher(ctx)
+	wc.logger.Debug("Watcher cache starting...")
 
-	wc.logger.Debug("Starting main event processing loop")
-mainLoop:
+	// On shutdown, send deletions for all the objects we're tracking.
+	defer wc.sendDeletionsForAllResources()
+
+	// Main loop, repeatedly resync with the store and then watch for changes
+	// until our watch fails.
+	for ctx.Err() == nil {
+		wc.resyncAndLoopReadingFromWatcher(ctx)
+	}
+}
+
+func (wc *watcherCache) resyncAndLoopReadingFromWatcher(ctx context.Context) {
+	defer wc.cleanExistingWatcher()
+	wc.maybeResyncAndCreateWatcher(ctx)
+	wc.loopReadingFromWatcher(ctx)
+}
+
+func (wc *watcherCache) loopReadingFromWatcher(ctx context.Context) {
+	eventLogger := wc.logger.WithField("event", nil)
+
 	for {
-		if wc.watch == nil {
-			// The watcher will be nil if the context cancelled during a resync.
-			wc.logger.Debug("Watch is nil. Returning")
-			break mainLoop
-		}
 		select {
 		case <-ctx.Done():
 			wc.logger.Debug("Context is done. Returning")
-			wc.cleanExistingWatcher()
-			break mainLoop
+			return
 		case event, ok := <-wc.watch.ResultChan():
 			if !ok {
 				// If the channel is closed then resync/recreate the watch.
 				wc.logger.Debug("Watch channel closed by remote - recreate watcher")
-				wc.resyncAndCreateWatcher(ctx)
-				continue
+				return
 			}
-			wc.logger.WithField("RC", wc.watch.ResultChan()).Debug("Reading event from results channel")
+
+			// Re-use this log event so that we don't allocate every time.
+			eventLogger.Data["event"] = event
+			eventLogger.Debug("Got event from results channel")
 
 			// Handle the specific event type.
 			switch event.Type {
@@ -120,7 +140,7 @@ mainLoop:
 				kvp := event.Old
 				if kvp == nil {
 					// Bug, we're about to panic when we hit the nil pointer, log something useful.
-					wc.logger.WithField("watcher", wc).WithField("event", event).Panic("Deletion event without old value")
+					eventLogger.Panic("Deletion event without old value")
 				}
 				kvp.Value = nil
 				wc.handleWatchListEvent(kvp)
@@ -130,7 +150,7 @@ mainLoop:
 				if kerrors.IsResourceExpired(event.Error) {
 					// Our current watch revision is too old.  Even with watch bookmarks, we hit this path after the
 					// API server restarts (and presumably does an immediate compaction).
-					wc.logger.WithError(event.Error).Info("Watch has expired, triggering full resync.")
+					eventLogger.Info("Watch has expired, triggering full resync.")
 					wc.resetWatchRevisionForFullResync()
 				} else {
 					// Unknown error, default is to just try restarting the watch on assumption that it's
@@ -139,35 +159,24 @@ mainLoop:
 					wc.errorCountAtCurrentRev++
 					if wc.errorCountAtCurrentRev >= MaxErrorsPerRevision {
 						// Too many errors at the current revision, trigger a full resync.
-						wc.logger.WithError(event.Error).Warn("Watch repeatedly failed without making progress, triggering full resync")
+						eventLogger.Warn("Watch repeatedly failed without making progress, triggering full resync")
 						wc.resetWatchRevisionForFullResync()
 					} else {
-						wc.logger.WithError(event.Error).Info("Watch of resource finished. Attempting to restart it...")
+						eventLogger.Info("Watch of resource finished. Attempting to restart it...")
 					}
 				}
-				wc.resyncAndCreateWatcher(ctx)
+				return
 			default:
 				// Unknown event type - not much we can do other than log.
-				wc.logger.WithField("EventType", event.Type).Errorf("Unknown event type received from the datastore")
+				eventLogger.Errorf("Unknown event type received from the datastore")
 			}
 		}
 	}
-
-	// The watcher cache has exited. This can only mean that it has been shutdown, so emit all updates in the cache as
-	// delete events.
-	for _, value := range wc.resources {
-		wc.results <- []api.Update{{
-			UpdateType: api.UpdateTypeKVDeleted,
-			KVPair: model.KVPair{
-				Key: value.key,
-			},
-		}}
-	}
 }
 
-// resyncAndCreateWatcher loops performing resync processing until it successfully
+// maybeResyncAndCreateWatcher loops performing resync processing until it successfully
 // completes a resync and starts a watcher.
-func (wc *watcherCache) resyncAndCreateWatcher(ctx context.Context) {
+func (wc *watcherCache) maybeResyncAndCreateWatcher(ctx context.Context) {
 	// The passed in context allows a resync to be stopped mid-resync. The resync should be stopped as quickly as
 	// possible, but there should be usable data available in wc.resources so that delete events can be sent.
 	// The strategy is to
@@ -186,7 +195,6 @@ func (wc *watcherCache) resyncAndCreateWatcher(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			wc.logger.Debug("Context is done. Returning")
-			wc.cleanExistingWatcher()
 			return
 		case <-wc.resyncThrottleC():
 			// Start the resync.  This processing loops until we create the watcher.  If the
@@ -500,5 +508,16 @@ func (wc *watcherCache) markAsValid(resourceKey string) {
 			wc.resources[resourceKey] = oldResource
 			delete(wc.oldResources, resourceKey)
 		}
+	}
+}
+
+func (wc *watcherCache) sendDeletionsForAllResources() {
+	for _, value := range wc.resources {
+		wc.results <- []api.Update{{
+			UpdateType: api.UpdateTypeKVDeleted,
+			KVPair: model.KVPair{
+				Key: value.key,
+			},
+		}}
 	}
 }

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -32,7 +32,7 @@ const (
 // ResourceType groups together the watch and conversion information for a
 // specific resource type.
 type ResourceType struct {
-	// ListInterface specifies the resource type to watch\.
+	// ListInterface specifies the resource type to watch.
 	ListInterface model.ListInterface
 
 	// UpdateProcessor converts the raw KVPairs returned from the datastore into the appropriate

--- a/libcalico-go/lib/errors/errors.go
+++ b/libcalico-go/lib/errors/errors.go
@@ -29,6 +29,10 @@ type ErrorDatastoreError struct {
 	Identifier interface{}
 }
 
+func (e ErrorDatastoreError) Unwrap() error {
+	return e.Err
+}
+
 func (e ErrorDatastoreError) Error() string {
 	return e.Err.Error()
 }
@@ -61,6 +65,10 @@ func (e ErrorResourceDoesNotExist) Error() string {
 	return fmt.Sprintf("resource does not exist: %v with error: %v", e.Identifier, e.Err)
 }
 
+func (e ErrorResourceDoesNotExist) Unwrap() error {
+	return e.Err
+}
+
 // Error indicating an operation is not supported.
 type ErrorOperationNotSupported struct {
 	Operation  string
@@ -83,6 +91,10 @@ type ErrorResourceAlreadyExists struct {
 	Identifier interface{}
 }
 
+func (e ErrorResourceAlreadyExists) Unwrap() error {
+	return e.Err
+}
+
 func (e ErrorResourceAlreadyExists) Error() string {
 	return fmt.Sprintf("resource already exists: %v", e.Identifier)
 }
@@ -90,6 +102,10 @@ func (e ErrorResourceAlreadyExists) Error() string {
 // Error indicating a problem connecting to the backend.
 type ErrorConnectionUnauthorized struct {
 	Err error
+}
+
+func (e ErrorConnectionUnauthorized) Unwrap() error {
+	return e.Err
 }
 
 func (e ErrorConnectionUnauthorized) Error() string {
@@ -149,6 +165,10 @@ func (e ErrorInsufficientIdentifiers) Error() string {
 type ErrorResourceUpdateConflict struct {
 	Err        error
 	Identifier interface{}
+}
+
+func (e ErrorResourceUpdateConflict) Unwrap() error {
+	return e.Err
 }
 
 func (e ErrorResourceUpdateConflict) Error() string {

--- a/libcalico-go/lib/testutils/syncertester.go
+++ b/libcalico-go/lib/testutils/syncertester.go
@@ -77,6 +77,7 @@ type SyncerTester struct {
 func (st *SyncerTester) OnStatusUpdated(status api.SyncStatus) {
 	defer GinkgoRecover()
 	st.lock.Lock()
+	log.WithField("status", status).Info("OnStatusUpdated")
 	current := st.status
 	st.status = status
 	st.statusChanged = true
@@ -177,7 +178,7 @@ func (st *SyncerTester) ExpectStatusUpdate(status api.SyncStatus, timeout ...tim
 	} else {
 		EventuallyWithOffset(1, cs, timeout[0], "1ms").Should(Equal(status))
 	}
-	ConsistentlyWithOffset(1, cs).Should(Equal(status))
+	ConsistentlyWithOffset(1, cs, "10ms", "1ms").Should(Equal(status))
 
 	log.Infof("Status is at expected status: %s", status)
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add support for [watch bookmarks](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks) to the Kubernetes Datastore Driver and then use them in the watchersyncer.  This prevents a wasteful re-List() every time the API server does a compaction of a little-updated resource.

While researching watch bookmarks, I noticed that we were mishandling various errors relative to the Kubernetes reflector/informer machinery.  In particular, watch bookmarks are only useful if we don't reset the revision when we get "expected" errors such as "connection refused" or "too many requests".

Includes a refactoring of the main watchercache loop (all in the final commit):

- Split the god method and use defer to clean up the watcher instead of doing it on the various error paths.
- Resync/recreate watcher at the top of the loop only, not in error paths.  I find this style a lot easier to grok!
- Tune the logging: re-use an event-scoped logger to avoid allocs and make the stringification of a WatchEvent a lot more useful.

Note: this does **not** expose watch bookmarks on the "v3" watch API.  The challenge to doing that is that the watch bookmark is conveyed as an "empty" k8s resource with only a `resourceVersion` populated and translating that to a similar Calico object is non-trivial (because the existing conversion functions expect a valid, populated object as input).  

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Builds on #9577, which added the options struct needed to plumb through the AllowWatchBookmarks flag. 
CORE-10820

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico now takes advantage of "watch bookmarks" when watching Kubernetes resources.  This prevents "resource version too old" errors, which result in unnecessary resyncs (which delay updates and increase API server CPU load).
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
