### PR TITLE
Add private keys to go-build auto pin update workflow

### DIFF
--- a/.semaphore/update-go-build-pins.yml
+++ b/.semaphore/update-go-build-pins.yml
@@ -9,8 +9,12 @@ execution_time_limit:
   minutes: 30
 
 global_job_config:
+  secrets:
+    - name: private-repo
   prologue:
     commands:
+      - chmod 0600 ~/.keys/*
+      - ssh-add ~/.keys/*
       - checkout
 
 blocks:
@@ -20,6 +24,13 @@ blocks:
         - name: marvin-github-token
       jobs:
         - name: Auto calico/go-build update
+          env_vars:
+            - name: GITHUB_TOKEN
+              value: ${MARVIN_GITHUB_TOKEN}
+            - name: GIT_COMMIT_EXTRA_FILES
+              value: metadata.mk
+            - name: GIT_COMMIT_TITLE
+              value: "Semaphore Auto go-build Update"
           commands:
             - CONFIRM=true make git-config
-            - CONFIRM=true GITHUB_TOKEN=${MARVIN_GITHUB_TOKEN} make trigger-auto-pin-update-process
+            - CONFIRM=true make trigger-auto-pin-update-process

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -487,6 +487,7 @@ commit-and-push-pr:
 #   Helper macros and targets to help with communicating with the github API
 ###############################################################################
 GIT_COMMIT_MESSAGE?="Automatic Pin Updates"
+GIT_COMMIT_TITLE?="Semaphore Auto Pin Update"
 GIT_PR_BRANCH_BASE?=$(SEMAPHORE_GIT_BRANCH)
 PIN_UPDATE_BRANCH?=semaphore-auto-pin-updates-$(GIT_PR_BRANCH_BASE)
 GIT_PR_BRANCH_HEAD?=$(PIN_UPDATE_BRANCH)
@@ -563,7 +564,7 @@ endif
 	git checkout -b $(GIT_PR_BRANCH_HEAD)
 
 create-pin-update-pr:
-	$(call github_pr_create,$(GIT_REPO_SLUG),[$(GIT_PR_BRANCH_BASE)] Semaphore Auto Pin Update,$(GIT_PR_BRANCH_HEAD),$(GIT_PR_BRANCH_BASE))
+	$(call github_pr_create,$(GIT_REPO_SLUG),[$(GIT_PR_BRANCH_BASE)] $(GIT_COMMIT_TITLE),$(GIT_PR_BRANCH_HEAD),$(GIT_PR_BRANCH_BASE))
 	echo 'Created pin update pull request $(PR_NUMBER)'
 
 # Add the "/merge-when-ready" comment to enable the "merge when ready" functionality, i.e. when the pull request is passing


### PR DESCRIPTION
## Description

This changeset adds necessary private keys to the go-build auto pin update semaphore workflow. It also adds variables to customize git commit title.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
