### PR TITLE
Refactor: Use interface to configure libbpf global data when loading bpf programs.

### DIFF
--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -38,7 +38,8 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
-	"github.com/projectcalico/calico/felix/bpf/hook"
+	"github.com/projectcalico/calico/felix/bpf/libbpf"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/utils"
 	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/labelindex"
@@ -2247,7 +2248,7 @@ func PolicyDebugJSONFileName(iface, polDir string, ipFamily proto.IPVersion) str
 	return path.Join(RuntimePolDir, fmt.Sprintf("%s_%s_v%d.json", iface, polDir, ipFamily))
 }
 
-func MapPinDir(typ int, name, iface string, h hook.Hook) string {
+func MapPinDir() string {
 	PinBaseDir := path.Join(bpfdefs.DefaultBPFfsPath, "tc")
 	subDir := "globals"
 	return path.Join(PinBaseDir, subDir)
@@ -2348,4 +2349,68 @@ func IterPerCpuMapCmdOutput(output []byte, f func(k, v []byte)) error {
 		f(k, v)
 	}
 	return nil
+}
+
+func ConfigureAndLoad(file string, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
+	obj, err := libbpf.OpenObject(file)
+	if err != nil {
+		return nil, err
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			err := obj.Close()
+			if err != nil {
+				log.WithError(err).Error("Error closing BPF object.")
+			}
+		}
+	}()
+
+	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
+		// In case of global variables, libbpf creates an internal map <prog_name>.rodata
+		// The values are read only for the BPF programs, but can be set to a value from
+		// userspace before the program is loaded.
+		mapName := m.Name()
+		if m.IsMapInternal() {
+			if strings.HasPrefix(mapName, ".rodata") {
+				continue
+			}
+
+			if err := data.Set(m); err != nil {
+				return nil, fmt.Errorf("failed to configure %s: %w", file, err)
+			}
+			continue
+		}
+
+		if size := maps.Size(mapName); size != 0 {
+			if err := m.SetSize(size); err != nil {
+				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
+			}
+		}
+
+		log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())
+		pinDir := MapPinDir()
+		// If mapsToBePinned is not specified, pin all the maps.
+		if len(mapsToBePinned) == 0 {
+			if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
+				return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
+			}
+		} else {
+			for _, name := range mapsToBePinned {
+				if mapName == name {
+					if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
+						return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
+					}
+				}
+			}
+		}
+	}
+
+	if err := obj.Load(); err != nil {
+		return nil, fmt.Errorf("error loading program: %w", err)
+	}
+
+	success = true
+	return obj, nil
 }

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2351,7 +2351,7 @@ func IterPerCpuMapCmdOutput(output []byte, f func(k, v []byte)) error {
 	return nil
 }
 
