### PR TITLE
Remove unnecessary docker restart commands from Semaphore configs

### DIFF
--- a/.semaphore/push-images/alp.yml
+++ b/.semaphore/push-images/alp.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/calicoctl.yml
+++ b/.semaphore/push-images/calicoctl.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/key-cert-provisioner.yml
+++ b/.semaphore/push-images/key-cert-provisioner.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/pod2daemon.yml
+++ b/.semaphore/push-images/pod2daemon.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -18,12 +18,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow

--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -26,26 +26,9 @@ global_job_config:
     commands:
       - chmod 0600 ~/.keys/*
       - ssh-add ~/.keys/*
-      # For some reason, /mnt is 100 GB and has a qemu-nbd image file.
-      # Let's delete it and use it for our own purposes (building calico
-      # without running out of space)
-      - sudo killall qemu-nbd || true
-      - sudo rm -f /mnt/docker.qcow2
-      - sudo chown $(id -u):$(id -g) /mnt/
-      - mkdir calico
-      - sudo mount --bind /mnt calico
       # Checkout the code and unshallow it.
-      # (this is going to throw an error because it can't remove
-      # the `calico` directory, which is a mount, but it will
-      # continue anyway)
       - checkout
       - retry git fetch --quiet --unshallow
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       # Log in to container registries needed for release.
       - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -5,7 +5,7 @@ agent:
     type: f1-standard-4
     os_image: ubuntu2204
 execution_time_limit:
-  minutes: 800
+  hours: 14
 blocks:
   - name: "Publish official release"
     dependencies: []
@@ -24,26 +24,9 @@ blocks:
           # Load the github access secrets.  First fix the permissions.
           - chmod 0600 /home/semaphore/.keys/git_ssh_rsa
           - ssh-add /home/semaphore/.keys/git_ssh_rsa
-          # For some reason, /mnt is 100 GB and has a qemu-nbd image file.
-          # Let's delete it and use it for our own purposes (building calico
-          # without running out of space)
-          - sudo killall qemu-nbd || true
-          - sudo rm -f /mnt/docker.qcow2
-          - sudo chown $(id -u):$(id -g) /mnt/
-          - mkdir calico
-          - sudo mount --bind /mnt calico
           # Checkout the code and unshallow it.
-          # (this is going to throw an error because it can't remove
-          # the `calico` directory, which is a mount, but it will
-          # continue anyway)
           - checkout
           - retry git fetch --quiet --unshallow
-          # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-          # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-          # how much we churn docker containers during the build.  Disable it.
-          - sudo systemctl stop docker
-          - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-          - sudo systemctl start docker
           # Log in to container registries needed for release.
           - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
           - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -24,17 +24,7 @@ global_job_config:
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      # Disable initramfs update to save space on the Semaphore VM (and we don't need it because we're not going to reboot).
-      - sudo apt-get install -y -u crudini
-      - sudo crudini --set /etc/initramfs-tools/update-initramfs.conf '' update_initramfs no
-      - cat /etc/initramfs-tools/update-initramfs.conf
   epilogue:
     commands:
       - cd "$REPO_DIR"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,17 +24,7 @@ global_job_config:
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      # Disable initramfs update to save space on the Semaphore VM (and we don't need it because we're not going to reboot).
-      - sudo apt-get install -y -u crudini
-      - sudo crudini --set /etc/initramfs-tools/update-initramfs.conf '' update_initramfs no
-      - cat /etc/initramfs-tools/update-initramfs.conf
   epilogue:
     commands:
       - cd "$REPO_DIR"

--- a/.semaphore/semaphore.yml.d/02-global_job_config.yml
+++ b/.semaphore/semaphore.yml.d/02-global_job_config.yml
@@ -9,17 +9,7 @@ global_job_config:
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
       - retry git fetch --unshallow
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during the build.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      # Disable initramfs update to save space on the Semaphore VM (and we don't need it because we're not going to reboot).
-      - sudo apt-get install -y -u crudini
-      - sudo crudini --set /etc/initramfs-tools/update-initramfs.conf '' update_initramfs no
-      - cat /etc/initramfs-tools/update-initramfs.conf
   epilogue:
     commands:
       - cd "$REPO_DIR"


### PR DESCRIPTION
## Description

This changeset removes unnecessary docker restart steps from sempahore prologue. This steps may be useful for semaphore e1 generation machines which have limited resources. As we have migrated to newer f1 generation machine with better cpu and bigger disk spaces, we can remove these steps and reduce churns to the system during setup.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
