### PR TITLE
[TSLA-8766] expanded row ux

### DIFF
--- a/whisker/src/api/index.ts
+++ b/whisker/src/api/index.ts
@@ -77,7 +77,6 @@ export const useStream = <T>(path: string): UseStreamResult<T> => {
             eventSource.onmessage = (event) => {
                 setIsDataStreaming(true);
                 const stream = JSON.parse(event.data);
-                console.info({ event });
                 setData((list) => [stream, ...list]);
             };
 

--- a/whisker/src/components/layout/AppHeader/index.tsx
+++ b/whisker/src/components/layout/AppHeader/index.tsx
@@ -1,36 +1,37 @@
 import { CalicoCatIcon, CalicoWhiskerIcon } from '@/icons';
-import { Box, Flex, Heading, Link, Text } from '@chakra-ui/react';
+import { Flex, Heading, LinkBox, LinkOverlay, Text } from '@chakra-ui/react';
 import React from 'react';
 import { appHeaderStyles } from './styles';
 
 const AppHeader: React.FC = () => {
     return (
-        <Box>
-            <Flex as='header' sx={appHeaderStyles}>
-                <Flex alignItems='center'>
-                    <CalicoWhiskerIcon fontSize='xl' />
-                    <Heading fontSize='2xl'>Calico Whisker</Heading>
-                </Flex>
+        <Flex as='header' sx={appHeaderStyles}>
+            <Flex alignItems='center'>
+                <CalicoWhiskerIcon fontSize='xl' />
+                <Heading fontSize='2xl'>Calico Whisker</Heading>
+            </Flex>
 
+            <LinkBox>
                 <Flex alignItems='center' gap={2}>
                     <Flex alignItems='flex-end' flexDirection='column' gap={0}>
                         <Text fontSize='xs' as='span' fontWeight='medium'>
                             Calico Whisker is a simplified version of the
                         </Text>
-                        <Link
+                        <LinkOverlay
                             fontSize='xs'
                             fontWeight='bold'
+                            color='tigeraGoldMedium'
                             isExternal
                             href='https://calicocloud.io'
                         >
                             Service Graph from Calico Cloud
-                        </Link>
+                        </LinkOverlay>
                     </Flex>
 
                     <CalicoCatIcon fontSize='35px' />
                 </Flex>
-            </Flex>
-        </Box>
+            </LinkBox>
+        </Flex>
     );
 };
 

--- a/whisker/src/components/layout/AppHeader/styles.ts
+++ b/whisker/src/components/layout/AppHeader/styles.ts
@@ -2,6 +2,7 @@ export const appHeaderStyles = {
     bg: 'tigera-bg',
     minHeight: 12,
     px: 4,
+    py: 2,
     alignItems: 'center',
     justifyContent: 'space-between',
     borderBottom: '2px solid',

--- a/whisker/src/components/layout/AppLayout/styles.ts
+++ b/whisker/src/components/layout/AppLayout/styles.ts
@@ -18,5 +18,5 @@ export const gridStyles = {
     overflowY: 'hidden',
     bg: 'tigera-color-surface-secondary',
     gridTemplateAreas: '"alert" "header" "main"',
-    gridTemplateRows: 'max-content minmax(48px, max-content) auto',
+    gridTemplateRows: 'max-content minmax(54px, max-content) auto',
 };

--- a/whisker/src/features/flowLogs/components/FlowLogsContainer/index.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogsContainer/index.tsx
@@ -1,21 +1,20 @@
+import { VirtualizedRow } from '@/libs/tigera/ui-components/components/common/DataTable';
+import { ApiError, FlowLog } from '@/types/api';
 import React from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { ApiError, FlowLog } from '@/types/api';
 import FlowLogsList from '../FlowLogsList';
 
 export type FlowLogsContext = {
     view: 'all' | 'denied';
     flowLogs: FlowLog[];
     error: ApiError | null;
-    onRowClicked: () => void;
+    onRowClicked: (row: VirtualizedRow) => void;
+    onSortClicked: () => void;
 };
 
 const FlowLogsContainer: React.FC = () => {
-    const { flowLogs, error, onRowClicked } =
+    const { flowLogs, error, onRowClicked, onSortClicked } =
         useOutletContext<FlowLogsContext>();
-    // const { data, isLoading, error } = useFlowLogs(
-    //     view === 'denied' ? { action: 'deny' } : undefined,
-    // );
 
     return (
         <FlowLogsList
@@ -23,6 +22,7 @@ const FlowLogsContainer: React.FC = () => {
             isLoading={false}
             error={error}
             onRowClicked={onRowClicked}
+            onSortClicked={onSortClicked}
         />
     );
 };

--- a/whisker/src/features/flowLogs/components/FlowLogsList/__tests__/index.test.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogsList/__tests__/index.test.tsx
@@ -27,9 +27,14 @@ const flowLogs: FlowLog[] = [
     },
 ];
 
+const defaultProps = {
+    onRowClicked: jest.fn(),
+    onSortClicked: jest.fn(),
+};
+
 describe('FlowLogsList', () => {
     it('should render the expanded content', () => {
-        render(<FlowLogsList flowLogs={flowLogs} onRowClicked={jest.fn()} />);
+        render(<FlowLogsList flowLogs={flowLogs} {...defaultProps} />);
 
         fireEvent.click(screen.getByText('fake-source-name'));
 
@@ -37,7 +42,7 @@ describe('FlowLogsList', () => {
     });
 
     it('should render a loading skeleton', () => {
-        render(<FlowLogsList isLoading={true} onRowClicked={jest.fn()} />);
+        render(<FlowLogsList isLoading={true} {...defaultProps} />);
 
         expect(
             screen.getByTestId('flow-logs-loading-skeleton'),
@@ -45,7 +50,7 @@ describe('FlowLogsList', () => {
     });
 
     it('should render an error message', () => {
-        render(<FlowLogsList error={{ data: {} }} onRowClicked={jest.fn()} />);
+        render(<FlowLogsList error={{ data: {} }} {...defaultProps} />);
 
         expect(
             screen.getByText('Could not display any flow logs at this time'),

--- a/whisker/src/features/flowLogs/components/FlowLogsList/index.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogsList/index.tsx
@@ -8,21 +8,36 @@ import {
     DataTable,
     TableSkeleton,
 } from '@/libs/tigera/ui-components/components/common';
+import { VirtualizedRow } from '@/libs/tigera/ui-components/components/common/DataTable';
 
 type FlowLogsListProps = {
     flowLogs?: FlowLog[];
     isLoading?: boolean;
     error?: ApiError | null;
-    onRowClicked: () => void;
+    onRowClicked: (row: VirtualizedRow) => void;
+    onSortClicked: () => void;
 };
 //sum of height of table header, tablist, filters, banner and info
-const HEADER_HEIGHT = 210;
+const bannerHeight = 36;
+const headerHeight = 54;
+const containerPadding = 4;
+const omniFiltersHeight = 46;
+const tabsHeight = 34;
+const columnsHeight = 32;
+const HEADER_HEIGHT =
+    bannerHeight +
+    headerHeight +
+    containerPadding +
+    omniFiltersHeight +
+    tabsHeight +
+    columnsHeight;
 
 const FlowLogsList: React.FC<FlowLogsListProps> = ({
     flowLogs,
     isLoading,
     error,
     onRowClicked,
+    onSortClicked,
 }) => {
     const renderRowSubComponent = React.useCallback(
         ({ row }: CellProps<FlowLog>) => (
@@ -57,16 +72,17 @@ const FlowLogsList: React.FC<FlowLogsListProps> = ({
                 '>div': { fontSize: 'sm' },
             }}
             expandRowComponent={renderRowSubComponent}
-            onRowClicked={onRowClicked}
+            onRowClicked={(row) => onRowClicked(row)}
             sx={tableStyles}
             headerStyles={headerStyles}
-            autoResetExpandedRow={false}
+            autoResetExpandedRow={true}
             virtualisationProps={{
                 tableHeight: flowLogs?.length ? height : 0,
                 subRowHeight: 630,
                 rowHeight: 35,
                 subRowStyles: subRowStyles,
             }}
+            onSortClicked={onSortClicked}
         />
     );
 };

--- a/whisker/src/features/flowLogs/components/OmniFilters/index.tsx
+++ b/whisker/src/features/flowLogs/components/OmniFilters/index.tsx
@@ -78,7 +78,7 @@ const OmniFilters: React.FC<OmniFiltersProps> = ({
                     onRequestMore={(filterId) =>
                         onRequestNextPage(filterId as OmniFilterParam)
                     }
-                    isDisabled
+                    // isDisabled
                 />
             ))}
         </OmniFilterList>

--- a/whisker/src/libs/tigera/ui-components/components/common/DataTable/ResizableBody/index.tsx
+++ b/whisker/src/libs/tigera/ui-components/components/common/DataTable/ResizableBody/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tr, Tbody, Td, Checkbox } from '@chakra-ui/react';
-import { CellProps, ReducerTableState } from 'react-table';
+import { CellProps, ReducerTableState, Row } from 'react-table';
 import type { HTMLChakraProps } from '@chakra-ui/react';
 import has from 'lodash/has';
 import { Column } from 'react-table';
@@ -36,6 +36,10 @@ interface ResizableBodyProps extends HTMLChakraProps<'div'> {
     selectedRow?: any; //depending on the content can be diferent things
     virtualisationProps?: VirtualisationProps;
 }
+
+export type VirtualizedRow = Row & {
+    closeVirtualizedRow: () => void;
+};
 
 const VariableSizeList = _VariableSizeList as unknown as React.ComponentType<
     VariableSizeListProps & { ref?: React.Ref<_VariableSizeList> }
@@ -116,8 +120,19 @@ const ResizableBody: React.FC<React.PropsWithChildren<ResizableBodyProps>> = ({
                     onClick={() => {
                         // check the prop is set before executing the callback
                         if (onRowClicked) {
-                            onRowClicked(row);
+                            onRowClicked({
+                                ...row,
+                                ...(virtualisationProps && {
+                                    closeVirtualizedRow: () => {
+                                        if ((row as Row).isExpanded) {
+                                            (row as Row).toggleRowExpanded();
+                                            ref.current?.resetAfterIndex(0);
+                                        }
+                                    },
+                                }),
+                            });
                         }
+
                         if (virtualisationProps) {
                             //force re-calculating the row height
                             ref.current?.resetAfterIndex(0);

--- a/whisker/src/libs/tigera/ui-components/components/common/DataTable/ResizableHeader/index.tsx
+++ b/whisker/src/libs/tigera/ui-components/components/common/DataTable/ResizableHeader/index.tsx
@@ -14,6 +14,7 @@ import {
 } from './styles';
 import Sorter from './components/Sorter';
 import { EXPANDO_COLUMN_ID } from '../ResizableBody';
+import { ColumnInstance } from 'react-table';
 
 interface ResizableHeaderProps {
     isFixed?: boolean;
@@ -24,6 +25,7 @@ interface ResizableHeaderProps {
     sx?: SystemStyleObject;
     enableResize?: boolean;
     onSortCustomHandler?: (column: any) => void;
+    onSortClicked?: () => void;
 }
 
 export enum SORT_DIRECTION {
@@ -59,6 +61,7 @@ const ResizableHeader: React.FC<
     enableResize = true,
     sx,
     onSortCustomHandler,
+    onSortClicked,
     ...rest
 }) => {
     const handleCheckboxKey = ({ keyCode }: any) => {
@@ -128,6 +131,14 @@ const ResizableHeader: React.FC<
                                         if (isCheckCell) {
                                             handleCheckboxClick(e);
                                         }
+                                    },
+                                })}
+                                {...(onSortClicked && {
+                                    onClick: (e) => {
+                                        onSortClicked();
+                                        (column as ColumnInstance)
+                                            ?.getSortByToggleProps?.()
+                                            .onClick?.(e);
                                     },
                                 })}
                             >

--- a/whisker/src/libs/tigera/ui-components/components/common/DataTable/Table/index.tsx
+++ b/whisker/src/libs/tigera/ui-components/components/common/DataTable/Table/index.tsx
@@ -61,6 +61,7 @@ export interface TableProps {
     memoizedColumnsGenerator?: any;
     isSelectable?: boolean;
     onSort?: (column: ColumnSortEvent) => void;
+    onSortClicked?: () => void;
     initialState?: TableState;
     virtualisationProps?: VirtualisationProps;
 }
@@ -94,6 +95,7 @@ const Table: React.FC<React.PropsWithChildren<TableProps>> = ({
     noResultsStyles,
     isSelectable,
     onSort,
+    onSortClicked,
     initialState,
     virtualisationProps,
     ...rest
@@ -200,6 +202,7 @@ const Table: React.FC<React.PropsWithChildren<TableProps>> = ({
                 isAllChecked={isAllChecked}
                 onAllChecked={onAllChecked}
                 onSortCustomHandler={onSort}
+                onSortClicked={onSortClicked}
             />
 
             {items && !isFetching && (

--- a/whisker/src/libs/tigera/ui-components/components/common/DataTable/index.tsx
+++ b/whisker/src/libs/tigera/ui-components/components/common/DataTable/index.tsx
@@ -12,6 +12,7 @@ import ResizableBody, {
     getTableStateReducer,
     checkedTableColumn,
     expandoTableColumn,
+    VirtualizedRow,
 } from './ResizableBody';
 import { useCheckedTable } from './hooks';
 
@@ -28,4 +29,4 @@ export {
     Table,
     SORT_DIRECTION,
 };
-export type { ServerSorting };
+export type { ServerSorting, VirtualizedRow };

--- a/whisker/src/pages/FlowLogsPage/__tests__/index.test.tsx
+++ b/whisker/src/pages/FlowLogsPage/__tests__/index.test.tsx
@@ -9,15 +9,18 @@ import FlowLogsPage from '..';
 
 import { useOmniFilterData } from '@/hooks/omniFilters';
 import { act } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 const MockOutlet = {
     onRowClicked: jest.fn(),
+    onSortClicked: jest.fn(),
 };
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     Outlet: ({ context }: any) => {
         MockOutlet.onRowClicked = context.onRowClicked;
+        MockOutlet.onSortClicked = context.onSortClicked;
         return <>Flow logs view: {context.view}</>;
     },
 }));
@@ -254,24 +257,84 @@ describe('FlowLogsPage', () => {
         });
         renderWithRouter(<FlowLogsPage />);
 
-        act(() => MockOutlet.onRowClicked());
+        act(() => MockOutlet.onRowClicked({}));
 
-        expect(
-            screen.getByText('Flow logs stream paused.'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Flows stream paused')).toBeInTheDocument();
     });
 
-    it('should not show a toast message when opening a row', () => {
+    it('should show resume the stream when clicking the same row', () => {
+        const id = '1234';
+        jest.mocked(useFlowLogsStream).mockReturnValue({
+            ...useStreamStub,
+            isDataStreaming: true,
+        });
+        const { rerender } = renderWithRouter(<FlowLogsPage />);
+
+        act(() => MockOutlet.onRowClicked({ id }));
+
+        jest.mocked(useFlowLogsStream).mockReturnValue({
+            ...useStreamStub,
+            isDataStreaming: false,
+        });
+
+        rerender(
+            <MemoryRouter>
+                <FlowLogsPage />
+            </MemoryRouter>,
+        );
+
+        act(() => MockOutlet.onRowClicked({ id }));
+
+        expect(screen.getByText('Flows stream resumed.')).toBeInTheDocument();
+    });
+
+    it('should not toast when the stream is already paused', () => {
+        const id = '1234';
+        jest.mocked(useFlowLogsStream).mockReturnValue({
+            ...useStreamStub,
+            hasStoppedStreaming: true,
+        });
+        renderWithRouter(<FlowLogsPage />);
+
+        act(() => MockOutlet.onRowClicked({ id }));
+
+        expect(
+            screen.queryByText('Flows stream resumed.'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('Flows stream paused'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('should not show a toast message when opening another row', () => {
         jest.mocked(useFlowLogsStream).mockReturnValue({
             ...useStreamStub,
             isDataStreaming: false,
         });
         renderWithRouter(<FlowLogsPage />);
 
-        act(() => MockOutlet.onRowClicked());
+        act(() => MockOutlet.onRowClicked({}));
 
         expect(
-            screen.queryByText('Flow logs stream paused.'),
+            screen.queryByText('Flows stream paused'),
         ).not.toBeInTheDocument();
+    });
+
+    it('should close a virtualized row on sort', () => {
+        const closeVirtualizedRowMock = jest.fn();
+        jest.mocked(useFlowLogsStream).mockReturnValue({
+            ...useStreamStub,
+            isDataStreaming: true,
+        });
+        renderWithRouter(<FlowLogsPage />);
+
+        act(() =>
+            MockOutlet.onRowClicked({
+                closeVirtualizedRow: closeVirtualizedRowMock,
+            }),
+        );
+        act(() => MockOutlet.onSortClicked());
+
+        expect(closeVirtualizedRowMock).toHaveBeenCalled();
     });
 });

--- a/whisker/src/pages/FlowLogsPage/index.tsx
+++ b/whisker/src/pages/FlowLogsPage/index.tsx
@@ -22,6 +22,7 @@ import {
     TabList,
     Tabs,
     Text,
+    ToastPosition,
     useToast,
 } from '@chakra-ui/react';
 import React from 'react';
@@ -29,10 +30,10 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { streamButtonStyles } from './styles';
 
 const toastProps = {
-    isClosable: true,
-    duration: 10000,
+    duration: 7500,
     variant: 'toast',
     status: 'info' as AlertStatus,
+    position: 'top' as ToastPosition,
 };
 
 const FlowLogsPage: React.FC = () => {

--- a/whisker/src/pages/FlowLogsPage/index.tsx
+++ b/whisker/src/pages/FlowLogsPage/index.tsx
@@ -6,12 +6,14 @@ import { useOmniFilterData } from '@/hooks/omniFilters';
 import PauseIcon from '@/icons/PauseIcon';
 import PlayIcon from '@/icons/PlayIcon';
 import { Link, TabTitle } from '@/libs/tigera/ui-components/components/common';
+import { VirtualizedRow } from '@/libs/tigera/ui-components/components/common/DataTable';
 import {
     OmniFilterChangeEvent,
     useOmniFilterUrlState,
 } from '@/libs/tigera/ui-components/components/common/OmniFilter';
 import { OmniFilterParam, OmniFilterProperties } from '@/utils/omniFilter';
 import {
+    AlertStatus,
     Box,
     Button,
     Flex,
@@ -25,6 +27,13 @@ import {
 import React from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { streamButtonStyles } from './styles';
+
+const toastProps = {
+    isClosable: true,
+    duration: 10000,
+    variant: 'toast',
+    status: 'info' as AlertStatus,
+};
 
 const FlowLogsPage: React.FC = () => {
     const location = useLocation();
@@ -50,7 +59,6 @@ const FlowLogsPage: React.FC = () => {
     };
 
     const [omniFilterData, fetchFilter] = useOmniFilterData();
-
     const selectedOmniFilterData = {};
     const selectedFilters = useSelectedOmniFilters(
         urlFilterParams,
@@ -68,18 +76,47 @@ const FlowLogsPage: React.FC = () => {
     } = useFlowLogsStream(urlFilterParams);
 
     const toast = useToast();
+    const selectedRowIdRef = React.useRef<string | null>(null);
+    const selectedRowRef = React.useRef<VirtualizedRow | null>(null);
+    const isWaitingRef = React.useRef<boolean>(false);
+    const hasStoppedRef = React.useRef<boolean>(false);
+    isWaitingRef.current = isWaiting;
+    hasStoppedRef.current = hasStoppedStreaming;
 
-    const onRowClicked = () => {
-        if (isDataStreaming || isWaiting) {
-            stopStream();
-            toast({
-                description: 'Flow logs stream paused.',
-                isClosable: true,
-                duration: 10000,
-                variant: 'toast',
-                status: 'info',
-            });
+    const onRowClicked = (row: VirtualizedRow) => {
+        selectedRowRef.current = row;
+
+        if (hasStoppedRef.current && !selectedRowIdRef.current) {
+            return;
         }
+
+        toast.closeAll();
+        stopStream();
+
+        if (isDataStreaming || isWaitingRef.current) {
+            selectedRowIdRef.current = row.id;
+            toast({
+                title: 'Flows stream paused',
+                description: 'Close all rows to continue streaming flows.',
+                ...toastProps,
+            });
+            stopStream();
+        } else if (row.id === selectedRowIdRef.current) {
+            selectedRowIdRef.current = null;
+            selectedRowRef.current = null;
+            toast({
+                description: 'Flows stream resumed.',
+                ...toastProps,
+            });
+            startStream();
+        } else {
+            selectedRowIdRef.current = row.id;
+        }
+    };
+
+    const onSortClicked = () => {
+        selectedRowRef.current?.closeVirtualizedRow();
+        selectedRowIdRef.current = null;
     };
 
     return (
@@ -97,7 +134,6 @@ const FlowLogsPage: React.FC = () => {
                         fetchFilter(filterParam)
                     }
                 />
-
                 <Flex>
                     {isWaiting && (
                         <Flex gap={2} alignItems='center'>
@@ -115,7 +151,12 @@ const FlowLogsPage: React.FC = () => {
                     {(hasStoppedStreaming || error) && (
                         <Button
                             variant='ghost'
-                            onClick={() => startStream()}
+                            onClick={() => {
+                                selectedRowRef.current?.closeVirtualizedRow();
+                                selectedRowIdRef.current = null;
+                                selectedRowRef.current = null;
+                                startStream();
+                            }}
                             leftIcon={<PlayIcon fill='tigeraGoldMedium' />}
                             sx={streamButtonStyles}
                         >
@@ -164,6 +205,7 @@ const FlowLogsPage: React.FC = () => {
                             flowLogs: data,
                             error,
                             onRowClicked,
+                            onSortClicked,
                         } satisfies FlowLogsContext
                     }
                 />

--- a/whisker/src/theme/colors.ts
+++ b/whisker/src/theme/colors.ts
@@ -42,7 +42,7 @@ export default {
     tigeraBlueMedium80: '#3A97C5',
     tigeraBlueMedium: '#1084BD',
     tigeraBlueMediumAlpha40: 'rgba(9, 125, 182, 0.4)',
-    tigeraBlueMediumDark: '#043249',
+    tigeraBlueMediumDark: '#183E55',
     tigeraBlueDark: '#273981',
     tigeraGoldLight: '#FCE181',
     tigeraGoldMedium20: '#FDE9D2',

--- a/whisker/src/theme/components/Alert.ts
+++ b/whisker/src/theme/components/Alert.ts
@@ -52,17 +52,18 @@ export default defineMultiStyleConfig({
     variants: {
         toast: {
             container: {
+                top: '40px',
                 '&[data-status="info"]': {
                     _dark: {
-                        backgroundColor: 'tigeraBlueMedium40',
-                        color: 'tigeraBlack',
+                        backgroundColor: 'tigeraBlueMediumDark',
+                        color: 'tigeraBlueMedium40',
                     },
                 },
             },
             icon: {
                 '&[data-status="info"]': {
                     _dark: {
-                        color: 'tigeraBlueMediumDark',
+                        color: 'tigeraBlueMedium40',
                     },
                 },
             },


### PR DESCRIPTION
![whisker-show-toast-on-row-click](https://github.com/user-attachments/assets/ea84c0a3-d586-472a-8d57-e37cde8b00f5)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
