### PR TITLE
[EV-5470] unify logging to logrus in calico-apiserver

### DIFF
--- a/apiserver/cmd/apiserver/apiserver.go
+++ b/apiserver/cmd/apiserver/apiserver.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/cli"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/apiserver/cmd/apiserver/server"
 )
@@ -42,7 +42,7 @@ func main() {
 		string(features.ConsistentListFromCache): false,
 	})
 	if err != nil {
-		klog.Errorf("Error setting feature gates: %v.", err)
+		logrus.Errorf("Error setting feature gates: %v.", err)
 		logs.FlushLogs()
 		os.Exit(1)
 	}
@@ -53,13 +53,13 @@ func main() {
 
 	err = server.Version()
 	if err != nil {
-		klog.Errorf("Error printing version info: %v.", err)
+		logrus.Errorf("Error printing version info: %v.", err)
 		logs.FlushLogs()
 	}
 
 	cmd, _, err := server.NewCommandStartCalicoServer(os.Stdout)
 	if err != nil {
-		klog.Errorf("Error creating server: %v", err)
+		logrus.Errorf("Error creating server: %v", err)
 		logs.FlushLogs()
 		os.Exit(1)
 	}

--- a/apiserver/cmd/apiserver/server/logging.go
+++ b/apiserver/cmd/apiserver/server/logging.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+)
+
+// logrusLevel sets LOG_LEVEL and if not defined will set it based on klog verbosity
+// v=0 --> ERROR
+// v=1 --> WARN
+// v=2 --> INFO
+// v=3-6 --> DEBUG
+// v=7-9 --> TRACE
+func logrusLevel() logrus.Level {
+	if env := os.Getenv("LOG_LEVEL"); env != "" {
+		return logutils.SafeParseLogLevel(env)
+	}
+	if klog.V(0).Enabled() && !klog.V(1).Enabled() {
+		return logrus.ErrorLevel
+	}
+	if klog.V(1).Enabled() && !klog.V(2).Enabled() {
+		return logrus.WarnLevel
+	}
+	if klog.V(2).Enabled() && !klog.V(3).Enabled() {
+		return logrus.InfoLevel
+	}
+	if (klog.V(3).Enabled() || klog.V(4).Enabled() || klog.V(5).Enabled() || klog.V(6).Enabled()) && !klog.V(7).Enabled() {
+		return logrus.DebugLevel
+	}
+
+	// klog.V(7).Enabled() || klog.V(8).Enabled() || klog.V(9).Enabled()
+	return logrus.TraceLevel
+}
+
+// verbosityLevel sets VERBOSITY based on LOG_LEVEL
+// ERROR, FATAL --> v=0
+// WARN --> v=1
+// INFO --> v=2
+// DEBUG --> v=3:6
+// TRACE --> v=7 and above (i.e., show everything)
+func logLevelToVerbosityLevel() string {
+	switch logrus.GetLevel() {
+	case logrus.TraceLevel:
+		return "20"
+	case logrus.DebugLevel:
+		return "6"
+	case logrus.InfoLevel:
+		return "2"
+	case logrus.WarnLevel:
+		return "1"
+	case logrus.ErrorLevel:
+		return "0"
+	case logrus.FatalLevel:
+		return "0"
+	}
+	return "2" // return default "2" for info.
+}
+
+// CustomLogger is a wrapper around logrus to forward klog messages
+type logrusKlog struct {
+	logger *logrus.Entry
+}
+
+func (l logrusKlog) Init(info logr.RuntimeInfo) {
+	l.logger.Logger.SetLevel(logrusLevel())
+}
+
+func (l logrusKlog) Enabled(level int) bool {
+	l.logger.Trace("loglevel: ", logLevelToVerbosityLevel())
+	logLevel, err := strconv.ParseInt(logLevelToVerbosityLevel(), 10, 64)
+	if err != nil {
+		l.logger.Error("failed to parseInt log level verbosity: ", logLevelToVerbosityLevel())
+		return false
+	}
+	return int64(level) == logLevel
+}
+
+func toLogrusFields(keysAndValues ...interface{}) logrus.Fields {
+	fields := logrus.Fields{}
+	for i := 0; i < len(keysAndValues); i += 2 {
+		key := fmt.Sprintf("%v", keysAndValues[i])
+		fields[key] = keysAndValues[i+1]
+	}
+	return fields
+}
+
+func (l logrusKlog) Info(level int, msg string, keysAndValues ...any) {
+	l.logger.WithFields(toLogrusFields(keysAndValues...)).Info(msg)
+}
+
+func (l logrusKlog) Error(err error, msg string, keysAndValues ...any) {
+	l.logger.WithFields(toLogrusFields(keysAndValues...)).WithError(err).Error(msg)
+}
+
+func (l logrusKlog) WithName(name string) logr.LogSink {
+	// do nothing
+	return l
+}
+
+func (l logrusKlog) WithValues(keysAndValues ...any) logr.LogSink {
+	// do nothing
+	return l
+}
+
+func configureLogging() {
+	// set logrus log-level for tigera-apiserver logging
+	logrus.SetLevel(logrusLevel())
+
+	// create a logrus logger to be used by klog
+	logrusLogger := logrus.New().WithField("klog-logger", "tigera-apiserver")
+	logrusLogger.Logger.SetLevel(logrusLevel())
+
+	logrusLoggerWrapper := logrusKlog{logger: logrusLogger}
+
+	klogLogger := logr.New(logrusLoggerWrapper)
+	klog.SetLogger(klogLogger)
+
+	// set klog verbosity for libraries used in tigera-apiserver
+	msg, err := logs.GlogSetter(logLevelToVerbosityLevel())
+	if err != nil {
+		logrus.Errorf("Failed to set glog setter: %v", err)
+	}
+	if err == nil && msg != "" {
+		logrus.Tracef("Successfully set glog setter: %s", msg)
+	}
+}

