### PR TITLE
Fix incorrect comment for TCPResetSeen

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -1015,7 +1015,7 @@ type BPFConntrackTimeouts struct {
 	// its own default value. [Default: Auto].
 	// +optional
 	TCPFinsSeen *BPFConntrackTimeout `json:"tcpFinsSeen,omitempty"`
-	// TCPFinsSeen controls how long it takes before considering this entry for
+	// TCPResetSeen controls how long it takes before considering this entry for
 	// cleanup after the connection was aborted. If nil, Calico uses its own
 	// default value. [Default: 40s].
 	// +optional

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -1303,7 +1303,7 @@ func schema_pkg_apis_projectcalico_v3_BPFConntrackTimeouts(ref common.ReferenceC
 					},
 					"tcpResetSeen": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TCPFinsSeen controls how long it takes before considering this entry for cleanup after the connection was aborted. If nil, Calico uses its own default value. [Default: 40s].",
+							Description: "TCPResetSeen controls how long it takes before considering this entry for cleanup after the connection was aborted. If nil, Calico uses its own default value. [Default: 40s].",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -160,7 +160,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1172,7 +1172,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1182,7 +1182,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1183,7 +1183,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1167,7 +1167,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1167,7 +1167,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1184,7 +1184,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1077,7 +1077,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1167,7 +1167,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -19703,7 +19703,7 @@ spec:
                     type: string
                   tcpResetSeen:
                     description: |-
-                      TCPFinsSeen controls how long it takes before considering this entry for
+                      TCPResetSeen controls how long it takes before considering this entry for
                       cleanup after the connection was aborted. If nil, Calico uses its own
                       default value. [Default: 40s].
                     pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$


### PR DESCRIPTION
## Description

The comment for `TCPResetSeen` incorrectly refers to it as `TCPFinsSeen`, so let's correct that.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

 ```release-note
Fix incorrect comment for TCPResetSeen.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
