### PR TITLE
[release-v3.29] Auto pick #10083: Remove CRDs from manifests/ocp and add new preflight check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ clean:
 ci-preflight-checks:
 	$(MAKE) check-dockerfiles
 	$(MAKE) check-language
+	$(MAKE) check-ocp-no-crds
 	$(MAKE) generate
 	$(MAKE) check-dirty
 
@@ -47,6 +48,11 @@ check-dockerfiles:
 
 check-language:
 	./hack/check-language.sh
+
+CRD_FILES_IN_OCP_DIR=$(shell grep "^kind: CustomResourceDefinition" manifests/ocp/* -l)
+check-ocp-no-crds:
+	@echo "Checking for files in  manifests/ocp with CustomResourceDefinitions"
+	@if [ ! -z "$(CRD_FILES_IN_OCP_DIR)" ]; then echo "ERROR: manifests/ocp should not have any CustomResourceDefinitions, these files should be removed:"; echo "$(CRD_FILES_IN_OCP_DIR)"; exit 1; fi
 
 generate:
 	$(MAKE) gen-semaphore-yaml


### PR DESCRIPTION
Cherry pick of #10083 on release-v3.29.

#10083: Remove CRDs from manifests/ocp and add new preflight check

# Original PR Body below

Remove files that shouldn't be present in manifests/ocp (CRDs and duplicated custom resources) and add a new preflight check (check-ocp-no-crds) to avoid CRDs from being added to that dir.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.