### PR TITLE
Allow users to disable generating pending trace in flowlogs

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -114,6 +114,14 @@ const (
 	WindowsManageFirewallRulesDisabled WindowsManageFirewallRulesMode = "Disabled"
 )
 
+// +kubebuilder:validation:Enum=OnNewConnection;Continuous
+type FlowLogsPolicyEvaluationModeType string
+
+const (
+	FlowLogsPolicyEvaluationModeOnNewConnection FlowLogsPolicyEvaluationModeType = "OnNewConnection"
+	FlowLogsPolicyEvaluationModeContinuous      FlowLogsPolicyEvaluationModeType = "Continuous"
+)
+
 // FelixConfigurationSpec contains the values of the Felix configuration.
 type FelixConfigurationSpec struct {
 	// UseInternalDataplaneDriver, if true, Felix will use its internal dataplane programming logic.  If false, it
@@ -798,6 +806,15 @@ type FelixConfigurationSpec struct {
 	// [Default: 1]
 	BPFExportBufferSizeMB *int `json:"bpfExportBufferSizeMB,omitempty" validate:"omitempty,cidrs"`
 
+	// FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+	// OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+	// made in the dataplane. Staged/active policy changes will not be reflected in the
+	// `pending_policies` field of flow logs for long lived connections.
+	// Continuous - Felix evaluates active flows on a regular basis to determine the rule
+	// traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+	// pending_policies field, offering a near-real-time view of policy changes across flows.
+	// [Default: Continuous]
+	FlowLogsPolicyEvaluationMode *string `json:"flowLogsPolicyEvaluationMode,omitempty"`
 	// BPFRedirectToPeer controls which whether it is allowed to forward straight to the
 	// peer side of the workload devices. It is allowed for any host L2 devices by default
 	// (L2Only), but it breaks TCP dump on the host side of workload device as it bypasses

--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -114,12 +114,12 @@ const (
 	WindowsManageFirewallRulesDisabled WindowsManageFirewallRulesMode = "Disabled"
 )
 
-// +kubebuilder:validation:Enum=OnNewConnection;Continuous
+// +kubebuilder:validation:Enum=None;Continuous
 type FlowLogsPolicyEvaluationModeType string
 
 const (
-	FlowLogsPolicyEvaluationModeOnNewConnection FlowLogsPolicyEvaluationModeType = "OnNewConnection"
-	FlowLogsPolicyEvaluationModeContinuous      FlowLogsPolicyEvaluationModeType = "Continuous"
+	FlowLogsPolicyEvaluationModNone        FlowLogsPolicyEvaluationModeType = "None"
+	FlowLogsPolicyEvaluationModeContinuous FlowLogsPolicyEvaluationModeType = "Continuous"
 )
 
 // FelixConfigurationSpec contains the values of the Felix configuration.
@@ -814,7 +814,7 @@ type FelixConfigurationSpec struct {
 	// traces in the flow logs. Any policy updates that impact a flow will be reflected in the
 	// pending_policies field, offering a near-real-time view of policy changes across flows.
 	// [Default: Continuous]
-	FlowLogsPolicyEvaluationMode *string `json:"flowLogsPolicyEvaluationMode,omitempty"`
+	FlowLogsPolicyEvaluationMode *FlowLogsPolicyEvaluationModeType `json:"flowLogsPolicyEvaluationMode,omitempty"`
 	// BPFRedirectToPeer controls which whether it is allowed to forward straight to the
 	// peer side of the workload devices. It is allowed for any host L2 devices by default
 	// (L2Only), but it breaks TCP dump on the host side of workload device as it bypasses

--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -118,7 +118,7 @@ const (
 type FlowLogsPolicyEvaluationModeType string
 
 const (
-	FlowLogsPolicyEvaluationModNone        FlowLogsPolicyEvaluationModeType = "None"
+	FlowLogsPolicyEvaluationModeNone       FlowLogsPolicyEvaluationModeType = "None"
 	FlowLogsPolicyEvaluationModeContinuous FlowLogsPolicyEvaluationModeType = "Continuous"
 )
 
@@ -806,15 +806,13 @@ type FelixConfigurationSpec struct {
 	// [Default: 1]
 	BPFExportBufferSizeMB *int `json:"bpfExportBufferSizeMB,omitempty" validate:"omitempty,cidrs"`
 
-	// FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-	// OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-	// made in the dataplane. Staged/active policy changes will not be reflected in the
-	// `pending_policies` field of flow logs for long lived connections.
 	// Continuous - Felix evaluates active flows on a regular basis to determine the rule
 	// traces in the flow logs. Any policy updates that impact a flow will be reflected in the
 	// pending_policies field, offering a near-real-time view of policy changes across flows.
+	// None - Felix stops evaluating pending traces.
 	// [Default: Continuous]
 	FlowLogsPolicyEvaluationMode *FlowLogsPolicyEvaluationModeType `json:"flowLogsPolicyEvaluationMode,omitempty"`
+
 	// BPFRedirectToPeer controls which whether it is allowed to forward straight to the
 	// peer side of the workload devices. It is allowed for any host L2 devices by default
 	// (L2Only), but it breaks TCP dump on the host side of workload device as it bypasses

--- a/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1606,6 +1606,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.FlowLogsPolicyEvaluationMode != nil {
+		in, out := &in.FlowLogsPolicyEvaluationMode, &out.FlowLogsPolicyEvaluationMode
+		*out = new(string)
+		**out = **in
+	}
 	if in.FlowLogsFlushInterval != nil {
 		in, out := &in.FlowLogsFlushInterval, &out.FlowLogsFlushInterval
 		*out = new(v1.Duration)

--- a/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1608,7 +1608,7 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 	}
 	if in.FlowLogsPolicyEvaluationMode != nil {
 		in, out := &in.FlowLogsPolicyEvaluationMode, &out.FlowLogsPolicyEvaluationMode
-		*out = new(string)
+		*out = new(FlowLogsPolicyEvaluationModeType)
 		**out = **in
 	}
 	if in.FlowLogsFlushInterval != nil {

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -3327,7 +3327,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 					},
 					"flowLogsPolicyEvaluationMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs. OnNewConnection - In this mode, staged policies are only evaluated when new connections are made in the dataplane. Staged/active policy changes will not be reflected in the `pending_policies` field of flow logs for long lived connections. Continuous - Felix evaluates active flows on a regular basis to determine the rule traces in the flow logs. Any policy updates that impact a flow will be reflected in the pending_policies field, offering a near-real-time view of policy changes across flows. [Default: Continuous]",
+							Description: "Continuous - Felix evaluates active flows on a regular basis to determine the rule traces in the flow logs. Any policy updates that impact a flow will be reflected in the pending_policies field, offering a near-real-time view of policy changes across flows. None - Felix stops evaluating pending traces. [Default: Continuous]",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -3325,6 +3325,13 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 							Format:      "int32",
 						},
 					},
+					"flowLogsPolicyEvaluationMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs. OnNewConnection - In this mode, staged policies are only evaluated when new connections are made in the dataplane. Staged/active policy changes will not be reflected in the `pending_policies` field of flow logs for long lived connections. Continuous - Felix evaluates active flows on a regular basis to determine the rule traces in the flow logs. Any policy updates that impact a flow will be reflected in the pending_policies field, offering a near-real-time view of policy changes across flows. [Default: Continuous]",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"bpfRedirectToPeer": {
 						SchemaProps: spec.SchemaProps{
 							Description: "BPFRedirectToPeer controls which whether it is allowed to forward straight to the peer side of the workload devices. It is allowed for any host L2 devices by default (L2Only), but it breaks TCP dump on the host side of workload device as it bypasses it on ingress. Value of Enabled also allows redirection from L3 host devices like IPIP tunnel or Wireguard directly to the peer side of the workload's device. This makes redirection faster, however, it breaks tools like tcpdump on the peer side. Use Enabled with caution. [Default: L2Only]",

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gavv/monotime"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 

--- a/felix/collector/dataplane_info_reader.go
+++ b/felix/collector/dataplane_info_reader.go
@@ -45,6 +45,7 @@ func NewDataplaneInfoReader(c chan interface{}) *dataplaneInfoReader {
 
 // Start starts the reader.
 func (r *dataplaneInfoReader) Start() error {
+	log.Info("Start dataplane info reader")
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()

--- a/felix/collector/dpstatshelper.go
+++ b/felix/collector/dpstatshelper.go
@@ -46,6 +46,7 @@ func New(
 			ExportingInterval:     config.DefaultExportingInterval,
 			EnableServices:        true,
 			EnableNetworkSets:     true,
+			PolicyEvaluationMode:  configParams.FlowLogsPolicyEvaluationMode,
 			FlowLogsFlushInterval: configParams.FlowLogsFlushInterval,
 			IsBPFDataplane:        configParams.BPFEnabled,
 			DisplayDebugTraceLogs: configParams.FlowLogsCollectorDebugTrace,

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -409,7 +409,7 @@ type Config struct {
 	FlowLogsFlushInterval        time.Duration `config:"seconds;300"`
 	FlowLogsCollectorDebugTrace  bool          `config:"bool;false"`
 	FlowLogsGoldmaneServer       string        `config:"string;"`
-	FlowLogsPolicyEvaluationMode string        `config:"oneof(OnNewConnection,Continuous);Continuous"`
+	FlowLogsPolicyEvaluationMode string        `config:"oneof(None,Continuous);Continuous"`
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
 	NATPortRange       numorstring.Port   `config:"portrange;"`

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -406,9 +406,10 @@ type Config struct {
 	FailsafeInboundHostPorts  []ProtoPort `config:"port-list;tcp:22,udp:68,tcp:179,tcp:2379,tcp:2380,tcp:5473,tcp:6443,tcp:6666,tcp:6667;die-on-fail"`
 	FailsafeOutboundHostPorts []ProtoPort `config:"port-list;udp:53,udp:67,tcp:179,tcp:2379,tcp:2380,tcp:5473,tcp:6443,tcp:6666,tcp:6667;die-on-fail"`
 
-	FlowLogsFlushInterval       time.Duration `config:"seconds;300"`
-	FlowLogsCollectorDebugTrace bool          `config:"bool;false"`
-	FlowLogsGoldmaneServer      string        `config:"string;"`
+	FlowLogsFlushInterval        time.Duration `config:"seconds;300"`
+	FlowLogsCollectorDebugTrace  bool          `config:"bool;false"`
+	FlowLogsGoldmaneServer       string        `config:"string;"`
+	FlowLogsPolicyEvaluationMode string        `config:"oneof(OnNewConnection,Continuous);Continuous"`
 
 	KubeNodePortRanges []numorstring.Port `config:"portrange-list;30000:32767"`
 	NATPortRange       numorstring.Port   `config:"portrange;"`

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -493,14 +493,16 @@ configRetry:
 	}
 
 	if dpStatsCollector != nil {
-		// Fork the calculation graph for dataplane updates that will be sent to the Collector.
-		toCollectorDataplaneSync := make(chan interface{})
-		// The DataplaneInfoReader wraps and sends the dataplane updates to the Collector.
-		dpir := collector.NewDataplaneInfoReader(toCollectorDataplaneSync)
-		dpStatsCollector.SetDataplaneInfoReader(dpir)
-		log.Info("DataplaneInfoReader added to collector")
+		if apiv3.FlowLogsPolicyEvaluationModeType(configParams.FlowLogsPolicyEvaluationMode) == apiv3.FlowLogsPolicyEvaluationModeContinuous {
+			// Fork the calculation graph for dataplane updates that will be sent to the Collector.
+			toCollectorDataplaneSync := make(chan interface{})
+			// The DataplaneInfoReader wraps and sends the dataplane updates to the Collector.
+			dpir := collector.NewDataplaneInfoReader(toCollectorDataplaneSync)
+			dpStatsCollector.SetDataplaneInfoReader(dpir)
+			log.Info("DataplaneInfoReader added to collector")
 
-		calcGraphClientChannels = append(calcGraphClientChannels, toCollectorDataplaneSync)
+			calcGraphClientChannels = append(calcGraphClientChannels, toCollectorDataplaneSync)
+		}
 
 		// Everybody who wanted to tweak the dpStatsCollector had a go, we can start it now!
 		if err := dpStatsCollector.Start(); err != nil {

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -4504,6 +4504,32 @@
           "DescriptionHTML": "<p>FlowLogGoldmaneServer is the flow server endpoint to which flow data should be published.</p>",
           "UserEditable": true,
           "GoType": "*string"
+        },
+        {
+          "Group": "Flow logs: file reports",
+          "GroupWithSortPrefix": "40 Flow logs: file reports",
+          "NameConfigFile": "FlowLogsPolicyEvaluationMode",
+          "NameEnvVar": "FELIX_FlowLogsPolicyEvaluationMode",
+          "NameYAML": "flowLogsPolicyEvaluationMode",
+          "NameGoAPI": "FlowLogsPolicyEvaluationMode",
+          "StringSchema": "One of: `Continuous`, `OnNewConnection` (case insensitive)",
+          "StringSchemaHTML": "One of: <code>Continuous</code>, <code>OnNewConnection</code> (case insensitive)",
+          "StringDefault": "Continuous",
+          "ParsedDefault": "Continuous",
+          "ParsedDefaultJSON": "\"Continuous\"",
+          "ParsedType": "string",
+          "YAMLType": "string",
+          "YAMLSchema": "String.",
+          "YAMLEnumValues": null,
+          "YAMLSchemaHTML": "String.",
+          "YAMLDefault": "Continuous",
+          "Required": false,
+          "OnParseFailure": "ReplaceWithDefault",
+          "AllowedConfigSources": "All",
+          "Description": "Defines how policies are evaluated and reflected in flow logs.\nOnNewConnection - In this mode, staged policies are only evaluated when new connections are\nmade in the dataplane. Staged/active policy changes will not be reflected in the\n`pending_policies` field of flow logs for long lived connections.\nContinuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.",
+          "DescriptionHTML": "<p>Defines how policies are evaluated and reflected in flow logs.\nOnNewConnection - In this mode, staged policies are only evaluated when new connections are\nmade in the dataplane. Staged/active policy changes will not be reflected in the\n<code>pending_policies</code> field of flow logs for long lived connections.\nContinuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.</p>",
+          "UserEditable": true,
+          "GoType": "*string"
         }
       ]
     },

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -4512,16 +4512,19 @@
           "NameEnvVar": "FELIX_FlowLogsPolicyEvaluationMode",
           "NameYAML": "flowLogsPolicyEvaluationMode",
           "NameGoAPI": "FlowLogsPolicyEvaluationMode",
-          "StringSchema": "One of: `Continuous`, `OnNewConnection` (case insensitive)",
-          "StringSchemaHTML": "One of: <code>Continuous</code>, <code>OnNewConnection</code> (case insensitive)",
+          "StringSchema": "One of: `Continuous`, `None` (case insensitive)",
+          "StringSchemaHTML": "One of: <code>Continuous</code>, <code>None</code> (case insensitive)",
           "StringDefault": "Continuous",
           "ParsedDefault": "Continuous",
           "ParsedDefaultJSON": "\"Continuous\"",
           "ParsedType": "string",
           "YAMLType": "string",
-          "YAMLSchema": "String.",
-          "YAMLEnumValues": null,
-          "YAMLSchemaHTML": "String.",
+          "YAMLSchema": "One of: `\"Continuous\"`, `\"None\"`.",
+          "YAMLEnumValues": [
+            "`\"Continuous\"`",
+            "`\"None\"`"
+          ],
+          "YAMLSchemaHTML": "One of: <code>\"Continuous\"</code>, <code>\"None\"</code>.",
           "YAMLDefault": "Continuous",
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
@@ -4529,7 +4532,7 @@
           "Description": "Defines how policies are evaluated and reflected in flow logs.\nOnNewConnection - In this mode, staged policies are only evaluated when new connections are\nmade in the dataplane. Staged/active policy changes will not be reflected in the\n`pending_policies` field of flow logs for long lived connections.\nContinuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.",
           "DescriptionHTML": "<p>Defines how policies are evaluated and reflected in flow logs.\nOnNewConnection - In this mode, staged policies are only evaluated when new connections are\nmade in the dataplane. Staged/active policy changes will not be reflected in the\n<code>pending_policies</code> field of flow logs for long lived connections.\nContinuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.</p>",
           "UserEditable": true,
-          "GoType": "*string"
+          "GoType": "*v3.FlowLogsPolicyEvaluationModeType"
         }
       ]
     },

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -4529,8 +4529,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Defines how policies are evaluated and reflected in flow logs.\nOnNewConnection - In this mode, staged policies are only evaluated when new connections are\nmade in the dataplane. Staged/active policy changes will not be reflected in the\n`pending_policies` field of flow logs for long lived connections.\nContinuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.",
-          "DescriptionHTML": "<p>Defines how policies are evaluated and reflected in flow logs.\nOnNewConnection - In this mode, staged policies are only evaluated when new connections are\nmade in the dataplane. Staged/active policy changes will not be reflected in the\n<code>pending_policies</code> field of flow logs for long lived connections.\nContinuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.</p>",
+          "Description": "Continuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.\nNone - Felix stops evaluating pending traces.",
+          "DescriptionHTML": "<p>Continuous - Felix evaluates active flows on a regular basis to determine the rule\ntraces in the flow logs. Any policy updates that impact a flow will be reflected in the\npending_policies field, offering a near-real-time view of policy changes across flows.\nNone - Felix stops evaluating pending traces.</p>",
           "UserEditable": true,
           "GoType": "*v3.FlowLogsPolicyEvaluationModeType"
         }

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -2490,13 +2490,10 @@ FlowLogGoldmaneServer is the flow server endpoint to which flow data should be p
 
 ### `FlowLogsPolicyEvaluationMode` (config file) / `flowLogsPolicyEvaluationMode` (YAML)
 
-Defines how policies are evaluated and reflected in flow logs.
-OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-made in the dataplane. Staged/active policy changes will not be reflected in the
-`pending_policies` field of flow logs for long lived connections.
 Continuous - Felix evaluates active flows on a regular basis to determine the rule
 traces in the flow logs. Any policy updates that impact a flow will be reflected in the
 pending_policies field, offering a near-real-time view of policy changes across flows.
+None - Felix stops evaluating pending traces.
 
 | Detail |   |
 | --- | --- |

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -2501,10 +2501,10 @@ pending_policies field, offering a near-real-time view of policy changes across 
 | Detail |   |
 | --- | --- |
 | Environment variable | `FELIX_FlowLogsPolicyEvaluationMode` |
-| Encoding (env var/config file) | One of: <code>Continuous</code>, <code>OnNewConnection</code> (case insensitive) |
+| Encoding (env var/config file) | One of: <code>Continuous</code>, <code>None</code> (case insensitive) |
 | Default value (above encoding) | `Continuous` |
 | `FelixConfiguration` field | `flowLogsPolicyEvaluationMode` (YAML) `FlowLogsPolicyEvaluationMode` (Go API) |
-| `FelixConfiguration` schema | String. |
+| `FelixConfiguration` schema | One of: <code>"Continuous"</code>, <code>"None"</code>. |
 | Default value (YAML) | `Continuous` |
 
 ## <a id="aws-integration">AWS integration

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -2488,6 +2488,25 @@ FlowLogGoldmaneServer is the flow server endpoint to which flow data should be p
 | `FelixConfiguration` schema | String. |
 | Default value (YAML) | none |
 
+### `FlowLogsPolicyEvaluationMode` (config file) / `flowLogsPolicyEvaluationMode` (YAML)
+
+Defines how policies are evaluated and reflected in flow logs.
+OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+made in the dataplane. Staged/active policy changes will not be reflected in the
+`pending_policies` field of flow logs for long lived connections.
+Continuous - Felix evaluates active flows on a regular basis to determine the rule
+traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+pending_policies field, offering a near-real-time view of policy changes across flows.
+
+| Detail |   |
+| --- | --- |
+| Environment variable | `FELIX_FlowLogsPolicyEvaluationMode` |
+| Encoding (env var/config file) | One of: <code>Continuous</code>, <code>OnNewConnection</code> (case insensitive) |
+| Default value (above encoding) | `Continuous` |
+| `FelixConfiguration` field | `flowLogsPolicyEvaluationMode` (YAML) `FlowLogsPolicyEvaluationMode` (Go API) |
+| `FelixConfiguration` schema | String. |
+| Default value (YAML) | `Continuous` |
+
 ## <a id="aws-integration">AWS integration
 
 ### `AWSSrcDstCheck` (config file) / `awsSrcDstCheck` (YAML)

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -610,6 +610,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -620,6 +620,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -612,13 +612,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	numBaseFelixConfigs = 159
+	numBaseFelixConfigs = 160
 )
 
 var _ = Describe("Test the generic configuration update processor and the concrete implementations", func() {

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1624,13 +1624,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1622,6 +1622,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1632,6 +1632,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1634,13 +1634,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1642,6 +1642,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1632,6 +1632,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1635,13 +1635,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1633,6 +1633,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1643,6 +1643,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1627,6 +1627,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1619,13 +1619,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1617,6 +1617,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1627,6 +1627,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1619,13 +1619,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1617,6 +1617,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1636,13 +1636,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1644,6 +1644,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1634,6 +1634,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1527,6 +1527,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1537,6 +1537,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1529,13 +1529,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1627,6 +1627,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1619,13 +1619,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1617,6 +1617,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -20763,13 +20763,10 @@ spec:
                 type: string
               flowLogsPolicyEvaluationMode:
                 description: |-
-                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
-                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
-                  made in the dataplane. Staged/active policy changes will not be reflected in the
-                  `pending_policies` field of flow logs for long lived connections.
                   Continuous - Felix evaluates active flows on a regular basis to determine the rule
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
+                  None - Felix stops evaluating pending traces.
                   [Default: Continuous]
                 enum:
                 - None

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -20761,6 +20761,17 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
+              flowLogsPolicyEvaluationMode:
+                description: |-
+                  FlowLogsPolicyEvaluationMode defines how policies are evaluated and reflected in flow logs.
+                  OnNewConnection - In this mode, staged policies are only evaluated when new connections are
+                  made in the dataplane. Staged/active policy changes will not be reflected in the
+                  `pending_policies` field of flow logs for long lived connections.
+                  Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                  traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                  pending_policies field, offering a near-real-time view of policy changes across flows.
+                  [Default: Continuous]
+                type: string
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -20771,6 +20771,9 @@ spec:
                   traces in the flow logs. Any policy updates that impact a flow will be reflected in the
                   pending_policies field, offering a near-real-time view of policy changes across flows.
                   [Default: Continuous]
+                enum:
+                - None
+                - Continuous
                 type: string
               genericXDPEnabled:
                 description: |-


### PR DESCRIPTION
## Description

Allow users to disable populating pending trace in flow logs. This allows to save some cpu cycles in clusters.
This PR includes:

- Cherry pick of https://github.com/tigera/calico-private/pull/8323
- Remove the option value of `OnNewConnection` since staged policies are not programmed in dataplane anymore: https://github.com/projectcalico/calico/pull/9839
- Introduce a `None` value to disable the feature.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
