### PR TITLE
optimizes ResolvePools

### DIFF
--- a/cni-plugin/internal/pkg/utils/utils.go
+++ b/cni-plugin/internal/pkg/utils/utils.go
@@ -769,6 +769,11 @@ func ConfigureLogging(conf types.NetConf) {
 
 // ResolvePools takes an array of CIDRs or IP Pool names and resolves it to a slice of pool CIDRs.
 func ResolvePools(ctx context.Context, c client.Interface, pools []string, isv4 bool) ([]cnet.IPNet, error) {
+	// if pools are empty,return directly
+	if len(pools) == 0 {
+		return []cnet.IPNet{}, nil
+	}
+
 	// First, query all IP pools. We need these so we can resolve names to CIDRs.
 	pl, err := c.IPPools().List(ctx, options.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
## Description

This PR optimizes the implementation of the `ResolvePools` method. reduces unnecessary calls to k8s apiserver.
When there is no `IPv4Pools` or `IPv6Pools` in ipam  configuration, the result of list the `IPPools` has no effect.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Optimization: avoid listing all IPPools for simple IPAM assignments.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
