### PR TITLE
[release tool] fix hashrelease hanging on image checks

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -233,6 +233,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
 				}
+				// Note: We only need to check that the correct images exist if we haven't built them ourselves.
+				// So, skip this check if we're configured to build and publish images from the local codebase.
 				if !c.Bool(publishHashreleaseImageFlag.Name) {
 					components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir)
 					if err != nil {


### PR DESCRIPTION
## Description

The components were not being pased on for hashrelease publish leading to the goroutine getting stuck waiting for results.

This adds timeout to each image check, includes more logs and validation checks during that process. 

## Related issues/PRs

- needs to be part of #9636 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
