### PR TITLE
[v3.29] Fix List() calls that didn't fill in revision

### DIFF
--- a/calicoctl/calicoctl/commands/datastore/migrate/migrateipam_test.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/migrateipam_test.go
@@ -353,7 +353,7 @@ func (bc *MockIPAMBackendClient) List(ctx context.Context, list model.ListInterf
 	return nil, nil
 }
 
-func (bc *MockIPAMBackendClient) Watch(ctx context.Context, list model.ListInterface, revision string) (bapi.WatchInterface, error) {
+func (bc *MockIPAMBackendClient) Watch(ctx context.Context, list model.ListInterface, options bapi.WatchOptions) (bapi.WatchInterface, error) {
 	// DO NOTHING
 	return bapi.NewFake(), nil
 }

--- a/calicoctl/tests/st/calicoctl/test_crud.py
+++ b/calicoctl/tests/st/calicoctl/test_crud.py
@@ -2485,7 +2485,7 @@ class InvalidData(TestBase):
         '  metadata:\n'
         '    creationTimestamp: null\n'
         '    name: projectcalico-default-allow\n'
-        '    resourceVersion: "0"\n'
+        '    resourceVersion: "1"\n'
         '  spec:\n'
         '    egress:\n'
         '    - action: Allow\n'

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -113,7 +113,7 @@ type Client interface {
 
 	// Watch returns a WatchInterface used for watching a resources matching the
 	// input list options.
-	Watch(ctx context.Context, list model.ListInterface, revision string) (WatchInterface, error)
+	Watch(ctx context.Context, list model.ListInterface, options WatchOptions) (WatchInterface, error)
 
 	// EnsureInitialized ensures that the backend is initialized
 	// any ready to be used.
@@ -124,6 +124,10 @@ type Client interface {
 
 	// Close the client.
 	//Close()
+}
+
+type WatchOptions struct {
+	Revision string
 }
 
 type Syncer interface {

--- a/libcalico-go/lib/backend/etcdv3/watcher.go
+++ b/libcalico-go/lib/backend/etcdv3/watcher.go
@@ -31,11 +31,11 @@ const (
 )
 
 // Watch entries in the datastore matching the resources specified by the ListInterface.
-func (c *etcdV3Client) Watch(cxt context.Context, l model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *etcdV3Client) Watch(cxt context.Context, l model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	var rev int64
-	if len(revision) != 0 {
+	if len(options.Revision) != 0 {
 		var err error
-		rev, err = strconv.ParseInt(revision, 10, 64)
+		rev, err = strconv.ParseInt(options.Revision, 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/libcalico-go/lib/backend/k8s/k8s.go
+++ b/libcalico-go/lib/backend/k8s/k8s.go
@@ -717,9 +717,8 @@ func (c *KubeClient) List(ctx context.Context, l model.ListInterface, revision s
 	return client.List(ctx, l, revision)
 }
 
-// List entries in the datastore.  This may return an empty list if there are
-// no entries matching the request in the ListInterface.
-func (c *KubeClient) Watch(ctx context.Context, l model.ListInterface, revision string) (api.WatchInterface, error) {
+// Watch starts a watch on a particular resource type.
+func (c *KubeClient) Watch(ctx context.Context, l model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	log.Debugf("Performing 'Watch' for %+v %v", l, reflect.TypeOf(l))
 	client := c.getResourceClientFromList(l)
 	if client == nil {
@@ -729,7 +728,7 @@ func (c *KubeClient) Watch(ctx context.Context, l model.ListInterface, revision 
 			Operation:  "Watch",
 		}
 	}
-	return client.Watch(ctx, l, revision)
+	return client.Watch(ctx, l, options)
 }
 
 func (c *KubeClient) getReadyStatus(ctx context.Context, k model.ReadyFlagKey, revision string) (*model.KVPair, error) {

--- a/libcalico-go/lib/backend/k8s/k8s.go
+++ b/libcalico-go/lib/backend/k8s/k8s.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
+	calischeme "github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/scheme"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -514,8 +514,6 @@ func (c *KubeClient) Close() error {
 	return nil
 }
 
-var addToSchemeOnce sync.Once
-
 // buildK8SAdminPolicyClient builds a RESTClient configured to interact (Baseline) Admin Network Policy.
 func buildK8SAdminPolicyClient(cfg *rest.Config) (*adminpolicyclient.PolicyV1alpha1Client, error) {
 	return adminpolicyclient.NewForConfig(cfg)
@@ -537,64 +535,8 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 		return nil, err
 	}
 
-	// We're operating on the pkg level scheme.Scheme, so make sure that multiple
-	// calls to this function don't do this simultaneously, which can cause crashes
-	// due to concurrent access to underlying maps.  For good measure, use a once
-	// since this really only needs to happen one time.
-	addToSchemeOnce.Do(func() {
-		// We also need to register resources.
-		schemeBuilder := runtime.NewSchemeBuilder(
-			func(scheme *runtime.Scheme) error {
-				scheme.AddKnownTypes(
-					*cfg.GroupVersion,
-					&apiv3.FelixConfiguration{},
-					&apiv3.FelixConfigurationList{},
-					&apiv3.IPPool{},
-					&apiv3.IPPoolList{},
-					&apiv3.IPReservation{},
-					&apiv3.IPReservationList{},
-					&apiv3.BGPPeer{},
-					&apiv3.BGPPeerList{},
-					&apiv3.BGPConfiguration{},
-					&apiv3.BGPConfigurationList{},
-					&apiv3.ClusterInformation{},
-					&apiv3.ClusterInformationList{},
-					&apiv3.GlobalNetworkSet{},
-					&apiv3.GlobalNetworkSetList{},
-					&apiv3.GlobalNetworkPolicy{},
-					&apiv3.GlobalNetworkPolicyList{},
-					&apiv3.NetworkPolicy{},
-					&apiv3.NetworkPolicyList{},
-					&apiv3.NetworkSet{},
-					&apiv3.NetworkSetList{},
-					&apiv3.Tier{},
-					&apiv3.TierList{},
-					&apiv3.HostEndpoint{},
-					&apiv3.HostEndpointList{},
-					&libapiv3.BlockAffinity{},
-					&libapiv3.BlockAffinityList{},
-					&libapiv3.IPAMBlock{},
-					&libapiv3.IPAMBlockList{},
-					&libapiv3.IPAMHandle{},
-					&libapiv3.IPAMHandleList{},
-					&libapiv3.IPAMConfig{},
-					&libapiv3.IPAMConfigList{},
-					&apiv3.KubeControllersConfiguration{},
-					&apiv3.KubeControllersConfigurationList{},
-					&apiv3.CalicoNodeStatus{},
-					&apiv3.CalicoNodeStatusList{},
-					&apiv3.BGPFilter{},
-					&apiv3.BGPFilterList{},
-				)
-				return nil
-			})
+	calischeme.AddCalicoResourcesToScheme()
 
-		err := schemeBuilder.AddToScheme(scheme.Scheme)
-		if err != nil {
-			log.WithError(err).Fatal("failed to add calico resources to scheme")
-		}
-		metav1.AddToGroupVersion(scheme.Scheme, schema.GroupVersion{Group: "crd.projectcalico.org", Version: "v1"})
-	})
 	return cli, nil
 }
 

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -650,7 +650,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("watching all profiles with a valid rv does not return an event for the default-allow profile", func() {
 			rvs := []string{"", "0", "1000000/", "1000/1000", "/100000000"}
 			for _, rv := range rvs {
-				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindProfile}, rv)
+				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindProfile}, api.WatchOptions{Revision: rv})
 				Expect(err).NotTo(HaveOccurred())
 				defer watch.Stop()
 
@@ -661,7 +661,8 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("watching the default-allow profile with any rv does not return an event", func() {
 			rvs := []string{"", "0"}
 			for _, rv := range rvs {
-				watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "projectcalico-default-allow", Kind: apiv3.KindProfile}, rv)
+				watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "projectcalico-default-allow", Kind: apiv3.KindProfile},
+					api.WatchOptions{Revision: rv})
 				Expect(err).NotTo(HaveOccurred())
 				defer watch.Stop()
 				select {
@@ -2783,27 +2784,27 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			deleteAllServiceAccounts()
 		})
 		It("supports watching a specific profile (from namespace)", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "kns.default", Kind: apiv3.KindProfile}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "kns.default", Kind: apiv3.KindProfile}, api.WatchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			event := ExpectAddedEvent(watch.ResultChan())
 			Expect(event.New.Key.String()).To(Equal("Profile(kns.default)"))
 		})
 		It("supports watching a specific profile (from serviceAccount)", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "ksa.default.test-sa-1", Kind: apiv3.KindProfile}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "ksa.default.test-sa-1", Kind: apiv3.KindProfile}, api.WatchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			event := ExpectAddedEvent(watch.ResultChan())
 			Expect(event.New.Key.String()).To(Equal("Profile(ksa.default.test-sa-1)"))
 		})
 		It("supports watching all profiles", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindProfile}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindProfile}, api.WatchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
 		})
 		It("rejects names without prefixes", func() {
-			_, err := c.Watch(ctx, model.ResourceListOptions{Name: "default", Kind: apiv3.KindProfile}, "")
+			_, err := c.Watch(ctx, model.ResourceListOptions{Name: "default", Kind: apiv3.KindProfile}, api.WatchOptions{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Unsupported prefix for resource name: default"))
 		})
@@ -2846,18 +2847,18 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			deleteAllAdminNetworkPolicies()
 		})
 		It("supports watching all adminnetworkpolicies", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
 		})
 		It("supports resuming watch from previous revision", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			event := ExpectAddedEvent(watch.ResultChan())
 			watch.Stop()
 
-			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, event.New.Revision)
+			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, api.WatchOptions{Revision: event.New.Revision})
 			Expect(err).NotTo(HaveOccurred())
 			watch.Stop()
 		})
