### PR TITLE
[release tool] pass in GitHub token as flag for actual release

### DIFF
--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -359,6 +359,12 @@ var (
 		Name:  "publish-github-release",
 		Usage: "Publish the release to GitHub",
 		Value: true,
+		Action: func(c *cli.Context, b bool) error {
+			if b && c.String(githubTokenFlag.Name) == "" {
+				return fmt.Errorf("GitHub token is required to publish release")
+			}
+			return nil
+		},
 	}
 )
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -138,6 +138,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithPublishImages(c.Bool(publishImagesFlag.Name)),
 					calico.WithPublishGitTag(c.Bool(publishGitTagFlag.Name)),
 					calico.WithPublishGithubRelease(c.Bool(publishGitHubReleaseFlag.Name)),
+					calico.WithGithubToken(c.String(githubTokenFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -155,6 +156,7 @@ func releaseBuildFlags() []cli.Flag {
 		archFlag,
 		registryFlag,
 		buildImagesFlag,
+		githubTokenFlag,
 		skipValidationFlag)
 	return f
 }
@@ -166,6 +168,7 @@ func releasePublishFlags() []cli.Flag {
 		publishImagesFlag,
 		publishGitTagFlag,
 		publishGitHubReleaseFlag,
+		githubTokenFlag,
 		skipValidationFlag)
 	return f
 }

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -194,7 +194,7 @@ func GenerateOperatorComponents(outputDir string) (registry.OperatorComponent, s
 	operatorComponentsFilePath := operatorComponentsFilePath(outputDir)
 	operatorComponentsFile, err := os.Create(operatorComponentsFilePath)
 	if err != nil {
-	return op, "", err
+		return op, "", err
 	}
 	defer operatorComponentsFile.Close()
 	if err = yaml.NewEncoder(operatorComponentsFile).Encode(pinnedversion[0]); err != nil {

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -194,7 +194,7 @@ func GenerateOperatorComponents(outputDir string) (registry.OperatorComponent, s
 	operatorComponentsFilePath := operatorComponentsFilePath(outputDir)
 	operatorComponentsFile, err := os.Create(operatorComponentsFilePath)
 	if err != nil {
-		return op, "", err
+	return op, "", err
 	}
 	defer operatorComponentsFile.Close()
 	if err = yaml.NewEncoder(operatorComponentsFile).Encode(pinnedversion[0]); err != nil {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -203,6 +203,9 @@ type CalicoManager struct {
 	// image scanning configuration.
 	imageScanning       bool
 	imageScanningConfig imagescanner.Config
+
+	// external configuration.
+	githubToken string
 }
 
 func releaseImages(version, operatorVersion string) []string {
@@ -518,13 +521,6 @@ func (r *CalicoManager) releasePrereqs() error {
 	branch := r.determineBranch()
 	if branch == "master" {
 		return fmt.Errorf("cannot cut release from branch: %s", branch)
-	}
-
-	// Make sure we have a github token - needed for publishing to GH.
-	// Strictly only needed for publishing, but we check during release anyway so
-	// that we don't get all the way through the build to find out we're missing it!
-	if token := os.Getenv("GITHUB_TOKEN"); token == "" {
-		return fmt.Errorf("no GITHUB_TOKEN present in environment")
 	}
 
 	// If we are releasing to projectcalico/calico, make sure we are releasing to the default registries.

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -164,3 +164,10 @@ func WithImageScanning(scanning bool, cfg imagescanner.Config) Option {
 		return nil
 	}
 }
+
+func WithGithubToken(token string) Option {
+	return func(r *CalicoManager) error {
+		r.githubToken = token
+		return nil
+	}
+}


### PR DESCRIPTION
## Description

This switches to passing in the Github token as a flag. The flag is added to both building and publishing a release so it gets validated earlier (as expected).

The github token flag already has check to ensure it is set in CI.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
