### PR TITLE
[release tool] fix hashrelease failure

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -30,9 +30,13 @@ ci: static-checks
 ###############################################################################
 # Hashrelease
 ###############################################################################
-.PHONY: hashrelease
-hashrelease: bin/release var-require-all-GITHUB_TOKEN
+.PHONY: hashrelease hashrelease-build hashrelease-publish
+hashrelease: hashrelease-build hashrelease-publish
+
+hashrelease-build: bin/release var-require-all-GITHUB_TOKEN
 	@bin/release hashrelease build
+
+hashrelease-publish: bin/release var-require-all-GITHUB_TOKEN
 	@bin/release hashrelease publish
 
 ###############################################################################

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -85,13 +85,10 @@ func remoteReleasesLibraryPath(user string) string {
 	return filepath.Join(RemoteDocsPath(user), "all-releases")
 }
 
-func HasHashrelease(hash string, cfg *Config) (bool, error) {
+func HasHashrelease(hash string, cfg *Config) bool {
 	logrus.WithField("hash", hash).Debug("Checking if hashrelease exists")
 	out, err := runSSHCommand(cfg, fmt.Sprintf("cat %s | grep %s", remoteReleasesLibraryPath(cfg.User), hash))
-	if err == nil {
-		return strings.Contains(out, hash), nil
-	}
-	return false, err
+	return err != nil && strings.Contains(out, hash)
 }
 
 // SetHashreleaseAsLatest sets the hashrelease as the latest for the stream

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -85,10 +85,20 @@ func remoteReleasesLibraryPath(user string) string {
 	return filepath.Join(RemoteDocsPath(user), "all-releases")
 }
 
-func HasHashrelease(hash string, cfg *Config) bool {
+func HasHashrelease(hash string, cfg *Config) (bool, error) {
 	logrus.WithField("hash", hash).Debug("Checking if hashrelease exists")
 	out, err := runSSHCommand(cfg, fmt.Sprintf("cat %s | grep %s", remoteReleasesLibraryPath(cfg.User), hash))
-	return err != nil && strings.Contains(out, hash)
+	if err != nil {
+		if strings.Contains(err.Error(), "exited with status 1") {
+			// Process exited with status 1 is from grep when no match is found
+			logrus.WithError(err).Error("Hashrelease not found")
+			return false, nil
+		} else {
+			logrus.WithError(err).Error("Failed to check hashrelease library")
+			return false, err
+		}
+	}
+	return strings.Contains(out, hash), nil
 }
 
 // SetHashreleaseAsLatest sets the hashrelease as the latest for the stream

--- a/release/internal/hashreleaseserver/ssh.go
+++ b/release/internal/hashreleaseserver/ssh.go
@@ -70,7 +70,7 @@ func runSSHCommand(cfg *Config, command string) (string, error) {
 	defer session.Close()
 	var stdoutBuf bytes.Buffer
 	session.Stdout = &stdoutBuf
-	logrus.WithField("command", command).Info("Running command in remote host")
+	logrus.WithField("command", command).Debug("Running command in remote host")
 	if err := session.Run(command); err != nil {
 		return "", err
 	}

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -40,7 +40,7 @@ func HashreleasePublished(cfg *hashreleaseserver.Config, hash string, ci bool) (
 		return false, nil
 	}
 
-	return hashreleaseserver.HasHashrelease(hash, cfg)
+	return hashreleaseserver.HasHashrelease(hash, cfg), nil
 }
 
 // HashreleaseSlackMessage sends a slack message to notify that a hashrelease has been published.

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -40,7 +40,7 @@ func HashreleasePublished(cfg *hashreleaseserver.Config, hash string, ci bool) (
 		return false, nil
 	}
 
-	return hashreleaseserver.HasHashrelease(hash, cfg), nil
+	return hashreleaseserver.HasHashrelease(hash, cfg)
 }
 
 // HashreleaseSlackMessage sends a slack message to notify that a hashrelease has been published.


### PR DESCRIPTION
## Description

Hashrelease was failing because the grep command to check if a hash already exists in server was exiting with 1 and was being propagated up.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
