### PR TITLE
[release-tool] refactor update branch command and manager

### DIFF
--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
 
 	"github.com/projectcalico/calico/release/internal/utils"
@@ -53,7 +52,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				skipValidationFlag,
 			},
 			Action: func(c *cli.Context) error {
-				configureLogging("cut-branch.log")
+				configureLogging("branch-cut.log")
 
 				m := branch.NewManager(
 					branch.WithRepoRoot(cfg.RepoRootDir),
@@ -79,12 +78,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				skipValidationFlag,
 			),
 			Action: func(c *cli.Context) error {
-				configureLogging("cut-operator-branch.log")
-
-				// Warn if the new branch is not the default base branch
-				if c.String(newBranchFlag.Name) != newBranchFlag.Value {
-					logrus.Warnf("The new branch will be created from %s which is not the default branch %s", c.String(newBranchFlag.Name), newBranchFlag.Value)
-				}
+				configureLogging("branch-cut-operator.log")
 
 				// Clone the operator repository
 				operatorDir := filepath.Join(cfg.TmpDir, operator.DefaultRepoName)

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -98,6 +98,13 @@ var (
 		Name:    "base-branch",
 		Usage:   "The base branch to cut the release branch from",
 		EnvVars: []string{"RELEASE_BRANCH_BASE"},
+		Value:   utils.DefaultBranch,
+		Action: func(c *cli.Context, str string) error {
+			if str != utils.DefaultBranch {
+				logrus.Warnf("The new branch will be created from %s which is not the default branch %s", str, utils.DefaultBranch)
+			}
+			return nil
+		},
 	}
 )
 
@@ -216,6 +223,13 @@ var (
 		Name:    operatorBranchFlag.Name,
 		Usage:   "The base branch to cut the Tigera operator release branch from",
 		EnvVars: []string{"OPERATOR_BRANCH_BASE"},
+		Value:   operator.DefaultBranchName,
+		Action: func(c *cli.Context, str string) error {
+			if str != operator.DefaultBranchName {
+				logrus.Warnf("The new branch will be created from %s which is not the default branch %s", str, operator.DefaultBranchName)
+			}
+			return nil
+		},
 	}
 
 	// Container image flags

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -100,15 +100,34 @@ func (v *Version) Milestone() string {
 	return fmt.Sprintf("%s v%d.%d.%d", utils.DisplayProductName(), ver.Major(), ver.Minor(), ver.Patch())
 }
 
-// Stream returns the "release stream" of the version, i.e., the major and minor version without the patch version.
+// Stream returns the "release stream" of the version
+// typically it is the major and minor version without the patch version.
+// For example, for version "v3.15.0", the stream is "v3.15".
+// For EP 1, appends "-1" to the stream.
 func (v *Version) Stream() string {
 	ver := semver.MustParse(string(*v))
-	return fmt.Sprintf("v%d.%d", ver.Major(), ver.Minor())
+	stream := fmt.Sprintf("v%d.%d", ver.Major(), ver.Minor())
+	if ver.Prerelease() != "" && strings.HasPrefix(ver.Prerelease(), "1.") {
+		return fmt.Sprintf("%s-1", stream)
+	}
+	return stream
 }
 
 func (v *Version) Semver() *semver.Version {
 	ver := semver.MustParse(string(*v))
 	return ver
+}
+
+// NextBranchVersion returns version of the next branch.
+// If the version is a EP1 version, then return EP2.
+// Otherwise, increment the minor version.
+func (v *Version) NextBranchVersion() Version {
+	ver := v.Semver()
+	if ver.Prerelease() != "" && strings.HasPrefix(ver.Prerelease(), "1.") {
+		return New(fmt.Sprintf("v%d.%d.0-2.0", ver.Major(), ver.Minor()))
+	}
+	nextVer := ver.IncMinor()
+	return New(nextVer.String())
 }
 
 // GitVersion returns the current git version of the directory as a Version object.
@@ -123,30 +142,38 @@ func GitVersion() Version {
 }
 
 // HasDevTag returns true if the version has the given dev tag suffix.
-// The dev tag suffix is expected to be in the format "vX.Y.Z-<devTagSuffix>-N-gCOMMIT" or "vX.Y.Z-<devTagSuffix>-N-gCOMMIT-dirty".
+// The dev tag suffix is expected to be in one of the following formats:
+//   - vX.Y.Z-<devTagSuffix>-N-gCOMMIT
+//   - vX.Y.Z-<devTagSuffix>-N-gCOMMIT-dirty
+//   - vX.Y.Z-A.B-<devTagSuffix>-N-gCOMMIT
+//   - vX.Y.Z-A.B-<devTagSuffix>-N-gCOMMIT-dirty
+//
+// where vX.Y.Z is the semver version, <devTagSuffix> is the dev tag suffix, N is the number of commits since the tag,
+// A.B is the EP version, and COMMIT is the git commit hash abbreviated to 12 characters (e.g., 1a2b3c4d5e67).
+// The "dirty" suffix indicates that the working directory is dirty.
 func HasDevTag(v Version, devTagSuffix string) bool {
 	devTagSuffix = strings.TrimPrefix(devTagSuffix, "-")
-	re := regexp.MustCompile(fmt.Sprintf(`^v\d+\.\d+\.\d+-%s-\d+-g[0-9a-f]{12}(-dirty)?$`, devTagSuffix))
+	re := regexp.MustCompile(fmt.Sprintf(`^v\d+\.\d+\.\d+(-\d+\.\d+)?-%s-\d+-g[0-9a-f]{12}(-dirty)?$`, devTagSuffix))
 	return re.MatchString(string(v))
 }
 
 // DetermineReleaseVersion uses historical clues to figure out the next semver
 // release number to use for this release based on the current git revision.
-//
-// OSS Calico uses the following rules:
-// - If the current git revision is a "vX.Y.Z-0.dev-N-gCOMMIT" tag, then the next release version is simply vX.Y.Z.
-// - If the current git revision is a patch release (e.g., vX.Y.Z-N-gCOMMIT), then the next release version is vX.Y.Z+1.
+// - If the current git revision is a "vX.Y.Z-<devTagSuffix>-N-gCOMMIT" tag, then the next release version is simply vX.Y.Z.
+// - If the current git revision is a patch release with no dev tag (e.g., vX.Y.Z-N-gCOMMIT), then the next release version is vX.Y.Z+1.
+// - If the current git revision is a patch release with a dev tag (e.g., vX.Y.Z-<devTagSuffix>-N-gCOMMIT), then the next release version is vX.Y.Z.
 func DetermineReleaseVersion(v Version, devTagSuffix string) (Version, error) {
 	gitVersion := v.FormattedString()
 
 	// There are two types of tag that this might be - either it was a previous patch release,
-	// or it was a "vX.Y.Z-0.dev" tag produced when cutting the release branch.
+	// or it was a "vX.Y.Z-<devTagSuffix>" tag produced when cutting the release branch.
 	if HasDevTag(v, devTagSuffix) {
 		// This is the first release from this branch - we can simply extract the version from
 		// the dev tag.
 		if !strings.HasPrefix(devTagSuffix, "-") {
 			// The dev tag marker should start with a hyphen.
-			// For example in "v3.15.0-0.dev-1-g1234567", we want to split on the "-0.dev" part.
+			// For example in "v3.15.0-0.dev-1-g1a2b3c4d5e67" with devTagSuffix "0.dev",
+			// we want to split on the "-0.dev" part and return "v3.15.0".
 			devTagSuffix = "-" + devTagSuffix
 		}
 		return New(strings.Split(gitVersion, devTagSuffix)[0]), nil


### PR DESCRIPTION
## Description

This update the `branch` subcommands and branch manager.

As an extension, version package is also updated to support EPs and allow avoiding conflicts in closed source.

## Related issues/PRs

- split from #9563 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
