### PR TITLE
[release-v3.28] Auto pick #9747: fix icmp error delivery to host networked pods

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -924,7 +924,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		CALI_DEBUG("Packet returned from tunnel %x\n", debug_ip(ctx->state->tun_ip));
 	} else if (CALI_F_TO_HOST || (skb_from_host(ctx->skb) && result.flags & CALI_CT_FLAG_HOST_PSNAT)) {
 		/* Source of the packet is the endpoint, so check the src approval flag. */
-		if (CALI_F_LO || src_to_dst->approved) {
+		if (CALI_F_LO || src_to_dst->approved || (related && dst_to_src->approved)) {
 			CALI_CT_VERB("Packet approved by this workload's policy.\n");
 		} else {
 			/* Only approved by the other side (so far)?  Unlike
@@ -937,7 +937,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		}
 	} else if (CALI_F_FROM_HOST) {
 		/* Dest of the packet is the endpoint, so check the dest approval flag. */
-		if (CALI_F_LO || dst_to_src->approved) {
+		if (CALI_F_LO || dst_to_src->approved || (related && src_to_dst->approved)) {
 			// Packet was approved by the policy attached to this endpoint.
 			CALI_CT_VERB("Packet approved by this workload's policy.\n");
 		} else {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -179,7 +179,7 @@ const expectedRouteDump = `10.65.0.0/16: remote in-pool nat-out
 111.222.0.1/32: local host
 111.222.1.1/32: remote host
 111.222.2.1/32: remote host
-FELIX_0/32: local host
+FELIX_0/32: local host idx -
 FELIX_1/32: remote host
 FELIX_2/32: remote host`
 
@@ -191,7 +191,7 @@ const expectedRouteDumpWithTunnelAddr = `10.65.0.0/16: remote in-pool nat-out
 111.222.0.1/32: local host
 111.222.1.1/32: remote host
 111.222.2.1/32: remote host
-FELIX_0/32: local host
+FELIX_0/32: local host idx -
 FELIX_0_TNL/32: local host
 FELIX_1/32: remote host
 FELIX_1_TNL/32: remote host in-pool nat-out tunneled
@@ -207,7 +207,7 @@ const expectedRouteDumpDSR = `10.65.0.0/16: remote in-pool nat-out
 111.222.1.1/32: remote host
 111.222.2.1/32: remote host
 245.245.0.0/16: remote no-dsr
-FELIX_0/32: local host
+FELIX_0/32: local host idx -
 FELIX_1/32: remote host
 FELIX_2/32: remote host`
 
@@ -220,7 +220,7 @@ const expectedRouteDumpWithTunnelAddrDSR = `10.65.0.0/16: remote in-pool nat-out
 111.222.1.1/32: remote host
 111.222.2.1/32: remote host
 245.245.0.0/16: remote no-dsr
-FELIX_0/32: local host
+FELIX_0/32: local host idx -
 FELIX_0_TNL/32: local host
 FELIX_1/32: remote host
 FELIX_1_TNL/32: remote host in-pool nat-out tunneled
@@ -1198,6 +1198,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					testOpts.protocol)
 
 				hostW[ii].WorkloadEndpoint.Labels = map[string]string{"name": hostW[ii].Name}
+				hostW[ii].ConfigureInInfra(infra)
 
 				// Two workloads on each host so we can check the same host and other host cases.
 				w[ii][0] = addWorkload(true, ii, 0, 8055, map[string]string{"port": "8055"})
@@ -3990,6 +3991,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						testOpts.protocol == "tcp" && !testOpts.dsr {
 						Context("with small MTU between remote client and cluster", func() {
 							var remoteWL *workload.Workload
+							hostNP := uint16(30555)
 
 							BeforeEach(func() {
 								remoteWL = &workload.Workload{
@@ -4009,6 +4011,18 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 								err := remoteWL.Start()
 								Expect(err).NotTo(HaveOccurred())
+
+								clusterIP := "10.101.0.211"
+								if testOpts.ipv6 {
+									clusterIP = "dead:beef::abcd:0:0:211"
+								}
+
+								svcHostNP := k8sService("test-host-np", clusterIP, hostW[0], 81, 8055, int32(hostNP), testOpts.protocol)
+								testSvcNamespace := svcHostNP.ObjectMeta.Namespace
+								_, err = k8sClient.CoreV1().Services(testSvcNamespace).Create(context.Background(), svcHostNP, metav1.CreateOptions{})
+								Expect(err).NotTo(HaveOccurred())
+								Eventually(k8sGetEpsForServiceFunc(k8sClient, svcHostNP), "10s").Should(HaveLen(1),
+									"Service endpoints didn't get created? Is controller-manager happy?")
 
 								if testOpts.ipv6 {
 									externalClient.Exec("ip", "-6", "route", "add", remoteWLIP, "dev",
@@ -4082,6 +4096,46 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								cc.Expect(Some, remoteWL, TargetIP(felixIP(1)), ExpectWithPorts(npPort), ExpectWithRecvLen(1350))
 								cc.CheckConnectivity()
 								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+							})
+
+							It("should have connectivity to service host-networked backend", func() {
+								tcpdump := tc.Felixes[0].AttachTCPDump("eth0")
+								tcpdump.SetLogEnabled(true)
+								tcpdump.AddMatcher("mtu-1300", regexp.MustCompile("mtu 1300"))
+								// we also need to watch for the ICMP forwarded to the host with the backend via VXLAN
+								tcpdump.Start("-vvv", "icmp", "or", "icmp6", "or", "udp", "port", "4789")
+								defer tcpdump.Stop()
+
+								ipRouteFlushCache := []string{"ip", "route", "flush", "cache"}
+								if testOpts.ipv6 {
+									ipRouteFlushCache = []string{"ip", "-6", "route", "flush", "cache"}
+								}
+
+								By("Trying directly to host")
+								tc.Felixes[0].Exec(ipRouteFlushCache...)
+								cc.Expect(Some, remoteWL, hostW[0], ExpectWithPorts(8055), ExpectWithRecvLen(1350))
+								cc.CheckConnectivity()
+								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+
+								By("Trying directly to node with pod")
+								cc.ResetExpectations()
+								tcpdump.ResetCount("mtu-1300")
+								tc.Felixes[0].Exec(ipRouteFlushCache...)
+								cc.Expect(Some, remoteWL, TargetIP(felixIP(0)), ExpectWithPorts(hostNP), ExpectWithRecvLen(1350))
+								cc.CheckConnectivity()
+								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+
+								By("Trying to node without pod")
+								cc.ResetExpectations()
+								tcpdump.ResetCount("mtu-1300")
+								tc.Felixes[0].Exec(ipRouteFlushCache...)
+								cc.Expect(Some, remoteWL, TargetIP(felixIP(1)), ExpectWithPorts(hostNP), ExpectWithRecvLen(1350))
+								cc.CheckConnectivity()
+								// tpcudmp for some reason does not print content of the vxlan
+								// packet when it is over ipv6
+								if !testOpts.ipv6 {
+									Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+								}
 							})
 						})
 					}
@@ -4470,7 +4524,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			It("should have connectivity from host-networked pods via service to host-networked backend", func() {
 				By("Setting up the service")
-				hostW[0].ConfigureInInfra(infra)
 				testSvc := k8sService("host-svc", clusterIP, hostW[0], 80, 8055, 0, testOpts.protocol)
 				testSvcNamespace := testSvc.ObjectMeta.Namespace
 				k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient


### PR DESCRIPTION
Cherry pick of #9747 on release-v3.28.

#9747: fix icmp error delivery to host networked pods

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix icmp error delivery to host networked pods
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.