### PR TITLE
Make operator init container use k8s-svc-configmap if present.

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -98,12 +98,20 @@ spec:
             - operator
           args:
             - -bootstrap-crds
+          envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
         # Install any v3 API resources provided in the calico-resources ConfigMap.
         - name: create-initial-resources
           image: {{.Values.calicoctl.image}}:{{.Values.calicoctl.tag}}
           env:
             - name: DATASTORE_TYPE
               value: kubernetes
+          envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
           command:
             - calicoctl
           args:

--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -108,10 +108,6 @@ spec:
           env:
             - name: DATASTORE_TYPE
               value: kubernetes
-          envFrom:
-            - configMapRef:
-                name: kubernetes-services-endpoint
-                optional: true
           command:
             - calicoctl
           args:

--- a/manifests/ocp/02-tigera-operator.yaml
+++ b/manifests/ocp/02-tigera-operator.yaml
@@ -88,10 +88,6 @@ spec:
           env:
             - name: DATASTORE_TYPE
               value: kubernetes
-          envFrom:
-            - configMapRef:
-                name: kubernetes-services-endpoint
-                optional: true
           command:
             - calicoctl
           args:

--- a/manifests/ocp/02-tigera-operator.yaml
+++ b/manifests/ocp/02-tigera-operator.yaml
@@ -78,12 +78,20 @@ spec:
             - operator
           args:
             - -bootstrap-crds
+          envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
         # Install any v3 API resources provided in the calico-resources ConfigMap.
         - name: create-initial-resources
           image: docker.io/calico/ctl:master
           env:
             - name: DATASTORE_TYPE
               value: kubernetes
+          envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
           command:
             - calicoctl
           args:


### PR DESCRIPTION
## Description

Change the operator manifest to set KUBERNETES_SERVICES_HOST and PORT from k8s-svc-endpoint configmap if present for the operator init containers.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