-func ConfigureAndLoad(file string, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
+func LoadObject(file string, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	obj, err := libbpf.OpenObject(file)
 	if err != nil {
 		return nil, err

--- a/felix/bpf/conntrack/bpf_scanner.go
+++ b/felix/bpf/conntrack/bpf_scanner.go
@@ -27,7 +27,6 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
-	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
 type BPFLogLevel string
@@ -112,89 +111,25 @@ func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 	// needs a newer than co-re.
 	binaryToLoad := path.Join(bpfdefs.ObjectDir,
 		fmt.Sprintf("conntrack_cleanup_%s_co-re_v%d.o", s.logLevel, s.ipVersion))
-	obj, err := libbpf.OpenObject(binaryToLoad)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load conntrack cleanup BPF program: %w", err)
-	}
-
-	success := false
-	defer func() {
-		if !success {
-			err := obj.Close()
-			if err != nil {
-				log.WithError(err).Error("Error closing BPF object.")
-			}
-		}
-	}()
-
 	ctMapParams := MapParams
 	if s.ipVersion == 6 {
 		ctMapParams = MapParamsV6
 	}
-	configuredGlobals := false
-	pinnedCTMap := false
-	var internalMaps []string
-	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
-		// In case of global variables, libbpf creates an internal map <prog_name>.rodata
-		// The values are read only for the BPF programs, but can be set to a value from
-		// userspace before the program is loaded.
-		mapName := m.Name()
-		if m.IsMapInternal() {
-			internalMaps = append(internalMaps, mapName)
-			if mapName != "conntrac.rodata" {
-				continue
-			}
 
-			err := (&libbpf.CTCleanupGlobalData{
-				CreationGracePeriod: s.timeouts.CreationGracePeriod,
-				TCPPreEstablished:   s.timeouts.TCPPreEstablished,
-				TCPEstablished:      s.timeouts.TCPEstablished,
-				TCPFinsSeen:         s.timeouts.TCPFinsSeen,
-				TCPResetSeen:        s.timeouts.TCPResetSeen,
-				UDPLastSeen:         s.timeouts.UDPLastSeen,
-				GenericIPLastSeen:   s.timeouts.GenericIPLastSeen,
-				ICMPLastSeen:        s.timeouts.ICMPLastSeen}).Set(m)
-			if err != nil {
-				return nil, fmt.Errorf("error setting global variables for map %s: %w", mapName, err)
-			}
-			configuredGlobals = true
-			continue
-		}
+	ctCleanupData := &libbpf.CTCleanupGlobalData{
+		CreationGracePeriod: s.timeouts.CreationGracePeriod,
+		TCPPreEstablished:   s.timeouts.TCPPreEstablished,
+		TCPEstablished:      s.timeouts.TCPEstablished,
+		TCPFinsSeen:         s.timeouts.TCPFinsSeen,
+		TCPResetSeen:        s.timeouts.TCPResetSeen,
+		UDPLastSeen:         s.timeouts.UDPLastSeen,
+		GenericIPLastSeen:   s.timeouts.GenericIPLastSeen,
+		ICMPLastSeen:        s.timeouts.ICMPLastSeen}
 
-		if size := maps.Size(mapName); size != 0 {
-			log.WithField("mapName", mapName).Info("Resizing map")
-			if err := m.SetSize(size); err != nil {
-				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
-			}
-		}
-
-		if mapName == ctMapParams.VersionedName() {
-			log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())
-			pinDir := bpf.MapPinDir(m.Type(), mapName, "", 0)
-			if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
-				return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
-			}
-			pinnedCTMap = true
-		}
+	obj, err := bpf.ConfigureAndLoad(binaryToLoad, ctCleanupData, ctMapParams.VersionedName())
+	if err != nil {
+		return nil, fmt.Errorf("error loading %s: %w", binaryToLoad, err)
 	}
-
-	if !configuredGlobals {
-		// Panic here because it indicates a coding error that we want to
-		// catch in testing.
-		log.WithField("maps", internalMaps).Panic("Bug: failed to find/set global variable map.")
-	}
-
-	if !pinnedCTMap {
-		// Panic here because it indicates a coding error that we want to
-		// catch in testing.
-		log.Panic("Bug: failed to find/pin conntrack map.")
-	}
-
-	if err := obj.Load(); err != nil {
-		return nil, fmt.Errorf("error loading conntrack expiry program: %w", err)
-	}
-
-	success = true
 	s.bpfExpiryProgram = obj
 	return s.bpfExpiryProgram, nil
 }

--- a/felix/bpf/conntrack/bpf_scanner.go
+++ b/felix/bpf/conntrack/bpf_scanner.go
@@ -145,17 +145,15 @@ func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 				continue
 			}
 
-			err := libbpf.SetGlobalData(
-				m,
-				&libbpf.CTCleanupGlobalData{
-					CreationGracePeriod: s.timeouts.CreationGracePeriod,
-					TCPPreEstablished:   s.timeouts.TCPPreEstablished,
-					TCPEstablished:      s.timeouts.TCPEstablished,
-					TCPFinsSeen:         s.timeouts.TCPFinsSeen,
-					TCPResetSeen:        s.timeouts.TCPResetSeen,
-					UDPLastSeen:         s.timeouts.UDPLastSeen,
-					GenericIPLastSeen:   s.timeouts.GenericIPLastSeen,
-					ICMPLastSeen:        s.timeouts.ICMPLastSeen})
+			err := (&libbpf.CTCleanupGlobalData{
+				CreationGracePeriod: s.timeouts.CreationGracePeriod,
+				TCPPreEstablished:   s.timeouts.TCPPreEstablished,
+				TCPEstablished:      s.timeouts.TCPEstablished,
+				TCPFinsSeen:         s.timeouts.TCPFinsSeen,
+				TCPResetSeen:        s.timeouts.TCPResetSeen,
+				UDPLastSeen:         s.timeouts.UDPLastSeen,
+				GenericIPLastSeen:   s.timeouts.GenericIPLastSeen,
+				ICMPLastSeen:        s.timeouts.ICMPLastSeen}).Set(m)
 			if err != nil {
 				return nil, fmt.Errorf("error setting global variables for map %s: %w", mapName, err)
 			}

