### PR TITLE
LoadBalancer kube-controller release IPs when last IPPool is deleted

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -386,6 +386,22 @@ func (c *loadBalancerController) syncIPAM() {
 // - Updates the IP addresses in the Service Status to match the IPAM DB.
 func (c *loadBalancerController) syncService(svcKey serviceKey) error {
 	if len(c.ipPools) == 0 {
+		if _, ok := c.allocationTracker.ipsByService[svcKey]; ok {
+			// Last LoadBalancer IPPool was deleted, and we have previously assigned IPs to this service. We need to release the IPs now and update the service status
+			err := c.releaseIPsByHandle(svcKey)
+			if err != nil {
+				return err
+			}
+			svc, err := c.serviceLister.Services(svcKey.namespace).Get(svcKey.name)
+			if err != nil {
+				return err
+			}
+			err = c.updateServiceStatus(svc, svcKey)
+			if err != nil {
+				log.WithError(err).Errorf("Failed to update service status for %s/%s", svc.Namespace, svc.Name)
+				return err
+			}
+		}
 		// We can skip service sync if there are no ippools defined that can be used for Service LoadBalancer
 		log.Debugf("No ippools with allowedUse LoadBalancer found. Skipping IP assignment for Service %s/%s", svcKey.namespace, svcKey.name)
 		return nil

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_fv_test.go
@@ -228,6 +228,31 @@ var _ = Describe("Calico loadbalancer controller FV tests (etcd mode)", func() {
 			}, time.Second*15, 500*time.Millisecond).ShouldNot(BeEmpty())
 		})
 
+		It("Should remove previously assigned IP when all IPPools are deleted", func() {
+			_, err := k8sClient.CoreV1().Services(testNamespace).Create(context.Background(), &basicService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []v1.LoadBalancerIngress {
+				service, _ := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), basicService.Name, metav1.GetOptions{})
+				return service.Status.LoadBalancer.Ingress
+			}, time.Second*15, 500*time.Millisecond).ShouldNot(BeEmpty())
+
+			_, err = calicoClient.IPPools().Delete(context.Background(), v4poolManual.Name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = calicoClient.IPPools().Delete(context.Background(), v4poolManualSpecific.Name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// We delete the automatic pool last, ensuring that the service will not be reassigned IP before last pool is deleted
+			_, err = calicoClient.IPPools().Delete(context.Background(), v4poolAutomatic.Name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []v1.LoadBalancerIngress {
+				service, _ := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), basicService.Name, metav1.GetOptions{})
+				return service.Status.LoadBalancer.Ingress
+			}, time.Second*15, 500*time.Millisecond).Should(BeEmpty())
+		})
+
 		It("Should assign IP from specified IP pool", func() {
 			_, err := k8sClient.CoreV1().Services(testNamespace).Create(context.Background(), &serviceIpv4PoolSpecified, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -310,7 +310,7 @@ func (c ipamClient) determinePools(ctx context.Context, requestedPoolNets []net.
 	// We only want to use IP pools which actually match this node, so do a filter based on
 	// selector. Additionally, we check the ippools assignmentMode type so we don't use ips from Manual pool when no pool was specified
 	for _, pool := range enabledPools {
-		if len(requestedPools) == 0 && *pool.Spec.AssignmentMode != v3.Automatic {
+		if len(requestedPoolNets) == 0 && *pool.Spec.AssignmentMode != v3.Automatic {
 			continue
 		}
 		var matches bool

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -310,7 +310,7 @@ func (c ipamClient) determinePools(ctx context.Context, requestedPoolNets []net.
 	// We only want to use IP pools which actually match this node, so do a filter based on
 	// selector. Additionally, we check the ippools assignmentMode type so we don't use ips from Manual pool when no pool was specified
 	for _, pool := range enabledPools {
-		if requestedPoolNets == nil && *pool.Spec.AssignmentMode != v3.Automatic {
+		if len(requestedPools) == 0 && *pool.Spec.AssignmentMode != v3.Automatic {
 			continue
 		}
 		var matches bool


### PR DESCRIPTION
## Description
Update for the LoadBalancer kube-controller to be able to update service status and release any assigned IPs when the last LoadBalancer IPPool is deleted

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
