### PR TITLE
Don't use internal __PROFILE__ tier in Goldmane API

### DIFF
--- a/goldmane/proto/methods.go
+++ b/goldmane/proto/methods.go
@@ -47,10 +47,16 @@ func (h *PolicyHit) ToString() (string, error) {
 		return "", err
 	}
 
+	tier := h.Tier
+	if h.Kind == PolicyKind_Profile {
+		// Profiles are a special case where the tier is always __PROFILE__.
+		tier = "__PROFILE__"
+	}
+
 	// Convert action from enum to string.
 	action := strings.ToLower(Action_name[int32(h.Action)])
 
-	return fmt.Sprintf(tmpl, h.PolicyIndex, h.Tier, namePart, action, h.RuleIndex), nil
+	return fmt.Sprintf(tmpl, h.PolicyIndex, tier, namePart, action, h.RuleIndex), nil
 }
 
 func (h *PolicyHit) Validate() error {
@@ -239,9 +245,15 @@ func HitFromString(s string) (*PolicyHit, error) {
 
 	if tier == "" {
 		return nil, fmt.Errorf("tier is required")
-	} else if tier != "__PROFILE__" {
-		if res := validation.ValidatePodName(tier, true); res != nil {
-			return nil, fmt.Errorf("invalid tier: %s: %s", tier, strings.Join(res, ", "))
+	} else {
+		if tier == "__PROFILE__" {
+			// __PROFILE__ is a special internal tier used for Profiles, but we don't
+			// want to show this in the API as it's nto a real v3 Tier.
+			tier = ""
+		} else {
+			if res := validation.ValidatePodName(tier, true); res != nil {
+				return nil, fmt.Errorf("invalid tier: %s: %s", tier, strings.Join(res, ", "))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Felix uses an intenral __PROFILE__ tier for Profile objects, but these aren't real v3 objects. 

We want to keep the Goldmane API in terms of real API objects, so don't populate the Tier field with this value.

All the necessary information is avaialble from the "Kind: Profile" field.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.