### PR TITLE
[release tool] fix generating release notes

### DIFF
--- a/release/internal/outputs/releasenotes.go
+++ b/release/internal/outputs/releasenotes.go
@@ -37,6 +37,7 @@ const (
 	releaseNoteRequiredLabel = "release-note-required"
 	closedState              = issueState("closed")
 	openState                = issueState("open")
+	allState                 = issueState("all")
 )
 
 var (
@@ -204,6 +205,7 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 	opts := &github.MilestoneListOptions{
 		State: string(openState),
 	}
+	prIssues := []*github.Issue{}
 	for _, repo := range repos {
 		milestoneNumber, err := milestoneNumber(githubClient, owner, repo, milestone, opts)
 		if err != nil {
@@ -211,29 +213,41 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 			continue
 		}
 		logrus.WithField("repo", repo).Debugf("Found milestone %s: %d", milestone, milestoneNumber)
-		opts := &github.IssueListByRepoOptions{
-			Milestone: strconv.Itoa(milestoneNumber),
-			State:     string(closedState),
-			Labels:    []string{releaseNoteRequiredLabel},
-		}
 		logrus.WithField("repo", repo).Debug("Getting issues")
-		prIssues, err := prIssuesByRepo(githubClient, owner, repo, opts)
+		prIssuesByRepo, err := prIssuesByRepo(githubClient, owner, repo, &github.IssueListByRepoOptions{
+			Milestone: strconv.Itoa(milestoneNumber),
+			State:     string(allState),
+		})
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to get issues for %s", repo)
 			return "", err
 		}
-		logrus.WithField("repo", repo).Debugf("Found %d PRs with release notes", len(prIssues))
-		relNoteDataList, err := extractReleaseNote(repo, prIssues)
+		logrus.WithField("repo", repo).Debugf("Found %d PRs", len(prIssuesByRepo))
+		prIssues = append(prIssues, prIssuesByRepo...)
+		closedReleaseNoteIssues := []*github.Issue{}
+		for _, issue := range prIssuesByRepo {
+			if issue.GetState() == string(closedState) {
+				for _, label := range issue.Labels {
+					if label.GetName() == releaseNoteRequiredLabel {
+						closedReleaseNoteIssues = append(closedReleaseNoteIssues, issue)
+					}
+				}
+			}
+		}
+		relNoteDataList, err := extractReleaseNote(repo, closedReleaseNoteIssues)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to extract release notes")
 			return "", err
 		}
 		releaseNoteDataList = append(releaseNoteDataList, relNoteDataList...)
 	}
-	logrus.WithField("milestone", milestone).Debugf("Found %d closed issues with release notes", len(releaseNoteDataList))
+	if len(prIssues) == 0 {
+		logrus.WithField("milestone", milestone).Error("No PRs found for milestone")
+		return "", fmt.Errorf("no PRs found for milestone %s", milestone)
+	}
+
 	if len(releaseNoteDataList) == 0 {
-		logrus.WithField("milestone", milestone).Error("No closed issues with release notes for milestone")
-		return "", fmt.Errorf("no closed issues with release notes found for milestone %s", milestone)
+		logrus.WithField("milestone", milestone).Warn("No closed issues requiring release notes found in milestone")
 	}
 	releaseNoteFilePath := filepath.Join(outputDir, fmt.Sprintf("%s-release-notes.md", ver.FormattedString()))
 	if err := outputReleaseNotes(releaseNoteDataList, releaseNoteFilePath); err != nil {


### PR DESCRIPTION
## Description

Currently master hashreleases are failing and outputting the wrong error reason. Additionally, it should allow generating an empty release notes if there has been changes (determined by PRs against the milestone) even if those changes do not require release notes.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