--- a/felix/bpf/conntrack/bpf_scanner.go
+++ b/felix/bpf/conntrack/bpf_scanner.go
@@ -145,17 +145,17 @@ func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 				continue
 			}
 
-			err := libbpf.CTCleanupSetGlobals(
+			err := libbpf.SetGlobalData(
 				m,
-				s.timeouts.CreationGracePeriod,
-				s.timeouts.TCPPreEstablished,
-				s.timeouts.TCPEstablished,
-				s.timeouts.TCPFinsSeen,
-				s.timeouts.TCPResetSeen,
-				s.timeouts.UDPLastSeen,
-				s.timeouts.GenericIPLastSeen,
-				s.timeouts.ICMPLastSeen,
-			)
+				&libbpf.CTCleanupGlobalData{
+					CreationGracePeriod: s.timeouts.CreationGracePeriod,
+					TCPPreEstablished:   s.timeouts.TCPPreEstablished,
+					TCPEstablished:      s.timeouts.TCPEstablished,
+					TCPFinsSeen:         s.timeouts.TCPFinsSeen,
+					TCPResetSeen:        s.timeouts.TCPResetSeen,
+					UDPLastSeen:         s.timeouts.UDPLastSeen,
+					GenericIPLastSeen:   s.timeouts.GenericIPLastSeen,
+					ICMPLastSeen:        s.timeouts.ICMPLastSeen})
 			if err != nil {
 				return nil, fmt.Errorf("error setting global variables for map %s: %w", mapName, err)
 			}

--- a/felix/bpf/conntrack/bpf_scanner.go
+++ b/felix/bpf/conntrack/bpf_scanner.go
@@ -126,7 +126,7 @@ func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 		GenericIPLastSeen:   s.timeouts.GenericIPLastSeen,
 		ICMPLastSeen:        s.timeouts.ICMPLastSeen}
 
-	obj, err := bpf.ConfigureAndLoad(binaryToLoad, ctCleanupData, ctMapParams.VersionedName())
+	obj, err := bpf.LoadObject(binaryToLoad, ctCleanupData, ctMapParams.VersionedName())
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s: %w", binaryToLoad, err)
 	}

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -18,6 +18,10 @@ import (
 	"time"
 )
 
