### PR TITLE
[release-tool] fix hashrelease local src directory

### DIFF
--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -291,7 +291,7 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 		Stream:          version.DeterminePublishStream(productBranch, pinnedVersion.Title),
 		ProductVersion:  pinnedVersion.Title,
 		OperatorVersion: pinnedVersion.TigeraOperator.Version,
-		Source:          filepath.Join(hashreleaseSrcBaseDir, pinnedVersion.ReleaseName),
+		Source:          filepath.Join(hashreleaseSrcBaseDir, pinnedVersion.Hash),
 		Time:            time.Now(),
 		Latest:          latest,
 	}, nil


### PR DESCRIPTION
## Description

master hashrelease is currently failing because it is trying to get the hashrelease content from the wrong location - the content are actually stored in `_output/hashrelease/<hashrelease hash>

```sh
time="2025-01-03T02:11:50Z" level=info msg="Publishing hashrelease" note="2025-01-03-master-headed - generated at Fri, 03 Jan 2025 00:02:16 UTC using master release branch with master operator branch"
time="2025-01-03T02:11:53Z" level=error msg="Failed to publish hashrelease" error="exit status 23: rsync: [sender] change_dir \"/home/semaphore/calico/release/_output/hashrelease/2025-01-03-master-headed\" failed: No such file or directory (2)\nrsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1338) [sender=3.2.7]"
time="2025-01-03T02:11:53Z" level=fatal msg="Error running task" error="failed to publish hashrelease: exit status 23: rsync: [sender] change_dir \"/home/semaphore/calico/release/_output/hashrelease/2025-01-03-master-headed\" failed: No such file or directory (2)\nrsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1338) [sender=3.2.7]"
make: *** [Makefile:40: hashrelease-publish] Error 1
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
