### PR TITLE
OpenShift needs RBAC for gatewayapis/finalizers

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -152,6 +152,7 @@ rules:
     resources:
       - apiservers/finalizers
       - gatewayapis
+      - gatewayapis/finalizers
       - installations
       - installations/status
       - installations/finalizers

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -152,6 +152,7 @@ rules:
     resources:
       - apiservers/finalizers
       - gatewayapis
+      - gatewayapis/finalizers
       - installations
       - installations/status
       - installations/finalizers

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -190,6 +190,7 @@ rules:
     resources:
       - apiservers/finalizers
       - gatewayapis
+      - gatewayapis/finalizers
       - installations
       - installations/status
       - installations/finalizers


### PR DESCRIPTION
To resolve this error:

    {"level":"error","ts":"2025-03-12T12:36:06Z","logger":"controller_gatewayapi","msg":"Failed to create object.","Name":"tigera-gateway","Namespace":"","Kind":"Namespace","key":{"name":"tigera-gateway"},"error":"namespaces \"tigera-gateway\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":...}
