### PR TITLE
Re-use connection checking thread pool.

### DIFF
--- a/node/tests/st/test_base.py
+++ b/node/tests/st/test_base.py
@@ -190,12 +190,12 @@ class TestBase(TestCase):
         assert False not in results, ("Self-connectivity check error!\r\n"
                                       "Results:\r\n %s\r\n" % diagstring)
 
+
+    # Empirically, 18 threads works well on my machine!
+    check_pool = ThreadPool(18)
+
     def probe_connectivity(self, conn_check_list):
-        # Empirically, 18 threads works well on my machine!
-        check_pool = ThreadPool(18)
-        results = check_pool.map(self._conn_checker, conn_check_list)
-        check_pool.close()
-        check_pool.join()
+        results = self.check_pool.map(self._conn_checker, conn_check_list)
         # _conn_checker should only return None if there is an error in calling it
         assert None not in results, ("_conn_checker error - returned None")
         diagstring = ""


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Speculative change: hoping this will help with a hang in this area.

We saw a CI run where nosetests hung mid-test.  It was a background thread using 100% CPU, with `perf top` showing all the CPU usage in `ld-musl-x86_64.so.1`.  `strace` revealed nothing (no syscalls).  Sending a SIGTERM to the background thread unblocked the test and it completed normally.  Suspect that the call to `join()` was hanging, or something like that.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
