### PR TITLE
Conform networking-calico version to latest Python standard

### DIFF
--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -33,14 +33,17 @@ function git_auto_version {
     timestamp=`date -u '+%Y%m%d%H%M%S+0000'`
 
     # Generate corresponding PEP 440 version number.
+    # Note that PEP 440 only allows [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+    # https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers
     if test ${commits_since} -eq 0; then
 	# There are no commits since the last tag.
 	version=${last_tag}
     else
-	version=${last_tag}.post${commits_since}+${timestamp}+${sha}
+	version=${last_tag}.post${commits_since}
     fi
 
-    echo $version
+    echo $version | sed 's/-0.dev/rc/'
+
 }
 
 # Get the current Git commit ID.


### PR DESCRIPTION
Python setuptools now enforces that versions conform to https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers

This comes into play when installing Calico with OpenStack Caracal:

    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]: Traceback (most recent call last):
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]:   File "/usr/bin/calico-dhcp-agent", line 33, in <module>
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]:     sys.exit(load_entry_point('networking-calico===3.30.0-0.dev.post356-20250204140450-0000-bbfb954', 'console_scripts', 'calico-dhcp-agent')())
                                                             ...
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]:   File "/usr/lib/python3/dist-packages/pkg_resources/_vendor/packaging/specifiers.py", line 905, in contains
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]:     item = Version(item)
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]:   File "/usr/lib/python3/dist-packages/pkg_resources/_vendor/packaging/version.py", line 198, in __init__
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]:     raise InvalidVersion(f"Invalid version: '{version}'")
    Feb 04 15:01:26 <host> calico-dhcp-agent[26946]: pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '3.30.0-0.dev.post356-20250204140450-0000-bbfb954'

This change should trim that `3.30.0-0.dev.post356-20250204140450-0000-bbfb954` version down to `3.30.0rc.post356`.