+type GlobalData interface {
+	Set(m *Map) error
+}
+
 type TcGlobalData struct {
 	IfaceName      string
 	HostIPv4       [16]byte

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -14,6 +14,10 @@
 
 package libbpf
 
+import (
+	"time"
+)
+
 type TcGlobalData struct {
 	IfaceName      string
 	HostIPv4       [16]byte
@@ -43,4 +47,20 @@ type XDPGlobalData struct {
 	IfaceName string
 	Jumps     [16]uint32
 	JumpsV6   [16]uint32
+}
+
+type CTCleanupGlobalData struct {
+	CreationGracePeriod time.Duration
+	TCPPreEstablished   time.Duration
+	TCPEstablished      time.Duration
+	TCPFinsSeen         time.Duration
+	TCPResetSeen        time.Duration
+	UDPLastSeen         time.Duration
+	GenericIPLastSeen   time.Duration
+	ICMPLastSeen        time.Duration
+}
+
+type CTLBGlobalData struct {
+	UDPNotSeen time.Duration
+	ExcludeUDP bool
 }

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -18,7 +18,6 @@ package libbpf
 
 import (
 	"runtime"
-	"time"
 )
 
 type Obj struct {
@@ -139,29 +138,7 @@ const (
 	GlobalsRedirectPeer     uint32 = 12345
 )
 
-func TcSetGlobals(_ *Map, globalData *TcGlobalData) error {
-	panic("LIBBPF syscall stub")
-}
-
-func CTLBSetGlobals(_ *Map, _ time.Duration, _ bool) error {
-	panic("LIBBPF syscall stub")
-}
-
-func CTCleanupSetGlobals(
-	m *Map,
-	CreationGracePeriod time.Duration,
-	TCPPreEstablished time.Duration,
-	TCPEstablished time.Duration,
-	TCPFinsSeen time.Duration,
-	TCPResetSeen time.Duration,
-	UDPLastSeen time.Duration,
-	GenericIPLastSeen time.Duration,
-	ICMPLastSeen time.Duration,
-) error {
-	panic("LIBBPF syscall stub")
-}
-
-func XDPSetGlobals(_ *Map, _ *XDPGlobalData) error {
+func SetGlobalData(m *Map, data interface{}) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -138,10 +138,6 @@ const (
 	GlobalsRedirectPeer     uint32 = 12345
 )
 
-func SetGlobalData(m *Map, data interface{}) error {
-	panic("LIBBPF syscall stub")
-}
-
 func (m *Map) SetSize(size int) error {
 	panic("LIBBPF syscall stub")
 }
@@ -155,5 +151,21 @@ func ObjPin(_ int, _ string) error {
 }
 
 func ObjGet(_ string) (int, error) {
+	panic("LIBBPF syscall stub")
+}
+
+func (t *TcGlobalData) Set(m *Map) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (t *XDPGlobalData) Set(m *Map) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (t *CTCleanupGlobalData) Set(m *Map) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (t *CTLBGlobalData) Set(m *Map) error {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -119,7 +119,7 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 
 func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bool) (*libbpf.Obj, error) {
 	filename := path.Join(bpfdefs.ObjectDir, ProgFileName(logLevel, ipver))
-	obj, err := bpf.ConfigureAndLoad(filename, &libbpf.CTLBGlobalData{UDPNotSeen: udpNotSeen, ExcludeUDP: excludeUDP})
+	obj, err := bpf.LoadObject(filename, &libbpf.CTLBGlobalData{UDPNotSeen: udpNotSeen, ExcludeUDP: excludeUDP})
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s:%w", filename, err)
 	}

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -119,45 +119,9 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 
 func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bool) (*libbpf.Obj, error) {
 	filename := path.Join(bpfdefs.ObjectDir, ProgFileName(logLevel, ipver))
-
-	log.WithField("filename", filename).Debug("Loading object file")
-	obj, err := libbpf.OpenObject(filename)
+	obj, err := bpf.ConfigureAndLoad(filename, &libbpf.CTLBGlobalData{UDPNotSeen: udpNotSeen, ExcludeUDP: excludeUDP})
 	if err != nil {
-		return nil, fmt.Errorf("failed to load %s: %w", filename, err)
-	}
-
-	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
-		// In case of global variables, libbpf creates an internal map <prog_name>.rodata
-		// The values are read only for the BPF programs, but can be set to a value from
-		// userspace before the program is loaded.
-		mapName := m.Name()
-		if m.IsMapInternal() {
-			if strings.HasPrefix(mapName, ".rodata") {
-				continue
-			}
-			err := (&libbpf.CTLBGlobalData{
-				UDPNotSeen: udpNotSeen,
-				ExcludeUDP: excludeUDP}).Set(m)
-			if err != nil {
-				return nil, fmt.Errorf("error setting globals: %w", err)
-			}
-			continue
-		}
-
-		if size := maps.Size(mapName); size != 0 {
-			err := m.SetSize(size)
-			if err != nil {
-				return nil, fmt.Errorf("error set map size %s: %w", m.Name(), err)
-			}
-		}
-		if err := m.SetPinPath(path.Join(bpfdefs.GlobalPinDir, mapName)); err != nil {
-			return nil, fmt.Errorf("error pinning map %s: %w", mapName, err)
-		}
-		log.WithFields(log.Fields{"obj": filename, "map": mapName}).Debug("Pinned map")
-	}
-
-	if err := obj.Load(); err != nil {
-		return nil, fmt.Errorf("error loading object %s: %w", filename, err)
+		return nil, fmt.Errorf("error loading %s:%w", filename, err)
 	}
 	return obj, nil
 }

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -135,9 +135,10 @@ func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bo
 			if strings.HasPrefix(mapName, ".rodata") {
 				continue
 			}
-			if err := libbpf.SetGlobalData(m, &libbpf.CTLBGlobalData{
+			err := (&libbpf.CTLBGlobalData{
 				UDPNotSeen: udpNotSeen,
-				ExcludeUDP: excludeUDP}); err != nil {
+				ExcludeUDP: excludeUDP}).Set(m)
+			if err != nil {
 				return nil, fmt.Errorf("error setting globals: %w", err)
 			}
 			continue

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -135,7 +135,9 @@ func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bo
 			if strings.HasPrefix(mapName, ".rodata") {
 				continue
 			}
-			if err := libbpf.CTLBSetGlobals(m, udpNotSeen, excludeUDP); err != nil {
+			if err := libbpf.SetGlobalData(m, &libbpf.CTLBGlobalData{
+				UDPNotSeen: udpNotSeen,
+				ExcludeUDP: excludeUDP}); err != nil {
 				return nil, fmt.Errorf("error setting globals: %w", err)
 			}
 			continue

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -489,5 +489,5 @@ func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalDa
 	copy(in, iface)
 	globalData.IfaceName = string(in)
 
-	return libbpf.SetGlobalData(m, globalData)
+	return globalData.Set(m)
 }

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -30,7 +30,8 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
-	"github.com/projectcalico/calico/felix/bpf/maps"
+
+	//"github.com/projectcalico/calico/felix/bpf/maps"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 
@@ -80,44 +81,10 @@ func (ap *AttachPoint) Log() *log.Entry {
 }
 
 func (ap *AttachPoint) loadObject(file string) (*libbpf.Obj, error) {
-	obj, err := libbpf.OpenObject(file)
+	obj, err := bpf.ConfigureAndLoad(file, ap.ConfigureProgram())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error loading %s: %w", file, err)
 	}
-
-	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
-		// In case of global variables, libbpf creates an internal map <prog_name>.rodata
-		// The values are read only for the BPF programs, but can be set to a value from
-		// userspace before the program is loaded.
-		mapName := m.Name()
-		if m.IsMapInternal() {
-			if strings.HasPrefix(mapName, ".rodata") {
-				continue
-			}
-
-			if err := ap.ConfigureProgram(m); err != nil {
-				return nil, fmt.Errorf("failed to configure %s: %w", file, err)
-			}
-			continue
-		}
-
-		if size := maps.Size(mapName); size != 0 {
-			if err := m.SetSize(size); err != nil {
-				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
-			}
-		}
-
-		log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())
-		pinDir := bpf.MapPinDir(m.Type(), mapName, ap.Iface, ap.Hook)
-		if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
-			return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
-		}
-	}
-
-	if err := obj.Load(); err != nil {
-		return nil, fmt.Errorf("error loading program: %w", err)
-	}
-
 	return obj, nil
 }
 
