### PR TITLE
Pin calico/base to release tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ endif
 		python:3 \
 		bash -c '/usr/local/bin/python release/get-contributors.py >> /code/AUTHORS.md'
 
-update-pins: update-go-build-pin
+update-pins: update-go-build-pin update-calico-base-pin
 
 ###############################################################################
 # Post-release validation

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -265,7 +265,7 @@ CERTS_PATH := $(REPO_ROOT)/hack/test/certs
 ifdef USE_UBI_AS_CALICO_BASE
 CALICO_BASE ?= $(UBI_IMAGE)
 else
-CALICO_BASE ?= calico/base
+CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)
 endif
 
 ifndef NO_DOCKER_PULL
@@ -355,12 +355,12 @@ define get_go_build_version
 	$(shell git ls-remote --tags --refs --sort=-version:refname $(GO_BUILD_REPO) | head -n 1 | awk -F '/' '{print $$NF}')
 endef
 
-# update_go_build updates the GO_BUILD_VER in metadata.mk or Makefile.
+# update_go_build_pin updates the GO_BUILD_VER in metadata.mk or Makefile.
 # for annotated git tags, we need to remove the trailing `^{}`.
 # for the obsoleted vx.y go-build version, we need to remove the leading `v` for bash string comparison to work properly.
 define update_go_build_pin
 	$(eval new_ver := $(subst ^{},,$(call get_go_build_version)))
-	$(eval old_ver := $(subst v,,$(shell grep -E "^GO_BUILD_VER" $(1) | cut -d'=' -f2 | xargs)))
+	$(eval old_ver := $(shell grep -E "^GO_BUILD_VER" $(1) | cut -d'=' -f2 | xargs | sed 's/^v//'))
 
 	@echo "current GO_BUILD_VER=$(old_ver)"
 	@echo "latest GO_BUILD_VER=$(new_ver)"
@@ -371,6 +371,23 @@ define update_go_build_pin
 			echo "GO_BUILD_VER is updated to $(new_ver)"; \
 		else \
 			echo "no need to update GO_BUILD_VER"; \
+		fi'
+endef
+
+# update_calico_base_pin updates the CALICO_BASE_VER in metadata.mk.
+define update_calico_base_pin
+	$(eval new_ver := $(shell curl -s "https://hub.docker.com/v2/repositories/calico/base/tags/?page_size=100" | jq -r '.results[].name' | grep -E "^ubi8-[0-9]+$$" | sort -r | head -n 1))
+	$(eval old_ver := $(shell grep -E "^CALICO_BASE_VER" $(1) | cut -d'=' -f2 | xargs))
+
+	@echo "current CALICO_BASE_VER=$(old_ver)"
+	@echo "latest CALICO_BASE_VER=$(new_ver)"
+
+	bash -c '\
+		if [[ "$(new_ver)" > "$(old_ver)" ]]; then \
+			sed -i "s/^CALICO_BASE_VER[[:space:]]*=.*/CALICO_BASE_VER=$(new_ver)/" $(1); \
+			echo "CALICO_BASE_VER is updated to $(new_ver)"; \
+		else \
+			echo "no need to update CALICO_BASE_VER"; \
 		fi'
 endef
 
@@ -432,6 +449,9 @@ replace-cni-pin:
 
 update-go-build-pin:
 	$(call update_go_build_pin,$(GIT_GO_BUILD_UPDATE_COMMIT_FILE))
+
+update-calico-base-pin:
+	$(call update_calico_base_pin,$(GIT_GO_BUILD_UPDATE_COMMIT_FILE))
 
 git-status:
 	git status --porcelain

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -199,7 +199,7 @@ ifeq ($(BUILDARCH),amd64)
 	# *-amd64 tagged images for etcd are not available until v3.5.0
 	ETCD_IMAGE = quay.io/coreos/etcd:$(ETCD_VERSION)
 endif
-UBI_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal:$(UBI_VERSION)
+UBI_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ifeq ($(GIT_USE_SSH),true)
 	GIT_CONFIG_SSH ?= git config --global url."ssh://git@github.com/".insteadOf "https://github.com/";

--- a/metadata.mk
+++ b/metadata.mk
@@ -2,8 +2,10 @@
 # This file contains Makefile configuration parameters and metadata for this branch.
 #################################################################################################
 
-# The version of github.com/projectcalico/go-build to use.
+# The version of calico/go-build and calico/base to use.
 GO_BUILD_VER=1.24.0-llvm18.1.8-k8s1.31.5-2
+CALICO_BASE_VER=ubi8-1739912267
+
 # Env var to ACK Ginkgo deprecation warnings, may need updating with go-build.
 ACK_GINKGO=ACK_GINKGO_DEPRECATIONS=1.16.5
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -19,8 +19,6 @@ GHR_VERSION=v0.17.0
 HELM_VERSION=v3.11.3
 KINDEST_NODE_VERSION=v1.31.4
 KIND_VERSION=v0.25.0
-PROTOC_VER=v0.1
-UBI_VERSION=8.10
 
 # Configuration for Semaphore/Github integration.  This needs to be set
 # differently for a forked repo.


### PR DESCRIPTION
## Description

This change pins calico/base version to a particular tag instead of `latest`. It resolves issues during a (hash) release when non-amd64 components accidentally pull in amd64 bases.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
