### PR TITLE
Use new set.Adaptive type in named port index

### DIFF
--- a/felix/labelindex/label_inheritance_index.go
+++ b/felix/labelindex/label_inheritance_index.go
@@ -88,7 +88,7 @@ func (itemData *itemData) GetHandle(labelName uniquestr.Handle) (handle uniquest
 type parentData struct {
 	id      string
 	labels  uniquelabels.Map
-	itemIDs set.Set[any]
+	itemIDs set.Typed[any]
 }
 
 type MatchCallback func(selId, labelId interface{})
@@ -99,14 +99,14 @@ type InheritIndex struct {
 	selectorsById        map[interface{}]*selector.Selector
 
 	// Current matches.
-	selIdsByLabelId map[interface{}]set.Set[any]
-	labelIdsBySelId map[interface{}]set.Set[any]
+	selIdsByLabelId map[interface{}]set.Typed[any]
+	labelIdsBySelId map[interface{}]set.Typed[any]
 
 	// Callback functions
 	OnMatchStarted MatchCallback
 	OnMatchStopped MatchCallback
 
-	dirtyItemIDs set.Set[any]
+	dirtyItemIDs set.Typed[any]
 }
 
 func NewInheritIndex(onMatchStarted, onMatchStopped MatchCallback) *InheritIndex {
@@ -116,8 +116,8 @@ func NewInheritIndex(onMatchStarted, onMatchStopped MatchCallback) *InheritIndex
 		parentDataByParentID: map[string]*parentData{},
 		selectorsById:        map[interface{}]*selector.Selector{},
 
-		selIdsByLabelId: map[interface{}]set.Set[any]{},
-		labelIdsBySelId: map[interface{}]set.Set[any]{},
+		selIdsByLabelId: map[interface{}]set.Typed[any]{},
+		labelIdsBySelId: map[interface{}]set.Typed[any]{},
 
 		// Callback functions
 		OnMatchStarted: onMatchStarted,

--- a/felix/labelindex/labelnamevalueindex/label_name_value_index.go
+++ b/felix/labelindex/labelnamevalueindex/label_name_value_index.go
@@ -55,7 +55,7 @@ func New[ItemID comparable, Item Labeled](nameOfTrackedItems string) *LabelNameV
 }
 
 type values[ItemID comparable] struct {
-	m     map[uniquestr.Handle]set.Set[ItemID]
+	m     map[uniquestr.Handle]*set.Adaptive[ItemID]
 	count int
 }
 
@@ -77,13 +77,13 @@ func (idx *LabelNameValueIndex[ItemID, Item]) Add(id ItemID, item Item) {
 		vals, ok := idx.labelNameToValueToIDs[k]
 		if !ok {
 			vals = values[ItemID]{
-				m: map[uniquestr.Handle]set.Set[ItemID]{},
+				m: map[uniquestr.Handle]*set.Adaptive[ItemID]{},
 			}
 			idx.labelNameToValueToIDs[k] = vals
 		}
 		setOfIDs := vals.m[v]
 		if setOfIDs == nil {
-			setOfIDs = set.New[ItemID]()
+			setOfIDs = set.NewAdaptive[ItemID]()
 			vals.m[v] = setOfIDs
 		}
 		setOfIDs.Add(id)

--- a/felix/labelindex/labelrestrictionindex/label_restriction_index.go
+++ b/felix/labelindex/labelrestrictionindex/label_restriction_index.go
@@ -42,7 +42,7 @@ type LabelRestrictionIndex[SelID comparable] struct {
 
 	// unoptimizedIDs contains an entry for any selectors that have no
 	// valid label restrictions (and hence no entries in labelToValueToIDs).
-	unoptimizedIDs set.Set[SelID]
+	unoptimizedIDs set.Typed[SelID]
 
 	gaugeOptimizedSelectors   Gauge
 	gaugeUnoptimizedSelectors Gauge
@@ -269,13 +269,13 @@ func (s *LabelRestrictionIndex[SelID]) updateGauges() {
 // label, either matching particular values or a wildcard (such as
 // "has(labelName)").
 type valuesSubIndex[SelID comparable] struct {
-	selsMatchingSpecificValues map[uniquestr.Handle]set.Set[SelID]
-	selsMatchingWildcard       set.Set[SelID]
+	selsMatchingSpecificValues map[uniquestr.Handle]set.Typed[SelID]
+	selsMatchingWildcard       set.Typed[SelID]
 }
 
 func (t *valuesSubIndex[SelID]) Add(value uniquestr.Handle, id SelID) {
 	if t.selsMatchingSpecificValues == nil {
-		t.selsMatchingSpecificValues = map[uniquestr.Handle]set.Set[SelID]{}
+		t.selsMatchingSpecificValues = map[uniquestr.Handle]set.Typed[SelID]{}
 	}
 	values, ok := t.selsMatchingSpecificValues[value]
 	if !ok {

--- a/felix/labelindex/named_port_index.go
+++ b/felix/labelindex/named_port_index.go
@@ -208,7 +208,7 @@ func (d *endpointData) Equals(other *endpointData) bool {
 type npParentData struct {
 	id          string
 	labels      uniquelabels.Map
-	endpointIDs set.Set[any]
+	endpointIDs set.Typed[any]
 }
 
 func (d *npParentData) OwnLabelHandles() iter.Seq2[uniquestr.Handle, uniquestr.Handle] {

--- a/felix/labelindex/named_port_index.go
+++ b/felix/labelindex/named_port_index.go
@@ -79,24 +79,15 @@ type endpointData struct {
 	ports   []model.EndpointPort
 	parents []*npParentData
 
-	cachedMatchingIPSetIDs set.Set[string] /* or, as an optimization, nil if there are none */
+	cachedMatchingIPSetIDs set.Adaptive[string]
 }
 
 func (d *endpointData) AddMatchingIPSetID(id string) {
-	if d.cachedMatchingIPSetIDs == nil {
-		d.cachedMatchingIPSetIDs = set.New[string]()
-	}
 	d.cachedMatchingIPSetIDs.Add(id)
 }
 
 func (d *endpointData) RemoveMatchingIPSetID(id string) {
-	if d.cachedMatchingIPSetIDs == nil {
-		return
-	}
 	d.cachedMatchingIPSetIDs.Discard(id)
-	if d.cachedMatchingIPSetIDs.Len() == 0 {
-		d.cachedMatchingIPSetIDs = nil
-	}
 }
 
 func (d *endpointData) HasParent(parent *npParentData) bool {
@@ -675,7 +666,7 @@ func (idx *SelectorAndNamedPortIndex) scanEndpointAgainstIPSets(
 ) {
 	// Remove any previous match from the endpoint's cache.  We'll re-add it
 	// below if the match is still correct.
-	epData.cachedMatchingIPSetIDs = nil
+	epData.cachedMatchingIPSetIDs.Clear()
 
 	// Iterate over potential new matches and incref any members that
 	// that produces.  (This may temporarily over count.)
@@ -736,7 +727,9 @@ func (idx *SelectorAndNamedPortIndex) DeleteEndpoint(id any) {
 		return
 	}
 
-	log.WithField("oldContrib", oldEndpointData.cachedMatchingIPSetIDs).Debug("Old matching IP sets")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithField("oldContrib", oldEndpointData.cachedMatchingIPSetIDs.String()).Debug("Old matching IP sets")
+	}
 	oldIPSetContributions := idx.RecalcCachedContributions(oldEndpointData)
 	for ipSetID, contributions := range oldIPSetContributions {
 		// Decref all the old members.  If they hit 0 references, then the member has been
@@ -846,7 +839,7 @@ func (idx *SelectorAndNamedPortIndex) CalculateEndpointContribution(d *endpointD
 // RecalcCachedContributions uses the cached set of matching IP set IDs in the endpoint
 // struct to quickly recalculate the endpoint's contribution to all IP sets.
 func (idx *SelectorAndNamedPortIndex) RecalcCachedContributions(epData *endpointData) map[string][]ipsetmember.IPSetMember {
-	if epData.cachedMatchingIPSetIDs == nil {
+	if epData.cachedMatchingIPSetIDs.Len() == 0 {
 		return nil
 	}
 	contrib := map[string][]ipsetmember.IPSetMember{}

--- a/felix/multidict/multidict.go
+++ b/felix/multidict/multidict.go
@@ -18,7 +18,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
-type Multidict[K comparable, V comparable] map[K]set.Set[V]
+type Multidict[K comparable, V comparable] map[K]set.Typed[V]
 
 func New[K comparable, V comparable]() Multidict[K, V] {
 	return make(Multidict[K, V])

--- a/libcalico-go/lib/set/adaptive.go
+++ b/libcalico-go/lib/set/adaptive.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package set
+
+import (
+	"unsafe"
+)
+
+const (
+	adaptiveSetArrayLimit = 16
+	sizeStoredInMap       = -1
+)
+
+var arrCapForSize = [adaptiveSetArrayLimit + 1]int{
+	0, 1, 2, 4, 4, 8, 8, 8, 8, 16, 16, 16, 16, 16, 16, 16, 16,
+}
+
+// Adaptive is a set implementation that uses different underlying data
+// structures depending on the size of the set.  For sets that are typically
+// empty, or, have only one or two elements, it is more than twice as fast and
+// it uses ~10x less memory. Above adaptiveSetArrayLimit it switches to a
+// map-based implementation like set.Typed.
+//
+// The zero value of Adaptive is an empty set (so it may be embedded in other
+// datastructures).
+//
+// Should not be copied after first use. Since the struct carries the size,
+// copying by value and then mutating can result in two Adaptive instances
+// sharing storage but with different sizes; this is not recommended!
+type Adaptive[T comparable] struct {
+	// size is either the number of elements in the set, or sizeStoredInMap
+	// if the set is backed by a map.
+	size int
+
+	// p holds different types depending on size.
+	// if size == 0, p is nil.
+	// if size is in the range [1, adaptiveSetArrayLimit], p is a pointer to
+	//    an array with length size, rounded up to next power of two.
+	// if size == sizeStoredInMap, p is a pointer to a map[T]v
+	p unsafe.Pointer
+}
+
+func NewAdaptive[T comparable]() *Adaptive[T] {
+	return &Adaptive[T]{}
+}
+
+func AdaptiveFromArray[T comparable](items []T) *Adaptive[T] {
+	s := NewAdaptive[T]()
+	for _, t := range items {
+		s.Add(t)
+	}
+	return s
+}
+
+func AdaptiveFrom(items ...int) *Adaptive[int] {
+	return AdaptiveFromArray(items)
+}
+
+func (a *Adaptive[T]) Len() int {
+	if a.size == sizeStoredInMap {
+		return len(*(*map[T]v)(a.p))
+	}
+	return int(a.size)
+}
+
+func (a *Adaptive[T]) Add(item T) {
+	switch a.size {
+	case 0:
+		// Array of one item is just the item.
+		a.p = unsafe.Pointer(&item)
+		a.size = 1
+	default:
+		tPtr := (*T)(a.p)
+		tSlice := unsafe.Slice(tPtr, arrCapForSize[a.size])[:a.size]
+		for _, t := range tSlice {
+			if t == item {
+				// The element is already in the set.
+				return
+			}
+		}
+
+		// If we get here, need to add the element to the set.
+		if a.size < adaptiveSetArrayLimit {
+			// Set is still small enough to use a slice.
+			if len(tSlice) == cap(tSlice) {
+				// Need to grow the slice; we do it manually so we can control
+				// the exact new capacity.
+				tSlice = growSliceCap(tSlice, arrCapForSize[a.size+1])
+				a.p = unsafe.Pointer(&tSlice[0])
+			}
+			tSlice = append(tSlice, item)
+			a.size++
+			return
+		}
+
+		// Need to upgrade to a map.
+		m := make(map[T]v, a.size+1)
+		for _, t := range tSlice {
+			m[t] = emptyValue
+		}
+		m[item] = emptyValue
+		a.p = unsafe.Pointer(&m)
+		a.size = sizeStoredInMap
+	case sizeStoredInMap:
+		m := *(*map[T]v)(a.p)
+		m[item] = emptyValue
+	}
+}
+
+func growSliceCap[T any](in []T, newCap int) []T {
+	out := make([]T, len(in), newCap)
+	copy(out, in)
+	return out
+}
+
+func (a *Adaptive[T]) AddAll(itemArray []T) {
+	for _, v := range itemArray {
+		a.Add(v)
+	}
+}
+
+func (a *Adaptive[T]) AddSet(other Set[T]) {
+	other.Iter(func(item T) error {
+		a.Add(item)
+		return nil
+	})
+}
+
+func (a *Adaptive[T]) Discard(item T) {
+	switch a.size {
+	case 0:
+		return
+	case 1:
+		theOne := (*T)(a.p)
+		if *theOne == item {
+			a.p = nil
+			a.size = 0
+		}
+	case sizeStoredInMap:
+		m := *(*map[T]v)(a.p)
+		delete(m, item)
+		if len(m) <= adaptiveSetArrayLimit {
+			// Downgrade to an array.
+			s := make([]T, 0, arrCapForSize[len(m)])
+			for t := range m {
+				s = append(s, t)
+			}
+			a.p = unsafe.Pointer(&s[0])
+			a.size = len(m)
+		}
+	default:
+		tPtr := (*T)(a.p)
+		tSlice := unsafe.Slice(tPtr, arrCapForSize[a.size])[:a.size]
+		for i, t := range tSlice {
+			if t == item {
+				// Found the element to remove.
+				newSize := a.size - 1
+				newCap := arrCapForSize[newSize]
+				if newCap < cap(tSlice) {
+					// Downgrade to a smaller array.
+					updatedSlice := make([]T, arrCapForSize[newSize])
+					// Copy the elements before and after the removed element.
+					copy(updatedSlice, tSlice[:i])
+					copy(updatedSlice[i:], tSlice[i+1:])
+					a.p = unsafe.Pointer(&updatedSlice[0])
+				} else {
+					// Keep the same slice.  Swap the last element into the
+					// removed element's slot.
+					tSlice[i] = tSlice[newSize]
+					var zeroT T
+					tSlice[newSize] = zeroT
+				}
+				a.size = newSize
+				return
+			}
+		}
+
+	}
+}
+
+func (a *Adaptive[T]) Clear() {
+	a.size = 0
+	a.p = nil
+}
+
+func (a *Adaptive[T]) Contains(t T) bool {
+	switch a.size {
+	case 0:
+		return false
+	case sizeStoredInMap:
+		m := *(*map[T]v)(a.p)
+		_, present := m[t]
+		return present
+	default:
+		tPtr := (*T)(a.p)
+		tSlice := unsafe.Slice(tPtr, a.size)
+		for _, v := range tSlice {
+			if v == t {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func (a *Adaptive[T]) Iter(f func(item T) error) {
+	switch a.size {
+	case 0:
+		return
+	case sizeStoredInMap:
+		m := *(*map[T]v)(a.p)
+		for v := range m {
+			err := f(v)
+			if err == StopIteration {
+				return
+			}
+			if err == RemoveItem {
+				// Discarding from a map is safe.  If the set did shrink and
+				// get turned into an array then we'd just keep iterating
+				// over the map, which would be fine.
+				a.Discard(v)
+			}
+		}
+	default:
+		tPtr := (*T)(a.p)
+		tSlice := unsafe.Slice(tPtr, a.size)
+
+		// Must take a copy so that Discard doesn't break iteration. Since
+		// this is a fixed size array, it should get stack allocated and be
+		// very fast.
+		var tCopy [adaptiveSetArrayLimit]T
+		copy(tCopy[:], tSlice)
+		tSlice = tCopy[:a.size]
+
+		for _, v := range tSlice {
+			err := f(v)
+			if err == StopIteration {
+				return
+			}
+			if err == RemoveItem {
+				a.Discard(v)
+			}
+		}
+	}
+}
+
+func (a *Adaptive[T]) Copy() Set[T] {
+	other := NewAdaptive[T]()
+	a.Iter(func(item T) error {
+		other.Add(item)
+		return nil
+	})
+	return other
+}
+
+func (a *Adaptive[T]) Equals(s Set[T]) bool {
+	if a.Len() != s.Len() {
+		return false
+	}
+	equal := true
+	a.Iter(func(item T) error {
+		if !s.Contains(item) {
+			equal = false
+			return StopIteration
+		}
+		return nil
+	})
+	return equal
+}
+
+func (a *Adaptive[T]) ContainsAll(s Set[T]) bool {
+	if s.Len() > a.Len() {
+		return false
+	}
+	seenAll := true
+	s.Iter(func(item T) error {
+		if !a.Contains(item) {
+			seenAll = false
+			return StopIteration
+		}
+		return nil
+	})
+	return seenAll
+}
+
+func (a *Adaptive[T]) Slice() []T {
+	s := make([]T, 0, a.Len())
+	a.Iter(func(item T) error {
+		s = append(s, item)
+		return nil
+	})
+	return s
+}
+
+func (a *Adaptive[T]) String() string {
+	return stringify(a)
+}
+
+var _ Set[any] = &Adaptive[any]{}

--- a/libcalico-go/lib/set/adaptive_test.go
+++ b/libcalico-go/lib/set/adaptive_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package set_test
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+)
+
+var _ = Describe("Adaptive set", func() {
+	describeSetTests(
+		func() set.Set[int] {
+			return set.NewAdaptive[int]()
+		},
+		func(is []int) set.Set[int] { return set.AdaptiveFromArray(is) },
+		func(is ...int) set.Set[int] { return set.AdaptiveFrom(is...) },
+	)
+})
+
+func FuzzAdaptiveSet(f *testing.F) {
+	f.Add("a", "ab")
+	f.Add("aa", "ab")
+	f.Add("ab", "d")
+	f.Add("abb", "ab")
+	f.Add("aaabc", "abbbbc")
+	f.Add("aaabc", "g")
+	f.Add("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz")
+	f.Fuzz(func(t *testing.T, itemsToAdd, itemsToDel string) {
+		s1 := set.NewAdaptive[string]()
+		s2 := set.New[string]()
+		for i := 0; i < len(itemsToAdd); i++ {
+			item := itemsToAdd[i : i+1]
+			s1.Add(item)
+			s2.Add(item)
+
+			if !s1.Equals(s2) || !s2.Equals(s1) {
+				t.Fatal("Sets are not equal")
+			}
+			s1.Iter(func(item string) error {
+				if !s2.Contains(item) {
+					t.Fatal("Set 2 does not contain item")
+				}
+				return nil
+			})
+			if !s1.Contains(item) {
+				t.Fatal("Set does not contain item")
+			}
+			if !s1.ContainsAll(s2) {
+				t.Fatal("Set does not contain all items")
+			}
+
+			sl1 := s1.Slice()
+			sl2 := s2.Slice()
+			if len(sl1) != len(sl2) {
+				t.Fatal("Slices are not the same length")
+			}
+			sort.Strings(sl1)
+			sort.Strings(sl2)
+			for i := 0; i < len(sl1); i++ {
+				if sl1[i] != sl2[i] {
+					t.Fatal("Slices are not the same")
+				}
+			}
+		}
+		stopped := false
+		s1.Iter(func(item string) error {
+			if stopped {
+				t.Fatal("Iteration continued after stop")
+			}
+			stopped = true
+			if !s2.Contains(item) {
+				t.Fatal("Set 2 does not contain item")
+			}
+			return set.StopIteration
+		})
+		for i := 0; i < len(itemsToDel); i++ {
+			item := itemsToDel[i : i+1]
+			s1.Discard(item)
+			s2.Discard(item)
+
+			if !s1.Equals(s2) || !s2.Equals(s1) {
+				t.Fatal("Sets are not equal")
+			}
+			if s1.Contains(item) {
+				t.Fatal("Set still contained item")
+			}
+		}
+	})
+}

--- a/libcalico-go/lib/set/adaptive_test.go
+++ b/libcalico-go/lib/set/adaptive_test.go
@@ -31,6 +31,22 @@ var _ = Describe("Adaptive set", func() {
 		func(is []int) set.Set[int] { return set.AdaptiveFromArray(is) },
 		func(is ...int) set.Set[int] { return set.AdaptiveFrom(is...) },
 	)
+
+	It("should be constructable via FromAdaptive[int]", func() {
+		s1 := set.AdaptiveFrom(1, 2, 3)
+		s2 := set.From(1, 2, 3)
+		if !s1.Equals(s2) || !s2.Equals(s1) {
+			Fail("Sets are not equal")
+		}
+	})
+
+	It("should be constructable via FromAdaptive[string]", func() {
+		s1 := set.AdaptiveFrom("1", "2", "3")
+		s2 := set.From("1", "2", "3")
+		if !s1.Equals(s2) || !s2.Equals(s1) {
+			Fail("Sets are not equal")
+		}
+	})
 })
 
 func FuzzAdaptiveSet(f *testing.F) {

--- a/libcalico-go/lib/set/benchmarks_test.go
+++ b/libcalico-go/lib/set/benchmarks_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package set_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+)
+
+func BenchmarkAdaptive1Items(b *testing.B) {
+	benchmarkSet(b, makeAdaptive, 1)
+}
+
+func BenchmarkAdaptive2Items(b *testing.B) {
+	benchmarkSet(b, makeAdaptive, 2)
+}
+
+func BenchmarkAdaptive10Items(b *testing.B) {
+	benchmarkSet(b, makeAdaptive, 10)
+}
+
+func BenchmarkAdaptive100Items(b *testing.B) {
+	benchmarkSet(b, makeAdaptive, 100)
+}
+
+func BenchmarkMap1Items(b *testing.B) {
+	benchmarkSet(b, makeMap, 1)
+}
+
+func BenchmarkMap2Items(b *testing.B) {
+	benchmarkSet(b, makeMap, 2)
+}
+
+func BenchmarkMap10Items(b *testing.B) {
+	benchmarkSet(b, makeMap, 10)
+}
+
+func BenchmarkMap100Items(b *testing.B) {
+	benchmarkSet(b, makeMap, 100)
+}
+
+func makeAdaptive() set.Set[int] {
+	return set.NewAdaptive[int]()
+}
+
+func makeMap() set.Set[int] {
+	return set.New[int]()
+}
+
+func benchmarkSet(b *testing.B, factory func() set.Set[int], items int) {
+	b.Run("Add", func(b *testing.B) {
+		b.ReportAllocs()
+		var s set.Set[int]
+		for i := 0; i < b.N; i++ {
+			s = factory()
+			for j := 0; j < items; j++ {
+				s.Add(j)
+			}
+		}
+		runtime.KeepAlive(s)
+	})
+	b.Run("Contains", func(b *testing.B) {
+		b.ReportAllocs()
+		s := factory()
+		for j := 0; j < items; j++ {
+			s.Add(j)
+		}
+		var x bool
+		for i := 0; i < b.N; i++ {
+			x = s.Contains(i % items)
+		}
+		runtime.KeepAlive(x)
+	})
+}

--- a/libcalico-go/lib/set/set.go
+++ b/libcalico-go/lib/set/set.go
@@ -49,6 +49,10 @@ func FromArray[T comparable](membersArray []T) Typed[T] {
 type Typed[T comparable] map[T]v
 
 func (set Typed[T]) String() string {
+	return stringify(set)
+}
+
+func stringify[T any](set Set[T]) string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("set.Set{")
 	first := true
@@ -145,6 +149,9 @@ func (set Typed[T]) Equals(other Set[T]) bool {
 }
 
 func (set Typed[T]) ContainsAll(other Set[T]) bool {
+	if other.Len() > set.Len() {
+		return false
+	}
 	result := true
 	other.Iter(func(item T) error {
 		if !set.Contains(item) {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add an "adaptive" implementation of `set.Set` that uses a different storage approach depending on number of items.

* 0 items: store a nil pointer.
* 1 item: store pointer to the item
* 2-16 items: store pointer to array of that length rounded up to power of 2
* 17+: store pointer to a proper map.

It is faster and uses a fraction of the RAM for 0-16 items, then its performance becomes similar to the normal set.Typed (with slight overhead).

Use the map in the named port index, where we have many sets that are generally expected to be very small.

It knocks 20% off the `BenchmarkSnapshot200Local250kTotal10000TagPols` benchmark, which has a very large number of small sets.  It gives almost no improvement on the others, but those are dominated by having large numbers of active policies and very few labels.

```
Before:

goos: linux
goarch: amd64
pkg: github.com/projectcalico/calico/felix/calc
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkSnapshot200Local250kTotal10000TagPols-12                     	       1	3245931822 ns/op	       307.9 HeapAllocMB	        29.00 IPSets	     10432 Msgs	     10000 Policies	         3.246 s	970140472 B/op	10684941 allocs/op
BenchmarkSnapshot200Local10kTotal1000NetsetPols-12                    	       2	 516745681 ns/op	        78.60 HeapAllocMB	      1000 IPSets	      2403 Msgs	      1000 Policies	         0.5117 s	245642908 B/op	 1909899 allocs/op
BenchmarkSnapshot200Local10kTotal10000NetsetPols-12                   	       1	5866074645 ns/op	       604.9 HeapAllocMB	     10000 IPSets	     20403 Msgs	     10000 Policies	         5.866 s	2525107568 B/op	17306981 allocs/op

After:

goos: linux
goarch: amd64
pkg: github.com/projectcalico/calico/felix/calc
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkSnapshot200Local250kTotal10000TagPols-12                     	       1	3230500160 ns/op	       249.8 HeapAllocMB	        29.00 IPSets	     10432 Msgs	     10000 Policies	         3.230 s	929163456 B/op	11895089 allocs/op
BenchmarkSnapshot200Local10kTotal1000NetsetPols-12                    	       2	 510494161 ns/op	        77.94 HeapAllocMB	      1000 IPSets	      2403 Msgs	      1000 Policies	         0.5055 s	245306080 B/op	 1962315 allocs/op
BenchmarkSnapshot200Local10kTotal10000NetsetPols-12                   	       1	5766052793 ns/op	       598.9 HeapAllocMB	     10000 IPSets	     20403 Msgs	     10000 Policies	         5.766 s	2514418280 B/op	17287133 allocs/op
```

Also included: store sets as their concrete type in the places where we store a lot of them; saves a few MB.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-11400

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now stores its selector index more efficiently resulting in reduced memory usage in large clusters.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