@@ -406,8 +373,8 @@ func (ap *AttachPoint) Config() string {
 	return fmt.Sprintf("%+v", ap)
 }
 
-func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
-	globalData := libbpf.TcGlobalData{
+func (ap *AttachPoint) ConfigureProgram() *libbpf.TcGlobalData {
+	globalData := &libbpf.TcGlobalData{
 		ExtToSvcMark: ap.ExtToServiceConnmark,
 		VxlanPort:    ap.VXLANPort,
 		Tmtu:         ap.TunnelMTU,
@@ -481,13 +448,12 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 		globalData.JumpsV6[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV6)
 	}
 
-	return ConfigureProgram(m, ap.Iface, &globalData)
+	ConfigureProgram(ap.Iface, globalData)
+	return globalData
 }
 
-func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalData) error {
+func ConfigureProgram(iface string, globalData *libbpf.TcGlobalData) {
 	in := []byte("---------------")
 	copy(in, iface)
 	globalData.IfaceName = string(in)
-
-	return globalData.Set(m)
 }

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -489,5 +489,5 @@ func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalDa
 	copy(in, iface)
 	globalData.IfaceName = string(in)
 
-	return libbpf.TcSetGlobals(m, globalData)
+	return libbpf.SetGlobalData(m, globalData)
 }

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -751,8 +751,9 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					}
 				}
 
