### PR TITLE
Fix concurrent access panic in DiachronicFlow

### DIFF
--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -407,7 +407,7 @@ func (a *LogAggregator) backfill(stream *Stream, request *proto.FlowStreamReques
 		flow := resp.flows[i]
 		logrus.WithField("flow", flow).Debug("Sending backfilled flow to stream")
 		k := types.ProtoToFlowKey(flow.Flow.Key)
-		builder := bucketing.NewFlowBuilder(a.diachronics[*k], flow.Flow.StartTime, flow.Flow.EndTime)
+		builder := bucketing.NewCachedFlowBuilder(a.diachronics[*k], flow.Flow.StartTime, flow.Flow.EndTime)
 		if f, id := builder.Build(request.Filter); f != nil {
 			stream.Receive(&proto.FlowResult{
 				Id:   id,

--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -407,11 +407,13 @@ func (a *LogAggregator) backfill(stream *Stream, request *proto.FlowStreamReques
 		flow := resp.flows[i]
 		logrus.WithField("flow", flow).Debug("Sending backfilled flow to stream")
 		k := types.ProtoToFlowKey(flow.Flow.Key)
-		stream.Receive(bucketing.NewFlowBuilder(
-			a.diachronics[*k],
-			flow.Flow.StartTime,
-			flow.Flow.EndTime,
-		))
+		builder := bucketing.NewFlowBuilder(a.diachronics[*k], flow.Flow.StartTime, flow.Flow.EndTime)
+		if f, id := builder.Build(request.Filter); f != nil {
+			stream.Receive(&proto.FlowResult{
+				Id:   id,
+				Flow: types.FlowToProto(f),
+			})
+		}
 	}
 }
 

--- a/goldmane/pkg/aggregator/stream_manager.go
+++ b/goldmane/pkg/aggregator/stream_manager.go
@@ -14,7 +14,7 @@ import (
 type Stream struct {
 	id   string
 	out  chan *proto.FlowResult
-	in   chan bucketing.FlowBuilder
+	in   chan *proto.FlowResult
 	done chan<- string
 	req  streamRequest
 }
@@ -30,7 +30,7 @@ func (s *Stream) Flows() <-chan *proto.FlowResult {
 // Receive tells the Stream about a newly learned Flow to consider for output.
 // The Stream will decide whether to include the Flow in its output based on its configuration.
 // Note that emission of the Flow to the Stream's output channel is asynchronous.
-func (s *Stream) Receive(f bucketing.FlowBuilder) {
+func (s *Stream) Receive(f *proto.FlowResult) {
 	select {
 	case s.in <- f:
 	case <-time.After(5 * time.Second):
@@ -53,15 +53,8 @@ func (s *Stream) recv() {
 
 // handle decides whether to include a Flow in the Stream's output based on the Stream's configuration,
 // and sends it to the Stream's output channel if appropriate.
-func (s *Stream) handle(f bucketing.FlowBuilder) {
-	flow, id := f.Build(s.req.req.Filter)
-	if flow != nil {
-		res := &proto.FlowResult{
-			Flow: types.FlowToProto(flow),
-			Id:   id,
-		}
-		s.send(res)
-	}
+func (s *Stream) handle(f *proto.FlowResult) {
+	s.send(f)
 }
 
 func (s *Stream) send(f *proto.FlowResult) {
@@ -103,7 +96,13 @@ type streamManager struct {
 // informs all streams about the new flow, so they can decide to include it in their output.
 func (m *streamManager) Receive(b bucketing.FlowBuilder) {
 	for _, s := range m.streams {
-		s.Receive(b)
+		// Build the flow, checking if the flow matches the stream's filter.
+		if f, id := b.Build(s.req.req.Filter); f != nil {
+			s.Receive(&proto.FlowResult{
+				Id:   id,
+				Flow: types.FlowToProto(f),
+			})
+		}
 	}
 }
 
@@ -120,7 +119,7 @@ func (m *streamManager) register(req streamRequest) *Stream {
 	stream := &Stream{
 		id:   uuid.NewString(),
 		out:  make(chan *proto.FlowResult, 100),
-		in:   make(chan bucketing.FlowBuilder, 100),
+		in:   make(chan *proto.FlowResult, 100),
 		done: m.closedStreamsCh,
 		req:  req,
 	}

--- a/goldmane/pkg/internal/types/diachronic_flow.go
+++ b/goldmane/pkg/internal/types/diachronic_flow.go
@@ -76,12 +76,14 @@ func (d *DiachronicFlow) Rollover(limiter int64) {
 	// c.Windows is sorted oldest -> newest, so we can do this pretty easily by iterating in order.
 	// We can stop iterating when we find a Window that is still valid.
 	// Note: Since we Rollover() ever aggregation period, we should never need to remove more than one Window at a time.
-	for i, w := range d.Windows {
+	for i := len(d.Windows) - 1; i >= 0; i-- {
+		w := d.Windows[i]
 		if w.end <= limiter {
 			logrus.WithFields(logrus.Fields{
 				"limiter": limiter,
 				"index":   i,
-			}).Debug("Removing Window from diachronic flow")
+				"endTime": w.end,
+			}).Debug("Removing Window(s) before limiter from diachronic flow")
 
 			// Remove the Window and all corresponding statistics.
 			d.Windows = d.Windows[i+1:]

--- a/goldmane/pkg/internal/types/diachronic_flow_test.go
+++ b/goldmane/pkg/internal/types/diachronic_flow_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/projectcalico/calico/goldmane/pkg/aggregator"
+	"github.com/projectcalico/calico/goldmane/pkg/internal/types"
+	"github.com/projectcalico/calico/goldmane/pkg/internal/utils"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTest(t *testing.T, opts ...aggregator.Option) func() {
+	// Hook logrus into testing.T
+	utils.ConfigureLogging("DEBUG")
+	logCancel := logutils.RedirectLogrusToTestingT(t)
+	return func() {
+		logCancel()
+	}
+}
+
+func TestDiachronicFlow(t *testing.T) {
+	defer setupTest(t)()
+
+	// Create a DF.
+	k := types.FlowKey{}
+	df := types.NewDiachronicFlow(&k)
+
+	// Add flow data over a bunch of windows.
+	f := types.Flow{
+		PacketsIn:               1,
+		PacketsOut:              2,
+		BytesIn:                 3,
+		BytesOut:                4,
+		NumConnectionsLive:      5,
+		NumConnectionsStarted:   6,
+		NumConnectionsCompleted: 7,
+	}
+	for i := range 400 {
+		df.AddFlow(&f, int64(i), int64(i+1))
+	}
+
+	// Check aggregation across full range.
+	af := df.Aggregate(0, 400)
+	require.Equal(t, f.PacketsIn*400, af.PacketsIn)
+	require.Equal(t, f.PacketsOut*400, af.PacketsOut)
+	require.Equal(t, f.BytesIn*400, af.BytesIn)
+	require.Equal(t, f.BytesOut*400, af.BytesOut)
+	require.Equal(t, f.NumConnectionsLive*400, af.NumConnectionsLive)
+	require.Equal(t, f.NumConnectionsStarted*400, af.NumConnectionsStarted)
+	require.Equal(t, f.NumConnectionsCompleted*400, af.NumConnectionsCompleted)
+
+	// Aggregate across a subset of the range.
+	af = df.Aggregate(100, 200)
+	require.Equal(t, f.PacketsIn*100, af.PacketsIn)
+	require.Equal(t, f.PacketsOut*100, af.PacketsOut)
+	require.Equal(t, f.BytesIn*100, af.BytesIn)
+	require.Equal(t, f.BytesOut*100, af.BytesOut)
+	require.Equal(t, f.NumConnectionsLive*100, af.NumConnectionsLive)
+	require.Equal(t, f.NumConnectionsStarted*100, af.NumConnectionsStarted)
+	require.Equal(t, f.NumConnectionsCompleted*100, af.NumConnectionsCompleted)
+
+	// Aggregate across a superset of the range.
+	af = df.Aggregate(-100, 500)
+	require.Equal(t, f.PacketsIn*400, af.PacketsIn)
+
+	// Rollover a few times.
+	for i := range 200 {
+		df.Rollover(int64(i + 1))
+	}
+
+	// Check aggregation across full range. We just rolled windows 0-200
+	// out, so we should only have 200 left.
+	af = df.Aggregate(0, 400)
+	require.Equal(t, f.PacketsIn*200, af.PacketsIn)
+
+	// Roll over the rest. Nothing should remain.
+	df.Rollover(401)
+	af = df.Aggregate(0, 400)
+	require.Nil(t, af)
+}

--- a/goldmane/pkg/internal/types/diachronic_flow_test.go
+++ b/goldmane/pkg/internal/types/diachronic_flow_test.go
@@ -17,11 +17,12 @@ package types_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/projectcalico/calico/goldmane/pkg/aggregator"
 	"github.com/projectcalico/calico/goldmane/pkg/internal/types"
 	"github.com/projectcalico/calico/goldmane/pkg/internal/utils"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
-	"github.com/stretchr/testify/require"
 )
 
 func setupTest(t *testing.T, opts ...aggregator.Option) func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

DiachronciFlow was originally written to be accessed only from a single goroutine. 

When we introduced the Stream() API, each stream was responsible for building its own result objects - this allowed us to do context-aware rendering of the Flow objects (to prevent rendering them when the stream would filter them out) but resulted in accessing DiachronicFlow from another goroutine, causing occasional race conditions and panics.

We have three main options:

- Introduce a per-DF Mutex to lock access of important fields.
- Introduce a global Mutex / channel to protect DF access across goroutines (less memory, more contention)
- Stop accessing the DF from the Stream goroutines. Instead, render it on the main goroutine and send the already rendered Flow objects to the Streams. 

This PR goes with the third option.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.