### PR TITLE
[BPF] remove created value from conntrack

### DIFF
--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -62,7 +62,7 @@ struct calico_ct_leg {
 
 #define CT_INVALID_IFINDEX	0
 struct calico_ct_value {
-	__u64 created;
+	__u64 unused;
 	__u64 last_seen; // 8
 	__u8 type;		 // 16
 	__u8 flags;

--- a/felix/bpf/conntrack/cleanup.go
+++ b/felix/bpf/conntrack/cleanup.go
@@ -64,12 +64,6 @@ func (l *LivenessScanner) Check(ctKey KeyInterface, ctVal ValueInterface, get En
 	}
 	now := l.cachedKTime
 
-	if now-ctVal.Created() < int64(l.timeouts.CreationGracePeriod) {
-		// Very new entry; make sure we don't delete it while dataplane is still
-		// setting it up.
-		return ScanVerdictOK
-	}
-
 	debug := log.GetLevel() >= log.DebugLevel
 
 	switch ctVal.Type() {

--- a/felix/bpf/conntrack/conntrack_test.go
+++ b/felix/bpf/conntrack/conntrack_test.go
@@ -159,36 +159,36 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 		},
 		Entry("keyA - revA",
 			conntrack.NewKey(123, clientIP, clientPort, svcIP, svcPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, clientIP, clientPort, backendIP, backendPort)),
+			conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, clientIP, clientPort, backendIP, backendPort)),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("keyA - revB",
 			conntrack.NewKey(123, clientIP, clientPort, svcIP, svcPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
+			conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("keyB - revA",
 			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, clientIP, clientPort, backendIP, backendPort)),
+			conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, clientIP, clientPort, backendIP, backendPort)),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("keyB - revB",
 			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
+			conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("mismatch IP",
 			conntrack.NewKey(123, svcIP, svcPort, net.IPv4(6, 6, 6, 6), clientPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP2, backendPort2, clientIP, clientPort)),
+			conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, backendIP2, backendPort2, clientIP, clientPort)),
 			conntrack.ScanVerdictOK,
 			func(conntrack.KeyInterface) (conntrack.ValueInterface, error) {
-				return conntrack.NewValueNATReverse(0, 0, 0, conntrack.Leg{}, conntrack.Leg{},
+				return conntrack.NewValueNATReverse(0, 0, conntrack.Leg{}, conntrack.Leg{},
 					net.IPv4(0, 0, 0, 0), svcIP, svcPort), nil
 			},
 		),
 		Entry("mismatch rev IP missing rev",
 			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, net.IPv4(3, 2, 2, 3), clientPort)),
+			conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, backendIP, backendPort, net.IPv4(3, 2, 2, 3), clientPort)),
 			conntrack.ScanVerdictDelete,
 			func(conntrack.KeyInterface) (conntrack.ValueInterface, error) {
 				return nil, unix.ENOENT
@@ -197,25 +197,25 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 		Entry("snatport keyA - revA",
 			conntrack.NewKey(123, clientIP, clientPort, svcIP, svcPort),
 			withSNATPort(snatPort,
-				conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, clientIP, snatPort, backendIP, backendPort))),
+				conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, clientIP, snatPort, backendIP, backendPort))),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("snatport keyA - revB",
 			conntrack.NewKey(123, clientIP, clientPort, svcIP, svcPort),
 			withSNATPort(snatPort,
-				conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, snatPort))),
+				conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, snatPort))),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("snatport keyB - revA",
 			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
 			withSNATPort(snatPort,
-				conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, clientIP, snatPort, backendIP, backendPort))),
+				conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, clientIP, snatPort, backendIP, backendPort))),
 			conntrack.ScanVerdictDelete,
 		),
 		Entry("snatport keyB - revB",
 			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
 			withSNATPort(snatPort,
-				conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, snatPort))),
+				conntrack.NewValueNATForward(0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, snatPort))),
 			conntrack.ScanVerdictDelete,
 		),
 	)
