### PR TITLE
[BPF] cleanup CT entries for new UDP service IPs

### DIFF
--- a/felix/bpf/conntrack/cleanup.go
+++ b/felix/bpf/conntrack/cleanup.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/timeshim"
 )
@@ -190,6 +191,7 @@ type NATChecker interface {
 	ConntrackScanStart()
 	ConntrackScanEnd()
 	ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP, backendPort uint16, proto uint8) bool
+	ConntrackDestIsService(ip net.IP, port uint16, proto uint8) bool
 }
 
 // StaleNATScanner removes any entries to frontend that do not have the backend anymore.
@@ -215,7 +217,36 @@ again:
 
 	switch v.Type() {
 	case TypeNormal:
-		// skip non-NAT entry
+		proto := k.Proto()
+		if proto != ProtoUDP {
+			// skip non-NAT entry
+			break
+		}
+
+		// Check if we have an entry to a service IP:port without it being
+		// NATed. Remove such entry as it was created when the service wasn't
+		// programmed yet and there was a NAT miss.
+		//
+		// When CTLB is used, we should not see service ip:port on the wire at
+		// all.
+
+		var (
+			ip   net.IP
+			port uint16
+		)
+
+		if v.Flags()&v3.FlagSrcDstBA != 0 {
+			ip = k.AddrA()
+			port = k.PortA()
+		} else {
+			ip = k.AddrB()
+			port = k.PortB()
+		}
+
+		if sns.natChecker.ConntrackDestIsService(ip, port, proto) {
+			log.WithField("key", k).Debugf("TypeNormal to UDP service IP is stale")
+			return ScanVerdictDelete
+		}
 
 	case TypeNATReverse:
 

--- a/felix/bpf/conntrack/conntrack_test.go
+++ b/felix/bpf/conntrack/conntrack_test.go
@@ -107,6 +107,10 @@ func (d dummyNATChecker) ConntrackFrontendHasBackend(
 	return d.check(fIP, fPort, bIP, bPort, proto)
 }
 
+func (dummyNATChecker) ConntrackDestIsService(ip net.IP, port uint16, proto uint8) bool {
+	return true
+}
+
 func (dummyNATChecker) ConntrackScanStart() {}
 func (dummyNATChecker) ConntrackScanEnd()   {}
 

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -261,3 +261,13 @@ func (kp *KubeProxy) ConntrackFrontendHasBackend(ip net.IP, port uint16, backend
 	// We cannot say yet, so do not break anything
 	return true
 }
+
+// ConntrackDestIsService to satisfy conntrack.NATChecker - forwards to syncer.
+func (kp *KubeProxy) ConntrackDestIsService(ip net.IP, port uint16, proto uint8) bool {
+	if kp.syncer != nil {
+		return kp.syncer.ConntrackDestIsService(ip, port, proto)
+	}
+
+	// We cannot say yet, so do not break anything
+	return false
+}

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -73,6 +73,7 @@ type DPSyncer interface {
 	ConntrackScanStart()
 	ConntrackScanEnd()
 	ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP, backendPort uint16, proto uint8) bool
+	ConntrackDestIsService(ip net.IP, port uint16, proto uint8) bool
 	Stop()
 	SetTriggerFn(func())
 }

--- a/felix/bpf/proxy/proxy_test.go
+++ b/felix/bpf/proxy/proxy_test.go
@@ -650,6 +650,9 @@ func (*syncerConntrackAPIDummy) ConntrackFrontendHasBackend(ip net.IP, port uint
 	backendPort uint16, proto uint8) bool {
 	return false
 }
+func (*syncerConntrackAPIDummy) ConntrackDestIsService(ip net.IP, port uint16, proto uint8) bool {
+	return true
+}
 
 func (s *mockSyncer) checkState(f func(proxy.DPSyncerState)) {
 	tickC := time.After(10 * time.Second)


### PR DESCRIPTION
When scanning conntrack for stale entries clean up UDP entries that point to any UDP service without NAT (Normal entries, type 0). Those were created when the service wasn't programmed yet/fully.

Without this cleanup, UDP flows that race with service creation may get stuck in never getting resolved to any backend.

Fixes https://github.com/projectcalico/calico/issues/9967

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note


<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix cleanup of UDP service entries when a service gets (re)created
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
