### PR TITLE
AutoHEP FV wait for node labels to sync

### DIFF
--- a/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
@@ -337,25 +337,14 @@ var _ = Describe("Auto Hostendpoint FV tests", func() {
 		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Create a Calico node with a reference to it.
-		cn := libapi.NewNode()
-		cn.Name = cNodeName
-		cn.Labels = map[string]string{"calico-label": "calico-value"}
-		cn.Spec = libapi.NodeSpec{
-			BGP: &libapi.NodeBGPSpec{
-				IPv4Address:        "172.16.1.1/24",
-				IPv6Address:        "fe80::1",
-				IPv4IPIPTunnelAddr: "192.168.100.1",
-			},
-			OrchRefs: []libapi.OrchRef{
-				{
-					NodeName:     kNodeName,
-					Orchestrator: "k8s",
-				},
-			},
-		}
+		cn := calicoNode(c, cNodeName, kNodeName, map[string]string{"calico-label": "calico-value"})
 		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		// Expect the node label to sync.
+		expectedNodeLabels := map[string]string{"label1": "value1", "calico-label": "calico-value"}
+		Eventually(func() error { return testutils.ExpectNodeLabels(c, expectedNodeLabels, cNodeName) },
+			time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		expectedHepName := cn.Name + "-auto-hep"
 

--- a/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
@@ -337,6 +337,7 @@ var _ = Describe("Auto Hostendpoint FV tests", func() {
 		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
+		// Create a Calico node with a reference to it.
 		cn := calicoNode(c, cNodeName, kNodeName, map[string]string{"calico-label": "calico-value"})
 		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description
Update test to wait for node labels to sync before continuing

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
