### PR TITLE
Forward packets from workload to host interfaces not managed by calico.

### DIFF
--- a/felix/bpf-gpl/fib_common.h
+++ b/felix/bpf-gpl/fib_common.h
@@ -53,8 +53,9 @@ static CALI_BPF_INLINE bool fib_approve(struct cali_tc_ctx *ctx, __u32 ifindex)
 					val->name, val->flags);
 			return false;
 		}
-		if (iface_is_not_managed_host(val->flags)) {
+		if (iface_is_not_managed(val->flags)) {
 			CALI_DEBUG("Allow packets to host interface not managed by calico (ifindex %d).", ifindex);
+			return true;
 		}
 	}
 

--- a/felix/bpf-gpl/fib_common.h
+++ b/felix/bpf-gpl/fib_common.h
@@ -53,6 +53,9 @@ static CALI_BPF_INLINE bool fib_approve(struct cali_tc_ctx *ctx, __u32 ifindex)
 					val->name, val->flags);
 			return false;
 		}
+		if (iface_is_not_managed_host(val->flags)) {
+			CALI_DEBUG("Allow packets to host interface not managed by calico (ifindex %d).", ifindex);
+		}
 	}
 
 	return true;

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -23,11 +23,14 @@ CALI_MAP(cali_iface, 4,
 		__u32, struct ifstate_val,
 		1000, BPF_F_NO_PREALLOC)
 
-#define IFACE_STATE_WEP		0x1
-#define IFACE_STATE_V4_READY	0x2
-#define IFACE_STATE_V6_READY	0x4
+#define IFACE_STATE_WEP         0x1
+#define IFACE_STATE_V4_READY    0x2
+#define IFACE_STATE_V6_READY    0x4
+#define IFACE_STATE_HEP         0x8
+#define IFACE_STATE_NOT_MANAGED 0x400
 
 #define iface_is_workload(state)		((state) & IFACE_STATE_WEP)
