### PR TITLE
fix ci-preflight-checks failing (#10060)

### DIFF
--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -9,8 +9,6 @@ KUBE_MOCK_NODE_MANIFEST?=mock-node.yaml
 # e.g., <registry>/<name>:<tag>
 CALICOCTL_IMAGE       ?=ctl
 BUILD_IMAGES          ?=$(CALICOCTL_IMAGE)
-RELEASE_BRANCH_PREFIX ?= release
-DEV_TAG_SUFFIX        ?= 0.dev
 
 # Remove any excluded architectures since for calicoctl we want to build everything.
 EXCLUDEARCH?=

--- a/metadata.mk
+++ b/metadata.mk
@@ -27,6 +27,9 @@ KIND_VERSION=v0.27.0
 ORGANIZATION = projectcalico
 GIT_REPO = calico
 
+RELEASE_BRANCH_PREFIX ?=release
+DEV_TAG_SUFFIX        ?= 0.dev
+
 # Part of the git remote that is common to git and HTTP representations.
 # Used to auto-detect the right remote.
 GIT_REPO_SLUG ?= $(ORGANIZATION)/$(GIT_REPO)

--- a/node/Makefile
+++ b/node/Makefile
@@ -2,9 +2,6 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/node
 
-RELEASE_BRANCH_PREFIX ?=release
-DEV_TAG_SUFFIX        ?=0.dev
-
 # Name of the images.
 # e.g., <registry>/<name>:<tag>
 NODE_IMAGE            ?=node


### PR DESCRIPTION
## Description

when running fix-changed target in cni-plugin, there is no release branch prefix env var so it was not able to figure out the parent branch to compare for changed files

this change moves RELEASE_BRANCH_PREFIX (and DEV_TAG_SUFFIX) to metadata.mk as they should be in the global file instead of detected in individual components

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
