### PR TITLE
Read all commands off backlog channel before executing backlog

### DIFF
--- a/guardian/Makefile
+++ b/guardian/Makefile
@@ -102,3 +102,14 @@ ci: static-checks ut
 ## Run all CD steps, normally pushing images out to registries.
 cd: image-all cd-common
 
+release-build: .release-$(VERSION).created
+.release-$(VERSION).created:
+	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
+	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
+	touch $@
+
+release-publish: release-prereqs .release-$(VERSION).published
+.release-$(VERSION).published:
+	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+	touch $@

--- a/guardian/pkg/asyncutil/async_test.go
+++ b/guardian/pkg/asyncutil/async_test.go
@@ -77,6 +77,8 @@ func TestRequestHandlerStopAndRequeue(t *testing.T) {
 
 	wg.Wait()
 
+	// We don't wait on the signal returned because we want to test the unhappy path where the user didn't wait on the
+	// signal.
 	cmdExec.DrainAndBacklog()
 	pause = false
 	cmdExec.Resume()
@@ -87,6 +89,7 @@ func TestRequestHandlerStopAndRequeue(t *testing.T) {
 	Expect(err).Should(BeNil())
 
 	cancel()
-	cmdExec.ShutdownSignaler().Receive()
-
+	logrus.Debug("Waiting for shutdown...")
+	<-cmdExec.ShutdownSignaler().Receive()
+	logrus.Debug("Finished waiting for shutdown.")
 }


### PR DESCRIPTION
## Description
There's a possible race where we execute the backlogged commands but there is still a command on the backlog channel.

To fix this, we just ensure that we read any outstanding backloged commands into the backlog slice before exectuting them.

This PR also adds a commit to fix the hash release by adding the release sections.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