-				if err := xdp.ConfigureProgram(m, bpfIfaceName, &globals); err != nil {
-					return nil, err
+				xdp.ConfigureProgram(bpfIfaceName, &globals)
+				if err := globals.Set(m); err != nil {
+					return nil, fmt.Errorf("failed to configure xdp program: %w", err)
 				}
 			} else if topts.ipv6 {
 				ifaceLog := topts.progLog + "-" + bpfIfaceName
@@ -775,7 +776,8 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 
 				log.WithField("globals", globals).Debugf("configure program v6")
 
-				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
+				tc.ConfigureProgram(ifaceLog, &globals)
+				if err := globals.Set(m); err != nil {
 					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}
 				log.WithField("program", fname).Debugf("Configured BPF program iface \"%s\"", ifaceLog)
@@ -800,7 +802,8 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 
 				log.WithField("globals", globals).Debugf("configure program")
 
-				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
+				tc.ConfigureProgram(ifaceLog, &globals)
+				if err := globals.Set(m); err != nil {
 					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}
 				log.WithField("program", fname).Debugf("Configured BPF program iface \"%s\"", ifaceLog)
@@ -906,8 +909,9 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 				copy(globals.HostIPv6[:], hostIP.To16())
 				copy(globals.IntfIPv6[:], intfIPV6.To16())
 
-				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
-					return nil, fmt.Errorf("failed to configure v6 tc program: %w", err)
+				tc.ConfigureProgram(ifaceLog, &globals)
+				if err := globals.Set(m); err != nil {
+					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}
 			} else {
 				globals := libbpf.TcGlobalData{
@@ -921,7 +925,8 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 				copy(globals.HostIPv4[0:4], hostIP.To4())
 				copy(globals.IntfIPv4[0:4], intfIP.To4())
 
-				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
+				tc.ConfigureProgram(ifaceLog, &globals)
+				if err := globals.Set(m); err != nil {
 					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}
 			}

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -54,9 +54,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/profiling"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/bpf/state"
-	"github.com/projectcalico/calico/felix/bpf/tc"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
-	"github.com/projectcalico/calico/felix/bpf/xdp"
 	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/idalloc"
 	"github.com/projectcalico/calico/felix/ip"
@@ -751,36 +749,10 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					}
 				}
 
-				xdp.ConfigureProgram(bpfIfaceName, &globals)
+				globals.IfaceName = setLogPrefix(bpfIfaceName)
 				if err := globals.Set(m); err != nil {
 					return nil, fmt.Errorf("failed to configure xdp program: %w", err)
 				}
-			} else if topts.ipv6 {
-				ifaceLog := topts.progLog + "-" + bpfIfaceName
-				globals := libbpf.TcGlobalData{
-					Tmtu:         natTunnelMTU,
-					VxlanPort:    testVxlanPort,
-					PSNatStart:   uint16(topts.psnaStart),
-					PSNatLen:     uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:        libbpf.GlobalsNoDSRCidrs | libbpf.GlobalsRPFOptionStrict,
-					LogFilterJmp: 0xffffffff,
-				}
-
-				copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())
-				copy(globals.HostIPv6[:], hostIP.To16())
-				copy(globals.IntfIPv6[:], intfIPV6.To16())
-
-				for i := 0; i < tcdefs.ProgIndexEnd; i++ {
-					globals.JumpsV6[i] = uint32(i)
-				}
-
-				log.WithField("globals", globals).Debugf("configure program v6")
-
-				tc.ConfigureProgram(ifaceLog, &globals)
-				if err := globals.Set(m); err != nil {
-					return nil, fmt.Errorf("failed to configure tc program: %w", err)
-				}
-				log.WithField("program", fname).Debugf("Configured BPF program iface \"%s\"", ifaceLog)
 			} else {
 				ifaceLog := topts.progLog + "-" + bpfIfaceName
 				globals := libbpf.TcGlobalData{
@@ -790,19 +762,28 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					PSNatLen:     uint16(topts.psnatEnd-topts.psnaStart) + 1,
 					Flags:        libbpf.GlobalsNoDSRCidrs,
 					LogFilterJmp: 0xffffffff,
+					IfaceName:    setLogPrefix(ifaceLog),
 				}
+				if topts.ipv6 {
+					copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())
+					copy(globals.HostIPv6[:], hostIP.To16())
+					copy(globals.IntfIPv6[:], intfIPV6.To16())
 
-				copy(globals.HostIPv4[0:4], hostIP)
-				copy(globals.IntfIPv4[0:4], intfIP)
-				copy(globals.HostTunnelIPv4[0:4], node1tunIP.To4())
+					for i := 0; i < tcdefs.ProgIndexEnd; i++ {
+						globals.JumpsV6[i] = uint32(i)
+					}
+					globals.Flags |= libbpf.GlobalsRPFOptionStrict
+					log.WithField("globals", globals).Debugf("configure program v6")
+				} else {
+					copy(globals.HostIPv4[0:4], hostIP)
+					copy(globals.IntfIPv4[0:4], intfIP)
+					copy(globals.HostTunnelIPv4[0:4], node1tunIP.To4())
 
-				for i := 0; i < tcdefs.ProgIndexEnd; i++ {
-					globals.Jumps[i] = uint32(i)
+					for i := 0; i < tcdefs.ProgIndexEnd; i++ {
+						globals.Jumps[i] = uint32(i)
+					}
+					log.WithField("globals", globals).Debugf("configure program")
 				}
-
-				log.WithField("globals", globals).Debugf("configure program")
-
-				tc.ConfigureProgram(ifaceLog, &globals)
 				if err := globals.Set(m); err != nil {
 					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}
@@ -895,40 +876,25 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 
 	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
 		if m.IsMapInternal() {
-			ifaceLog := topts.progLog + "-" + bpfIfaceName
+			globals := libbpf.TcGlobalData{
+				Tmtu:       natTunnelMTU,
+				VxlanPort:  testVxlanPort,
+				PSNatStart: uint16(topts.psnaStart),
+				PSNatLen:   uint16(topts.psnatEnd-topts.psnaStart) + 1,
+				Flags:      libbpf.GlobalsNoDSRCidrs,
+				IfaceName:  setLogPrefix(topts.progLog + "-" + bpfIfaceName),
+			}
 			if topts.ipv6 {
-				globals := libbpf.TcGlobalData{
-					Tmtu:       natTunnelMTU,
-					VxlanPort:  testVxlanPort,
-					PSNatStart: uint16(topts.psnaStart),
-					PSNatLen:   uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:      libbpf.GlobalsNoDSRCidrs,
-				}
-
 				copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())
 				copy(globals.HostIPv6[:], hostIP.To16())
 				copy(globals.IntfIPv6[:], intfIPV6.To16())
-
-				tc.ConfigureProgram(ifaceLog, &globals)
-				if err := globals.Set(m); err != nil {
-					return nil, fmt.Errorf("failed to configure tc program: %w", err)
-				}
 			} else {
-				globals := libbpf.TcGlobalData{
-					Tmtu:       natTunnelMTU,
-					VxlanPort:  testVxlanPort,
-					PSNatStart: uint16(topts.psnaStart),
-					PSNatLen:   uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:      libbpf.GlobalsNoDSRCidrs,
-				}
 				copy(globals.HostTunnelIPv4[0:4], node1tunIP.To4())
 				copy(globals.HostIPv4[0:4], hostIP.To4())
 				copy(globals.IntfIPv4[0:4], intfIP.To4())
-
-				tc.ConfigureProgram(ifaceLog, &globals)
-				if err := globals.Set(m); err != nil {
-					return nil, fmt.Errorf("failed to configure tc program: %w", err)
-				}
+			}
+			if err := globals.Set(m); err != nil {
+				return nil, fmt.Errorf("failed to configure tc program: %w", err)
 			}
 			break
 		}
