### PR TITLE
Refactor key-cert-provisioner to be compatible with felix config

### DIFF
--- a/key-cert-provisioner/cmd/main.go
+++ b/key-cert-provisioner/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,12 +49,12 @@ func main() {
 			log.WithError(err).Fatalf("Unable to create x509 certificate request")
 		}
 
-		if err := k8s.SubmitCSR(ctx, config, restClient, csr); err != nil {
+		if err := k8s.SubmitCSR(ctx, config, restClient.Clientset, csr); err != nil {
 			log.WithError(err).Fatalf("Unable to submit a CSR")
 		}
 
-		if err := k8s.WatchCSR(ctx, restClient, config, csr); err != nil {
-			log.WithError(err).Fatalf("Unable to watch CSR")
+		if err := k8s.WatchAndWriteCSR(ctx, restClient.Clientset, config, csr); err != nil {
+			log.WithError(err).Fatalf("Unable to watch or write a CSR")
 		}
 		// Signal the channel that we completed the task within the designated deadline.
 		channelWithTimeout <- true

--- a/key-cert-provisioner/pkg/cfg/config.go
+++ b/key-cert-provisioner/pkg/cfg/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ package cfg
 import (
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -27,14 +29,14 @@ import (
 // Config holds parameters that are used during runtime.
 type Config struct {
 	CSRName             string
-	EmptyDirLocation    string
+	CSRLabels           map[string]string
 	Signer              string
 	CommonName          string
 	EmailAddress        string
-	PodIP               string
-	KeyName             string
-	CertName            string
-	CACertName          string
+	IPAddresses         []net.IP
+	KeyPath             string
+	CertPath            string
+	CACertPath          string
 	CACertPEM           []byte
 	DNSNames            []string
 	SignatureAlgorithm  string
@@ -89,18 +91,18 @@ func GetConfigOrDie() *Config {
 		}
 
 	}
+	dir := GetEnvOrDie("CERTIFICATE_PATH")
 	return &Config{
 		CSRName:             csrName,
 		SignatureAlgorithm:  os.Getenv("SIGNATURE_ALGORITHM"),
 		Signer:              GetEnvOrDie("SIGNER"),
 		CommonName:          GetEnvOrDie("COMMON_NAME"),
 		EmailAddress:        os.Getenv("EMAIL_ADDRESS"),
-		EmptyDirLocation:    GetEnvOrDie("CERTIFICATE_PATH"),
-		KeyName:             GetEnvOrDie("KEY_NAME"),
-		CertName:            GetEnvOrDie("CERT_NAME"),
-		CACertName:          caCertName,
+		KeyPath:             filepath.Join(dir, GetEnvOrDie("KEY_NAME")),
+		CertPath:            filepath.Join(dir, GetEnvOrDie("CERT_NAME")),
+		CACertPath:          filepath.Join(dir, caCertName),
 		CACertPEM:           caCert,
-		PodIP:               GetEnvOrDie("POD_IP"),
+		IPAddresses:         []net.IP{net.ParseIP(GetEnvOrDie("POD_IP"))},
 		AppName:             GetEnvOrDie("APP_NAME"),
 		PrivateKeyAlgorithm: os.Getenv("KEY_ALGORITHM"),
 		DNSNames:            dnsNames,

--- a/key-cert-provisioner/pkg/k8s/certificate_test.go
+++ b/key-cert-provisioner/pkg/k8s/certificate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,10 +37,9 @@ var _ = Describe("Test Certificates", func() {
 
 	var (
 		// Clients and configurations that will be initialized.
-		config     *cfg.Config
-		clientset  kubernetes.Interface
-		tlsCsr     *tls.X509CSR
-		restClient *k8s.RestClient
+		config    *cfg.Config
+		clientset kubernetes.Interface
+		tlsCsr    *tls.X509CSR
 
 		// Variables that are set and tested.
 		csrName = "calico-node:calico-node:12345"
@@ -51,29 +50,24 @@ var _ = Describe("Test Certificates", func() {
 	BeforeEach(func() {
 		clientset = fake.NewSimpleClientset()
 		config = &cfg.Config{
-			Signer:  signer,
-			CSRName: csrName,
+			Signer:    signer,
+			CSRName:   csrName,
+			CSRLabels: map[string]string{"label-key": "label-value"},
 		}
 		tlsCsr = &tls.X509CSR{
 			CSR: csrPem,
 		}
 	})
+
 	Context("Test submitting a CSR", func() {
 		It("should list no CSRs when the suite starts", func() {
-			By("create a k8s client with high version")
-			restClient = &k8s.RestClient{
-				APIRegistrationClient: nil,
-				Clientset:             clientset,
-				RestConfig:            nil,
-			}
-
 			By("verifying no v1 CSRs are present yet")
 			resp, err := clientset.CertificatesV1().CertificateSigningRequests().List(ctx, v1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.Items).To(HaveLen(0))
 
 			By("creating the v1 CSRs are present yet")
-			Expect(k8s.SubmitCSR(ctx, config, restClient, tlsCsr)).ToNot(HaveOccurred())
+			Expect(k8s.SubmitCSR(ctx, config, clientset, tlsCsr)).ToNot(HaveOccurred())
 
 			By("Verifying the object exists with the right settings")
 			csrs, err := clientset.CertificatesV1().CertificateSigningRequests().List(ctx, v1.ListOptions{})
@@ -82,6 +76,7 @@ var _ = Describe("Test Certificates", func() {
 			csr := csrs.Items[0]
 
 			Expect(csr.Name).To(Equal(csrName))
+			Expect(csr.Labels).To(HaveKeyWithValue("label-key", "label-value"))
 			Expect(csr.Spec.Request).To(Equal(csrPem))
 			Expect(csr.Spec.SignerName).To(Equal(signer))
 			Expect(csr.Spec.Usages).To(ConsistOf(certV1.UsageServerAuth, certV1.UsageClientAuth,
@@ -101,6 +96,7 @@ var _ = Describe("Test writing TLS secrets to disk", func() {
 		keyName    = "tls.key"
 		caCertName = "ca.crt"
 	)
+
 	var (
 		dir     string
 		config  *cfg.Config
@@ -114,12 +110,15 @@ var _ = Describe("Test writing TLS secrets to disk", func() {
 		dir, err = os.MkdirTemp("", "certificate_test.go")
 		Expect(err).NotTo(HaveOccurred())
 		config = &cfg.Config{
-			CACertPEM:        []byte(caCert),
-			EmptyDirLocation: dir,
-			CertName:         certName,
-			KeyName:          keyName,
-			CACertName:       caCertName,
+			CACertPEM:  []byte(caCert),
+			CertPath:   filepath.Join(dir, certName),
+			KeyPath:    filepath.Join(dir, keyName),
+			CACertPath: filepath.Join(dir, caCertName),
 		}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dir)).NotTo(HaveOccurred())
 	})
 
 	It("should write the TLS secrets to file", func() {
@@ -142,7 +141,7 @@ var _ = Describe("Test writing TLS secrets to disk", func() {
 	})
 
 	It("should write the TLS secrets to file even if no ca.crt is provided", func() {
-		config.CACertName = ""
+		config.CACertPath = ""
 		Expect(k8s.WriteCertificateToFile(config, []byte(cert), x509CSR)).NotTo(HaveOccurred())
 		files, err := os.ReadDir(dir)
 		Expect(err).NotTo(HaveOccurred())
@@ -179,9 +178,5 @@ var _ = Describe("Test writing TLS secrets to disk", func() {
 		bytes, err = os.ReadFile(filepath.Join(dir, caCertName))
 		Expect(err).To(HaveOccurred())
 		Expect(bytes).To(BeNil())
-	})
-
-	AfterEach(func() {
-		Expect(os.RemoveAll(dir)).NotTo(HaveOccurred())
 	})
 })

--- a/key-cert-provisioner/pkg/tls/tls.go
+++ b/key-cert-provisioner/pkg/tls/tls.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
-	"net"
 
 	"github.com/projectcalico/calico/key-cert-provisioner/pkg/cfg"
 )
@@ -86,7 +85,7 @@ func CreateX509CSR(config *cfg.Config) (*X509CSR, error) {
 	csrTemplate := x509.CertificateRequest{
 		Subject:            subj,
 		DNSNames:           config.DNSNames,
-		IPAddresses:        []net.IP{net.ParseIP(config.PodIP)},
+		IPAddresses:        config.IPAddresses,
 		SignatureAlgorithm: SignatureAlgorithm(config.SignatureAlgorithm),
 		ExtraExtensions: []pkix.Extension{
 			{
@@ -134,22 +133,16 @@ func GeneratePrivateKey(algorithm string) (interface{}, []byte, error) {
 	switch algorithm {
 	case "RSAWithSize2048":
 		return genRSA(2048)
-
 	case "RSAWithSize4096":
 		return genRSA(4096)
-
 	case "RSAWithSize8192":
 		return genRSA(8192)
-
 	case "ECDSAWithCurve256":
 		return genECDSA(elliptic.P256())
-
 	case "ECDSAWithCurve384":
 		return genECDSA(elliptic.P384())
-
 	case "ECDSAWithCurve521":
 		return genECDSA(elliptic.P521())
-
 	default:
 		return genRSA(2048)
 	}
@@ -187,25 +180,18 @@ func genRSA(size int) (*rsa.PrivateKey, []byte, error) {
 // Default: SHA256WithRSA
 func SignatureAlgorithm(algorithm string) x509.SignatureAlgorithm {
 	switch algorithm {
-
 	case "SHA256WithRSA":
 		return x509.SHA256WithRSA
-
 	case "SHA384WithRSA":
 		return x509.SHA384WithRSA
-
 	case "SHA512WithRSA":
 		return x509.SHA512WithRSA
-
 	case "ECDSAWithSHA256":
 		return x509.ECDSAWithSHA256
-
 	case "ECDSAWithSHA384":
 		return x509.ECDSAWithSHA384
-
 	case "ECDSAWithSHA512":
 		return x509.ECDSAWithSHA512
-
 	default:
 		return x509.SHA256WithRSA
 	}

--- a/key-cert-provisioner/pkg/tls/tls_test.go
+++ b/key-cert-provisioner/pkg/tls/tls_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ var _ = Describe("Certificate requests", func() {
 	Context("Create a certificate request based on a config", func() {
 		It("should include all required fields", func() {
 			config := cfg.Config{
-				PodIP:               "1.2.3.4",
+				IPAddresses:         []net.IP{net.IPv4(1, 2, 3, 4)},
 				SignatureAlgorithm:  "SHA256WithRSA",
 				DNSNames:            []string{"localhost"},
 				CommonName:          "lh",


### PR DESCRIPTION
## Description

This change prepares key-cert-provisioner to accept felix config format. It also fixes permission issues when writing private key and certificates to the disk. It upstreams key-cert-provisioner changes to open source.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
