### PR TITLE
[release tool] refactor pinnedversion

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -91,10 +91,8 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
-					calico.WithVersions(&version.Data{
-						ProductVersion:  ver,
-						OperatorVersion: operatorVer,
-					}),
+					calico.WithVersion(ver.FormattedString()),
+					calico.WithOperatorVersion(operatorVer.FormattedString()),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
@@ -127,10 +125,8 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 				}
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
-					calico.WithVersions(&version.Data{
-						ProductVersion:  ver,
-						OperatorVersion: operatorVer,
-					}),
+					calico.WithVersion(ver.FormattedString()),
+					calico.WithOperatorVersion(operatorVer.FormattedString()),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -31,10 +31,11 @@ import (
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
+	"github.com/projectcalico/calico/release/pkg/manager/calico"
 )
 
-//go:embed templates/calico-version.yaml.gotmpl
-var calicoVersionTemplateData string
+//go:embed templates/calico-versions.yaml.gotmpl
+var calicoTemplate string
 
 const (
 	pinnedVersionFileName      = "pinned-version.yaml"
@@ -47,200 +48,173 @@ var noImageComponents = []string{
 	"networking-calico",
 }
 
-type OperatorConfig struct {
-	// Dir is the directory to clone the operator repository.
-	Dir string
-
-	// Branch is the repository for the operator
-	Branch string
-
-	// Registry is the registry for Tigera operator
-	Registry string
-
-	// Image is the image for Tigera operator
-	Image string
+type PinnedVersions interface {
+	GenerateFile() (version.Data, error)
+	ManagerOptions() ([]calico.Option, error)
 }
 
-func (c OperatorConfig) GitVersion() version.Version {
-	previousTag, err := command.GitVersion(c.Dir, true)
+type OperatorConfig struct {
+	Dir      string
+	Branch   string
+	Registry string
+	Image    string
+}
+
+func (c OperatorConfig) GitVersion() (string, error) {
+	tag, err := command.GitVersion(c.Dir, true)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to determine latest git version")
+		logrus.WithError(err).Error("Failed to determine operator git version")
+		return "", err
 	}
-	logrus.WithField("out", previousTag).Info("Current git describe")
-	return version.New(previousTag)
+	logrus.WithField("out", tag).Info("Current git describe")
+	return tag, nil
 }
 
 func (c OperatorConfig) GitBranch() (string, error) {
 	return command.GitInDir(c.Dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
-// Config represents the configuration needed to generate the pinned version file.
-type Config struct {
-	// RootDir is the root directory of the repository.
-	RootDir string
-
-	// ReleaseBranchPrefix is the prefix for the release branch.
-	ReleaseBranchPrefix string
-
-	// Operator is the configuration for the operator.
-	Operator OperatorConfig
-}
-
-// PinnedVersionData represents the data needed to generate the pinned version file from the template.
-type PinnedVersionData struct {
-	// ReleaseName is the name of the release.
-	ReleaseName string
-
-	// BaseDomain is the base domain for the docs site.
-	BaseDomain string
-
-	// ProductVersion is the version of the product.
-	ProductVersion string
-
-	// Operator is the operator component.
-	Operator registry.Component
-
-	// Note is the note for the release.
-	Note string
-
-	// Hash is the hash of the release.
-	Hash string
-
-	// ReleaseBranch is the release branch of the release.
-	ReleaseBranch string
-}
-
 // PinnedVersion represents an entry in pinned version file.
 type PinnedVersion struct {
 	Title          string                        `yaml:"title"`
 	ManifestURL    string                        `yaml:"manifest_url"`
-	ReleaseName    string                        `yaml:"release_name"`
+	ReleaseName    string                        `yaml:"release_name,omitempty"`
 	Note           string                        `yaml:"note"`
 	Hash           string                        `yaml:"full_hash"`
 	TigeraOperator registry.Component            `yaml:"tigera-operator"`
 	Components     map[string]registry.Component `yaml:"components"`
 }
 
-// PinnedVersionFile represents the pinned version file.
-type PinnedVersionFile []PinnedVersion
+func NewCalicoVersionData(productVersion, operatorVersion string) *CalicoPinnedVersionData {
+	return &CalicoPinnedVersionData{
+		calico:   version.New(productVersion),
+		operator: version.New(operatorVersion),
+	}
+}
+
+type CalicoPinnedVersionData struct {
+	calico   version.Version
+	operator version.Version
+}
+
+func (v *CalicoPinnedVersionData) ProductVersion() string {
+	return v.calico.FormattedString()
+}
+
+func (v *CalicoPinnedVersionData) OperatorVersion() string {
+	return v.operator.FormattedString()
+}
+
+func (v *CalicoPinnedVersionData) HelmChartVersion() string {
+	return v.calico.FormattedString()
+}
+
+func (v *CalicoPinnedVersionData) Hash() string {
+	return fmt.Sprintf("%s-%s", v.calico.FormattedString(), v.operator.FormattedString())
+}
+
+func (v *CalicoPinnedVersionData) ReleaseBranch(releaseBranchPrefix string) string {
+	return fmt.Sprintf("%s-%s", releaseBranchPrefix, v.calico.Stream())
+}
+
+// calicoTemplateData is used to generate the pinned version file from the template.
+type calicoTemplateData struct {
+	ReleaseName    string
+	BaseDomain     string
+	ProductVersion string
+	Operator       registry.Component
+	Note           string
+	Hash           string
+	ReleaseBranch  string
+}
+
+func (d *calicoTemplateData) ReleaseURL() string {
+	return fmt.Sprintf("https://%s.%s", d.ReleaseName, d.BaseDomain)
+}
 
 func pinnedVersionFilePath(outputDir string) string {
 	return filepath.Join(outputDir, pinnedVersionFileName)
 }
 
-func operatorComponentsFilePath(outputDir string) string {
-	return filepath.Join(outputDir, operatorComponentsFileName)
+type CalicoPinnedVersions struct {
+	// RootDir is the root directory of the repository.
+	RootDir string
+
+	// Dir is the directory to store the pinned version file.
+	Dir string
+
+	// ReleaseBranchPrefix is the prefix for the release branch.
+	ReleaseBranchPrefix string
+
+	// OperatorCfg is the configuration for the operator.
+	OperatorCfg OperatorConfig
 }
 
-// GeneratePinnedVersionFile generates the pinned version file.
-func GeneratePinnedVersionFile(cfg Config, outputDir string) (string, *PinnedVersionData, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
+// GenerateFile generates the pinned version file.
+func (p *CalicoPinnedVersions) GenerateFile() (version.Data, error) {
+	pinnedVersionPath := pinnedVersionFilePath(p.Dir)
+	versionData := &CalicoPinnedVersionData{}
 
-	productBranch, err := utils.GitBranch(cfg.RootDir)
+	productBranch, err := utils.GitBranch(p.RootDir)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
-
-	productVersion := version.GitVersion()
-	releaseName := fmt.Sprintf("%s-%s-%s", time.Now().Format("2006-01-02"), version.DeterminePublishStream(productBranch, string(productVersion)), RandomWord())
+	productVer, err := command.GitVersion(p.RootDir, true)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to determine product git version")
+		return nil, err
+	}
+	releaseName := fmt.Sprintf("%s-%s-%s", time.Now().Format("2006-01-02"), version.DeterminePublishStream(productBranch, productVer), RandomWord())
 	releaseName = strings.ReplaceAll(releaseName, ".", "-")
-	operatorBranch, err := cfg.Operator.GitBranch()
+	operatorBranch, err := p.OperatorCfg.GitBranch()
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
-	operatorVersion := cfg.Operator.GitVersion()
-	tmpl, err := template.New("pinnedversion").Parse(calicoVersionTemplateData)
+	operatorVer, err := p.OperatorCfg.GitVersion()
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
-	data := &PinnedVersionData{
+	versionData = NewCalicoVersionData(productVer, fmt.Sprintf("%s-%s", operatorVer, releaseName))
+	tmpl, err := template.New("pinnedversion").Parse(calicoTemplate)
+	if err != nil {
+		return nil, err
+	}
+	tmplData := &calicoTemplateData{
 		ReleaseName:    releaseName,
 		BaseDomain:     hashreleaseserver.BaseDomain,
-		ProductVersion: productVersion.FormattedString(),
+		ProductVersion: versionData.ProductVersion(),
 		Operator: registry.Component{
-			Version:  operatorVersion.FormattedString() + "-" + releaseName,
-			Image:    cfg.Operator.Image,
-			Registry: cfg.Operator.Registry,
+			Version:  versionData.OperatorVersion(),
+			Image:    p.OperatorCfg.Image,
+			Registry: p.OperatorCfg.Registry,
 		},
-		Hash: productVersion.FormattedString() + "-" + operatorVersion.FormattedString(),
+		Hash: versionData.Hash(),
 		Note: fmt.Sprintf("%s - generated at %s using %s release branch with %s operator branch",
 			releaseName, time.Now().Format(time.RFC1123), productBranch, operatorBranch),
-		ReleaseBranch: productVersion.ReleaseBranch(cfg.ReleaseBranchPrefix),
+		ReleaseBranch: versionData.ReleaseBranch(p.ReleaseBranchPrefix),
 	}
 	logrus.WithField("file", pinnedVersionPath).Info("Generating pinned version file")
 	pinnedVersionFile, err := os.Create(pinnedVersionPath)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 	defer pinnedVersionFile.Close()
-	if err := tmpl.Execute(pinnedVersionFile, data); err != nil {
-		return "", nil, err
+	if err := tmpl.Execute(pinnedVersionFile, tmplData); err != nil {
+		return nil, err
 	}
 
-	return pinnedVersionPath, data, nil
+	return versionData, nil
 }
 
-// GenerateOperatorComponents generates the components-version.yaml for operator.
-func GenerateOperatorComponents(outputDir string) (registry.OperatorComponent, string, error) {
-	op := registry.OperatorComponent{}
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	logrus.WithField("file", pinnedVersionPath).Info("Generating components-version.yaml for operator")
-	var pinnedversion PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return op, "", err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
-		return op, "", err
-	}
-	operatorComponentsFilePath := operatorComponentsFilePath(outputDir)
-	operatorComponentsFile, err := os.Create(operatorComponentsFilePath)
+// ManagerOptions returns the options for the manager.
+func (p *CalicoPinnedVersions) ManagerOptions() ([]calico.Option, error) {
+	pinnedVersion, err := retrievePinnedVersion(p.Dir)
 	if err != nil {
-		return op, "", err
-	}
-	defer operatorComponentsFile.Close()
-	if err = yaml.NewEncoder(operatorComponentsFile).Encode(pinnedversion[0]); err != nil {
-		return op, "", err
-	}
-	op.Component = pinnedversion[0].TigeraOperator
-	return op, operatorComponentsFilePath, nil
-}
-
-// RetrievePinnedVersion retrieves the pinned version from the pinned version file.
-func RetrievePinnedVersion(outputDir string) (PinnedVersion, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedVersionFile PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return PinnedVersion{}, err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedVersionFile); err != nil {
-		return PinnedVersion{}, err
-	}
-	return pinnedVersionFile[0], nil
-}
-
-// RetrievePinnedOperatorVersion retrieves the operator version from the pinned version file.
-func RetrievePinnedOperator(outputDir string) (registry.OperatorComponent, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedVersionFile PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return registry.OperatorComponent{}, err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedVersionFile); err != nil {
-		return registry.OperatorComponent{}, err
-	}
-	return registry.OperatorComponent{
-		Component: pinnedVersionFile[0].TigeraOperator,
-	}, nil
-}
-
-// RetrieveComponentsToValidate retrieves the components to validate from the pinned version file.
-func RetrieveComponentsToValidate(outputDir string) (map[string]registry.Component, error) {
-	pinnedVersionPath := pinnedVersionFilePath(outputDir)
-	var pinnedversion PinnedVersionFile
-	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
-		return nil, err
-	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedversion); err != nil {
 		return nil, err
 	}
-	components := pinnedversion[0].Components
-	operator := registry.OperatorComponent{Component: pinnedversion[0].TigeraOperator}
+
+	components := pinnedVersion.Components
+	operator := registry.OperatorComponent{Component: pinnedVersion.TigeraOperator}
 	components[operator.Image] = operator.Component
 	initImage := operator.InitImage()
 	components[initImage.Image] = operator.InitImage()
@@ -258,7 +232,55 @@ func RetrieveComponentsToValidate(outputDir string) (map[string]registry.Compone
 		}
 		components[name] = component
 	}
-	return components, nil
+
+	return []calico.Option{
+		calico.WithVersion(pinnedVersion.Title),
+		calico.WithOperatorVersion(pinnedVersion.TigeraOperator.Version),
+		calico.WithComponents(components),
+	}, nil
+}
+
+// GenerateOperatorComponents generates the components-version.yaml for operator.
+func GenerateOperatorComponents(outputDir string) (registry.OperatorComponent, string, error) {
+	op := registry.OperatorComponent{}
+	pinnedVersion, err := retrievePinnedVersion(outputDir)
+	if err != nil {
+		return op, "", err
+	}
+	operatorComponentsFilePath := filepath.Join(outputDir, operatorComponentsFileName)
+	operatorComponentsFile, err := os.Create(operatorComponentsFilePath)
+	if err != nil {
+		return op, "", err
+	}
+	defer operatorComponentsFile.Close()
+	if err = yaml.NewEncoder(operatorComponentsFile).Encode(pinnedVersion); err != nil {
+		return op, "", err
+	}
+	op.Component = pinnedVersion.TigeraOperator
+	return op, operatorComponentsFilePath, nil
+}
+
+// retrievePinnedVersion retrieves the pinned version from the pinned version file.
+func retrievePinnedVersion(outputDir string) (PinnedVersion, error) {
+	pinnedVersionPath := pinnedVersionFilePath(outputDir)
+	var pinnedVersionFile []PinnedVersion
+	if pinnedVersionData, err := os.ReadFile(pinnedVersionPath); err != nil {
+		return PinnedVersion{}, err
+	} else if err := yaml.Unmarshal([]byte(pinnedVersionData), &pinnedVersionFile); err != nil {
+		return PinnedVersion{}, err
+	}
+	return pinnedVersionFile[0], nil
+}
+
+// RetrievePinnedOperatorVersion retrieves the operator version from the pinned version file.
+func RetrievePinnedOperator(outputDir string) (registry.OperatorComponent, error) {
+	pinnedVersion, err := retrievePinnedVersion(outputDir)
+	if err != nil {
+		return registry.OperatorComponent{}, err
+	}
+	return registry.OperatorComponent{
+		Component: pinnedVersion.TigeraOperator,
+	}, nil
 }
 
 // LoadHashrelease loads the hashrelease from the pinned version file.
@@ -268,7 +290,7 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 		logrus.WithError(err).Error("Failed to get current branch")
 		return nil, err
 	}
-	pinnedVersion, err := RetrievePinnedVersion(outputDir)
+	pinnedVersion, err := retrievePinnedVersion(outputDir)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get pinned version")
 	}
@@ -283,4 +305,13 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 		Time:            time.Now(),
 		Latest:          latest,
 	}, nil
