### PR TITLE
Increase timeout for IPAM tests to 5s from 1s: the test runners are inconsistent and these often fail

### DIFF
--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -240,7 +240,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 5))
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 26", func(b Benchmarker) {
@@ -257,7 +257,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 5))
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 20", func(b Benchmarker) {
@@ -274,7 +274,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 5))
 		}, 100)
 
 		Measure("It should be able to allocate a lot of addresses quickly", func(b Benchmarker) {
@@ -291,7 +291,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(64))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 5))
 		}, 20)
 
 		Measure("It should be able to allocate and release addresses quickly", func(b Benchmarker) {
@@ -315,7 +315,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(out)).To(Equal(0))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 5))
 		}, 20)
 	})
 


### PR DESCRIPTION
## Description

These tests fail regularly, for example: https://tigera.semaphoreci.com/jobs/572a8e58-287e-4857-8cd7-30f67819479b and https://tigera.semaphoreci.com/jobs/5c74a8b6-f1dd-4c4a-98f6-f95be319da91).

Semaphore is not a good place for running one off performance tests like this.  All observed failures took 1-3 seconds, so 5s should suppress the vast majority at least.