+#define iface_is_not_managed_host(state)	((state) & (IFACE_STATE_HEP | IFACE_STATE_NOT_MANAGED))
 #ifdef IPVER6
 #define iface_is_ready(state)	((state) & IFACE_STATE_V6_READY)
 #else

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -30,7 +30,7 @@ CALI_MAP(cali_iface, 4,
 #define IFACE_STATE_NOT_MANAGED 0x400
 
 #define iface_is_workload(state)		((state) & IFACE_STATE_WEP)
-#define iface_is_not_managed_host(state)	((state) & IFACE_STATE_NOT_MANAGED)
+#define iface_is_not_managed(state)		((state) & IFACE_STATE_NOT_MANAGED)
 #ifdef IPVER6
 #define iface_is_ready(state)	((state) & IFACE_STATE_V6_READY)
 #else

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -30,7 +30,7 @@ CALI_MAP(cali_iface, 4,
 #define IFACE_STATE_NOT_MANAGED 0x400
 
 #define iface_is_workload(state)		((state) & IFACE_STATE_WEP)
-#define iface_is_not_managed_host(state)	((state) & (IFACE_STATE_HEP | IFACE_STATE_NOT_MANAGED))
+#define iface_is_not_managed_host(state)	((state) & IFACE_STATE_NOT_MANAGED)
 #ifdef IPVER6
 #define iface_is_ready(state)	((state) & IFACE_STATE_V6_READY)
 #else

--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -39,30 +39,32 @@ const (
 )
 
 const (
-	FlgWEP       = uint32(0x1)
-	FlgIPv4Ready = uint32(0x2)
-	FlgIPv6Ready = uint32(0x4)
-	FlgHEP       = uint32(0x8)
-	FlgBond      = uint32(0x10)
-	FlgBondSlave = uint32(0x20)
-	FlgVxlan     = uint32(0x40)
-	FlgIPIP      = uint32(0x80)
-	FlgWireguard = uint32(0x100)
-	FlgL3        = uint32(0x200)
-	FlgMax       = uint32(0x3ff)
+	FlgWEP        = uint32(0x1)
+	FlgIPv4Ready  = uint32(0x2)
+	FlgIPv6Ready  = uint32(0x4)
+	FlgHEP        = uint32(0x8)
+	FlgBond       = uint32(0x10)
+	FlgBondSlave  = uint32(0x20)
+	FlgVxlan      = uint32(0x40)
+	FlgIPIP       = uint32(0x80)
+	FlgWireguard  = uint32(0x100)
+	FlgL3         = uint32(0x200)
+	FlgNotManaged = uint32(0x400)
+	FlgMax        = uint32(0x7ff)
 )
 
 var flagsToStr = map[uint32]string{
-	FlgWEP:       "workload",
-	FlgIPv4Ready: "v4Ready",
-	FlgIPv6Ready: "v6Ready",
-	FlgHEP:       "host",
-	FlgBond:      "bond",
-	FlgBondSlave: "bondslave",
-	FlgVxlan:     "vxlan",
-	FlgIPIP:      "ipip",
-	FlgWireguard: "wg",
-	FlgL3:        "l3",
+	FlgWEP:        "workload",
+	FlgIPv4Ready:  "v4Ready",
+	FlgIPv6Ready:  "v6Ready",
+	FlgHEP:        "host",
+	FlgBond:       "bond",
+	FlgBondSlave:  "bondslave",
+	FlgVxlan:      "vxlan",
+	FlgIPIP:       "ipip",
+	FlgWireguard:  "wg",
+	FlgL3:         "l3",
+	FlgNotManaged: "notmanaged",
 }
 
 var MapParams = maps.MapParameters{

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -991,7 +991,7 @@ func (m *bpfEndpointManager) getIfTypeFlags(name string, ifaceType IfaceType) ui
 
 func (m *bpfEndpointManager) addIgnoredHostIfaceToIfState(name string, ifIndex int) {
 	k := ifstate.NewKey(uint32(ifIndex))
-	flags := ifstate.FlgHEP | ifstate.FlgNotManaged
+	flags := ifstate.FlgNotManaged
 	v := ifstate.NewValue(flags, name, -1, -1, -1, -1, -1, -1, -1, -1)
 	m.ifStateMap.Desired().Set(k, v)
 }

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -989,6 +989,18 @@ func (m *bpfEndpointManager) getIfTypeFlags(name string, ifaceType IfaceType) ui
 	return flags
 }
 
+func (m *bpfEndpointManager) addIgnoredHostIfaceToIfState(name string, ifIndex int) {
+	k := ifstate.NewKey(uint32(ifIndex))
+	flags := ifstate.FlgHEP | ifstate.FlgNotManaged
+	v := ifstate.NewValue(flags, name, -1, -1, -1, -1, -1, -1, -1, -1)
+	m.ifStateMap.Desired().Set(k, v)
+}
+
+func (m *bpfEndpointManager) deleteIgnoredHostIfaceFromIfState(ifIndex int) {
+	k := ifstate.NewKey(uint32(ifIndex))
+	m.ifStateMap.Desired().Delete(k)
+}
+
 func (m *bpfEndpointManager) updateIfaceStateMap(name string, iface *bpfInterface) {
 	k := ifstate.NewKey(uint32(iface.info.ifIndex))
 	if iface.info.ifaceIsUp() {
@@ -1100,6 +1112,15 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 				}
 			}
 		}
+
+		// Add host interface not managed by calico to the ifstate map,
+		// so that packets from workload are not dropped.
+		if update.State == ifacemonitor.StateNotPresent {
+			m.deleteIgnoredHostIfaceFromIfState(update.Index)
+		} else {
+			m.addIgnoredHostIfaceToIfState(update.Name, update.Index)
+		}
+
 		if m.initUnknownIfaces != nil {
 			m.initUnknownIfaces.Add(update.Name)
 		}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1115,10 +1115,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 
 		// Add host interface not managed by calico to the ifstate map,
 		// so that packets from workload are not dropped.
-		if update.State == ifacemonitor.StateNotPresent {
-			m.deleteIgnoredHostIfaceFromIfState(update.Index)
-		} else {
-			m.addIgnoredHostIfaceToIfState(update.Name, update.Index)
+		if update.Name != dataplanedefs.BPFInDev && update.Name != dataplanedefs.BPFOutDev {
+			if update.State == ifacemonitor.StateNotPresent {
+				m.deleteIgnoredHostIfaceFromIfState(update.Index)
+			} else {
+				m.addIgnoredHostIfaceToIfState(update.Name, update.Index)
+			}
 		}
 
 		if m.initUnknownIfaces != nil {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -4873,7 +4873,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			})
 		})
 
