### PR TITLE
Revert declaration that _our_ plugin provides QoS support

### DIFF
--- a/networking-calico/networking_calico/plugins/calico/plugin.py
+++ b/networking-calico/networking_calico/plugins/calico/plugin.py
@@ -38,9 +38,6 @@ class CalicoPlugin(Ml2Plugin, l3_db.L3_NAT_db_mixin):
         # Add the ability to handle floating IPs.
         self._supported_extension_aliases.extend(["router"])
 
-        # Add the ability to handle QoS.
-        self._supported_extension_aliases.extend(["qos", "qos-bw-limit-direction"])
-
         # Suppress the Neutron server's DHCP agent scheduling.  This is useful
         # because it suppresses many WARNING logs that would otherwise appear,
         # but that are actually spurious in a Calico/OpenStack deployment.


### PR DESCRIPTION
In fact QoS support is provided by the 'qos' service plugin, which is configured with

    service_plugins = qos

in `/etc/neutron/neutron.conf`.  It's wrong to declare it here as well, and that causes a traceback ending with:

    2025-02-17 12:34:56.469 40638 ERROR neutron   File "/usr/lib/python3/dist-packages/neutron/api/extensions.py", line 492, in __init__
    2025-02-17 12:34:56.469 40638 ERROR neutron     self.check_if_plugin_extensions_loaded()
    2025-02-17 12:34:56.469 40638 ERROR neutron   File "/usr/lib/python3/dist-packages/neutron/api/extensions.py", line 572, in check_if_plugin_extensions_loaded
    2025-02-17 12:34:56.469 40638 ERROR neutron     raise exceptions.ExtensionsNotFound(
    2025-02-17 12:34:56.469 40638 ERROR neutron neutron_lib.exceptions.ExtensionsNotFound: Extensions not found: ['qos'].

Looking at `check_if_plugin_extensions_loaded`, we see

    def check_if_plugin_extensions_loaded(self):
        """Check if an extension supported by a plugin has been loaded."""
        plugin_extensions = self.get_supported_extension_aliases()
        missing_aliases = plugin_extensions - set(self.extensions)
        missing_aliases -= _PLUGIN_AGNOSTIC_EXTENSIONS
        if missing_aliases:
            raise exceptions.ExtensionsNotFound(
                extensions=list(missing_aliases))

so it's clear that this is caused by the wrong `_supported_extension_aliases` declaration in our plugin code.
