### PR TITLE
Calicoctl ipam config support MaxBlocksPerHost

### DIFF
--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -29,7 +29,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
 )
 
-func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, enabled bool) error {
+func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, enabled bool, maxBlocks *int) error {
 	ipamConfig, err := ipamClient.GetIPAMConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("Error: %v", err)
@@ -39,12 +39,20 @@ func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, en
 	// host with block affinity.
 	ipamConfig.StrictAffinity = enabled
 
+	// Set MaxBlocksPerHost if specified
+	if maxBlocks != nil {
+		ipamConfig.MaxBlocksPerHost = *maxBlocks
+	}
+
 	err = ipamClient.SetIPAMConfig(ctx, *ipamConfig)
 	if err != nil {
 		return fmt.Errorf("Error: %v", err)
 	}
 
 	fmt.Println("Successfully set StrictAffinity to:", enabled)
+	if maxBlocks != nil {
+		fmt.Println("Successfully set MaxBlocksPerHost to:", *maxBlocks)
+	}
 
 	return nil
 }
@@ -52,12 +60,13 @@ func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, en
 // Configure IPAM.
 func Configure(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  <BINARY_NAME> ipam configure --strictaffinity=<true/false> [--config=<CONFIG>] [--allow-version-mismatch]
+  <BINARY_NAME> ipam configure --strictaffinity=<true/false> [--maxblockhost=<number>] [--config=<CONFIG>] [--allow-version-mismatch]
 
 Options:
   -h --help                        Show this screen.
      --strictaffinity=<true/false> Set StrictAffinity to true/false. When StrictAffinity
                                    is true, borrowing IP addresses is not allowed.
+     --maxblockhost=<number>       Set the maximum number of blocks that can be affine to a host.
   -c --config=<CONFIG>             Path to the file containing connection configuration in
                                    YAML or JSON format.
                                    [default: ` + constants.DefaultConfigPath + `]
@@ -99,5 +108,14 @@ Description:
 		return fmt.Errorf("Invalid value. Use true or false to set strictaffinity")
 	}
 
-	return updateIPAMStrictAffinity(ctx, ipamClient, enabled)
+	var maxBlocks *int
+	if maxBlockStr, ok := parsedArgs["--maxblockhost"].(string); ok && maxBlockStr != "" {
+		maxBlocksVal, err := strconv.Atoi(maxBlockStr)
+		if err != nil {
+			return fmt.Errorf("Invalid value for maxblockhost. Use a valid number")
+		}
+		maxBlocks = &maxBlocksVal
+	}
+
+	return updateIPAMStrictAffinity(ctx, ipamClient, enabled, maxBlocks)
 }

--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -66,7 +66,7 @@ Options:
   -h --help                        Show this screen.
      --strictaffinity=<true/false> Set StrictAffinity to true/false. When StrictAffinity
                                    is true, borrowing IP addresses is not allowed.
-     --maxblockhost=<number>       Set the maximum number of blocks that can be affine to a host.
+     --max-blocks-per-host=<number>       Set the maximum number of blocks that can be affine to a host.
   -c --config=<CONFIG>             Path to the file containing connection configuration in
                                    YAML or JSON format.
                                    [default: ` + constants.DefaultConfigPath + `]

--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -60,7 +60,7 @@ func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, en
 // Configure IPAM.
 func Configure(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  <BINARY_NAME> ipam configure --strictaffinity=<true/false> [--maxblockhost=<number>] [--config=<CONFIG>] [--allow-version-mismatch]
+  <BINARY_NAME> ipam configure --strictaffinity=<true/false> [--max-blocks-per-host=<number>] [--config=<CONFIG>] [--allow-version-mismatch]
 
 Options:
   -h --help                        Show this screen.
@@ -109,7 +109,7 @@ Description:
 	}
 
 	var maxBlocks *int
-	if maxBlockStr, ok := parsedArgs["--maxblockhost"].(string); ok && maxBlockStr != "" {
+	if maxBlockStr, ok := parsedArgs["--max-blocks-per-host"].(string); ok && maxBlockStr != "" {
 		maxBlocksVal, err := strconv.Atoi(maxBlockStr)
 		if err != nil {
 			return fmt.Errorf("Invalid value for maxblockhost. Use a valid number")


### PR DESCRIPTION
## Description
Calicoctl ipam config support MaxBlocksPerHost


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

release-note
```release-note
Added support for configuring `MaxBlocksPerHost` via `calicoctl ipam configure --maxblockhost`. This allows operators to limit the number of IP blocks assigned to a host.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
