### PR TITLE
Load value from metadata.mk in release tool

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -4,6 +4,12 @@ PACKAGE_NAME = github.com/projectcalico/calico/release
 
 include ../lib.Makefile
 
+export ORGANIZATION
+export GIT_REPO
+export GIT_REPO_SLUG
+export DEV_REGISTRIES
+export OPERATOR_BRANCH
+
 .PHONY: build
 build: bin/release
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -34,6 +34,4 @@ hashrelease: bin/release var-require-all-GITHUB_TOKEN
 ###############################################################################
 .PHONY: release-notes
 release-notes: bin/release var-require-all-GITHUB_TOKEN
-	@ORGANIZATION=$(ORGANIZATION) \
-	REPO_ROOT=$(REPO_ROOT) \
-	bin/release release generate-release-notes
+	@bin/release release generate-release-notes

--- a/release/cmd/main.go
+++ b/release/cmd/main.go
@@ -15,12 +15,9 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
@@ -68,10 +65,6 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to load configuration")
 	}
-	metadataFile := filepath.Join(cfg.RepoRootDir, "metadata.mk")
-	if err := loadMetadata(metadataFile); err != nil {
-		logrus.WithError(err).Fatalf("Failed to load values from %s", metadataFile)
-	}
 
 	app := &cli.App{
 		Name:     "release",
@@ -84,41 +77,4 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		logrus.WithError(err).Fatal("Error running task")
 	}
-}
-
-func loadMetadata(filename string) error {
-	file, err := os.Open(filename)
-	if err != nil {
-		return fmt.Errorf("failed to open metadata file: %v", err)
-	}
-	defer file.Close()
-
-	// Regex to split on either "=" or "?=" as the delimiter.
-	delimiterRegex := regexp.MustCompile(`\s*(=|\?=)\s*`)
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		// Skip comments and empty lines.
-		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		parts := delimiterRegex.Split(line, 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid line in metadata file: %s", line)
-		}
-
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		// Existing environment variables take precedence.
-		if os.Getenv(key) == "" {
-			os.Setenv(key, value)
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to read metadata file: %v", err)
-	}
-	return nil
 }

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -47,7 +47,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 		{
 			Name:  "generate-release-notes",
 			Usage: "Generate release notes for the next release",
-			Flags: []cli.Flag{orgFlag, githubTokenFlag},
+			Flags: []cli.Flag{orgFlag, devTagSuffixFlag, githubTokenFlag},
 			Action: func(c *cli.Context) error {
 				configureLogging("release-notes.log")
 


### PR DESCRIPTION
## Description

Since values in `metadata.mk` are not getting exported and they are needed/used in the release tool; this attempts to fix that.

Also noticed an error while testing with the release notes.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
