### PR TITLE
Increase ANP/BANP conformance test timeout to 10s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ image:
 E2E_FOCUS ?= "sig-network.*Conformance"
 ADMINPOLICY_SUPPORTED_FEATURES ?= "AdminNetworkPolicy,BaselineAdminNetworkPolicy"
 ADMINPOLICY_UNSUPPORTED_FEATURES ?= ""
-e2e-test:
+e2e-test: e2e/cmd
 	$(MAKE) -C e2e build
 	$(MAKE) -C node kind-k8st-setup
 	KUBECONFIG=$(KIND_KUBECONFIG) ./e2e/bin/k8s/e2e.test -ginkgo.focus=$(E2E_FOCUS)

--- a/e2e/cmd/adminpolicy/e2e_test.go
+++ b/e2e/cmd/adminpolicy/e2e_test.go
@@ -69,9 +69,12 @@ func TestConformance(t *testing.T) {
 		ExemptFeatures:             exemptFeatures,
 		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 		TimeoutConfig: config_utils.TimeoutConfig{
-			// Use default value for other time outs:
-			// https://github.com/kubernetes-sigs/network-policy-api/blob/main/conformance/utils/config/timeout.go#L50
-			RequestTimeout: time.Second * 10,
+			CreateTimeout:         60 * time.Second,
+			DeleteTimeout:         20 * time.Second,
+			GetTimeout:            20 * time.Second,
+			ManifestFetchTimeout:  10 * time.Second,
+			NamespacesMustBeReady: 300 * time.Second,
+			RequestTimeout:        10 * time.Second,
 		},
 	})
 	cSuite.Setup(t)

--- a/e2e/cmd/adminpolicy/e2e_test.go
+++ b/e2e/cmd/adminpolicy/e2e_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -26,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
 	"sigs.k8s.io/network-policy-api/conformance/tests"
+	config_utils "sigs.k8s.io/network-policy-api/conformance/utils/config"
 	"sigs.k8s.io/network-policy-api/conformance/utils/flags"
 	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
 )
@@ -66,6 +68,11 @@ func TestConformance(t *testing.T) {
 		SupportedFeatures:          supportedFeatures,
 		ExemptFeatures:             exemptFeatures,
 		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
+		TimeoutConfig: config_utils.TimeoutConfig{
+			// Use default value for other time outs:
+			// https://github.com/kubernetes-sigs/network-policy-api/blob/main/conformance/utils/config/timeout.go#L50
+			RequestTimeout: time.Second * 10,
+		},
 	})
 	cSuite.Setup(t)
 


### PR DESCRIPTION
## Description

Increase request time outs in ANP/BANP conformance test from 3s (default) to 10s.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
