### PR TITLE
Replace `golang.org/x/exp/rand` with `math/rand/v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/go-ini/ini v1.67.0
 	github.com/go-logr/logr v1.4.2
 	github.com/gofrs/flock v0.12.1
+	github.com/gogo/googleapis v1.4.1
 	github.com/golang/snappy v0.0.4
 	github.com/google/btree v1.1.3
 	github.com/google/go-cmp v0.6.0
@@ -36,7 +37,6 @@ require (
 	github.com/google/netstack v0.0.0-20191123085552-55fcc16cd0eb
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gruntwork-io/terratest v0.48.0
 	github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2
 	github.com/joho/godotenv v1.5.1
@@ -113,11 +113,6 @@ require (
 	sigs.k8s.io/knftables v0.0.18
 	sigs.k8s.io/network-policy-api v0.1.5
 	sigs.k8s.io/yaml v1.4.0
-)
-
-require (
-	github.com/gogo/googleapis v1.4.1
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 )
 
 require (
@@ -223,6 +218,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
@@ -318,6 +314,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/term v0.27.0 // indirect

--- a/goldmane/pkg/aggregator/aggregator_test.go
+++ b/goldmane/pkg/aggregator/aggregator_test.go
@@ -16,12 +16,12 @@ package aggregator_test
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/rand"
 	googleproto "google.golang.org/protobuf/proto"
 
 	"github.com/projectcalico/calico/goldmane/pkg/aggregator"
@@ -1274,5 +1274,5 @@ func newRandomFlow(start int64) *proto.Flow {
 
 func randomFromMap[E comparable](m map[int]E) E {
 	// Generate a random number within the size of the map.
-	return m[rand.Intn(len(m))]
+	return m[rand.IntN(len(m))]
 }

--- a/goldmane/pkg/flowgen/testserver.go
+++ b/goldmane/pkg/flowgen/testserver.go
@@ -16,12 +16,12 @@ package flowgen
 
 import (
 	"context"
+	"math/rand/v2"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/rand"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -111,7 +111,7 @@ func (t *flowGenerator) generateFlogs() {
 		wait := time.After(15 * time.Second)
 
 		// Generate Several flows during this interval.
-		num := rand.Intn(30)
+		num := rand.IntN(30)
 		for i := 0; i < num; i++ {
 			t.Lock()
 			// Use some randomness to simulate different flows.
@@ -133,10 +133,10 @@ func (t *flowGenerator) generateFlogs() {
 				},
 				StartTime:  int64(startTime.Unix()),
 				EndTime:    int64(endTime.Unix()),
-				BytesIn:    int64(rand.Intn(1000)),
-				BytesOut:   int64(rand.Intn(1000)),
-				PacketsIn:  int64(rand.Intn(100)),
-				PacketsOut: int64(rand.Intn(100)),
+				BytesIn:    int64(rand.IntN(1000)),
+				BytesOut:   int64(rand.IntN(1000)),
+				PacketsIn:  int64(rand.IntN(100)),
+				PacketsOut: int64(rand.IntN(100)),
 			}
 			index++
 			t.Unlock()
@@ -151,5 +151,5 @@ func (t *flowGenerator) generateFlogs() {
 
 func randomFrommap(m map[int]string) string {
 	// Generate a random number within the size of the map.
-	return m[rand.Intn(len(m))]
+	return m[rand.IntN(len(m))]
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Since Go 1.22, `math/rand/v2` is the replacement for `golang.org/x/exp/rand`:

> Once math/rand/v2 has shipped, we would tag and delete x/exp/rand.
> https://github.com/golang/go/issues/61716

Reference: https://go.dev/doc/go1.22#math_rand_v2

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