-		Context("With unknown host interface", func() {
+		Context("With host interface not managed by calico", func() {
 			BeforeEach(func() {
 				setupCluster()
 				poolName := infrastructure.DefaultIPPoolName
@@ -4899,7 +4899,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			if testOpts.protocol == "udp" || testOpts.tunnel == "ipip" || testOpts.ipv6 {
 				return
 			}
-			It("should allow traffic from workload to host IF not managed by calico", func() {
+			It("should allow traffic from workload to this host device", func() {
 
 				var (
 					test30            *workload.Workload

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -4873,6 +4873,92 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			})
 		})
 
+		Context("With unknown host interface", func() {
+			BeforeEach(func() {
+				setupCluster()
+				poolName := infrastructure.DefaultIPPoolName
+				if testOpts.ipv6 {
+					poolName = infrastructure.DefaultIPv6PoolName
+				}
+				pool, err := calicoClient.IPPools().Get(context.TODO(), poolName, options2.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				pool.Spec.NATOutgoing = false
+				pool, err = calicoClient.IPPools().Update(context.TODO(), pool, options2.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				pol := api.NewGlobalNetworkPolicy()
+				pol.Name = "allow-all"
+				pol.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+				pol.Spec.Egress = []api.Rule{{Action: api.Allow}}
+				pol.Spec.Selector = "all()"
+
+				pol = createPolicy(pol)
+
+			})
+
+			if testOpts.protocol == "udp" || testOpts.tunnel == "ipip" || testOpts.ipv6 {
+				return
+			}
+			It("should allow traffic from workload to host IF not managed by calico", func() {
+
+				var (
+					test30            *workload.Workload
+					test30IP          string
+					test30ExtIP       string
+					test30Route, mask string
+				)
+				if testOpts.ipv6 {
+					test30IP = "fd00::3001"
+					test30ExtIP = "1000::0030"
+					test30Route = "fd00::3000/120"
+					mask = "128"
+				} else {
+					test30IP = "192.168.30.1"
+					test30ExtIP = "10.0.0.30"
+					test30Route = "192.168.30.0/24"
+					mask = "32"
+				}
+
+				test30 = &workload.Workload{
+					Name:          "test30",
+					C:             tc.Felixes[1].Container,
+					IP:            test30IP,
+					Ports:         "57005", // 0xdead
+					Protocol:      testOpts.protocol,
+					InterfaceName: "test30",
+					MTU:           1500, // Need to match host MTU or felix will restart.
+				}
+				err := test30.Start()
+				Expect(err).NotTo(HaveOccurred())
+				// assign address to test30 and add route to the .30 network
+				if testOpts.ipv6 {
+					tc.Felixes[1].Exec("ip", "-6", "route", "add", test30Route, "dev", "test30")
+					tc.Felixes[1].Exec("ip", "-6", "addr", "add", test30ExtIP+"/"+mask, "dev", "test30")
+					_, err = test30.RunCmd("ip", "-6", "route", "add", test30ExtIP+"/"+mask, "dev", "eth0")
+					Expect(err).NotTo(HaveOccurred())
+					// Add a route to the test workload to the fake external
+					// client emulated by the test-workload
+					_, err = test30.RunCmd("ip", "-6", "route", "add", w[1][1].IP+"/"+mask, "via", test30ExtIP)
+					Expect(err).NotTo(HaveOccurred())
+
+				} else {
+					tc.Felixes[1].Exec("ip", "route", "add", test30Route, "dev", "test30")
+					tc.Felixes[1].Exec("ip", "addr", "add", test30ExtIP+"/"+mask, "dev", "test30")
+					_, err = test30.RunCmd("ip", "route", "add", test30ExtIP+"/"+mask, "dev", "eth0")
+					Expect(err).NotTo(HaveOccurred())
+					// Add a route to the test workload to the fake external
+					// client emulated by the test-workload
+					_, err = test30.RunCmd("ip", "route", "add", w[1][1].IP+"/"+mask, "via", test30ExtIP)
+					Expect(err).NotTo(HaveOccurred())
+
+				}
+
+				cc.ResetExpectations()
+				cc.ExpectSome(w[1][1], TargetIP(test30.IP), 0xdead)
+				cc.CheckConnectivity()
+			})
+		})
+
 		Context("With BPFEnforceRPF=Strict", func() {
 			BeforeEach(func() {
 				options.ExtraEnvVars["FELIX_BPFEnforceRPF"] = "Strict"

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -494,6 +494,9 @@ func (f *Felix) BPFIfState(family int) map[string]BPFIfState {
 
 		name := match[3]
 		flags := match[2]
+		if strings.Contains(flags, "notmanaged") {
+			continue
+		}
 		ifIndex, _ := strconv.Atoi(match[1])
 
 		inPolV4 := -1


### PR DESCRIPTION
## Description

When workloads send packets to a host interface not managed by calico, we were dropping it as the destination ep did not have BPF programs attached to it. This is to ensure we don't send packets to workloads which are not ready.

Fix - Add the host interfaces not managed by calico to the ```ifstate``` map with `not managed` flag.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf - Fix dropping packets from workloads to host interfaces not managed by calico.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
