### PR TITLE
[release-v3.30] Auto pick #10129: Fix reporting of policy stats for EndOfTier hits

### DIFF
--- a/goldmane/pkg/aggregator/bucketing/stats.go
+++ b/goldmane/pkg/aggregator/bucketing/stats.go
@@ -228,38 +228,45 @@ func (s *statisticsIndex) AddFlow(flow *types.Flow) {
 
 	// For each policy in the flow, add the stats to the policy. The PolicyStatistics object
 	// is responsible for tracking the stats for each rule in the policy.
-	rules := types.FlowLogPolicyToProto(flow.Key.Policies()).EnforcedPolicies
+	policyHits := types.FlowLogPolicyToProto(flow.Key.Policies()).EnforcedPolicies
 
 	// Add pending policies as well - these may contain duplicates of the enforced rules, but
 	// we deduplicate them in the loop below.
-	rules = append(rules, types.FlowLogPolicyToProto(flow.Key.Policies()).PendingPolicies...)
+	policyHits = append(policyHits, types.FlowLogPolicyToProto(flow.Key.Policies()).PendingPolicies...)
 
 	// Build a map of policies to rules within the policy hit by this Flow. We want to add this Flow's
 	// statistics contribution once to each Policy, and once to each Rule within the Policy.
 	polToRules := make(map[StatisticsKey]map[StatisticsKey]proto.Action)
-	for _, rule := range rules {
+	for _, hit := range policyHits {
 		// Build a key for the policy, excluding per-rule information.
+		meta := hit
+		if meta.Kind == proto.PolicyKind_EndOfTier {
+			// For EndOfTier policies, use the policy that triggered the end of tier action to come into effect.
+			// Note that the Action is still attached to the EndOfTier hit, not the trigger.
+			meta = hit.Trigger
+		}
+
 		sk := StatisticsKey{
-			Namespace: rule.Namespace,
-			Name:      rule.Name,
-			Kind:      rule.Kind,
-			Tier:      rule.Tier,
-			Action:    rule.Action,
-			RuleIndex: rule.PolicyIndex,
+			Namespace: meta.Namespace,
+			Name:      meta.Name,
+			Kind:      meta.Kind,
+			Tier:      meta.Tier,
+			Action:    hit.Action,
+			RuleIndex: meta.PolicyIndex,
 			Direction: direction(flow),
 		}
 		pk := sk.policyID()
 		if _, ok := polToRules[pk]; !ok {
 			polToRules[pk] = make(map[StatisticsKey]proto.Action)
 		}
-		if action, ok := polToRules[pk][sk]; ok && action != rule.Action {
+		if action, ok := polToRules[pk][sk]; ok && action != hit.Action {
 			logrus.WithFields(logrus.Fields{
 				"policy":      sk,
-				"conflicting": rule.Action,
+				"conflicting": hit.Action,
 				"selected":    action,
 			}).Warnf("Policy rule has conflicting actions, using the first action")
 		} else {
-			polToRules[pk][sk] = rule.Action
+			polToRules[pk][sk] = hit.Action
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #10129 on release-v3.30.

#10129: Fix reporting of policy stats for EndOfTier hits

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We weren't handling EndOfTier policy hits correctly in the stats index, which was resulting in EOT policy hits showing up as a separate result instead
of being aggregated into the statistic result for the policy that triggered the hit.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.