+}
+
+func RetrieveVersions(outputDir string) (version.Data, error) {
+	pinnedVersion, err := retrievePinnedVersion(outputDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCalicoVersionData(pinnedVersion.Title, pinnedVersion.TigeraOperator.Version), nil
 }

--- a/release/internal/pinnedversion/templates/calico-versions.yaml.gotmpl
+++ b/release/internal/pinnedversion/templates/calico-versions.yaml.gotmpl
@@ -1,5 +1,5 @@
 - title: {{.ProductVersion}}
-  manifests_url: https://{{.ReleaseName}}.{{.BaseDomain}}
+  manifests_url: {{.ReleaseURL}}
   release_name: {{.ReleaseName}}
   note: {{.Note}}
   full_hash: {{.Hash}}

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -27,11 +27,46 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
+// Data is the interface that provides version data for a release.
 type Data interface {
 	Hash() string
 	ProductVersion() string
 	OperatorVersion() string
 	HelmChartVersion() string
+	ReleaseBranch(releaseBranchPrefix string) string
+}
+
+func NewVersionData(calico Version, operator string) Data {
+	return &CalicoVersionData{
+		calico:   calico,
+		operator: operator,
+	}
+}
+
+// CalicoVersionData provides version data for a Calico release.
+type CalicoVersionData struct {
+	calico   Version
+	operator string
+}
+
+func (v *CalicoVersionData) ProductVersion() string {
+	return v.calico.FormattedString()
+}
+
+func (v *CalicoVersionData) OperatorVersion() string {
+	return v.operator
+}
+
+func (v *CalicoVersionData) HelmChartVersion() string {
+	return v.calico.FormattedString()
+}
+
+func (v *CalicoVersionData) Hash() string {
+	return fmt.Sprintf("%s-%s", v.calico.FormattedString(), v.operator)
+}
+
+func (v *CalicoVersionData) ReleaseBranch(releaseBranchPrefix string) string {
+	return fmt.Sprintf("%s-%s", releaseBranchPrefix, v.calico.Stream())
 }
 
 // Version represents a version, and contains methods for working with versions.

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -27,12 +27,11 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
-type Data struct {
-	// ProductVersion is the version of the product
-	ProductVersion Version
-
-	// OperatorVersion is the version of operator
-	OperatorVersion Version
+type Data interface {
+	Hash() string
+	ProductVersion() string
+	OperatorVersion() string
+	HelmChartVersion() string
 }
 
 // Version represents a version, and contains methods for working with versions.
@@ -70,11 +69,6 @@ func (v *Version) Milestone() string {
 func (v *Version) Stream() string {
 	ver := semver.MustParse(string(*v))
 	return fmt.Sprintf("v%d.%d", ver.Major(), ver.Minor())
-}
-
-// ReleaseBranch returns the release branch which corresponds with this version.
-func (v *Version) ReleaseBranch(releaseBranchPrefix string) string {
-	return fmt.Sprintf("%s-%s", releaseBranchPrefix, v.Stream())
 }
 
 func (v *Version) Semver() *semver.Version {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -30,7 +30,6 @@ import (
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
-	"github.com/projectcalico/calico/release/internal/pinnedversion"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
@@ -203,6 +202,7 @@ type CalicoManager struct {
 	// image scanning configuration.
 	imageScanning       bool
 	imageScanningConfig imagescanner.Config
+	imageComponents map[string]registry.Component
 
 	// external configuration.
 	githubToken string
@@ -556,16 +556,12 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 			return fmt.Errorf("missing hashrelease server configuration")
 		}
 	}
-	images, err := pinnedversion.RetrieveComponentsToValidate(r.tmpDir)
-	if err != nil {
-		return fmt.Errorf("failed to get components to validate: %s", err)
-	}
 	if r.publishImages {
 		return r.assertImageVersions()
 	} else {
-		results := make(map[string]imageExistsResult, len(images))
+		results := make(map[string]imageExistsResult, len(r.imageComponents))
 		ch := make(chan imageExistsResult)
-		for name, component := range images {
+		for name, component := range r.imageComponents {
 			go imgExists(name, component, ch)
 		}
 		for range images {
@@ -573,14 +569,14 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 			results[res.name] = res
 		}
 		failedImageList := []string{}
-		for name, r := range results {
+		for name, result := range results {
 			logrus.WithFields(logrus.Fields{
-				"image":  r.image,
-				"exists": r.exists,
+				"image":  result.image,
+				"exists": result.exists,
 			}).Info("Validating image")
-			if r.err != nil || !r.exists {
-				logrus.WithError(r.err).WithField("image", name).Error("Error checking image")
-				failedImageList = append(failedImageList, images[name].String())
+			if result.err != nil || !result.exists {
+				logrus.WithError(result.err).WithField("image", name).Error("Error checking image")
+				failedImageList = append(failedImageList, r.imageComponents[name].String())
 			} else {
 				logrus.WithField("image", name).Info("Image exists")
 			}
@@ -593,7 +589,7 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 	if r.imageScanning {
 		logrus.Info("Sending images to ISS")
 		imageList := []string{}
-		for _, component := range images {
+		for _, component := range r.imageComponents {
 			imageList = append(imageList, component.String())
 		}
 		imageScanner := imagescanner.New(r.imageScanningConfig)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -202,7 +202,7 @@ type CalicoManager struct {
 	// image scanning configuration.
 	imageScanning       bool
 	imageScanningConfig imagescanner.Config
-	imageComponents map[string]registry.Component
+	imageComponents     map[string]registry.Component
 
 	// external configuration.
 	githubToken string

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -17,7 +17,7 @@ package calico
 import (
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
-	"github.com/projectcalico/calico/release/internal/version"
+	"github.com/projectcalico/calico/release/internal/registry"
 )
 
 type Option func(*CalicoManager) error
@@ -50,10 +50,16 @@ func WithReleaseBranchValidation(validate bool) Option {
 	}
 }
 
-func WithVersions(versions *version.Data) Option {
+func WithVersion(version string) Option {
 	return func(r *CalicoManager) error {
-		r.calicoVersion = versions.ProductVersion.FormattedString()
-		r.operatorVersion = versions.OperatorVersion.FormattedString()
+		r.calicoVersion = version
+		return nil
+	}
+}
+
+func WithOperatorVersion(version string) Option {
+	return func(r *CalicoManager) error {
+		r.operatorVersion = version
 		return nil
 	}
 }
@@ -161,6 +167,13 @@ func WithImageScanning(scanning bool, cfg imagescanner.Config) Option {
 	return func(r *CalicoManager) error {
 		r.imageScanning = scanning
 		r.imageScanningConfig = cfg
+		return nil
+	}
+}
+
+func WithComponents(components map[string]registry.Component) Option {
+	return func(r *CalicoManager) error {
+		r.imageComponents = components
 		return nil
 	}
 }


### PR DESCRIPTION
## Description

This refactors the pinnedversion package to allow for different pinnedversion per product.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
