### PR TITLE
Refactor initial creation of flow client / connection flow

### DIFF
--- a/felix/collector/dpstatshelper.go
+++ b/felix/collector/dpstatshelper.go
@@ -57,8 +57,12 @@ func New(
 	goldmaneAddr := configParams.FlowLogsGoldmaneServer
 	if goldmaneAddr != "" {
 		log.Infof("Creating Flow Logs GoldmaneReporter with address %v", goldmaneAddr)
-		gd := goldmane.NewReporter(goldmaneAddr)
-		dispatchers[FlowLogsGoldmaneReporterName] = gd
+		gd, err := goldmane.NewReporter(goldmaneAddr)
+		if err != nil {
+			log.WithError(err).Error("Failed to create Flow Logs GoldmaneReporter, skipping adding reporter.")
+		} else {
+			dispatchers[FlowLogsGoldmaneReporterName] = gd
+		}
 	}
 	if len(dispatchers) > 0 {
 		log.Info("Creating Flow Logs Reporter")

--- a/felix/collector/goldmane/client.go
+++ b/felix/collector/goldmane/client.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/projectcalico/calico/felix/collector/flowlog"
 	"github.com/projectcalico/calico/felix/collector/types/endpoint"
@@ -38,22 +36,22 @@ type GoldmaneReporter struct {
 	once    sync.Once
 }
 
-func NewReporter(addr string) *GoldmaneReporter {
+func NewReporter(addr string) (*GoldmaneReporter, error) {
+	cli, err := client.NewFlowClient(addr)
+	if err != nil {
+		return nil, err
+	}
 	return &GoldmaneReporter{
 		address: addr,
-		client:  client.NewFlowClient(addr),
-	}
+		client:  cli,
+	}, nil
 }
 
 func (g *GoldmaneReporter) Start() error {
 	var err error
 	g.once.Do(func() {
-		var grpcClient *grpc.ClientConn
-		grpcClient, err = grpc.NewClient(g.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return
-		}
-		go g.client.Run(context.Background(), grpcClient)
+		// We don't wait for the initial connection to start so we don't block the caller. This could be changed later.
+		g.client.Connect(context.Background())
 	})
 	return err
 }

--- a/goldmane/cmd/main.go
+++ b/goldmane/cmd/main.go
@@ -17,5 +17,5 @@ package main
 import "github.com/projectcalico/calico/goldmane/pkg/daemon"
 
 func main() {
-	daemon.Run()
+	daemon.Run(daemon.ConfigFromEnv())
 }

--- a/goldmane/pkg/client/client.go
+++ b/goldmane/pkg/client/client.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/projectcalico/calico/goldmane/pkg/internal/flowcache"
 	"github.com/projectcalico/calico/goldmane/proto"
@@ -30,20 +31,35 @@ const (
 	FlowCacheCleanup = 30 * time.Second
 )
 
-func NewFlowClient(server string) *FlowClient {
-	return &FlowClient{
-		inChan: make(chan *proto.Flow, 5000),
-		cache:  flowcache.NewExpiringFlowCache(FlowCacheExpiry),
+// NewFlowClient creates a new client to the goldmane grpc API. It creates the initial grpcClient connection to verify
+// that an initial connection can be created when connect is called (grpc.NewClient doesn't establish an initial connection,
+// just validates that it should be able to with the given parameters).
+//
+// If an error is returned, it means that no amount of retrying will create the client with the same parameters.
+func NewFlowClient(server string) (*FlowClient, error) {
+	grpcClient, err := grpc.NewClient(server, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
 	}
+
+	return &FlowClient{
+		inChan:      make(chan *proto.Flow, 5000),
+		cache:       flowcache.NewExpiringFlowCache(FlowCacheExpiry),
+		grpcCliConn: grpcClient,
+	}, nil
 }
 
 // FlowClient pushes flow updates to the flow server.
 type FlowClient struct {
-	inChan chan *proto.Flow
-	cache  *flowcache.ExpiringFlowCache
+	inChan      chan *proto.Flow
+	cache       *flowcache.ExpiringFlowCache
+	grpcCliConn *grpc.ClientConn
 }
 
-func (c *FlowClient) Run(ctx context.Context, grpcClient grpc.ClientConnInterface) {
+// Connect starts the grpc connection to stream flows to goldmane. It returns a channel that closes once the initial
+// connection has been established which gives callers the option to wait for an initial connection before proceeding
+// to use the client.
+func (c *FlowClient) Connect(ctx context.Context) <-chan struct{} {
 	logrus.Info("Starting flow client")
 	defer func() {
 		logrus.Info("Stopping flow client")
@@ -52,8 +68,52 @@ func (c *FlowClient) Run(ctx context.Context, grpcClient grpc.ClientConnInterfac
 	// Start the cache cleanup task.
 	go c.cache.Run(FlowCacheCleanup)
 
+	startUp := make(chan struct{})
+	go func() {
+		rc, err := c.connect(ctx)
+		// Close this regardless of the error since we don't want the other side of the channel to hang forever.
+		close(startUp)
+		if err != nil {
+			logrus.WithError(err).Warn("Unable to connect to flow server.")
+			return
+		}
+
+		// Send new Flows as they are received.
+		for flog := range c.inChan {
+			// Add the flow to our cache. It will automatically be expired in the background.
+			// We don't need to pass in a value for scope, since the client is intrinsically scoped
+			// to a particular node.
+			c.cache.Add(flog, "")
+
+			// Send the flow.
+			if err := rc.Send(&proto.FlowUpdate{Flow: flog}); err != nil {
+				logrus.WithError(err).Warn("Failed to send flow")
+				break
+			}
+
+			// Receive a receipt.
+			if _, err := rc.Recv(); err != nil {
+				logrus.WithError(err).Warn("Failed to receive receipt")
+				break
+			}
+		}
+
+		if err := rc.CloseSend(); err != nil {
+			logrus.WithError(err).Warn("Failed to close connection")
+		}
+
+		rc, err = c.connect(ctx)
+		if err != nil {
+			return
+		}
+	}()
+
+	return startUp
+}
+
+func (c *FlowClient) connect(ctx context.Context) (grpc.BidiStreamingClient[proto.FlowUpdate, proto.FlowReceipt], error) {
 	// Create a new client to push flows to the server.
-	cli := proto.NewFlowCollectorClient(grpcClient)
+	cli := proto.NewFlowCollectorClient(c.grpcCliConn)
 
 	// Create a backoff helper.
 	b := newBackoff(1*time.Second, 10*time.Second)
@@ -62,11 +122,13 @@ func (c *FlowClient) Run(ctx context.Context, grpcClient grpc.ClientConnInterfac
 		// Check if the parent context has been canceled.
 		if err := ctx.Err(); err != nil {
 			logrus.WithError(err).Warn("Parent context canceled")
-			return
+			return nil, err
 		}
 
 		// Connect to the flow server. This establishes a streaming connection over which
 		// we can send flow updates.
+
+		var err error
 		rc, err := cli.Connect(ctx)
 		if err != nil {
 			logrus.WithError(err).Warn("Failed to connect to flow server")
@@ -97,31 +159,7 @@ func (c *FlowClient) Run(ctx context.Context, grpcClient grpc.ClientConnInterfac
 			b.Wait()
 			continue
 		}
-
-		// Send new Flows as they are received.
-		for flog := range c.inChan {
-			// Add the flow to our cache. It will automatically be expired in the background.
-			// We don't need to pass in a value for scope, since the client is intrinsically scoped
-			// to a particular node.
-			c.cache.Add(flog, "")
-
-			// Send the flow.
-			if err := rc.Send(&proto.FlowUpdate{Flow: flog}); err != nil {
-				logrus.WithError(err).Warn("Failed to send flow")
-				break
-			}
-
-			// Receive a receipt.
-			if _, err := rc.Recv(); err != nil {
-				logrus.WithError(err).Warn("Failed to receive receipt")
-				break
-			}
-		}
-
-		if err := rc.CloseSend(); err != nil {
-			logrus.WithError(err).Warn("Failed to close connection")
-		}
-		b.Wait()
+		return rc, nil
 	}
 }
 

--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -66,7 +66,7 @@ type Config struct {
 	PushIndex int `json:"push_index" envconfig:"PUSH_INDEX" default:"30"`
 }
 
-func Run() {
+func ConfigFromEnv() Config {
 	// Load configuration from environment variables.
 	var cfg Config
 	if err := envconfig.Process("", &cfg); err != nil {
@@ -74,6 +74,15 @@ func Run() {
 	}
 
 	utils.ConfigureLogging(cfg.LogLevel)
+
+	return cfg
+}
+
+func (cfg Config) ConfigureLogging() {
+	utils.ConfigureLogging(cfg.LogLevel)
+}
+
+func Run(cfg Config) {
 	logrus.WithField("cfg", cfg).Info("Loaded configuration")
 
 	// Create a stop channel.


### PR DESCRIPTION
This commit does the following:
- Create the grpc client in the goldmane constructor and return an error if it fails (the client doesn't initiate a connection, just validates the given parameters)
- Return a channel from the "Connect" function (previously Run) so that callers have the option to wait for an initial connection to be established with goldmane
- Change the goldmane daemon to accept the config parameters. This allows for configuring and running the  daemon in tests as it would be run in the container for fv like tests.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
