### PR TITLE
Fix whisker-backend fv failure - type mismatch on cli.Push()

### DIFF
--- a/whisker-backend/test/fv/goldmaneintegration_test.go
+++ b/whisker-backend/test/fv/goldmaneintegration_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/projectcalico/calico/goldmane/pkg/client"
 	gmdaemon "github.com/projectcalico/calico/goldmane/pkg/daemon"
+	"github.com/projectcalico/calico/goldmane/pkg/types"
 	"github.com/projectcalico/calico/goldmane/proto"
 	"github.com/projectcalico/calico/lib/httpmachinery/pkg/apiutil"
 	"github.com/projectcalico/calico/lib/std/chanutil"
@@ -127,7 +128,7 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 	// uploaded flow.
 	waitForClockIntervalAlignment(aggrWindow + 1)
 
-	cli.Push(&proto.Flow{
+	cli.Push(types.ProtoToFlow(&proto.Flow{
 		Key: &proto.FlowKey{
 			SourceName:      "test-source-2",
 			SourceNamespace: "test-namespace-3",
@@ -135,7 +136,7 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 		},
 		StartTime: time.Now().Add(-1 * time.Second).Unix(),
 		EndTime:   time.Now().Unix(),
-	})
+	}))
 
 	obj, err := chanutil.ReadWithDeadline(ctx, scanner, time.Second*30)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -211,7 +212,7 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 	// This fixes a flake where we might push the flow at the rollover interval and streaming flows won't pick up the
 	// uploaded flow.
 	waitForClockIntervalAlignment(aggrWindow + 1)
-	cli.Push(&proto.Flow{
+	cli.Push(types.ProtoToFlow(&proto.Flow{
 		Key: &proto.FlowKey{
 			SourceName:      "test-source-2",
 			SourceNamespace: "test-namespace-3",
@@ -219,9 +220,9 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 		},
 		StartTime: time.Now().Add(-1 * time.Second).Unix(),
 		EndTime:   time.Now().Unix(),
-	})
+	}))
 
-	cli.Push(&proto.Flow{
+	cli.Push(types.ProtoToFlow(&proto.Flow{
 		Key: &proto.FlowKey{
 			SourceName:      "test-source-3",
 			SourceNamespace: "test-namespace-3",
@@ -229,9 +230,9 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 		},
 		StartTime: time.Now().Add(-1 * time.Second).Unix(),
 		EndTime:   time.Now().Unix(),
-	})
+	}))
 
-	cli.Push(&proto.Flow{
+	cli.Push(types.ProtoToFlow(&proto.Flow{
 		Key: &proto.FlowKey{
 			SourceName:      "test-source-3",
 			SourceNamespace: "test-namespace-4",
@@ -239,7 +240,7 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 		},
 		StartTime: time.Now().Add(-1 * time.Second).Unix(),
 		EndTime:   time.Now().Unix(),
-	})
+	}))
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:8080/%s", whiskerv1.FlowsFilterHintsPath), nil)
 	Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
## Description

```
Starting with UID: 1000
test/fv/util.go:1: : # github.com/projectcalico/calico/whisker-backend/test/fv [github.com/projectcalico/calico/whisker-backend/test/fv.test]
test/fv/goldmaneintegration_test.go:130:11: cannot use &proto.Flow{…} (value of type *"github.com/projectcalico/calico/goldmane/proto".Flow) as *"github.com/projectcalico/calico/goldmane/pkg/types".Flow value in argument to cli.Push
test/fv/goldmaneintegration_test.go:214:11: cannot use &proto.Flow{…} (value of type *"github.com/projectcalico/calico/goldmane/proto".Flow) as *"github.com/projectcalico/calico/goldmane/pkg/types".Flow value in argument to cli.Push
test/fv/goldmaneintegration_test.go:224:11: cannot use &proto.Flow{…} (value of type *"github.com/projectcalico/calico/goldmane/proto".Flow) as *"github.com/projectcalico/calico/goldmane/pkg/types".Flow value in argument to cli.Push
test/fv/goldmaneintegration_test.go:234:11: cannot use &proto.Flow{…} (value of type *"github.com/projectcalico/calico/goldmane/proto".Flow) as *"github.com/projectcalico/calico/goldmane/pkg/types".Flow value in argument to cli.Push (typecheck)
package fv
make[1]: *** [../lib.Makefile:642: golangci-lint] Error 1
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
