### PR TITLE
Kube-controllers - init system, autoHEP hash name

### DIFF
--- a/kube-controllers/Dockerfile
+++ b/kube-controllers/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 Tigera, Inc
+# Copyright 2015-2025 Tigera, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ COPY LICENSE /licenses/LICENSE
 
 COPY ${BIN_DIR}/kube-controllers-linux-${TARGETARCH} /usr/bin/kube-controllers
 COPY ${BIN_DIR}/check-status-linux-${TARGETARCH} /usr/bin/check-status
+COPY ${BIN_DIR}/wrapper-${TARGETARCH} /usr/bin/wrapper
 
 FROM ${CALICO_BASE}
 
@@ -51,4 +52,4 @@ COPY --from=source / /
 
 USER 999
 
-ENTRYPOINT ["/usr/bin/kube-controllers"]
+ENTRYPOINT ["/usr/bin/wrapper", "/usr/bin/kube-controllers"]

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -90,7 +90,7 @@ sub-image-fips-%:
 
 image: $(KUBE_CONTROLLER_CONTAINER_MARKER)
 
-$(KUBE_CONTROLLER_CONTAINER_CREATED): register Dockerfile docker-image/flannel-migration/Dockerfile $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/kubectl-$(ARCH)
+$(KUBE_CONTROLLER_CONTAINER_CREATED): register Dockerfile docker-image/flannel-migration/Dockerfile $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/wrapper-$(ARCH) $(BINDIR)/kubectl-$(ARCH)
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) -f Dockerfile .
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) -f docker-image/flannel-migration/Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -96,7 +96,7 @@ $(KUBE_CONTROLLER_CONTAINER_CREATED): register Dockerfile docker-image/flannel-m
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
-$(KUBE_CONTROLLER_CONTAINER_FIPS_CREATED): register Dockerfile docker-image/flannel-migration/Dockerfile $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/kubectl-$(ARCH)
+$(KUBE_CONTROLLER_CONTAINER_FIPS_CREATED): register Dockerfile docker-image/flannel-migration/Dockerfile $(BINDIR)/kube-controllers-linux-$(ARCH) $(BINDIR)/check-status-linux-$(ARCH) $(BINDIR)/wrapper-$(ARCH) $(BINDIR)/kubectl-$(ARCH)
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(KUBE_CONTROLLERS_IMAGE):latest-fips-$(ARCH) -f Dockerfile .
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(FLANNEL_MIGRATION_IMAGE):latest-fips-$(ARCH) -f docker-image/flannel-migration/Dockerfile .
 	$(MAKE) FIPS=true retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/debugserver"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/calico/libcalico-go/lib/winutils"
+	"github.com/projectcalico/calico/typha/pkg/cmdwrapper"
 )
 
 // VERSION is filled out during the build process (using git describe output)
@@ -230,6 +231,7 @@ func main() {
 	//       but many of our controllers are based on cache.ResourceCache which
 	//       runs forever once it is started.  It needs to be enhanced to respect
 	//       the stop channel passed to the controllers.
+	os.Exit(cmdwrapper.RestartReturnCode)
 }
 
 // Run the controller health checks.

--- a/kube-controllers/cmd/wrapper/wrapper.go
+++ b/kube-controllers/cmd/wrapper/wrapper.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/projectcalico/calico/typha/pkg/cmdwrapper"
+)
+
+// This is a wrapper program to restart the passed in program anytime it exits
+// with a status code of 129, which should be used by typha or kube-controllers
+// to signal they are restarting due to a configuration change.
+func main() {
+	cmdwrapper.Run()
+}

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -447,6 +447,10 @@ func mergeAutoHostEndpoints(envVars map[string]string, status *v3.KubeController
 			sc.Node.HostEndpoint.AutoCreate = v3.Disabled
 		}
 