@@ -960,6 +926,12 @@ func xdpUpdateJumpMap(obj *libbpf.Obj, progs map[int]string) error {
 	}
 
 	return nil
+}
+
+func setLogPrefix(ifaceLog string) string {
+	in := []byte("---------------")
+	copy(in, ifaceLog)
+	return string(in)
 }
 
 type bpfRunResult struct {

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -26,7 +26,6 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
-
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -115,7 +115,7 @@ func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.XDPGlobalD
 	copy(in, iface)
 	globalData.IfaceName = string(in)
 
-	if err := libbpf.SetGlobalData(m, globalData); err != nil {
+	if err := globalData.Set(m); err != nil {
 		return fmt.Errorf("failed to configure xdp: %w", err)
 	}
 

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -26,7 +26,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
-	"github.com/projectcalico/calico/felix/bpf/maps"
+
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 
@@ -110,16 +110,10 @@ func (ap *AttachPoint) AlreadyAttached(object string) (int, bool) {
 	return -1, false
 }
 
-func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.XDPGlobalData) error {
+func ConfigureProgram(iface string, globalData *libbpf.XDPGlobalData) {
 	in := []byte("---------------")
 	copy(in, iface)
 	globalData.IfaceName = string(in)
-
-	if err := globalData.Set(m); err != nil {
-		return fmt.Errorf("failed to configure xdp: %w", err)
-	}
-
-	return nil
 }
 
 type AttachResult int
@@ -128,58 +122,31 @@ func (ar AttachResult) ProgID() int {
 	return int(ar)
 }
 
+func (ap *AttachPoint) Configuration() *libbpf.XDPGlobalData {
+	globalData := &libbpf.XDPGlobalData{}
+	if ap.HookLayoutV4 != nil {
+		for p, i := range ap.HookLayoutV4 {
+			globalData.Jumps[p] = uint32(i)
+		}
+		globalData.Jumps[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV4)
+	}
+	if ap.HookLayoutV6 != nil {
+		for p, i := range ap.HookLayoutV6 {
+			globalData.JumpsV6[p] = uint32(i)
+		}
+		globalData.JumpsV6[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV6)
+	}
+
+	ConfigureProgram(ap.Iface, globalData)
+	return globalData
+}
+
 func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 	// By now the attach type specific generic set of programs is loaded and we
 	// only need to load and configure the preamble that will pass the
 	// configuration further to the selected set of programs.
 
 	binaryToLoad := path.Join(bpfdefs.ObjectDir, "xdp_preamble.o")
-
-	obj, err := libbpf.OpenObject(binaryToLoad)
-	if err != nil {
-		return nil, err
-	}
-	defer obj.Close()
-
-	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
-		mapName := m.Name()
-		if m.IsMapInternal() {
-			if strings.HasPrefix(mapName, ".rodata") {
-				continue
-			}
-			var globals libbpf.XDPGlobalData
-
-			if ap.HookLayoutV4 != nil {
-				for p, i := range ap.HookLayoutV4 {
-					globals.Jumps[p] = uint32(i)
-				}
-				globals.Jumps[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV4)
-			}
-			if ap.HookLayoutV6 != nil {
-				for p, i := range ap.HookLayoutV6 {
-					globals.JumpsV6[p] = uint32(i)
-				}
-				globals.JumpsV6[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV6)
-			}
-
-			if err := ConfigureProgram(m, ap.Iface, &globals); err != nil {
-				return nil, err
-			}
-			continue
-		}
-
-		if size := maps.Size(mapName); size != 0 {
-			if err := m.SetSize(size); err != nil {
-				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
-			}
-		}
-
-		pinDir := bpf.MapPinDir(m.Type(), mapName, ap.Iface, hook.XDP)
-		if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
-			return nil, fmt.Errorf("error pinning map %s: %w", mapName, err)
-		}
-	}
-
 	// Check if the bpf object is already attached, and we should skip re-attaching it
 	progID, isAttached := ap.AlreadyAttached(binaryToLoad)
 	if isAttached {
@@ -187,10 +154,9 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 		return AttachResult(progID), nil
 	}
 	ap.Log().Infof("Continue with attaching BPF program %s", binaryToLoad)
