### PR TITLE
fix conversion for protobuf to flow response - the BytesOut in the fl…

### DIFF
--- a/whisker-backend/pkg/handlers/v1/protoconvert.go
+++ b/whisker-backend/pkg/handlers/v1/protoconvert.go
@@ -145,6 +145,6 @@ func protoToFlow(flow *proto.Flow) whiskerv1.FlowResponse {
 		PacketsIn:  flow.PacketsIn,
 		PacketsOut: flow.PacketsOut,
 		BytesIn:    flow.BytesIn,
-		BytesOut:   flow.PacketsIn,
+		BytesOut:   flow.BytesOut,
 	}
 }


### PR DESCRIPTION
fix conversion for protobuf to flow response - the BytesOut in the flow response, was being set to PacketsIn from proto

## Description
A simple bug fix for PacketsIn being set to BytesOut in whisker-backend (proto to response conversion)
