### PR TITLE
make dataplanes dual (internal plus external together)

### DIFF
--- a/felix/dataplane/decorator.go
+++ b/felix/dataplane/decorator.go
@@ -1,0 +1,32 @@
+// Copyright © 2024 NeuReality Ltd., and its licensors. All rights reserved.
+// This software contains proprietary information of NeuReality Ltd.
+// You shall use such proprietary information only as may be permitted in writing by NeuReality Ltd.
+// All materials contained herein are the property of NeuReality Ltd.
+
+// THIS SOFTWARE IS PROVIDED BY NEUREALITY “AS IS” AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL NEUREALITY OR ITS LICENSORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package dataplane
+
+type dataplaneDriverDecorator struct {
+     primaryDriver DataplaneDriver
+     secondaryDriver DataplaneDriver 
+}
+
+func (decorator dataplaneDriverDecorator) SendMessage(msg interface{}) error {
+     decorator.secondaryDriver.SendMessage(msg)
+     return decorator.primaryDriver.SendMessage(msg) // return message from the primary driver only
+}
+
+func (decorator dataplaneDriverDecorator) RecvMessage() (msg interface{}, err error) {
+     return decorator.primaryDriver.RecvMessage() // receive message from the primary driver only
+}


### PR DESCRIPTION
## Description

Currently, for Felix it is possible to use either the Internal dataplane driver or an external one. In NeuReality, our hardware, employs a dual network stack for different types of traffic. One is the standard Linux stack, for which the internal Felix dataplane is used. For the other network stack, we developed our own dataplane driver (external).

We propose to change Calico code to enable using two dataplane drivers simultaneously. The internal dataplane driver will be designated as the primary one, the external dataplane driver will be designated as the secondary one. Felix will send messages to both dataplanes, but will receive messages from the primary dataplane only.

The change should not be disruptive to the current users of Calico since they will continue to specify either internal or external dataplane driver. In case both drivers will be specified, the dual dataplane mode will be employed.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
