### PR TITLE
 [cherrypick 3.29] use fedora archives url for iptables src rpm (#9617)

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -34,7 +34,7 @@ ARG RUNIT_VER
 ARG CENTOS_MIRROR_BASE_URL=https://linuxsoft.cern.ch/cern/centos/s9
 ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/libnftnl-${LIBNFTNL_VER}.el9.src.rpm
 ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/iptables-${IPTABLES_VER}.el9.src.rpm
-ARG IPTABLES_LEGACY_SOURCERPM_URL=https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/x86_64/getPackageSource/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
+ARG IPTABLES_LEGACY_SOURCERPM_URL=https://archives.fedoraproject.org/pub/archive/epel/9.3/Everything/source/tree/Packages/i/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
 ARG IPSET_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -40,7 +40,7 @@ ARG RUNIT_VER
 ARG CENTOS_MIRROR_BASE_URL=https://linuxsoft.cern.ch/cern/centos/s9
 ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/libnftnl-${LIBNFTNL_VER}.el9.src.rpm
 ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/iptables-${IPTABLES_VER}.el9.src.rpm
-ARG IPTABLES_LEGACY_SOURCERPM_URL=https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/aarch64/getPackageSource/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
+ARG IPTABLES_LEGACY_SOURCERPM_URL=https://archives.fedoraproject.org/pub/archive/epel/9.3/Everything/source/tree/Packages/i/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
 ARG IPSET_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.


### PR DESCRIPTION
## Description

Cherry pick docker build fix b88f57168d90ae58fc499be988d828c1495df5f1 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
