### PR TITLE
Update the label controller to wait if we get node syncer update

### DIFF
--- a/kube-controllers/pkg/controllers/node/labels.go
+++ b/kube-controllers/pkg/controllers/node/labels.go
@@ -139,7 +139,7 @@ func (c *nodeLabelController) syncNodeLabels(node *v1.Node) {
 		// Get the Calico node representation.
 		name, ok := c.getCalicoNode(node.Name)
 		if !ok {
-			//We haven't learned this Calico node yet. It's possible that we have not received the syncer update, we retry to see if we receive the node via syncer in the meantime
+			// We haven't learned this Calico node yet. It's possible that we have not received the syncer update, we retry to see if we receive the node via syncer in the meantime
 			logrus.Debugf("Update for node with no Calico equivalent, retrying")
 			time.Sleep(retrySleepTime)
 			continue

--- a/kube-controllers/pkg/controllers/node/labels.go
+++ b/kube-controllers/pkg/controllers/node/labels.go
@@ -139,9 +139,10 @@ func (c *nodeLabelController) syncNodeLabels(node *v1.Node) {
 		// Get the Calico node representation.
 		name, ok := c.getCalicoNode(node.Name)
 		if !ok {
-			// We haven't learned this Calico node yet.
-			logrus.Debugf("Skipping update for node with no Calico equivalent")
-			return
+			//We haven't learned this Calico node yet. It's possible that we have not received the syncer update, we retry to see if we receive the node via syncer in the meantime
+			logrus.Debugf("Update for node with no Calico equivalent, retrying")
+			time.Sleep(retrySleepTime)
+			continue
 		}
 		calNode, err := c.client.Nodes().Get(context.Background(), name, options.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
## Description
When k8s node is created and quickly after calico node is created, it's possible the syncNodeLabels function is triggered before we get the calico node via the syncer. We want to retry to see if we update the node cache in the meantime

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