@@ -226,16 +226,16 @@ var _ = Describe("BPF Conntrack upgrade entries", func() {
 	k3 := conntrack.NewKey(1, net.ParseIP("10.0.0.1"), 0, net.ParseIP("10.0.0.2"), 0)
 
 	v2Normal := v2.NewValueNormal(cttestdata.Now-1, cttestdata.Now-1, 0, v2.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, v2.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201})
-	v3Normal := conntrack.NewValueNormal(cttestdata.Now-1, cttestdata.Now-1, 0, conntrack.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, conntrack.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201})
+	v3Normal := conntrack.NewValueNormal(cttestdata.Now-1, 0, conntrack.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, conntrack.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201})
 
 	v2NatReverse := v2.NewValueNATReverse(cttestdata.Now-1, cttestdata.Now-1, 0, v2.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, v2.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201}, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234)
-	v3NatReverse := conntrack.NewValueNATReverse(cttestdata.Now-1, cttestdata.Now-1, 0, conntrack.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, conntrack.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201}, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234)
+	v3NatReverse := conntrack.NewValueNATReverse(cttestdata.Now-1, 0, conntrack.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, conntrack.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201}, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234)
 
 	v2NatRevSnat := v2.NewValueNATReverseSNAT(cttestdata.Now-1, cttestdata.Now-1, 0, v2.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, v2.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201}, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), net.IPv4(9, 10, 11, 12), 1234)
-	v3NatRevSnat := conntrack.NewValueNATReverseSNAT(cttestdata.Now-1, cttestdata.Now-1, 0, conntrack.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, conntrack.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201}, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), net.IPv4(9, 10, 11, 12), 1234)
+	v3NatRevSnat := conntrack.NewValueNATReverseSNAT(cttestdata.Now-1, 0, conntrack.Leg{Seqno: 1000, SynSeen: true, Ifindex: 200}, conntrack.Leg{Seqno: 1001, RstSeen: true, Ifindex: 201}, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), net.IPv4(9, 10, 11, 12), 1234)
 
 	v2NatFwd := v2.NewValueNATForward(cttestdata.Now-1, cttestdata.Now-1, 0, v2.NewKey(3, net.ParseIP("20.0.0.1"), 0, net.ParseIP("20.0.0.2"), 0))
