### PR TITLE
Watchercache fixes

### DIFF
--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,9 +120,16 @@ type Client interface {
 
 	// Clean removes Calico data from the backend datastore.  Used for test purposes.
 	Clean() error
+}
 
-	// Close the client.
-	//Close()
+// StatusClient extends Client, is the interface to the backend datastore.
+type StatusClient interface {
+	Client
+
+	// UpdateStatus modifies the status section of the existing object specified in the KVPair.
+	// On success, returns a KVPair for the object with revision information filled-in.
+	// If the input KVPair has revision information then the update only succeeds if the revision is still current.
+	UpdateStatus(ctx context.Context, object *model.KVPair) (*model.KVPair, error)
 }
 
 type WatchOptions struct {
@@ -159,6 +166,14 @@ type SyncerCallbacks interface {
 // parse a particular key or value.
 type SyncerParseFailCallbacks interface {
 	ParseFailed(rawKey string, rawValue string)
+}
+
+// SyncFailCallbacks is an optional interface that can be
+// implemented by a syncer callback. Callbacks that support it can report
+// a failure to sync with a remote cluster backend.
+type SyncFailCallbacks interface {
+	// TODO: Should also add a Connected callback to handle when a connection is available again.
+	SyncFailed(err error)
 }
 
 // Update from the Syncer.  A KV pair plus extra metadata.

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ type watcherCache struct {
 	currentWatchRevision   string
 	errorCountAtCurrentRev int
 	resyncBlockedUntil     time.Time
+	lastSuccessfulConnTime time.Time
+	watchRetryTimeout      time.Duration
 }
 
 const (
@@ -57,9 +59,10 @@ const (
 )
 
 var (
-	MinResyncInterval = 500 * time.Millisecond
-	ListRetryInterval = 1000 * time.Millisecond
-	WatchPollInterval = 5000 * time.Millisecond
+	MinResyncInterval        = 500 * time.Millisecond
+	ListRetryInterval        = 1000 * time.Millisecond
+	WatchPollInterval        = 5000 * time.Millisecond
+	DefaultWatchRetryTimeout = 600 * time.Second
 )
 
 // cacheEntry is an entry in our cache.  It groups the a key with the last known
@@ -72,7 +75,7 @@ type cacheEntry struct {
 }
 
 // Create a new watcherCache.
-func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- interface{}) *watcherCache {
+func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- interface{}, watchTimeout time.Duration) *watcherCache {
 	return &watcherCache{
 		logger:               logrus.WithField("ListRoot", listRootForLog(resourceType.ListInterface)),
 		client:               client,
@@ -81,6 +84,7 @@ func newWatcherCache(client api.Client, resourceType ResourceType, results chan<
 		resources:            make(map[string]cacheEntry, 0),
 		currentWatchRevision: "0",
 		resyncBlockedUntil:   time.Now(),
+		watchRetryTimeout:    watchTimeout,
 	}
 }
 
@@ -108,6 +112,11 @@ func (wc *watcherCache) run(ctx context.Context) {
 func (wc *watcherCache) resyncAndLoopReadingFromWatcher(ctx context.Context) {
 	defer wc.cleanExistingWatcher()
 	wc.maybeResyncAndCreateWatcher(ctx)
+	if ctx.Err() != nil {
+		// maybeResyncAndCreateWatcher may have returned early with no watcher,
+		// in which case it's not safe to call loopReadingFromWatcher.
+		return
+	}
 	wc.loopReadingFromWatcher(ctx)
 }
 
@@ -223,14 +232,32 @@ func (wc *watcherCache) maybeResyncAndCreateWatcher(ctx context.Context) {
 			if err != nil {
 				// Failed to perform the list.  Pause briefly (so we don't tight loop) and retry.
 				wc.logger.WithError(err).Info("Failed to perform list of current data during resync")
-				if kerrors.IsResourceExpired(err) {
-					// Our current watch revision is too old. Start again without a revision.
-					wc.logger.Info("Clearing cached watch revision for next List call")
+				if kerrors.IsResourceExpired(err) || isTooLargeResourceVersionError(err) {
+					// Our current watch revision is out of sync. Start again without a revision.
+					wc.logger.Info("Resource too old/new error from server, clearing cached watch revision.")
 					wc.resetWatchRevisionForFullResync()
+					// Error is a "layer 7" error; so connection is good!
+					wc.lastSuccessfulConnTime = time.Now()
+				} else if time.Since(wc.lastSuccessfulConnTime) > wc.watchRetryTimeout {
+					// Need to send back an error here for handling. Only callbacks with connection failure handling should actually kick off anything.
+					wc.logger.Warn("Connection to datastore has failed - signaling error to client.")
+					wc.results <- errorSyncBackendError{
+						Err: err,
+					}
+
+					if wc.resourceType.SendDeletesOnConnFail {
+						// Unable to List, and we need to send deletes on connection failure. Send them now.
+						// Note: We do not need to check if the context is done since we will send deletes during exit
+						// processing anyway.
+						wc.logger.Info("connection failed, sending deletion events for all resources.")
+						wc.sendDeletionsForAllResources()
+					}
 				}
+
 				wc.resyncBlockedUntil = time.Now().Add(ListRetryInterval)
 				continue
 			}
+			wc.lastSuccessfulConnTime = time.Now()
 
 			// Once this point is reached, it's important not to drop out if the context is cancelled.
 			// Move the current resources over to the oldResources
@@ -283,12 +310,20 @@ func (wc *watcherCache) maybeResyncAndCreateWatcher(ctx context.Context) {
 				// without a revision. Condition cribbed from client-go's reflector.
 				wc.logger.Info("Watch has expired, queueing full resync.")
 				wc.resetWatchRevisionForFullResync()
+				// Error is a "layer 7" error; so connection is good!
+				wc.lastSuccessfulConnTime = time.Now()
 				continue
 			}
 
 			if utilnet.IsConnectionRefused(err) || kerrors.IsTooManyRequests(err) {
 				// Connection-related error, we can just retry without resetting
-				// the watch. Condition cribbed from client-go's reflector.
+				// the watch. Condition cribbed from client-go's reflector
+				if time.Since(wc.lastSuccessfulConnTime) > wc.watchRetryTimeout {
+					// Too long since we were connected, and we may need to signal an error to the client.
+					// The signalling is done as part of the resync machinery so trigger a resync now.
+					wc.logger.WithError(err).Warn("Timed out waiting for connection to be restored, forcing a resync.")
+					wc.resetWatchRevisionForFullResync()
+				}
 				wc.logger.WithError(err).Warn("API server refused connection, will retry.")
 				continue
 			}
@@ -412,7 +447,7 @@ func (wc *watcherCache) handleWatchListEvent(kvp *model.KVPair) {
 		wc.handleConvertedWatchEvent(kvp)
 	}
 
-	// If we hit a conversion error, notify the main syncer.
+	// If we hit a conversion error, log the error and notify the main syncer.
 	if err != nil {
 		wc.results <- err
 	}
@@ -520,4 +555,8 @@ func (wc *watcherCache) sendDeletionsForAllResources() {
 			},
 		}}
 	}
+	clear(wc.resources)
+
+	// Just signaled deletion of all resources, must perform a full resync to restore them.
+	wc.resetWatchRevisionForFullResync()
 }

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package watchersyncer
 import (
 	"context"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -38,6 +39,19 @@ type ResourceType struct {
 	// UpdateProcessor converts the raw KVPairs returned from the datastore into the appropriate
 	// KVPairs required for the syncer.  This is optional.
 	UpdateProcessor SyncerUpdateProcessor
+
+	// SendDeletesOnConnFail will send deletes for all resources (and therefore do a full resync) if
+	// the connection fails at any point.
+	SendDeletesOnConnFail bool
+}
+
+// Error indicating a problem with a watcher communicating with the backend.
+type errorSyncBackendError struct {
+	Err error
+}
+
+func (e errorSyncBackendError) Error() string {
+	return e.Err.Error()
 }
 
 // SyncerUpdateProcessor is used to convert a Watch update into one or more additional
@@ -60,29 +74,44 @@ type SyncerUpdateProcessor interface {
 	OnSyncerStarting()
 }
 
+type Option func(*watcherSyncer)
+
+func WithWatchRetryTimeout(t time.Duration) Option {
+	return func(ws *watcherSyncer) {
+		ws.watchRetryTimeout = t
+	}
+}
+
+var _ = WithWatchRetryTimeout
+
 // New creates a new multiple Watcher-backed api.Syncer.
-func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks) api.Syncer {
+func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
 	rs := &watcherSyncer{
-		watcherCaches: make([]*watcherCache, len(resourceTypes)),
-		results:       make(chan interface{}, 2000),
-		callbacks:     callbacks,
+		watcherCaches:     make([]*watcherCache, len(resourceTypes)),
+		results:           make(chan interface{}, 2000),
+		callbacks:         callbacks,
+		watchRetryTimeout: DefaultWatchRetryTimeout,
+	}
+	for _, o := range options {
+		o(rs)
 	}
 	for i, r := range resourceTypes {
-		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results)
+		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results, rs.watchRetryTimeout)
 	}
 	return rs
 }
 
 // watcherSyncer implements the api.Syncer interface.
 type watcherSyncer struct {
-	status        api.SyncStatus
-	watcherCaches []*watcherCache
-	results       chan interface{}
-	numSynced     int
-	callbacks     api.SyncerCallbacks
-	wgwc          *sync.WaitGroup
-	wgws          *sync.WaitGroup
-	cancel        context.CancelFunc
+	status            api.SyncStatus
+	watcherCaches     []*watcherCache
+	results           chan interface{}
+	numSynced         int
+	callbacks         api.SyncerCallbacks
+	wgwc              *sync.WaitGroup
+	wgws              *sync.WaitGroup
+	cancel            context.CancelFunc
+	watchRetryTimeout time.Duration
 }
 
 func (ws *watcherSyncer) Start() {
@@ -194,10 +223,17 @@ func (ws *watcherSyncer) processResult(updates []api.Update, result interface{})
 		// If this is a parsing error, and if the callbacks support
 		// it, then send the error update.
 		log.WithError(r).Debug("Error received in main syncer event processing loop")
-		if ec, ok := ws.callbacks.(api.SyncerParseFailCallbacks); ok {
-			log.Debug("syncer receiver can receive parse failed callbacks")
-			if pe, ok := r.(cerrors.ErrorParsingDatastoreEntry); ok {
+		if pe, ok := r.(cerrors.ErrorParsingDatastoreEntry); ok {
+			if ec, ok := ws.callbacks.(api.SyncerParseFailCallbacks); ok {
+				log.Debug("syncer receiver can receive parse failed callbacks")
 				ec.ParseFailed(pe.RawKey, pe.RawValue)
+			}
+		}
+
+		if se, ok := r.(errorSyncBackendError); ok {
+			if ec, ok := ws.callbacks.(api.SyncFailCallbacks); ok {
+				log.Debug("syncer receiver can receive sync failed callbacks")
+				ec.SyncFailed(se.Err)
 			}
 		}
 

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -214,7 +214,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		By("Driving a bunch of List complete, Watch fail events for 2/3 resource types")
 		expectedDuration := watchersyncer.WatchPollInterval * 2
 		minDuration := 70 * expectedDuration / 100
-		maxDuration := 150 * expectedDuration / 100
+		maxDuration := 250 * expectedDuration / 100
 		before := time.Now()
 		rs.clientListResponse(r1, emptyList)
 		rs.ExpectStatusUpdate(api.ResyncInProgress)

--- a/libcalico-go/lib/testutils/syncertester.go
+++ b/libcalico-go/lib/testutils/syncertester.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,6 +70,7 @@ type SyncerTester struct {
 	onUpdates   [][]api.Update
 	updates     []api.Update
 	parseErrors []parseError
+	connErrors  []error
 }
 
 // OnStatusUpdated updates the current status and then blocks until a call to
@@ -99,6 +100,28 @@ func (st *SyncerTester) OnStatusUpdated(status api.SyncStatus) {
 	// to unblock the processing.
 	st.statusBlocker.Wait()
 	log.Infof("OnStatusUpdated now unblocked waiting for: %s", status)
+}
+
+// SyncFailed stores a sync failed message.
+func (st *SyncerTester) SyncFailed(err error) {
+	defer GinkgoRecover()
+
+	func() {
+		// Store the updates and onUpdates.
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		st.connErrors = append(st.connErrors, err)
+	}()
+
+	// We may need to block if the test has blocked the main event processing.
+	st.updateBlocker.Wait()
+}
+
+// ParseFailed just stores the parse failure.
+func (st *SyncerTester) ParseFailed(rawKey string, rawValue string) {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	st.parseErrors = append(st.parseErrors, parseError{rawKey: rawKey, rawValue: rawValue})
 }
 
 // OnUpdates just stores the update and asserts the state of the cache and the update.
@@ -140,6 +163,8 @@ func (st *SyncerTester) OnUpdates(updates []api.Update) {
 				Expect(st.cache).To(HaveKey(k))
 				Expect(u.Value).NotTo(BeNil())
 				st.cache[k] = CacheEntry{KVPair: u.KVPair}
+			default:
+				Fail(fmt.Sprintf("Unknown update type: %v", u.UpdateType))
 			}
 
 			// Check that KeyFromDefaultPath supports parsing the path again;
@@ -153,13 +178,6 @@ func (st *SyncerTester) OnUpdates(updates []api.Update) {
 
 	// We may need to block if the test has blocked the main event processing.
 	st.updateBlocker.Wait()
-}
-
-// ParseFailed just stores the parse failure.
-func (st *SyncerTester) ParseFailed(rawKey string, rawValue string) {
-	st.lock.Lock()
-	defer st.lock.Unlock()
-	st.parseErrors = append(st.parseErrors, parseError{rawKey: rawKey, rawValue: rawValue})
 }
 
 // ExpectStatusUpdate verifies a status update message has been received.  This should only
@@ -205,6 +223,29 @@ func (st *SyncerTester) ExpectStatusUnchanged() {
 	}
 	EventuallyWithOffset(1, sc, "6s", "1ms").Should(BeFalse())
 	ConsistentlyWithOffset(1, sc).Should(BeFalse(), "Status changed unexpectedly")
+}
+
+// ExpectConnErrors verifies the supplied connection errors were received.
+func (st *SyncerTester) ExpectConnErrors(errs []error, timeout ...time.Duration) {
+	log.Infof("Expecting errors of: %v", errs)
+	ce := func() []error {
+		st.lock.Lock()
+		defer st.lock.Unlock()
+		return st.connErrors[:]
+	}
+	if len(timeout) == 0 {
+		EventuallyWithOffset(1, ce, "6s", "1ms").Should(Equal(errs))
+	} else {
+		EventuallyWithOffset(1, ce, timeout[0], "1ms").Should(Equal(errs))
+	}
+	ConsistentlyWithOffset(1, ce).Should(Equal(errs))
+
+	log.Infof("Connection errors are as expected: %v", errs)
+
+	// Reset the received errors.
+	st.lock.Lock()
+	st.connErrors = nil
+	st.lock.Unlock()
 }
 
 // ExpectCacheSize verifies that the cache size is as expected. If this fails, the entire cache is included in the
@@ -327,7 +368,7 @@ func (st *SyncerTester) hasUpdates(expectedUpdates []api.Update, checkOrder bool
 	updateAsKey := func(update api.Update) string {
 		path, err := model.KeyToDefaultPath(update.Key)
 		Expect(err).NotTo(HaveOccurred())
-		return fmt.Sprintf("%d;%s", update.UpdateType, path)
+		return fmt.Sprintf("%v;%s", update.UpdateType, path)
 	}
 
 	// removeFromActualUpdatesMap removes the update from the map, and returns an error if not found. It will remove
@@ -427,6 +468,26 @@ func (st *SyncerTester) ExpectUpdates(expectedUpdates []api.Update, checkOrder b
 	defer st.lock.Unlock()
 	st.updates = nil
 	st.onUpdates = nil
+}
+
+// HasUpdates checks whether the updates have been received, returning an error if not. This does not remove the
+// updates from the cache.
+func (st *SyncerTester) HasUpdates(expectedUpdates []api.Update, checkOrder bool, sanitizer ...func(u []api.Update) []api.Update) error {
+	var sfn func(u []api.Update) []api.Update
+	if len(sanitizer) == 1 {
+		sfn = sanitizer[0]
+	} else if len(sanitizer) > 1 {
+		log.Panic("Multiple sanitizers passed in - only one expected")
+	}
+	if sfn == nil {
+		sfn = st.DefaultSanitizer
+	}
+
+	// Sanitize the expected updates.
+	expectedUpdates = sfn(expectedUpdates)
+
+	// Wait for the sanitized cache updates to match the sanitized expected updates.
+	return st.hasUpdates(expectedUpdates, checkOrder, sfn)
 }
 
 // ExpectOnUpdates tests which onUpdate events were received.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Upstream various fixes from enterprise made while merging watch bookmarks:

- Avoid a nil pointer if context expires while listing.
- Timeout bump in test.

Sync up code structure with enterprise.  Support returning watch errors (even though that's not used in OS yet).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-11188
#9593 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
