### PR TITLE
Modify IPSet Setfilter to make it suitable for filtering ipsets dynamically

### DIFF
--- a/felix/bpf/ipsets/ipsets.go
+++ b/felix/bpf/ipsets/ipsets.go
@@ -57,6 +57,8 @@ type bpfIPSets struct {
 	opRecorder logutils.OpRecorder
 
 	lg *log.Entry
+
+	filterIPSet func(string) bool
 }
 
 func NewBPFIPSets(
@@ -370,9 +372,11 @@ func (m *bpfIPSets) markIPSetDirty(data *bpfIPSet) {
 	m.dirtyIPSetIDs.Add(data.ID)
 }
 
-func (m *bpfIPSets) SetFilter(ipSetNames set.Set[string]) {
-	// Not needed for this IP set dataplane.  All known IP sets
-	// are written into the corresponding BPF map.
+func (m *bpfIPSets) SetFilter(fn func(ipSetName string) bool) {
+	m.filterIPSet = fn
+}
+
+func (m *bpfIPSets) MarkDirty(ipsetNames set.Set[string]) {
 }
 
 type bpfIPSet struct {

--- a/felix/dataplane/ipsets/ipsets_mgr.go
+++ b/felix/dataplane/ipsets/ipsets_mgr.go
@@ -33,7 +33,8 @@ type IPSetsDataplane interface {
 	QueueResync()
 	ApplyUpdates()
 	ApplyDeletions() (reschedule bool)
-	SetFilter(neededIPSets set.Set[string])
+	SetFilter(fn func(string) bool)
+	MarkDirty(set.Set[string])
 }
 
 // Except for domain IP sets, IPSetsManager simply passes through IP set updates from the datastore

--- a/felix/dataplane/ipsets/mock_ipsets.go
+++ b/felix/dataplane/ipsets/mock_ipsets.go
@@ -101,6 +101,10 @@ func (s *MockIPSets) ApplyDeletions() bool {
 	return false
 }
 
-func (s *MockIPSets) SetFilter(ipSetNames set.Set[string]) {
+func (s *MockIPSets) SetFilter(fn func(string) bool) {
+	// Not implemented for UT.
+}
+
+func (s *MockIPSets) MarkDirty(ipSetNames set.Set[string]) {
 	// Not implemented for UT.
 }

--- a/felix/dataplane/linux/policy_mgr.go
+++ b/felix/dataplane/linux/policy_mgr.go
@@ -173,3 +173,14 @@ func (m *policyManager) CompleteDeferredWork() error {
 	m.ipSetsCallback(merged)
 	return nil
 }
+
+func (m *policyManager) GetNeededIPSets() set.Set[string] {
+	merged := set.New[string]()
+	for _, ipSets := range m.neededIPSets {
+		ipSets.Iter(func(item string) error {
+			merged.Add(item)
+			return nil
+		})
+	}
+	return merged
+}

--- a/felix/dataplane/windows/ipsets/ipsets.go
+++ b/felix/dataplane/windows/ipsets/ipsets.go
@@ -193,6 +193,8 @@ func (m *IPSets) ApplyDeletions() bool {
 	return false
 }
 
-func (s *IPSets) SetFilter(ipSetNames set.Set[string]) {
-	// Not needed for Windows.
+func (m *IPSets) SetFilter(fn func(ipSetName string) bool) {
+}
+
+func (m *IPSets) MarkDirty(ipsetNames set.Set[string]) {
 }

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -598,7 +598,10 @@ var _ = Describe("IP sets dataplane", func() {
 
 	Context("with filtering to two IP sets", func() {
 		BeforeEach(func() {
-			ipsets.SetFilter(set.From(v4MainIPSetName2, v4MainIPSetName))
+			ipsets.SetFilter(func(ipSetName string) bool {
+				neededIPSets := set.From(v4MainIPSetName2, v4MainIPSetName)
+				return neededIPSets.Contains(ipSetName)
+			})
 			ipsets.QueueResync()
 			apply()
 		})
@@ -699,7 +702,11 @@ var _ = Describe("IP sets dataplane", func() {
 
 			Context("with filtering to single IP set", func() {
 				BeforeEach(func() {
-					ipsets.SetFilter(set.From(v4MainIPSetName2))
+					ipsets.SetFilter(func(ipSetName string) bool {
+						neededIPSets := set.From(v4MainIPSetName2)
+						return neededIPSets.Contains(ipSetName)
+					})
+					ipsets.MarkDirty(set.From(v4MainIPSetName2))
 					apply()
 				})
 
@@ -714,7 +721,12 @@ var _ = Describe("IP sets dataplane", func() {
 
 				Context("with filtering to both known IP sets", func() {
 					BeforeEach(func() {
-						ipsets.SetFilter(set.From(v4MainIPSetName2, v4MainIPSetName))
+						ipsets.SetFilter(func(ipSetName string) bool {
+							neededIPSets := set.From(v4MainIPSetName2, v4MainIPSetName)
+							return neededIPSets.Contains(ipSetName)
+						})
+						ipsets.MarkDirty(set.From(v4MainIPSetName2, v4MainIPSetName))
+
 						apply()
 					})
 


### PR DESCRIPTION
## Description

This PR modifies `SetFilter` in ipsets to make it suitable to filter ipsets dynamically. The changes are
1. Change SetFilter to set a func which takes ipset name and returns whether it needs to be filtered or not.
2. Provide another API `MarkDirty` which takes a set of ipset names and marks it dirty. This is used for rawEgressPolicy when in BPF mode.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
