### PR TITLE
Program MTU on vxlan routes

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -668,6 +668,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			config,
 			dp.loopSummarizer,
 			4,
+			config.VXLANMTU,
 		)
 		dp.vxlanParentC = make(chan string, 1)
 		go dp.vxlanManager.KeepVXLANDeviceInSync(context.Background(), config.VXLANMTU, dataplaneFeatures.ChecksumOffloadBroken, 10*time.Second, dp.vxlanParentC)
@@ -1130,6 +1131,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				config,
 				dp.loopSummarizer,
 				6,
+				config.VXLANMTUV6,
 			)
 			dp.vxlanParentCV6 = make(chan string, 1)
 			go dp.vxlanManagerV6.KeepVXLANDeviceInSync(context.Background(), config.VXLANMTUV6, dataplaneFeatures.ChecksumOffloadBroken, 10*time.Second, dp.vxlanParentCV6)

--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -76,6 +76,7 @@ type vxlanManager struct {
 	vxlanID     int
 	vxlanPort   int
 	ipVersion   uint8
+	mtu         int
 
 	// Indicates if configuration has changed since the last apply.
 	routesDirty       bool
@@ -104,6 +105,7 @@ func newVXLANManager(
 	dpConfig Config,
 	opRecorder logutils.OpRecorder,
 	ipVersion uint8,
+	mtu int,
 ) *vxlanManager {
 	nlHandle, _ := netlinkshim.NewRealNetlink()
 	return newVXLANManagerWithShims(
@@ -115,6 +117,7 @@ func newVXLANManager(
 		opRecorder,
 		nlHandle,
 		ipVersion,
+		mtu,
 	)
 }
 
@@ -127,6 +130,7 @@ func newVXLANManagerWithShims(
 	opRecorder logutils.OpRecorder,
 	nlHandle netlinkHandle,
 	ipVersion uint8,
+	mtu int,
 ) *vxlanManager {
 	logCtx := logrus.WithField("ipVersion", ipVersion)
 	return &vxlanManager{
@@ -147,6 +151,7 @@ func newVXLANManagerWithShims(
 		vxlanID:           dpConfig.RulesConfig.VXLANVNI,
 		vxlanPort:         dpConfig.RulesConfig.VXLANPort,
 		ipVersion:         ipVersion,
+		mtu:               mtu,
 		externalNodeCIDRs: dpConfig.ExternalNodesCidrs,
 		routesDirty:       true,
 		vtepsDirty:        true,
@@ -531,7 +536,10 @@ func (m *vxlanManager) tunneledRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routet
 	if isRemoteTunnelRoute(r) {
 		// We treat remote tunnel routes as directly connected. They don't have a gateway of
 		// the VTEP because they ARE the VTEP!
-		return &routetable.Target{CIDR: cidr}
+		return &routetable.Target{
+			CIDR: cidr,
+			MTU:  m.mtu,
+		}
 	}
 
 	// Extract the gateway addr for this route based on its remote VTEP.
@@ -548,6 +556,7 @@ func (m *vxlanManager) tunneledRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routet
 		Type: routetable.TargetTypeVXLAN,
 		CIDR: cidr,
 		GW:   ip.FromString(vtepAddr),
+		MTU:  m.mtu,
 	}
 }
 

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -157,6 +157,7 @@ var _ = Describe("VXLANManager", func() {
 				ipVersion: 4,
 			},
 			4,
+			4444,
 		)
 
 		managerV6 = newVXLANManagerWithShims(
@@ -179,6 +180,7 @@ var _ = Describe("VXLANManager", func() {
 				ipVersion: 6,
 			},
 			6,
+			6666,
 		)
 	})
 
@@ -478,7 +480,11 @@ var _ = Describe("VXLANManager", func() {
 
 		// Expect a directly connected route to the borrowed IP.
 		Expect(rt.currentRoutes[dataplanedefs.VXLANIfaceNameV4]).To(HaveLen(1))
-		Expect(rt.currentRoutes[dataplanedefs.VXLANIfaceNameV4][0]).To(Equal(routetable.Target{CIDR: ip.MustParseCIDROrIP("10.0.1.1/32")}))
+		Expect(rt.currentRoutes[dataplanedefs.VXLANIfaceNameV4][0]).To(Equal(
+			routetable.Target{
+				CIDR: ip.MustParseCIDROrIP("10.0.1.1/32"),
+				MTU:  4444,
+			}))
 
 		// Delete the route.
 		manager.OnUpdate(&proto.RouteRemove{
@@ -508,7 +514,11 @@ var _ = Describe("VXLANManager", func() {
 
 		// Expect a directly connected route to the borrowed IP.
 		Expect(rt.currentRoutes[dataplanedefs.VXLANIfaceNameV6]).To(HaveLen(1))
-		Expect(rt.currentRoutes[dataplanedefs.VXLANIfaceNameV6][0]).To(Equal(routetable.Target{CIDR: ip.MustParseCIDROrIP("fc00:10:244::1/112")}))
+		Expect(rt.currentRoutes[dataplanedefs.VXLANIfaceNameV6][0]).To(Equal(
+			routetable.Target{
+				CIDR: ip.MustParseCIDROrIP("fc00:10:244::1/112"),
+				MTU:  6666,
+			}))
 
 		// Delete the route.
 		managerV6.OnUpdate(&proto.RouteRemove{

--- a/felix/routetable/defs.go
+++ b/felix/routetable/defs.go
@@ -73,6 +73,7 @@ type Target struct {
 	DestMAC   net.HardwareAddr
 	Protocol  netlink.RouteProtocol
 	MultiPath []NextHop
+	MTU       int
 }
 
 func (t Target) Equal(t2 Target) bool {


### PR DESCRIPTION
## Description
    This is a stepping stone for ebpf to move to a single vxlan device for
    both v4/6. We do not want to set MTU on the device, but host networked
    processes will need to know what the MTU should be.

    routes targets can take MTU
    
    It is sometimes handy to set explicitly what MTU should be used on a
    certain route, for instance when a tunnel device is used for both ipv4/6
    and the MTU is different each.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
