### PR TITLE
fix operator version for hashrelease

### DIFF
--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -49,7 +49,7 @@ var noImageComponents = []string{
 }
 
 type PinnedVersions interface {
-	GenerateFile() (version.Data, error)
+	GenerateFile() (version.Versions, error)
 	ManagerOptions() ([]calico.Option, error)
 }
 
@@ -125,7 +125,7 @@ type CalicoPinnedVersions struct {
 }
 
 // GenerateFile generates the pinned version file.
-func (p *CalicoPinnedVersions) GenerateFile() (version.Data, error) {
+func (p *CalicoPinnedVersions) GenerateFile() (version.Versions, error) {
 	pinnedVersionPath := pinnedVersionFilePath(p.Dir)
 
 	productBranch, err := utils.GitBranch(p.RootDir)
@@ -147,7 +147,7 @@ func (p *CalicoPinnedVersions) GenerateFile() (version.Data, error) {
 	if err != nil {
 		return nil, err
 	}
-	versionData := version.NewVersionData(version.New(productVer), operatorVer)
+	versionData := version.NewHashreleaseVersions(version.New(productVer), operatorVer)
 	tmpl, err := template.New("pinnedversion").Parse(calicoTemplate)
 	if err != nil {
 		return nil, err
@@ -303,11 +303,11 @@ func RetrieveImageComponents(outputDir string) (map[string]registry.Component, e
 	return components, nil
 }
 
-func RetrieveVersions(outputDir string) (version.Data, error) {
+func RetrieveVersions(outputDir string) (version.Versions, error) {
 	pinnedVersion, err := retrievePinnedVersion(outputDir)
 	if err != nil {
 		return nil, err
 	}
 
-	return version.NewVersionData(version.New(pinnedVersion.Title), pinnedVersion.TigeraOperator.Version), nil
+	return version.NewHashreleaseVersions(version.New(pinnedVersion.Title), pinnedVersion.TigeraOperator.Version), nil
 }

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -147,7 +147,7 @@ func (p *CalicoPinnedVersions) GenerateFile() (version.Data, error) {
 	if err != nil {
 		return nil, err
 	}
-	versionData := version.NewVersionData(version.New(productVer), operatorVer, releaseName)
+	versionData := version.NewVersionData(version.New(productVer), operatorVer)
 	tmpl, err := template.New("pinnedversion").Parse(calicoTemplate)
 	if err != nil {
 		return nil, err

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -147,7 +147,7 @@ func (p *CalicoPinnedVersions) GenerateFile() (version.Data, error) {
 	if err != nil {
 		return nil, err
 	}
-	versionData := version.NewVersionData(version.New(productVer), operatorVer)
+	versionData := version.NewVersionData(version.New(productVer), operatorVer, releaseName)
 	tmpl, err := template.New("pinnedversion").Parse(calicoTemplate)
 	if err != nil {
 		return nil, err

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -27,8 +27,8 @@ import (
 	"github.com/projectcalico/calico/release/internal/utils"
 )
 
-// Data is the interface that provides version data for a release.
-type Data interface {
+// Versions is the interface that provides version data for a hashrelease or release.
+type Versions interface {
 	Hash() string
 	ProductVersion() string
 	OperatorVersion() string
@@ -36,36 +36,36 @@ type Data interface {
 	ReleaseBranch(releaseBranchPrefix string) string
 }
 
-func NewVersionData(calico Version, operator string) Data {
-	return &CalicoPinnedVersionData{
+func NewHashreleaseVersions(calico Version, operator string) Versions {
+	return &HashreleaseVersions{
 		calico:   calico,
 		operator: operator,
 	}
 }
 
-// CalicoPinnedVersionData provides version data for a Calico hashrelease.
-type CalicoPinnedVersionData struct {
+// HashreleaseVersions implements the Versions interface for a hashrelease.
+type HashreleaseVersions struct {
 	calico   Version
 	operator string
 }
 
-func (v *CalicoPinnedVersionData) ProductVersion() string {
+func (v *HashreleaseVersions) ProductVersion() string {
 	return v.calico.FormattedString()
 }
 
-func (v *CalicoPinnedVersionData) OperatorVersion() string {
+func (v *HashreleaseVersions) OperatorVersion() string {
 	return fmt.Sprintf("%s-%s", v.operator, v.ProductVersion())
 }
 
-func (v *CalicoPinnedVersionData) HelmChartVersion() string {
+func (v *HashreleaseVersions) HelmChartVersion() string {
 	return v.calico.FormattedString()
 }
 
-func (v *CalicoPinnedVersionData) Hash() string {
+func (v *HashreleaseVersions) Hash() string {
 	return fmt.Sprintf("%s-%s", v.calico.FormattedString(), v.operator)
 }
 
-func (v *CalicoPinnedVersionData) ReleaseBranch(releaseBranchPrefix string) string {
+func (v *HashreleaseVersions) ReleaseBranch(releaseBranchPrefix string) string {
 	return fmt.Sprintf("%s-%s", releaseBranchPrefix, v.calico.Stream())
 }
 

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -36,17 +36,19 @@ type Data interface {
 	ReleaseBranch(releaseBranchPrefix string) string
 }
 
-func NewVersionData(calico Version, operator string) Data {
+func NewVersionData(calico Version, operator, releaseName string) Data {
 	return &CalicoVersionData{
-		calico:   calico,
-		operator: operator,
+		calico:      calico,
+		operator:    operator,
+		releaseName: releaseName,
 	}
 }
 
 // CalicoVersionData provides version data for a Calico release.
 type CalicoVersionData struct {
-	calico   Version
-	operator string
+	calico      Version
+	operator    string
+	releaseName string
 }
 
 func (v *CalicoVersionData) ProductVersion() string {
@@ -54,7 +56,7 @@ func (v *CalicoVersionData) ProductVersion() string {
 }
 
 func (v *CalicoVersionData) OperatorVersion() string {
-	return v.operator
+	return fmt.Sprintf("%s-%s", v.operator, v.releaseName)
 }
 
 func (v *CalicoVersionData) HelmChartVersion() string {

--- a/release/internal/version/version.go
+++ b/release/internal/version/version.go
@@ -36,38 +36,36 @@ type Data interface {
 	ReleaseBranch(releaseBranchPrefix string) string
 }
 
-func NewVersionData(calico Version, operator, releaseName string) Data {
-	return &CalicoVersionData{
-		calico:      calico,
-		operator:    operator,
-		releaseName: releaseName,
+func NewVersionData(calico Version, operator string) Data {
+	return &CalicoPinnedVersionData{
+		calico:   calico,
+		operator: operator,
 	}
 }
 
-// CalicoVersionData provides version data for a Calico release.
-type CalicoVersionData struct {
-	calico      Version
-	operator    string
-	releaseName string
+// CalicoPinnedVersionData provides version data for a Calico hashrelease.
+type CalicoPinnedVersionData struct {
+	calico   Version
+	operator string
 }
 
-func (v *CalicoVersionData) ProductVersion() string {
+func (v *CalicoPinnedVersionData) ProductVersion() string {
 	return v.calico.FormattedString()
 }
 
-func (v *CalicoVersionData) OperatorVersion() string {
-	return fmt.Sprintf("%s-%s", v.operator, v.releaseName)
+func (v *CalicoPinnedVersionData) OperatorVersion() string {
+	return fmt.Sprintf("%s-%s", v.operator, v.ProductVersion())
 }
 
-func (v *CalicoVersionData) HelmChartVersion() string {
+func (v *CalicoPinnedVersionData) HelmChartVersion() string {
 	return v.calico.FormattedString()
 }
 
-func (v *CalicoVersionData) Hash() string {
+func (v *CalicoPinnedVersionData) Hash() string {
 	return fmt.Sprintf("%s-%s", v.calico.FormattedString(), v.operator)
 }
 
-func (v *CalicoVersionData) ReleaseBranch(releaseBranchPrefix string) string {
+func (v *CalicoPinnedVersionData) ReleaseBranch(releaseBranchPrefix string) string {
 	return fmt.Sprintf("%s-%s", releaseBranchPrefix, v.calico.Stream())
 }
 


### PR DESCRIPTION
## Description

Current operator version for hashrelease is incorrect as it is missing the hashrelease it was built for which can cause issues when operator has not changed but there have been changes in calico.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
