### PR TITLE
Add ctx in PoolAccessorInterface

### DIFF
--- a/libcalico-go/lib/clientv3/client.go
+++ b/libcalico-go/lib/clientv3/client.go
@@ -199,8 +199,8 @@ type poolAccessor struct {
 	client *client
 }
 
-func (p poolAccessor) GetEnabledPools(ipVersion int) ([]v3.IPPool, error) {
-	return p.getPools(func(pool *v3.IPPool) bool {
+func (p poolAccessor) GetEnabledPools(ctx context.Context, ipVersion int) ([]v3.IPPool, error) {
+	return p.getPools(ctx, func(pool *v3.IPPool) bool {
 		if pool.Spec.Disabled {
 			log.Debugf("Skipping disabled IP pool (%s)", pool.Name)
 			return false
@@ -217,8 +217,8 @@ func (p poolAccessor) GetEnabledPools(ipVersion int) ([]v3.IPPool, error) {
 	})
 }
 
-func (p poolAccessor) getPools(filter func(pool *v3.IPPool) bool) ([]v3.IPPool, error) {
-	pools, err := p.client.IPPools().List(context.Background(), options.ListOptions{})
+func (p poolAccessor) getPools(ctx context.Context, filter func(pool *v3.IPPool) bool) ([]v3.IPPool, error) {
+	pools, err := p.client.IPPools().List(ctx, options.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -232,8 +232,8 @@ func (p poolAccessor) getPools(filter func(pool *v3.IPPool) bool) ([]v3.IPPool, 
 	return filtered, nil
 }
 
-func (p poolAccessor) GetAllPools() ([]v3.IPPool, error) {
-	return p.getPools(func(pool *v3.IPPool) bool {
+func (p poolAccessor) GetAllPools(ctx context.Context) ([]v3.IPPool, error) {
+	return p.getPools(ctx, func(pool *v3.IPPool) bool {
 		return true
 	})
 }

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer.go
@@ -451,10 +451,10 @@ func (rw blockReaderWriter) deleteHandle(ctx context.Context, kvp *model.KVPair)
 
 // getPoolForIP returns the pool if the given IP is within a configured
 // Calico pool, and nil otherwise.
-func (rw blockReaderWriter) getPoolForIP(ip cnet.IP, enabledPools []v3.IPPool) (*v3.IPPool, error) {
+func (rw blockReaderWriter) getPoolForIP(ctx context.Context, ip cnet.IP, enabledPools []v3.IPPool) (*v3.IPPool, error) {
 	if enabledPools == nil {
 		var err error
-		enabledPools, err = rw.pools.GetEnabledPools(ip.Version())
+		enabledPools, err = rw.pools.GetEnabledPools(ctx, ip.Version())
 		if err != nil {
 			return nil, err
 		}

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -61,7 +61,7 @@ type pool struct {
 	assignmentMode v3.AssignmentMode
 }
 
-func (i *ipPoolAccessor) GetEnabledPools(ipVersion int) ([]v3.IPPool, error) {
+func (i *ipPoolAccessor) GetEnabledPools(ctx context.Context, ipVersion int) ([]v3.IPPool, error) {
 	sorted := make([]string, 0)
 	// Get a sorted list of enabled pool CIDR strings.
 	for p, e := range i.pools {
@@ -115,7 +115,7 @@ func (i *ipPoolAccessor) getPools(sorted []string, ipVersion int, caller string)
 	return pools
 }
 
-func (i *ipPoolAccessor) GetAllPools() ([]v3.IPPool, error) {
+func (i *ipPoolAccessor) GetAllPools(ctx context.Context) ([]v3.IPPool, error) {
 	sorted := make([]string, 0)
 	// Get a sorted list of pool CIDR strings.
 	for p := range i.pools {
@@ -1008,10 +1008,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				deleteAllPools()
 				applyPool("20.0.0.0/24", true, "")
 
-				p, _ := ipPools.GetEnabledPools(4)
+				p, _ := ipPools.GetEnabledPools(context.Background(), 4)
 				Expect(len(p)).To(Equal(1))
 				Expect(p[0].Spec.CIDR).To(Equal(pool2.String()))
-				p, _ = ipPools.GetEnabledPools(6)
+				p, _ = ipPools.GetEnabledPools(context.Background(), 6)
 				Expect(len(p)).To(BeZero())
 
 				args := AutoAssignArgs{
@@ -2389,7 +2389,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyNode(bc, kc, host, nil)
 			// ippool with 4 ips
 			ipPools.pools[pool1.String()] = pool{enabled: true, nodeSelector: "", blockSize: 30}
-			pools, _ = ipPools.GetEnabledPools(4)
+			pools, _ = ipPools.GetEnabledPools(context.Background(), 4)
 			Expect(len(pools)).To(Equal(1))
 
 			ctx = context.Background()

--- a/libcalico-go/lib/ipam/ipam_win_test.go
+++ b/libcalico-go/lib/ipam/ipam_win_test.go
@@ -44,7 +44,7 @@ type ipamClientWindows struct {
 
 // Returns the block CIDR for the given IP
 func (c ipamClientWindows) GetAssignmentBlockCIDR(ctx context.Context, addr cnet.IP) cnet.IPNet {
-	pool, err := c.blockReaderWriter.getPoolForIP(addr, nil)
+	pool, err := c.blockReaderWriter.getPoolForIP(ctx, addr, nil)
 	Expect(err).NotTo(HaveOccurred())
 	blockCIDR := getBlockCIDRForAddress(addr, pool)
 	return blockCIDR

--- a/libcalico-go/lib/ipam/pools.go
+++ b/libcalico-go/lib/ipam/pools.go
@@ -14,6 +14,8 @@
 package ipam
 
 import (
+	"context"
+
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
@@ -23,9 +25,9 @@ import (
 // Interface used to access the enabled IPPools.
 type PoolAccessorInterface interface {
 	// Returns a list of enabled pools sorted in alphanumeric name order.
-	GetEnabledPools(ipVersion int) ([]v3.IPPool, error)
+	GetEnabledPools(ctx context.Context, ipVersion int) ([]v3.IPPool, error)
 	// Returns a list of all pools sorted in alphanumeric name order.
-	GetAllPools() ([]v3.IPPool, error)
+	GetAllPools(ctx context.Context) ([]v3.IPPool, error)
 }
 
 // SelectsNode determines whether or not the IPPool's nodeSelector

--- a/node/pkg/allocateip/allocateip_test.go
+++ b/node/pkg/allocateip/allocateip_test.go
@@ -1478,11 +1478,11 @@ func newIPPoolErrorAccessor(err error) *ipPoolErrorAccessor {
 	return &ipPoolErrorAccessor{err}
 }
 
-func (i *ipPoolErrorAccessor) GetEnabledPools(ipVersion int) ([]api.IPPool, error) {
+func (i *ipPoolErrorAccessor) GetEnabledPools(ctx context.Context, ipVersion int) ([]api.IPPool, error) {
 	return nil, i.err
 }
 
-func (i *ipPoolErrorAccessor) GetAllPools() ([]api.IPPool, error) {
+func (i *ipPoolErrorAccessor) GetAllPools(ctx context.Context) ([]api.IPPool, error) {
 	return nil, i.err
 }
 


### PR DESCRIPTION
## Description
List the IP pools by making use of the `context` (ctx). Make sure to prevent it from being indefinitely suspended in the event of an exception.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