-	v3NatFwd := conntrack.NewValueNATForward(cttestdata.Now-1, cttestdata.Now-1, 0, conntrack.NewKey(3, net.ParseIP("20.0.0.1"), 0, net.ParseIP("20.0.0.2"), 0))
+	v3NatFwd := conntrack.NewValueNATForward(cttestdata.Now-1, 0, conntrack.NewKey(3, net.ParseIP("20.0.0.1"), 0, net.ParseIP("20.0.0.2"), 0))
 	DescribeTable("upgrade entries",
 		func(k2 v2.Key, v2 v2.Value, k3 conntrack.Key, v3 conntrack.Value) {
 			upgradedKey := k2.Upgrade()

--- a/felix/bpf/conntrack/cttestdata/ct_data.go
+++ b/felix/bpf/conntrack/cttestdata/ct_data.go
@@ -42,27 +42,23 @@ var (
 	icmpKey    = conntrack.NewKey(conntrack.ProtoICMP, ip1, 1234, ip2, 3456)
 	genericKey = conntrack.NewKey(253, ip1, 0, ip2, 0)
 
-	genericJustCreated    = makeValue(Now-1, Now-1, conntrack.Leg{}, conntrack.Leg{})
-	genericAlmostTimedOut = makeValue(Now-(20*time.Minute), Now-(599*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
-	genericTimedOut       = makeValue(Now-(20*time.Minute), Now-(601*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
+	genericAlmostTimedOut = makeValue(Now-(599*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
+	genericTimedOut       = makeValue(Now-(601*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
 
-	udpJustCreated    = makeValue(Now-1, Now-1, conntrack.Leg{}, conntrack.Leg{})
-	udpAlmostTimedOut = makeValue(Now-(2*time.Minute), Now-(59*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
-	udpTimedOut       = makeValue(Now-(2*time.Minute), Now-(61*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
+	udpAlmostTimedOut = makeValue(Now-(59*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
+	udpTimedOut       = makeValue(Now-(61*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
 
-	icmpJustCreated    = makeValue(Now-1, Now-1, conntrack.Leg{}, conntrack.Leg{})
-	icmpAlmostTimedOut = makeValue(Now-(2*time.Minute), Now-(4*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
-	icmpTimedOut       = makeValue(Now-(2*time.Minute), Now-(6*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
+	icmpAlmostTimedOut = makeValue(Now-(4*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
+	icmpTimedOut       = makeValue(Now-(6*time.Second), conntrack.Leg{Approved: true}, conntrack.Leg{})
 
-	tcpJustCreated        = makeValue(Now-1, Now-1, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
-	tcpHandshakeTimeout   = makeValue(Now-22*time.Second, Now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
-	tcpHandshakeTimeout2  = makeValue(Now-22*time.Second, Now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpEstablished        = makeValue(Now-(10*time.Second), Now-1, conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpEstablishedTimeout = makeValue(Now-(3*time.Hour), Now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpSingleFin          = makeValue(Now-(3*time.Hour), Now-(50*time.Minute), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpSingleFinTimeout   = makeValue(Now-(3*time.Hour), Now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
-	tcpBothFin            = makeValue(Now-(3*time.Hour), Now-(29*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
-	tcpBothFinTimeout     = makeValue(Now-(3*time.Hour), Now-(31*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
+	tcpHandshakeTimeout   = makeValue(Now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{})
+	tcpHandshakeTimeout2  = makeValue(Now-21*time.Second, conntrack.Leg{SynSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpEstablished        = makeValue(Now-1, conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpEstablishedTimeout = makeValue(Now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpSingleFin          = makeValue(Now-(50*time.Minute), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpSingleFinTimeout   = makeValue(Now-(2*time.Hour), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true})
+	tcpBothFin            = makeValue(Now-(29*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
+	tcpBothFinTimeout     = makeValue(Now-(31*time.Second), conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true, FinSeen: true})
 )
 
 type CTCleanupTest struct {
@@ -119,8 +115,8 @@ func init() {
 			KVs: map[conntrack.Key]conntrack.Value{
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
-				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, Now-3*time.Hour, 0, tcpRevKey),
-				tcpRevKey: conntrack.NewValueNATReverse(Now-3*time.Hour, Now-time.Second, 0,
+				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
+				tcpRevKey: conntrack.NewValueNATReverse(Now-time.Second, 0,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true},
 					nil, nil, 5555),
 			},
@@ -131,8 +127,8 @@ func init() {
 			KVs: map[conntrack.Key]conntrack.Value{
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
-				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, Now-3*time.Hour, 0, tcpRevKey),
-				tcpRevKey: conntrack.NewValueNATReverse(Now-3*time.Hour, Now-2*time.Hour, 0,
+				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
+				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, 0,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true},
 					nil, nil, 5555),
 			},
@@ -142,20 +138,20 @@ func init() {
 		CTCleanupTest{
 			Description: "forward NAT entry with no reverse entry",
 			KVs: map[conntrack.Key]conntrack.Value{
-				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, Now-3*time.Hour, 0, tcpRevKey),
+				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
 			},
 			ExpectedDeletions: []conntrack.Key{tcpFwdKey},
 		},
 		CTCleanupTest{
 			Description: "forward NAT entry without reverse in grace period",
 			KVs: map[conntrack.Key]conntrack.Value{
-				tcpFwdKey: conntrack.NewValueNATForward(Now-9*time.Second, Now-9*time.Second, 0, tcpRevKey),
+				tcpFwdKey: conntrack.NewValueNATForward(Now-9*time.Second, 0, tcpRevKey),
 			},
 		},
 		CTCleanupTest{
 			Description: "forward NAT entry without reverse out of grace period",
 			KVs: map[conntrack.Key]conntrack.Value{
-				tcpFwdKey: conntrack.NewValueNATForward(Now-11*time.Second, Now-11*time.Second, 0, tcpRevKey),
+				tcpFwdKey: conntrack.NewValueNATForward(Now-11*time.Second, 0, tcpRevKey),
 			},
 			ExpectedDeletions: []conntrack.Key{tcpFwdKey},
 		},
@@ -165,13 +161,12 @@ func init() {
 			KVs: map[conntrack.Key]conntrack.Value{
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
-				udpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, Now-3*time.Hour, 0, udpRevKey),
-				udpRevKey: conntrack.NewValueNATReverse(Now-3*time.Hour, Now-time.Second, 0, conntrack.Leg{}, conntrack.Leg{}, nil, nil, 5555),
+				udpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, udpRevKey),
+				udpRevKey: conntrack.NewValueNATReverse(Now-time.Second, 0, conntrack.Leg{}, conntrack.Leg{}, nil, nil, 5555),
 			},
 		},
 	)
 
-	addSingleKVTest("TCP just created", tcpKey, tcpJustCreated, false)
 	addSingleKVTest("TCP handshake timeout", tcpKey, tcpHandshakeTimeout, true)
 	addSingleKVTest("TCP handshake timeout on response", tcpKey, tcpHandshakeTimeout2, true)
 	addSingleKVTest("TCP established", tcpKey, tcpEstablished, false)
@@ -181,19 +176,16 @@ func init() {
 	addSingleKVTest("TCP both fin", tcpKey, tcpBothFin, false)
 	addSingleKVTest("TCP both fin timed out", tcpKey, tcpBothFinTimeout, true)
 
-	addSingleKVTest("UDP just created", udpKey, udpJustCreated, false)
 	addSingleKVTest("UDP almost timed out", udpKey, udpAlmostTimedOut, false)
 	addSingleKVTest("UDP timed out", udpKey, udpTimedOut, true)
 
-	addSingleKVTest("Generic just created", genericKey, genericJustCreated, false)
 	addSingleKVTest("Generic almost timed out", genericKey, genericAlmostTimedOut, false)
 	addSingleKVTest("Generic timed out", genericKey, genericTimedOut, true)
 
-	addSingleKVTest("icmp just created", icmpKey, icmpJustCreated, false)
 	addSingleKVTest("icmp almost timed out", icmpKey, icmpAlmostTimedOut, false)
 	addSingleKVTest("icmp timed out", icmpKey, icmpTimedOut, true)
 }
 
-func makeValue(created time.Duration, lastSeen time.Duration, legA conntrack.Leg, legB conntrack.Leg) conntrack.Value {
-	return conntrack.NewValueNormal(created, lastSeen, 0, legA, legB)
+func makeValue(lastSeen time.Duration, legA conntrack.Leg, legB conntrack.Leg) conntrack.Value {
+	return conntrack.NewValueNormal(lastSeen, 0, legA, legB)
 }

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -71,59 +71,59 @@ const (
 )
 
 // NewValueNormal creates a new Value of type TypeNormal based on the given parameters
-func NewValueNormal(created, lastSeen time.Duration, flags uint16, legA, legB Leg) Value {
-	return curVer.NewValueNormal(created, lastSeen, flags, legA, legB)
+func NewValueNormal(lastSeen time.Duration, flags uint16, legA, legB Leg) Value {
+	return curVer.NewValueNormal(lastSeen, flags, legA, legB)
 }
 
 // NewValueNATForward creates a new Value of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueNATForward(created, lastSeen time.Duration, flags uint16, revKey Key) Value {
-	return curVer.NewValueNATForward(created, lastSeen, flags, revKey)
+func NewValueNATForward(lastSeen time.Duration, flags uint16, revKey Key) Value {
+	return curVer.NewValueNATForward(lastSeen, flags, revKey)
 }
 
 // NewValueNATReverse creates a new Value of type TypeNATReverse for the given
 // arguments and reverse parameters
 func NewValueNATReverse(
-	created, lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16,
 ) Value {
-	return curVer.NewValueNATReverse(created, lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
+	return curVer.NewValueNATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
 }
 
 // NewValueNATReverseSNAT in addition to NewValueNATReverse sets the orig source IP
 func NewValueNATReverseSNAT(
-	created, lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16,
 ) Value {
-	return curVer.NewValueNATReverseSNAT(created, lastSeen, flags, legA, legB, tunnelIP, origIP, origSrcIP, origPort)
+	return curVer.NewValueNATReverseSNAT(lastSeen, flags, legA, legB, tunnelIP, origIP, origSrcIP, origPort)
 }
 
 // NewValueV6Normal creates a new ValueV6 of type TypeNormal based on the given parameters
-func NewValueV6Normal(created, lastSeen time.Duration, flags uint16, legA, legB Leg) ValueV6 {
-	return curVer.NewValueV6Normal(created, lastSeen, flags, legA, legB)
+func NewValueV6Normal(lastSeen time.Duration, flags uint16, legA, legB Leg) ValueV6 {
+	return curVer.NewValueV6Normal(lastSeen, flags, legA, legB)
 }
 
 // NewValueV6NATForward creates a new ValueV6 of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueV6NATForward(created, lastSeen time.Duration, flags uint16, revKey KeyV6) ValueV6 {
-	return curVer.NewValueV6NATForward(created, lastSeen, flags, revKey)
+func NewValueV6NATForward(lastSeen time.Duration, flags uint16, revKey KeyV6) ValueV6 {
+	return curVer.NewValueV6NATForward(lastSeen, flags, revKey)
 }
 
 // NewValueV6NATReverse creates a new ValueV6 of type TypeNATReverse for the given
 // arguments and reverse parameters
 func NewValueV6NATReverse(
-	created, lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16,
 ) ValueV6 {
-	return curVer.NewValueV6NATReverse(created, lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
+	return curVer.NewValueV6NATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
 }
 
 // NewValueV6NATReverseSNAT in addition to NewValueV6NATReverse sets the orig source IP
 func NewValueV6NATReverseSNAT(
-	created, lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16,
 ) ValueV6 {
-	return curVer.NewValueV6NATReverseSNAT(created, lastSeen, flags, legA, legB, tunnelIP, origIP, origSrcIP, origPort)
+	return curVer.NewValueV6NATReverseSNAT(lastSeen, flags, legA, legB, tunnelIP, origIP, origSrcIP, origPort)
 }
 
 type Leg = curVer.Leg

--- a/felix/bpf/conntrack/timeouts.go
+++ b/felix/bpf/conntrack/timeouts.go
@@ -48,11 +48,6 @@ type Timeouts struct {
 // WARNING: this implementation is duplicated in the conntrack_cleanup.c BPF
 // program.
 func (t *Timeouts) EntryExpired(nowNanos int64, proto uint8, entry ValueInterface) (reason string, expired bool) {
-	sinceCreation := time.Duration(nowNanos - entry.Created())
-	if sinceCreation < t.CreationGracePeriod {
-		log.Debug("Conntrack entry in creation grace period. Ignoring.")
-		return
-	}
 	age := time.Duration(nowNanos - entry.LastSeen())
 	switch proto {
 	case ProtoTCP:

--- a/felix/bpf/conntrack/v2/map.go
+++ b/felix/bpf/conntrack/v2/map.go
@@ -464,7 +464,6 @@ func (e Value) Upgrade() maps.Upgradable {
 	var val3 v3.Value
 
 	ctType := e.Type()
-	copy(val3[v3.VoCreated:v3.VoFlags2+1], e[voCreated:voFlags2+1])
 
 	switch ctType {
 	case TypeNormal, TypeNATReverse:

--- a/felix/bpf/conntrack/v3/map6.go
+++ b/felix/bpf/conntrack/v3/map6.go
@@ -114,7 +114,6 @@ func NewKeyV6(proto uint8, ipA net.IP, portA uint16, ipB net.IP, portB uint16) K
 // };
 
 const (
-	VoCreatedV6   int = 0
 	VoLastSeenV6  int = 8
 	VoTypeV6      int = 16
 	VoFlagsV6     int = 17
@@ -131,10 +130,6 @@ const (
 )
 
 type ValueV6 [ValueV6Size]byte
-
-func (e ValueV6) Created() int64 {
-	return int64(binary.LittleEndian.Uint64(e[VoCreatedV6 : VoCreatedV6+8]))
-}
 
 func (e ValueV6) LastSeen() int64 {
 	return int64(binary.LittleEndian.Uint64(e[VoLastSeenV6 : VoLastSeenV6+8]))
@@ -204,8 +199,7 @@ func (e *ValueV6) SetNATSport(sport uint16) {
 	binary.LittleEndian.PutUint16(e[VoNATSPortV6:VoNATSPortV6+2], sport)
 }
 
-func initValueV6(v *ValueV6, created, lastSeen time.Duration, typ uint8, flags uint16) {
-	binary.LittleEndian.PutUint64(v[VoCreatedV6:VoCreatedV6+8], uint64(created))
+func initValueV6(v *ValueV6, lastSeen time.Duration, typ uint8, flags uint16) {
 	binary.LittleEndian.PutUint64(v[VoLastSeenV6:VoLastSeenV6+8], uint64(lastSeen))
 	v[VoTypeV6] = typ
 	v[VoFlagsV6] = byte(flags & 0xff)
@@ -213,10 +207,10 @@ func initValueV6(v *ValueV6, created, lastSeen time.Duration, typ uint8, flags u
 }
 
 // NewValueV6Normal creates a new ValueV6 of type TypeNormal based on the given parameters
-func NewValueV6Normal(created, lastSeen time.Duration, flags uint16, legA, legB Leg) ValueV6 {
+func NewValueV6Normal(lastSeen time.Duration, flags uint16, legA, legB Leg) ValueV6 {
 	v := ValueV6{}
 
-	initValueV6(&v, created, lastSeen, TypeNormal, flags)
+	initValueV6(&v, lastSeen, TypeNormal, flags)
 
 	v.SetLegA2B(legA)
 	v.SetLegB2A(legB)
@@ -226,10 +220,10 @@ func NewValueV6Normal(created, lastSeen time.Duration, flags uint16, legA, legB 
 
 // NewValueV6NATForward creates a new ValueV6 of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueV6NATForward(created, lastSeen time.Duration, flags uint16, revKey KeyV6) ValueV6 {
+func NewValueV6NATForward(lastSeen time.Duration, flags uint16, revKey KeyV6) ValueV6 {
 	v := ValueV6{}
 
-	initValueV6(&v, created, lastSeen, TypeNATForward, flags)
+	initValueV6(&v, lastSeen, TypeNATForward, flags)
 
 	copy(v[VoRevKeyV6:VoRevKeyV6+KeySize], revKey.AsBytes())
 
@@ -238,11 +232,11 @@ func NewValueV6NATForward(created, lastSeen time.Duration, flags uint16, revKey 
 
 // NewValueV6NATReverse creates a new ValueV6 of type TypeNATReverse for the given
 // arguments and reverse parameters
-func NewValueV6NATReverse(created, lastSeen time.Duration, flags uint16, legA, legB Leg,
+func NewValueV6NATReverse(lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16) ValueV6 {
 	v := ValueV6{}
 
-	initValueV6(&v, created, lastSeen, TypeNATReverse, flags)
+	initValueV6(&v, lastSeen, TypeNATReverse, flags)
 
 	v.SetLegA2B(legA)
 	v.SetLegB2A(legB)
@@ -256,9 +250,9 @@ func NewValueV6NATReverse(created, lastSeen time.Duration, flags uint16, legA, l
 }
 
 // NewValueV6NATReverseSNAT in addition to NewValueV6NATReverse sets the orig source IP
-func NewValueV6NATReverseSNAT(created, lastSeen time.Duration, flags uint16, legA, legB Leg,
+func NewValueV6NATReverseSNAT(lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16) ValueV6 {
-	v := NewValueV6NATReverse(created, lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
+	v := NewValueV6NATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
 	copy(v[VoOrigSIPV6:VoOrigSIPV6+16], origIP.To4())
 
 	return v
@@ -352,8 +346,8 @@ func (e ValueV6) String() string {
 		}
 	}
 
-	ret := fmt.Sprintf("Entry{Type:%d, Created:%d, LastSeen:%d, Flags:%s ",
-		e.Type(), e.Created(), e.LastSeen(), flagsStr)
+	ret := fmt.Sprintf("Entry{Type:%d, LastSeen:%d, Flags:%s ",
+		e.Type(), e.LastSeen(), flagsStr)
 
 	switch e.Type() {
 	case TypeNATForward:

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -1561,12 +1561,12 @@ func ctEntriesForSvc(ct maps.Map, proto v1.Protocol,
 
 	key := conntrack.NewKey(p, srcIP, srcPort, svcIP, svcPort)
 	revKey := conntrack.NewKey(p, srcIP, srcPort, net.ParseIP(ep.IP()), uint16(epPort))
-	val := conntrack.NewValueNATForward(0, 0, 0, revKey)
+	val := conntrack.NewValueNATForward(0, 0, revKey)
 
 	err = ct.Update(key.AsBytes(), val.AsBytes())
 	Expect(err).NotTo(HaveOccurred(), "Test failed to populate ct map with FWD entry")
 
-	val = conntrack.NewValueNATReverse(0, 0, 0, conntrack.Leg{}, conntrack.Leg{},
+	val = conntrack.NewValueNATReverse(0, 0, conntrack.Leg{}, conntrack.Leg{},
 		net.IPv4(0, 0, 0, 0), svcIP, svcPort)
 
 	err = ct.Update(revKey.AsBytes(), val.AsBytes())

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -2444,8 +2444,8 @@ func TestNATSourceCollision(t *testing.T) {
 	// Create an active TCP conntrack entry pair
 	ctKey := conntrack.NewKey(tcpProto, clientIP, clientPort, node1ip, nodeportPort)
 	revKey := conntrack.NewKey(tcpProto, clientIP, clientPort, podIP, podPort)
-	ctVal := conntrack.NewValueNATForward(0, 0, 0, revKey)
-	revVal := conntrack.NewValueNATReverse(0, 0, 0,
+	ctVal := conntrack.NewValueNATForward(0, 0, revKey)
+	revVal := conntrack.NewValueNATReverse(0, 0,
 		conntrack.Leg{
 			Seqno:    12345,
 			SynSeen:  true,

--- a/felix/bpf/ut/to_host_allowed_test.go
+++ b/felix/bpf/ut/to_host_allowed_test.go
@@ -51,7 +51,7 @@ func TestToHostAllowedCTFull(t *testing.T) {
 	logrus.SetLevel(logrus.WarnLevel)
 	defer logrus.SetLevel(loglevel)
 
-	val := conntrack.NewValueNormal(0, 0, 0, conntrack.Leg{}, conntrack.Leg{})
+	val := conntrack.NewValueNormal(0, 0, conntrack.Leg{}, conntrack.Leg{})
 
 	var err error
 	var firstCTKey conntrack.Key

--- a/felix/cmd/calico-bpf/commands/conntrack.go
+++ b/felix/cmd/calico-bpf/commands/conntrack.go
@@ -217,8 +217,7 @@ func (cmd *conntrackDumpCmd) prettyDump(k conntrack.KeyInterface, v conntrack.Va
 	}
 
 	now := bpf.KTimeNanos()
-	cmd.Printf(" Age: %s Active ago %s Duration %s",
-		time.Duration(now-v.Created()), time.Duration(now-v.LastSeen()), time.Duration(v.LastSeen()-v.Created()))
+	cmd.Printf(" Active ago %s", time.Duration(now-v.LastSeen()))
 
 	if k.Proto() == 6 {
 		if (v.IsForwardDSR() && d.FINsSeenDSR()) || d.FINsSeen() {
@@ -238,8 +237,7 @@ func (cmd *conntrackDumpCmd) prettyDump(k conntrack.KeyInterface, v conntrack.Va
 func dumpExtrav2(k v2.Key, v v2.Value) {
 	now := bpf.KTimeNanos()
 
-	fmt.Printf(" Age: %s Active ago %s",
-		time.Duration(now-v.Created()), time.Duration(now-v.LastSeen()))
+	fmt.Printf(" Active ago %s", time.Duration(now-v.LastSeen()))
 
 	if k.Proto() != conntrack.ProtoTCP {
 		return
@@ -272,8 +270,7 @@ func dumpExtrav2(k v2.Key, v v2.Value) {
 func dumpExtra(k conntrack.KeyInterface, v conntrack.ValueInterface) {
 	now := bpf.KTimeNanos()
 
-	fmt.Printf(" Age: %s Active ago %s",
-		time.Duration(now-v.Created()), time.Duration(now-v.LastSeen()))
+	fmt.Printf(" Active ago %s", time.Duration(now-v.LastSeen()))
 
 	if k.Proto() != conntrack.ProtoTCP {
 		return

--- a/felix/fv/bpf_map_resize_test.go
+++ b/felix/fv/bpf_map_resize_test.go
@@ -82,7 +82,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 
 		now := time.Duration(timeshim.RealTime().KTimeNanos())
 		leg := conntrack.Leg{SynSeen: true, AckSeen: true, Opener: true}
-		val := conntrack.NewValueNormal(now, now, 0, leg, leg)
+		val := conntrack.NewValueNormal(now, 0, leg, leg)
 		val64 := base64.StdEncoding.EncodeToString(val[:])
 
 		key := conntrack.NewKey(6 /* TCP */, srcIP, 0, dstIP, 0)

--- a/felix/fv/bpf_map_upgrade_test.go
+++ b/felix/fv/bpf_map_upgrade_test.go
@@ -79,7 +79,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test conntrack ma
 
 		k3Normal := conntrack.NewKey(6, srcIP, 0, dstIP, 0)
 		leg3Normal := conntrack.Leg{SynSeen: true, AckSeen: true, Opener: true}
-		val3Normal := conntrack.NewValueNormal(now, now, 0, leg3Normal, leg3Normal)
+		val3Normal := conntrack.NewValueNormal(now, 0, leg3Normal, leg3Normal)
 
 		srcIP = net.IPv4(121, 123, 125, 124)
 		dstIP = net.IPv4(120, 121, 121, 119)
@@ -91,7 +91,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test conntrack ma
 
 		tc.Felixes[0].Exec("calico-bpf", "conntrack", "write", "--ver=2", key64, val64)
 		k3NatFwd := conntrack.NewKey(11, srcIP, 0, dstIP, 0)
-		val3NatFwd := conntrack.NewValueNATForward(now, now, 0, k3NatFwd)
+		val3NatFwd := conntrack.NewValueNATForward(now, 0, k3NatFwd)
 		val3NatFwd.SetNATSport(4321)
 
 		srcIP = net.IPv4(1, 2, 3, 4)
@@ -105,7 +105,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test conntrack ma
 
 		tc.Felixes[0].Exec("calico-bpf", "conntrack", "write", "--ver=2", key64, val64)
 		k3NatRev := conntrack.NewKey(11, srcIP, 0, dstIP, 0)
-		val3NatRev := conntrack.NewValueNATReverse(now, now, 0, leg3Normal, leg3Normal, tunIP, origIP, 1234)
+		val3NatRev := conntrack.NewValueNATReverse(now, 0, leg3Normal, leg3Normal, tunIP, origIP, 1234)
 
 		srcIP = net.IPv4(5, 6, 7, 8)
 		dstIP = net.IPv4(55, 66, 77, 88)
@@ -120,7 +120,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test conntrack ma
 
 		tc.Felixes[0].Exec("calico-bpf", "conntrack", "write", "--ver=2", key64, val64)
 		k3NatRevSnat := conntrack.NewKey(11, srcIP, 0, dstIP, 0)
-		val3NatRevSnat := conntrack.NewValueNATReverseSNAT(now, now, 0, leg3Normal, leg3Normal, tunIP, origIP, origSIP, 1234)
+		val3NatRevSnat := conntrack.NewValueNATReverseSNAT(now, 0, leg3Normal, leg3Normal, tunIP, origIP, origSIP, 1234)
 
 		tc.Felixes[0].Restart()
 		Eventually(func() conntrack.MapMem { return dumpCTMap(tc.Felixes[0]) }, "10s", "100ms").Should(HaveKeyWithValue(k3Normal, val3Normal))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -4423,7 +4423,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								srcIP := net.ParseIP("dead:beef::123:123:123:123")
 								dstIP := net.ParseIP("dead:beef::121:121:121:121")
 
-								val := conntrack.NewValueV6Normal(now, now, 0, leg, leg)
+								val := conntrack.NewValueV6Normal(now, 0, leg, leg)
 								val64 := base64.StdEncoding.EncodeToString(val[:])
 
 								key := conntrack.NewKeyV6(6 /* TCP */, srcIP, 0, dstIP, 0)
@@ -4435,7 +4435,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								srcIP := net.IPv4(123, 123, 123, 123)
 								dstIP := net.IPv4(121, 121, 121, 121)
 
-								val := conntrack.NewValueNormal(now, now, 0, leg, leg)
+								val := conntrack.NewValueNormal(now, 0, leg, leg)
 								val64 := base64.StdEncoding.EncodeToString(val[:])
 
 								key := conntrack.NewKey(6 /* TCP */, srcIP, 0, dstIP, 0)


### PR DESCRIPTION
Not used for anything useful and not used by the bpf conntrack cleanup at all.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
