### PR TITLE
Adding tiers Resource to calicoctl ClusterRole

### DIFF
--- a/manifests/calicoctl.yaml
+++ b/manifests/calicoctl.yaml
@@ -83,6 +83,7 @@ rules:
       - blockaffinities
       - ipamhandles
       - ipamconfigs
+      - tiers
     verbs:
       - create
       - get


### PR DESCRIPTION
## Description

This PR adds the `tiers` resource to the `crd.projectcalico.org` apiGroup in the calicoctl ClusterRole when installed as a `k8s-pod`. This change allows the pod to create NetworkPolicies.

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed tiers RBAC for calicoctl when it runs as a k8s pod.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
