### PR TITLE
Don't check every IPAM allocation on every sync.

### DIFF
--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	uruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -67,7 +68,8 @@ func NewNodeController(ctx context.Context,
 	calicoClient client.Interface,
 	cfg config.NodeControllerConfig,
 	nodeInformer, podInformer cache.SharedIndexInformer,
-	dataFeed *utils.DataFeed) controller.Controller {
+	dataFeed *utils.DataFeed,
+) controller.Controller {
 	nc := &NodeController{
 		ctx:          ctx,
 		calicoClient: calicoClient,
@@ -78,12 +80,14 @@ func NewNodeController(ctx context.Context,
 	}
 
 	// Store functions to call on node deletion.
-	nodeDeletionFuncs := []func(){}
+	nodeDeletionFuncs := []func(*v1.Node){}
+	podDeletionFuncs := []func(*v1.Pod){}
 
 	// Create the IPAM controller.
 	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, podInformer.GetIndexer(), nodeInformer.GetIndexer())
 	nc.ipamCtrl.RegisterWith(nc.dataFeed)
 	nodeDeletionFuncs = append(nodeDeletionFuncs, nc.ipamCtrl.OnKubernetesNodeDeleted)
+	podDeletionFuncs = append(podDeletionFuncs, nc.ipamCtrl.OnKubernetesPodDeleted)
 
 	if cfg.DeleteNodes {
 		// If we're running in etcd mode, then we also need to delete the node resource.
@@ -100,7 +104,15 @@ func NewNodeController(ctx context.Context,
 		DeleteFunc: func(obj interface{}) {
 			// Call all of the registered node deletion funcs.
 			for _, f := range nodeDeletionFuncs {
-				f()
+				f(obj.(*v1.Node))
+			}
+		},
+	}
+	podHandlers := cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			// Call all of the registered pod deletion funcs.
+			for _, f := range podDeletionFuncs {
+				f(obj.(*v1.Pod))
 			}
 		},
 	}
