### PR TITLE
eBPF: Fix cleanup of DSR flows

### DIFF
--- a/felix/bpf/conntrack/cttestdata/ct_data.go
+++ b/felix/bpf/conntrack/cttestdata/ct_data.go
@@ -15,11 +15,11 @@
 package cttestdata
 
 import (
-	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 	"net"
 	"time"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 	"github.com/projectcalico/calico/felix/timeshim/mocktime"
 )
 

--- a/felix/bpf/conntrack/cttestdata/ct_data.go
+++ b/felix/bpf/conntrack/cttestdata/ct_data.go
@@ -15,6 +15,7 @@
 package cttestdata
 
 import (
+	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 	"net"
 	"time"
 
@@ -116,7 +117,7 @@ func init() {
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
 				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
-				tcpRevKey: conntrack.NewValueNATReverse(Now-time.Second, 0,
+				tcpRevKey: conntrack.NewValueNATReverse(Now-59*time.Minute, 0,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true},
 					nil, nil, 5555),
 			},
@@ -130,6 +131,31 @@ func init() {
 				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
 				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, 0,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: true, AckSeen: true},
+					nil, nil, 5555),
+			},
+			ExpectedDeletions: []conntrack.Key{tcpFwdKey, tcpRevKey},
+		},
+
+		CTCleanupTest{
+			Description: "long-lived TCP NAT entries (DSR)",
+			KVs: map[conntrack.Key]conntrack.Value{
+				// Note: last seen time on the forward entry should be ignored in
+				// favour of the last-seen time on the reverse entry.
+				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
+				tcpRevKey: conntrack.NewValueNATReverse(Now-59*time.Minute, v3.FlagNATFwdDsr,
+					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: false, AckSeen: false},
+					nil, nil, 5555),
+			},
+		},
+
+		CTCleanupTest{
+			Description: "expired TCP NAT entries (DSR)",
+			KVs: map[conntrack.Key]conntrack.Value{
+				// Note: last seen time on the forward entry should be ignored in
+				// favour of the last-seen time on the reverse entry.
+				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
+				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, 0,
+					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: false, AckSeen: false},
 					nil, nil, 5555),
 			},
 			ExpectedDeletions: []conntrack.Key{tcpFwdKey, tcpRevKey},

--- a/felix/bpf/conntrack/cttestdata/ct_data.go
+++ b/felix/bpf/conntrack/cttestdata/ct_data.go
@@ -154,7 +154,7 @@ func init() {
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
 				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
-				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, 0,
+				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, v3.FlagNATFwdDsr,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: false, AckSeen: false},
 					nil, nil, 5555),
 			},


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fix that BPF-based conntrack cleaner would expire DSR entries too soon due to missing type check.

* Add macros to do the various checks.
* Adjust code structure to match Go version of cleaner.
* Add missing DSR check.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-10941

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that BPF-based conntrack cleaner would expire DSR entries too soon due to missing type check.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
