### PR TITLE
[cherry pick] allow generating empty release note

### DIFF
--- a/release/internal/outputs/releasenotes.go
+++ b/release/internal/outputs/releasenotes.go
@@ -37,6 +37,7 @@ const (
 	releaseNoteRequiredLabel = "release-note-required"
 	closedState              = issueState("closed")
 	openState                = issueState("open")
+	allState                 = issueState("all")
 )
 
 var (
@@ -203,33 +204,49 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 	opts := &github.MilestoneListOptions{
 		State: string(openState),
 	}
+	prIssues := []*github.Issue{}
 	for _, repo := range repos {
 		milestoneNumber, error := milestoneNumber(githubClient, owner, repo, milestone, opts)
 		if error != nil {
 			logrus.WithError(error).Warnf("Failed to retrieve milestone for %s", repo)
 			continue
 		}
-		opts := &github.IssueListByRepoOptions{
-			Milestone: strconv.Itoa(milestoneNumber),
-			State:     string(closedState),
-			Labels:    []string{releaseNoteRequiredLabel},
-		}
+		logrus.WithField("repo", repo).Debugf("Found milestone %s: %d", milestone, milestoneNumber)
 		logrus.WithField("repo", repo).Debug("Getting issues")
-		prIssues, err := prIssuesByRepo(githubClient, owner, repo, opts)
+		prIssuesByRepo, err := prIssuesByRepo(githubClient, owner, repo, &github.IssueListByRepoOptions{
+			Milestone: strconv.Itoa(milestoneNumber),
+			State:     string(allState),
+		})
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to get issues for %s", repo)
 			return "", err
 		}
-		relNoteDataList, err := extractReleaseNote(repo, prIssues)
+		logrus.WithField("repo", repo).Debugf("Found %d PRs", len(prIssuesByRepo))
+		prIssues = append(prIssues, prIssuesByRepo...)
+		closedReleaseNoteIssues := []*github.Issue{}
+		for _, issue := range prIssuesByRepo {
+			if issue.GetState() == string(closedState) {
+				for _, label := range issue.Labels {
+					if label.GetName() == releaseNoteRequiredLabel {
+						closedReleaseNoteIssues = append(closedReleaseNoteIssues, issue)
+					}
+				}
+			}
+		}
+		relNoteDataList, err := extractReleaseNote(repo, closedReleaseNoteIssues)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to extract release notes")
 			return "", err
 		}
 		releaseNoteDataList = append(releaseNoteDataList, relNoteDataList...)
 	}
+	if len(prIssues) == 0 {
+		logrus.WithField("milestone", milestone).Error("No PRs found for milestone")
+		return "", fmt.Errorf("no PRs found for milestone %s", milestone)
+	}
+
 	if len(releaseNoteDataList) == 0 {
-		logrus.WithField("milestone", milestone).Error("No issues found for milestone")
-		return "", fmt.Errorf("no issues found for milestone %s", milestone)
+		logrus.WithField("milestone", milestone).Warn("No closed issues requiring release notes found in milestone")
 	}
 	releaseNoteFilePath := filepath.Join(outputDir, fmt.Sprintf("%s-release-notes.md", ver.FormattedString()))
 	if err := outputReleaseNotes(releaseNoteDataList, releaseNoteFilePath); err != nil {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
