### PR TITLE
enable dual CNI plugin dataplanes

### DIFF
--- a/cni-plugin/pkg/dataplane/multiplexer.go
+++ b/cni-plugin/pkg/dataplane/multiplexer.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 NeuReality Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	cniv1 "github.com/containernetworking/cni/pkg/types/100"
+	api "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	calicoclient "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+)
+
+type multiplexer struct {
+	primary   Dataplane
+	secondary Dataplane
+}
+
+func (m multiplexer) DoNetworking(
+	ctx context.Context,
+	calicoClient calicoclient.Interface,
+	args *skel.CmdArgs,
+	result *cniv1.Result,
+	desiredVethName string,
+	routes []*net.IPNet,
+	endpoint *api.WorkloadEndpoint,
+	annotations map[string]string,
+) (string, string, error) {
+	_, _, secondaryErr := m.secondary.DoNetworking(ctx, calicoClient, args, result, desiredVethName, routes, endpoint, annotations)
+	hostVethName, contVethMAC, primaryErr := m.primary.DoNetworking(ctx, calicoClient, args, result, desiredVethName, routes, endpoint, annotations)
+
+	if primaryErr != nil || secondaryErr != nil {
+		return "", "", fmt.Errorf("errors in sending message to dataplanes: primary error %w, secondary error %w",
+			primaryErr, secondaryErr)
+	}
+
+	return hostVethName, contVethMAC, nil
+}
+
+func (m multiplexer) CleanUpNamespace(args *skel.CmdArgs) error {
+	secondaryErr := m.secondary.CleanUpNamespace(args)
+	primaryErr := m.primary.CleanUpNamespace(args)
+
+	if primaryErr != nil || secondaryErr != nil {
+		return fmt.Errorf("errors in clean up namespaces of dataplanes: primary error %w, secondary error %w",
+			primaryErr, secondaryErr)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

Currently, for CNI plugin it is possible to use either the default system dataplane or a grpc one. In NeuReality, our hardware, employs a dual network stack for different types of traffic. One is the standard Linux stack, for which the default system dataplane is used. For the other network stack, we developed our own dataplane (external).

We propose to change Calico code to enable using two dataplanes simultaneously. The default system dataplane will be designated as the primary one, the external dataplane will be designated as the secondary one. Calico will send messages to both dataplanes.

The change should not be disruptive to the current users of Calico since they will continue to specify either default system dataplane or a grpc dataplane. In case a dataplane option `"useAsSecondary": "true"` in addition to `"type": "grpc"`, two dataplanes will be used simultaneously.

## Related issues/PRs

* https://github.com/projectcalico/calico/issues/9724
* https://github.com/projectcalico/calico/pull/9723

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->
