### PR TITLE
OpenStack: Complete what we need for QoS support in our driver

### DIFF
--- a/networking-calico/networking_calico/plugins/calico/plugin.py
+++ b/networking-calico/networking_calico/plugins/calico/plugin.py
@@ -50,6 +50,8 @@ class CalicoPlugin(Ml2Plugin, l3_db.L3_NAT_db_mixin):
         cfg.CONF.set_override('type_drivers', ['local', 'flat'], group='ml2')
         LOG.info("Forcing ML2 tenant_network_types to 'local'")
         cfg.CONF.set_override('tenant_network_types', ['local'], group='ml2')
+        LOG.info("Forcing ML2 extension_drivers to 'qos'")
+        cfg.CONF.set_override('extension_drivers', ['qos'], group='ml2')
 
         # This is a bit of a hack to get the models_v2.Port attributes setup in such
         # a way as to avoid tracebacks in the neutron-server log.

--- a/networking-calico/networking_calico/plugins/calico/plugin.py
+++ b/networking-calico/networking_calico/plugins/calico/plugin.py
@@ -50,8 +50,13 @@ class CalicoPlugin(Ml2Plugin, l3_db.L3_NAT_db_mixin):
         cfg.CONF.set_override('type_drivers', ['local', 'flat'], group='ml2')
         LOG.info("Forcing ML2 tenant_network_types to 'local'")
         cfg.CONF.set_override('tenant_network_types', ['local'], group='ml2')
-        LOG.info("Forcing ML2 extension_drivers to 'qos'")
-        cfg.CONF.set_override('extension_drivers', ['qos'], group='ml2')
+
+        # Here we add, rather than forcing the entire value, because DevStack
+        # testing configures 'port-security' here.
+        LOG.info("Add 'qos' to ML2 extension_drivers")
+        cfg.CONF.set_override('extension_drivers',
+                              cfg.CONF.ml2.extension_drivers + ['qos'],
+                              group='ml2')
 
         # This is a bit of a hack to get the models_v2.Port attributes setup in such
         # a way as to avoid tracebacks in the neutron-server log.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -80,6 +80,8 @@ from networking_calico.plugins.ml2.drivers.calico.endpoints import \
 from networking_calico.plugins.ml2.drivers.calico.endpoints import \
     WorkloadEndpointSyncer
 from networking_calico.plugins.ml2.drivers.calico.policy import PolicySyncer
+from networking_calico.plugins.ml2.drivers.calico.qos_driver import register \
+    as register_qos_driver
 from networking_calico.plugins.ml2.drivers.calico.status import StatusWatcher
 from networking_calico.plugins.ml2.drivers.calico.subnets import SubnetSyncer
 
@@ -195,6 +197,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             'tap',
             {'port_filter': True,
              'mac_address': '00:61:fe:ed:ca:fe'})
+        register_qos_driver()
         # Lock to prevent concurrent initialisation.
         self._init_lock = Semaphore()
         # Generally initialize attributes to nil values.  They get initialized

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/qos_driver.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/qos_driver.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025 Tigera, Inc. All rights reserved.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from networking_calico.compat import log
+
+from neutron_lib import constants
+from neutron_lib.api.definitions import portbindings
+from neutron_lib.db import constants as db_consts
+from neutron_lib.services.qos import base
+from neutron_lib.services.qos import constants as qos_consts
+
+
+LOG = log.getLogger(__name__)
+
+DRIVER = None
+
+SUPPORTED_RULES = {
+    qos_consts.RULE_TYPE_BANDWIDTH_LIMIT: {
+        qos_consts.MAX_KBPS: {
+            'type:range': [0, db_consts.DB_INTEGER_MAX_VALUE]},
+        qos_consts.MAX_BURST: {
+            'type:range': [0, db_consts.DB_INTEGER_MAX_VALUE]},
+        qos_consts.DIRECTION: {
+            'type:values': constants.VALID_DIRECTIONS}
+    },
+    qos_consts.RULE_TYPE_PACKET_RATE_LIMIT: {
+        qos_consts.MAX_KPPS: {
+            'type:range': [0, db_consts.DB_INTEGER_MAX_VALUE]},
+        qos_consts.MAX_BURST_KPPS: {
+            'type:range': [0, 0]},
+        qos_consts.DIRECTION: {
+            'type:values': constants.VALID_DIRECTIONS}
+    },
+}
+
+
+class CalicoQoSDriver(base.DriverBase):
+
+    @staticmethod
+    def create():
+        return CalicoQoSDriver(
+            name='calico',
+            vif_types=[portbindings.VIF_TYPE_TAP],
+            vnic_types=[portbindings.VNIC_NORMAL],
+            supported_rules=SUPPORTED_RULES,
+            requires_rpc_notifications=False)
+
+
+def register():
+    """Register the driver."""
+    global DRIVER
+    if not DRIVER:
+        DRIVER = CalicoQoSDriver.create()
+    LOG.debug('Calico QoS driver registered')


### PR DESCRIPTION
Sorry, these are more required plumbing changes that I missed in #9811 and #9856.

Also a key fix to query bandwidth limit and packet rate rules directly, instead of via the policy, as the policy object does not really have a 'rules' attribute.

After these, I've verified that I can execute the QoS workflow in https://docs.openstack.org/neutron/latest/admin/config-qos.html#user-workflow.