### PR TITLE
Use calico/base:ubi9 for components that require newer glibc

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,4 +1,19 @@
+# Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG BIN_DIR

--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+# Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG TARGETARCH

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG BIN_DIR

--- a/key-cert-provisioner/Dockerfile
+++ b/key-cert-provisioner/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Tigera, Inc. All rights reserved.
+# Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG TARGETARCH

--- a/key-cert-provisioner/test-signer/Dockerfile
+++ b/key-cert-provisioner/test-signer/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Tigera, Inc. All rights reserved.
+# Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 ARG CALICO_BASE
 
 FROM scratch AS source

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -204,7 +204,7 @@ endif
 # Meanwhile other components (e.g. third_party/envoy-proxy) use UBI 9.  While it may be possible to
 # update calico/base to UBI 9, fully transitioning to UBI 9 would require dropping support for RHEL
 # 8.
-UBI_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal:latest
+UBI8_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal:latest
 UBI9_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ifeq ($(GIT_USE_SSH),true)

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -273,6 +273,8 @@ CALICO_BASE ?= $(UBI_IMAGE)
 else
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)
 endif
+# TODO Remove once CALICO_BASE is updated to UBI9
+CALICO_BASE_UBI9 ?= calico/base:$(CALICO_BASE_UBI9_VER)
 
 ifndef NO_DOCKER_PULL
 DOCKER_PULL = --pull
@@ -282,11 +284,13 @@ endif
 
 # DOCKER_BUILD is the base build command used for building all images.
 DOCKER_BUILD=docker buildx build --load --platform=linux/$(ARCH) $(DOCKER_PULL)\
-	     --build-arg UBI_IMAGE=$(UBI_IMAGE) \
-	     --build-arg UBI9_IMAGE=$(UBI9_IMAGE) \
-	     --build-arg GIT_VERSION=$(GIT_VERSION) \
-	     --build-arg CALICO_BASE=$(CALICO_BASE) \
-	     --build-arg BPFTOOL_IMAGE=$(BPFTOOL_IMAGE)
+	--build-arg UBI8_IMAGE=$(UBI8_IMAGE) \
+	--build-arg UBI9_IMAGE=$(UBI9_IMAGE) \
+	--build-arg GIT_VERSION=$(GIT_VERSION) \
+	--build-arg BPFTOOL_IMAGE=$(BPFTOOL_IMAGE) \
+	--build-arg CALICO_BASE=$(CALICO_BASE) \
+	--build-arg CALICO_BASE_UBI9=$(CALICO_BASE_UBI9)
+
 
 DOCKER_RUN := mkdir -p $(REPO_ROOT)/.go-pkg-cache bin $(GOMOD_CACHE) && \
 	docker run --rm \

--- a/metadata.mk
+++ b/metadata.mk
@@ -5,6 +5,8 @@
 # The version of calico/go-build and calico/base to use.
 GO_BUILD_VER=1.24.1-llvm18.1.8-k8s1.32.2
 CALICO_BASE_VER=ubi8-1741131622
+# TODO Remove once CALICO_BASE is updated to UBI9
+CALICO_BASE_UBI9_VER=ubi9-1741131622
 
 # Env var to ACK Ginkgo deprecation warnings, may need updating with go-build.
 ACK_GINKGO=ACK_GINKGO_DEPRECATIONS=1.16.5

--- a/pod2daemon/csidriver/Dockerfile
+++ b/pod2daemon/csidriver/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Tigera, Inc. All rights reserved.
+# Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG BIN_DIR

--- a/pod2daemon/node-driver-registrar-docker/Dockerfile
+++ b/pod2daemon/node-driver-registrar-docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Tigera, Inc. All rights reserved.
+# Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG BIN_DIR

--- a/test-tools/mocknode/Dockerfile
+++ b/test-tools/mocknode/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Tigera, Inc. All rights reserved.
+# Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG TARGETARCH
@@ -19,7 +21,7 @@ ARG TARGETARCH
 # And the mock-node itself...
 COPY bin/test-tools/mocknode-${TARGETARCH} /usr/bin/mocknode
 
-FROM calico/base
+FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 

--- a/third_party/envoy-gateway/Dockerfile
+++ b/third_party/envoy-gateway/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
+
 # This is a copy of
 # https://github.com/envoyproxy/gateway/blob/v1.1.2/tools/docker/envoy-gateway/Dockerfile
 # but:
