### PR TITLE
Remove redundant flow log FV tests

### DIFF
--- a/felix/fv/flow_logs_goladmane_test.go
+++ b/felix/fv/flow_logs_goladmane_test.go
@@ -128,10 +128,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ flow log goldmane tests", [
 		opts.IPIPEnabled = false
 		opts.FlowLogSource = infrastructure.FlowLogSourceGoldmane
 
-		opts.ExtraEnvVars["FELIX_BPFCONNTRACKTIMEOUTS"] = "CreationGracePeriod=10s,TCPPreEstablished=20s,TCPEstablished=1h,TCPFinsSeen=30s,TCPResetSeen=40s,UDPLastSeen=60s,GenericIPLastSeen=10m,ICMPLastSeen=5s"
-		opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "120"
+		opts.ExtraEnvVars["FELIX_BPFCONNTRACKTIMEOUTS"] = "TCPFinsSeen=30s"
 		opts.ExtraEnvVars["FELIX_FLOWLOGSCOLLECTORDEBUGTRACE"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "2"
 		opts.ExtraEnvVars["FELIX_FLOWLOGSGOLDMANESERVER"] = localGoldmaneServer
+
+		// Defaults for how we expect flow logs to be generated.
+		expectation.aggregationForAllowed = AggrByPodPrefix
+		expectation.aggregationForDenied = AggrByPodPrefix
 	})
 
 	JustBeforeEach(func() {
@@ -497,62 +501,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ flow log goldmane tests", [
 		}, "30s", "3s").ShouldNot(HaveOccurred())
 	}
 
-	cloudAndFile := func() {
-		BeforeEach(func() {
-			opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "2"
-			opts.ExtraEnvVars["FELIX_FLOWLOGSGOLDMANESERVER"] = localGoldmaneServer
-
-			// Defaults for how we expect flow logs to be generated.
-			expectation.aggregationForAllowed = AggrByPodPrefix
-			expectation.aggregationForDenied = AggrByPodPrefix
-		})
-
-		Context("with endpoint labels", func() {
-			It("should get expected flow logs", func() {
-				checkFlowLogs()
-			})
-		})
-
-		Context("with allowed aggregation by pod prefix", func() {
-			BeforeEach(func() {
-				expectation.aggregationForAllowed = AggrByPodPrefix
-			})
-
-			It("should get expected flow logs", func() {
-				checkFlowLogs()
-			})
-		})
-
-		Context("with denied aggregation by pod prefix", func() {
-			BeforeEach(func() {
-				expectation.aggregationForDenied = AggrByPodPrefix
-			})
-
-			It("should get expected flow logs", func() {
-				checkFlowLogs()
-			})
-		})
-
-		Context("with policies", func() {
-			It("should get expected flow logs", func() {
-				checkFlowLogs()
-			})
-		})
-	}
-
-	Context("flow logs", func() {
-		Context("flow log output", func() { cloudAndFile() })
-	})
-
 	Context("flow logs only", func() {
-		BeforeEach(func() {
-			// Defaults for how we expect flow logs to be generated.
-			expectation.aggregationForAllowed = AggrByPodPrefix
-			expectation.aggregationForDenied = AggrByPodPrefix
-
-			opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "2"
-		})
-
 		It("should get expected flow logs", func() {
 			checkFlowLogs()
 		})


### PR DESCRIPTION
## Description

Given the extra flow log options are remove here: https://github.com/projectcalico/calico/pull/9750
Including labels, policies, network sets and services is always enabled. As such in FVs we run several redundant tests, which can be removed.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
