### PR TITLE
Adjust UI disaply of Global, Public, Private

### DIFF
--- a/goldmane/pkg/aggregator/index.go
+++ b/goldmane/pkg/aggregator/index.go
@@ -16,6 +16,7 @@ package aggregator
 
 import (
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -195,9 +196,9 @@ func (idx *index[E]) Remove(d *types.DiachronicFlow) {
 		// The DiachronicFlow at the returned index is the same as the DiachronicFlow to be removed.
 		// Remove it from the index.
 		if logrus.IsLevelEnabled(logrus.DebugLevel) {
-			logrus.WithFields(d.Key.Fields()).Debug("Removing diachronic flow from index")
+			logrus.WithFields(d.Key.Fields()).Debug("Removing flow from index")
 		}
-		idx.diachronics = append(idx.diachronics[:index], idx.diachronics[index+1:]...)
+		idx.diachronics = slices.Delete(idx.diachronics, index, index+1)
 		return
 	} else {
 		// The DiachronicFlow at the returned index is not the same as the DiachronicFlow to be removed.

--- a/whisker-backend/pkg/apis/v1/flows.go
+++ b/whisker-backend/pkg/apis/v1/flows.go
@@ -116,8 +116,10 @@ func (a Actions) AsProtos() []proto.Action {
 	return protos
 }
 
-type SortBy proto.SortBy
-type SortBys []SortBy
+type (
+	SortBy  proto.SortBy
+	SortBys []SortBy
+)
 
 func (p SortBy) String() string                { return proto.SortBy(p).String() }
 func (p SortBy) MarshalJSON() ([]byte, error)  { return marshalToBytes(p) }

--- a/whisker-backend/pkg/handlers/v1/flows.go
+++ b/whisker-backend/pkg/handlers/v1/flows.go
@@ -139,6 +139,12 @@ func (hdlr *flowsHdlr) ListFilterHints(ctx apictx.Context, params whiskerv1.Flow
 
 	hints := make([]whiskerv1.FlowFilterHintResponse, len(gmhints))
 	for i, hint := range gmhints {
+		switch params.Type.AsProto() {
+		case proto.FilterType_FilterTypeSourceNamespace, proto.FilterType_FilterTypeDestNamespace:
+			hint.Value = protoToNamespace(hint.Value)
+		case proto.FilterType_FilterTypeSourceName, proto.FilterType_FilterTypeDestName:
+			hint.Value = protoToName(hint.Value)
+		}
 		hints[i] = whiskerv1.FlowFilterHintResponse{Value: hint.Value}
 	}
 

--- a/whisker-backend/pkg/handlers/v1/protoconvert.go
+++ b/whisker-backend/pkg/handlers/v1/protoconvert.go
@@ -22,6 +22,16 @@ import (
 	whiskerv1 "github.com/projectcalico/calico/whisker-backend/pkg/apis/v1"
 )
 
+const (
+	global = "Global"
+
+	publicNetwork  = "Public Network"
+	privateNetwork = "Private Network"
+
+	pub = "pub"
+	pvt = "pvt"
+)
+
 func toProtoStringMatches(matches []whiskerv1.FilterMatch[string]) []*proto.StringMatch {
 	var protos []*proto.StringMatch
 	for _, match := range matches {
@@ -130,12 +140,12 @@ func protoToFlow(flow *proto.Flow) whiskerv1.FlowResponse {
 		EndTime:   time.Unix(flow.EndTime, 0),
 		Action:    whiskerv1.Action(flow.Key.Action),
 
-		SourceName:      flow.Key.SourceName,
-		SourceNamespace: flow.Key.SourceNamespace,
+		SourceName:      protoToName(flow.Key.SourceName),
+		SourceNamespace: protoToNamespace(flow.Key.SourceNamespace),
 		SourceLabels:    strings.Join(flow.SourceLabels, " | "),
 
-		DestName:      flow.Key.DestName,
-		DestNamespace: flow.Key.DestNamespace,
+		DestName:      protoToName(flow.Key.DestName),
+		DestNamespace: protoToNamespace(flow.Key.DestNamespace),
 		DestLabels:    strings.Join(flow.DestLabels, " | "),
 
 		Protocol:   flow.Key.Proto,
@@ -147,4 +157,40 @@ func protoToFlow(flow *proto.Flow) whiskerv1.FlowResponse {
 		BytesIn:    flow.BytesIn,
 		BytesOut:   flow.BytesOut,
 	}
+}
+
+// The Goldmane API uses an empty namespace to represent "no namespace", but the UI wants a value.
+func protoToNamespace(namespace string) string {
+	if namespace == "" {
+		return global
+	}
+	return namespace
+}
+
+func toProtoNamespace(namespace string) string {
+	if namespace == global {
+		return ""
+	}
+	return namespace
+}
+
+// The Goldmane API uses "pub" and "pvt" for special names - for public and private network spaces.
+func protoToName(name string) string {
+	switch name {
+	case pub:
+		return publicNetwork
+	case pvt:
+		return privateNetwork
+	}
+	return name
+}
+
+func toProtoName(name string) string {
+	switch name {
+	case publicNetwork:
+		return pub
+	case privateNetwork:
+		return pvt
+	}
+	return name
 }

--- a/whisker-backend/pkg/handlers/v1/protoconvert.go
+++ b/whisker-backend/pkg/handlers/v1/protoconvert.go
@@ -125,7 +125,7 @@ func protoToPolicyHit(policyHit *proto.PolicyHit) *whiskerv1.PolicyHit {
 	return &whiskerv1.PolicyHit{
 		Kind:        whiskerv1.PolicyKind(policyHit.Kind),
 		Name:        policyHit.Name,
-		Namespace:   policyHit.Namespace,
+		Namespace:   protoToNamespace(policyHit.Namespace),
 		Tier:        policyHit.Tier,
 		Action:      whiskerv1.Action(policyHit.Action),
 		PolicyIndex: policyHit.PolicyIndex,


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Mostly to get the discussion going...

We want the UI to show "user facing" values for these cases:

- No namespace -> "Global"
- pvt -> "Private Network"
- pub -> "Public Network"


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.