### PR TITLE
Goldmane emitter improvements

### DIFF
--- a/goldmane/pkg/aggregator/aggregator_test.go
+++ b/goldmane/pkg/aggregator/aggregator_test.go
@@ -760,8 +760,8 @@ func TestSink(t *testing.T) {
 	// - The first window we aggregated covered 952-972 (but had now flows)
 	// - The second window we aggregated covered 972-992 (but had no flows)
 	// - The third window we aggregated covered 992-1012 (and had flows!)
-	require.Equal(t, int64(1012), sink.buckets[0].EndTime)
-	require.Equal(t, int64(992), sink.buckets[0].StartTime)
+	require.Equal(t, int64(1011), sink.buckets[0].EndTime)
+	require.Equal(t, int64(991), sink.buckets[0].StartTime)
 	require.Equal(t, int64(20), sink.buckets[0].EndTime-sink.buckets[0].StartTime)
 
 	// Expect the bucket to have aggregated to a single flow.

--- a/goldmane/pkg/aggregator/bucketing/bucket_ring.go
+++ b/goldmane/pkg/aggregator/bucketing/bucket_ring.go
@@ -130,7 +130,7 @@ func NewBucketRing(n, interval int, now int64, opts ...BucketRingOption) *Bucket
 	oldestBucketStart := time.Unix(newestBucketStart-int64(interval*n), 0)
 	oldestBucketEnd := time.Unix(oldestBucketStart.Unix()+int64(interval), 0)
 	ring.buckets[0] = *NewAggregationBucket(oldestBucketStart, oldestBucketEnd)
-	for i := 0; i < n; i++ {
+	for range n {
 		ring.Rollover()
 	}
 
@@ -268,18 +268,26 @@ func (r *BucketRing) findBucket(time int64) (int, *AggregationBucket) {
 	return -1, nil
 }
 
+// nowIndex returns the index of the bucket that represents the current time.
+// This is different from the head index, which is actually one bucket into the future.
+func (r *BucketRing) nowIndex() int {
+	return r.indexSubtract(r.headIndex, 1)
+}
+
 // FlowCollection returns a collection of flows to emit, or nil if we are still waiting for more data.
 // The BucketRing builds a FlowCollection by aggregating flow data from across a window of buckets. The window
 // is a fixed size (i.e., a fixed number of buckets), and starts a fixed period of time in the past in order to allow
 // for statistics to settle down before publishing.
 func (r *BucketRing) FlowCollection() *FlowCollection {
-	// Determine the newest bucket in the aggregation - this is always N buckets back from the head.
-	endIndex := r.indexSubtract(r.headIndex, r.pushAfter)
+	// Determine the newest bucket in the aggregation - this is always pushAfter buckets back from "now".
+	endIndex := r.indexSubtract(r.nowIndex(), r.pushAfter)
 	startIndex := r.indexSubtract(endIndex, r.bucketsToAggregate)
 
 	logrus.WithFields(logrus.Fields{
 		"startIndex": startIndex,
 		"endIndex":   endIndex,
+		"startTime":  r.buckets[startIndex].StartTime,
+		"endTime":    r.buckets[endIndex].StartTime,
 	}).Debug("Checking if bucket range should be emitted")
 
 	// Check if we're ready to emit. Wait until the oldest bucket in the window has not yet

--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -63,14 +63,17 @@ type Config struct {
 	// from each node in the cluster.
 	AggregationWindow time.Duration `json:"aggregation_window" envconfig:"AGGREGATION_WINDOW" default:"15s"`
 
-	// The number of buckets to combine when pushing flows to the sink. This can be used to reduce the number
-	// buckets combined into time-aggregated flows that are sent to the sink.
-	NumBucketsToCombine int `json:"num_buckets_to_combine" envconfig:"NUM_BUCKETS_TO_COMBINE" default:"20"`
+	// EmitAfterSeconds is the number of seconds from flow receipt to wait before a flow becomes eligible to be
+	// pushed to the emitter. Increasing this value will increase the latency of emitted flows, while a smaller
+	// value will cause the emitter to emit potentially incomplete flows.
+	//
+	// This must be a multiple of the aggregation window.
+	EmitAfterSeconds int `json:"emit_after_seconds" envconfig:"EMIT_AFTER_SECONDS" default:"30"`
 
-	// PushIndex is the index of the bucket which triggers pushing to the emitter. A larger value
-	// will increase the latency of emitted flows, while a smaller value will cause the emitter to emit
-	// potentially incomplete flows.
-	PushIndex int `json:"push_index" envconfig:"PUSH_INDEX" default:"30"`
+	// EmitterAggregationWindow is the duration of time across which flows are aggregated before being pushed to the emitter.
+	// This must be a multiple of the aggregation window.
+	// Emitted flows will be aggregated from "now-EmitAfterSeconds-EmitterAggregationWindow" to "now-EmitAfterSeconds"
+	EmitterAggregationWindow time.Duration `json:"emitter_aggregation_window" envconfig:"EMITTER_AGGREGATION_WINDOW" default:"5m"`
 }
 
 func ConfigFromEnv() Config {
@@ -116,8 +119,8 @@ func Run(ctx context.Context, cfg Config) {
 	// Track options for log aggregator.
 	aggOpts := []aggregator.Option{
 		aggregator.WithRolloverTime(cfg.AggregationWindow),
-		aggregator.WithBucketsToCombine(cfg.NumBucketsToCombine),
-		aggregator.WithPushIndex(cfg.PushIndex),
+		aggregator.WithBucketsToCombine(int(cfg.EmitterAggregationWindow.Seconds()) / int(cfg.AggregationWindow.Seconds())),
+		aggregator.WithPushIndex(cfg.EmitAfterSeconds / int(cfg.AggregationWindow.Seconds())),
 	}
 
 	if cfg.PushURL != "" {

--- a/goldmane/pkg/emitter/http_client.go
+++ b/goldmane/pkg/emitter/http_client.go
@@ -121,8 +121,11 @@ func watchFiles(updChan chan struct{}, files ...string) (func(), error) {
 		return nil, fmt.Errorf("error creating file watcher: %s", err)
 	}
 	for _, file := range files {
+		if err := fileWatcher.Add(file); err != nil {
+			logrus.WithError(err).Warn("Error watching file for changes")
+			continue
+		}
 		logrus.WithField("file", file).Debug("Watching file for changes")
-		fileWatcher.Add(file)
 	}
 
 	return func() {
@@ -151,9 +154,8 @@ func watchFiles(updChan chan struct{}, files ...string) (func(), error) {
 }
 
 type emitterClient struct {
-	url        string
-	reloadChan chan fsnotify.Event
-	getClient  func() (*http.Client, error)
+	url       string
+	getClient func() (*http.Client, error)
 }
 
 func (e *emitterClient) Post(body io.Reader) error {

--- a/goldmane/pkg/emitter/http_client.go
+++ b/goldmane/pkg/emitter/http_client.go
@@ -24,7 +24,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/lib/std/chanutil"
 )
 
 const ContentTypeMultilineJSON = "application/x-ndjson"
@@ -71,20 +74,94 @@ func newHTTPClient(caCert, clientKey, clientCert, serverName string) (*http.Clie
 }
 
 func newEmitterClient(url, caCert, clientKey, clientCert, serverName string) (*emitterClient, error) {
+	// Create an initial HTTP client, and a function to help encapsualte the reload logic.
 	client, err := newHTTPClient(caCert, clientKey, clientCert, serverName)
 	if err != nil {
 		return nil, err
 	}
-	return &emitterClient{url: url, client: client}, nil
+
+	updChan := make(chan struct{})
+	getClient := func() (*http.Client, error) {
+		select {
+		case _, ok := <-updChan:
+			if ok {
+				// Only reload the client if the channel is still open. If the filewatcher
+				// has been closed, we'll just continue using the existing client as best-effort.
+				logrus.Info("Reloading client after certificate change")
+				client, err = newHTTPClient(caCert, clientKey, clientCert, serverName)
+				if err != nil {
+					return nil, fmt.Errorf("error reloading CA cert: %s", err)
+				}
+			}
+		default:
+			// No change, return the existing client.
+		}
+		return client, nil
+	}
+
+	if caCert != "" || clientKey != "" || clientCert != "" {
+		// Start a goroutine to watch for changes to the CA cert file and feed
+		// them into the update channel.
+		monitorFn, err := watchFiles(updChan, caCert, clientCert, clientKey)
+		if err != nil {
+			return nil, fmt.Errorf("error setting up CA cert file watcher: %s", err)
+		}
+		go monitorFn()
+	}
+
+	return &emitterClient{
+		url:       url,
+		getClient: getClient,
+	}, nil
+}
+
+func watchFiles(updChan chan struct{}, files ...string) (func(), error) {
+	fileWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("error creating file watcher: %s", err)
+	}
+	for _, file := range files {
+		logrus.WithField("file", file).Debug("Watching file for changes")
+		fileWatcher.Add(file)
+	}
+
+	return func() {
+		// If we exit this function, make sure to close the file watcher and update channel.
+		defer fileWatcher.Close()
+		defer close(updChan)
+		defer logrus.Info("File watcher closed")
+		for {
+			select {
+			case event, ok := <-fileWatcher.Events:
+				if !ok {
+					return
+				}
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					logrus.WithField("file", event.Name).Info("File changed, triggering update")
+					_ = chanutil.WriteNonBlocking(updChan, struct{}{})
+				}
+			case err, ok := <-fileWatcher.Errors:
+				if !ok {
+					return
+				}
+				logrus.Errorf("error watching CA cert file: %s", err)
+			}
+		}
+	}, nil
 }
 
 type emitterClient struct {
-	url    string
-	client *http.Client
+	url        string
+	reloadChan chan fsnotify.Event
+	getClient  func() (*http.Client, error)
 }
 
 func (e *emitterClient) Post(body io.Reader) error {
-	resp, err := e.client.Post(e.url, ContentTypeMultilineJSON, body)
+	client, err := e.getClient()
+	if err != nil {
+		return err
+	}
+	resp, err := client.Post(e.url, ContentTypeMultilineJSON, body)
 	if err != nil {
 		return err
 	}

--- a/lib/std/chanutil/chan.go
+++ b/lib/std/chanutil/chan.go
@@ -6,8 +6,10 @@ import (
 	"time"
 )
 
-var ErrChannelClosed = errors.New("channel closed")
-var ErrDeadlineExceeded = errors.New("deadline exceeded")
+var (
+	ErrChannelClosed    = errors.New("channel closed")
+	ErrDeadlineExceeded = errors.New("deadline exceeded")
+)
 
 // Read reads from the given channel and blocks until either an object is pulled off the channel, the context
 // is done, or the channel is closed.
@@ -43,5 +45,16 @@ func ReadWithDeadline[E any](ctx context.Context, ch <-chan E, duration time.Dur
 		return v, nil
 	case <-time.After(duration):
 		return def, ErrDeadlineExceeded
+	}
+}
+
+// WriteNonBlocking writes to the given channel in a non-blocking manner. It return true if the write was successful,
+// and false otherwise.
+func WriteNonBlocking[E any](ch chan<- E, v E) bool {
+	select {
+	case ch <- v:
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Reload certificates when they change. This allows us to mount new
  certs without restarting the pod and losing in-memory state.
- Switch config model to be time-based, and adjust the default emission
  window to reduce latency.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.