@@ -128,6 +140,10 @@ func NewNodeController(ctx context.Context,
 	// Set the handlers on the informers.
 	if _, err := nc.nodeInformer.AddEventHandler(nodeHandlers); err != nil {
 		log.WithError(err).Error("failed to add event handler for node")
+		return nil
+	}
+	if _, err := nc.podInformer.AddEventHandler(podHandlers); err != nil {
+		log.WithError(err).Error("failed to add event handler for pod")
 		return nil
 	}
 

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -59,7 +59,7 @@ type NodeController struct {
 	dataFeed     *utils.DataFeed
 
 	// Sub-controllers
-	ipamCtrl *ipamController
+	ipamCtrl *IPAMController
 }
 
 // NewNodeController Constructor for NodeController

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -118,12 +118,12 @@ type rateLimiterItemKey struct {
 	Name string
 }
 
-func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs kubernetes.Interface, pi, ni cache.Indexer) *ipamController {
+func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs kubernetes.Interface, pi, ni cache.Indexer) *IPAMController {
 	var leakGracePeriod *time.Duration
 	if cfg.LeakGracePeriod != nil {
 		leakGracePeriod = &cfg.LeakGracePeriod.Duration
 	}
-	return &ipamController{
+	return &IPAMController{
 		client:    c,
 		clientset: cs,
 		config:    cfg,
@@ -138,7 +138,7 @@ func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs k
 		podLister:  v1lister.NewPodLister(pi),
 		nodeLister: v1lister.NewNodeLister(ni),
 
-		nodeDeletionChan: make(chan *v1.Node, batchUpdateSize),
+		nodeDeletionChan: make(chan struct{}, batchUpdateSize),
 		podDeletionChan:  make(chan *v1.Pod, batchUpdateSize),
 
 		// Buffered channels for potentially bursty channels.
@@ -155,6 +155,7 @@ func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs k
 		emptyBlocks:                 make(map[string]string),
 		poolManager:                 newPoolManager(),
 		datastoreReady:              true,
+		consolidationWindow:         1 * time.Second,
 
 		// Track blocks which we might want to release.
 		blockReleaseTracker: newBlockReleaseTracker(leakGracePeriod),
@@ -164,7 +165,7 @@ func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs k
 	}
 }
 
-type ipamController struct {
+type IPAMController struct {
 	rl         workqueue.TypedRateLimiter[any]
 	client     client.Interface
 	clientset  kubernetes.Interface
@@ -214,29 +215,36 @@ type ipamController struct {
 	// Cache datastoreReady to avoid too much API queries.
 	datastoreReady bool
 
-	// channels for indicating that Kubernetes nodes or pods have been deleted.
-	nodeDeletionChan chan *v1.Node
+	// Channel for indicating that Kubernetes nodes have been deleted.
+	nodeDeletionChan chan struct{}
 	podDeletionChan  chan *v1.Pod
+
+	// consolidationWindow is the time to wait for additional updates after receiving one before processing the updates
+	// received. This is to allow for multiple node deletion events to be consolidated into a single event.
+	consolidationWindow time.Duration
 
 	// For unit testing purposes.
 	pauseRequestChannel chan pauseRequest
+
+	// fullSyncRequired marks whether or not a full scan of IPAM data is required on the next sync.
+	fullSyncRequired bool
 }
 
-func (c *ipamController) Start(stop chan struct{}) {
+func (c *IPAMController) Start(stop chan struct{}) {
 	go c.acceptScheduleRequests(stop)
 }
 
-func (c *ipamController) RegisterWith(f *utils.DataFeed) {
+func (c *IPAMController) RegisterWith(f *utils.DataFeed) {
 	f.RegisterForNotification(model.BlockKey{}, c.onUpdate)
 	f.RegisterForNotification(model.ResourceKey{}, c.onUpdate)
 	f.RegisterForSyncStatus(c.onStatusUpdate)
 }
 
-func (c *ipamController) onStatusUpdate(s bapi.SyncStatus) {
+func (c *IPAMController) onStatusUpdate(s bapi.SyncStatus) {
 	c.syncerUpdates <- s
 }
 
-func (c *ipamController) onUpdate(update bapi.Update) {
+func (c *IPAMController) onUpdate(update bapi.Update) {
 	switch update.KVPair.Key.(type) {
 	case model.ResourceKey:
 		switch update.KVPair.Key.(model.ResourceKey).Kind {
@@ -250,19 +258,29 @@ func (c *ipamController) onUpdate(update bapi.Update) {
 	}
 }
 
-func (c *ipamController) OnKubernetesNodeDeleted(node *v1.Node) {
-	log.Debug("Kubernetes node deletion event")
-	c.nodeDeletionChan <- node
+func (c *IPAMController) OnKubernetesNodeDeleted(n *v1.Node) {
+	log.WithField("node", n.Name).Debug("Kubernetes node deletion event")
+	c.nodeDeletionChan <- struct{}{}
 }
 
-func (c *ipamController) OnKubernetesPodDeleted(pod *v1.Pod) {
-	log.WithField("pod", pod.Name).Debug("Kubernetes pod deletion event")
-	c.podDeletionChan <- pod
+func (c *IPAMController) OnKubernetesPodDeleted(p *v1.Pod) {
+	log.WithField("pod", p.Name).Debug("Kubernetes pod deletion event")
+	c.podDeletionChan <- p
+}
+
+// fullScanNextSync marks the IPAMController for a full resync on the next syncIPAM call.
+func (c *IPAMController) fullScanNextSync(reason string) {
+	if c.fullSyncRequired {
+		log.WithField("reason", reason).Debug("Full resync already pending")
+		return
+	}
+	c.fullSyncRequired = true
+	log.WithField("reason", reason).Info("Marking IPAM for full resync")
 }
 
 // acceptScheduleRequests is the main worker routine of the IPAM controller. It monitors
 // the updates channel and triggers syncs.
-func (c *ipamController) acceptScheduleRequests(stopCh <-chan struct{}) {
+func (c *IPAMController) acceptScheduleRequests(stopCh <-chan struct{}) {
 	// Periodic sync ticker.
 	period := 5 * time.Minute
 	if c.config.LeakGracePeriod != nil {
@@ -275,33 +293,58 @@ func (c *ipamController) acceptScheduleRequests(stopCh <-chan struct{}) {
 	for {
 		// Wait until something wakes us up, or we are stopped.
 		select {
-		case node := <-c.nodeDeletionChan:
-			// When a node is deleted, mark it as dirty and schedule a sync.
-			log.WithField("node", node.Name).Debug("Received node deletion event")
-			c.allocationState.markDirty(node.Name)
+		case <-c.nodeDeletionChan:
+			// Allow bursts of node deletion events to be consolidated.
+			// We wait a short time to see if more events come in before processing.
+			wait := time.After(c.consolidationWindow)
+			var i int
+		nodeConsolidationLoop:
+			for i = 1; i < batchUpdateSize; i++ {
+				select {
+				case <-c.nodeDeletionChan:
+					i++
+				case <-wait:
+					break nodeConsolidationLoop
+				}
+			}
+
+			// When one or more nodes are deleted, trigger a full sync to ensure that we release
+			// their affinities.
+			c.fullScanNextSync(fmt.Sprintf("%d node deletion event(s)", i))
 			kick(c.syncChan)
 		case pod := <-c.podDeletionChan:
-			// When a pod is deleted, mark its node as dirty and schedule a sync.
-			// TODO: We could be tracking dirtiness at the allocation level instead.
-			log.WithFields(log.Fields{
-				"pod":  pod.Name,
-				"ns":   pod.Namespace,
-				"node": pod.Spec.NodeName,
-			}).Debug("Received pod deletion event")
-			c.allocationState.markDirty(pod.Spec.NodeName)
+			// Mark the pod's node as dirty.
+			c.allocationState.markDirty(pod.Spec.NodeName, "pod deletion")
+
+			// Allow bursts of pod deletion events to be consolidated.
+			// We wait a short time to see if more events come in before processing.
+			wait := time.After(c.consolidationWindow)
+			var i int
+		podConsolidationLoop:
+			for i = 1; i < batchUpdateSize; i++ {
+				select {
+				case pod = <-c.podDeletionChan:
+					i++
+					c.allocationState.markDirty(pod.Spec.NodeName, "pod deletion")
+				case <-wait:
+					break podConsolidationLoop
+				}
+			}
 			kick(c.syncChan)
 		case upd := <-c.syncerUpdates:
 			c.handleUpdate(upd)
 
 			// It's possible we get a rapid series of updates in a row. Use
 			// a consolidation loop to handle "batches" of updates before triggering a sync.
+			// We wait a short time to see if more events come in before processing.
+			wait := time.After(c.consolidationWindow)
 			var i int
 		consolidationLoop:
 			for i = 1; i < batchUpdateSize; i++ {
 				select {
 				case upd = <-c.syncerUpdates:
 					c.handleUpdate(upd)
-				default:
+				case <-wait:
 					break consolidationLoop
 				}
 			}
@@ -310,10 +353,8 @@ func (c *ipamController) acceptScheduleRequests(stopCh <-chan struct{}) {
 			log.WithField("batchSize", i).Debug("Triggering sync after batch of updates")
 			kick(c.syncChan)
 		case <-t.C:
-			// Periodic IPAM sync.
-
-			// Mark all nodes as dirty.
-			c.allocationState.markAllDirty()
+			// Periodic IPAM sync, queue a full scan of the IPAM data.
+			c.fullScanNextSync("periodic sync")
 
 			log.Debug("Periodic IPAM sync")
 			err := c.syncIPAM()
@@ -348,7 +389,7 @@ func (c *ipamController) acceptScheduleRequests(stopCh <-chan struct{}) {
 
 // handleUpdate fans out proper handling of the update depending on the
 // information in the update.
-func (c *ipamController) handleUpdate(upd interface{}) {
+func (c *IPAMController) handleUpdate(upd interface{}) {
 	switch upd := upd.(type) {
 	case bapi.SyncStatus:
 		c.syncStatus = upd
@@ -381,7 +422,7 @@ func (c *ipamController) handleUpdate(upd interface{}) {
 }
 
 // handleBlockUpdate wraps up the logic to execute when receiving a block update.
-func (c *ipamController) handleBlockUpdate(kvp model.KVPair) {
+func (c *IPAMController) handleBlockUpdate(kvp model.KVPair) {
 	if kvp.Value != nil {
 		c.onBlockUpdated(kvp)
 	} else {
@@ -390,7 +431,7 @@ func (c *ipamController) handleBlockUpdate(kvp model.KVPair) {
 }
 
 // handleNodeUpdate wraps up the logic to execute when receiving a node update.
-func (c *ipamController) handleNodeUpdate(kvp model.KVPair) {
+func (c *IPAMController) handleNodeUpdate(kvp model.KVPair) {
 	if kvp.Value != nil {
 		n := kvp.Value.(*libapiv3.Node)
 		kn, err := getK8sNodeName(*n)
@@ -416,7 +457,7 @@ func (c *ipamController) handleNodeUpdate(kvp model.KVPair) {
 	}
 }
 
-func (c *ipamController) handlePoolUpdate(kvp model.KVPair) {
+func (c *IPAMController) handlePoolUpdate(kvp model.KVPair) {
 	if kvp.Value != nil {
 		pool := kvp.Value.(*apiv3.IPPool)
 		c.onPoolUpdated(pool)
@@ -427,7 +468,7 @@ func (c *ipamController) handlePoolUpdate(kvp model.KVPair) {
 }
 
 // handleClusterInformationUpdate wraps the logic to execute when receiving a clusterinformation update.
-func (c *ipamController) handleClusterInformationUpdate(kvp model.KVPair) {
+func (c *IPAMController) handleClusterInformationUpdate(kvp model.KVPair) {
 	if kvp.Value != nil {
 		ci := kvp.Value.(*apiv3.ClusterInformation)
 		if ci.Spec.DatastoreReady != nil {
@@ -438,7 +479,7 @@ func (c *ipamController) handleClusterInformationUpdate(kvp model.KVPair) {
 	}
 }
 
-func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
+func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 	blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
 	log.WithField("block", blockCIDR).Debug("Received block update")
 	b := kvp.Value.(*model.AllocationBlock)
@@ -549,7 +590,7 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 	c.allBlocks[blockCIDR] = kvp
 }
 
-func (c *ipamController) onBlockDeleted(key model.BlockKey) {
+func (c *IPAMController) onBlockDeleted(key model.BlockKey) {
 	blockCIDR := key.CIDR.String()
 	log.WithField("block", blockCIDR).Info("Received block delete")
 
@@ -576,7 +617,7 @@ func (c *ipamController) onBlockDeleted(key model.BlockKey) {
 	c.poolManager.onBlockDeleted(blockCIDR)
 }
 
-func (c *ipamController) onPoolUpdated(pool *apiv3.IPPool) {
+func (c *IPAMController) onPoolUpdated(pool *apiv3.IPPool) {
 	if c.poolManager.allPools[pool.Name] == nil {
 		registerMetricVectorsForPool(pool.Name)
 		publishPoolSizeMetric(pool)
@@ -585,14 +626,25 @@ func (c *ipamController) onPoolUpdated(pool *apiv3.IPPool) {
 	c.poolManager.onPoolUpdated(pool)
 }
 
-func (c *ipamController) onPoolDeleted(poolName string) {
+func (c *IPAMController) onPoolDeleted(poolName string) {
 	unregisterMetricVectorsForPool(poolName)
 	clearPoolSizeMetric(poolName)
 
 	c.poolManager.onPoolDeleted(poolName)
 }
 
-func (c *ipamController) updateMetrics() {
+func (c *IPAMController) updateMetrics() {
+	if !c.datastoreReady {
+		log.Warn("datastore is locked, skipping metrics sync")
+		return
+	}
+
+	// Skip if not InSync yet.
+	if c.syncStatus != bapi.InSync {
+		log.WithField("status", c.syncStatus).Debug("Have not yet received InSync notification, skipping metrics sync.")
+		return
+	}
+
 	log.Debug("Gathering latest IPAM state for metrics")
 
 	// Keep track of various counts so that we can report them as metrics. These counts track legacy metrics by node.
@@ -652,9 +704,9 @@ func (c *ipamController) updateMetrics() {
 
 	// Update legacy gauges
 	legacyAllocationsGauge.Reset()
-	for node, allocations := range c.allocationState.allocationsByNode {
+	c.allocationState.iter(func(node string, allocations map[string]*allocation) {
 		legacyAllocationsGauge.WithLabelValues(node).Set(float64(len(allocations)))
-	}
+	})
 	legacyBlocksGauge.Reset()
 	for node, num := range legacyBlocksByNode {
 		legacyBlocksGauge.WithLabelValues(node).Set(float64(num))
@@ -666,7 +718,7 @@ func (c *ipamController) updateMetrics() {
 	log.Debug("IPAM metrics updated")
 }
 
-// checkEmptyBlocks looks at known empty blocks, and releases their affinity
+// releaseUnusedBlocks looks at known empty blocks, and releases their affinity
 // if appropriate. A block is a candidate for having its affinity released if:
 //
 // - The block is empty.
@@ -675,7 +727,7 @@ func (c *ipamController) updateMetrics() {
 //
 // A block will only be released if it has been in this state for longer than the configured
 // grace period, which defaults to 15m.
-func (c *ipamController) checkEmptyBlocks() error {
+func (c *IPAMController) releaseUnusedBlocks() error {
 	for blockCIDR, node := range c.emptyBlocks {
 		logc := log.WithFields(log.Fields{"blockCIDR": blockCIDR, "node": node})
 		nodeBlocks := c.blocksByNode[node]
@@ -749,19 +801,44 @@ func (c *ipamController) checkEmptyBlocks() error {
 // - The node no longer exists in the Kubernetes API, AND
 // - There are no longer any IP allocations on the node, OR
 // - The remaining IP allocations on the node are all determined to be leaked IP addresses.
-func (c *ipamController) checkAllocations() ([]string, error) {
+func (c *IPAMController) checkAllocations() ([]string, error) {
 	// For each node present in IPAM, if it doesn't exist in the Kubernetes API then we
 	// should consider it a candidate for cleanup.
-	//
-	// Build a map of any nodes that have had their allocation
-	// state change since the last sync.
-	nodesAndAllocations := map[string]map[string]*allocation{}
-	for node := range c.allocationState.dirtyNodes {
-		nodesAndAllocations[node] = c.allocationState.allocationsByNode[node]
+	nodesToCheck := map[string]map[string]*allocation{}
+
+	if c.fullSyncRequired {
+		// If a full sync is required, we need to consider all nodes in the IPAM cache - not just the ones that
+		// have changed since the last sync. This is a more expensive operation, so we only do it periodically.
+		log.Info("Performing a full scan of IPAM allocations to check for leaks and redundant affinities")
+
+		for _, node := range c.nodesByBlock {
+			// For each affine block, add an entry. This makes sure we consider them even
+			// if they have no allocations.
+			nodesToCheck[node] = nil
+		}
+
+		// Add in allocations for any nodes that have them.
+		c.allocationState.iter(func(node string, allocations map[string]*allocation) {
+			nodesToCheck[node] = allocations
+		})
+
+		// Clear the full sync flag.
+		c.fullSyncRequired = false
+	} else {
+		log.Info("Checking dirty nodes for leaks and redundant affinities")
+
+		// Collect allocation state for all nodes that have changed since the last sync.
+		c.allocationState.iterDirty(func(node string, allocations map[string]*allocation) {
+			log.WithField("node", node).Debug("Node is dirty, checking for leaks")
+			nodesToCheck[node] = allocations
+		})
 	}
+
+	// nodesToRelease tracks nodes that exist in Calico IPAM, but do not exist in the Kubernetes API.
+	// These nodes should have all of their block affinities released.
 	nodesToRelease := []string{}
 
-	for cnode, allocations := range nodesAndAllocations {
+	for cnode, allocations := range nodesToCheck {
 		// Lookup the corresponding Kubernetes node for each Calico node we found in IPAM.
 		// In KDD mode, these are identical. However, in etcd mode its possible that the Calico node has a
 		// different name from the Kubernetes node.
@@ -882,7 +959,7 @@ func (c *ipamController) checkAllocations() ([]string, error) {
 
 // allocationIsValid returns true if the allocation is still in use, and false if the allocation
 // appears to be leaked.
-func (c *ipamController) allocationIsValid(a *allocation, preferCache bool) bool {
+func (c *IPAMController) allocationIsValid(a *allocation, preferCache bool) bool {
 	ns := a.attrs[ipam.AttributeNamespace]
 	pod := a.attrs[ipam.AttributePod]
 	logc := log.WithFields(a.fields())
@@ -985,7 +1062,7 @@ func (c *ipamController) allocationIsValid(a *allocation, preferCache bool) bool
 	return false
 }
 
-func (c *ipamController) syncIPAM() error {
+func (c *IPAMController) syncIPAM() error {
 	if !c.datastoreReady {
 		log.Warn("datastore is locked, skipping ipam sync")
 		return nil
@@ -997,26 +1074,32 @@ func (c *ipamController) syncIPAM() error {
 		return nil
 	}
 
-	// Check if any nodes in IPAM need to have affinities released.
 	log.Debug("Synchronizing IPAM data")
+
+	// Scan known allocations, determining if there are any IP address leaks
+	// or nodes that should have their block affinities released.
 	nodesToRelease, err := c.checkAllocations()
 	if err != nil {
 		return err
 	}
 
-	// Release all confirmed leaks.
-	err = c.garbageCollectIPs()
+	// Release all confirmed leaks. Leaks are confirmed in checkAllocations() above.
+	err = c.garbageCollectKnownLeaks()
 	if err != nil {
 		return err
 	}
 
-	// Check if any empty blocks should be removed.
-	err = c.checkEmptyBlocks()
+	// Release any block affinities for empty blocks that are no longer needed.
+	// This ensures Nodes don't hold on to blocks that are no longer in use, allowing them to
+	// to be claimed elsewhere.
+	err = c.releaseUnusedBlocks()
 	if err != nil {
 		return err
 	}
 
-	// Delete any nodes that we determined can be removed above.
+	// Delete any nodes that we determined can be removed in checkAllocations. These
+	// nodes are no longer in the Kubernetes API, and have no valid allocations, so can be cleaned up entirely
+	// from Calico IPAM.
 	var storedErr error
 	if len(nodesToRelease) > 0 {
 		log.WithField("num", len(nodesToRelease)).Info("Found a batch of nodes to release")
@@ -1040,13 +1123,13 @@ func (c *ipamController) syncIPAM() error {
 		return storedErr
 	}
 
-	log.Debug("IPAM sync completed")
 	c.allocationState.syncComplete()
+	log.Debug("IPAM sync completed")
 	return nil
 }
 
-// garbageCollectIPs checks all known allocations and garbage collects any confirmed leaks.
-func (c *ipamController) garbageCollectIPs() error {
+// garbageCollectKnownLeaks checks all known allocations and garbage collects any confirmed leaks.
+func (c *IPAMController) garbageCollectKnownLeaks() error {
 	for id, a := range c.confirmedLeaks {
 		logc := log.WithFields(a.fields())
 
@@ -1086,7 +1169,7 @@ func (c *ipamController) garbageCollectIPs() error {
 	return nil
 }
 
-func (c *ipamController) cleanupNode(cnode string) error {
+func (c *IPAMController) cleanupNode(cnode string) error {
 	// At this point, we've verified that the node isn't in Kubernetes and that all the allocations
 	// are tied to pods which don't exist anymore. Clean up any allocations which may still be laying around.
 	logc := log.WithField("calicoNode", cnode)
@@ -1109,7 +1192,7 @@ func (c *ipamController) cleanupNode(cnode string) error {
 }
 
 // nodeExists returns true if the given node still exists in the Kubernetes API.
-func (c *ipamController) nodeExists(knode string) bool {
+func (c *IPAMController) nodeExists(knode string) bool {
 	_, err := c.nodeLister.Get(knode)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -1122,7 +1205,7 @@ func (c *ipamController) nodeExists(knode string) bool {
 
 // nodeIsBeingMigrated looks up a Kubernetes node for a Calico node and checks,
 // if it is marked by the flannel-migration controller to undergo migration.
-func (c *ipamController) nodeIsBeingMigrated(name string) (bool, error) {
+func (c *IPAMController) nodeIsBeingMigrated(name string) (bool, error) {
 	// Find the Kubernetes node referenced by the Calico node
 	kname, err := c.kubernetesNodeForCalico(name)
 	if err != nil {
@@ -1153,7 +1236,7 @@ func (c *ipamController) nodeIsBeingMigrated(name string) (bool, error) {
 // kubernetesNodeForCalico returns the name of the Kubernetes node that corresponds to this Calico node.
 // This function returns an empty string if no corresponding node could be found.
 // Returns ErrorNotKubernetes if the given Calico node is not a Kubernetes node.
-func (c *ipamController) kubernetesNodeForCalico(cnode string) (string, error) {
+func (c *IPAMController) kubernetesNodeForCalico(cnode string) (string, error) {
 	// Check if we have the node name cached.
 	if kn, ok := c.kubernetesNodesByCalicoName[cnode]; ok && kn != "" {
 		return kn, nil
@@ -1178,7 +1261,7 @@ func (c *ipamController) kubernetesNodeForCalico(cnode string) (string, error) {
 	return getK8sNodeName(*calicoNode)
 }
 
-func (c *ipamController) incrementReclamationMetric(block string, node string) {
+func (c *IPAMController) incrementReclamationMetric(block string, node string) {
 	pool := c.poolManager.poolsByBlock[block]
 	if node == "" {
 		node = unknownNodeLabel
@@ -1263,7 +1346,7 @@ func unregisterMetricVectorsForPool(poolName string) {
 // Creates map used to index gauge values by node, and seeds with zeroes to create explicit zero values rather than
 // absence of data for a node. This enables users to construct utilization expressions that return 0 when the numerator
 // is zero, rather than no data. If the pool is the 'unknown' pool, the map is not seeded.
-func (c *ipamController) createZeroedMapForNodeValues(poolName string) map[string]int {
+func (c *IPAMController) createZeroedMapForNodeValues(poolName string) map[string]int {
 	valuesByNode := map[string]int{}
 
 	if poolName != unknownPoolLabel {
@@ -1327,7 +1410,7 @@ type pauseRequest struct {
 // pause pauses the controller's main loop until the returned function is called.
 // this function is for TESTING PURPOSES ONLY, allowing the tests to safely access
 // the controller's data caches without races.
-func (c *ipamController) pause() func() {
+func (c *IPAMController) pause() func() {
 	doneChan := make(chan struct{})
 	pauseConfirmed := make(chan struct{})
 	c.pauseRequestChannel <- pauseRequest{doneChan: doneChan, pauseConfirmed: pauseConfirmed}

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -215,77 +215,6 @@ type ipamController struct {
 	pauseRequestChannel chan pauseRequest
 }
 
-func newAllocationState() *allocationState {
-	return &allocationState{
-		allocationsByNode: map[string]map[string]*allocation{},
-		dirtyNodes:        map[string]bool{},
-	}
-}
-
-// allocationState is a helper struct to track in-memory representation of actual IPAM allocations.
-// It uses internal indexing of IPAM state to provide more efficient lookups than the raw IPAM data model.
-type allocationState struct {
-	// allocationsByNode maps a node name to a map of allocations keyed by a unique identifier.
-	allocationsByNode map[string]map[string]*allocation
-
-	// dirtyNodes is a set of nodes that have had allocations added or removed since the last sync.
-	dirtyNodes map[string]bool
-}
-
-// allocate marks an allocation as being allocated.
-func (t *allocationState) allocate(a *allocation) {
-	log.WithFields(a.fields()).Debug("Adding IP allocation to internal state")
-
-	if _, ok := t.allocationsByNode[a.node()]; !ok {
-		t.allocationsByNode[a.node()] = map[string]*allocation{}
-	}
-	t.allocationsByNode[a.node()][a.id()] = a
-
-	// Mark the node as dirty.
-	t.markDirty(a.node())
-}
-
-func (t *allocationState) markDirty(node string) {
-	if _, ok := t.dirtyNodes[node]; !ok {
-		log.WithField("node", node).Debug("Marking node as dirty")
-		t.dirtyNodes[node] = true
-	}
-}
-
-// release marks an allocation as not being allocated.
-func (t *allocationState) release(a *allocation) {
-	log.WithFields(a.fields()).Debug("Removing IP allocation from internal state")
-
-	if _, ok := t.allocationsByNode[a.node()]; !ok {
-		return
-	}
-
-	// Delete the allocation.
-	delete(t.allocationsByNode[a.node()], a.id())
-
-	// Mark the node as dirty.
-	t.markDirty(a.node())
-
-	// Check if the node is empty and clean it up if so.
-	if len(t.allocationsByNode[a.node()]) == 0 {
-		delete(t.allocationsByNode, a.node())
-	}
-}
-
-func (t *allocationState) syncComplete() {
-	for node := range t.dirtyNodes {
-		log.WithField("node", node).Debug("Marking node as handled after sync")
-	}
-	t.dirtyNodes = map[string]bool{}
-}
-
-// queueAll marks all nodes as dirty, so that they will be re-processed on the next sync.
-func (t *allocationState) queueAll() {
-	for node := range t.allocationsByNode {
-		t.dirtyNodes[node] = true
-	}
-}
-
 func (c *ipamController) Start(stop chan struct{}) {
 	go c.acceptScheduleRequests(stop)
 }
@@ -805,6 +734,7 @@ func (c *ipamController) checkAllocations() ([]string, error) {
 		nodesAndAllocations[node] = c.allocationState.allocationsByNode[node]
 	}
 	nodesToRelease := []string{}
+
 	for cnode, allocations := range nodesAndAllocations {
 		// Lookup the corresponding Kubernetes node for each Calico node we found in IPAM.
 		// In KDD mode, these are identical. However, in etcd mode its possible that the Calico node has a

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -143,7 +143,7 @@ func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs k
 
 		allBlocks:                   make(map[string]model.KVPair),
 		allocationsByBlock:          make(map[string]map[string]*allocation),
-		allocationsByNode:           make(map[string]map[string]*allocation),
+		allocationState:             newAllocationState(),
 		handleTracker:               newHandleTracker(),
 		kubernetesNodesByCalicoName: make(map[string]string),
 		confirmedLeaks:              make(map[string]*allocation),
@@ -183,10 +183,16 @@ type ipamController struct {
 	// Raw block storage.
 	allBlocks map[string]model.KVPair
 
-	// Store allocations broken out from the raw blocks by their handle.
-	allocationsByBlock  map[string]map[string]*allocation
-	allocationsByNode   map[string]map[string]*allocation
-	handleTracker       *handleTracker
+	// allocationState is the primary in-memory representation of IPAM allocations used by the garbage collector.
+	allocationState *allocationState
+
+	// allocationsByBlock maps a block CIDR to a map of allocations keyed by a unique identifier.
+	// It's used as a helper to efficiently update allocationState, as well as for populating metrics.
+	allocationsByBlock map[string]map[string]*allocation
+
+	// handleTracker is used to track which handles are in use, which are potentially leaked, and which are confirmed as leaks.
+	handleTracker *handleTracker
+
 	nodesByBlock        map[string]string
 	blocksByNode        map[string]map[string]bool
 	emptyBlocks         map[string]string
@@ -199,6 +205,77 @@ type ipamController struct {
 
 	// For unit testing purposes.
 	pauseRequestChannel chan pauseRequest
+}
+
+func newAllocationState() *allocationState {
+	return &allocationState{
+		allocationsByNode: map[string]map[string]*allocation{},
+		dirtyNodes:        map[string]bool{},
+	}
+}
+
+// allocationState is a helper struct to track in-memory representation of actual IPAM allocations.
+// It uses internal indexing of IPAM state to provide more efficient lookups than the raw IPAM data model.
+type allocationState struct {
+	// allocationsByNode maps a node name to a map of allocations keyed by a unique identifier.
+	allocationsByNode map[string]map[string]*allocation
+
+	// dirtyNodes is a set of nodes that have had allocations added or removed since the last sync.
+	dirtyNodes map[string]bool
+}
+
+// allocate marks an allocation as being allocated.
+func (t *allocationState) allocate(a *allocation) {
+	log.WithFields(a.fields()).Debug("Adding IP allocation to internal state")
+
+	if _, ok := t.allocationsByNode[a.node()]; !ok {
+		t.allocationsByNode[a.node()] = map[string]*allocation{}
+	}
+	t.allocationsByNode[a.node()][a.id()] = a
+
+	// Mark the node as dirty.
+	t.markDirty(a.node())
+}
+
+func (t *allocationState) markDirty(node string) {
+	if _, ok := t.dirtyNodes[node]; !ok {
+		log.WithField("node", node).Debug("Marking node as dirty")
+		t.dirtyNodes[node] = true
+	}
+}
+
+// release marks an allocation as not being allocated.
+func (t *allocationState) release(a *allocation) {
+	log.WithFields(a.fields()).Debug("Removing IP allocation from internal state")
+
+	if _, ok := t.allocationsByNode[a.node()]; !ok {
+		return
+	}
+
+	// Delete the allocation.
+	delete(t.allocationsByNode[a.node()], a.id())
+
+	// Mark the node as dirty.
+	t.markDirty(a.node())
+
+	// Check if the node is empty and clean it up if so.
+	if len(t.allocationsByNode[a.node()]) == 0 {
+		delete(t.allocationsByNode, a.node())
+	}
+}
+
+func (t *allocationState) syncComplete() {
+	for node := range t.dirtyNodes {
+		log.WithField("node", node).Debug("Marking node as handled after sync")
+	}
+	t.dirtyNodes = map[string]bool{}
+}
+
+// queueAll marks all nodes as dirty, so that they will be re-processed on the next sync.
+func (t *allocationState) queueAll() {
+	for node := range t.allocationsByNode {
+		t.dirtyNodes[node] = true
+	}
 }
 
 func (c *ipamController) Start(stop chan struct{}) {
@@ -271,6 +348,10 @@ func (c *ipamController) acceptScheduleRequests(stopCh <-chan struct{}) {
 			kick(c.syncChan)
 		case <-t.C:
 			// Periodic IPAM sync.
+
+			// Mark all nodes as dirty.
+			c.allocationState.queueAll()
+
 			log.Debug("Periodic IPAM sync")
 			err := c.syncIPAM()
 			if err != nil {
@@ -461,10 +542,7 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 
 		// Update the allocations-by-node view.
 		if node := alloc.node(); node != "" {
-			if _, ok := c.allocationsByNode[node]; !ok {
-				c.allocationsByNode[node] = map[string]*allocation{}
-			}
-			c.allocationsByNode[node][alloc.id()] = &alloc
+			c.allocationState.allocate(&alloc)
 		}
 		c.handleTracker.setAllocation(&alloc)
 		log.WithFields(alloc.fields()).Debug("New IP allocation")
@@ -494,10 +572,7 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 			// Also remove from the node view.
 			node := alloc.node()
 			if node != "" {
-				delete(c.allocationsByNode[node], id)
-			}
-			if len(c.allocationsByNode[node]) == 0 {
-				delete(c.allocationsByNode, node)
+				c.allocationState.release(alloc)
 			}
 
 			// And to be safe, remove from confirmed leaks just in case.
@@ -517,13 +592,10 @@ func (c *ipamController) onBlockDeleted(key model.BlockKey) {
 
 	// Remove allocations that were contributed by this block.
 	allocations := c.allocationsByBlock[blockCIDR]
-	for id, alloc := range allocations {
+	for _, alloc := range allocations {
 		node := alloc.node()
 		if node != "" {
-			delete(c.allocationsByNode[node], id)
-		}
-		if len(c.allocationsByNode[node]) == 0 {
-			delete(c.allocationsByNode, node)
+			c.allocationState.release(alloc)
 		}
 	}
 	delete(c.allocationsByBlock, blockCIDR)
@@ -617,7 +689,7 @@ func (c *ipamController) updateMetrics() {
 
 	// Update legacy gauges
 	legacyAllocationsGauge.Reset()
-	for node, allocations := range c.allocationsByNode {
+	for node, allocations := range c.allocationState.allocationsByNode {
 		legacyAllocationsGauge.WithLabelValues(node).Set(float64(len(allocations)))
 	}
 	legacyBlocksGauge.Reset()
@@ -714,20 +786,15 @@ func (c *ipamController) checkEmptyBlocks() error {
 // - The node no longer exists in the Kubernetes API, AND
 // - There are no longer any IP allocations on the node, OR
 // - The remaining IP allocations on the node are all determined to be leaked IP addresses.
-// TODO: We're effectively iterating every allocation in the cluster on every execution. Can we optimize? Or at least rate-limit?
 func (c *ipamController) checkAllocations() ([]string, error) {
 	// For each node present in IPAM, if it doesn't exist in the Kubernetes API then we
 	// should consider it a candidate for cleanup.
+	//
+	// Build a map of any nodes that have had their allocation
+	// state change since the last sync.
 	nodesAndAllocations := map[string]map[string]*allocation{}
-	for _, node := range c.nodesByBlock {
-		// For each affine block, add an entry. This makes sure we consider them even
-		// if they have no allocations.
-		nodesAndAllocations[node] = nil
-	}
-	for node, allocations := range c.allocationsByNode {
-		// For each allocation, add an entry. This make sure we consider them even
-		// if the node has no affine blocks.
-		nodesAndAllocations[node] = allocations
+	for node := range c.allocationState.dirtyNodes {
+		nodesAndAllocations[node] = c.allocationState.allocationsByNode[node]
 	}
 	nodesToRelease := []string{}
 	for cnode, allocations := range nodesAndAllocations {
@@ -1010,6 +1077,7 @@ func (c *ipamController) syncIPAM() error {
 	}
 
 	log.Debug("IPAM sync completed")
+	c.allocationState.syncComplete()
 	return nil
 }
 
@@ -1043,12 +1111,9 @@ func (c *ipamController) garbageCollectIPs() error {
 			return err
 		}
 
-		// No longer a leak. Remove it from the map here so we're not dependent on receiving
+		// No longer a leak. Remove it here so we're not dependent on receiving
 		// the update from the syncer (which we will do eventually, this is just cleaner).
-		delete(c.allocationsByNode[a.node()], id)
-		if len(c.allocationsByNode[a.node()]) == 0 {
-			delete(c.allocationsByNode, a.node())
-		}
+		c.allocationState.release(a)
 
 		c.incrementReclamationMetric(a.block, a.node())
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -180,7 +180,7 @@ type ipamController struct {
 	// For update / deletion events from the syncer.
 	syncerUpdates chan interface{}
 
-	// Raw block storage.
+	// Raw block storage, keyed by CIDR.
 	allBlocks map[string]model.KVPair
 
 	// allocationState is the primary in-memory representation of IPAM allocations used by the garbage collector.
@@ -193,12 +193,20 @@ type ipamController struct {
 	// handleTracker is used to track which handles are in use, which are potentially leaked, and which are confirmed as leaks.
 	handleTracker *handleTracker
 
-	nodesByBlock        map[string]string
-	blocksByNode        map[string]map[string]bool
-	emptyBlocks         map[string]string
-	confirmedLeaks      map[string]*allocation
-	poolManager         *poolManager
+	// confirmedLeaks indexes allocations that are confirmed to be leaks and are awaiting cleanup.
+	confirmedLeaks map[string]*allocation
+
+	// nodesByBlock and blocksByNode are used together to decide when block affinities are redundant and safe to release.
+	nodesByBlock map[string]string
+	blocksByNode map[string]map[string]bool
+
+	// blockReleaseTracker is used to track blocks that are candidates for GC due to both redundancy and inactivity.
 	blockReleaseTracker *blockReleaseTracker
+
+	emptyBlocks map[string]string
+
+	// poolManager associates IPPools with their blocks.
+	poolManager *poolManager
 
 	// Cache datastoreReady to avoid too much API queries.
 	datastoreReady bool

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -260,7 +260,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() map[string]*allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"]
+			return c.allocationState.allocationsByNode["cnode"]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 
 		// Now, allocate an address in the block and send it in as an update.
@@ -302,9 +302,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() map[string]*allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"]
+			return c.allocationState.allocationsByNode["cnode"]
 		}, 1*time.Second, 100*time.Millisecond).ShouldNot(BeNil())
-
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
@@ -313,7 +312,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"][id]
+			return c.allocationState.allocationsByNode["cnode"][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(expectedAllocation))
 
 		// Release the address from above and expect original state to be restored.
@@ -334,7 +333,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() map[string]*allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"]
+			return c.allocationState.allocationsByNode["cnode"]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 		Eventually(func() *allocation {
 			done := c.pause()
@@ -345,7 +344,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"][id]
+			return c.allocationState.allocationsByNode["cnode"][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 
 		// Delete the block and expect everything to be cleaned up.
@@ -360,7 +359,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() map[string]*allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"]
+			return c.allocationState.allocationsByNode["cnode"]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 		Eventually(func() map[string]*allocation {
 			done := c.pause()
@@ -800,7 +799,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			done := c.pause()
 			defer done()
-			_, ok := c.allocationsByNode["cnode"]
+			_, ok := c.allocationState.allocationsByNode["cnode"]
 			return ok
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 
@@ -840,7 +839,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			done := c.pause()
 			defer done()
-			_, ok := c.allocationsByNode["cnode"]
+			_, ok := c.allocationState.allocationsByNode["cnode"]
 			return ok
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 
@@ -882,7 +881,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			done := c.pause()
 			defer done()
-			_, ok := c.allocationsByNode["cnode"]
+			_, ok := c.allocationState.allocationsByNode["cnode"]
 			return ok
 		}, 1*time.Second, 100*time.Millisecond).Should(BeFalse())
 
@@ -1004,7 +1003,7 @@ var _ = Describe("IPAM controller UTs", func() {
 				// Should have two allocations.
 				done := c.pause()
 				defer done()
-				return len(c.allocationsByNode["cnode"])
+				return len(c.allocationState.allocationsByNode["cnode"])
 			}, 1*time.Second, 100*time.Millisecond).Should(Equal(2))
 		})
 
@@ -1018,7 +1017,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			Consistently(func() bool {
 				done := c.pause()
 				defer done()
-				a := c.allocationsByNode["cnode"]["test-handle/10.0.0.0"]
+				a := c.allocationState.allocationsByNode["cnode"]["test-handle/10.0.0.0"]
 				return a.isConfirmedLeak()
 			}, assertionTimeout, 100*time.Millisecond).Should(BeFalse())
 
@@ -1026,7 +1025,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			Eventually(func() bool {
 				done := c.pause()
 				defer done()
-				a := c.allocationsByNode["cnode"]["test-handle/fe80::"]
+				a := c.allocationState.allocationsByNode["cnode"]["test-handle/fe80::"]
 				return a.isConfirmedLeak()
 			}, assertionTimeout, 1*time.Second).Should(BeTrue())
 
@@ -1211,7 +1210,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			done := c.pause()
 			defer done()
-			_, ok := c.allocationsByNode["cnode"]
+			_, ok := c.allocationState.allocationsByNode["cnode"]
 			return ok
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 
@@ -1320,7 +1319,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			done := c.pause()
 			defer done()
-			_, ok := c.allocationsByNode["cnode"]
+			_, ok := c.allocationState.allocationsByNode["cnode"]
 			return ok
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -1611,7 +1611,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		It("should handle pod deletion", func() {
 			// Send a pod deletion event for one of the pods.
-			cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})
+			Expect(cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 			c.OnKubernetesPodDeleted(&podsNode1[0])
 
 			// We should see the allocation marked as a candidate for GC.
@@ -1640,7 +1640,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		It("should handle node deletion", func() {
 			// Delete node1.
-			cs.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})
+			Expect(cs.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})).NotTo(HaveOccurred())
 			c.OnKubernetesNodeDeleted(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}})
 
 			// The allocations won't be marked as leaked yet, since the controller is confused about the node's status (deleted,
@@ -1661,8 +1661,8 @@ var _ = Describe("IPAM controller UTs", func() {
 			}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 			// Delete the pods too.
-			cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})
-			cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[1].Name, metav1.DeleteOptions{})
+			Expect(cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+			Expect(cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[1].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 			c.OnKubernetesPodDeleted(&podsNode1[0])
 			c.OnKubernetesPodDeleted(&podsNode1[1])
 

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -16,11 +16,13 @@ package node
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -52,7 +54,7 @@ const (
 // assertConsistentState performs checks on the provided IPAM controller's internal
 // caches to ensure that they are consistent with each other. Useful for ensuring that
 // at any arbitrary point in time, we're not in an unknown state.
-func assertConsistentState(c *ipamController) {
+func assertConsistentState(c *IPAMController) {
 	// Stop the world so we can inspect it.
 	done := c.pause()
 	defer done()
@@ -93,7 +95,7 @@ func assertConsistentState(c *ipamController) {
 }
 
 var _ = Describe("IPAM controller UTs", func() {
-	var c *ipamController
+	var c *IPAMController
 	var cli client.Interface
 	var cs kubernetes.Interface
 	var stopChan chan struct{}
@@ -144,6 +146,9 @@ var _ = Describe("IPAM controller UTs", func() {
 		// Create a new controller. We don't register with a data feed,
 		// as the tests themselves will drive the controller.
 		c = NewIPAMController(cfg, cli, cs, podInformer.GetIndexer(), nodeInformer.GetIndexer())
+
+		// For testing, speed up update batching.
+		c.consolidationWindow = 1 * time.Millisecond
 	})
 
 	AfterEach(func() {
@@ -1533,7 +1538,30 @@ var _ = Describe("IPAM controller UTs", func() {
 		Consistently(numBlocks, assertionTimeout, 100*time.Millisecond).Should(Equal(1))
 	})
 
-	Context("with several allocations across nodes", func() {
+	It("should delete empty IPAM blocks when the node no longer exists", func() {
+		// This testcase handles an edge case in our code, to make sure we spot node affinities that
+		// must be released even when there are no allocations in the block. Since much of the GC controller logic
+		// is based on allocations, it's important to have an explicit test for this case.
+
+		// Create an empty block with an affinity to a node that doesn't exist. Then, trigger a full GC cycle. The controller
+		// should spot the empty block and release it.
+		c.onUpdate(createBlock(nil, "dead-node", "10.0.0.0/26"))
+
+		// Start the controller.
+		c.Start(stopChan)
+
+		// Mark the syncer as InSync so that the GC will be enabled.
+		c.fullScanNextSync("forced by test")
+		c.onStatusUpdate(bapi.InSync)
+
+		// Expect the block to be released.
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("dead-node")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "Affinity for dead-node should be released")
+	})
+
+	Context("with a 1hr grace period", func() {
 		ns := "test-namespace"
 		podsNode1 := []v1.Pod{
 			{
@@ -1591,54 +1619,17 @@ var _ = Describe("IPAM controller UTs", func() {
 			}
 
 			// Create some IPAM blocks, assigning IPs to the pods.
-			createBlock(podsNode1, c, "10.0.1.0/24")
-			createBlock(podsNode2, c, "10.0.2.0/24")
+			c.onUpdate(createBlock(podsNode1, "node1", "10.0.1.0/24"))
+			c.onUpdate(createBlock(podsNode2, "node2", "10.0.2.0/24"))
 
 			// Mark the syncer as InSync so that the GC will be enabled.
 			c.onStatusUpdate(bapi.InSync)
 
 			// Start the controller.
 			c.Start(stopChan)
-
-			// Expect nothing to be dirty initially. This makes sure initial sync has completed
-			// before starting the tests.
-			Eventually(func() bool {
-				done := c.pause()
-				defer done()
-				return len(c.allocationState.dirtyNodes) == 0
-			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue(), "initial state was dirty")
 		})
 
-		It("should handle pod deletion", func() {
-			// Send a pod deletion event for one of the pods.
-			Expect(cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
-			c.OnKubernetesPodDeleted(&podsNode1[0])
-
-			// We should see the allocation marked as a candidate for GC.
-			Eventually(func() error {
-				done := c.pause()
-				defer done()
-				if _, ok := c.allocationState.allocationsByNode["node1"]; !ok {
-					return fmt.Errorf("node1 not found")
-				}
-				if _, ok := c.allocationState.allocationsByNode["node1"]["pod1-1/10.0.1.1"]; !ok {
-					return fmt.Errorf("allocation not found")
-				}
-				if c.allocationState.allocationsByNode["node1"]["pod1-1/10.0.1.1"].leakedAt == nil {
-					return fmt.Errorf("allocation was not marked as leaked")
-				}
-				return nil
-			}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-			// Eventually node1 should be cleared of dirty status.
-			Eventually(func() bool {
-				done := c.pause()
-				defer done()
-				return c.allocationState.dirtyNodes["node1"]
-			}, 1*time.Second, 100*time.Millisecond).Should(BeFalse(), "node1 was not cleared of dirty status")
-		})
-
-		It("should handle node deletion", func() {
+		It("should handle node deletion events", func() {
 			// Delete node1.
 			Expect(cs.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})).NotTo(HaveOccurred())
 			c.OnKubernetesNodeDeleted(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}})
@@ -1663,8 +1654,9 @@ var _ = Describe("IPAM controller UTs", func() {
 			// Delete the pods too.
 			Expect(cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 			Expect(cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[1].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
-			c.OnKubernetesPodDeleted(&podsNode1[0])
-			c.OnKubernetesPodDeleted(&podsNode1[1])
+
+			// Trigger another sync.
+			c.OnKubernetesNodeDeleted(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}})
 
 			// All state should be cleaned up now.
 			fakeClient := cli.IPAM().(*fakeIPAMClient)
@@ -1684,11 +1676,168 @@ var _ = Describe("IPAM controller UTs", func() {
 			}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 		})
 	})
+
+	Context("with a large number of nodes and allocatoins", func() {
+		// This is a sort of stress test to see how well the controller handles a large number of nodes and allocations.
+		numNodes := 1000
+		podsPerNode := 5
+
+		var allPods []v1.Pod
+		var allBlocks []bapi.Update
+
+		BeforeEach(func() {
+			// Set a normal grace period to prevent frequent syncs, which can cause excessive resource usage
+			// at such a large scale.
+			c.config.LeakGracePeriod = &metav1.Duration{Duration: 1 * time.Hour}
+			c.consolidationWindow = 1 * time.Second
+
+			// Start the controller - we need to do this before creating the nodes, so that the controller is ready to
+			// consume from its channels.
+			c.Start(stopChan)
+
+			// Create 5k nodes.
+			for i := 0; i < numNodes; i++ {
+				n := libapiv3.Node{}
+				n.Name = fmt.Sprintf("node%d", i)
+				n.Spec.OrchRefs = []libapiv3.OrchRef{{NodeName: n.Name, Orchestrator: apiv3.OrchestratorKubernetes}}
+				_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				kn := v1.Node{}
+				kn.Name = n.Name
+				_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				var node *v1.Node
+				Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+			}
+
+			// For each node, create 30 pods and assign them IPs. Pre-create the blocks, and then
+			// send them all in at once to separate the test setup from the controller processing.
+			for nodeNum := 0; nodeNum < numNodes; nodeNum++ {
+				// Determine the block CIDR for this node. Each node is given a /26,
+				// which means for 5k nodes we need a /13 IP pool.
+				baseIPInt := big.NewInt(int64(0x0a000000 + nodeNum*64))
+				baseIP := net.BigIntToIP(baseIPInt, false)
+				blockCIDR := fmt.Sprintf("%s/26", baseIP.String())
+
+				podIP := baseIP
+				nodeName := fmt.Sprintf("node%d", nodeNum)
+				nodePods := []v1.Pod{}
+				for podNum := 0; podNum < podsPerNode; podNum++ {
+					p := v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("pod%d-%d", nodeNum, podNum),
+							Namespace: "test-namespace",
+						},
+						Spec: v1.PodSpec{NodeName: nodeName},
+						Status: v1.PodStatus{
+							PodIP:  podIP.String(),
+							PodIPs: []v1.PodIP{{IP: podIP.String()}},
+						},
+					}
+					allPods = append(allPods, p)
+					nodePods = append(nodePods, p)
+					podIP = net.IncrementIP(podIP, big.NewInt(1))
+
+				}
+				allBlocks = append(allBlocks, createBlock(nodePods, nodeName, blockCIDR))
+				logrus.WithField("nodeNum", nodeNum).WithField("blockCIDR", blockCIDR).Info("[TEST] Created node + block")
+			}
+
+			// Create all the pods. This loop consumes the vast majority of the time this test takes to run.
+			// It would be great to parallelize this, but it's not possible to create pods in parallel  with
+			// the current fake client.
+			for _, p := range allPods {
+				_, err := cs.CoreV1().Pods(p.Namespace).Create(context.TODO(), &p, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				var gotPod *v1.Pod
+				Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+				logrus.WithField("pod", p.Name).Info("[TEST] Created pod")
+			}
+
+			By("Sending updates for all blocks")
+
+			// Create all the blocks
+			for _, u := range allBlocks {
+				c.onUpdate(u)
+			}
+
+			// Mark in sync
+			c.onStatusUpdate(bapi.InSync)
+
+			By("Waiting for controller to be in sync")
+
+			// Wait for the controller to process all the updates.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return len(c.allBlocks) == numNodes
+			}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return len(c.allocationState.dirtyNodes) == 0
+			}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "Controller did not process all blocks")
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return c.fullSyncRequired
+			}, 5*time.Second, 100*time.Millisecond).Should(BeFalse())
+		})
+
+		It("should detect a leaked IP reasonably quickly", func() {
+			By("Deleting a pod to trigger a leak")
+
+			// Delete one of the pods to trigger a leak, and check that the controller detects it.
+			pod := allPods[numNodes-1]
+			Expect(cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+			c.OnKubernetesPodDeleted(&pod)
+
+			// Delete a pod on node 0 but don't inform the controller. This should not trigger a leak,
+			// since the controller is not aware of the pod deletion.
+			pod2 := allPods[0]
+			Expect(cs.CoreV1().Pods(pod2.Namespace).Delete(context.TODO(), pod2.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+
+			// Wait for the controller to detect the leak. This should happen quickly, since the controller
+			// will only need to process a single block.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				a := c.allocationState.allocationsByNode[pod.Spec.NodeName][fmt.Sprintf("%s/%s", pod.Name, pod.Status.PodIP)]
+				return a.leakedAt != nil
+			}, 3*time.Second, 100*time.Millisecond).Should(BeTrue(), "IP was not marked as leaked")
+			Consistently(func() bool {
+				// While it would not be WRONG to mark the other pod as leaked, we know that the controller won't do so
+				// because we haven't told it the pod was deleted. This verifies that the controller is doing work incrementally based
+				// on the events it receives, rather than brute force syncing.
+				done := c.pause()
+				defer done()
+				a := c.allocationState.allocationsByNode[pod2.Spec.NodeName][fmt.Sprintf("%s/%s", pod2.Name, pod2.Status.PodIP)]
+				return a.leakedAt == nil
+			}, 3*time.Second, 100*time.Millisecond).Should(BeTrue(), "IP was unexpected marked as leaked")
+
+			By("Triggering a full IPAM scan")
+			// Now do a brute force full scan to ensure that the controller eventually catches up.
+			c.fullScanNextSync("forced by test")
+			c.onStatusUpdate(bapi.InSync)
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				a := c.allocationState.allocationsByNode[pod2.Spec.NodeName][fmt.Sprintf("%s/%s", pod2.Name, pod2.Status.PodIP)]
+				return a.leakedAt != nil
+			}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "IP was not marked as leaked")
+		})
+	})
 })
 
 // createBlock creates a block based on the given pods and CIDR, and sends it as an update to the controller.
-func createBlock(pods []v1.Pod, c *ipamController, cidrStr string) {
-	affinity := fmt.Sprintf("host:%s", pods[0].Spec.NodeName)
+func createBlock(pods []v1.Pod, host, cidrStr string) bapi.Update {
+	var affinity *string
+	if host != "" {
+		aff := fmt.Sprintf("host:%s", host)
+		affinity = &aff
+	}
 	cidr := net.MustParseCIDR(cidrStr)
 
 	// Create a bootstrap block for access to IPToOrdinal.
@@ -1700,7 +1849,7 @@ func createBlock(pods []v1.Pod, c *ipamController, cidrStr string) {
 		attrs = append(attrs, model.AllocationAttribute{
 			AttrPrimary: &pod.Name,
 			AttrSecondary: map[string]string{
-				ipam.AttributeNode:      pod.Spec.NodeName,
+				ipam.AttributeNode:      host,
 				ipam.AttributePod:       pod.Name,
 				ipam.AttributeNamespace: pod.Namespace,
 			},
@@ -1713,14 +1862,13 @@ func createBlock(pods []v1.Pod, c *ipamController, cidrStr string) {
 	alloc, unalloc := makeAllocationsArrays(int(cidr.Network().NumAddrs().Int64()), assignments)
 	block = model.AllocationBlock{
 		CIDR:        cidr,
-		Affinity:    &affinity,
+		Affinity:    affinity,
 		Allocations: alloc,
 		Unallocated: unalloc,
 		Attributes:  attrs,
 	}
 	kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &block}
-	update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
-	c.onUpdate(update)
+	return bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
 }
 
 // makeAllocationsArray creates an array of pointers to integers, with the given assignments.

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -82,6 +82,14 @@ func assertConsistentState(c *ipamController) {
 	for cidr, n := range c.nodesByBlock {
 		ExpectWithOffset(1, c.blocksByNode[n][cidr]).To(BeTrue(), fmt.Sprintf("Block %s not present in blocksByNode", cidr))
 	}
+
+	// Make sure every allocation within the allocationState is present in the other maps.
+	for node, allocations := range c.allocationState.allocationsByNode {
+		for id, a := range allocations {
+			ExpectWithOffset(1, c.allocationsByBlock[a.block][id]).To(Equal(a), fmt.Sprintf("Allocation %s not present in allocationsByBlock", id))
+		}
+		ExpectWithOffset(1, c.blocksByNode).To(HaveKey(node), fmt.Sprintf("Node %s not present in blocksByNode", node))
+	}
 }
 
 var _ = Describe("IPAM controller UTs", func() {
@@ -599,7 +607,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Trigger a node deletion. The node referenced in the allocation above
 		// never existed in the k8s API and neither does the pod, so this should result in a GC.
-		c.OnKubernetesNodeDeleted()
+		c.OnKubernetesNodeDeleted(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "kname"}})
 
 		// Confirm the IP and block affinity were released.
 		fakeClient := cli.IPAM().(*fakeIPAMClient)
@@ -1524,4 +1532,213 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(numBlocks, 1*time.Second, 100*time.Millisecond).Should(Equal(1))
 		Consistently(numBlocks, assertionTimeout, 100*time.Millisecond).Should(Equal(1))
 	})
+
+	Context("with several allocations across nodes", func() {
+		ns := "test-namespace"
+		podsNode1 := []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1-1", Namespace: ns},
+				Spec:       v1.PodSpec{NodeName: "node1"},
+				Status:     v1.PodStatus{PodIP: "10.0.1.1", PodIPs: []v1.PodIP{{IP: "10.0.1.1"}}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1-2", Namespace: ns},
+				Spec:       v1.PodSpec{NodeName: "node1"},
+				Status:     v1.PodStatus{PodIP: "10.0.1.2", PodIPs: []v1.PodIP{{IP: "10.0.1.2"}}},
+			},
+		}
+		podsNode2 := []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2-1", Namespace: ns},
+				Spec:       v1.PodSpec{NodeName: "node2"},
+				Status:     v1.PodStatus{PodIP: "10.0.2.1", PodIPs: []v1.PodIP{{IP: "10.0.2.1"}}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2-2", Namespace: ns},
+				Spec:       v1.PodSpec{NodeName: "node2"},
+				Status:     v1.PodStatus{PodIP: "10.0.2.2", PodIPs: []v1.PodIP{{IP: "10.0.2.2"}}},
+			},
+		}
+
+		BeforeEach(func() {
+			// Set the controller's grace period to a large value, to take the periodic GC out of the equation.
+			// This suite of tests is focused on response to events, not periodic GC.
+			c.config.LeakGracePeriod = &metav1.Duration{Duration: 1 * time.Hour}
+
+			// Create Calico and k8s nodes for the test.
+			for _, name := range []string{"node1", "node2"} {
+				n := libapiv3.Node{}
+				n.Name = name
+				n.Spec.OrchRefs = []libapiv3.OrchRef{{NodeName: name, Orchestrator: apiv3.OrchestratorKubernetes}}
+				_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				kn := v1.Node{}
+				kn.Name = name
+				_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				var node *v1.Node
+				Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+			}
+
+			// Create some pods in the API, across two different nodes.
+			for _, p := range append(podsNode1, podsNode2...) {
+				_, err := cs.CoreV1().Pods(p.Namespace).Create(context.TODO(), &p, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				var gotPod *v1.Pod
+				Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+			}
+
+			// Create some IPAM blocks, assigning IPs to the pods.
+			createBlock(podsNode1, c, "10.0.1.0/24")
+			createBlock(podsNode2, c, "10.0.2.0/24")
+
+			// Mark the syncer as InSync so that the GC will be enabled.
+			c.onStatusUpdate(bapi.InSync)
+
+			// Start the controller.
+			c.Start(stopChan)
+
+			// Expect nothing to be dirty initially. This makes sure initial sync has completed
+			// before starting the tests.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return len(c.allocationState.dirtyNodes) == 0
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue(), "initial state was dirty")
+		})
+
+		It("should handle pod deletion", func() {
+			// Send a pod deletion event for one of the pods.
+			cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})
+			c.OnKubernetesPodDeleted(&podsNode1[0])
+
+			// We should see the allocation marked as a candidate for GC.
+			Eventually(func() error {
+				done := c.pause()
+				defer done()
+				if _, ok := c.allocationState.allocationsByNode["node1"]; !ok {
+					return fmt.Errorf("node1 not found")
+				}
+				if _, ok := c.allocationState.allocationsByNode["node1"]["pod1-1/10.0.1.1"]; !ok {
+					return fmt.Errorf("allocation not found")
+				}
+				if c.allocationState.allocationsByNode["node1"]["pod1-1/10.0.1.1"].leakedAt == nil {
+					return fmt.Errorf("allocation was not marked as leaked")
+				}
+				return nil
+			}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+			// Eventually node1 should be cleared of dirty status.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return c.allocationState.dirtyNodes["node1"]
+			}, 1*time.Second, 100*time.Millisecond).Should(BeFalse(), "node1 was not cleared of dirty status")
+		})
+
+		It("should handle node deletion", func() {
+			// Delete node1.
+			cs.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})
+			c.OnKubernetesNodeDeleted(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}})
+
+			// The allocations won't be marked as leaked yet, since the controller is confused about the node's status (deleted,
+			// but still has pods).
+			Eventually(func() error {
+				done := c.pause()
+				defer done()
+				if _, ok := c.allocationState.allocationsByNode["node1"]; !ok {
+					return fmt.Errorf("node1 not found")
+				}
+				if _, ok := c.allocationState.allocationsByNode["node1"]["pod1-1/10.0.1.1"]; !ok {
+					return fmt.Errorf("allocation not found")
+				}
+				if c.allocationState.allocationsByNode["node1"]["pod1-1/10.0.1.1"].leakedAt != nil {
+					return fmt.Errorf("allocation was marked as leaked")
+				}
+				return nil
+			}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+			// Delete the pods too.
+			cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[0].Name, metav1.DeleteOptions{})
+			cs.CoreV1().Pods(ns).Delete(context.TODO(), podsNode1[1].Name, metav1.DeleteOptions{})
+			c.OnKubernetesPodDeleted(&podsNode1[0])
+			c.OnKubernetesPodDeleted(&podsNode1[1])
+
+			// All state should be cleaned up now.
+			fakeClient := cli.IPAM().(*fakeIPAMClient)
+			Eventually(func() error {
+				done := c.pause()
+				defer done()
+				if _, ok := c.allocationState.allocationsByNode["node1"]; ok {
+					return fmt.Errorf("node1 still being tracked")
+				}
+				if !fakeClient.affinityReleased("node1") {
+					return fmt.Errorf("node1 affinity not released")
+				}
+				if len(fakeClient.handlesReleased) != 2 {
+					return fmt.Errorf("expected 2 handles to be released, got %d", len(fakeClient.handlesReleased))
+				}
+				return nil
+			}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		})
+	})
 })
+
+// createBlock creates a block based on the given pods and CIDR, and sends it as an update to the controller.
+func createBlock(pods []v1.Pod, c *ipamController, cidrStr string) {
+	affinity := fmt.Sprintf("host:%s", pods[0].Spec.NodeName)
+	cidr := net.MustParseCIDR(cidrStr)
+
+	// Create a bootstrap block for access to IPToOrdinal.
+	block := model.AllocationBlock{CIDR: cidr}
+
+	assignments := map[int]int{}
+	attrs := []model.AllocationAttribute{}
+	for i, pod := range pods {
+		attrs = append(attrs, model.AllocationAttribute{
+			AttrPrimary: &pod.Name,
+			AttrSecondary: map[string]string{
+				ipam.AttributeNode:      pod.Spec.NodeName,
+				ipam.AttributePod:       pod.Name,
+				ipam.AttributeNamespace: pod.Namespace,
+			},
+		})
+		ord, err := block.IPToOrdinal(net.MustParseIP(pod.Status.PodIP))
+		Expect(err).NotTo(HaveOccurred())
+		assignments[ord] = i
+	}
+
+	alloc, unalloc := makeAllocationsArrays(int(cidr.Network().NumAddrs().Int64()), assignments)
+	block = model.AllocationBlock{
+		CIDR:        cidr,
+		Affinity:    &affinity,
+		Allocations: alloc,
+		Unallocated: unalloc,
+		Attributes:  attrs,
+	}
+	kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &block}
+	update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+	c.onUpdate(update)
+}
+
+// makeAllocationsArray creates an array of pointers to integers, with the given assignments.
+// assigned is a map of ordinal to attribute index.
+func makeAllocationsArrays(n int, assinged map[int]int) ([]*int, []int) {
+	allocs := make([]*int, n)
+	for i := range allocs {
+		allocs[i] = nil
+	}
+	for k, v := range assinged {
+		allocs[k] = &v
+	}
+
+	unalloc := []int{}
+	for i := range allocs {
+		if allocs[i] == nil {
+			unalloc = append(unalloc, i)
+		}
+	}
+	return allocs, unalloc
+}

--- a/kube-controllers/pkg/controllers/node/node_deleter.go
+++ b/kube-controllers/pkg/controllers/node/node_deleter.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -58,7 +59,7 @@ func (c *nodeDeleter) RegisterWith(f *utils.DataFeed) {
 	f.RegisterForSyncStatus(c.onStatusUpdate)
 }
 
-func (c *nodeDeleter) OnKubernetesNodeDeleted() {
+func (c *nodeDeleter) OnKubernetesNodeDeleted(_ *v1.Node) {
 	// When a Kubernetes node is deleted, trigger a sync.
 	log.Debug("Kubernetes node deletion event")
 	c.syncChan <- struct{}{}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/7841

The IPAM GC controller currently iterates every IP address allocation in the cluster every time an IP address is assigned or released. This can result in excessive CPU usage on larger / more active clusters. 

Instead, this PR changes the behavior such that we limit the allocations we check to:

- Those on nodes whose IPAM state has changed since the last sync.
- Those on nodes who have had a Pod Deletion Event since the last sync.

The idea is that this set should be much smaller than every node, and will allow us to incrementally scan the cluster instead of checking the entire cluster on every syncIPAM() call. 

We will have a periodic (by default every 5m) sync that will check every node, as a backstop, and it's worth noting that this change on its own means we may be relying on the periodic sync slightly more often in order to determine when IPAM allocations have leaked, as it is possible leaks can occur on nodes without the controller receiving the requisite notifications to notice it.

We might be able to enhance this further by tracking when individual allocations are dirty (and, for example, only clearing them after the grace period proves they are OK or leaked). But I think that's a larger change and this one should do the trick I hope. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve CPU efficiency of IP address garbage collection controller
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.