### PR TITLE
make CRD management optional in helm chart

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -53,7 +53,7 @@ spec:
             - operator
           args:
             # Configure tigera-operator to manage installation of the necessary CRDs.
-            - -manage-crds=true
+            - -manage-crds={{ .Values.manageCRDs }}
           volumeMounts:
             - name: var-lib-calico
               readOnly: true

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -38,6 +38,10 @@ certs:
     commonName:
     caBundle:
 
+# Whether or not the tigera/operator should manange CustomResourceDefinitions
+# needed to run itself and Calico. If disabled, you must manage these resources out-of-band.
+manageCRDs: true
+
 # Resource requests and limits for the tigera/operator pod.
 resources: {}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In case anyone wants to opt-out of CRD management by the operator

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add helm values.yaml config option for operator management of CRDs (default: true) 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.