### PR TITLE
Node ST tests: split stdout/err when shelling out

### DIFF
--- a/node/tests/k8st/utils/utils.py
+++ b/node/tests/k8st/utils/utils.py
@@ -184,18 +184,20 @@ def function_name(f):
 def run(command, logerr=True, allow_fail=False, allow_codes=[], returnerr=False):
     out = ""
     _log.info("[%s] %s", datetime.datetime.now(), command)
-    try:
-        out = subprocess.check_output(command,
-                                      shell=True,
-                                      stderr=subprocess.STDOUT)
-        _log.info("Output:\n%s", out)
-    except subprocess.CalledProcessError as e:
+
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = process.communicate()
+    _log.info("Out:\n%s", out)
+    _log.info("Err:\n%s", err)
+
+    retcode = process.poll()
+    if retcode:
         if logerr:
-            _log.exception("Failure output:\n%s", e.output)
+            _log.exception("Failure output:\n%s\nerr:\n%s", out, err)
         if not allow_fail:
-            raise
+            raise subprocess.CalledProcessError(retcode, command, output="stdout: " + out + " stderr: " + err)
         if returnerr:
-            return e.output
+            return err
     return out
 
 


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
kubectl has been emitting random warnings to stderr, causing test flakes due to failure to decode as JSON. Stop combining stdout/err so that these go into the log but shouldn't influence the JSON.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