@@ -2895,18 +2896,18 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			deleteAllNetworkPolicies()
 		})
 		It("supports watching all networkpolicies", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
 		})
 		It("supports resuming watch from previous revision", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			event := ExpectAddedEvent(watch.ResultChan())
 			watch.Stop()
 
-			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, event.New.Revision)
+			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, api.WatchOptions{Revision: event.New.Revision})
 			Expect(err).NotTo(HaveOccurred())
 			watch.Stop()
 		})
@@ -2955,19 +2956,19 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			deleteAllNetworkPolicies()
 		})
 		It("supports watching a specific networkpolicy", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "test-net-policy-3", Namespace: "default", Kind: apiv3.KindNetworkPolicy}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "test-net-policy-3", Namespace: "default", Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			event := ExpectAddedEvent(watch.ResultChan())
 			Expect(event.New.Key.String()).To(Equal("NetworkPolicy(default/test-net-policy-3)"))
 		})
 		It("rejects watching a specific networkpolicy without a namespace", func() {
-			_, err := c.Watch(ctx, model.ResourceListOptions{Name: "test-net-policy-3", Kind: apiv3.KindNetworkPolicy}, "")
+			_, err := c.Watch(ctx, model.ResourceListOptions{Name: "test-net-policy-3", Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name present, but missing namespace on watch request"))
 		})
 		It("supports watching all networkpolicies", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
@@ -3085,7 +3086,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			Expect(found).To(Equal(2))
 
 			log.WithField("revision", l.Revision).Info("[TEST] first watch")
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, l.Revision)
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: l.Revision})
 			Expect(err).NotTo(HaveOccurred())
 
 			// We should see 2 events for Calico NPs.
@@ -3105,7 +3106,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 
 			// Resume watching at the revision of the event we got
 			log.WithField("revision", event.New.Revision).Info("second watch")
-			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, event.New.Revision)
+			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: event.New.Revision})
 			Expect(err).NotTo(HaveOccurred())
 
 			// We should only get 1 update, because the event from the previous watch should have been "latest"
@@ -3146,7 +3147,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			Expect(found).To(Equal(2))
 
 			log.WithField("revision", l.Revision).Info("[TEST] first watch")
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, l.Revision)
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, api.WatchOptions{Revision: l.Revision})
 			Expect(err).NotTo(HaveOccurred())
 
 			event := ExpectModifiedEvent(watch.ResultChan())
@@ -3171,7 +3172,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 
 			// Resume watching at the revision of the event we got
 			log.WithField("revision", event.New.Revision).Info("second watch")
-			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, event.New.Revision)
+			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, api.WatchOptions{Revision: event.New.Revision})
 			Expect(err).NotTo(HaveOccurred())
 
 			// We should only get 1 update, because the event from the previous watch should have been "latest"
@@ -3212,7 +3213,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			Expect(found).To(Equal(2))
 
 			log.WithField("revision", l.Revision).Info("[TEST] first watch")
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, l.Revision)
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, api.WatchOptions{Revision: l.Revision})
 			Expect(err).NotTo(HaveOccurred())
 
 			event := ExpectModifiedEvent(watch.ResultChan())
@@ -3237,7 +3238,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 
 			// Resume watching at the revision of the event we got
 			log.WithField("revision", event.New.Revision).Info("second watch")
-			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, event.New.Revision)
+			watch, err = c.Watch(ctx, model.ResourceListOptions{Kind: model.KindKubernetesAdminNetworkPolicy}, api.WatchOptions{Revision: event.New.Revision})
 			Expect(err).NotTo(HaveOccurred())
 
 			// We should only get 1 update, because the event from the previous watch should have been "latest"
@@ -3261,7 +3262,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 					"revision": revision,
 					"key":      l.KVPairs[i].Key.String(),
 				}).Info("[Test] starting watch")
-				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, revision)
+				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: revision})
 				Expect(err).ToNot(HaveOccurred())
 				// Since the items in the list aren't guaranteed to be in any specific order, we
 				// can't assert anything useful about what you should get out of this watch, so we
@@ -3283,7 +3284,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 					"revision": revision,
 					"key":      l.KVPairs[i].Key.String(),
 				}).Info("[Test] starting watch")
-				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, revision)
+				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy}, api.WatchOptions{Revision: revision})
 				Expect(err).ToNot(HaveOccurred())
 				// Since the items in the list aren't guaranteed to be in any specific order, we
 				// can't assert anything useful about what you should get out of this watch, so we
@@ -3305,7 +3306,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 					"revision": revision,
 					"key":      l.KVPairs[i].Key.String(),
 				}).Info("[Test] starting watch")
-				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindGlobalNetworkPolicy}, revision)
+				watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindGlobalNetworkPolicy}, api.WatchOptions{Revision: revision})
 				Expect(err).ToNot(HaveOccurred())
 				// Since the items in the list aren't guaranteed to be in any specific order, we
 				// can't assert anything useful about what you should get out of this watch, so we
@@ -3351,14 +3352,14 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			deleteAllIPPools()
 		})
 		It("supports watching a specific custom resource (IPPool)", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "test-ippool-1", Kind: apiv3.KindIPPool}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "test-ippool-1", Kind: apiv3.KindIPPool}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			event := ExpectAddedEvent(watch.ResultChan())
 			Expect(event.New.Key.String()).To(Equal("IPPool(test-ippool-1)"))
 		})
 		It("supports watching all custom resources (IPPool)", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindIPPool}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: apiv3.KindIPPool}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
@@ -3399,19 +3400,19 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			deleteAllPods()
 		})
 		It("supports watching a specific workloadEndpoint", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "127.0.0.1-k8s-test--pod--1-eth0", Namespace: "default", Kind: libapiv3.KindWorkloadEndpoint}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: "127.0.0.1-k8s-test--pod--1-eth0", Namespace: "default", Kind: libapiv3.KindWorkloadEndpoint}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			event := ExpectAddedEvent(watch.ResultChan())
 			Expect(event.New.Key.String()).To(Equal("WorkloadEndpoint(default/127.0.0.1-k8s-test--pod--1-eth0)"))
 		})
 		It("rejects watching a specific workloadEndpoint without a namespace", func() {
-			_, err := c.Watch(ctx, model.ResourceListOptions{Name: "127.0.0.1-k8s-test--pod--1-eth0", Kind: libapiv3.KindWorkloadEndpoint}, "")
+			_, err := c.Watch(ctx, model.ResourceListOptions{Name: "127.0.0.1-k8s-test--pod--1-eth0", Kind: libapiv3.KindWorkloadEndpoint}, api.WatchOptions{Revision: ""})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("cannot watch a specific WorkloadEndpoint without a namespace"))
 		})
 		It("supports watching all workloadEndpoints", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: libapiv3.KindWorkloadEndpoint}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: libapiv3.KindWorkloadEndpoint}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 			ExpectAddedEvent(watch.ResultChan())
