### PR TITLE
[release tool] refactor generating hashrelease and release

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -33,9 +32,9 @@ import (
 	"github.com/projectcalico/calico/release/pkg/tasks"
 )
 
-func hashreleaseOutputDir(repoRootDir, hash string) string {
+func baseHashreleaseOutputDir(repoRootDir string) string {
 	baseOutputDir := filepath.Join(append([]string{repoRootDir}, releaseOutputPath...)...)
-	return filepath.Join(baseOutputDir, "hashrelease", hash)
+	return filepath.Join(baseOutputDir, "hashrelease")
 }
 
 // hashreleaseCommand is used to build and publish hashreleases,
@@ -55,7 +54,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 		// The build command is used to produce a new local hashrelease in the output directory.
 		{
 			Name:  "build",
-			Usage: "Build a hashrelease locally in _output/",
+			Usage: "Build a hashrelease locally",
 			Flags: hashreleaseBuildFlags(),
 			Action: func(c *cli.Context) error {
 				configureLogging("hashrelease-build.log")
@@ -72,6 +71,9 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					return fmt.Errorf("failed to clone operator repository: %v", err)
 				}
 
+				// Define the base hashrelease directory.
+				baseHashreleaseDir := baseHashreleaseOutputDir(cfg.RepoRootDir)
+
 				// Create the pinned config.
 				pinned := pinnedversion.CalicoPinnedVersions{
 					Dir:                 cfg.TmpDir,
@@ -83,17 +85,11 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 						Branch:   c.String(operatorBranchFlag.Name),
 						Dir:      operatorDir,
 					},
+					BaseHashreleaseDir: baseHashreleaseDir,
 				}
-
 				data, err := pinned.GenerateFile()
 				if err != nil {
 					return fmt.Errorf("failed to generate pinned version file: %v", err)
-				}
-
-				// Create the output directory for the hashrelease.
-				dir := hashreleaseOutputDir(cfg.RepoRootDir, data.Hash())
-				if err := os.MkdirAll(dir, utils.DirPerms); err != nil {
-					return fmt.Errorf("failed to create hashrelease output directory: %v", err)
 				}
 
 				// Check if the hashrelease has already been published.
@@ -128,6 +124,9 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					}
 				}
 
+				// Define the hashrelease directory using the hash from the pinned file.
+				hashreleaseDir := filepath.Join(baseHashreleaseDir, data.Hash())
+
 				// Configure a release builder using the generated versions, and use it
 				// to build a Calico release.
 				pinnedOpts, err := pinned.ManagerOptions()
@@ -138,7 +137,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.IsHashRelease(),
-					calico.WithOutputDir(dir),
+					calico.WithOutputDir(hashreleaseDir),
 					calico.WithBuildImages(c.Bool(buildHashreleaseImageFlag.Name)),
 					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
@@ -162,19 +161,23 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if err != nil {
 					return fmt.Errorf("failed to determine release version: %v", err)
 				}
