### PR TITLE
Avoid calls to WithFields in StatsCollector/HealthAggregator

### DIFF
--- a/felix/calc/stats_collector.go
+++ b/felix/calc/stats_collector.go
@@ -135,23 +135,29 @@ func (s *StatsCollector) OnUpdate(update api.Update) (filterOut bool) {
 	}
 	if update.UpdateType == api.UpdateTypeKVNew {
 		s.keyCountByHost[hostname] += 1
-		log.WithFields(log.Fields{
-			"key":      update.Key,
-			"host":     hostname,
-			"newCount": s.keyCountByHost[hostname],
-		}).Debug("Host-specific key added")
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.WithFields(log.Fields{
+				"key":      update.Key,
+				"host":     hostname,
+				"newCount": s.keyCountByHost[hostname],
+			}).Debug("Host-specific key added")
+		}
 		if counter != nil {
 			*counter += 1
 		}
 	} else if update.UpdateType == api.UpdateTypeKVDeleted {
 		s.keyCountByHost[hostname] -= 1
-		log.WithFields(log.Fields{
-			"key":      update.Key,
-			"host":     hostname,
-			"newCount": s.keyCountByHost[hostname],
-		}).Debug("Host-specific key deleted")
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.WithFields(log.Fields{
+				"key":      update.Key,
+				"host":     hostname,
+				"newCount": s.keyCountByHost[hostname],
+			}).Debug("Host-specific key deleted")
+		}
 		if s.keyCountByHost[hostname] <= 0 {
-			log.WithField("host", hostname).Debug("Host no longer has any keys")
+			if log.IsLevelEnabled(log.DebugLevel) {
+				log.WithField("host", hostname).Debug("Host no longer has any keys")
+			}
 			delete(s.keyCountByHost, hostname)
 		}
 		if counter != nil {
@@ -166,13 +172,14 @@ func (s *StatsCollector) UpdatePolicyCounts(numTiers, numPolicies, numProfiles, 
 	if numTiers == s.numTiers && numPolicies == s.numPolicies && numProfiles == s.numProfiles && numALPPolicies == s.numALPPolicies {
 		return
 	}
-
-	log.WithFields(log.Fields{
-		"numTiers":       numTiers,
-		"numPolicies":    numPolicies,
-		"numProfiles":    numProfiles,
-		"numALPPolicies": numALPPolicies,
-	}).Debug("Number of tiers/policies/profiles changed")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithFields(log.Fields{
+			"numTiers":       numTiers,
+			"numPolicies":    numPolicies,
+			"numProfiles":    numProfiles,
+			"numALPPolicies": numALPPolicies,
+		}).Debug("Number of tiers/policies/profiles changed")
+	}
 	s.numTiers = numTiers
 	s.numPolicies = numPolicies
 	s.numProfiles = numProfiles
@@ -181,7 +188,9 @@ func (s *StatsCollector) UpdatePolicyCounts(numTiers, numPolicies, numProfiles, 
 }
 
 func (s *StatsCollector) sendUpdate() {
-	log.Debug("Checking whether we should send an update")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debug("Checking whether we should send an update")
+	}
 	update := StatsUpdate{
 		NumHosts:             len(s.keyCountByHost),
 		NumHostEndpoints:     s.numHostEndpoints,

--- a/libcalico-go/lib/health/health.go
+++ b/libcalico-go/lib/health/health.go
@@ -196,14 +196,12 @@ func (aggregator *HealthAggregator) Report(name string, report *HealthReport) {
 	reporter := aggregator.reporters[name]
 
 	reports := aggregator.reporters[name].reports
-	logCxt := log.WithFields(log.Fields{
-		"name":      name,
-		"newReport": formatReport(&reports, report),
-		"oldReport": formatReport(&reports, &reporter.latest),
-	})
-
 	if reporter.latest != *report {
-		logCxt.Info("Health of component changed")
+		log.WithFields(log.Fields{
+			"name":      name,
+			"newReport": formatReport(&reports, report),
+			"oldReport": formatReport(&reports, &reporter.latest),
+		}).Info("Health of component changed")
 		reporter.latest = *report
 	}
 	reporter.timestamp = time.Now()


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Noticed these calls producing a lot of garbage in a heap trace.  Let's skip them if debug is disabled; some of them get called for every endpoint update, which is quite a warm path in a large cluster.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Reduce logging-related allocations in hot path.  Reduces garbage collection overheads.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
