### PR TITLE
Fix a few bugs in policy hit parsing to/from string, and stop panicking

### DIFF
--- a/felix/collector/goldmane/client.go
+++ b/felix/collector/goldmane/client.go
@@ -261,7 +261,11 @@ func toFlowPolicySet(policies []*proto.PolicyHit) flowlog.FlowPolicySet {
 
 	policySet := make(flowlog.FlowPolicySet)
 	for _, pol := range policies {
-		policySet[pol.ToString()] = struct{}{}
+		if s, err := pol.ToString(); err != nil {
+			logrus.WithError(err).WithField("policy", pol).Error("Failed to convert policy hit to string")
+		} else {
+			policySet[s] = struct{}{}
+		}
 	}
 	return policySet
 }

--- a/goldmane/pkg/aggregator/bucketing/bucket_ring.go
+++ b/goldmane/pkg/aggregator/bucketing/bucket_ring.go
@@ -402,10 +402,12 @@ func (r *BucketRing) Statistics(req *proto.StatisticsRequest) ([]*proto.Statisti
 		}
 		s1, err := resultsList[i].Policy.ToString()
 		if err != nil {
+			logrus.WithError(err).Error("Invalid policy hit, statistics sorting may be off")
 			return false
 		}
 		s2, err := resultsList[j].Policy.ToString()
 		if err != nil {
+			logrus.WithError(err).Error("Invalid policy hit, statistics sorting may be off")
 			return false
 		}
 		return s1 < s2

--- a/goldmane/pkg/aggregator/bucketing/bucket_ring.go
+++ b/goldmane/pkg/aggregator/bucketing/bucket_ring.go
@@ -400,7 +400,15 @@ func (r *BucketRing) Statistics(req *proto.StatisticsRequest) ([]*proto.Statisti
 		if p1Str == p2Str {
 			return resultsList[i].Direction < resultsList[j].Direction
 		}
-		return resultsList[i].Policy.ToString() < resultsList[j].Policy.ToString()
+		s1, err := resultsList[i].Policy.ToString()
+		if err != nil {
+			return false
+		}
+		s2, err := resultsList[j].Policy.ToString()
+		if err != nil {
+			return false
+		}
+		return s1 < s2
 	})
 	return resultsList, nil
 }

--- a/goldmane/proto/methods.go
+++ b/goldmane/proto/methods.go
@@ -20,26 +20,53 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 // ToString converts a PolicyHit struct into a string label.
 // TODO: This is a temporary solution - we should be pushing the structured PolicyHit representation
 // further down the stack, rather than converting between string / struct.
