### PR TITLE
fix when CertFile and Cert is ""

### DIFF
--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -99,7 +99,8 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 			Key:    config.EtcdKey,
 		}
 		tlsConfig, err = tlsInfo.ClientConfigInlineCertKey()
-	} else {
+	}
+	if haveFiles {
 		tlsInfo := &transport.TLSInfo{
 			TrustedCAFile: config.EtcdCACertFile,
 			CertFile:      config.EtcdCertFile,
@@ -112,12 +113,14 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 		return nil, fmt.Errorf("could not initialize etcdv3 client: %+v", err)
 	}
 
-	baseTLSConfig := calicotls.NewTLSConfig()
-	tlsConfig.MaxVersion = baseTLSConfig.MaxVersion
-	tlsConfig.MinVersion = baseTLSConfig.MinVersion
-	tlsConfig.CipherSuites = baseTLSConfig.CipherSuites
-	tlsConfig.CurvePreferences = baseTLSConfig.CurvePreferences
-	tlsConfig.Renegotiation = baseTLSConfig.Renegotiation
+	if tlsConfig != nil {
+		baseTLSConfig := calicotls.NewTLSConfig()
+		tlsConfig.MaxVersion = baseTLSConfig.MaxVersion
+		tlsConfig.MinVersion = baseTLSConfig.MinVersion
+		tlsConfig.CipherSuites = baseTLSConfig.CipherSuites
+		tlsConfig.CurvePreferences = baseTLSConfig.CurvePreferences
+		tlsConfig.Renegotiation = baseTLSConfig.Renegotiation
+	}
 
 	// Build the etcdv3 config.
 	cfg := clientv3.Config{


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
When my etcd is not configured with a file such as cert, this code is problematic.
With the original code, it is predictable that the default user of the code filled in the details of the cert, or the location of the cert file. This results in an etcd with no cert configured and a connection error.
## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/9883

<!-- If appropriate, include a link to the issue this fixes.
fixes [<ISSUE LINK>](https://github.com/projectcalico/calico/issues/9883)

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
