### PR TITLE
Cherry pick parts of #9614 to fix hashrelease

### DIFF
--- a/metadata.mk
+++ b/metadata.mk
@@ -20,8 +20,14 @@ PROTOC_VER=v0.1
 UBI_VERSION=8.10
 GHR_VERSION=v0.17.0
 
-# Configuration for Semaphore integration.
+# Configuration for Semaphore/Github integration.  This needs to be set
+# differently for a forked repo.
 ORGANIZATION = projectcalico
+GIT_REPO = calico
+
+# Part of the git remote that is common to git and HTTP representations.
+# Used to auto-detect the right remote.
+GIT_REPO_SLUG ?= $(ORGANIZATION)/$(GIT_REPO)
 
 # Configure git to access repositories using SSH.
 GIT_USE_SSH = true


### PR DESCRIPTION
## Description

* Fix name clash in Makefile variables.

Use existing GIT_REPO_SLUG name but calculate it in metadata.mk.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
