### PR TITLE
[release-v3.30] Auto pick #10071: Fix race condition in Goldmane UTs

### DIFF
--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -66,6 +66,11 @@ type streamRequest struct {
 	req    *proto.FlowStreamRequest
 }
 
+type sinkRequest struct {
+	sink bucketing.Sink
+	done chan struct{}
+}
+
 type LogAggregator struct {
 	// indices allow for quick handling of flow queries sorted by various methods.
 	indices map[proto.SortBy]Index[string]
@@ -106,7 +111,7 @@ type LogAggregator struct {
 	sink bucketing.Sink
 
 	// sinkChan allows setting the sink asynchronously.
-	sinkChan chan bucketing.Sink
+	sinkChan chan *sinkRequest
 
 	// recvChan is the channel to receive flow updates on.
 	recvChan chan *types.Flow
@@ -146,8 +151,8 @@ func NewLogAggregator(opts ...Option) *LogAggregator {
 		listRequests:        make(chan listRequest),
 		filterHintsRequests: make(chan filterHintsRequest),
 		streamRequests:      make(chan streamRequest),
-		sinkChan:            make(chan bucketing.Sink, 10),
 		recvChan:            make(chan *types.Flow, channelDepth),
+		sinkChan:            make(chan *sinkRequest, 10),
 		rolloverFunc:        time.After,
 		bucketsToAggregate:  20,
 		pushIndex:           30,
@@ -252,10 +257,11 @@ func (a *LogAggregator) Run(startTime int64) {
 			a.backfill(stream, req.req)
 		case id := <-a.streams.closedStreams():
 			a.streams.close(id)
-		case sink := <-a.sinkChan:
-			logrus.WithField("sink", sink).Info("Setting aggregator sink")
-			a.sink = sink
+		case req := <-a.sinkChan:
+			logrus.WithField("sink", req.sink).Info("Setting aggregator sink")
+			a.sink = req.sink
 			a.buckets.EmitFlowCollections(a.sink)
+			close(req.done)
 		case <-a.done:
 			logrus.Warn("Aggregator shutting down")
 			return
@@ -263,8 +269,12 @@ func (a *LogAggregator) Run(startTime int64) {
 	}
 }
 
-func (a *LogAggregator) SetSink(s bucketing.Sink) {
-	a.sinkChan <- s
+// SetSink sets the sink for the aggregator and returns a channel that can be used to wait for the sink to be set,
+// if desired by the caller.
+func (a *LogAggregator) SetSink(s bucketing.Sink) chan struct{} {
+	done := make(chan struct{})
+	a.sinkChan <- &sinkRequest{sink: s, done: done}
+	return done
 }
 
 // Receive is used to send a flow update to the aggregator.

--- a/goldmane/pkg/aggregator/aggregator_test.go
+++ b/goldmane/pkg/aggregator/aggregator_test.go
@@ -752,7 +752,10 @@ func TestSink(t *testing.T) {
 		// Start the aggregator, and rollover to trigger an emission.
 		// We shouldn't see any buckets pushed to the sink, as we haven't sent any flows.
 		go agg.Run(now)
-		agg.SetSink(sink)
+
+		// Set the sink. Setting the Sink is asynchronous and triggers a check for flow emission - as such,
+		// we need to wait for this to complete before we can start sending flows.
+		Eventually(agg.SetSink(sink), waitTimeout, retryTime).Should(BeClosed())
 
 		roller.rolloverAndAdvanceClock(1)
 		require.Len(t, sink.buckets, 0)
@@ -885,7 +888,10 @@ func TestSink(t *testing.T) {
 		// Start the aggregator, and rollover to trigger an emission.
 		// We shouldn't see any buckets pushed to the sink, as we haven't sent any flows.
 		go agg.Run(now)
-		agg.SetSink(sink)
+
+		// Set the sink. Setting the Sink is asynchronous and triggers a check for flow emission - as such,
+		// we need to wait for this to complete before we can start sending flows.
+		Eventually(agg.SetSink(sink), waitTimeout, retryTime).Should(BeClosed())
 
 		// Load up the aggregator with Flow data across a widge range of buckets, spanning
 		// multiple emission windows.
@@ -975,8 +981,9 @@ func TestSink(t *testing.T) {
 			return len(sink.buckets)
 		}, waitTimeout, retryTime).Should(Equal(0), "Unexpected bucket pushed to sink")
 
-		// Set the sink.
-		agg.SetSink(sink)
+		// Set the sink. Setting the Sink is asynchronous and triggers a check for flow emission - as such,
+		// we need to wait for this to complete before we can start sending flows.
+		Eventually(agg.SetSink(sink), waitTimeout, retryTime).Should(BeClosed())
 
 		// We should see the emissions now.
 		Eventually(func() int {


### PR DESCRIPTION
Cherry pick of #10071 on release-v3.30.

#10071: Fix race condition in Goldmane UTs

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->


Setting the Sink is now an asynchronous action - this PR adds the
capabilities for callers to wait for it to complete before continuing.

This allows callers to wait until the Sink has been received by the main
loop before continuing - specifically needed by the unit tests, as they
need to wait to populate Flow data until after Sink backfilling happens.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.