### PR TITLE
[release-v3.30] Auto pick #10047: Fix historical streaming of Flows

### DIFF
--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -415,10 +415,10 @@ func (a *LogAggregator) backfill(stream *Stream, request *proto.FlowStreamReques
 
 	// Go through the bucket ring, generating stream events for each flow that matches the request.
 	// Right now, the stream endpoint only supports aggregation windows of a single bucket interval.
-	a.buckets.IterBucketsTime(request.StartTimeGte, a.nowFunc().Unix(), func(b *bucketing.AggregationBucket) {
+	a.buckets.IterBucketsTime(request.StartTimeGte, a.nowFunc().Unix(), func(bucket *bucketing.AggregationBucket) {
 		// Iterate all of the keys in this bucket.
-		b.FlowKeys.Iter(func(key types.FlowKey) error {
-			builder := bucketing.NewCachedFlowBuilder(a.diachronics[key], b.StartTime, b.EndTime)
+		bucket.FlowKeys.Iter(func(key types.FlowKey) error {
+			builder := bucketing.NewCachedFlowBuilder(a.diachronics[key], bucket.StartTime, bucket.EndTime)
 			if f, id := builder.Build(request.Filter); f != nil {
 				// The key matches the filter and time range. Aggregate the flow and send it to the stream.
 				logrus.WithField("flow", key).Debug("Sending backfilled flow to stream")

--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -420,7 +420,7 @@ func (a *LogAggregator) backfill(stream *Stream, request *proto.FlowStreamReques
 		bucket.FlowKeys.Iter(func(key types.FlowKey) error {
 			builder := bucketing.NewCachedFlowBuilder(a.diachronics[key], bucket.StartTime, bucket.EndTime)
 			if f, id := builder.Build(request.Filter); f != nil {
-				// The key matches the filter and time range. Aggregate the flow and send it to the stream.
+				// The flow matches the filter and time range.
 				logrus.WithField("flow", key).Debug("Sending backfilled flow to stream")
 				stream.Receive(&proto.FlowResult{
 					Id:   id,

--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -415,7 +415,7 @@ func (a *LogAggregator) backfill(stream *Stream, request *proto.FlowStreamReques
 
 	// Go through the bucket ring, generating stream events for each flow that matches the request.
 	// Right now, the stream endpoint only supports aggregation windows of a single bucket interval.
-	a.buckets.IterBucketsTime(request.StartTimeGte, a.nowFunc().Unix(), func(bucket *bucketing.AggregationBucket) {
+	err := a.buckets.IterBucketsTime(request.StartTimeGte, a.nowFunc().Unix(), func(bucket *bucketing.AggregationBucket) {
 		// Iterate all of the keys in this bucket.
 		bucket.FlowKeys.Iter(func(key types.FlowKey) error {
 			builder := bucketing.NewCachedFlowBuilder(a.diachronics[key], bucket.StartTime, bucket.EndTime)
@@ -430,6 +430,9 @@ func (a *LogAggregator) backfill(stream *Stream, request *proto.FlowStreamReques
 			return nil
 		})
 	})
+	if err != nil {
+		logrus.WithError(err).Error("Error backfilling stream")
+	}
 }
 
 // normalizeTimeRange normalizes the time range for a query, converting absent and relative time indicators


### PR DESCRIPTION
Cherry pick of #10047 on release-v3.30.

#10047: Fix historical streaming of Flows

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The stream endpoint was returning singular aggregated Flows instead of a Flow per time window.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.