-
-	if err := obj.Load(); err != nil {
-		ap.Log().Warn("Failed to load program")
-		return nil, fmt.Errorf("error loading program: %w", err)
+	obj, err := bpf.ConfigureAndLoad(binaryToLoad, ap.Configuration())
+	if err != nil {
+		return nil, fmt.Errorf("error loading %s:%w", binaryToLoad, err)
 	}
 
 	oldID, err := ap.ProgramID()

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -115,7 +115,7 @@ func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.XDPGlobalD
 	copy(in, iface)
 	globalData.IfaceName = string(in)
 
-	if err := libbpf.XDPSetGlobals(m, globalData); err != nil {
+	if err := libbpf.SetGlobalData(m, globalData); err != nil {
 		return fmt.Errorf("failed to configure xdp: %w", err)
 	}
 

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -109,12 +109,6 @@ func (ap *AttachPoint) AlreadyAttached(object string) (int, bool) {
 	return -1, false
 }
 
-func ConfigureProgram(iface string, globalData *libbpf.XDPGlobalData) {
-	in := []byte("---------------")
-	copy(in, iface)
-	globalData.IfaceName = string(in)
-}
-
 type AttachResult int
 
 func (ar AttachResult) ProgID() int {
@@ -135,8 +129,10 @@ func (ap *AttachPoint) Configuration() *libbpf.XDPGlobalData {
 		}
 		globalData.JumpsV6[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV6)
 	}
+	in := []byte("---------------")
+	copy(in, ap.Iface)
+	globalData.IfaceName = string(in)
 
-	ConfigureProgram(ap.Iface, globalData)
 	return globalData
 }
 
@@ -153,7 +149,7 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 		return AttachResult(progID), nil
 	}
 	ap.Log().Infof("Continue with attaching BPF program %s", binaryToLoad)
-	obj, err := bpf.ConfigureAndLoad(binaryToLoad, ap.Configuration())
+	obj, err := bpf.LoadObject(binaryToLoad, ap.Configuration())
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s:%w", binaryToLoad, err)
 	}


### PR DESCRIPTION
## Description

We have different set of global data one for Tc programs, one for CTLB and one for conntrack cleanup when loading bpf programs. Configuring each global has a separate API. This PR provides a single API to configure global data for bpf programs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