--- a/apiserver/cmd/apiserver/server/logging_test.go
+++ b/apiserver/cmd/apiserver/server/logging_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"k8s.io/component-base/logs"
+)
+
+func TestLogLevel(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging Suite")
+}
+
+var _ = Describe("", func() {
+	It("test logrus log level calculated with different verbosity values", func() {
+		_, err := logs.GlogSetter("0")
+		Expect(logrusLevel()).To(Equal(logrus.ErrorLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("1")
+		Expect(logrusLevel()).To(Equal(logrus.WarnLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("2")
+		Expect(logrusLevel()).To(Equal(logrus.InfoLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("3")
+		Expect(logrusLevel()).To(Equal(logrus.DebugLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("4")
+		Expect(logrusLevel()).To(Equal(logrus.DebugLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("5")
+		Expect(logrusLevel()).To(Equal(logrus.DebugLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("6")
+		Expect(logrusLevel()).To(Equal(logrus.DebugLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("7")
+		Expect(logrusLevel()).To(Equal(logrus.TraceLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("8")
+		Expect(logrusLevel()).To(Equal(logrus.TraceLevel))
+		Expect(err).To(BeNil())
+
+		_, err = logs.GlogSetter("9")
+		Expect(logrusLevel()).To(Equal(logrus.TraceLevel))
+		Expect(err).To(BeNil())
+	})
+
+	It("test verbosity values calculated from various logrus log level", func() {
+		logrus.SetLevel(logrus.TraceLevel)
+		Expect(logLevelToVerbosityLevel()).To(Equal("20"))
+
+		logrus.SetLevel(logrus.DebugLevel)
+		Expect(logLevelToVerbosityLevel()).To(Equal("6"))
+
+		logrus.SetLevel(logrus.InfoLevel)
+		Expect(logLevelToVerbosityLevel()).To(Equal("2"))
+
+		logrus.SetLevel(logrus.WarnLevel)
+		Expect(logLevelToVerbosityLevel()).To(Equal("1"))
+
+		logrus.SetLevel(logrus.ErrorLevel)
+		Expect(logLevelToVerbosityLevel()).To(Equal("0"))
+
+		logrus.SetLevel(logrus.FatalLevel)
+		Expect(logLevelToVerbosityLevel()).To(Equal("0"))
+	})
+})

--- a/apiserver/cmd/apiserver/server/options.go
+++ b/apiserver/cmd/apiserver/server/options.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/projectcalico/api/pkg/openapi"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
@@ -35,7 +36,6 @@ import (
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/apiserver/pkg/apiserver"
 )
@@ -164,7 +164,7 @@ func (o *CalicoServerOptions) Config() (*apiserver.Config, error) {
 		// [1] https://kubernetes.io/blog/2024/04/24/validating-admission-policy-ga/
 		serverConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()
 		// always warn when auth is disabled, since this should only be used for testing
-		klog.Infof("Authentication and authorization disabled for testing purposes")
+		logrus.Info("Authentication and authorization disabled for testing purposes")
 	}
 
 	if err := o.RecommendedOptions.Audit.ApplyTo(&serverConfig.Config); err != nil {

--- a/apiserver/cmd/apiserver/server/server.go
+++ b/apiserver/cmd/apiserver/server/server.go
@@ -21,36 +21,19 @@ package server
 import (
 	"flag"
 	"io"
-	"os"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/util/interrupt"
 
 	"github.com/projectcalico/calico/apiserver/pkg/apiserver"
-	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 const defaultEtcdPathPrefix = ""
 
-func logrusLevel() logrus.Level {
-	if env := os.Getenv("LOG_LEVEL"); env != "" {
-		return logutils.SafeParseLogLevel(env)
-	}
-
-	if klog.V(2).Enabled() {
-		return logrus.DebugLevel
-	}
-	if klog.V(1).Enabled() {
-		return logrus.InfoLevel
-	}
-	return logrus.ErrorLevel
-}
-
-// NewCommandStartCalicoServer provides a CLI handler for 'start master' command
+// NewCommandStartMaster provides a CLI handler for 'start master' command
 func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, *CalicoServerOptions, error) {
 	//	o := NewCalicoServerOptions(out, errOut)
 
@@ -74,7 +57,7 @@ func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, *CalicoServerOp
 	opts.addFlags(flags)
 
 	cmd.Run = func(c *cobra.Command, args []string) {
-		logrus.SetLevel(logrusLevel())
+		configureLogging()
 
 		h := interrupt.New(nil, func() {
 			close(stopCh)
@@ -86,7 +69,7 @@ func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, *CalicoServerOp
 			}
 			return RunServer(opts, server)
 		}); err != nil {
-			klog.Fatalf("error running server (%s)", err)
+			logrus.Fatalf("error running server (%s)", err)
 			return
 		}
 	}

--- a/apiserver/pkg/registry/projectcalico/authorizer/authorizer.go
+++ b/apiserver/pkg/registry/projectcalico/authorizer/authorizer.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sauth "k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/filters"
-	"k8s.io/klog/v2"
 )
 
 type TierAuthorizer interface {
@@ -39,13 +39,13 @@ func (a *authorizer) AuthorizeTierOperation(
 	tierName string,
 ) error {
 	if a.Authorizer == nil {
-		klog.V(4).Info("No authorizer - allow operation")
+		logrus.Debug("No authorizer - allow operation")
 		return nil
 	}
 
 	attributes, err := filters.GetAuthorizerAttributes(ctx)
 	if err != nil {
-		klog.Errorf("Unable to extract authorizer attributes: %s", err)
+		logrus.Errorf("Unable to extract authorizer attributes: %s", err)
 		return err
 	}
 
@@ -78,7 +78,7 @@ func (a *authorizer) AuthorizeTierOperation(
 			Path:            "/apis/projectcalico.org/v3/tiers/" + tierName,
 		}
 
-		klog.V(4).Infof("Checking authorization using tier resource type (user can get tier)")
+		logrus.Trace("Checking authorization using tier resource type (user can get tier)")
 		logAuthorizerAttributes(attrs)
 		decisionGetTier, _, _ = a.Authorizer.Authorize(context.TODO(), attrs)
 	}()
@@ -111,7 +111,7 @@ func (a *authorizer) AuthorizeTierOperation(
 			Path:            path,
 		}
 
-		klog.V(4).Infof("Checking authorization using tier scoped resource type (policy name match)")
+		logrus.Trace("Checking authorization using tier scoped resource type (policy name match)")
 		logAuthorizerAttributes(attrs)
 		decisionPolicy, _, _ = a.Authorizer.Authorize(context.TODO(), attrs)
 	}()
@@ -132,7 +132,7 @@ func (a *authorizer) AuthorizeTierOperation(
 			Path:            path,
 		}
 
-		klog.V(4).Infof("Checking authorization using tier scoped resource type (tier name match)")
+		logrus.Trace("Checking authorization using tier scoped resource type (tier name match)")
 		logAuthorizerAttributes(attrs)
 		decisionTierWildcard, _, _ = a.Authorizer.Authorize(context.TODO(), attrs)
 	}()
@@ -144,13 +144,13 @@ func (a *authorizer) AuthorizeTierOperation(
 	// then allow the request.
 	if decisionGetTier == k8sauth.DecisionAllow &&
 		(decisionPolicy == k8sauth.DecisionAllow || decisionTierWildcard == k8sauth.DecisionAllow) {
-		klog.Infof("Operation allowed")
+		logrus.Trace("Operation allowed")
 		return nil
 	}
 
 	// Request is forbidden.
 	reason := forbiddenMessage(attributes, "tier", tierName, decisionGetTier)
-	klog.V(4).Infof("Operation on Calico tiered policy is forbidden: %v", reason)
+	logrus.Debugf("Operation on Calico tiered policy is forbidden: %v", reason)
 	return k8serrors.NewForbidden(calico.Resource(attributes.GetResource()), policyName, errors.New(reason))
 }
 
@@ -186,15 +186,15 @@ func forbiddenMessage(attributes k8sauth.Attributes, ownerResource, ownerName st
 
 // logAuthorizerAttributes logs out the auth attributes.
 func logAuthorizerAttributes(requestAttributes k8sauth.Attributes) {
-	if klog.V(4).Enabled() {
-		klog.Infof("Authorizer APIGroup: %s", requestAttributes.GetAPIGroup())
-		klog.Infof("Authorizer APIVersion: %s", requestAttributes.GetAPIVersion())
-		klog.Infof("Authorizer Name: %s", requestAttributes.GetName())
-		klog.Infof("Authorizer Namespace: %s", requestAttributes.GetNamespace())
-		klog.Infof("Authorizer Resource: %s", requestAttributes.GetResource())
-		klog.Infof("Authorizer Subresource: %s", requestAttributes.GetSubresource())
-		klog.Infof("Authorizer User: %s", requestAttributes.GetUser())
-		klog.Infof("Authorizer Verb: %s", requestAttributes.GetVerb())
-		klog.Infof("Authorizer Path: %s", requestAttributes.GetPath())
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		logrus.Debugf("Authorizer APIGroup: %s", requestAttributes.GetAPIGroup())
+		logrus.Debugf("Authorizer APIVersion: %s", requestAttributes.GetAPIVersion())
+		logrus.Debugf("Authorizer Name: %s", requestAttributes.GetName())
+		logrus.Debugf("Authorizer Namespace: %s", requestAttributes.GetNamespace())
+		logrus.Debugf("Authorizer Resource: %s", requestAttributes.GetResource())
+		logrus.Debugf("Authorizer Subresource: %s", requestAttributes.GetSubresource())
+		logrus.Debugf("Authorizer User: %s", requestAttributes.GetUser())
+		logrus.Debugf("Authorizer Verb: %s", requestAttributes.GetVerb())
+		logrus.Debugf("Authorizer Path: %s", requestAttributes.GetPath())
 	}
 }

--- a/apiserver/pkg/registry/projectcalico/server/options.go
+++ b/apiserver/pkg/registry/projectcalico/server/options.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/apiserver/pkg/storage/calico"
 	"github.com/projectcalico/calico/apiserver/pkg/storage/etcd"
@@ -165,7 +165,7 @@ func (o Options) GetStorage(
 			indexers,
 		)
 		if err != nil {
-			klog.Warning("error (%w)", err)
+			logrus.Warning("error (%w)", err)
 			return registry.DryRunnableStorage{}, nil, err
 		}
 		dryRunnableStorage := registry.DryRunnableStorage{Storage: storageInterface, Codec: etcdRESTOpts.StorageConfig.Codec}

--- a/apiserver/pkg/storage/calico/converter.go
+++ b/apiserver/pkg/storage/calico/converter.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage"
-	"k8s.io/klog/v2"
 
 	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
@@ -106,7 +106,7 @@ func convertToAAPI(libcalicoObject runtime.Object) (res runtime.Object) {
 		BlockAffinityConverter{}.convertToAAPI(obj, aapi)
 		return aapi
 	default:
-		klog.Infof("Unrecognized libcalico object (type %v)", reflect.TypeOf(libcalicoObject))
+		logrus.Tracef("Unrecognized libcalico object (type %v)", reflect.TypeOf(libcalicoObject))
 		return nil
 	}
 }

--- a/apiserver/pkg/storage/calico/policy_storage_test.go
+++ b/apiserver/pkg/storage/calico/policy_storage_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/apitesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -24,7 +25,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
-	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -385,7 +385,7 @@ func TestNetworkPolicyGuaranteedUpdate(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		klog.Infof("Start to run test on tt: %+v", tt)
+		logrus.Infof("Start to run test on tt: %+v", tt)
 		out := &v3.NetworkPolicy{}
 		selector := fmt.Sprintf("my_label == \"foo-%d\"", i)
 		if tt.expectNoUpdate {
@@ -616,18 +616,18 @@ func testSetup(t *testing.T) (context.Context, *resourceStore, *resourceStore) {
 	codec := apitesting.TestCodec(codecs, v3.SchemeGroupVersion)
 	cfg, err := apiconfig.LoadClientConfig("")
 	if err != nil {
-		klog.Errorf("Failed to load client config: %q", err)
+		logrus.Errorf("Failed to load client config: %q", err)
 		os.Exit(1)
 	}
 	cfg.Spec.DatastoreType = "etcdv3"
 	cfg.Spec.EtcdEndpoints = "http://localhost:2379"
 	c, err := clientv3.New(*cfg)
 	if err != nil {
-		klog.Errorf("Failed creating client: %q", err)
+		logrus.Errorf("Failed creating client: %q", err)
 		os.Exit(1)
 	}
 
-	klog.Infof("Client: %v", c)
+	logrus.Infof("Client: %v", c)
 	opts := Options{
 		RESTOptions: generic.RESTOptions{
 			StorageConfig: &storagebackend.ConfigForResource{

--- a/apiserver/pkg/storage/calico/storage_interface.go
+++ b/apiserver/pkg/storage/calico/storage_interface.go
@@ -3,14 +3,14 @@
 package calico
 
 import (
+	"github.com/sirupsen/logrus"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
-	"k8s.io/klog/v2"
 )
 
 // NewStorage creates a new libcalico-based storage.Interface implementation
 func NewStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc) {
-	klog.V(4).Infoln("Constructing Calico Storage")
+	logrus.Debug("Constructing Calico Storage")
 
 	switch opts.RESTOptions.ResourcePrefix {
 	case "projectcalico.org/networkpolicies":
@@ -50,7 +50,7 @@ func NewStorage(opts Options) (registry.DryRunnableStorage, factory.DestroyFunc)
 	case "projectcalico.org/blockaffinities":
 		return NewBlockAffinityStorage(opts)
 	default:
-		klog.Fatalf("Unable to create storage for resource %v", opts.RESTOptions.ResourcePrefix)
+		logrus.Fatalf("Unable to create storage for resource %v", opts.RESTOptions.ResourcePrefix)
 		return registry.DryRunnableStorage{}, nil
 	}
 }

--- a/apiserver/pkg/storage/calico/tier_storage_test.go
+++ b/apiserver/pkg/storage/calico/tier_storage_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	apitesting "k8s.io/apimachinery/pkg/api/apitesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
-	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -348,7 +348,7 @@ func TestTierGuaranteedUpdate(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		klog.Infof("Start to run test on tt: %+v", tt)
+		logrus.Infof("Start to run test on tt: %+v", tt)
 		out := &v3.Tier{}
 		selector := fmt.Sprintf("foo-%d", i)
 		if tt.expectNoUpdate {
@@ -597,17 +597,17 @@ func testTierSetup(t *testing.T) (context.Context, *resourceStore) {
 	codec := apitesting.TestCodec(codecs, v3.SchemeGroupVersion)
 	cfg, err := apiconfig.LoadClientConfig("")
 	if err != nil {
-		klog.Errorf("Failed to load client config: %q", err)
+		logrus.Errorf("Failed to load client config: %q", err)
 		os.Exit(1)
 	}
 	cfg.Spec.DatastoreType = "etcdv3"
 	cfg.Spec.EtcdEndpoints = "http://localhost:2379"
 	c, err := clientv3.New(*cfg)
 	if err != nil {
-		klog.Errorf("Failed creating client: %q", err)
+		logrus.Errorf("Failed creating client: %q", err)
 		os.Exit(1)
 	}
-	klog.Infof("Client: %v", c)
+	logrus.Tracef("Client: %v", c)
 
 	opts := Options{
 		RESTOptions: generic.RESTOptions{

--- a/apiserver/test/integration/framework.go
+++ b/apiserver/test/integration/framework.go
@@ -26,11 +26,11 @@ import (
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	calicoclient "github.com/projectcalico/api/pkg/client/clientset_generated/clientset"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
 
 	"github.com/projectcalico/calico/apiserver/cmd/apiserver/server"
 	"github.com/projectcalico/calico/apiserver/pkg/apiserver"
@@ -136,14 +136,14 @@ func waitForApiserverUp(serverURL string, stopCh <-chan struct{}) error {
 			case <-stopCh:
 				return true, fmt.Errorf("apiserver failed")
 			default:
-				klog.Infof("Waiting for : %#v", serverURL)
+				logrus.Infof("Waiting for : %#v", serverURL)
 				tr := &http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 				}
 				c := &http.Client{Transport: tr}
 				_, err := c.Get(serverURL)
 				if err == nil {
-					klog.Infof("Found server after %v tries and duration %v",
+					logrus.Tracef("Found server after %v tries and duration %v",
 						tries, time.Since(startWaiting))
 					return true, nil
 				}

--- a/apiserver/test/util/util.go
+++ b/apiserver/test/util/util.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	calicoclient "github.com/projectcalico/api/pkg/client/clientset_generated/clientset/typed/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 )
 
 // WaitForGlobalNetworkPoliciesToNotExist waits for the GlobalNetworkPolicy with the given name to no
@@ -30,7 +30,7 @@ import (
 func WaitForGlobalNetworkPoliciesToNotExist(client calicoclient.ProjectcalicoV3Interface, name string) error {
 	return wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true,
 		func(ctx context.Context) (bool, error) {
-			klog.V(5).Infof("Waiting for broker %v to not exist", name)
+			logrus.Tracef("Waiting for broker %v to not exist", name)
 			_, err := client.GlobalNetworkPolicies().Get(ctx, name, metav1.GetOptions{})
 			if nil == err {
 				return false, nil
@@ -50,7 +50,7 @@ func WaitForGlobalNetworkPoliciesToNotExist(client calicoclient.ProjectcalicoV3I
 func WaitForGlobalNetworkPoliciesToExist(client calicoclient.ProjectcalicoV3Interface, name string) error {
 	return wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true,
 		func(ctx context.Context) (bool, error) {
-			klog.V(5).Infof("Waiting for serviceClass %v to exist", name)
+			logrus.Tracef("Waiting for serviceClass %v to exist", name)
 			_, err := client.GlobalNetworkPolicies().Get(context.Background(), name, metav1.GetOptions{})
 			if nil == err {
 				return true, nil
@@ -66,7 +66,7 @@ func WaitForGlobalNetworkPoliciesToExist(client calicoclient.ProjectcalicoV3Inte
 func WaitForTierToNotExist(client calicoclient.ProjectcalicoV3Interface, name string) error {
 	return wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true,
 		func(ctx context.Context) (bool, error) {
-			klog.V(5).Infof("Waiting for serviceClass %v to not exist", name)
+			logrus.Tracef("Waiting for serviceClass %v to not exist", name)
 			_, err := client.Tiers().Get(ctx, name, metav1.GetOptions{})
 			if nil == err {
 				return false, nil
@@ -86,7 +86,7 @@ func WaitForTierToNotExist(client calicoclient.ProjectcalicoV3Interface, name st
 func WaitForTierToExist(client calicoclient.ProjectcalicoV3Interface, name string) error {
 	return wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true,
 		func(ctx context.Context) (bool, error) {
-			klog.V(5).Infof("Waiting for serviceClass %v to exist", name)
+			logrus.Tracef("Waiting for serviceClass %v to exist", name)
 			_, err := client.Tiers().Get(ctx, name, metav1.GetOptions{})
 			if nil == err {
 				return true, nil


### PR DESCRIPTION
1. change all logging statements inside calico-apiserver code base to use logrus.
used within calico-apiserver will log with logrus.
3. fix some log levels to better reflect of the log severity.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Unify all logging to logrus for consistency in logging across all components which also enables controlling what is logged via only one parameter `LOG_LEVEL`
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
