### PR TITLE
[release-v3.30] Auto pick #10076: Goldmane should emit proto.Flow objects, not type.Flows

### DIFF
--- a/goldmane/pkg/emitter/emitter.go
+++ b/goldmane/pkg/emitter/emitter.go
@@ -26,17 +26,18 @@ import (
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectcalico/calico/goldmane/pkg/aggregator/bucketing"
+	"github.com/projectcalico/calico/goldmane/pkg/types"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 )
 
 var (
 	maxRetries   = 15
-	configMapKey = types.NamespacedName{Name: "flow-emitter-state", Namespace: "calico-system"}
+	configMapKey = apitypes.NamespacedName{Name: "flow-emitter-state", Namespace: "calico-system"}
 	healthName   = "emitter"
 )
 
@@ -232,7 +233,10 @@ func (e *Emitter) collectionToReader(bucket *bucketing.FlowCollection) (*bytes.R
 			body = append(body, []byte("\n")...)
 		}
 
-		flowJSON, err := json.Marshal(flow)
+		// Convert to public format.
+		f := types.FlowToProto(&flow)
+		logrus.WithField("flow", f).Info("Emitting flow.")
+		flowJSON, err := json.Marshal(f)
 		if err != nil {
 			return nil, fmt.Errorf("Error marshalling flow: %v", err)
 		}


### PR DESCRIPTION
Cherry pick of #10076 on release-v3.30.

#10076: Goldmane should emit proto.Flow objects, not type.Flows

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.