### PR TITLE
Add proper prefix for ANP|BANP policies in flowlogs

### DIFF
--- a/felix/calc/endpoint_lookup_cache.go
+++ b/felix/calc/endpoint_lookup_cache.go
@@ -31,6 +31,7 @@ import (
 	v3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
@@ -232,7 +233,7 @@ func (ec *EndpointLookupsCache) CreateEndpointData(key model.EndpointKey, ep mod
 		tdEgress := &TierData{}
 		var hasIngress, hasEgress bool
 		for _, pol := range ti.OrderedPolicies {
-			namespace, tier, name, err := deconstructPolicyName(pol.Key.Name)
+			namespace, tier, name, err := names.DeconstructPolicyName(pol.Key.Name)
 			if err != nil {
 				log.WithError(err).Error("Unable to parse policy name")
 				continue

--- a/felix/calc/policy_lookups_cache_test.go
+++ b/felix/calc/policy_lookups_cache_test.go
@@ -102,6 +102,46 @@ var (
 	prefix_knp1_t1_i0D = toprefix("DPI0|namespace-1/knp.default.policy-1.1.1.1")
 	ruleID_knp1_t1_i0D = NewRuleID("default", "knp.default.policy-1.1.1.1", "namespace-1", 0, rules.RuleDirIngress, rules.RuleActionDeny)
 
+	// K8s AdminNetworkPolicy kanp.adminnetworkpolicy.policy-1.1
+	kanp1_t1_1i0e_key = model.PolicyKey{
+		Tier: "adminnetworkpolicy",
+		Name: "kanp.adminnetworkpolicy.policy-1.1.1.1",
+	}
+	kanp1_t1_1i0e = &model.Policy{
+		InboundRules: []model.Rule{
+			{Action: "deny"},
+		},
+	}
+	prefix_kanp1_t1_i0D = toprefix("DPI0|kanp.adminnetworkpolicy.policy-1.1.1.1")
+	ruleID_kanp1_t1_i0D = NewRuleID(
+		"adminnetworkpolicy",
+		"kanp.adminnetworkpolicy.policy-1.1.1.1",
+		"",
+		0,
+		rules.RuleDirIngress,
+		rules.RuleActionDeny,
+	)
+
+	// K8s BaselineAdminNetworkPolicy kbanp.baselineadminnetworkpolicy.policy-1.1
+	kbanp1_t1_1i0e_key = model.PolicyKey{
+		Tier: "baselineadminnetworkpolicy",
+		Name: "kbanp.baselineadminnetworkpolicy.policy-1.1.1.1",
+	}
+	kbanp1_t1_1i0e = &model.Policy{
+		InboundRules: []model.Rule{
+			{Action: "deny"},
+		},
+	}
+	prefix_kbanp1_t1_i0D = toprefix("DPI0|kbanp.baselineadminnetworkpolicy.policy-1.1.1.1")
+	ruleID_kbanp1_t1_i0D = NewRuleID(
+		"baselineadminnetworkpolicy",
+		"kbanp.baselineadminnetworkpolicy.policy-1.1.1.1",
+		"",
+		0,
+		rules.RuleDirIngress,
+		rules.RuleActionDeny,
+	)
+
 	// Profile profile-1
 	pr1_1i1e_key = model.ProfileRulesKey{
 		ProfileKey: model.ProfileKey{Name: "profile-1"},
@@ -120,14 +160,22 @@ var (
 	ruleID_prof_e0D = NewRuleID("", "profile-1", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
 
 	// Tier no-matches
-	prefix_nomatch_t1_i = toprefix("DPI|tier-1")
-	ruleID_nomatch_t1_i = NewRuleID("tier-1", "", "", 0, rules.RuleDirIngress, rules.RuleActionDeny)
-	prefix_nomatch_t1_e = toprefix("DPE|tier-1")
-	ruleID_nomatch_t1_e = NewRuleID("tier-1", "", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
-	prefix_nomatch_td_i = toprefix("DPI|default")
-	ruleID_nomatch_td_i = NewRuleID("default", "", "", 0, rules.RuleDirIngress, rules.RuleActionDeny)
-	prefix_nomatch_td_e = toprefix("DPE|default")
-	ruleID_nomatch_td_e = NewRuleID("default", "", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
+	prefix_nomatch_t1_i    = toprefix("DPI|tier-1")
+	ruleID_nomatch_t1_i    = NewRuleID("tier-1", "", "", 0, rules.RuleDirIngress, rules.RuleActionDeny)
+	prefix_nomatch_t1_e    = toprefix("DPE|tier-1")
+	ruleID_nomatch_t1_e    = NewRuleID("tier-1", "", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
+	prefix_nomatch_td_i    = toprefix("DPI|default")
+	ruleID_nomatch_td_i    = NewRuleID("default", "", "", 0, rules.RuleDirIngress, rules.RuleActionDeny)
+	prefix_nomatch_td_e    = toprefix("DPE|default")
+	ruleID_nomatch_td_e    = NewRuleID("default", "", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
+	prefix_nomatch_tanp_i  = toprefix("DPI|adminnetworkpolicy")
+	ruleID_nomatch_tanp_i  = NewRuleID("adminnetworkpolicy", "", "", 0, rules.RuleDirIngress, rules.RuleActionDeny)
+	prefix_nomatch_tanp_e  = toprefix("DPE|adminnetworkpolicy")
+	ruleID_nomatch_tanp_e  = NewRuleID("adminnetworkpolicy", "", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
+	prefix_nomatch_tbanp_i = toprefix("DPI|baselineadminnetworkpolicy")
+	ruleID_nomatch_tbanp_i = NewRuleID("baselineadminnetworkpolicy", "", "", 0, rules.RuleDirIngress, rules.RuleActionDeny)
+	prefix_nomatch_tbanp_e = toprefix("DPE|baselineadminnetworkpolicy")
+	ruleID_nomatch_tbanp_e = NewRuleID("baselineadminnetworkpolicy", "", "", 0, rules.RuleDirEgress, rules.RuleActionDeny)
 
 	// Profile no-matches
 	prefix_nomatch_prof_i = toprefix("DRI")
@@ -181,6 +229,12 @@ var _ = Describe("PolicyLookupsCache tests", func() {
 		Entry("KNP1 (1i0e) no match default ingress", knp1_t1_1i0e_key, knp1_t1_1i0e, prefix_nomatch_td_i, ruleID_nomatch_td_i),
 		Entry("KNP1 (1i0e) no match default egress", knp1_t1_1i0e_key, knp1_t1_1i0e, prefix_nomatch_td_e, ruleID_nomatch_td_e),
 		Entry("KNP1 (1i0e) i0", knp1_t1_1i0e_key, knp1_t1_1i0e, prefix_knp1_t1_i0D, ruleID_knp1_t1_i0D),
+		Entry("KANP1 (1i0e) no match default ingress", kanp1_t1_1i0e_key, kanp1_t1_1i0e, prefix_nomatch_tanp_i, ruleID_nomatch_tanp_i),
+		Entry("KANP1 (1i0e) no match default egress", kanp1_t1_1i0e_key, kanp1_t1_1i0e, prefix_nomatch_tanp_e, ruleID_nomatch_tanp_e),
+		Entry("KANP1 (1i0e) i0", kanp1_t1_1i0e_key, kanp1_t1_1i0e, prefix_kanp1_t1_i0D, ruleID_kanp1_t1_i0D),
+		Entry("KBANP1 (1i0e) no match default ingress", kbanp1_t1_1i0e_key, kbanp1_t1_1i0e, prefix_nomatch_tbanp_i, ruleID_nomatch_tbanp_i),
+		Entry("KBANP1 (1i0e) no match default egress", kbanp1_t1_1i0e_key, kbanp1_t1_1i0e, prefix_nomatch_tbanp_e, ruleID_nomatch_tbanp_e),
+		Entry("KBANP1 (1i0e) i0", kbanp1_t1_1i0e_key, kbanp1_t1_1i0e, prefix_kbanp1_t1_i0D, ruleID_kbanp1_t1_i0D),
 	)
 
 	DescribeTable(

--- a/libcalico-go/lib/upgrade/migrator/migrate.go
+++ b/libcalico-go/lib/upgrade/migrator/migrate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/libcalico-go/lib/upgrade/converters"
 	"github.com/projectcalico/calico/libcalico-go/lib/upgrade/migrator/clients"
@@ -372,7 +373,7 @@ var noFilter = func(_ model.Key) bool { return false }
 // Filter to filter out K8s backed network policies
 var filterGNP = func(k model.Key) bool {
 	gk := k.(model.PolicyKey)
-	return strings.HasPrefix(gk.Name, "knp.default.")
+	return strings.HasPrefix(gk.Name, names.K8sNetworkPolicyNamePrefix)
 }
 
 // Filter to filter out K8s (namespace) and OpenStack backed profiles


### PR DESCRIPTION
## Description

For (Baseline) Admin Network Policy deconstruct policy names correctly to include correct policy information in flow logs.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