@@ -3421,7 +3422,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 	It("Should support watching Nodes", func() {
 		By("Watching a single node", func() {
 			name := "127.0.0.1" // Node created by test/mock-node.yaml
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: name, Kind: libapiv3.KindNode}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Name: name, Kind: libapiv3.KindNode}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 
@@ -3443,7 +3444,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 		})
 
 		By("Watching all nodes", func() {
-			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: libapiv3.KindNode}, "")
+			watch, err := c.Watch(ctx, model.ResourceListOptions{Kind: libapiv3.KindNode}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 
@@ -3467,7 +3468,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 
 	It("should support watching BlockAffinities", func() {
 		By("watching all affinities", func() {
-			watch, err := c.Watch(ctx, model.BlockAffinityListOptions{}, "")
+			watch, err := c.Watch(ctx, model.BlockAffinityListOptions{}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 
@@ -3501,7 +3502,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 
 	It("should support watching IPAM blocks", func() {
 		By("watching all blocks", func() {
-			watch, err := c.Watch(ctx, model.BlockListOptions{}, "")
+			watch, err := c.Watch(ctx, model.BlockListOptions{}, api.WatchOptions{Revision: ""})
 			Expect(err).NotTo(HaveOccurred())
 			defer watch.Stop()
 

--- a/libcalico-go/lib/backend/k8s/resources/bgpconfig.go
+++ b/libcalico-go/lib/backend/k8s/resources/bgpconfig.go
@@ -29,7 +29,7 @@ const (
 	BGPConfigCRDName      = "bgpconfigurations.crd.projectcalico.org"
 )
 
-func NewBGPConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewBGPConfigClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/bgpfilter.go
+++ b/libcalico-go/lib/backend/k8s/resources/bgpfilter.go
@@ -29,7 +29,7 @@ const (
 	BGPFilterCRDName      = "BGPFilters.crd.projectcalico.org"
 )
 
-func NewBGPFilterClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewBGPFilterClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/bgppeer.go
+++ b/libcalico-go/lib/backend/k8s/resources/bgppeer.go
@@ -29,7 +29,7 @@ const (
 	BGPPeerCRDName      = "bgppeers.crd.projectcalico.org"
 )
 
-func NewBGPPeerClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewBGPPeerClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/caliconodestatus.go
+++ b/libcalico-go/lib/backend/k8s/resources/caliconodestatus.go
@@ -29,7 +29,7 @@ const (
 	CalicoNodeStatusCRDName      = "CalicoNodeStatuses.crd.projectcalico.org"
 )
 
-func NewCalicoNodeStatusClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewCalicoNodeStatusClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/client.go
+++ b/libcalico-go/lib/backend/k8s/resources/client.go
@@ -64,7 +64,7 @@ type K8sResourceClient interface {
 
 	// Watch returns a WatchInterface used for watching resources matching the
 	// input list options.
-	Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error)
+	Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error)
 
 	// EnsureInitialized ensures that the backend is initialized
 	// any ready to be used.

--- a/libcalico-go/lib/backend/k8s/resources/clusterinfo.go
+++ b/libcalico-go/lib/backend/k8s/resources/clusterinfo.go
@@ -29,7 +29,7 @@ const (
 	ClusterInfoCRDName      = "clusterinformations.crd.projectcalico.org"
 )
 
-func NewClusterInfoClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewClusterInfoClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/customresource.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource.go
@@ -37,15 +37,14 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
 
 // customK8sResourceClient implements the K8sResourceClient interface and provides a generic
 // mechanism for a 1:1 mapping between a Calico Resource and an equivalent Kubernetes
 // custom resource type.
 type customK8sResourceClient struct {
-	clientSet  *kubernetes.Clientset
-	restClient *rest.RESTClient
+	clientSet  kubernetes.Interface
+	restClient rest.Interface
 
 	// Name of the CRD. Not used.
 	name string
@@ -344,39 +343,25 @@ func (c *customK8sResourceClient) List(ctx context.Context, list model.ListInter
 	})
 	logContext.Debug("Received List request")
 
-	// Attempt to convert the ListInterface to a Key.  If possible, the parameters
-	// indicate a fully qualified resource, and we'll need to use Get instead of
-	// List.
-	if key := c.listInterfaceToKey(list); key != nil {
-		logContext.Debug("Performing List using Get")
-		kvps := []*model.KVPair{}
-		if kvp, err := c.Get(ctx, key, revision); err != nil {
-			// The error will already be a Calico error type.  Ignore
-			// error that it doesn't exist - we'll return an empty
-			// list.
-			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-				logContext.WithField("Resource", c.resource).WithError(err).Debug("Error listing resource")
-				return nil, err
-			}
-			return &model.KVPairList{
-				KVPairs:  kvps,
-				Revision: revision,
-			}, nil
-		} else {
-			kvps = append(kvps, kvp)
-			return &model.KVPairList{
-				KVPairs:  kvps,
-				Revision: revision,
-			}, nil
-		}
-	}
-
 	// If it is a namespaced resource, then we'll need the namespace.
-	namespace := list.(model.ResourceListOptions).Namespace
+	resList := list.(model.ResourceListOptions)
+	namespace := resList.Namespace
+	key := c.listInterfaceToKey(list)
 
 	// listFunc performs a list with the given options.
 	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		out := reflect.New(c.k8sListType).Interface().(ResourceList)
+
+		if key != nil {
+			// Being asked to list a single resource, add the filter.
+			key := key.(model.ResourceKey)
+			name, err := c.keyToName(key)
+			if err != nil {
+				logContext.WithError(err).Error("Failed to convert key to name of resource.")
+				return nil, err
+			}
+			opts.FieldSelector = fmt.Sprintf("metadata.name=%s", name)
+		}
 
 		// Build the request.
 		req := c.restClient.Get().
@@ -386,12 +371,12 @@ func (c *customK8sResourceClient) List(ctx context.Context, list model.ListInter
 
 		// If the prefix is specified, look for the resources with the label
 		// of prefix.
-		if list.(model.ResourceListOptions).Prefix {
+		if resList.Prefix {
 			// The prefix has a trailing "." character, remove it, since it is not valid for k8s labels
-			if !strings.HasSuffix(list.(model.ResourceListOptions).Name, ".") {
+			if !strings.HasSuffix(resList.Name, ".") {
 				return nil, errors.New("internal error: custom resource list invoked for a prefix not in the form '<tier>.'")
 			}
-			name := list.(model.ResourceListOptions).Name[:len(list.(model.ResourceListOptions).Name)-1]
+			name := resList.Name[:len(resList.Name)-1]
 			if name == "default" {
 				req = req.VersionedParams(&metav1.ListOptions{
 					LabelSelector: "!" + apiv3.LabelTier,

--- a/libcalico-go/lib/backend/k8s/resources/customresource.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource.go
@@ -427,9 +427,7 @@ func (c *customK8sResourceClient) List(ctx context.Context, list model.ListInter
 	return pagedList(ctx, logContext, revision, list, convertFunc, listFunc)
 }
 
-func (c *customK8sResourceClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
-	// Build watch options to pass to k8s.
-	opts := metav1.ListOptions{ResourceVersion: revision, Watch: true, AllowWatchBookmarks: false}
+func (c *customK8sResourceClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	rlo, ok := list.(model.ResourceListOptions)
 	if !ok {
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
@@ -447,7 +445,8 @@ func (c *customK8sResourceClient) Watch(ctx context.Context, list model.ListInte
 	}
 
 	k8sWatchClient := cache.NewListWatchFromClient(c.restClient, c.resource, rlo.Namespace, fieldSelector)
-	k8sWatch, err := k8sWatchClient.WatchFunc(opts)
+	k8sOpts := watchOptionsToK8sListOptions(options)
+	k8sWatch, err := k8sWatchClient.WatchFunc(k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/customresource_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource_test.go
@@ -15,17 +15,28 @@
 package resources
 
 import (
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-
-	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"context"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest/fake"
+
+	calischeme "github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/scheme"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
+
+func init() {
+	// Need to set up the scheme in order to use the fake REST client.
+	calischeme.AddCalicoResourcesToScheme()
+}
 
 var _ = Describe("Custom resource conversion methods (tested using BGPPeer)", func() {
 	// Create an empty client since we are only testing conversion functions.
@@ -225,5 +236,73 @@ var _ = Describe("Custom resource conversion methods (tested using BGPPeer)", fu
 		Expect(resConverted.(*apiv3.BGPPeer).ObjectMeta.Labels).To(HaveKeyWithValue("operator.tigera.io/foo", "bar"))
 		Expect(resConverted.(*apiv3.BGPPeer).ObjectMeta.Labels).NotTo(HaveKey("foo"))
 		Expect(resConverted.(*apiv3.BGPPeer).ObjectMeta.Labels).NotTo(HaveKey("foo2"))
+	})
+})
+
+var _ = Describe("Custom resource conversion methods (tested using namespaced NetworkSet)", func() {
+	var client *customK8sResourceClient
+	var fakeREST *fake.RESTClient
+
+	BeforeEach(func() {
+		fakeREST = &fake.RESTClient{
+			NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
+			GroupVersion: schema.GroupVersion{
+				Group:   "crd.projectcalico.org",
+				Version: "v1",
+			},
+			VersionedAPIPath: "/apis",
+		}
+		client = NewNetworkSetClient(nil, fakeREST).(*customK8sResourceClient)
+	})
+
+	It("should get by name", func() {
+		o, err := client.Get(context.TODO(), model.ResourceKey{
+			Name:      "mynetset",
+			Namespace: "mynamespace",
+			Kind:      apiv3.KindNetworkSet,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(o).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/namespaces/mynamespace/networksets/mynetset"))
+	})
+
+	It("should list all", func() {
+		l, err := client.List(context.TODO(), model.ResourceListOptions{
+			Kind: apiv3.KindNetworkSet,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/networksets"))
+		Expect(url.Query()).NotTo(HaveKey("metadata.name"))
+	})
+
+	It("should use a fieldSelector for a list name match", func() {
+		l, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name:      "foo",
+			Namespace: "mynamespace",
+			Kind:      apiv3.KindNetworkSet,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/namespaces/mynamespace/networksets"))
+		Expect(url.Query().Get("fieldSelector")).To(Equal("metadata.name=foo"))
 	})
 })

--- a/libcalico-go/lib/backend/k8s/resources/fake_clientset_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/fake_clientset_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+)
+
+// FakeClientSetWithListRevAndFiltering is a fake clientset that plugs a couple
+// of gaps in the upstream fake clientset.  Specifically, it allows setting the
+// resource version on list responses, and it allows filtering the list response
+// based on field selectors.
+type FakeClientSetWithListRevAndFiltering struct {
+	*fake.Clientset
+
+	DefaultCurrentListRevision string
+	CurrentListRevisionByType  map[string]string
+}
+
+func NewFakeClientSetWithListRevAndFiltering() *FakeClientSetWithListRevAndFiltering {
+	clientset := &FakeClientSetWithListRevAndFiltering{
+		Clientset:                  fake.NewSimpleClientset(),
+		DefaultCurrentListRevision: "123",
+		CurrentListRevisionByType:  map[string]string{},
+	}
+
+	reactor := clientset.ReactionChain[0].(*testing.SimpleReactor)
+	defaultReaction := reactor.Reaction
+	reactor.Reaction = func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+		handled, ret, err = defaultReaction(action)
+		if action, ok := action.(testing.ListActionImpl); !ok {
+			// Not a list, ignore.
+			return
+		} else if ret, ok := ret.(metav1.ListMetaAccessor); ok {
+			// List: set the resource version.
+			kind := action.Kind.Kind
+			listRev := clientset.CurrentListRevisionByType[kind]
+			if listRev == "" {
+				listRev = clientset.DefaultCurrentListRevision
+			}
+			ret.GetListMeta().SetResourceVersion(listRev)
+			// Then apply fieldSelector filtering, which is also missing.
+			// Using reflection here because generics don't quite have enough
+			// power: there's no way to get the Items slice, and we can't
+			// do the cast from the slice entry to metav1.ObjectMetaAccessor.
+			fieldSelector := action.GetListRestrictions().Fields
+			itemsVal := reflect.ValueOf(ret).Elem().FieldByName("Items")
+			itemsNew := reflect.MakeSlice(itemsVal.Type(), 0, itemsVal.Len())
+			for i := 0; i < itemsVal.Len(); i++ {
+				item := itemsVal.Index(i)
+				itemPtr := item.Addr().Interface().(metav1.ObjectMetaAccessor)
+				meta := itemPtr.GetObjectMeta()
+				fieldSet := fields.Set{
+					"metadata.name":      meta.GetName(),
+					"metadata.namespace": meta.GetNamespace(),
+				}
+				if fieldSelector.Matches(fieldSet) {
+					itemsNew = reflect.Append(itemsNew, item)
+				}
+			}
+			itemsVal.Set(itemsNew)
+		}
+		return
+	}
+
+	return clientset
+}

--- a/libcalico-go/lib/backend/k8s/resources/felixconfig.go
+++ b/libcalico-go/lib/backend/k8s/resources/felixconfig.go
@@ -29,7 +29,7 @@ const (
 	FelixConfigCRDName      = "felixconfigurations.crd.projectcalico.org"
 )
 
-func NewFelixConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewFelixConfigClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/globalnetworkpolicies.go
+++ b/libcalico-go/lib/backend/k8s/resources/globalnetworkpolicies.go
@@ -29,7 +29,7 @@ const (
 	GlobalNetworkPolicyCRDName      = "globalnetworkpolicies.crd.projectcalico.org"
 )
 
-func NewGlobalNetworkPolicyClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewGlobalNetworkPolicyClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/globalnetworkset.go
+++ b/libcalico-go/lib/backend/k8s/resources/globalnetworkset.go
@@ -29,7 +29,7 @@ const (
 	GlobalNetworkSetCRDName      = "globalnetworksets.crd.projectcalico.org"
 )
 
-func NewGlobalNetworkSetClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewGlobalNetworkSetClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/hostendpoint.go
+++ b/libcalico-go/lib/backend/k8s/resources/hostendpoint.go
@@ -29,7 +29,7 @@ const (
 	HostEndpointCRDName      = "hostendpoints.crd.projectcalico.org"
 )
 
-func NewHostEndpointClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewHostEndpointClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
@@ -45,7 +45,7 @@ const (
 	BlockAffinityCRDName      = "blockaffinities.crd.projectcalico.org"
 )
 
-func NewBlockAffinityClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewBlockAffinityClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	// Create a resource client which manages k8s CRDs.
 	rc := customK8sResourceClient{
 		clientSet:       c,
@@ -76,7 +76,7 @@ type blockAffinityClient struct {
 
 // toV1 converts the given v3 CRD KVPair into a v1 model representation
 // which can be passed to the IPAM code.
-func (c blockAffinityClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
+func (c *blockAffinityClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
 	// Parse the CIDR into a struct.
 	_, cidr, err := net.ParseCIDR(kvpv3.Value.(*libapiv3.BlockAffinity).Spec.CIDR)
 	if err != nil {
@@ -111,7 +111,7 @@ func (c blockAffinityClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
 
 // parseKey parses the given model.Key, returning a suitable name, CIDR
 // and host for use in the Kubernetes API.
-func (c blockAffinityClient) parseKey(k model.Key) (name, cidr, host string) {
+func (c *blockAffinityClient) parseKey(k model.Key) (name, cidr, host string) {
 	host = k.(model.BlockAffinityKey).Host
 	cidr = fmt.Sprintf("%s", k.(model.BlockAffinityKey).CIDR)
 	cidrname := names.CIDRToName(k.(model.BlockAffinityKey).CIDR)
@@ -137,7 +137,7 @@ func (c blockAffinityClient) parseKey(k model.Key) (name, cidr, host string) {
 
 // toV3 takes the given v1 KVPair and converts it into a v3 representation, suitable
 // for writing as a CRD to the Kubernetes API.
-func (c blockAffinityClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
+func (c *blockAffinityClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
 	name, cidr, host := c.parseKey(kvpv1.Key)
 	state := kvpv1.Value.(*model.BlockAffinity).State
 	return &model.KVPair{
@@ -366,7 +366,10 @@ func (c *blockAffinityClient) listV1(ctx context.Context, list model.BlockAffini
 	host := list.Host
 	requestedIPVersion := list.IPVersion
 
-	kvpl := &model.KVPairList{KVPairs: []*model.KVPair{}}
+	kvpl := &model.KVPairList{
+		KVPairs:  []*model.KVPair{},
+		Revision: v3list.Revision,
+	}
 	for _, i := range v3list.KVPairs {
 		v1kvp, err := c.toV1(i)
 		if err != nil {

--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
@@ -410,10 +410,11 @@ func (c *blockAffinityClient) toKVPairV3(r Resource) (*model.KVPair, error) {
 	return c.rc.convertResourceToKVPair(r)
 }
 
-func (c *blockAffinityClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *blockAffinityClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	resl := model.ResourceListOptions{Kind: libapiv3.KindBlockAffinity}
 	k8sWatchClient := cache.NewListWatchFromClient(c.rc.restClient, c.rc.resource, "", fields.Everything())
-	k8sWatch, err := k8sWatchClient.WatchFunc(metav1.ListOptions{ResourceVersion: revision})
+	k8sOpts := watchOptionsToK8sListOptions(options)
+	k8sWatch, err := k8sWatchClient.WatchFunc(k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity_test.go
@@ -19,9 +19,16 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/api/pkg/client/clientset_generated/clientset/scheme"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest/fake"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -60,5 +67,91 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affinity k8s backend tests", testut
 		_, err = be.Get(context.Background(), kvp.Key, "")
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(BeAssignableToTypeOf(errors.ErrorResourceDoesNotExist{}))
+	})
+})
+
+var _ = Describe("BlockAffinityClient tests with fake REST client", func() {
+	var client resources.K8sResourceClient
+	var fakeREST *fake.RESTClient
+
+	BeforeEach(func() {
+		fakeREST = &fake.RESTClient{
+			NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
+			GroupVersion: schema.GroupVersion{
+				Group:   "crd.projectcalico.org",
+				Version: "v1",
+			},
+			VersionedAPIPath: "/apis",
+		}
+		client = resources.NewBlockAffinityClient(nil, fakeREST)
+	})
+
+	It("should list all (v3)", func() {
+		l, err := client.List(context.TODO(), model.ResourceListOptions{
+			Kind: apiv3.KindBlockAffinity,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/blockaffinities"))
+		Expect(url.Query()).NotTo(HaveKey("metadata.name"))
+	})
+
+	It("should list all (v1)", func() {
+		l, err := client.List(context.TODO(), model.BlockAffinityListOptions{}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/blockaffinities"))
+		Expect(url.Query()).NotTo(HaveKey("metadata.name"))
+	})
+
+	It("should use a fieldSelector for a list name match (v3)", func() {
+		l, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "foo",
+			Kind: apiv3.KindBlockAffinity,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/blockaffinities"))
+		Expect(url.Query().Get("fieldSelector")).To(Equal("metadata.name=foo"))
+	})
+
+	It("should _not_ use a fieldSelector for a list name match (v1)", func() {
+		l, err := client.List(context.TODO(), model.BlockAffinityListOptions{
+			Host:      "host",
+			IPVersion: 0,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/blockaffinities"))
+
+		// TODO We can't currently use a field selector here but we'd like to!
+		//      The name of the resource combines the host and CIDR, so we can't
+		//      filter on just the host.  Possible fix: put the host in a label
+		//      so we can filter on that.
+		Expect(url.Query()).NotTo(HaveKey("metadata.name"))
 	})
 })

--- a/libcalico-go/lib/backend/k8s/resources/ipam_block.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_block.go
@@ -169,10 +169,11 @@ func (c *ipamBlockClient) List(ctx context.Context, list model.ListInterface, re
 	return kvpl, nil
 }
 
-func (c *ipamBlockClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *ipamBlockClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	resl := model.ResourceListOptions{Kind: libapiv3.KindIPAMBlock}
 	k8sWatchClient := cache.NewListWatchFromClient(c.rc.restClient, c.rc.resource, "", fields.Everything())
-	k8sWatch, err := k8sWatchClient.WatchFunc(metav1.ListOptions{ResourceVersion: revision, AllowWatchBookmarks: false})
+	k8sOpts := watchOptionsToK8sListOptions(options)
+	k8sWatch, err := k8sWatchClient.WatchFunc(k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/ipam_block.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_block.go
@@ -42,7 +42,7 @@ const (
 	IPAMBlockCRDName      = "ipamblocks.crd.projectcalico.org"
 )
 
-func NewIPAMBlockClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewIPAMBlockClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	// Create a resource client which manages k8s CRDs.
 	rc := customK8sResourceClient{
 		clientSet:       c,
@@ -158,7 +158,10 @@ func (c *ipamBlockClient) List(ctx context.Context, list model.ListInterface, re
 		return nil, err
 	}
 
-	kvpl := &model.KVPairList{KVPairs: []*model.KVPair{}}
+	kvpl := &model.KVPairList{
+		KVPairs:  []*model.KVPair{},
+		Revision: v3list.Revision,
+	}
 	for _, i := range v3list.KVPairs {
 		v1kvp, err := IPAMBlockV3toV1(i)
 		if err != nil {

--- a/libcalico-go/lib/backend/k8s/resources/ipam_block_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_block_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/api/pkg/client/clientset_generated/clientset/scheme"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest/fake"
+
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+var _ = Describe("ipamBlockClient tests with fake REST client", func() {
+	var client K8sResourceClient
+	var fakeREST *fake.RESTClient
+
+	BeforeEach(func() {
+		fakeREST = &fake.RESTClient{
+			NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
+			GroupVersion: schema.GroupVersion{
+				Group:   "crd.projectcalico.org",
+				Version: "v1",
+			},
+			VersionedAPIPath: "/apis",
+		}
+		client = NewIPAMBlockClient(nil, fakeREST)
+	})
+
+	It("should list all (v3)", func() {
+		l, err := client.List(context.TODO(), model.ResourceListOptions{
+			Kind: libapiv3.KindIPAMBlock,
+		}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/ipamblocks"))
+		Expect(url.Query()).NotTo(HaveKey("metadata.name"))
+	})
+
+	It("should list all (v1)", func() {
+		l, err := client.List(context.TODO(), model.BlockListOptions{}, "")
+
+		// Expect an error since the client is not implemented.
+		Expect(err).To(HaveOccurred())
+		Expect(l).To(BeNil())
+
+		// But we should be able to check the request...
+		url := fakeREST.Req.URL
+		logrus.Debug("URL: ", url)
+		Expect(url.Path).To(Equal("/apis/ipamblocks"))
+		Expect(url.Query()).NotTo(HaveKey("metadata.name"))
+	})
+})

--- a/libcalico-go/lib/backend/k8s/resources/ipam_config.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_config.go
@@ -36,7 +36,7 @@ const (
 	IPAMConfigCRDName      = "ipamconfigs.crd.projectcalico.org"
 )
 
-func NewIPAMConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewIPAMConfigClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &ipamConfigClient{
 		rc: customK8sResourceClient{
 			clientSet:       c,

--- a/libcalico-go/lib/backend/k8s/resources/ipam_config.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_config.go
@@ -251,10 +251,10 @@ func (c *ipamConfigClient) List(ctx context.Context, list model.ListInterface, r
 	return c.rc.List(ctx, list, revision)
 }
 
-func (c *ipamConfigClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *ipamConfigClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	// List can only ever come from the v3 client, by passing a ResourceListOptions.
 	log.Debug("Received Watch request on IPAMConfig type")
-	return c.rc.Watch(ctx, list, revision)
+	return c.rc.Watch(ctx, list, options)
 }
 
 // EnsureInitialized is a no-op since the CRD should be

--- a/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
@@ -39,7 +39,7 @@ const (
 	IPAMHandleCRDName      = "ipamhandles.crd.projectcalico.org"
 )
 
-func NewIPAMHandleClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewIPAMHandleClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	// Create a resource client which manages k8s CRDs.
 	rc := customK8sResourceClient{
 		clientSet:       c,
@@ -203,7 +203,10 @@ func (c *ipamHandleClient) List(ctx context.Context, list model.ListInterface, r
 		return nil, err
 	}
 
-	kvpl := &model.KVPairList{KVPairs: []*model.KVPair{}}
+	kvpl := &model.KVPairList{
+		KVPairs:  []*model.KVPair{},
+		Revision: v3list.Revision,
+	}
 	for _, i := range v3list.KVPairs {
 		v1kvp := c.toV1(i)
 		kvpl.KVPairs = append(kvpl.KVPairs, v1kvp)

--- a/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
@@ -68,7 +68,7 @@ type ipamHandleClient struct {
 	rc customK8sResourceClient
 }
 
-func (c ipamHandleClient) toV1(kvpv3 *model.KVPair) *model.KVPair {
+func (c *ipamHandleClient) toV1(kvpv3 *model.KVPair) *model.KVPair {
 	v3Handle := kvpv3.Value.(*libapiv3.IPAMHandle)
 	handleID := v3Handle.Spec.HandleID
 	block := v3Handle.Spec.Block
@@ -87,11 +87,11 @@ func (c ipamHandleClient) toV1(kvpv3 *model.KVPair) *model.KVPair {
 	}
 }
 
-func (c ipamHandleClient) parseKey(k model.Key) string {
+func (c *ipamHandleClient) parseKey(k model.Key) string {
 	return strings.ToLower(k.(model.IPAMHandleKey).HandleID)
 }
 
-func (c ipamHandleClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
+func (c *ipamHandleClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
 	name := c.parseKey(kvpv1.Key)
 	handle := kvpv1.Key.(model.IPAMHandleKey).HandleID
 	block := kvpv1.Value.(*model.IPAMHandle).Block
@@ -211,7 +211,7 @@ func (c *ipamHandleClient) List(ctx context.Context, list model.ListInterface, r
 	return kvpl, nil
 }
 
-func (c *ipamHandleClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *ipamHandleClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	log.Warn("Operation Watch is not supported on IPAMHandle type")
 	return nil, cerrors.ErrorOperationNotSupported{
 		Identifier: list,

--- a/libcalico-go/lib/backend/k8s/resources/ippool.go
+++ b/libcalico-go/lib/backend/k8s/resources/ippool.go
@@ -35,7 +35,7 @@ const (
 	IPPoolCRDName      = "ippools.crd.projectcalico.org"
 )
 
-func NewIPPoolClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewIPPoolClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/ipreservation.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipreservation.go
@@ -29,7 +29,7 @@ const (
 	IPReservationCRDName      = "ipreservations.crd.projectcalico.org"
 )
 
-func NewIPReservationClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewIPReservationClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/k8sservice.go
+++ b/libcalico-go/lib/backend/k8s/resources/k8sservice.go
@@ -38,7 +38,7 @@ import (
 // resources. This allows a syncer to return the kubernetes resources that are included in this client,
 // These resource types are only accessible through the backend client API.
 
-func NewServiceClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewServiceClient(c kubernetes.Interface) K8sResourceClient {
 	return &serviceClient{
 		Converter: conversion.NewConverter(),
 		clientSet: c,
@@ -48,7 +48,7 @@ func NewServiceClient(c *kubernetes.Clientset) K8sResourceClient {
 // Implements the api.Client interface for Kubernetes Service.
 type serviceClient struct {
 	conversion.Converter
-	clientSet *kubernetes.Clientset
+	clientSet kubernetes.Interface
 }
 
 // Create is not supported.
@@ -94,31 +94,13 @@ func (c *serviceClient) Get(ctx context.Context, key model.Key, revision string)
 func (c *serviceClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
 	log.Debug("Received List request on Kubernetes Service type")
 	rl := list.(model.ResourceListOptions)
-	kvps := []*model.KVPair{}
-
-	if rl.Name != "" {
-		// The service is already fully qualified, so perform a Get instead.
-		// If the entry does not exist then we just return an empty list.
-		kvp, err := c.Get(ctx, model.ResourceKey{Name: rl.Name, Namespace: rl.Namespace, Kind: model.KindKubernetesService}, revision)
-		if err != nil {
-			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-				return nil, err
-			}
-			return &model.KVPairList{
-				KVPairs:  kvps,
-				Revision: revision,
-			}, nil
-		}
-
-		kvps = append(kvps, kvp)
-		return &model.KVPairList{
-			KVPairs:  kvps,
-			Revision: revision,
-		}, nil
-	}
 
 	// Listing all services.
 	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		if rl.Name != "" {
+			// Filtering to a single Service.
+			opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", rl.Name).String()
+		}
 		return c.clientSet.CoreV1().Services(rl.Namespace).List(ctx, opts)
 	}
 	convertFunc := func(r Resource) ([]*model.KVPair, error) {

--- a/libcalico-go/lib/backend/k8s/resources/k8sservice.go
+++ b/libcalico-go/lib/backend/k8s/resources/k8sservice.go
@@ -138,20 +138,20 @@ func (c *serviceClient) EnsureInitialized() error {
 	return nil
 }
 
-func (c *serviceClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *serviceClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	// Build watch options to pass to k8s.
-	opts := metav1.ListOptions{ResourceVersion: revision, Watch: true}
 	rl, ok := list.(model.ResourceListOptions)
 	if !ok {
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
+	k8sOpts := watchOptionsToK8sListOptions(options)
 	if len(rl.Name) != 0 {
 		// We've been asked to watch a specific service resource.
 		log.WithField("name", rl.Name).Debug("Watching a single service")
-		opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", rl.Name).String()
+		k8sOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", rl.Name).String()
 	}
 
-	k8sWatch, err := c.clientSet.CoreV1().Services(rl.Namespace).Watch(ctx, opts)
+	k8sWatch, err := c.clientSet.CoreV1().Services(rl.Namespace).Watch(ctx, k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/k8sservice_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/k8sservice_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	k8sapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+var _ = Describe("Service tests with fake clientSet", func() {
+	var clientSet *FakeClientSetWithListRevAndFiltering
+	var client *serviceClient
+
+	BeforeEach(func() {
+		clientSet = NewFakeClientSetWithListRevAndFiltering()
+		client = NewServiceClient(clientSet).(*serviceClient)
+
+		service, err := clientSet.CoreV1().Services("some-ns").Create(context.TODO(), &k8sapi.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "10",
+				Name:            "some-service",
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(service).NotTo(BeNil())
+	})
+
+	It("should list all and return the collection revision", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("123"),
+			"revision should match the collection version")
+
+		clientSet.DefaultCurrentListRevision = "124"
+		list, err = client.List(context.TODO(), model.ResourceListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("124"),
+			"revision should match the collection version")
+	})
+
+	It("should filter by name, returning correct revision", func() {
+		// Name only.
+		list, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "some-service",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("123"),
+			"revision should match the collection version")
+
+		// With updated revision.
+		clientSet.DefaultCurrentListRevision = "124"
+		list, err = client.List(context.TODO(), model.ResourceListOptions{
+			Name: "some-service",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("124"),
+			"revision should match the collection version")
+
+		// Wrong name, doesn't match anything.
+		list, err = client.List(context.TODO(), model.ResourceListOptions{
+			Name: "some-other-service",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(0))
+		Expect(list.Revision).To(Equal("124"),
+			"revision should match the collection version, even if name doesn't match anything")
+
+		// Correct name, wrong namespace.
+		list, err = client.List(context.TODO(), model.ResourceListOptions{
+			Name:      "some-service",
+			Namespace: "some-other-ns",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(0))
+		Expect(list.Revision).To(Equal("124"),
+			"revision should match the collection version, even if namespace doesn't match anything")
+	})
+})

--- a/libcalico-go/lib/backend/k8s/resources/kubeadminnetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubeadminnetworkpolicy.go
@@ -109,17 +109,14 @@ func (c *adminNetworkPolicyClient) List(ctx context.Context, list model.ListInte
 	return pagedList(ctx, logContext, revision, list, convertFunc, listFunc)
 }
 
-func (c *adminNetworkPolicyClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
-	// Build watch options to pass to k8s.
-	opts := metav1.ListOptions{Watch: true, AllowWatchBookmarks: false}
+func (c *adminNetworkPolicyClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	_, ok := list.(model.ResourceListOptions)
 	if !ok {
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
-
-	opts.ResourceVersion = revision
-	log.Debugf("Watching Kubernetes AdminNetworkPolicy at revision %q", revision)
-	k8sRawWatch, err := c.adminPolicyClient.AdminNetworkPolicies().Watch(ctx, opts)
+	log.Debugf("Watching Kubernetes AdminNetworkPolicy at revision %q", options.Revision)
+	k8sOpts := watchOptionsToK8sListOptions(options)
+	k8sRawWatch, err := c.adminPolicyClient.AdminNetworkPolicies().Watch(ctx, k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/kubecontrollersconfig.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubecontrollersconfig.go
@@ -31,7 +31,7 @@ const (
 	KubeControllersConfigCRDName      = "kubecontrollersconfigurations.crd.projectcalico.org"
 )
 
-func NewKubeControllersConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewKubeControllersConfigClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/kubeendpointslice.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubeendpointslice.go
@@ -36,7 +36,7 @@ import (
 // NewKubernetesEndpointSliceClient returns a new client for interacting with Kubernetes EndpointSlice objects.
 // Note that this client is only intended for use by the felix syncer in KDD mode, and as such is largely unimplemented
 // except for the functions required by the syncer.
-func NewKubernetesEndpointSliceClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewKubernetesEndpointSliceClient(c kubernetes.Interface) K8sResourceClient {
 	return &endpointSliceClient{
 		Converter: conversion.NewConverter(),
 		clientSet: c,
@@ -46,7 +46,7 @@ func NewKubernetesEndpointSliceClient(c *kubernetes.Clientset) K8sResourceClient
 // Implements the api.Client interface for Kubernetes EndpointSlice.
 type endpointSliceClient struct {
 	conversion.Converter
-	clientSet *kubernetes.Clientset
+	clientSet kubernetes.Interface
 }
 
 func (c *endpointSliceClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {

--- a/libcalico-go/lib/backend/k8s/resources/kubeendpointslice.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubeendpointslice.go
@@ -107,17 +107,15 @@ func (c *endpointSliceClient) List(ctx context.Context, list model.ListInterface
 	return pagedList(ctx, logContext, revision, list, convertFunc, listFunc)
 }
 
-func (c *endpointSliceClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
-	// Build watch options to pass to k8s.
-	opts := metav1.ListOptions{Watch: true, AllowWatchBookmarks: false}
+func (c *endpointSliceClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	_, ok := list.(model.ResourceListOptions)
 	if !ok {
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
 
-	opts.ResourceVersion = revision
-	log.Debugf("Watching Kubernetes EndpointSlice at revision %q", revision)
-	k8sRawWatch, err := c.clientSet.DiscoveryV1().EndpointSlices("").Watch(ctx, opts)
+	log.Debugf("Watching Kubernetes EndpointSlice at revision %q", options.Revision)
+	k8sOpts := watchOptionsToK8sListOptions(options)
+	k8sRawWatch, err := c.clientSet.DiscoveryV1().EndpointSlices("").Watch(ctx, k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
@@ -36,7 +36,7 @@ import (
 // NewKubernetesNetworkPolicyClient returns a new client for interacting with Kubernetes NetworkPolicy objects.
 // Note that this client is only intended for use by the felix syncer in KDD mode, and as such is largely unimplemented
 // except for the functions required by the syncer.
-func NewKubernetesNetworkPolicyClient(c *kubernetes.Clientset) K8sResourceClient {
+func NewKubernetesNetworkPolicyClient(c kubernetes.Interface) K8sResourceClient {
 	return &networkPolicyClient{
 		Converter: conversion.NewConverter(),
 		clientSet: c,
@@ -46,7 +46,7 @@ func NewKubernetesNetworkPolicyClient(c *kubernetes.Clientset) K8sResourceClient
 // Implements the api.Client interface for Kubernetes NetworkPolicy.
 type networkPolicyClient struct {
 	conversion.Converter
-	clientSet *kubernetes.Clientset
+	clientSet kubernetes.Interface
 }
 
 func (c *networkPolicyClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {

--- a/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
@@ -112,17 +112,16 @@ func (c *networkPolicyClient) List(ctx context.Context, list model.ListInterface
 	return pagedList(ctx, logContext, revision, list, convertFunc, listFunc)
 }
 
-func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
-	// Build watch options to pass to k8s.
-	opts := metav1.ListOptions{Watch: true, AllowWatchBookmarks: false}
+func (c *networkPolicyClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
+
 	_, ok := list.(model.ResourceListOptions)
 	if !ok {
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
 
-	opts.ResourceVersion = revision
-	log.Debugf("Watching Kubernetes NetworkPolicy at revision %q", revision)
-	k8sRawWatch, err := c.clientSet.NetworkingV1().NetworkPolicies("").Watch(ctx, opts)
+	k8sOpts := watchOptionsToK8sListOptions(options)
+	log.Debugf("Watching Kubernetes NetworkPolicy at revision %q", options.Revision)
+	k8sRawWatch, err := c.clientSet.NetworkingV1().NetworkPolicies("").Watch(ctx, k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/networkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/networkpolicy.go
@@ -29,7 +29,7 @@ const (
 	NetworkPolicyCRDName      = "networkpolicies.crd.projectcalico.org"
 )
 
-func NewNetworkPolicyClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewNetworkPolicyClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/networkset.go
+++ b/libcalico-go/lib/backend/k8s/resources/networkset.go
@@ -29,7 +29,7 @@ const (
 	NetworkSetCRDName      = "networksets.crd.projectcalico.org"
 )
 
-func NewNetworkSetClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewNetworkSetClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/node.go
+++ b/libcalico-go/lib/backend/k8s/resources/node.go
@@ -58,7 +58,7 @@ const (
 	nodeWireguardPublicKeyV6Annotation    = "projectcalico.org/WireguardPublicKeyV6"
 )
 
-func NewNodeClient(c *kubernetes.Clientset, usePodCIDR bool) K8sResourceClient {
+func NewNodeClient(c kubernetes.Interface, usePodCIDR bool) K8sResourceClient {
 	return &nodeClient{
 		clientSet:  c,
 		usePodCIDR: usePodCIDR,
@@ -69,7 +69,7 @@ type validatorFunc func(string) error
 
 // Implements the api.Client interface for Nodes.
 type nodeClient struct {
-	clientSet  *kubernetes.Clientset
+	clientSet  kubernetes.Interface
 	usePodCIDR bool
 }
 
@@ -141,31 +141,13 @@ func (c *nodeClient) List(ctx context.Context, list model.ListInterface, revisio
 	logContext := log.WithField("Resource", "Node")
 	logContext.Debug("Received List request")
 	nl := list.(model.ResourceListOptions)
-	kvps := []*model.KVPair{}
-
-	if nl.Name != "" {
-		// The node is already fully qualified, so perform a Get instead.
-		// If the entry does not exist then we just return an empty list.
-		kvp, err := c.Get(ctx, model.ResourceKey{Name: nl.Name, Kind: libapiv3.KindNode}, revision)
-		if err != nil {
-			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-				return nil, err
-			}
-			return &model.KVPairList{
-				KVPairs:  kvps,
-				Revision: revision,
-			}, nil
-		}
-
-		kvps = append(kvps, kvp)
-		return &model.KVPairList{
-			KVPairs:  kvps,
-			Revision: revision,
-		}, nil
-	}
 
 	// List all nodes.
 	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		if nl.Name != "" {
+			// Filtering to a single node.
+			opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", nl.Name).String()
+		}
 		nodes, err := c.clientSet.CoreV1().Nodes().List(ctx, opts)
 		if err != nil {
 			return nil, err

--- a/libcalico-go/lib/backend/k8s/resources/node.go
+++ b/libcalico-go/lib/backend/k8s/resources/node.go
@@ -187,20 +187,20 @@ func (c *nodeClient) EnsureInitialized() error {
 	return nil
 }
 
-func (c *nodeClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *nodeClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	// Build watch options to pass to k8s.
-	opts := metav1.ListOptions{ResourceVersion: revision, Watch: true, AllowWatchBookmarks: false}
 	rlo, ok := list.(model.ResourceListOptions)
 	if !ok {
 		return nil, fmt.Errorf("ListInterface is not a ResourceListOptions: %s", list)
 	}
+	k8sOpts := watchOptionsToK8sListOptions(options)
 	if len(rlo.Name) != 0 {
 		// We've been asked to watch a specific node resource.
 		log.WithField("name", rlo.Name).Debug("Watching a single node")
-		opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", rlo.Name).String()
+		k8sOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", rlo.Name).String()
 	}
 
-	k8sWatch, err := c.clientSet.CoreV1().Nodes().Watch(ctx, opts)
+	k8sWatch, err := c.clientSet.CoreV1().Nodes().Watch(ctx, k8sOpts)
 	if err != nil {
 		return nil, K8sErrorToCalico(err, list)
 	}

--- a/libcalico-go/lib/backend/k8s/resources/node_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/node_test.go
@@ -15,16 +15,16 @@
 package resources
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
-
+	"github.com/projectcalico/api/pkg/lib/numorstring"
 	k8sapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/projectcalico/api/pkg/lib/numorstring"
-
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
@@ -608,5 +608,59 @@ var _ = Describe("Test Node conversion", func() {
 			{Address: "172.17.17.10", Type: libapiv3.InternalIP},   // from k8s InternalIP
 			{Address: "192.168.1.100", Type: libapiv3.ExternalIP},
 		}))
+	})
+})
+
+var _ = Describe("Node tests with fake clientSet", func() {
+	var clientSet *FakeClientSetWithListRevAndFiltering
+	var client *nodeClient
+
+	BeforeEach(func() {
+		clientSet = NewFakeClientSetWithListRevAndFiltering()
+		client = NewNodeClient(clientSet, false).(*nodeClient)
+
+		node, err := clientSet.CoreV1().Nodes().Create(context.TODO(), &k8sapi.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "10",
+				Name:            "some-node",
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node).NotTo(BeNil())
+	})
+
+	It("should list all and return the collection revision", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("123"),
+			"revision should match the collection version")
+
+		clientSet.DefaultCurrentListRevision = "124"
+		list, err = client.List(context.TODO(), model.ResourceListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("124"),
+			"revision should match the collection version")
+	})
+
+	It("should list by name", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "some-node",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("123"),
+			"revision should match the collection version")
+	})
+
+	It("should return correct revision even if name doesn't match", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "some-other-node",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(0))
+		Expect(list.Revision).To(Equal("123"),
+			"revision should match the collection version, even if list is empty")
 	})
 })

--- a/libcalico-go/lib/backend/k8s/resources/profile_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/profile_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+var _ = Describe("Profile tests with fake clientSet", func() {
+	var clientSet *FakeClientSetWithListRevAndFiltering
+	var client *profileClient
+
+	BeforeEach(func() {
+		clientSet = NewFakeClientSetWithListRevAndFiltering()
+
+		// Use unique revision for each of the base types so we can verify that
+		// they flow through correctly.
+		clientSet.CurrentListRevisionByType["Namespace"] = "100"
+		clientSet.CurrentListRevisionByType["ServiceAccount"] = "200"
+
+		defaultNS := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "default",
+				ResourceVersion: "10",
+				UID:             uuid.NewUUID(),
+			},
+		}
+		defaultNS, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), defaultNS, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		defaultSA := &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "default",
+				Namespace:       "default",
+				ResourceVersion: "20",
+				UID:             uuid.NewUUID(),
+			},
+		}
+		defaultSA, err = clientSet.CoreV1().ServiceAccounts("default").Create(context.TODO(), defaultSA, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		client = NewProfileClient(clientSet).(*profileClient)
+	})
+
+	It("should list all and return the collection revision", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(3))
+		Expect(list.Revision).To(Equal("100/200"),
+			"revision should match the combined collection versions")
+	})
+
+	It("should only return the default allow profile by name", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "projectcalico-default-allow",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("1"),
+			"revision should only relate to the namespace collection")
+	})
+
+	It("should only query namespaces when filtering to a namespace profile name", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "kns.default",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("100/"),
+			"revision should only relate to the namespace collection")
+	})
+
+	It("should only query service accounts when filtering to a service account profile name", func() {
+		list, err := client.List(context.TODO(), model.ResourceListOptions{
+			Name: "ksa.default.default",
+		}, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.KVPairs).To(HaveLen(1))
+		Expect(list.Revision).To(Equal("/200"),
+			"revision should only relate to the sa collection")
+	})
+})

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/json"
@@ -320,4 +321,11 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.DeepCopyInto(rom.(*metav1.ObjectMeta))
 
 	return nil
+}
+
+func watchOptionsToK8sListOptions(wo api.WatchOptions) metav1.ListOptions {
+	return metav1.ListOptions{
+		ResourceVersion: wo.Revision,
+		Watch:           true,
+	}
 }

--- a/libcalico-go/lib/backend/k8s/resources/tiers.go
+++ b/libcalico-go/lib/backend/k8s/resources/tiers.go
@@ -32,7 +32,7 @@ const (
 	TierCRDName      = "tiers.crd.projectcalico.org"
 )
 
-func NewTierClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourceClient {
+func NewTierClient(c kubernetes.Interface, r rest.Interface) K8sResourceClient {
 	return &customK8sResourceClient{
 		clientSet:       c,
 		restClient:      r,

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -22,25 +22,22 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
-	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
-	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-
-	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
-	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/calico/libcalico-go/lib/names"
-
 	k8sapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 )
 
 var _ = Describe("WorkloadEndpointClient", func() {
@@ -774,7 +771,7 @@ func testWatchWorkloadEndpoints(pods []*k8sapi.Pod, expectedWEPs []*libapiv3.Wor
 	ctx := context.Background()
 
 	wepClient := resources.NewWorkloadEndpointClient(k8sClient).(*resources.WorkloadEndpointClient)
-	wepWatcher, err := wepClient.Watch(context.Background(), model.ResourceListOptions{}, "")
+	wepWatcher, err := wepClient.Watch(context.Background(), model.ResourceListOptions{}, api.WatchOptions{})
 
 	Expect(err).ShouldNot(HaveOccurred())
 

--- a/libcalico-go/lib/backend/k8s/scheme/scheme.go
+++ b/libcalico-go/lib/backend/k8s/scheme/scheme.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheme
+
+import (
+	"sync"
+
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+)
+
+var addToSchemeOnce sync.Once
+
+func AddCalicoResourcesToScheme() {
+	addToSchemeOnce.Do(func() {
+		// We also need to register resources.
+		schemeBuilder := runtime.NewSchemeBuilder(
+			func(scheme *runtime.Scheme) error {
+				scheme.AddKnownTypes(
+					schema.GroupVersion{
+						Group:   "crd.projectcalico.org",
+						Version: "v1",
+					},
+					&apiv3.FelixConfiguration{},
+					&apiv3.FelixConfigurationList{},
+					&apiv3.IPPool{},
+					&apiv3.IPPoolList{},
+					&apiv3.IPReservation{},
+					&apiv3.IPReservationList{},
+					&apiv3.BGPPeer{},
+					&apiv3.BGPPeerList{},
+					&apiv3.BGPConfiguration{},
+					&apiv3.BGPConfigurationList{},
+					&apiv3.ClusterInformation{},
+					&apiv3.ClusterInformationList{},
+					&apiv3.GlobalNetworkSet{},
+					&apiv3.GlobalNetworkSetList{},
+					&apiv3.GlobalNetworkPolicy{},
+					&apiv3.GlobalNetworkPolicyList{},
+					&apiv3.NetworkPolicy{},
+					&apiv3.NetworkPolicyList{},
+					&apiv3.NetworkSet{},
+					&apiv3.NetworkSetList{},
+					&apiv3.Tier{},
+					&apiv3.TierList{},
+					&apiv3.HostEndpoint{},
+					&apiv3.HostEndpointList{},
+					&libapiv3.BlockAffinity{},
+					&libapiv3.BlockAffinityList{},
+					&libapiv3.IPAMBlock{},
+					&libapiv3.IPAMBlockList{},
+					&libapiv3.IPAMHandle{},
+					&libapiv3.IPAMHandleList{},
+					&libapiv3.IPAMConfig{},
+					&libapiv3.IPAMConfigList{},
+					&apiv3.KubeControllersConfiguration{},
+					&apiv3.KubeControllersConfigurationList{},
+					&apiv3.CalicoNodeStatus{},
+					&apiv3.CalicoNodeStatusList{},
+					&apiv3.BGPFilter{},
+					&apiv3.BGPFilterList{},
+				)
+				return nil
+			})
+
+		err := schemeBuilder.AddToScheme(scheme.Scheme)
+		if err != nil {
+			log.WithError(err).Fatal("failed to add calico resources to scheme")
+		}
+		metav1.AddToGroupVersion(scheme.Scheme, schema.GroupVersion{Group: "crd.projectcalico.org", Version: "v1"})
+	})
+}

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -226,7 +226,9 @@ func (wc *watcherCache) resyncAndCreateWatcher(ctx context.Context) {
 
 		// And now start watching from the revision returned by the List, or from a previous watch event
 		// (depending on whether we were performing a full resync).
-		w, err := wc.client.Watch(ctx, wc.resourceType.ListInterface, wc.currentWatchRevision)
+		w, err := wc.client.Watch(ctx, wc.resourceType.ListInterface, api.WatchOptions{
+			Revision: wc.currentWatchRevision,
+		})
 		if err != nil {
 			// Failed to create the watcher - we'll need to retry.
 			switch err.(type) {

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1058,14 +1058,14 @@ func (c *fakeClient) List(ctx context.Context, list model.ListInterface, revisio
 	}
 }
 
-func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	// Create a fake watcher keyed off the ListOptions (root path).
 	name := model.ListOptionsToDefaultPathRoot(list)
 	log.WithField("Name", name).Info("Watch request")
 	if l, ok := c.lws[name]; !ok || l == nil {
 		panic("Watch for unhandled resource type")
 	} else {
-		c.latestWatchRevision = revision
+		c.latestWatchRevision = options.Revision
 		return l.watch()
 	}
 }

--- a/libcalico-go/lib/clientv3/profile_e2e_test.go
+++ b/libcalico-go/lib/clientv3/profile_e2e_test.go
@@ -335,7 +335,7 @@ var _ = testutils.E2eDatastoreDescribe("Profile tests", testutils.DatastoreEtcdV
 			outList, outError := c.Profiles().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(outList.Items).To(HaveLen(1))
-			Expect(outList.Items[0].ResourceVersion).To(Equal("0"))
+			Expect(outList.Items[0].ResourceVersion).To(Equal("1"))
 			Expect(outList.Items[0].Spec.Ingress).To(ConsistOf(defaultAllowSpec.Ingress))
 			Expect(outList.Items[0].Spec.Egress).To(ConsistOf(defaultAllowSpec.Egress))
 			rev0 := outList.ResourceVersion

--- a/libcalico-go/lib/clientv3/resources.go
+++ b/libcalico-go/lib/clientv3/resources.go
@@ -251,7 +251,7 @@ func (c *resources) Watch(ctx context.Context, opts options.ListOptions, kind st
 
 	// Create the backend watcher.  We need to process the results to add revision data etc.
 	ctx, cancel := context.WithCancel(ctx)
-	backend, err := c.backend.Watch(ctx, list, opts.ResourceVersion)
+	backend, err := c.backend.Watch(ctx, list, bapi.WatchOptions{Revision: opts.ResourceVersion})
 	if err != nil {
 		cancel()
 		return nil, err

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
@@ -132,7 +132,7 @@ func (c *fakeClient) List(ctx context.Context, list model.ListInterface, revisio
 	panic(fmt.Sprintf("List called on unexpected object: %+v", list))
 }
 
-func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, revision string) (api.WatchInterface, error) {
+func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	panic("should not be called")
 }
 

--- a/libcalico-go/lib/resources/static.go
+++ b/libcalico-go/lib/resources/static.go
@@ -49,6 +49,6 @@ func DefaultAllowProfile() *model.KVPair {
 			Kind: v3.KindProfile,
 		},
 		Value:    profile,
-		Revision: "0",
+		Revision: "1",
 	}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The watchercache requires the KVList to contain the collection resource version for correctness.  Without it, it can miss updates from the datastore.

- Fix the resources that were missing the revision entirely.
- Retire code in the Kubernetes datastore driver that would turn `List()` calls into `Get()` calls when only one resource was needed.  This code was incorrect because `Get()` doesn't return the "collection resource version", which is what a `List()` call _should_ return (and must return for a subsequent `Watch()` to function correctly).
- Instead of `Get()` use a `List()` with a `FieldSelector` that matches on the name of the resource.  This returns the same resource but it wraps it in a List object that carries the needed collection version.
- As a special case, maintain the Get() logic for `WorkloadEndpoint` behind an opt-in `Context` flag (with a nice long name to make users of the hacky flag feel bad :-P).  The CNI plugin relies on that logic to avoid needing `list` RBAC permissions for Pods.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Pick of #9599 
CORE-10904

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that libcalico-go would not always fill in the revision when listing certain resources (or single instances of certain resources).  This could result in missed watch events in components such as Typha.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