+		if rc.Node.AutoHostEndpointConfig.CreateDefaultHostEndpoint == "" {
+			rc.Node.AutoHostEndpointConfig.CreateDefaultHostEndpoint = v3.DefaultHostEndpointsEnabled
+		}
+
 		sc.Node.HostEndpoint.CreateDefaultHostEndpoint = rc.Node.AutoHostEndpointConfig.CreateDefaultHostEndpoint
 
 		if rc.Node.AutoHostEndpointConfig.Templates != nil {

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -458,7 +458,7 @@ func (c *autoHostEndpointController) validateName(name string) (string, error) {
 
 	hash := base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
 	regex := regexp.MustCompile("([-_.])")
-	name = regex.ReplaceAllString(name, "")
+	hash = regex.ReplaceAllString(hash, "")
 	name = strings.ToLower(fmt.Sprintf("%s-%s", hash, hostEndpointNameSuffix))
 	if len(name) > validation.DNS1123SubdomainMaxLength {
 		name = name[:validation.DNS1123SubdomainMaxLength]

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"regexp"
+	"strings"
 	"time"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -455,7 +457,9 @@ func (c *autoHostEndpointController) validateName(name string) (string, error) {
 	}
 
 	hash := base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
-	name = fmt.Sprintf("%s-%s", hash, hostEndpointNameSuffix)
+	regex := regexp.MustCompile("([-_.])")
+	name = regex.ReplaceAllString(name, "")
+	name = strings.ToLower(fmt.Sprintf("%s-%s", hash, hostEndpointNameSuffix))
 	if len(name) > validation.DNS1123SubdomainMaxLength {
 		name = name[:validation.DNS1123SubdomainMaxLength]
 	}

--- a/libcalico-go/lib/clientv3/kubecontrollersconfig.go
+++ b/libcalico-go/lib/clientv3/kubecontrollersconfig.go
@@ -21,6 +21,7 @@ import (
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
@@ -73,6 +74,15 @@ func (r kubeControllersConfiguration) validateAndFillDefaults(res *apiv3.KubeCon
 						ErroredFields: []cerrors.ErroredField{{
 							Name:   "KubeControllersConfiguration.Node.HostEndpoint.Templates",
 							Reason: "Template name must be specified",
+						}},
+					}
+				}
+
+				if len(template.GenerateName) > validation.DNS1123SubdomainMaxLength {
+					return cerrors.ErrorValidation{
+						ErroredFields: []cerrors.ErroredField{{
+							Name:   "KubeControllersConfiguration.Node.HostEndpoint.Templates",
+							Reason: "Template name must be shorter than 253 characters",
 						}},
 					}
 				}

--- a/libcalico-go/lib/clientv3/kubecontrollersconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/kubecontrollersconfig_e2e_test.go
@@ -483,6 +483,17 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 				},
 			}
 
+			templateLongName := apiv3.AutoHostEndpointConfig{
+				AutoCreate:                "Enabled",
+				CreateDefaultHostEndpoint: "Enabled",
+				Templates: []apiv3.Template{
+					{
+						GenerateName:   "the-quick-brown-fox-jumps-over-the-lazy-dog-the-quick-brown-fox-jumps-over-the-lazy-dog-the-quick-brown-fox-jumps-over-the-lazy-dog-the-quick-brown-fox-jumps-over-the-lazy-dog-the-quick-brown-fox-jumps-over-the-lazy-dog-the-quick-brown-fox-jumps-over-the-lazy-dog",
+						InterfaceCIDRs: []string{"10.0.0.0/24"},
+					},
+				},
+			}
+
 			templateDuplicateName := apiv3.AutoHostEndpointConfig{
 				AutoCreate:                "Enabled",
 				CreateDefaultHostEndpoint: "Enabled",
@@ -522,6 +533,12 @@ var _ = testutils.E2eDatastoreDescribe("KubeControllersConfiguration tests", tes
 			_, outError = c.KubeControllersConfiguration().Create(ctx, kcc, options.SetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(ContainSubstring("Template name must be specified"))
+
+			By("Creating kcc with long template name")
+			kcc.Spec.Controllers.Node.HostEndpoint = &templateLongName
+			_, outError = c.KubeControllersConfiguration().Create(ctx, kcc, options.SetOptions{})
+			Expect(outError).To(HaveOccurred())
+			Expect(outError.Error()).To(ContainSubstring("Template name must be shorter than 253 characters"))
 
 			By("Creating kcc with duplicate template name")
 			kcc.Spec.Controllers.Node.HostEndpoint = &templateDuplicateName

--- a/typha/pkg/cmdwrapper/cmdwrapper.go
+++ b/typha/pkg/cmdwrapper/cmdwrapper.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdwrapper
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/typha/pkg/config"
+	"github.com/projectcalico/calico/typha/pkg/logutils"
+)
+
+const (
+	RestartReturnCode int = 129
+)
+
+// This is a wrapper program to restart the passed in program anytime it exits
+// with a status code of 129, which should be used by typha or kube-controllers
+// to signal they are restarting due to a configuration change.
+func Run() {
+	// Set up logging.
+	logutils.ConfigureEarlyLogging()
+	logutils.ConfigureLogging(&config.Config{
+		LogSeverityScreen:       "info",
+		DebugDisableLogDropping: true,
+	})
+	if len(os.Args) < 2 {
+		logrus.Fatalf("Invalid invocation of command wrapper, expected: %s <wrapped command>", os.Args[0])
+	}
+	prog := os.Args[1]
+	args := os.Args[2:]
+
+	c := make(chan os.Signal, 1)
+	// Capture all signals and send them to our channel which are then passed on to the
+	// wrapped command
+	signal.Notify(c)
+
+	for {
+		logrus.Infof("Starting %s", prog)
+		cmd := exec.Command(prog, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Start()
+		if err != nil {
+			logrus.WithError(err).Fatalf("Failed to start %s", prog)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		stop := make(chan interface{})
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case s := <-c:
+					// We don't need to know about SIGCHLD signals since cmd.Wait will give us
+					// all we need to know about the command we spawn
+					if s == syscall.SIGCHLD {
+						continue
+					}
+					err = cmd.Process.Signal(s)
+					if err != nil {
+						logrus.WithError(err).Error("Failed so send signal to wrapped command process")
+					}
+				case <-stop:
+					return
+				}
+			}
+		}()
+		cmdWaitErr := cmd.Wait()
+		close(stop)
+		wg.Wait()
+		if cmdWaitErr != nil {
+			if ee, ok := cmdWaitErr.(*exec.ExitError); ok {
+				// If the exitcode is the expected restart code then start our loop over
+				// again to re-run the command we're wrapping.
+				if ee.ExitCode() == RestartReturnCode {
+					logrus.Infof("Received exit status %d, restarting %s", ee.ExitCode(), prog)
+					continue
+				}
+				logrus.Infof("Received exit status %d", ee.ExitCode())
+				// Exit with the same exit status of the wrapped command so the code is returned
+				// to whatever is running us.
+				os.Exit(ee.ExitCode())
+			}
+			logrus.WithError(cmdWaitErr).Errorf("Failed to wait for %s to finish", prog)
+		}
+
+		// If the wrapped command exited successfully then we should do the same.
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
## Description

- Update the kube-controllers with init system to not restart the whole pod during configuration change
- Properly handle long generateName hashing for autoHEPs

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
