### PR TITLE
[BPF] clean up the right progs when ebpf is disabled

### DIFF
--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -47,6 +47,8 @@ const (
 	ProgIndexCTLBConnectV6 = iota
 	ProgIndexCTLBSendV6
 	ProgIndexCTLBRecvV6
+
+	ProgNamePrefix = "calico_"
 )
 
 var ctlbProgToIndex = map[string]int{
@@ -96,7 +98,7 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 	}
 
 	for _, p := range progs {
-		if !strings.HasPrefix(p.Name, "cali_") {
+		if !strings.HasPrefix(p.Name, ProgNamePrefix) {
 			continue
 		}
 
@@ -164,7 +166,7 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 	progPinDir := path.Join(bpfMount, "calico_connect4")
 	_ = os.RemoveAll(progPinDir)
 
-	progName := "calico_" + name + "_v" + ipver
+	progName := ProgNamePrefix + name + "_v" + ipver
 
 	// N.B. no need to remember the link since we are never going to detach
 	// these programs unless Felix restarts.


### PR DESCRIPTION
## Description

fixes https://github.com/projectcalico/calico/issues/9620

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: remove ctlb programs when ebpf is disabled
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
