### PR TITLE
[TSLA-8766] pause stream on row click

### DIFF
--- a/whisker/src/features/flowLogs/components/FlowLogsContainer/index.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogsContainer/index.tsx
@@ -7,15 +7,24 @@ export type FlowLogsContext = {
     view: 'all' | 'denied';
     flowLogs: FlowLog[];
     error: ApiError | null;
+    onRowClicked: () => void;
 };
 
 const FlowLogsContainer: React.FC = () => {
-    const { flowLogs, error } = useOutletContext<FlowLogsContext>();
+    const { flowLogs, error, onRowClicked } =
+        useOutletContext<FlowLogsContext>();
     // const { data, isLoading, error } = useFlowLogs(
     //     view === 'denied' ? { action: 'deny' } : undefined,
     // );
 
-    return <FlowLogsList flowLogs={flowLogs} isLoading={false} error={error} />;
+    return (
+        <FlowLogsList
+            flowLogs={flowLogs}
+            isLoading={false}
+            error={error}
+            onRowClicked={onRowClicked}
+        />
+    );
 };
 
 export default FlowLogsContainer;

--- a/whisker/src/features/flowLogs/components/FlowLogsList/__tests__/index.test.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogsList/__tests__/index.test.tsx
@@ -29,7 +29,7 @@ const flowLogs: FlowLog[] = [
 
 describe('FlowLogsList', () => {
     it('should render the expanded content', () => {
-        render(<FlowLogsList flowLogs={flowLogs} />);
+        render(<FlowLogsList flowLogs={flowLogs} onRowClicked={jest.fn()} />);
 
         fireEvent.click(screen.getByText('fake-source-name'));
 
@@ -37,7 +37,7 @@ describe('FlowLogsList', () => {
     });
 
     it('should render a loading skeleton', () => {
-        render(<FlowLogsList isLoading={true} />);
+        render(<FlowLogsList isLoading={true} onRowClicked={jest.fn()} />);
 
         expect(
             screen.getByTestId('flow-logs-loading-skeleton'),
@@ -45,7 +45,7 @@ describe('FlowLogsList', () => {
     });
 
     it('should render an error message', () => {
-        render(<FlowLogsList error={{ data: {} }} />);
+        render(<FlowLogsList error={{ data: {} }} onRowClicked={jest.fn()} />);
 
         expect(
             screen.getByText('Could not display any flow logs at this time'),

--- a/whisker/src/features/flowLogs/components/FlowLogsList/index.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogsList/index.tsx
@@ -13,12 +13,14 @@ type FlowLogsListProps = {
     flowLogs?: FlowLog[];
     isLoading?: boolean;
     error?: ApiError | null;
+    onRowClicked: () => void;
 };
 
 const FlowLogsList: React.FC<FlowLogsListProps> = ({
     flowLogs,
     isLoading,
     error,
+    onRowClicked,
 }) => {
     const renderRowSubComponent = React.useCallback(
         ({ row }: CellProps<FlowLog>) => (
@@ -49,6 +51,7 @@ const FlowLogsList: React.FC<FlowLogsListProps> = ({
                 '>div': { fontSize: 'sm' },
             }}
             expandRowComponent={renderRowSubComponent}
+            onRowClicked={onRowClicked}
             sx={tableStyles}
             headerStyles={headerStyles}
         />

--- a/whisker/src/pages/FlowLogsPage/__tests__/index.test.tsx
+++ b/whisker/src/pages/FlowLogsPage/__tests__/index.test.tsx
@@ -8,10 +8,18 @@ import { fireEvent, renderWithRouter, screen } from '@/test-utils/helper';
 import FlowLogsPage from '..';
 
 import { useOmniFilterData } from '@/hooks/omniFilters';
+import { act } from 'react';
+
+const MockOutlet = {
+    onRowClicked: jest.fn(),
+};
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
-    Outlet: ({ context }: any) => <>Flow logs view: {context.view}</>,
+    Outlet: ({ context }: any) => {
+        MockOutlet.onRowClicked = context.onRowClicked;
+        return <>Flow logs view: {context.view}</>;
+    },
 }));
 
 jest.mock('@/features/flowLogs/api', () => ({
@@ -237,5 +245,31 @@ describe('FlowLogsPage', () => {
         MockOmniFilters.onRequestNextPage(filterParam);
 
         expect(fetchDataMock).toHaveBeenCalledWith(filterParam);
+    });
+
+    it('should show a toast message when opening a row', () => {
+        jest.mocked(useFlowLogsStream).mockReturnValue({
+            ...useStreamStub,
+            isDataStreaming: true,
+        });
+        renderWithRouter(<FlowLogsPage />);
+
+        act(() => MockOutlet.onRowClicked());
+
+        expect(screen.getByText('Flow logs stream paused')).toBeInTheDocument();
+    });
+
+    it('should not show a toast message when opening a row', () => {
+        jest.mocked(useFlowLogsStream).mockReturnValue({
+            ...useStreamStub,
+            isDataStreaming: false,
+        });
+        renderWithRouter(<FlowLogsPage />);
+
+        act(() => MockOutlet.onRowClicked());
+
+        expect(
+            screen.queryByText('Flow logs stream paused'),
+        ).not.toBeInTheDocument();
     });
 });

--- a/whisker/src/pages/FlowLogsPage/__tests__/index.test.tsx
+++ b/whisker/src/pages/FlowLogsPage/__tests__/index.test.tsx
@@ -256,7 +256,9 @@ describe('FlowLogsPage', () => {
 
         act(() => MockOutlet.onRowClicked());
 
-        expect(screen.getByText('Flow logs stream paused')).toBeInTheDocument();
+        expect(
+            screen.getByText('Flow logs stream paused.'),
+        ).toBeInTheDocument();
     });
 
     it('should not show a toast message when opening a row', () => {
@@ -269,7 +271,7 @@ describe('FlowLogsPage', () => {
         act(() => MockOutlet.onRowClicked());
 
         expect(
-            screen.queryByText('Flow logs stream paused'),
+            screen.queryByText('Flow logs stream paused.'),
         ).not.toBeInTheDocument();
     });
 });

--- a/whisker/src/pages/FlowLogsPage/index.tsx
+++ b/whisker/src/pages/FlowLogsPage/index.tsx
@@ -73,7 +73,7 @@ const FlowLogsPage: React.FC = () => {
         if (isDataStreaming || isWaiting) {
             stopStream();
             toast({
-                description: 'Flow logs stream paused',
+                description: 'Flow logs stream paused.',
                 isClosable: true,
                 duration: 10000,
                 variant: 'toast',

--- a/whisker/src/pages/FlowLogsPage/index.tsx
+++ b/whisker/src/pages/FlowLogsPage/index.tsx
@@ -1,3 +1,4 @@
+import { useFlowLogsStream } from '@/features/flowLogs/api';
 import { FlowLogsContext } from '@/features/flowLogs/components/FlowLogsContainer';
 import OmniFilters from '@/features/flowLogs/components/OmniFilters';
 import { useSelectedOmniFilters } from '@/hooks';
@@ -19,11 +20,11 @@ import {
     TabList,
     Tabs,
     Text,
+    useToast,
 } from '@chakra-ui/react';
 import React from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { streamButtonStyles } from './styles';
-import { useFlowLogsStream } from '@/features/flowLogs/api';
 
 const FlowLogsPage: React.FC = () => {
     const location = useLocation();
@@ -65,6 +66,21 @@ const FlowLogsPage: React.FC = () => {
         isWaiting,
         hasStoppedStreaming,
     } = useFlowLogsStream(urlFilterParams);
+
+    const toast = useToast();
+
+    const onRowClicked = () => {
+        if (isDataStreaming || isWaiting) {
+            stopStream();
+            toast({
+                description: 'Flow logs stream paused',
+                isClosable: true,
+                duration: 10000,
+                variant: 'toast',
+                status: 'info',
+            });
+        }
+    };
 
     return (
         <Box pt={1}>
@@ -147,6 +163,7 @@ const FlowLogsPage: React.FC = () => {
                             view: isDeniedSelected ? 'denied' : 'all',
                             flowLogs: data,
                             error,
+                            onRowClicked,
                         } satisfies FlowLogsContext
                     }
                 />

--- a/whisker/src/theme/colors.ts
+++ b/whisker/src/theme/colors.ts
@@ -42,6 +42,7 @@ export default {
     tigeraBlueMedium80: '#3A97C5',
     tigeraBlueMedium: '#1084BD',
     tigeraBlueMediumAlpha40: 'rgba(9, 125, 182, 0.4)',
+    tigeraBlueMediumDark: '#043249',
     tigeraBlueDark: '#273981',
     tigeraGoldLight: '#FCE181',
     tigeraGoldMedium20: '#FDE9D2',

--- a/whisker/src/theme/components/Alert.ts
+++ b/whisker/src/theme/components/Alert.ts
@@ -47,4 +47,25 @@ const baseStyle = definePartsStyle({
     icon,
 });
 
-export default defineMultiStyleConfig({ baseStyle });
+export default defineMultiStyleConfig({
+    baseStyle,
+    variants: {
+        toast: {
+            container: {
+                '&[data-status="info"]': {
+                    _dark: {
+                        backgroundColor: 'tigeraBlueMedium40',
+                        color: 'tigeraBlack',
+                    },
+                },
+            },
+            icon: {
+                '&[data-status="info"]': {
+                    _dark: {
+                        color: 'tigeraBlueMediumDark',
+                    },
+                },
+            },
+        },
+    },
+});


### PR DESCRIPTION
![whisker-row-click](https://github.com/user-attachments/assets/c594b005-a20b-48bd-bed6-2c08dfdcd833)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