-func (h *PolicyHit) ToString() string {
+func (h *PolicyHit) ToString() (string, error) {
 	// Format is: "<policy index>|<tier>|<namePart>|<action>|<rule index>"
 	tmpl := "%d|%s|%s|%s|%d"
 
+	if err := h.Validate(); err != nil {
+		return "", err
+	}
+
 	var namePart string
+	var err error
 	if h.Kind == PolicyKind_EndOfTier {
-		namePart = makeNamePart(h.Trigger)
+		namePart, err = makeNamePart(h.Trigger)
 	} else {
-		namePart = makeNamePart(h)
+		namePart, err = makeNamePart(h)
+	}
+	if err != nil {
+		return "", err
 	}
 
 	// Convert action from enum to string.
 	action := strings.ToLower(Action_name[int32(h.Action)])
 
-	return fmt.Sprintf(tmpl, h.PolicyIndex, h.Tier, namePart, action, h.RuleIndex)
+	return fmt.Sprintf(tmpl, h.PolicyIndex, h.Tier, namePart, action, h.RuleIndex), nil
+}
+
+func (h *PolicyHit) Validate() error {
+	if _, ok := Action_name[int32(h.Action)]; !ok {
+		return fmt.Errorf("unexpected action: %v", h.Action)
+	}
+
+	switch h.Kind {
+	case PolicyKind_GlobalNetworkPolicy, PolicyKind_AdminNetworkPolicy, PolicyKind_BaselineAdminNetworkPolicy:
+		if h.Namespace != "" {
+			return fmt.Errorf("unexpected namespace for global policy")
+		}
+	case PolicyKind_EndOfTier:
+		if h.Trigger == nil {
+			return fmt.Errorf("EndOfTier hit missing trigger")
+		}
+	}
+	return nil
 }
 
 func (h *PolicyHit) fields() logrus.Fields {
@@ -54,7 +81,8 @@ func (h *PolicyHit) fields() logrus.Fields {
 	}
 }
 
-func makeNamePart(h *PolicyHit) string {
+func makeNamePart(h *PolicyHit) (string, error) {
+	logrus.WithFields(h.fields()).Debug("Generating name part from policy hit")
 	var namePart string
 	switch h.Kind {
 	case PolicyKind_GlobalNetworkPolicy:
@@ -66,9 +94,9 @@ func makeNamePart(h *PolicyHit) string {
 	case PolicyKind_StagedKubernetesNetworkPolicy:
 		namePart = fmt.Sprintf("%s/staged:knp.default.%s", h.Namespace, h.Name)
 	case PolicyKind_StagedGlobalNetworkPolicy:
-		namePart = fmt.Sprintf("staged:%s.%s", h.Tier, h.Name)
+		namePart = fmt.Sprintf("%s.staged:%s", h.Tier, h.Name)
 	case PolicyKind_StagedNetworkPolicy:
-		namePart = fmt.Sprintf("%s/staged:%s.%s", h.Namespace, h.Tier, h.Name)
+		namePart = fmt.Sprintf("%s/%s.staged:%s", h.Namespace, h.Tier, h.Name)
 	case PolicyKind_AdminNetworkPolicy:
 		namePart = fmt.Sprintf("kanp.adminnetworkpolicy.%s", h.Name)
 	case PolicyKind_BaselineAdminNetworkPolicy:
@@ -78,10 +106,11 @@ func makeNamePart(h *PolicyHit) string {
 		// profile - e.g., __PROFILE__.kns.default, __PROFILE__.ksa.svcacct.
 		namePart = fmt.Sprintf("__PROFILE__.%s", h.Name)
 	default:
-		logrus.WithFields(h.fields()).Panic("Unexpected policy kind")
+		logrus.WithFields(h.fields()).Error("Unexpected policy kind")
+		return "", fmt.Errorf("unexpected policy kind: %v", h.Kind)
 	}
 	logrus.WithFields(h.fields()).WithField("namePart", namePart).Debug("Generated name part")
-	return namePart
+	return namePart, nil
 }
 
 // HitFromString parses a policy hit label string into a PolicyHit struct.
@@ -129,9 +158,9 @@ func HitFromString(s string) (*PolicyHit, error) {
 		// Name format is "(staged:)tier.name".
 		n := nameParts[0]
 
-		if strings.HasPrefix(n, "staged:") {
+		if strings.Contains(n, "staged:") {
 			kind = PolicyKind_StagedGlobalNetworkPolicy
-			n = strings.TrimPrefix(n, "staged:")
+			n = strings.Replace(n, "staged:", "", 1)
 		} else if strings.HasPrefix(n, "kanp.") {
 			kind = PolicyKind_AdminNetworkPolicy
 			n = strings.TrimPrefix(n, "kanp.")
@@ -147,24 +176,33 @@ func HitFromString(s string) (*PolicyHit, error) {
 		// At this point, n is "tier.name". The name may of dots in it, so
 		// we need to recombine the parts except for the tier.
 		name = strings.Join(strings.Split(n, ".")[1:], ".")
+
+		// Verify the "tier" part of "tier.name" matches the tier.
+		if strings.Split(n, ".")[0] != tier {
+			return nil, fmt.Errorf("tier does not match: %s != %s", strings.Split(n, ".")[0], tier)
+		}
 	} else if len(nameParts) == 2 {
 		// Namespaced.
-		// Name format is "(staged:)(kind.)tier.name".
+		// Name format for Calico policies is "tier.(staged:)name".
+		// Name format for K8s policies is "(staged:)knp.default.name".
 		n := nameParts[1]
 		ns = nameParts[0]
-		if strings.HasPrefix(n, "staged:") {
-			n = strings.TrimPrefix(n, "staged:")
-			if strings.HasPrefix(n, "knp.") {
-				kind = PolicyKind_StagedKubernetesNetworkPolicy
-				n = strings.TrimPrefix(n, "knp.")
-			} else {
-				kind = PolicyKind_StagedNetworkPolicy
-			}
+		if strings.HasPrefix(n, "staged:knp.") {
+			// StagedKubernetesNetworkPolicy.
+			kind = PolicyKind_StagedKubernetesNetworkPolicy
+			n = strings.TrimPrefix(n, "staged:knp.")
+		} else if strings.HasPrefix(n, "knp.") {
+			// KubernetesNetworkPolicy.
+			kind = PolicyKind_NetworkPolicy
+			n = strings.TrimPrefix(n, "knp.")
 		} else {
-			if strings.HasPrefix(n, "knp.") {
-				kind = PolicyKind_NetworkPolicy
-				n = strings.TrimPrefix(n, "knp.")
+			// This is either a Calico NetworkPolicy or Calico StagedNetworkPolicy.
+			if strings.Contains(n, "staged:") {
+				kind = PolicyKind_StagedNetworkPolicy
+				n = strings.Replace(n, "staged:", "", 1)
 			} else {
+				// Calico NetworkPolicy.
+				// Name format is already "tier.name".
 				kind = PolicyKind_CalicoNetworkPolicy
 			}
 		}
@@ -172,6 +210,34 @@ func HitFromString(s string) (*PolicyHit, error) {
 		// At this point, n is "tier.name". The name may of dots in it, so
 		// we need to recombine the parts except for the tier.
 		name = strings.Join(strings.Split(n, ".")[1:], ".")
+
+		// Verify the "tier" part of "tier.name" matches the tier.
+		if strings.Split(n, ".")[0] != tier {
+			return nil, fmt.Errorf("tier does not match: %s != %s", strings.Split(n, ".")[0], tier)
+		}
+	}
+
+	// Verify the name is valid.
+	if name == "" {
+		return nil, fmt.Errorf("invalid name: %s", namePart)
+	}
+	if res := validation.ValidatePodName(name, true); res != nil {
+		return nil, fmt.Errorf("invalid name: %s: %s", name, strings.Join(res, ", "))
+	}
+
+	// Verify the namespace is valid.
+	if ns != "" {
+		if res := validation.ValidateNamespaceName(ns, true); res != nil {
+			return nil, fmt.Errorf("invalid namespace: %s: %s", ns, strings.Join(res, ", "))
+		}
+	}
+
+	if tier == "" {
+		return nil, fmt.Errorf("tier is required")
+	} else if tier != "__PROFILE__" {
+		if res := validation.ValidatePodName(tier, true); res != nil {
+			return nil, fmt.Errorf("invalid tier: %s: %s", tier, strings.Join(res, ", "))
+		}
 	}
 
 	if ruleIdx == -1 {

--- a/goldmane/proto/methods.go
+++ b/goldmane/proto/methods.go
@@ -59,7 +59,10 @@ func (h *PolicyHit) Validate() error {
 	}
 
 	switch h.Kind {
-	case PolicyKind_GlobalNetworkPolicy, PolicyKind_AdminNetworkPolicy, PolicyKind_BaselineAdminNetworkPolicy:
+	case PolicyKind_GlobalNetworkPolicy,
+		PolicyKind_StagedGlobalNetworkPolicy,
+		PolicyKind_AdminNetworkPolicy,
+		PolicyKind_BaselineAdminNetworkPolicy:
 		if h.Namespace != "" {
 			return fmt.Errorf("unexpected namespace for global policy")
 		}

--- a/goldmane/proto/methods.go
+++ b/goldmane/proto/methods.go
@@ -31,6 +31,7 @@ func (h *PolicyHit) ToString() (string, error) {
 	tmpl := "%d|%s|%s|%s|%d"
 
 	if err := h.Validate(); err != nil {
+		logrus.WithFields(h.fields()).WithError(err).Error("Failed to validate policy hit")
 		return "", err
 	}
 
@@ -42,6 +43,7 @@ func (h *PolicyHit) ToString() (string, error) {
 		namePart, err = makeNamePart(h)
 	}
 	if err != nil {
+		logrus.WithFields(h.fields()).WithError(err).Error("Failed to generate name part")
 		return "", err
 	}
 

--- a/goldmane/proto/methods_test.go
+++ b/goldmane/proto/methods_test.go
@@ -1,6 +1,10 @@
 package proto
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestConversion(t *testing.T) {
 	// Take a bunch of policy strings and convert them to PolicyHit structs, then back.
@@ -8,8 +12,10 @@ func TestConversion(t *testing.T) {
 	tests := []string{
 		// GNP
 		"0|tier|tier.name|allow|0",
-		"1|tier|staged:tier.name|deny|2",
-		"1|tier|staged:tier.name.with.dots|deny|2",
+
+		// Staged GNP
+		"1|tier|tier.staged:name|deny|2",
+		"1|tier|tier.staged:name.with.dots|deny|2",
 
 		// GNP in baseline / anp namespaces.
 		"0|adminnetworkpolicy|adminnetworkpolicy.name|deny|1",
@@ -17,14 +23,22 @@ func TestConversion(t *testing.T) {
 
 		// Namespaced Calico NP
 		"0|tier|namespace/tier.name|allow|1",
-		"1|tier|namespace/staged:tier.name|deny|0",
-		"1|tier|namespace/staged:tier.name.with.dots|deny|0",
 		"0|tier1|default/tier1.np1-1|pass|0",
 
 		// Namespaced KNP
-		"0|tier|namespace/knp.default.name|allow|2",
-		"1|tier|namespace/staged:knp.default.name|deny|3",
-		"1|tier|namespace/staged:knp.default.name.with.dots|deny|3",
+		"0|default|namespace/knp.default.name|allow|2",
+
+		// Staged poliicies have a different format depending on the Kind.
+		// For Calico policies:     <tier>|<namespace>/<tier>.staged:<name>
+		// For kubernetes policies: default|<namespace>/staged:knp.default.<name>
+		//
+		// Calico Namespaced StagedNetworkPolicy.
+		"1|tier|namespace/tier.staged:name|deny|0",
+		"1|tier|namespace/tier.staged:name.with.dots|deny|0",
+
+		// StagedKubernetesNetworkPolicy.
+		"1|default|namespace/staged:knp.default.name|deny|3",
+		"1|default|namespace/staged:knp.default.name.with.dots|deny|3",
 
 		// AdminNetworkPolicy
 		"3|adminnetworkpolicy|kanp.adminnetworkpolicy.name|pass|4",
@@ -46,6 +60,7 @@ func TestConversion(t *testing.T) {
 		"1|tier1|ns1/tier1.policy1|allow|-1",
 		"0|adminnetworkpolicy|kanp.adminnetworkpolicy.policy1|allow|-1",
 		"2|adminnetworkpolicy|adminnetworkpolicy.policy1|allow|-1",
+
 		"0|tier2|default/tier2.staged:np2-1|deny|-1",
 		"1|tier2|default/tier2.staged:np2-1|deny|-1",
 	}
@@ -57,9 +72,157 @@ func TestConversion(t *testing.T) {
 				t.Fatalf("Failed to convert string to PolicyHit: %v", err)
 			}
 
-			converted := hit.ToString()
+			converted, err := hit.ToString()
+			require.NoError(t, err)
 			if converted != strVal {
 				t.Fatalf("Conversion failed: expected %s, got %s", strVal, converted)
+			}
+		})
+	}
+}
+
+func TestInvalidStrings(t *testing.T) {
+	tests := []string{
+		// Invalid integer values.
+		"1|tier|staged:tier.name|deny|notInt",
+		"notint|baselineadminnetworkpolicy|baselineadminnetworkpolicy.name|deny|2",
+		"notint|baselineadminnetworkpolicy|kbanp.baselineadminnetworkpolicy.name|pass|4",
+		"notint|tier1|ns1/tier1.policy1|deny|-1",
+
+		// An extra section.
+		"0|tier|tier.name|allow|0|extra",
+
+		// Invalid characters.
+		"1|tier|invalid-ch@aracter|deny|2",
+		"1|_|namespace/staged:tier.name|deny|0",
+		"0|@dminnetworkpolicy|kanp.adminnetworkpolicy.policy1|allow|-1",
+
+		// Bad action field.
+		"0|adminnetworkpolicy|adminnetworkpolicy.name|badaction|1",
+
+		// Tier fields do not match.
+		"0|tier|namespace/knp.default.name|allow|2",
+		"0|adminnetworkpolicy|kanp.foobar.policy1|allow|-1",
+		"1|tier|tier2.name|allow|0",
+		"0||namespace/tier.name|allow|1",
+
+		// Missing a name section.
+		"0|tier1|default/|pass|0",
+		"1|tier|namespace/knp.default|deny|3",
+
+		// Profile rules.
+		"1|___PROFILE__|__PROFILE__.kns.default|allow|0",
+		"1|__PROFILE__|__PROFILE__.PSA.svcacct|allow|0",
+	}
+
+	for _, strVal := range tests {
+		t.Run(strVal, func(t *testing.T) {
+			_, err := HitFromString(strVal)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestToString(t *testing.T) {
+	type testCase struct {
+		name   string
+		hit    *PolicyHit
+		err    string
+		strVal string
+	}
+	tests := []testCase{
+		{
+			name:   "Valid base case",
+			strVal: "0|tier|tier.name|allow|0",
+			hit: &PolicyHit{
+				Kind:        PolicyKind_GlobalNetworkPolicy,
+				Tier:        "tier",
+				Name:        "name",
+				Namespace:   "",
+				Action:      Action_Allow,
+				RuleIndex:   0,
+				PolicyIndex: 0,
+			},
+		},
+		{
+			name: "Invalid tier",
+			err:  "unexpected policy kind",
+			hit: &PolicyHit{
+				Kind:        PolicyKind(500),
+				Tier:        "tier",
+				Name:        "name",
+				Namespace:   "namespace",
+				Action:      Action_Allow,
+				RuleIndex:   0,
+				PolicyIndex: 0,
+			},
+		},
+		{
+			name: "Invalid action",
+			err:  "unexpected action",
+			hit: &PolicyHit{
+				Kind:        PolicyKind_GlobalNetworkPolicy,
+				Tier:        "tier",
+				Name:        "name",
+				Namespace:   "",
+				Action:      Action(500),
+				RuleIndex:   0,
+				PolicyIndex: 0,
+			},
+		},
+		{
+			name: "Invalid kind",
+			err:  "unexpected policy kind",
+			hit: &PolicyHit{
+				Kind:        PolicyKind(500),
+				Tier:        "tier",
+				Name:        "name",
+				Namespace:   "namespace",
+				Action:      Action_Allow,
+				RuleIndex:   0,
+				PolicyIndex: 0,
+			},
+		},
+		{
+			name: "GNP with a Namespace specified",
+			err:  "unexpected namespace",
+			hit: &PolicyHit{
+				Kind:        PolicyKind_GlobalNetworkPolicy,
+				Tier:        "tier",
+				Name:        "name",
+				Namespace:   "namespace",
+				Action:      Action_Allow,
+				RuleIndex:   0,
+				PolicyIndex: 0,
+			},
+		},
+		{
+			name: "Missing trigger for EndOfTier",
+			err:  "missing trigger",
+			hit: &PolicyHit{
+				Kind:        PolicyKind_EndOfTier,
+				Tier:        "tier",
+				Name:        "name",
+				Namespace:   "namespace",
+				Action:      Action_Allow,
+				RuleIndex:   0,
+				PolicyIndex: 0,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := tc.hit.ToString()
+			if tc.err != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.strVal != "" {
+				require.Equal(t, tc.strVal, val)
 			}
 		})
 	}

--- a/goldmane/proto/methods_test.go
+++ b/goldmane/proto/methods_test.go
@@ -145,19 +145,6 @@ func TestToString(t *testing.T) {
 			},
 		},
 		{
-			name: "Invalid tier",
-			err:  "unexpected policy kind",
-			hit: &PolicyHit{
-				Kind:        PolicyKind(500),
-				Tier:        "tier",
-				Name:        "name",
-				Namespace:   "namespace",
-				Action:      Action_Allow,
-				RuleIndex:   0,
-				PolicyIndex: 0,
-			},
-		},
-		{
 			name: "Invalid action",
 			err:  "unexpected action",
 			hit: &PolicyHit{


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We didn't have a way of bubbling up errors if we were given invalid
policy hits (or there was a bug in the parsing). This PR changes that so
that, and also adds explicit validation to the input and output to
ensure we're not accepting bad data.

In the process, a couple of staged policy parsing bugs were found and
fixed.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.