### PR TITLE
Ensure existing CNI config file has correct permissions

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -401,6 +401,12 @@ func writeCNIConfig(c config) {
 		logrus.Fatal(err)
 	}
 
+	// Safeguarding since WriteFile does not change existing file's permissions.
+	err = os.Chmod(path, perm)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
 	content, err := os.ReadFile(path)
 	if err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
## Description

- enhancement
- [links to issues that this PR addresses](https://github.com/projectcalico/calico/issues/9619)


## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/9619


## Todos

- [X] Tests
- [X] Documentation
- [X] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ensure existing CNI config file has correct permissions on upgrade
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
