### PR TITLE
[v3.28] Fix race when setting wireguard NAPI setting. 

### DIFF
--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -58,6 +58,7 @@ const (
 var (
 	ErrUpdateFailed                = errors.New("netlink update operation failed")
 	ErrNotSupportedTooManyFailures = errors.New("operation not supported (too many failures)")
+	ErrWaitingForLink              = errors.New("waiting for wireguard link to come up")
 
 	// Internal types
 	errWrongInterfaceType = errors.New("incorrect interface type for wireguard")
@@ -724,22 +725,24 @@ func (w *Wireguard) Apply() (err error) {
 	// doing anything else.
 	if !w.inSyncLink {
 		w.logCtx.Debug("Ensure wireguard link is created and up")
-		linkUp, err := w.ensureLink(netlinkClient)
+		err := w.ensureLink(netlinkClient)
 		if netlinkshim.IsNotSupported(err) {
 			// Wireguard is not supported, set everything to "in-sync" since there is not a lot of point doing anything
 			// else. We don't return an error in this case, instead we'll retry every resync period.
 			w.logCtx.Debug("Wireguard is not supported - publishing no public key")
 			w.setNotSupported()
 			return nil
+		} else if errors.Is(err, ErrWaitingForLink) {
+			// Link isn't up yet, we should get a kick via OnIfaceStateChanged,
+			// but we return an error, just to make sure we get retried at some
+			// point.
+			w.logCtx.Info("Waiting for wireguard link to come up...")
+			return err
 		} else if err != nil {
 			// Error configuring link, pass up the stack. Close the netlink client as a precaution.
 			w.logCtx.WithError(err).Info("Unable to create wireguard link, retrying...")
 			w.closeNetlinkClient()
 			return ErrUpdateFailed
-		} else if !linkUp {
-			// Wait for oper up notification.
-			w.logCtx.Info("Waiting for wireguard link to come up...")
-			return nil
 		}
 
 		// The link is now sync'd.
@@ -1414,14 +1417,14 @@ func (w *Wireguard) constructWireguardDeltaForResync(wireguardClient netlinkshim
 }
 
 // ensureLink checks that the wireguard link is configured correctly. Returns true if the link is oper up.
-func (w *Wireguard) ensureLink(netlinkClient netlinkshim.Interface) (bool, error) {
+func (w *Wireguard) ensureLink(netlinkClient netlinkshim.Interface) error {
 	logCtx := w.logCtx.WithField("ifaceName", w.interfaceName)
 
 	if w.config.EncryptHostTraffic && w.ipVersion == 4 {
 		// TODO: what is the IPv6 equivalent for this?
 		logCtx.Debug("Enabling src valid mark for WireGuard")
 		if err := w.writeProcSys(allSrcValidMarkPath, "1"); err != nil {
-			return false, err
+			return err
 		}
 	}
 
@@ -1437,30 +1440,29 @@ func (w *Wireguard) ensureLink(netlinkClient netlinkshim.Interface) (bool, error
 		}
 
 		if err := netlinkClient.LinkAdd(&lwg); err != nil {
-			return false, err
+			return err
 		}
 
 		link, err = netlinkClient.LinkByName(w.interfaceName)
 		if err != nil {
 			w.logCtx.WithError(err).Error("error querying wireguard device")
-			return false, err
+			return err
 		}
 
 		logCtx.Info("Created wireguard device")
 	} else if err != nil {
 		logCtx.WithError(err).Error("unable to determine if wireguard device exists")
-		return false, err
+		return err
 	}
 
 	if link.Type() != wireguardType {
 		logCtx.WithField("type", link.Type()).Error("interface is not of type wireguard")
-		return false, errWrongInterfaceType
+		return errWrongInterfaceType
 	}
 
 	// If necessary, update the MTU and admin status of the device.
 	logCtx.Debug("Wireguard device exists, checking settings")
-	attrs := link.Attrs()
-	oldMTU := attrs.MTU
+	oldMTU := link.Attrs().MTU
 	configMTU := w.config.MTU
 	if w.ipVersion == 6 {
 		configMTU = w.config.MTUV6
@@ -1469,36 +1471,45 @@ func (w *Wireguard) ensureLink(netlinkClient netlinkshim.Interface) (bool, error
 		logCtx.WithFields(log.Fields{"oldMTU": oldMTU, "newMTU": configMTU}).Info("Wireguard device MTU needs to be updated")
 		if err := netlinkClient.LinkSetMTU(link, configMTU); err != nil {
 			w.logCtx.WithError(err).Warn("failed to set tunnel device MTU")
-			return false, err
+			return err
 		}
 		w.logCtx.Info("Updated wireguard device MTU")
 	}
-	if attrs.Flags&net.FlagUp == 0 {
-		w.logCtx.WithField("flags", attrs.Flags).Info("Wireguard interface wasn't admin up, enabling it")
+	if !linkIsUp(link) {
+		w.logCtx.WithField("flags", link.Attrs().Flags).Info("Wireguard interface wasn't admin up, enabling it")
 		if err := netlinkClient.LinkSetUp(link); err != nil {
 			w.logCtx.WithError(err).Warn("failed to set wireguard device up")
-			return false, err
+			return err
 		}
 		w.logCtx.Info("Set wireguard admin up")
 
 		if link, err = netlinkClient.LinkByName(w.interfaceName); err != nil {
 			w.logCtx.WithError(err).Warn("failed to get link device after creating link")
-			return false, err
+			return err
 		}
 	}
 
-	// Can only enable NAPI threading once the link is up
-	if attrs.Flags&net.FlagUp != 0 {
-		threadedNAPIBit := boolToBinaryString(w.config.ThreadedNAPI)
-		w.logCtx.WithField("flags", attrs.Flags).Infof("Set NAPI threading to %s for wireguard interface %s", threadedNAPIBit, w.interfaceName)
-		napiThreadedPath := fmt.Sprintf("/sys/class/net/%s/threaded", w.interfaceName)
-		if err := w.writeProcSys(napiThreadedPath, threadedNAPIBit); err != nil {
-			w.logCtx.WithError(err).Warnf("failed to set NAPI threading to %s for wireguard for interface %s", threadedNAPIBit, w.interfaceName)
-		}
+	// If the link was down, we'll have refreshed it above, check if it's
+	// still down.
+	if !linkIsUp(link) {
+		// Can't do the final update unless the link is up so we'd better
+		// return an error so that we get retried.
+		return ErrWaitingForLink
 	}
 
-	// Track whether the interface is oper up or not. We halt programming when it is down.
-	return link.Attrs().Flags&net.FlagUp != 0, nil
+	// Enable NAPI threading if desired.
+	threadedNAPIBit := boolToBinaryString(w.config.ThreadedNAPI)
+	w.logCtx.WithField("flags", link.Attrs().Flags).Infof("Set NAPI threading to %s for wireguard interface %s", threadedNAPIBit, w.interfaceName)
+	napiThreadedPath := fmt.Sprintf("/sys/class/net/%s/threaded", w.interfaceName)
+	if err := w.writeProcSys(napiThreadedPath, threadedNAPIBit); err != nil {
+		w.logCtx.WithError(err).Warnf("failed to set NAPI threading to %s for wireguard for interface %s", threadedNAPIBit, w.interfaceName)
+	}
+
+	return nil
+}
+
+func linkIsUp(link netlink.Link) bool {
+	return link.Attrs().Flags&net.FlagUp != 0
 }
 
 // ensureNoLink checks that the wireguard link is not present.

--- a/felix/wireguard/wireguard_test.go
+++ b/felix/wireguard/wireguard_test.go
@@ -135,8 +135,17 @@ func newApplyWithErrors(wg *Wireguard, numExpected int) *applyWithErrors {
 }
 
 func (a *applyWithErrors) Apply() error {
+	return a.ApplyAndIgnore()
+}
+
+func (a *applyWithErrors) ApplyAndIgnore(errsToIgnore ...error) error {
 	for {
 		err := a.wg.Apply()
+		for _, errToIgnore := range errsToIgnore {
+			if errors.Is(err, errToIgnore) {
+				return nil
+			}
+		}
 		if err == nil {
 			log.Debug("Successfully applied")
 			return nil
@@ -335,11 +344,11 @@ func describeEnableTests(enableV4, enableV6 bool) {
 		BeforeEach(func() {
 			if enableV4 {
 				err := wg.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 			}
 			if enableV6 {
 				err := wgV6.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 			}
 		})
 
@@ -367,14 +376,14 @@ func describeEnableTests(enableV4, enableV6 bool) {
 			if enableV4 {
 				wgDataplane.ResetDeltas()
 				err := wg.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				Expect(wgDataplane.NumLinkAddCalls).To(Equal(0))
 				Expect(wgDataplane.WireguardOpen).To(BeFalse())
 			}
 			if enableV6 {
 				wgDataplaneV6.ResetDeltas()
 				err := wgV6.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				Expect(wgDataplaneV6.NumLinkAddCalls).To(Equal(0))
 				Expect(wgDataplaneV6.WireguardOpen).To(BeFalse())
 			}
@@ -386,7 +395,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 				wgDataplane.ResetDeltas()
 				wg.OnIfaceStateChanged(ifaceName, ifacemonitor.StateDown)
 				err := wg.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				Expect(wgDataplane.NumLinkAddCalls).To(Equal(0))
 				Expect(wgDataplane.WireguardOpen).To(BeFalse())
 			}
@@ -394,7 +403,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 				wgDataplaneV6.ResetDeltas()
 				wgV6.OnIfaceStateChanged(ifaceNameV6, ifacemonitor.StateDown)
 				err := wgV6.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				Expect(wgDataplaneV6.NumLinkAddCalls).To(Equal(0))
 				Expect(wgDataplaneV6.WireguardOpen).To(BeFalse())
 			}
@@ -407,7 +416,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 				wgDataplane.AddIface(1919, ifaceName+".foobar", true, true)
 				wg.OnIfaceStateChanged(ifaceName+".foobar", ifacemonitor.StateUp)
 				err := wg.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				Expect(wgDataplane.NumLinkAddCalls).To(Equal(0))
 				Expect(wgDataplane.WireguardOpen).To(BeFalse())
 			}
@@ -416,7 +425,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 				wgDataplaneV6.AddIface(1919, ifaceNameV6+".foobar", true, true)
 				wgV6.OnIfaceStateChanged(ifaceNameV6+".foobar", ifacemonitor.StateUp)
 				err := wgV6.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				Expect(wgDataplaneV6.NumLinkAddCalls).To(Equal(0))
 				Expect(wgDataplaneV6.WireguardOpen).To(BeFalse())
 			}
@@ -2681,14 +2690,14 @@ func describeEnableTests(enableV4, enableV6 bool) {
 			if enableV4 {
 				wg.QueueResync()
 				err := wg.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				link := wgDataplane.NameToLink[ifaceName]
 				Expect(link).ToNot(BeNil())
 			}
 			if enableV6 {
 				wgV6.QueueResync()
 				err := wgV6.Apply()
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(Equal(ErrWaitingForLink))
 				linkV6 := wgDataplaneV6.NameToLink[ifaceNameV6]
 				Expect(linkV6).ToNot(BeNil())
 			}
@@ -2732,7 +2741,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 
 					// Set the wireguard interface ip address
 					wg.EndpointWireguardUpdate(hostname, zeroKey, ipv4_int1)
-					err := apply.Apply()
+					err := apply.ApplyAndIgnore(ErrWaitingForLink)
 					Expect(err).NotTo(HaveOccurred())
 
 					// We expect the link to exist.
@@ -2788,7 +2797,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 
 					// Set the wireguard interface ip address
 					wgV6.EndpointWireguardUpdate(hostname, zeroKey, ipv6_int1)
-					err := apply.Apply()
+					err := apply.ApplyAndIgnore(ErrWaitingForLink)
 					Expect(err).NotTo(HaveOccurred())
 
 					// We expect the link to exist.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fix a race when setting up the wireguard device.  The problem was that we were re-loading the link from the kernel but the NAPI threading conditional checked a cached `attrs` variable instead of checking the attrs of the reloaded link.

As belf-and-braces, return an error if NAPI cannot be configured yet so that the int dataplane's main loop will eventually retry.  Otherwise, we rely on the kick from the interface monitor, and it's not 100% clear to me that we can't miss a kick due to reconfiguring the device.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Pick of #9797 
CORE-11021

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race when setting wireguard NAPI setting that could cause the NAPI setting not to be applied for several minutes.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
