### PR TITLE
Improve EndpointLookupsCache occupancy

### DIFF
--- a/felix/calc/endpoint_lookup_cache.go
+++ b/felix/calc/endpoint_lookup_cache.go
@@ -90,7 +90,7 @@ type EndpointData interface {
 	EgressMatchData() *MatchData
 }
 
-// endpointData is out internal interface shared by our local/remote cache
+// endpointData is our internal interface shared by our local/remote cache
 // entries.
 type endpointData interface {
 	EndpointData
@@ -201,11 +201,11 @@ func (ec *EndpointLookupsCache) RegisterWith(
 // is ignored for remote endpoints.
 func (ec *EndpointLookupsCache) OnEndpointTierUpdate(key model.EndpointKey, ep model.Endpoint, filteredTiers []TierInfo) {
 	if ep == nil {
-		log.Infof("Queueing deletion of local endpoint data %v", key)
+		log.Debugf("Queueing deletion of local endpoint data %v", key)
 		ec.removeEndpointWithDelay(key)
 	} else {
 		ed := ec.CreateLocalEndpointData(key, ep, filteredTiers)
-		log.Infof("Updating endpoint cache with local endpoint data: %v", key)
+		log.Debugf("Updating endpoint cache with local endpoint data: %v", key)
 		ec.addOrUpdateEndpoint(key, ed)
 	}
 }

--- a/felix/calc/endpoint_lookup_cache.go
+++ b/felix/calc/endpoint_lookup_cache.go
@@ -15,6 +15,7 @@
 package calc
 
 import (
+	"iter"
 	"net"
 	"reflect"
 	"strings"
@@ -35,7 +36,7 @@ import (
 )
 
 const (
-	endpointDataTTLAfterMarkedAsRemovedSeconds = 2 * config.DefaultConntrackPollingInterval
+	endpointDataDeletionDelay time.Duration = 2 * config.DefaultConntrackPollingInterval
 )
 
 var gaugeEndpointCacheLength = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -77,25 +78,25 @@ func init() {
 //
 // With multiple tiers, the policy match index increments across the ordered set of tiers.
 
-type EndpointData struct {
-	Key model.Key
+// EndpointData is the exported interface for our cache entries, used by
+// the collector to interrogate the cached entry.
+type EndpointData interface {
+	Key() model.Key
+	GenerateName() string
+	IsLocal() bool
+	IsHostEndpoint() bool
+	Labels() map[string]string
+	IngressMatchData() *MatchData
+	EgressMatchData() *MatchData
+}
 
-	// Whether the endpoint is local or not.
-	IsLocal bool
-
-	// Ingress and egress match data.
-	Ingress *MatchData
-	Egress  *MatchData
-
-	// EndpointData will have either an Endpoint OR a Networkset.
-	// The networkset will only be set in the EndpointData if an
-	// endpoint for the IP is not found.
-	Endpoint   interface{}
-	Networkset interface{}
-
-	// used for deleting an EndpointData, to delegate the actual
-	// deletion endpointDataTTLAfterMarkedAsRemovedSeconds later
-	markedToBeDeleted bool
+// endpointData is out internal interface shared by our local/remote cache
+// entries.
+type endpointData interface {
+	EndpointData
+	allIPs() [][16]byte
+	isMarkedToBeDeleted() bool
+	setMarkedToBeDeleted(b bool)
 }
 
 type MatchData struct {
@@ -123,16 +124,6 @@ type TierData struct {
 	EndOfTierMatchIndex int
 }
 
-// IsHostEndpoint returns if this EndpointData corresponds to a hostendpoint.
-func (e *EndpointData) IsHostEndpoint() bool {
-	switch e.Key.(type) {
-	case model.HostEndpointKey:
-		return true
-	default:
-		return false
-	}
-}
-
 // EndpointLookupsCache provides an API to lookup endpoint information given
 // an IP address.
 //
@@ -144,9 +135,17 @@ func (e *EndpointData) IsHostEndpoint() bool {
 // with the remote endpoint dispatcher and updates the endpoint
 // cache appropriately.
 type EndpointLookupsCache struct {
-	epMutex       sync.RWMutex
-	endpointData  map[model.Key]*EndpointData
-	ipToEndpoints map[[16]byte][]*EndpointData
+	epMutex sync.RWMutex
+
+	// localEndpointData contains information about local endpoints only, it
+	// includes additional policy match information vs remoteEndpointData.
+	localEndpointData map[model.EndpointKey]*LocalEndpointData
+	// remoteEndpointData contains information about remote endpoints only.
+	// We use a separate map for remote endpoints to minimize the size in
+	// memory.
+	remoteEndpointData map[model.EndpointKey]*RemoteEndpointData
+
+	ipToEndpoints map[[16]byte][]endpointData
 
 	endpointDeletionTimers map[model.Key]*time.Timer
 
@@ -154,17 +153,33 @@ type EndpointLookupsCache struct {
 	// TODO(rlb): We should just treat this as an endpoint
 	nodes         map[string]v3.NodeSpec
 	nodeIPToNames map[[16]byte][]string
+	deletionDelay time.Duration
 }
 
-func NewEndpointLookupsCache() *EndpointLookupsCache {
+type EndpointLookupsCacheOption func(*EndpointLookupsCache)
+
+func WithDeletionDelay(d time.Duration) EndpointLookupsCacheOption {
+	return func(ec *EndpointLookupsCache) {
+		ec.deletionDelay = d
+	}
+}
+
+func NewEndpointLookupsCache(opts ...EndpointLookupsCacheOption) *EndpointLookupsCache {
 	ec := &EndpointLookupsCache{
 		epMutex:       sync.RWMutex{},
-		ipToEndpoints: map[[16]byte][]*EndpointData{},
-		endpointData:  map[model.Key]*EndpointData{},
+		ipToEndpoints: map[[16]byte][]endpointData{},
+
+		localEndpointData:  map[model.EndpointKey]*LocalEndpointData{},
+		remoteEndpointData: map[model.EndpointKey]*RemoteEndpointData{},
 
 		endpointDeletionTimers: map[model.Key]*time.Timer{},
 		nodeIPToNames:          make(map[[16]byte][]string),
 		nodes:                  make(map[string]v3.NodeSpec),
+		deletionDelay:          endpointDataDeletionDelay,
+	}
+
+	for _, opt := range opts {
+		opt(ec)
 	}
 
 	return ec
@@ -185,33 +200,20 @@ func (ec *EndpointLookupsCache) RegisterWith(
 // handler (below) is this method records tier information for local endpoints while this information
 // is ignored for remote endpoints.
 func (ec *EndpointLookupsCache) OnEndpointTierUpdate(key model.EndpointKey, ep model.Endpoint, filteredTiers []TierInfo) {
-	switch k := key.(type) {
-	case model.WorkloadEndpointKey:
-		if ep == nil {
-			ec.removeEndpointWithDelay(k)
-		} else {
-			endpoint := ep.(*model.WorkloadEndpoint)
-			ed := ec.CreateEndpointData(key, ep, filteredTiers)
-			ec.addOrUpdateEndpoint(k, ed, extractIPsFromWorkloadEndpoint(endpoint))
-		}
-	case model.HostEndpointKey:
-		if ep == nil {
-			ec.removeEndpointWithDelay(k)
-		} else {
-			endpoint := ep.(*model.HostEndpoint)
-			ed := ec.CreateEndpointData(key, ep, filteredTiers)
-			ec.addOrUpdateEndpoint(k, ed, extractIPsFromHostEndpoint(endpoint))
-		}
+	if ep == nil {
+		log.Infof("Queueing deletion of local endpoint data %v", key)
+		ec.removeEndpointWithDelay(key)
+	} else {
+		ed := ec.CreateLocalEndpointData(key, ep, filteredTiers)
+		log.Infof("Updating endpoint cache with local endpoint data: %v", key)
+		ec.addOrUpdateEndpoint(key, ed)
 	}
-	log.Infof("Updating endpoint cache with local endpoint data %v", key)
 }
 
-// CreateEndpointData creates the endpoint data based on tier
-func (ec *EndpointLookupsCache) CreateEndpointData(key model.EndpointKey, ep model.Endpoint, filteredTiers []TierInfo) *EndpointData {
-	ed := &EndpointData{
-		Key:      key,
-		Endpoint: ep,
-		IsLocal:  true,
+// CreateLocalEndpointData creates the endpoint data based on tier
+func (ec *EndpointLookupsCache) CreateLocalEndpointData(key model.EndpointKey, ep model.Endpoint, filteredTiers []TierInfo) *LocalEndpointData {
+	ed := &LocalEndpointData{
+		CommonEndpointData: CalculateCommonEndpointData(key, ep),
 		Ingress: &MatchData{
 			PolicyMatches:     make(map[PolicyID]int),
 			TierData:          make(map[string]*TierData),
@@ -291,39 +293,52 @@ func (ec *EndpointLookupsCache) CreateEndpointData(key model.EndpointKey, ep mod
 	return ed
 }
 
+func CalculateCommonEndpointData(key model.EndpointKey, ep model.Endpoint) CommonEndpointData {
+	generateName, ips := extractEndpointInfo(ep)
+	commonData := CommonEndpointData{
+		key:          key,
+		labels:       ep.GetLabels(),
+		generateName: generateName,
+		ips:          ips,
+	}
+	return commonData
+}
+
+func extractEndpointInfo(ep model.Endpoint) (string, [][16]byte) {
+	var generateName string
+	var ips [][16]byte
+	switch ep := ep.(type) {
+	case *model.WorkloadEndpoint:
+		generateName = ep.GenerateName
+		ips = extractIPsFromWorkloadEndpoint(ep)
+	case *model.HostEndpoint:
+		generateName = ""
+		ips = extractIPsFromHostEndpoint(ep)
+	}
+	return generateName, ips
+}
+
 // OnUpdate is the callback method registered with the RemoteEndpointDispatcher for
 // model.WorkloadEndpoint and model.HostEndpoint types. This method updates the
-// mapping between an remote endpoint and all the IPs that the endpoint contains.
+// mapping between a remote endpoint and all the IPs that the endpoint contains.
 // The difference between OnUpdate and OnEndpointTierUpdate is that this method
-// does not track tier information for a remote endpoint endpoint whereas
-// OnEndpointTierUpdate tracks a local endpoint and records its corresponding tier
-// information as well.
+// handles remote endpoints, which do not have policy match information, while
+// OnEndpointTierUpdate handles local endpoints and stores off their policy
+// match information.
 func (ec *EndpointLookupsCache) OnUpdate(epUpdate api.Update) (_ bool) {
 	switch k := epUpdate.Key.(type) {
-	case model.WorkloadEndpointKey:
+	case model.EndpointKey:
 		if epUpdate.Value == nil {
 			ec.removeEndpointWithDelay(k)
 		} else {
-			endpoint := epUpdate.Value.(*model.WorkloadEndpoint)
-			ed := &EndpointData{
-				Key:      k,
-				Endpoint: epUpdate.Value,
+			endpoint := epUpdate.Value.(model.Endpoint)
+			ed := &RemoteEndpointData{
+				CommonEndpointData: CalculateCommonEndpointData(k, endpoint),
 			}
-			ec.addOrUpdateEndpoint(k, ed, extractIPsFromWorkloadEndpoint(endpoint))
-		}
-	case model.HostEndpointKey:
-		if epUpdate.Value == nil {
-			ec.removeEndpointWithDelay(k)
-		} else {
-			endpoint := epUpdate.Value.(*model.HostEndpoint)
-			ed := &EndpointData{
-				Key:      k,
-				Endpoint: epUpdate.Value,
-			}
-			ec.addOrUpdateEndpoint(k, ed, extractIPsFromHostEndpoint(endpoint))
+			ec.addOrUpdateEndpoint(k, ed)
 		}
 	default:
-		log.Infof("Ignoring unexpected update: %v %#v",
+		log.Debugf("Ignoring unexpected update: %v %#v",
 			reflect.TypeOf(epUpdate.Key), epUpdate)
 		return
 	}
@@ -345,7 +360,7 @@ func (ec *EndpointLookupsCache) OnResourceUpdate(update api.Update) (_ bool) {
 				ec.addOrUpdateNode(k.Name, update.Value.(*v3.Node))
 			}
 		default:
-			log.Debugf("Ignoring update for resource: %s", k)
+			log.Tracef("Ignoring update for resource: %s", k)
 		}
 	default:
 		log.Errorf("Ignoring unexpected update: %v %#v",
@@ -356,7 +371,9 @@ func (ec *EndpointLookupsCache) OnResourceUpdate(update api.Update) (_ bool) {
 
 // addOrUpdateEndpoint tracks endpoint to IP mapping as well as IP to endpoint reverse mapping
 // for a workload or host endpoint.
-func (ec *EndpointLookupsCache) addOrUpdateEndpoint(key model.Key, incomingEndpointData *EndpointData, ipsOfIncomingEndpoint [][16]byte) {
+func (ec *EndpointLookupsCache) addOrUpdateEndpoint(key model.EndpointKey, incomingEndpointData endpointData) {
+	ipsOfIncomingEndpoint := incomingEndpointData.allIPs()
+
 	ec.epMutex.Lock()
 	defer ec.epMutex.Unlock()
 
@@ -365,17 +382,12 @@ func (ec *EndpointLookupsCache) addOrUpdateEndpoint(key model.Key, incomingEndpo
 	// First up, get all current ip addresses.
 	var ipsToRemove set.Set[[16]byte] = set.New[[16]byte]()
 
-	currentEndpoint, endpointAlreadyExists := ec.endpointData[key]
+	currentEndpoint, endpointAlreadyExists := ec.lookupEndpoint(key)
 	// Create a copy so that we can figure out which IPs to keep and
 	// which ones to remove.
 	if endpointAlreadyExists {
 		// collect all IPs from existing endpoint key
-		switch currentEndpoint.Key.(type) {
-		case model.WorkloadEndpointKey:
-			ipsToRemove.AddAll(extractIPsFromWorkloadEndpoint(currentEndpoint.Endpoint.(*model.WorkloadEndpoint)))
-		case model.HostEndpointKey:
-			ipsToRemove.AddAll(extractIPsFromHostEndpoint(currentEndpoint.Endpoint.(*model.HostEndpoint)))
-		}
+		ipsToRemove.AddAll(currentEndpoint.allIPs())
 	}
 
 	// Collect all IPs that correspond to this endpoint and mark
@@ -402,7 +414,7 @@ func (ec *EndpointLookupsCache) addOrUpdateEndpoint(key model.Key, incomingEndpo
 		delete(ec.endpointDeletionTimers, key)
 	}
 
-	ec.endpointData[incomingEndpointData.Key] = incomingEndpointData
+	ec.storeEndpoint(key, incomingEndpointData)
 
 	// update endpoint data lookup by ips
 	ipsToUpdate.Iter(func(newIP [16]byte) error {
@@ -419,11 +431,47 @@ func (ec *EndpointLookupsCache) addOrUpdateEndpoint(key model.Key, incomingEndpo
 	ec.reportEndpointCacheMetrics()
 }
 
+func (ec *EndpointLookupsCache) lookupEndpoint(key model.EndpointKey) (ed endpointData, ok bool) {
+	ed, ok = ec.localEndpointData[key]
+	if ok {
+		return
+	}
+	ed, ok = ec.remoteEndpointData[key]
+	if ok {
+		return
+	}
+	return nil, false
+}
+
+func (ec *EndpointLookupsCache) storeEndpoint(key model.EndpointKey, ed endpointData) {
+	switch ed := ed.(type) {
+	case *LocalEndpointData:
+		ec.localEndpointData[key] = ed
+	case *RemoteEndpointData:
+		ec.remoteEndpointData[key] = ed
+	}
+}
+
+func (ec *EndpointLookupsCache) allEndpoints() iter.Seq2[model.EndpointKey, endpointData] {
+	return func(yield func(model.EndpointKey, endpointData) bool) {
+		for k, v := range ec.localEndpointData {
+			if !yield(k, v) {
+				return
+			}
+		}
+		for k, v := range ec.remoteEndpointData {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
 // updateIPToEndpointMapping creates or appends the EndpointData to a corresponding
 // ip address in the ipToEndpoints map.
 // This method isn't safe to be used concurrently and the caller should acquire the
 // EndpointLookupsCache.epMutex before calling this method.
-func (ec *EndpointLookupsCache) updateIPToEndpointMapping(ip [16]byte, incomingEndpointData *EndpointData) {
+func (ec *EndpointLookupsCache) updateIPToEndpointMapping(ip [16]byte, incomingEndpointData endpointData) {
 	// Check if this IP already has a corresponding endpoint.
 	// If it has one, then append the endpoint to it. This is
 	// expected to happen if an IP address is reused in a very
@@ -432,7 +480,7 @@ func (ec *EndpointLookupsCache) updateIPToEndpointMapping(ip [16]byte, incomingE
 	existingEpDataForIp, ok := ec.ipToEndpoints[ip]
 
 	if !ok {
-		ec.ipToEndpoints[ip] = []*EndpointData{incomingEndpointData}
+		ec.ipToEndpoints[ip] = []endpointData{incomingEndpointData}
 		return
 	}
 
@@ -442,14 +490,14 @@ func (ec *EndpointLookupsCache) updateIPToEndpointMapping(ip [16]byte, incomingE
 	isExistingEp := false
 	i := 0
 	for i < len(existingEpDataForIp) {
-		if existingEpDataForIp[i].markedToBeDeleted {
+		if existingEpDataForIp[i].isMarkedToBeDeleted() {
 			existingEpDataForIp = removeEndpointDataFromSlice(existingEpDataForIp, i)
 			continue
 		}
 
 		// Check if this is an existing endpoint. If it is,
 		// then just store the updated endpoint.
-		if incomingEndpointData.Key == existingEpDataForIp[i].Key {
+		if incomingEndpointData.Key() == existingEpDataForIp[i].Key() {
 			isExistingEp = true
 			existingEpDataForIp[i] = incomingEndpointData
 		}
@@ -463,7 +511,7 @@ func (ec *EndpointLookupsCache) updateIPToEndpointMapping(ip [16]byte, incomingE
 	ec.ipToEndpoints[ip] = existingEpDataForIp
 }
 
-func removeEndpointDataFromSlice(s []*EndpointData, i int) []*EndpointData {
+func removeEndpointDataFromSlice(s []endpointData, i int) []endpointData {
 	s[len(s)-1], s[i] = s[i], s[len(s)-1]
 
 	return s[:len(s)-1]
@@ -475,11 +523,11 @@ func removeEndpointDataFromSlice(s []*EndpointData, i int) []*EndpointData {
 // has passed.  ipToEndpointDeletionTimers is used to track the all the timers
 // created for tentatively deleted endpoints as they are accessed by add/update
 // operations.
-func (ec *EndpointLookupsCache) removeEndpointWithDelay(key model.Key) {
+func (ec *EndpointLookupsCache) removeEndpointWithDelay(key model.EndpointKey) {
 	ec.epMutex.Lock()
 	defer ec.epMutex.Unlock()
 
-	endpointData, endpointExists := ec.endpointData[key]
+	ed, endpointExists := ec.lookupEndpoint(key)
 	if !endpointExists {
 		// for performance improvement - as time.AfterFunc creates a go routine
 		return
@@ -491,46 +539,39 @@ func (ec *EndpointLookupsCache) removeEndpointWithDelay(key model.Key) {
 	}
 
 	// mark the endpoint to be deleted and attach a timer to delegate the actual deletion
-	endpointData.markedToBeDeleted = true
+	ed.setMarkedToBeDeleted(true)
 
-	endpointDeletionTimer := time.AfterFunc(endpointDataTTLAfterMarkedAsRemovedSeconds, func() { ec.removeEndpoint(key) })
+	endpointDeletionTimer := time.AfterFunc(ec.deletionDelay, func() { ec.removeEndpoint(key) })
 	ec.endpointDeletionTimers[key] = endpointDeletionTimer
 }
 
 // removeEndpoint removes all EndpointData markedToBeDeleted from the slice
 // captures all IPs and removes all correspondoing IP to EndpointData mapping as well.
-func (ec *EndpointLookupsCache) removeEndpoint(key model.Key) {
+func (ec *EndpointLookupsCache) removeEndpoint(key model.EndpointKey) {
 	ec.epMutex.Lock()
 	defer ec.epMutex.Unlock()
 
 	// update ip mapping to remove all endpoints
-	currentEndpointData, ok := ec.endpointData[key]
+	currentEndpointData, ok := ec.lookupEndpoint(key)
 	if !ok {
 		return
 	}
 
-	ipsMarkedAsDeleted := set.New[[16]byte]()
-
-	// if the endpoint has not been marked for deletion ignore it as it may have been
-	// updated before the deletion timer has been triggered
-	if !currentEndpointData.markedToBeDeleted {
+	// If the endpoint has not been marked for deletion ignore it as it may have been
+	// updated before the deletion timer has been triggered.
+	if !currentEndpointData.isMarkedToBeDeleted() {
 		return
 	}
 
-	// collect the IPs of this endpoint as we will need to remove it as well from the ipmapping
-	switch currentEndpointData.Key.(type) {
-	case model.WorkloadEndpointKey:
-		ipsMarkedAsDeleted.AddAll(extractIPsFromWorkloadEndpoint(currentEndpointData.Endpoint.(*model.WorkloadEndpoint)))
-	case model.HostEndpointKey:
-		ipsMarkedAsDeleted.AddAll(extractIPsFromHostEndpoint(currentEndpointData.Endpoint.(*model.HostEndpoint)))
-	}
-
+	// Collect the IPs of this endpoint as we will need to remove it from the IP mapping.
+	ipsMarkedAsDeleted := set.From(currentEndpointData.allIPs()...)
 	ipsMarkedAsDeleted.Iter(func(ip [16]byte) error {
 		ec.removeEndpointDataIpMapping(key, ip)
 		return nil
 	})
 
-	delete(ec.endpointData, key)
+	delete(ec.localEndpointData, key)
+	delete(ec.remoteEndpointData, key)
 	delete(ec.endpointDeletionTimers, key)
 	ec.reportEndpointCacheMetrics()
 }
@@ -552,9 +593,9 @@ func (ec *EndpointLookupsCache) removeEndpointDataIpMapping(key model.Key, ip [1
 		// If there is more than one endpoint, then keep the reverse ip
 		// to endpoint mapping but only remove the endpoint corresponding
 		// to this remove call.
-		newEps := make([]*EndpointData, 0, len(existingEps)-1)
+		newEps := make([]endpointData, 0, len(existingEps)-1)
 		for _, ep := range existingEps {
-			if ep.Key == key {
+			if ep.Key() == key {
 				continue
 			}
 			newEps = append(newEps, ep)
@@ -563,16 +604,9 @@ func (ec *EndpointLookupsCache) removeEndpointDataIpMapping(key model.Key, ip [1
 	}
 }
 
-// IsEndpoint returns true if the supplied address is a endpoint, otherwise returns false.
-// Use the EndpointData.IsLocal() method to check if an EndpointData object (returned by the
-// EndpointLookupsCache.GetEndpoint() method) is a local endpoint or not.
-func (ec *EndpointLookupsCache) IsEndpoint(addr [16]byte) bool {
-	_, ok := ec.GetEndpoint(addr)
-	return ok
-}
-
-// GetEndpoint returns the ordered list of tiers for a particular endpoint.
-func (ec *EndpointLookupsCache) GetEndpoint(addr [16]byte) (*EndpointData, bool) {
+// GetEndpoint returns an endpoint matching the given IP, if there is one.
+// If more than one endpoint has the IP, the last observed endpoint is returned.
+func (ec *EndpointLookupsCache) GetEndpoint(addr [16]byte) (EndpointData, bool) {
 	ec.epMutex.RLock()
 	defer ec.epMutex.RUnlock()
 
@@ -589,22 +623,23 @@ func (ec *EndpointLookupsCache) GetEndpointKeys() []model.Key {
 	ec.epMutex.RLock()
 	defer ec.epMutex.RUnlock()
 
-	eps := []model.Key{}
-	for key := range ec.endpointData {
-		eps = append(eps, key)
+	eps := make([]model.Key, 0, len(ec.localEndpointData)+len(ec.remoteEndpointData))
+	for k := range ec.allEndpoints() {
+		eps = append(eps, k)
 	}
 	return eps
 }
 
-// GetEndpointKeys retrieves all EndpointData from the EndpointLookupCache
-// excluding those which are not marked as deleted
-func (ec *EndpointLookupsCache) GetAllEndpointData() []*EndpointData {
+// GetAllEndpointData retrieves all EndpointData from the EndpointLookupCache
+// excluding those which are not marked as deleted. Convenience method only
+// used for testing purposes.
+func (ec *EndpointLookupsCache) GetAllEndpointData() []EndpointData {
 	ec.epMutex.RLock()
 	defer ec.epMutex.RUnlock()
 
-	allEds := []*EndpointData{}
-	for _, ed := range ec.endpointData {
-		if ed.markedToBeDeleted {
+	allEds := []EndpointData{}
+	for _, ed := range ec.allEndpoints() {
+		if ed.isMarkedToBeDeleted() {
 			continue
 		}
 		allEds = append(allEds, ed)
@@ -614,7 +649,7 @@ func (ec *EndpointLookupsCache) GetAllEndpointData() []*EndpointData {
 
 // reportEndpointCacheMetrics reports endpoint cache performance metrics to prometheus
 func (ec *EndpointLookupsCache) reportEndpointCacheMetrics() {
-	gaugeEndpointCacheLength.Set(float64(len(ec.endpointData)))
+	gaugeEndpointCacheLength.Set(float64(len(ec.remoteEndpointData) + len(ec.localEndpointData)))
 }
 
 func (ec *EndpointLookupsCache) GetNode(ip [16]byte) (string, bool) {
@@ -699,31 +734,28 @@ func (ec *EndpointLookupsCache) DumpEndpoints() string {
 	for ip, eds := range ec.ipToEndpoints {
 		edNames := []string{}
 		for _, ed := range eds {
-			edNames = append(edNames, endpointName(ed.Key))
+			edNames = append(edNames, endpointName(ed.Key()))
 		}
 		lines = append(lines, net.IP(ip[:16]).String()+": "+strings.Join(edNames, ","))
 	}
 
 	lines = append(lines, "-------")
 
-	for key, endpointData := range ec.endpointData {
+	for key, endpointData := range ec.allEndpoints() {
 		ipStr := []string{}
 		ips := set.New[[16]byte]()
 
-		if !endpointData.markedToBeDeleted {
-			switch endpointData.Key.(type) {
-			case model.WorkloadEndpointKey:
-				ips.AddAll(extractIPsFromWorkloadEndpoint(endpointData.Endpoint.(*model.WorkloadEndpoint)))
-			case model.HostEndpointKey:
-				ips.AddAll(extractIPsFromHostEndpoint(endpointData.Endpoint.(*model.HostEndpoint)))
-			}
+		deleted := "deleted"
+		if !endpointData.isMarkedToBeDeleted() {
+			ips.AddAll(endpointData.allIPs())
+			deleted = ""
 		}
 
 		ips.Iter(func(ip [16]byte) error {
 			ipStr = append(ipStr, net.IP(ip[:16]).String())
 			return nil
 		})
-		lines = append(lines, endpointName(key), ": ", strings.Join(ipStr, ","))
+		lines = append(lines, endpointName(key)+": "+strings.Join(ipStr, ",")+deleted)
 	}
 
 	return strings.Join(lines, "\n")
@@ -736,11 +768,11 @@ func (ec *EndpointLookupsCache) addOrUpdateNode(name string, node *v3.Node) {
 
 	if existing, ok := ec.nodes[name]; ok {
 		if reflect.DeepEqual(existing, node.Spec) {
-			// Service data has not changed. Do nothing.
+			// Node data has not changed. Do nothing.
 			return
 		}
 
-		// Service data has changed, keep the logic simple by removing the old service and re-adding the new one.
+		// Node data has changed, keep the logic simple by removing the old service and re-adding the new one.
 		ec.handleNode(name, existing, ec.removeNodeMap)
 	}
 
@@ -802,4 +834,98 @@ func (ec *EndpointLookupsCache) addNodeMap(name string, ip [16]byte) {
 	if !stringutils.InSlice(ec.nodeIPToNames[ip], name) {
 		ec.nodeIPToNames[ip] = append(ec.nodeIPToNames[ip], name)
 	}
+}
+
+// CommonEndpointData contains the common fields between LocalEndpointData and RemoteEndpointData.
+type CommonEndpointData struct {
+	key model.EndpointKey
+
+	// Labels contains the labels extracted from the endpoint.
+	labels map[string]string
+	// IP addresses extracted from the endpoint.
+	ips [][16]byte
+	// GenerateName is only populated for WorkloadEndpoints, it contains the
+	// contents of the GenerateName field from the WorkloadEndpoint, which is
+	// used by the collector for determining the aggregation name.
+	generateName string
+
+	// used for deleting an EndpointData, to delegate the actual
+	// deletion endpointDataDeletionDelay later
+	markedToBeDeleted bool
+}
+
+func (e *CommonEndpointData) Key() model.Key {
+	return e.key
+}
+
+// IsHostEndpoint returns if this EndpointData corresponds to a hostendpoint.
+func (e *CommonEndpointData) IsHostEndpoint() (isHep bool) {
+	switch e.key.(type) {
+	case model.HostEndpointKey:
+		isHep = true
+	}
+	return
+}
+
+func (e *CommonEndpointData) allIPs() [][16]byte {
+	return e.ips
+}
+
+func (e *CommonEndpointData) Labels() map[string]string {
+	return e.labels
+}
+
+func (e *CommonEndpointData) GenerateName() string {
+	return e.generateName
+}
+
+func (e *CommonEndpointData) isMarkedToBeDeleted() bool {
+	return e.markedToBeDeleted
+}
+
+func (e *CommonEndpointData) setMarkedToBeDeleted(b bool) {
+	e.markedToBeDeleted = b
+}
+
+// LocalEndpointData is the cache entry struct for local endpoints.  We store
+// additional information for local endpoints.  Namely the locally-active
+// policy.
+type LocalEndpointData struct {
+	CommonEndpointData
+
+	// Ingress keeps track of the ingress policies that apply to this endpoint.
+	Ingress *MatchData
+	// Egress keeps track of the egress policies that apply to this endpoint.
+	Egress *MatchData
+}
+
+var _ endpointData = &LocalEndpointData{}
+var _ endpointData = &RemoteEndpointData{}
+
+func (ed *LocalEndpointData) IsLocal() bool {
+	return true
+}
+
+func (ed *LocalEndpointData) IngressMatchData() *MatchData {
+	return ed.Ingress
+}
+
+func (ed *LocalEndpointData) EgressMatchData() *MatchData {
+	return ed.Egress
+}
+
+type RemoteEndpointData struct {
+	CommonEndpointData
+}
+
+func (ed *RemoteEndpointData) IsLocal() bool {
+	return false
+}
+
+func (ed *RemoteEndpointData) IngressMatchData() *MatchData {
+	return nil
+}
+
+func (ed *RemoteEndpointData) EgressMatchData() *MatchData {
+	return nil
 }

--- a/felix/calc/endpoint_lookup_cache_test.go
+++ b/felix/calc/endpoint_lookup_cache_test.go
@@ -16,6 +16,7 @@ package calc_test
 
 import (
 	"net"
+	"regexp"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -23,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/projectcalico/calico/felix/calc"
-	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/rules"
 	v3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	endpointDataTTLAfterMarkedAsRemoved = 2 * config.DefaultConntrackPollingInterval
+	testDeletionDelay = 100 * time.Millisecond
 )
 
 var (
@@ -40,7 +40,11 @@ var (
 )
 
 var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
-	ec := NewEndpointLookupsCache()
+	var ec *EndpointLookupsCache
+
+	BeforeEach(func() {
+		ec = NewEndpointLookupsCache(WithDeletionDelay(testDeletionDelay))
+	})
 
 	DescribeTable(
 		"Check adding/deleting workload endpoint modifies the cache",
@@ -63,12 +67,12 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 			// test GetEndpointByIP retrieves the endpointData
 			ed, ok := ec.GetEndpoint(addrB)
 			Expect(ok).To(BeTrue(), c)
-			Expect(ed.Key).To(Equal(key))
+			Expect(ed.Key()).To(Equal(key))
 
 			// test GetEndpointKeys
 			keys := ec.GetEndpointKeys()
 			Expect(len(keys)).To(Equal(1))
-			Expect(keys).To(ConsistOf(ed.Key))
+			Expect(keys).To(ConsistOf(ed.Key()))
 
 			// test GetAllEndpointData also contains the one
 			// retrieved by the IP
@@ -86,10 +90,18 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 
 			// OnUpdate delays deletion with delay
 			ec.OnUpdate(update)
-			_, ok = ec.GetEndpoint(addrB)
+			ed, ok = ec.GetEndpoint(addrB)
 			Expect(ok).To(BeTrue(), c)
+			Expect(ed.IsLocal()).To(BeFalse())
+			Expect(ed.IngressMatchData()).To(BeNil())
+			Expect(ed.EgressMatchData()).To(BeNil())
 
-			time.Sleep(endpointDataTTLAfterMarkedAsRemoved + 1*time.Second)
+			epExists := func() bool {
+				_, ok = ec.GetEndpoint(addrB)
+				return ok
+			}
+			Consistently(epExists, testDeletionDelay*80/100, time.Millisecond).Should(BeTrue())
+			Eventually(epExists, testDeletionDelay*40/100, time.Millisecond).Should(BeFalse())
 
 			_, ok = ec.GetEndpoint(addrB)
 			Expect(ok).To(BeFalse(), c)
@@ -97,7 +109,7 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 			// test GetEndpointKeys are empty after deletion
 			keys = ec.GetEndpointKeys()
 			Expect(len(keys)).To(Equal(0))
-			Expect(keys).NotTo(ConsistOf(ed.Key))
+			Expect(keys).NotTo(ConsistOf(ed.Key()))
 
 			// test GetAllEndpointData are empty after deletion
 			endpoints = ec.GetAllEndpointData()
@@ -127,7 +139,12 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 			ec.OnUpdate(update)
 			ed, ok := ec.GetEndpoint(addrB)
 			Expect(ok).To(BeTrue(), c)
-			Expect(ed.Key).To(Equal(key))
+			Expect(ed.Key()).To(Equal(key))
+
+			// DumpEndpoint is only used for debug, just a basic sanity check.
+			Expect(ec.DumpEndpoints()).To(ContainSubstring(ipAddr.String() + ": " + c))
+			dumpIPsRegexp := MatchRegexp(regexp.QuoteMeta(c) + ":.*" + regexp.QuoteMeta(ipAddr.String()))
+			Expect(ec.DumpEndpoints()).To(dumpIPsRegexp)
 
 			// deletion process
 			update = api.Update{
@@ -140,6 +157,8 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 			ec.OnUpdate(update)
 			_, ok = ec.GetEndpoint(addrB)
 			Expect(ok).To(BeTrue(), c)
+			Expect(ec.DumpEndpoints()).To(ContainSubstring(ipAddr.String() + ": " + c))
+			Expect(ec.DumpEndpoints()).To(ContainSubstring(c + ": deleted"))
 
 			// re-add entry before the deletion is delegated
 			update = api.Update{
@@ -152,12 +171,16 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 			ec.OnUpdate(update)
 			ed, ok = ec.GetEndpoint(addrB)
 			Expect(ok).To(BeTrue(), c)
-			Expect(ed.Key).To(Equal(key))
+			Expect(ed.Key()).To(Equal(key))
 
-			// re-fetching the entry after expected time it was deleted
-			time.Sleep(endpointDataTTLAfterMarkedAsRemoved + 1*time.Second)
-			_, ok = ec.GetEndpoint(addrB)
-			Expect(ok).To(BeTrue(), c)
+			// Verify that the deletion is cancelled.
+			epExists := func() bool {
+				_, ok = ec.GetEndpoint(addrB)
+				return ok
+			}
+			Consistently(epExists, testDeletionDelay*120/100, time.Millisecond).Should(BeTrue())
+			Expect(ec.DumpEndpoints()).To(ContainSubstring(ipAddr.String() + ": " + c))
+			Expect(ec.DumpEndpoints()).To(dumpIPsRegexp)
 		},
 		Entry("Host Endpoint IPv4", hostEpWithNameKey, &hostEpWithName, hostEpWithName.ExpectedIPv4Addrs[0].IP),
 		Entry("Host Endpoint IPv6", hostEpWithNameKey, &hostEpWithName, hostEpWithName.ExpectedIPv6Addrs[0].IP),
@@ -205,41 +228,43 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 		ts := newTierInfoSlice()
 		ts = append(ts, *t1, *td)
 
-		ed := ec.CreateEndpointData(hostEpWithNameKey, &hostEpWithName, ts)
+		var ed EndpointData = ec.CreateLocalEndpointData(hostEpWithNameKey, &hostEpWithName, ts)
 
 		By("checking endpoint data")
-		Expect(ed.Key).To(Equal(hostEpWithNameKey))
-		Expect(ed.IsLocal).To(BeTrue())
+		Expect(ed.Key()).To(Equal(hostEpWithNameKey))
+		Expect(ed.IsLocal()).To(BeTrue())
 		Expect(ed.IsHostEndpoint()).To(BeTrue())
-		Expect(ed.Endpoint).To(Equal(&hostEpWithName))
+		Expect(ed.GenerateName()).To(Equal(""))
+		Expect(ed.Labels()).To(Equal(hostEpWithName.Labels))
+		Expect(ed.IsHostEndpoint()).To(BeTrue())
 
 		By("checking compiled ingress data")
-		Expect(ed.Ingress).ToNot(BeNil())
-		Expect(ed.Ingress.PolicyMatches).To(HaveLen(1))
-		Expect(ed.Ingress.PolicyMatches).To(HaveKey(p1id))
-		Expect(ed.Ingress.PolicyMatches[p1id]).To(Equal(0))
-		Expect(ed.Ingress.ProfileMatchIndex).To(Equal(1))
-		Expect(ed.Ingress.TierData).To(HaveLen(1))
-		Expect(ed.Ingress.TierData).To(HaveKey("tier1"))
-		Expect(ed.Ingress.TierData["tier1"]).ToNot(BeNil())
-		Expect(ed.Ingress.TierData["tier1"].ImplicitDropRuleID).To(Equal(
+		Expect(ed.IngressMatchData()).ToNot(BeNil())
+		Expect(ed.IngressMatchData().PolicyMatches).To(HaveLen(1))
+		Expect(ed.IngressMatchData().PolicyMatches).To(HaveKey(p1id))
+		Expect(ed.IngressMatchData().PolicyMatches[p1id]).To(Equal(0))
+		Expect(ed.IngressMatchData().ProfileMatchIndex).To(Equal(1))
+		Expect(ed.IngressMatchData().TierData).To(HaveLen(1))
+		Expect(ed.IngressMatchData().TierData).To(HaveKey("tier1"))
+		Expect(ed.IngressMatchData().TierData["tier1"]).ToNot(BeNil())
+		Expect(ed.IngressMatchData().TierData["tier1"].ImplicitDropRuleID).To(Equal(
 			NewRuleID("tier1", "pol1", "", RuleIndexTierDefaultAction, rules.RuleDirIngress, rules.RuleActionDeny)))
-		Expect(ed.Ingress.TierData["tier1"].EndOfTierMatchIndex).To(Equal(0))
+		Expect(ed.IngressMatchData().TierData["tier1"].EndOfTierMatchIndex).To(Equal(0))
 
 		By("checking compiled egress data")
-		Expect(ed.Egress).ToNot(BeNil())
-		Expect(ed.Egress.PolicyMatches).To(HaveLen(2))
-		Expect(ed.Egress.PolicyMatches).To(HaveKey(p2id))
-		Expect(ed.Egress.PolicyMatches[p2id]).To(Equal(0))
-		Expect(ed.Egress.PolicyMatches).To(HaveKey(p3id))
-		Expect(ed.Egress.PolicyMatches[p3id]).To(Equal(0))
-		Expect(ed.Egress.ProfileMatchIndex).To(Equal(1))
-		Expect(ed.Egress.TierData).To(HaveLen(1))
-		Expect(ed.Egress.TierData).To(HaveKey("default"))
-		Expect(ed.Egress.TierData["default"]).ToNot(BeNil())
-		Expect(ed.Egress.TierData["default"].ImplicitDropRuleID).To(Equal(
+		Expect(ed.EgressMatchData()).ToNot(BeNil())
+		Expect(ed.EgressMatchData().PolicyMatches).To(HaveLen(2))
+		Expect(ed.EgressMatchData().PolicyMatches).To(HaveKey(p2id))
+		Expect(ed.EgressMatchData().PolicyMatches[p2id]).To(Equal(0))
+		Expect(ed.EgressMatchData().PolicyMatches).To(HaveKey(p3id))
+		Expect(ed.EgressMatchData().PolicyMatches[p3id]).To(Equal(0))
+		Expect(ed.EgressMatchData().ProfileMatchIndex).To(Equal(1))
+		Expect(ed.EgressMatchData().TierData).To(HaveLen(1))
+		Expect(ed.EgressMatchData().TierData).To(HaveKey("default"))
+		Expect(ed.EgressMatchData().TierData["default"]).ToNot(BeNil())
+		Expect(ed.EgressMatchData().TierData["default"].ImplicitDropRuleID).To(Equal(
 			NewRuleID("default", "pol3", "ns1", RuleIndexTierDefaultAction, rules.RuleDirEgress, rules.RuleActionDeny)))
-		Expect(ed.Egress.TierData["default"].EndOfTierMatchIndex).To(Equal(0))
+		Expect(ed.EgressMatchData().TierData["default"].EndOfTierMatchIndex).To(Equal(0))
 	})
 
 	DescribeTable(
@@ -325,24 +350,25 @@ var _ = Describe("EndpointLookupsCache tests: endpoints", func() {
 			ts := newTierInfoSlice()
 			ts = append(ts, *t1, *td)
 
-			ed := ec.CreateEndpointData(localWlEpKey1, &localWlEp1, ts)
+			var ed EndpointData = ec.CreateLocalEndpointData(localWlEpKey1, &localWlEp1, ts)
 
 			By("checking endpoint data")
-			Expect(ed.Key).To(Equal(localWlEpKey1))
-			Expect(ed.IsLocal).To(BeTrue())
+			Expect(ed.Key()).To(Equal(localWlEpKey1))
+			Expect(ed.IsLocal()).To(BeTrue())
+			Expect(ed.GenerateName()).To(Equal(localWlEp1.GenerateName))
+			Expect(ed.Labels()).To(Equal(localWlEp1.Labels))
 			Expect(ed.IsHostEndpoint()).To(BeFalse())
-			Expect(ed.Endpoint).To(Equal(&localWlEp1))
 
 			By("checking compiled data size for both tiers")
 			var data, other *MatchData
 			var ruleDir rules.RuleDir
 			if ingress {
-				data = ed.Ingress
-				other = ed.Egress
+				data = ed.IngressMatchData()
+				other = ed.EgressMatchData()
 				ruleDir = rules.RuleDirIngress
 			} else {
-				data = ed.Egress
-				other = ed.Ingress
+				data = ed.EgressMatchData()
+				other = ed.IngressMatchData()
 				ruleDir = rules.RuleDirEgress
 			}
 

--- a/felix/calc/lookups_cache.go
+++ b/felix/calc/lookups_cache.go
@@ -47,15 +47,8 @@ func NewLookupsCache() *LookupsCache {
 	return lc
 }
 
-// IsEndpoint returns true if the supplied address is a endpoint, otherwise returns false.
-// Use the EndpointData.IsLocal() method to check if an EndpointData object (returned by the
-// LookupsCache.GetEndpoint() method) is a local endpoint or not.
-func (lc *LookupsCache) IsEndpoint(addr [16]byte) bool {
-	return lc.epCache.IsEndpoint(addr)
-}
-
 // GetEndpoint returns the ordered list of tiers for a particular endpoint.
-func (lc *LookupsCache) GetEndpoint(addr [16]byte) (*EndpointData, bool) {
+func (lc *LookupsCache) GetEndpoint(addr [16]byte) (EndpointData, bool) {
 	return lc.epCache.GetEndpoint(addr)
 }
 
@@ -65,9 +58,9 @@ func (lc *LookupsCache) GetEndpointKeys() []model.Key {
 	return lc.epCache.GetEndpointKeys()
 }
 
-// GetEndpointData returns all endpoint data that the cache is tracking.
+// GetAllEndpointData returns all endpoint data that the cache is tracking.
 // Convenience method only used for testing purposes.
-func (lc *LookupsCache) GetAllEndpointData() []*EndpointData {
+func (lc *LookupsCache) GetAllEndpointData() []EndpointData {
 	return lc.epCache.GetAllEndpointData()
 }
 
@@ -82,7 +75,7 @@ func (lc *LookupsCache) GetNode(addr [16]byte) (string, bool) {
 
 // GetNetworkSet returns the networkset information for an address.
 // It returns the first networkset it finds that contains the given address.
-func (lc *LookupsCache) GetNetworkSet(addr [16]byte) (*EndpointData, bool) {
+func (lc *LookupsCache) GetNetworkSet(addr [16]byte) (EndpointData, bool) {
 	return lc.nsCache.GetNetworkSetFromIP(addr)
 }
 
@@ -124,7 +117,7 @@ func (lc *LookupsCache) GetServiceSpecFromResourceKey(key model.ResourceKey) (ka
 // SetMockData fills in some of the data structures for use in the test code. This should not
 // be called from any mainline code.
 func (lc *LookupsCache) SetMockData(
-	em map[[16]byte]*EndpointData,
+	em map[[16]byte]EndpointData,
 	nm map[[64]byte]*RuleID,
 	ns map[model.NetworkSetKey]*model.NetworkSet,
 	svcs map[model.ResourceKey]*kapiv1.Service,
@@ -133,7 +126,7 @@ func (lc *LookupsCache) SetMockData(
 		if ed == nil {
 			delete(lc.epCache.ipToEndpoints, ip)
 		} else {
-			lc.epCache.ipToEndpoints[ip] = []*EndpointData{ed}
+			lc.epCache.ipToEndpoints[ip] = []endpointData{ed.(endpointData)}
 		}
 	}
 	for id, rid := range nm {

--- a/felix/calc/networkset_lookup_cache_test.go
+++ b/felix/calc/networkset_lookup_cache_test.go
@@ -45,7 +45,7 @@ var _ = Describe("NetworkSetLookupsCache IP tests", func() {
 			ec.OnUpdate(update)
 			ed, ok := ec.GetNetworkSetFromIP(addrB)
 			Expect(ok).To(BeTrue(), c)
-			Expect(ed.Key).To(Equal(key))
+			Expect(ed.Key()).To(Equal(key))
 
 			update = api.Update{
 				KVPair: model.KVPair{
@@ -83,9 +83,9 @@ var _ = Describe("NetworkSetLookupsCache IP tests", func() {
 			ed, ok := ec.GetNetworkSetFromIP(addrB)
 			if exists {
 				Expect(ok).To(BeTrue(), name+"\n"+ec.DumpNetworksets())
-				Expect(ed.Key).To(Equal(key), ec.DumpNetworksets())
+				Expect(ed.Key()).To(Equal(key), ec.DumpNetworksets())
 				if labels != nil {
-					Expect(ed.Networkset.(*model.NetworkSet).Labels).To(Equal(labels), ec.DumpNetworksets())
+					Expect(ed.Labels()).To(Equal(labels), ec.DumpNetworksets())
 				}
 			} else {
 				Expect(ok).To(BeFalse(), name+".\n"+ec.DumpNetworksets())
@@ -206,7 +206,7 @@ var _ = Describe("NetworkSetLookupsCache IP tests", func() {
 			ed, ok := ec.GetNetworkSetFromIP(addrB)
 			if exists {
 				Expect(ok).To(BeTrue(), name+"\n"+ec.DumpNetworksets())
-				Expect(ed.Key).To(Equal(key))
+				Expect(ed.Key()).To(Equal(key))
 			} else {
 				Expect(ok).To(BeFalse(), name+".\n"+ec.DumpNetworksets())
 			}

--- a/felix/collector/flowlog/aggregator_test.go
+++ b/felix/collector/flowlog/aggregator_test.go
@@ -113,23 +113,27 @@ var (
 	muNoConn1Rule1AllowUpdateWithEndpointMeta = metric.Update{
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		HasDenyRule:  false,
@@ -293,24 +297,28 @@ var _ = Describe("Flow log aggregator tests", func() {
 			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.Tuple = tuple1Copy
 
 			// Updating the Workload IDs for src and dst.
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-01",
-					OrchestratorID: "k8s",
-					WorkloadID:     "kube-system/iperf-4235-5434134",
-					EndpointID:     "23456",
-				},
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-01",
+						OrchestratorID: "k8s",
+						WorkloadID:     "kube-system/iperf-4235-5434134",
+						EndpointID:     "23456",
+					},
+					&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+				),
 			}
 
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-02",
-					OrchestratorID: "k8s",
-					WorkloadID:     "default/nginx-412354-6543645",
-					EndpointID:     "256267",
-				},
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-02",
+						OrchestratorID: "k8s",
+						WorkloadID:     "default/nginx-412354-6543645",
+						EndpointID:     "256267",
+					},
+					&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+				),
 			}
 
 			Expect(ca.FeedUpdate(&muNoConn1Rule1AllowUpdateWithEndpointMetaCopy)).NotTo(HaveOccurred())
@@ -318,26 +326,30 @@ var _ = Describe("Flow log aggregator tests", func() {
 			// Two updates should still result in 1 flow
 			Expect(len(messages)).Should(Equal(1))
 			// Updating the Workload IDs and labels for src and dst.
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-01",
-					OrchestratorID: "k8s",
-					WorkloadID:     "kube-system/iperf-4235-5434134",
-					EndpointID:     "23456",
-				},
-				// this new MetricUpdates src endpointMeta has a different label than one currently being tracked.
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"prod-app": "true"}},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-01",
+						OrchestratorID: "k8s",
+						WorkloadID:     "kube-system/iperf-4235-5434134",
+						EndpointID:     "23456",
+					},
+					// this new MetricUpdates src endpointMeta has a different label than one currently being tracked.
+					&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"prod-app": "true"}},
+				),
 			}
 
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-02",
-					OrchestratorID: "k8s",
-					WorkloadID:     "default/nginx-412354-6543645",
-					EndpointID:     "256267",
-				},
-				// different label on the destination workload than one being tracked.
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "false"}},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-02",
+						OrchestratorID: "k8s",
+						WorkloadID:     "default/nginx-412354-6543645",
+						EndpointID:     "256267",
+					},
+					// different label on the destination workload than one being tracked.
+					&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "false"}},
+				),
 			}
 
 			Expect(ca.FeedUpdate(&muNoConn1Rule1AllowUpdateWithEndpointMetaCopy)).NotTo(HaveOccurred())
@@ -347,14 +359,17 @@ var _ = Describe("Flow log aggregator tests", func() {
 
 			By("by endpoint IP classification as the meta name when meta info is missing")
 			ca = NewAggregator()
-			endpointMeta := calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-01",
-					OrchestratorID: "k8s",
-					WorkloadID:     "kube-system/iperf-4235-5623461",
-					EndpointID:     "4352",
-				},
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			endpointMeta := calc.RemoteEndpointData{
+
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-01",
+						OrchestratorID: "k8s",
+						WorkloadID:     "kube-system/iperf-4235-5623461",
+						EndpointID:     "4352",
+					},
+					&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+				),
 			}
 
 			muWithoutDstEndpointMeta := metric.Update{
@@ -496,30 +511,36 @@ var _ = Describe("Flow log aggregator tests", func() {
 			// Construct a similar update; but the endpoints have different labels
 			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy := muNoConn1Rule1AllowUpdateWithEndpointMeta
 			// Updating the Workload IDs for src and dst.
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-01",
-					OrchestratorID: "k8s",
-					WorkloadID:     "kube-system/iperf-4235-5623461",
-					EndpointID:     "4352",
-				},
-				Endpoint: &model.WorkloadEndpoint{
-					GenerateName: "iperf-4235-",
-					Labels:       map[string]string{"test-app": "true", "new-label": "true"}, // "new-label" appended
-				},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.RemoteEndpointData{
+
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-01",
+						OrchestratorID: "k8s",
+						WorkloadID:     "kube-system/iperf-4235-5623461",
+						EndpointID:     "4352",
+					},
+					&model.WorkloadEndpoint{
+						GenerateName: "iperf-4235-",
+						Labels:       map[string]string{"test-app": "true", "new-label": "true"}, // "new-label" appended
+					},
+				),
 			}
 
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-02",
-					OrchestratorID: "k8s",
-					WorkloadID:     "default/nginx-412354-5123451",
-					EndpointID:     "4352",
-				},
-				Endpoint: &model.WorkloadEndpoint{
-					GenerateName: "nginx-412354-",
-					Labels:       map[string]string{"k8s-app": "false"}, // conflicting labels; originally "k8s-app": "true"
-				},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.RemoteEndpointData{
+
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-02",
+						OrchestratorID: "k8s",
+						WorkloadID:     "default/nginx-412354-5123451",
+						EndpointID:     "4352",
+					},
+					&model.WorkloadEndpoint{
+						GenerateName: "nginx-412354-",
+						Labels:       map[string]string{"k8s-app": "false"}, // conflicting labels; originally "k8s-app": "true"
+					},
+				),
 			}
 			Expect(ca.FeedUpdate(&muNoConn1Rule1AllowUpdateWithEndpointMetaCopy)).NotTo(HaveOccurred())
 			messages := ca.GetAndCalibrate()
@@ -555,30 +576,34 @@ var _ = Describe("Flow log aggregator tests", func() {
 			// Construct a similar update; but the endpoints have different labels
 			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy = muNoConn1Rule1AllowUpdateWithEndpointMeta
 			// Updating the Workload IDs for src and dst.
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-01",
-					OrchestratorID: "k8s",
-					WorkloadID:     "kube-system/iperf-4235-5623461",
-					EndpointID:     "4352",
-				},
-				Endpoint: &model.WorkloadEndpoint{
-					GenerateName: "iperf-4235-",
-					Labels:       map[string]string{"test-app": "true", "new-label": "true"}, // "new-label" appended
-				},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-01",
+						OrchestratorID: "k8s",
+						WorkloadID:     "kube-system/iperf-4235-5623461",
+						EndpointID:     "4352",
+					},
+					&model.WorkloadEndpoint{
+						GenerateName: "iperf-4235-",
+						Labels:       map[string]string{"test-app": "true", "new-label": "true"}, // "new-label" appended
+					},
+				),
 			}
 
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-02",
-					OrchestratorID: "k8s",
-					WorkloadID:     "default/nginx-412354-5123451",
-					EndpointID:     "4352",
-				},
-				Endpoint: &model.WorkloadEndpoint{
-					GenerateName: "nginx-412354-",
-					Labels:       map[string]string{"k8s-app": "false"}, // conflicting labels; originally "k8s-app": "true"
-				},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-02",
+						OrchestratorID: "k8s",
+						WorkloadID:     "default/nginx-412354-5123451",
+						EndpointID:     "4352",
+					},
+					&model.WorkloadEndpoint{
+						GenerateName: "nginx-412354-",
+						Labels:       map[string]string{"k8s-app": "false"}, // conflicting labels; originally "k8s-app": "true"
+					},
+				),
 			}
 			Expect(ca.FeedUpdate(&muNoConn1Rule1AllowUpdateWithEndpointMetaCopy)).NotTo(HaveOccurred())
 			messages = ca.GetAndCalibrate()
@@ -727,24 +752,29 @@ var _ = Describe("Flow log aggregator tests", func() {
 			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.Tuple = tuple1Copy
 
 			// Updating the Workload IDs for src and dst.
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-01",
-					OrchestratorID: "k8s",
-					WorkloadID:     "kube-system/iperf-4235-5434134",
-					EndpointID:     "23456",
-				},
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.SrcEp = &calc.RemoteEndpointData{
+
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-01",
+						OrchestratorID: "k8s",
+						WorkloadID:     "kube-system/iperf-4235-5434134",
+						EndpointID:     "23456",
+					},
+					&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+				),
 			}
 
-			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.EndpointData{
-				Key: model.WorkloadEndpointKey{
-					Hostname:       "node-02",
-					OrchestratorID: "k8s",
-					WorkloadID:     "default/nginx-412354-6543645",
-					EndpointID:     "256267",
-				},
-				Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			muNoConn1Rule1AllowUpdateWithEndpointMetaCopy.DstEp = &calc.RemoteEndpointData{
+				CommonEndpointData: calc.CalculateCommonEndpointData(
+					model.WorkloadEndpointKey{
+						Hostname:       "node-02",
+						OrchestratorID: "k8s",
+						WorkloadID:     "default/nginx-412354-6543645",
+						EndpointID:     "256267",
+					},
+					&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+				),
 			}
 
 			Expect(ca.FeedUpdate(&muNoConn1Rule1AllowUpdateWithEndpointMetaCopy)).NotTo(HaveOccurred())

--- a/felix/collector/flowlog/fixtures_test.go
+++ b/felix/collector/flowlog/fixtures_test.go
@@ -49,10 +49,9 @@ var (
 			"id": "loc-ep-1",
 		},
 	}
-	localHostEd1 = &calc.EndpointData{
-		Key:      localHostEpKey1,
-		Endpoint: localHostEp1,
-		IsLocal:  true,
+	localHostEd1 = &calc.LocalEndpointData{
+		CommonEndpointData: calc.CalculateCommonEndpointData(localHostEpKey1, localHostEp1),
+
 		Ingress: &calc.MatchData{
 			PolicyMatches: map[calc.PolicyID]int{
 				calc.PolicyID{Name: "policy1", Tier: "default"}: 0,
@@ -94,10 +93,8 @@ var (
 			"id": "rem-ep-1",
 		},
 	}
-	remoteHostEd1 = &calc.EndpointData{
-		Key:      remoteHostEpKey1,
-		Endpoint: remoteHostEp1,
-		IsLocal:  false,
+	remoteHostEd1 = &calc.RemoteEndpointData{
+		CommonEndpointData: calc.CalculateCommonEndpointData(remoteHostEpKey1, remoteHostEp1),
 	}
 
 	flowMetaDefault = FlowMeta{
@@ -442,23 +439,27 @@ var (
 	muWithEndpointMeta = metric.Update{
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		IsConnection: false,
@@ -471,23 +472,27 @@ var (
 	muWithEndpointMetaExpire = metric.Update{
 		UpdateType: metric.UpdateTypeExpire,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		IsConnection: false,
@@ -496,23 +501,27 @@ var (
 	muWithEndpointMetaWithService = metric.Update{
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		DstService: metric.ServiceInfo{
 			ServicePortName: proxy.ServicePortName{
@@ -535,23 +544,27 @@ var (
 	muWithEndpointMetaAndDifferentLabels = metric.Update{
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true", "new-label": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true", "new-label": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "false"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "false"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		IsConnection: false,
@@ -565,14 +578,16 @@ var (
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
 		SrcEp:      nil,
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		IsConnection: false,
@@ -585,14 +600,16 @@ var (
 	muWithoutDstEndpointMeta = metric.Update{
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
 		DstEp:        nil,
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
@@ -607,14 +624,16 @@ var (
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
 		SrcEp:      nil,
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		OrigSourceIPs: boundedset.NewFromSlice(testMaxBoundedSetSize, []net.IP{net.ParseIP(publicIP1Str)}),
 		RuleIDs:       []*calc.RuleID{ingressRule1Allow},
@@ -629,14 +648,16 @@ var (
 		UpdateType: metric.UpdateTypeExpire,
 		Tuple:      tuple1,
 		SrcEp:      nil,
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		OrigSourceIPs: boundedset.NewFromSlice(testMaxBoundedSetSize, []net.IP{net.ParseIP(publicIP1Str)}),
 		RuleIDs:       []*calc.RuleID{ingressRule1Allow},
@@ -671,14 +692,16 @@ var (
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
 		SrcEp:      nil,
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		OrigSourceIPs: boundedset.NewFromSlice(testMaxBoundedSetSize, []net.IP{net.ParseIP(publicIP1Str), net.ParseIP(publicIP2Str)}),
 		RuleIDs:       []*calc.RuleID{ingressRule1Allow},
@@ -692,23 +715,27 @@ var (
 	muWithEndpointMetaWithoutGenerateName = metric.Update{
 		UpdateType: metric.UpdateTypeReport,
 		Tuple:      tuple1,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/manually-created-pod",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/manually-created-pod",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		IsConnection: false,
@@ -723,23 +750,27 @@ var (
 		UpdateType:      metric.UpdateTypeReport,
 		Tuple:           tuple1,
 		NatOutgoingPort: 6789,
-		SrcEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-01",
-				OrchestratorID: "k8s",
-				WorkloadID:     "kube-system/iperf-4235-5623461",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+		SrcEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-01",
+					OrchestratorID: "k8s",
+					WorkloadID:     "kube-system/iperf-4235-5623461",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "iperf-4235-", Labels: map[string]string{"test-app": "true"}},
+			),
 		},
-		DstEp: &calc.EndpointData{
-			Key: model.WorkloadEndpointKey{
-				Hostname:       "node-02",
-				OrchestratorID: "k8s",
-				WorkloadID:     "default/nginx-412354-5123451",
-				EndpointID:     "4352",
-			},
-			Endpoint: &model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+		DstEp: &calc.RemoteEndpointData{
+			CommonEndpointData: calc.CalculateCommonEndpointData(
+				model.WorkloadEndpointKey{
+					Hostname:       "node-02",
+					OrchestratorID: "k8s",
+					WorkloadID:     "default/nginx-412354-5123451",
+					EndpointID:     "4352",
+				},
+				&model.WorkloadEndpoint{GenerateName: "nginx-412354-", Labels: map[string]string{"k8s-app": "true"}},
+			),
 		},
 		RuleIDs:      []*calc.RuleID{ingressRule1Allow},
 		IsConnection: false,

--- a/felix/collector/stats.go
+++ b/felix/collector/stats.go
@@ -322,8 +322,8 @@ type Data struct {
 	// Contains endpoint information corresponding to source and
 	// destination endpoints. Either of these values can be nil
 	// if we don't have information about the endpoint.
-	SrcEp *calc.EndpointData
-	DstEp *calc.EndpointData
+	SrcEp calc.EndpointData
+	DstEp calc.EndpointData
 
 	// Pre-DNAT information used to lookup the service information.
 	IsDNAT      bool
@@ -365,7 +365,7 @@ type Data struct {
 	Expired              bool
 }
 
-func NewData(tuple tuple.Tuple, srcEp, dstEp *calc.EndpointData, maxOriginalIPsSize int) *Data {
+func NewData(tuple tuple.Tuple, srcEp, dstEp calc.EndpointData, maxOriginalIPsSize int) *Data {
 	now := monotime.Now()
 	d := &Data{
 		Tuple:         tuple,
@@ -389,12 +389,12 @@ func (d *Data) String() string {
 		osiTc            int
 	)
 	if d.SrcEp != nil {
-		srcName = utils.EndpointName(d.SrcEp.Key)
+		srcName = utils.EndpointName(d.SrcEp.Key())
 	} else {
 		srcName = utils.UnknownEndpoint
 	}
 	if d.DstEp != nil {
-		dstName = utils.EndpointName(d.DstEp.Key)
+		dstName = utils.EndpointName(d.DstEp.Key())
 	} else {
 		dstName = utils.UnknownEndpoint
 	}
@@ -509,8 +509,8 @@ func (d *Data) SetExpired() {
 // For such cases we make an exception in this logic
 func (d *Data) VerdictFound() bool {
 	// We expect at least one of the source or dest to be a local endpoint.
-	srcIsLocal := d.SrcEp != nil && d.SrcEp.IsLocal
-	dstIsLocal := d.DstEp != nil && d.DstEp.IsLocal
+	srcIsLocal := d.SrcEp != nil && d.SrcEp.IsLocal()
+	dstIsLocal := d.DstEp != nil && d.DstEp.IsLocal()
 
 	if d.IsProxied {
 		// This is a proxied flow, we'll see both legs but we only expect a verdict for one of them

--- a/felix/collector/types/metric/metric.go
+++ b/felix/collector/types/metric/metric.go
@@ -83,8 +83,8 @@ type Update struct {
 	OrigSourceIPs   *boundedset.BoundedSet
 
 	// Endpoint information.
-	SrcEp      *calc.EndpointData
-	DstEp      *calc.EndpointData
+	SrcEp      calc.EndpointData
+	DstEp      calc.EndpointData
 	DstService ServiceInfo
 
 	// isConnection is true if this update is from an active connection.
@@ -115,12 +115,12 @@ func (mu Update) String() string {
 		origIPs          []net.IP
 	)
 	if mu.SrcEp != nil {
-		srcName = utils.EndpointName(mu.SrcEp.Key)
+		srcName = utils.EndpointName(mu.SrcEp.Key())
 	} else {
 		srcName = utils.UnknownEndpoint
 	}
 	if mu.DstEp != nil {
-		dstName = utils.EndpointName(mu.DstEp.Key)
+		dstName = utils.EndpointName(mu.DstEp.Key())
 	} else {
 		dstName = utils.UnknownEndpoint
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Avoid storing complete `WorkloadEndpoint`/`HostEndpoint` objects in the EndpointLookupCache.  Extract the required fields and store only what is needed.  The rest of the calculation graph already discards data it doesn't need to reduce occupancy, but a single new place that stores the "original" object results in storing *both* the full original object and the smaller extracted structs elsewhere.

- Split the cache into local and remote maps.  

   - We need to store more information about local endpoints so splitting the type of the cache entry avoids storing extra fields for every remote endpoint.  
   - Using two maps instead of a map with interface value saves 8 bytes per map slot.  
   - Using two types stores the "is local" bool in the type rather than the value, saving another 8 bytes.

- Expose the EndpointData as an interface instead of a struct for the collector/aggregator to use.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-11061
Builds on #9977 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