-				if _, err := outputs.ReleaseNotes(utils.ProjectCalicoOrg, c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(dir, releaseNotesDir), releaseVersion); err != nil {
-					return err
+				if c.String(orgFlag.Name) == utils.TigeraOrg {
+					logrus.Warn("Release notes are not supported for Tigera releases, skipping...")
+				} else {
+					if _, err := outputs.ReleaseNotes(utils.ProjectCalicoOrg, c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(hashreleaseDir, releaseNotesDir), releaseVersion); err != nil {
+						return err
+					}
 				}
 
 				// Adjsut the formatting of the generated outputs to match the legacy hashrelease format.
-				return tasks.ReformatHashrelease(dir, cfg.TmpDir)
+				return tasks.ReformatHashrelease(hashreleaseDir, cfg.TmpDir)
 			},
 		},
 
 		// The publish command is used to publish a locally built hashrelease to the hashrelease server.
 		{
 			Name:  "publish",
-			Usage: "Publish hashrelease from _output/ to hashrelease server",
+			Usage: "Publish a pre-built hashrelease",
 			Flags: hashreleasePublishFlags(),
 			Action: func(c *cli.Context) error {
 				configureLogging("hashrelease-publish.log")
@@ -185,7 +188,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				// Extract the pinned version as a hashrelease.
-				hashrel, err := pinnedversion.LoadHashrelease(cfg.RepoRootDir, cfg.TmpDir, hashreleaseOutputDir(cfg.RepoRootDir, ""), c.Bool(latestFlag.Name))
+				hashrel, err := pinnedversion.LoadHashrelease(cfg.RepoRootDir, cfg.TmpDir, baseHashreleaseOutputDir(cfg.RepoRootDir), c.Bool(latestFlag.Name))
 				if err != nil {
 					return fmt.Errorf("failed to load hashrelease from pinned file: %v", err)
 				}

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -85,7 +85,6 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 						Branch:   c.String(operatorBranchFlag.Name),
 						Dir:      operatorDir,
 					},
-					BaseHashreleaseDir: baseHashreleaseDir,
 				}
 				data, err := pinned.GenerateFile()
 				if err != nil {

--- a/release/cmd/main.go
+++ b/release/cmd/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	app := &cli.App{
 		Name:     "release",
-		Usage:    fmt.Sprintf("a tool for building %s releases", utils.DisplayProductName()),
+		Usage:    "a tool for building releases",
 		Flags:    globalFlags,
 		Commands: Commands(cfg),
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -31,12 +31,12 @@ func releaseOutputDir(repoRootDir, version string) string {
 	return filepath.Join(baseOutputDir, "upload", version)
 }
 
-// The release command suite is used to build and publish official Calico releases.
+// The release command suite is used to build and publish official releases.
 func releaseCommand(cfg *Config) *cli.Command {
 	return &cli.Command{
 		Name:        "release",
 		Aliases:     []string{"rel"},
-		Usage:       "Build and publish official Calico releases.",
+		Usage:       "Build and publish official releases.",
 		Subcommands: releaseSubCommands(cfg),
 	}
 }
@@ -72,7 +72,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 		// Build a release.
 		{
 			Name:  "build",
-			Usage: "Build an official Calico release",
+			Usage: "Build an official release",
 			Flags: releaseBuildFlags(),
 			Action: func(c *cli.Context) error {
 				configureLogging("release-build.log")
@@ -114,7 +114,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 		// Publish a release.
 		{
 			Name:  "publish",
-			Usage: "Publish a pre-built Calico release",
+			Usage: "Publish a pre-built release",
 			Flags: releasePublishFlags(),
 			Action: func(c *cli.Context) error {
 				configureLogging("release-publish.log")

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -50,6 +50,9 @@ type Hashrelease struct {
 	// Stream is the version the hashrelease is for (e.g master, v3.19)
 	Stream string
 
+	// Product is the product in the hashrelease
+	Product string
+
 	// ProductVersion is the product version in the hashrelease
 	ProductVersion string
 

--- a/release/internal/imagescanner/scanner.go
+++ b/release/internal/imagescanner/scanner.go
@@ -24,8 +24,6 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/projectcalico/calico/release/internal/utils"
 )
 
 const (
@@ -61,7 +59,7 @@ func New(cfg Config) *Scanner {
 }
 
 // Scan sends a request to the image scanner to scan the given images for the given product code and stream.
-func (i *Scanner) Scan(images []string, stream string, release bool, outputDir string) error {
+func (i *Scanner) Scan(productCode string, images []string, stream string, release bool, outputDir string) error {
 	var bucketPath, scanType string
 	if release {
 		scanType = "release"
@@ -89,7 +87,7 @@ func (i *Scanner) Scan(images []string, stream string, release bool, outputDir s
 	query := req.URL.Query()
 	query.Add("scan_type", scanType)
 	query.Add("scanner_select", i.config.Scanner)
-	query.Add("project_name", utils.CalicoProductCode)
+	query.Add("project_name", productCode)
 	query.Add("project_version", stream)
 	req.URL.RawQuery = query.Encode()
 	logrus.WithFields(logrus.Fields{

--- a/release/internal/outputs/releasenotes.go
+++ b/release/internal/outputs/releasenotes.go
@@ -197,7 +197,7 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 		outputDir = "."
 	}
 	logrus.Infof("Generating release notes for %s", ver.FormattedString())
-	milestone := ver.Milestone()
+	milestone := ver.Milestone(utils.CalicoProductName())
 	githubClient := github.NewTokenClient(context.Background(), githubToken)
 	releaseNoteDataList := []*ReleaseNoteIssueData{}
 	opts := &github.MilestoneListOptions{

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -38,8 +38,8 @@ import (
 var calicoTemplate string
 
 const (
-	pinnedVersionFileName      = "pinned-version.yaml"
-	operatorComponentsFileName = "components.yaml"
+	pinnedVersionFileName      = "pinned_version.yml"
+	operatorComponentsFileName = "pinned_components.yml"
 )
 
 var noImageComponents = []string{
@@ -114,6 +114,9 @@ type CalicoPinnedVersions struct {
 	// Dir is the directory to store the pinned version file.
 	Dir string
 
+	// BaseHashreleaseDir is the release artifacts directory to also store the generated file.
+	BaseHashreleaseDir string
+
 	// ReleaseBranchPrefix is the prefix for the release branch.
 	ReleaseBranchPrefix string
 
@@ -173,6 +176,16 @@ func (p *CalicoPinnedVersions) GenerateFile() (version.Data, error) {
 		return nil, err
 	}
 
+	if p.BaseHashreleaseDir != "" {
+		hashreleaseDir := filepath.Join(p.BaseHashreleaseDir, versionData.Hash())
+		if err := os.MkdirAll(hashreleaseDir, utils.DirPerms); err != nil {
+			return nil, err
+		}
+		if err := utils.CopyFile(pinnedVersionPath, filepath.Join(hashreleaseDir, pinnedVersionFileName)); err != nil {
+			return nil, err
+		}
+	}
+
 	return versionData, nil
 }
 
@@ -211,13 +224,14 @@ func (p *CalicoPinnedVersions) ManagerOptions() ([]calico.Option, error) {
 }
 
 // GenerateOperatorComponents generates the components-version.yaml for operator.
-func GenerateOperatorComponents(outputDir string) (registry.OperatorComponent, string, error) {
+// It also copies the generated file to the output directory if provided.
+func GenerateOperatorComponents(srcDir, outputDir string) (registry.OperatorComponent, string, error) {
 	op := registry.OperatorComponent{}
-	pinnedVersion, err := retrievePinnedVersion(outputDir)
+	pinnedVersion, err := retrievePinnedVersion(srcDir)
 	if err != nil {
 		return op, "", err
 	}
-	operatorComponentsFilePath := filepath.Join(outputDir, operatorComponentsFileName)
+	operatorComponentsFilePath := filepath.Join(srcDir, operatorComponentsFileName)
 	operatorComponentsFile, err := os.Create(operatorComponentsFilePath)
 	if err != nil {
 		return op, "", err
@@ -225,6 +239,11 @@ func GenerateOperatorComponents(outputDir string) (registry.OperatorComponent, s
 	defer operatorComponentsFile.Close()
 	if err = yaml.NewEncoder(operatorComponentsFile).Encode(pinnedVersion); err != nil {
 		return op, "", err
+	}
+	if outputDir != "" {
+		if err := utils.CopyFile(operatorComponentsFilePath, filepath.Join(outputDir, "pinned_components.yml")); err != nil {
+			return op, "", err
+		}
 	}
 	op.Component = pinnedVersion.TigeraOperator
 	return op, operatorComponentsFilePath, nil
@@ -268,6 +287,7 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 		Name:            pinnedVersion.ReleaseName,
 		Hash:            pinnedVersion.Hash,
 		Note:            pinnedVersion.Note,
+		Product:         utils.CalicoProductName(),
 		Stream:          version.DeterminePublishStream(productBranch, pinnedVersion.Title),
 		ProductVersion:  pinnedVersion.Title,
 		OperatorVersion: pinnedVersion.TigeraOperator.Version,

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -241,7 +241,7 @@ func GenerateOperatorComponents(srcDir, outputDir string) (registry.OperatorComp
 		return op, "", err
 	}
 	if outputDir != "" {
-		if err := utils.CopyFile(operatorComponentsFilePath, filepath.Join(outputDir, "pinned_components.yml")); err != nil {
+		if err := utils.CopyFile(operatorComponentsFilePath, filepath.Join(outputDir, operatorComponentsFileName)); err != nil {
 			return op, "", err
 		}
 	}

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -39,8 +39,8 @@ const (
 	TigeraOrg = "tigera"
 )
 
-// DisplayProductName returns the product name in title case.
-func DisplayProductName() string {
+// CalicoProductName returns the calico product name in title case.
+func CalicoProductName() string {
 	return cases.Title(language.English).String(Calico)
 }
 

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -95,9 +95,9 @@ func (v *Version) FormattedString() string {
 }
 
 // Milestone returns the GitHub milestone name which corresponds with this version.
-func (v *Version) Milestone() string {
+func (v *Version) Milestone(prefix string) string {
 	ver := semver.MustParse(string(*v))
-	return fmt.Sprintf("%s v%d.%d.%d", utils.DisplayProductName(), ver.Major(), ver.Minor(), ver.Patch())
+	return fmt.Sprintf("%s v%d.%d.%d", prefix, ver.Major(), ver.Minor(), ver.Patch())
 }
 
 // Stream returns the "release stream" of the version.

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -96,6 +96,9 @@ func (v *Version) FormattedString() string {
 
 // Milestone returns the GitHub milestone name which corresponds with this version.
 func (v *Version) Milestone(prefix string) string {
+	if prefix == "" {
+		prefix = utils.CalicoProductName()
+	}
 	ver := semver.MustParse(string(*v))
 	return fmt.Sprintf("%s v%d.%d.%d", prefix, ver.Major(), ver.Minor(), ver.Patch())
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -448,7 +448,9 @@ func (r *CalicoManager) ModifyHelmChartsValues() error {
 
 func (r *CalicoManager) BuildHelm() error {
 	if r.isHashRelease {
-		r.ModifyHelmChartsValues()
+		if err := r.ModifyHelmChartsValues(); err != nil {
+			return fmt.Errorf("failed to modify helm chart values: %s", err)
+		}
 	}
 
 	// Build the helm chart, passing the version to use.

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -389,10 +389,8 @@ func (r *CalicoManager) PreReleaseValidate(ver string) error {
 	}
 
 	// Check that code generation is up-to-date.
-	for _, target := range []string{"generate", "get-operator-crds", "check-dirty"} {
-		if err := r.makeInDirectoryWithNoOutput(r.repoRoot, target); err != nil {
-			return fmt.Errorf("code generation error (try 'make generate' and/or 'make get-operator-crds' ?): %s", err)
-		}
+	if err := r.makeInDirectoryWithNoOutput(r.repoRoot, "generate get-operator-crds check-dirty"); err != nil {
+		return fmt.Errorf("code generation error (try 'make generate' and/or 'make get-operator-crds' ?): %s", err)
 	}
 
 	// Assert that manifests are using the correct version.

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -93,6 +93,7 @@ func NewManager(opts ...Option) *CalicoManager {
 	// Configure defaults here.
 	b := &CalicoManager{
 		runner:          &command.RealCommandRunner{},
+		productCode:     utils.CalicoProductCode,
 		validate:        true,
 		buildImages:     true,
 		publishImages:   true,
@@ -141,6 +142,9 @@ func NewManager(opts ...Option) *CalicoManager {
 type CalicoManager struct {
 	// Allow specification of command runner so it can be overridden in tests.
 	runner command.CommandRunner
+
+	// The product code for the release.
+	productCode string
 
 	// The abs path of the root of the repository.
 	repoRoot string
@@ -216,7 +220,7 @@ func releaseImages(version, operatorVersion string) []string {
 	return imgList
 }
 
-func (r *CalicoManager) helmChartVersion() string {
+func (r *CalicoManager) HelmChartVersion() string {
 	return r.calicoVersion
 }
 
@@ -285,7 +289,7 @@ func (r *CalicoManager) Build() error {
 		env := append(os.Environ(), fmt.Sprintf("VERSION=%s", ver))
 		targets := []string{"release-windows-archive", "dist/install-calico-windows.ps1"}
 		for _, target := range targets {
-			if _, err = r.runner.RunInDir(r.repoRoot, "make", []string{"-C", "node", target}, env); err != nil {
+			if err = r.makeInDirectoryWithNoOutput(filepath.Join(r.repoRoot, "node"), target, env...); err != nil {
 				return fmt.Errorf("error building target %s: %s", target, err)
 			}
 		}
@@ -314,7 +318,7 @@ func (r *CalicoManager) BuildMetadata(dir string) error {
 		Version:          r.calicoVersion,
 		OperatorVersion:  r.operatorVersion,
 		Images:           releaseImages(r.calicoVersion, r.operatorVersion),
-		HelmChartVersion: r.helmChartVersion(),
+		HelmChartVersion: r.HelmChartVersion(),
 	}
 
 	// Render it as yaml and write it to a file.
@@ -385,8 +389,10 @@ func (r *CalicoManager) PreReleaseValidate(ver string) error {
 	}
 
 	// Check that code generation is up-to-date.
-	if _, err := r.runner.RunInDir(r.repoRoot, "make", []string{"generate", "get-operator-crds", "check-dirty"}, nil); err != nil {
-		return fmt.Errorf("code generation error (try 'make generate' and/or 'make get-operator-crds' ?): %s", err)
+	for _, target := range []string{"generate", "get-operator-crds", "check-dirty"} {
+		if err := r.makeInDirectoryWithNoOutput(r.repoRoot, target); err != nil {
+			return fmt.Errorf("code generation error (try 'make generate' and/or 'make get-operator-crds' ?): %s", err)
+		}
 	}
 
 	// Assert that manifests are using the correct version.
@@ -425,23 +431,29 @@ func (r *CalicoManager) TagRelease(ver string) error {
 	return nil
 }
 
+// ModifyHelmChartsValues modifies values in helm charts to use the correct version.
+// This is only necessary for hashreleases.
+func (r *CalicoManager) ModifyHelmChartsValues() error {
+	valuesYAML := filepath.Join(r.repoRoot, "charts", "tigera-operator", "values.yaml")
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.operatorVersion), valuesYAML}, nil); err != nil {
+		logrus.WithError(err).Error("Failed to update operator version in values.yaml")
+		return err
+	}
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, r.calicoVersion), valuesYAML}, nil); err != nil {
+		logrus.WithError(err).Error("Failed to update calicoctl version in values.yaml")
+		return err
+	}
+	return nil
+}
+
 func (r *CalicoManager) BuildHelm() error {
 	if r.isHashRelease {
-		// We need to modify values.yaml to use the correct version.
-		valuesYAML := filepath.Join(r.repoRoot, "charts", "tigera-operator", "values.yaml")
-		if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.operatorVersion), valuesYAML}, nil); err != nil {
-			logrus.WithError(err).Error("Failed to update operator version in values.yaml")
-			return err
-		}
-		if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, r.calicoVersion), valuesYAML}, nil); err != nil {
-			logrus.WithError(err).Error("Failed to update calicoctl version in values.yaml")
-			return err
-		}
+		r.ModifyHelmChartsValues()
 	}
 
 	// Build the helm chart, passing the version to use.
 	env := append(os.Environ(), fmt.Sprintf("GIT_VERSION=%s", r.calicoVersion))
-	if _, err := r.runner.RunInDir(r.repoRoot, "make", []string{"chart"}, env); err != nil {
+	if err := r.makeInDirectoryWithNoOutput(r.repoRoot, "chart", env...); err != nil {
 		return err
 	}
 
@@ -457,7 +469,7 @@ func (r *CalicoManager) BuildHelm() error {
 
 func (r *CalicoManager) buildOCPBundle() error {
 	// Build OpenShift bundle.
-	if _, err := r.runner.RunInDir(r.repoRoot, "make", []string{"bin/ocp.tgz"}, []string{}); err != nil {
+	if err := r.makeInDirectoryWithNoOutput(r.repoRoot, "bin/ocp.tgz"); err != nil {
 		return err
 	}
 	return nil
@@ -593,7 +605,7 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 			imageList = append(imageList, component.String())
 		}
 		imageScanner := imagescanner.New(r.imageScanningConfig)
-		err := imageScanner.Scan(imageList, r.hashrelease.Stream, false, r.tmpDir)
+		err := imageScanner.Scan(r.productCode, imageList, r.hashrelease.Stream, false, r.tmpDir)
 		if err != nil {
 			// Error is logged and ignored as this is not considered a fatal error
 			logrus.WithError(err).Error("Failed to scan images")
@@ -819,7 +831,7 @@ func (r *CalicoManager) generateManifests() error {
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("CALICO_VERSION=%s", r.calicoVersion))
 	env = append(env, fmt.Sprintf("OPERATOR_VERSION=%s", r.operatorVersion))
-	if _, err := r.runner.RunInDir(r.repoRoot, "make", []string{"gen-manifests"}, env); err != nil {
+	if err := r.makeInDirectoryWithNoOutput(r.repoRoot, "gen-manifests", env...); err != nil {
 		logrus.WithError(err).Error("Failed to make manifests")
 		return err
 	}
@@ -1133,4 +1145,8 @@ func (r *CalicoManager) git(args ...string) (string, error) {
 
 func (r *CalicoManager) makeInDirectoryWithOutput(dir, target string, env ...string) (string, error) {
 	return r.runner.Run("make", []string{"-C", dir, target}, env)
+}
+
+func (r *CalicoManager) makeInDirectoryWithNoOutput(dir, target string, env ...string) error {
+	return r.runner.RunNoCapture("make", []string{"-C", dir, target}, env)
 }

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -60,6 +60,9 @@ type OperatorManager struct {
 	// tmpDir is the absolute path to the temporary directory
 	tmpDir string
 
+	// outputDir is the absolute path to the output directory
+	outputDir string
+
 	// origin remote repository
 	remote string
 
@@ -124,7 +127,7 @@ func (o *OperatorManager) Build() error {
 			return err
 		}
 	}
-	component, componentsVersionPath, err := pinnedversion.GenerateOperatorComponents(o.tmpDir)
+	component, componentsVersionPath, err := pinnedversion.GenerateOperatorComponents(o.tmpDir, o.outputDir)
 	if err != nil {
 		return err
 	}

--- a/release/pkg/manager/operator/options.go
+++ b/release/pkg/manager/operator/options.go
@@ -37,6 +37,13 @@ func WithTempDirectory(dir string) Option {
 	}
 }
 
+func WithOutputDirectory(dir string) Option {
+	return func(o *OperatorManager) error {
+		o.outputDir = dir
+		return nil
+	}
+}
+
 func WithRepoRemote(remote string) Option {
 	return func(o *OperatorManager) error {
 		o.remote = remote

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -56,7 +56,7 @@ func HashreleaseSlackMessage(slackCfg *slack.Config, hashrel *hashreleaseserver.
 		Config: *slackCfg,
 		Data: slack.MessageData{
 			ReleaseName:        hashrel.Name,
-			Product:            utils.DisplayProductName(),
+			Product:            hashrel.Product,
 			Stream:             hashrel.Stream,
 			Version:            hashrel.ProductVersion,
 			OperatorVersion:    hashrel.OperatorVersion,


### PR DESCRIPTION
## Description

This includes the following changes to prevent merge conflicts with close source for hashrelease and release.

- add ability to copy pinned files to hashrelease/release dir.
- exclude generating releae notes when the org is Tigera
- Update comments/ descriptions to be more generic _instead of stating Calico_
- add product to hashrelease (easier for notifications)
- allow specifying product code in image scanner
- getting a version's milestone requires stating the prefix instead of hardcoding calico
- calico manager
  - switch `helmChartVersion` fn to `HelmChartVersion` so it can be overriding by a _sub class_
  - add `makeInDirectoryWithNoOutput` fn
- operator manager
  - enable passing in hashrelease dir so pinned components can be included in the hashrelease/release dir

## Related issues/PRs

- final split from #9563 

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
