### PR TITLE
Quick fix for formatting of protobuf files.

### DIFF
--- a/hack/format-all-files.sh
+++ b/hack/format-all-files.sh
@@ -13,5 +13,11 @@ find . -iname "*.go" \
        ! -wholename "./third_party/*" \
        -print0 > ${file_list}
 
+
+# Run extra copy of goimports first to coalesce multiple single-line imports
+# into blocks.
+xargs -0 goimports -w -local github.com/projectcalico/calico/ < ${file_list}
+# Coalesce imports then removes whitespace within blocks.
 xargs -0 go run "${repo_dir}/hack/cmd/coalesce-imports" -w < ${file_list}
+# Finally run goimports again to insert only the desired whitespace.
 xargs -0 goimports -w -local github.com/projectcalico/calico/ < ${file_list}

--- a/hack/format-changed-files.sh
+++ b/hack/format-changed-files.sh
@@ -34,6 +34,12 @@ echo "Formatting changed files:"
 xargs -n 1 -0 echo "  " < $file_list
 
 pushd "$repo_dir" > /dev/null
+
+# Run extra copy of goimports first to coalesce multiple single-line imports
+# into blocks.
+xargs -0 goimports -w -local github.com/projectcalico/calico/ < $file_list
+# Coalesce imports then removes whitespace within blocks.
 xargs -0 go run ./hack/cmd/coalesce-imports -w < $file_list
+# Finally run goimports again to insert only the desired whitespace.
 xargs -0 goimports -w -local github.com/projectcalico/calico/ < $file_list
 popd > /dev/null


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
goimports can coalesce one-line import statements, resulting in adding unexpected whitespace.  Run an extra copy of goimports first to do that coalescing; then run our coalesce-imports script to remove the whitespace before a final goimports to get the desired whitespace.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
