### PR TITLE
[RS-2319] Map OpenStack-derived policy to the "default" tier

### DIFF
--- a/libcalico-go/lib/names/policy.go
+++ b/libcalico-go/lib/names/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,9 @@ func TierFromPolicyName(name string) (string, error) {
 	}
 	if strings.HasPrefix(name, K8sBaselineAdminNetworkPolicyNamePrefix) {
 		return BaselineAdminNetworkPolicyTierName, nil
+	}
+	if strings.HasPrefix(name, OssNetworkPolicyNamePrefix) {
+		return DefaultTierName, nil
 	}
 	parts := strings.SplitN(name, ".", 2)
 	if len(parts) < 2 {

--- a/libcalico-go/lib/names/policy_test.go
+++ b/libcalico-go/lib/names/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ var _ = DescribeTable("Parse Tiered policy name",
 	Entry("K8s admin network policy", "kanp.adminnetworkpolicy.barpolicy", false, "adminnetworkpolicy"),
 	Entry("Policy name without tier", "foopolicy", false, "default"),
 	Entry("Correct tiered policy name", "baztier.foopolicy", false, "baztier"),
+	Entry("OpenStack-derived policy name", "ossg.default.19bed2d3-12fc-4cc0-92d7-bea430a28a85", false, "default"),
 )
 
 var _ = DescribeTable("Backend Tiered policy name",


### PR DESCRIPTION
## Description

Since the merging of the multiple tier work, OpenStack-derived network policies are wrongly showing up as belonging to an "ossg" tier, whereas they should be in the default tier.  The "ossg" tier is being inferred because when our code translates an OpenStack security group to a corresponding network policy, it generates the name as "ossg.default."  followed by the security group ID.

## Related issues/PRs

https://tigera.atlassian.net/browse/RS-2319

## Release Note

```release-note
Fix: Map OpenStack-derived policy to the "default" tier, not "ossg".
```
