### PR TITLE
fix master hashrelease failures

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -5,7 +5,7 @@ agent:
     type: f1-standard-4
     os_image: ubuntu2204
 execution_time_limit:
-  hours: 4
+  hours: 6
 
 global_job_config:
   secrets:

--- a/goldmane/Makefile
+++ b/goldmane/Makefile
@@ -68,7 +68,7 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 	touch $@
 
-release-publish: release-prereqs release-verify .release-$(VERSION).published
+release-publish: release-prereqs .release-$(VERSION).published
 .release-$(VERSION).published:
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	touch $@


### PR DESCRIPTION
## Description

Fixing overnight hashrelease run failuer [here](https://tigera.semaphoreci.com/jobs/404f51a8-ac41-48a3-9e02-f105f125a5cf) and [here](https://tigera.semaphoreci.com/jobs/3951714d-8884-4100-a875-daffdbc2fab2) by:

- extending run time limit from 4 -> 6 hours
- remove `release-verify` target dependency that was missed from #9776

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