@@ -6,12 +8,15 @@
 
 ARG CALICO_BASE
 
-FROM --platform=linux/amd64 busybox AS source
+FROM busybox AS source
+
 # Create the data directory for the gateway
 RUN mkdir -p /var/lib/eg
 
 FROM ${CALICO_BASE}
+
 ARG TARGETARCH
+
 COPY bin/envoy-gateway-${TARGETARCH} /usr/local/bin/envoy-gateway
 COPY --from=source --chown=65532:65532 /var/lib /var/lib
 

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -59,7 +59,7 @@ sub-image-%:
 image: $(BUILD_IMAGES)
 
 $(ENVOY_GATEWAY_IMAGE): $(ENVOY_GATEWAY_IMAGE_CREATED)
-$(ENVOY_GATEWAY_IMAGE_CREATED): Dockerfile build
+$(ENVOY_GATEWAY_IMAGE_CREATED): register Dockerfile build
 	$(DOCKER_BUILD) -t $(ENVOY_GATEWAY_IMAGE):latest-$(ARCH) -f Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@

--- a/third_party/envoy-proxy/Dockerfile
+++ b/third_party/envoy-proxy/Dockerfile
@@ -1,4 +1,8 @@
+# Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
+
+ARG CALICO_BASE_UBI9
 ARG ENVOYBINARY_IMAGE
+ARG THIRD_PARTY_REGISTRY
 ARG UBI9_IMAGE
 
 FROM ${ENVOYBINARY_IMAGE} AS envoybinary
@@ -16,20 +20,14 @@ COPY --from=ubi /usr/bin/id /usr/bin/id
 COPY --from=ubi /usr/sbin/groupmod /usr/sbin/groupmod
 COPY --from=ubi /usr/sbin/usermod /usr/sbin/usermod
 
-# arm64 loader under /lib/ld-linux-aarch64.so.1
-COPY --from=ubi /lib/ld-linux-*.so.? /lib/
-# amd64 loader under /lib64/ld-linux-x86-64.so.2
-COPY --from=ubi /lib64/ld-linux-*.so.? /lib64/
 COPY --from=ubi /lib64/libacl.so.1 /lib64/libacl.so.1
 COPY --from=ubi /lib64/libattr.so.1 /lib64/libattr.so.1
 COPY --from=ubi /lib64/libaudit.so.1 /lib64/libaudit.so.1
-COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
 COPY --from=ubi /lib64/libcap-ng.so.0 /lib64/libcap-ng.so.0
 COPY --from=ubi /lib64/libcap.so.2 /lib64/libcap.so.2
 COPY --from=ubi /lib64/libdl.so.2 /lib64/libdl.so.2
 COPY --from=ubi /lib64/libm.so.6 /lib64/libm.so.6
 COPY --from=ubi /lib64/libpcre2-8.so.0 /lib64/libpcre2-8.so.0
-COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
 COPY --from=ubi /lib64/librt.so.1 /lib64/librt.so.1
 COPY --from=ubi /lib64/libselinux.so.1 /lib64/libselinux.so.1
 COPY --from=ubi /lib64/libtinfo.so.6 /lib64/libtinfo.so.6
@@ -39,7 +37,7 @@ COPY --from=envoybinary --chown=0:0 --chmod=644 \
 COPY --from=envoybinary --chown=0:0 --chmod=755 \
     /usr/local/bin/envoy /usr/local/bin/
 
-FROM scratch
+FROM ${CALICO_BASE_UBI9}
 
 COPY --from=source / /
 

--- a/third_party/envoy-ratelimit/Dockerfile
+++ b/third_party/envoy-ratelimit/Dockerfile
@@ -1,4 +1,9 @@
+# Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
+
 ARG CALICO_BASE
+
 FROM ${CALICO_BASE}
+
 ARG TARGETARCH
+
 COPY bin/envoy-ratelimit-${TARGETARCH} /bin/ratelimit

--- a/typha/docker-image/Dockerfile
+++ b/typha/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ARG CALICO_BASE
+
 FROM scratch AS source
 
 ARG TARGETARCH


### PR DESCRIPTION
## Description

This change introduces calico/base:ubi9 for some components like envoy gateway that require newer glibc.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
