### PR TITLE
confd: LocalBGPPeerWatcher has no in-sync message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ hack/test/kind/*kubeconfig.yaml
 pod2daemon/node-driver-registrar/
 
 /networking-calico/upper-constraints*.txt
+
+/* Created by libcalico-go UTs */
+ut-tmp-dir

--- a/confd/Makefile
+++ b/confd/Makefile
@@ -58,6 +58,7 @@ test-kdd: bin/confd-$(ARCH) bin/kubectl bin/bird bin/bird6 bin/calico-node bin/c
 		-v $(CURDIR)/bin:/calico/bin/ \
 		-v $(CURDIR)/etc/calico:/etc/calico/ \
 		-v $(CURDIR)/../:/go/src/github.com/projectcalico/calico:rw \
+		-v /var/run/calico/endpoint-status \
 		-e GOPATH=/go \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e FELIX_TYPHAADDR=127.0.0.1:5473 \
@@ -91,6 +92,7 @@ test-etcd: bin/confd-$(ARCH) bin/etcdctl bin/bird bin/bird6 bin/calico-node bin/
 		-v $(CURDIR)/bin:/calico/bin/ \
 		-v $(CURDIR)/etc/calico:/etc/calico/ \
 		-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
+		-v /var/run/calico/endpoint-status \
 		-e GOPATH=/go \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e UPDATE_EXPECTED_DATA=$(UPDATE_EXPECTED_DATA) \

--- a/confd/pkg/backends/calico/local_bgp_peer_watcher.go
+++ b/confd/pkg/backends/calico/local_bgp_peer_watcher.go
@@ -54,6 +54,7 @@ func NewLocalBGPPeerWatcher(client *client, prefix string, pollIntervalSeconds i
 		OnFileCreation: w.OnFileCreation,
 		OnFileUpdate:   w.OnFileUpdate,
 		OnFileDeletion: w.OnFileDeletion,
+		OnInSync:       w.OnInSync,
 	})
 
 	return w, nil
@@ -106,6 +107,12 @@ func (w *LocalBGPPeerWatcher) OnFileDeletion(fileName string) {
 	if w.deleteEpStatus(fileName) {
 		w.client.recheckPeerConfig("endpoint status file deleted")
 	}
+}
+
+func (w *LocalBGPPeerWatcher) OnInSync(inSync bool) {
+	log.WithField("newValue", inSync).Debug("Received new inSync msg from upstream")
+
+	w.client.OnSyncChange(SourceLocalBGPPeerWatcher, inSync)
 }
 
 func (w *LocalBGPPeerWatcher) updateEpStatus(fileName string, epStatus *epstatus.WorkloadEndpointStatus) (changed bool) {

--- a/libcalico-go/lib/epstatusfile/status_file_watcher.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher.go
@@ -32,6 +32,7 @@ type Callbacks struct {
 	OnFileCreation func(fileName string)
 	OnFileUpdate   func(fileName string)
 	OnFileDeletion func(fileName string)
+	OnInSync       func(inSync bool)
 }
 
 type FileWatcher struct {
@@ -49,16 +50,37 @@ type FileWatcher struct {
 	newFsnotifyWatcherFunc func() (*fsnotify.Watcher, error)
 
 	// variable for UT
-	fsnotifyActive bool
+	fsnotifyActive *activityReporter
+}
+
+// activityReporter is a test struct for reporting
+// whether a watch loop is running.
+type activityReporter struct {
+	active bool
+	mu     sync.Mutex
+}
+
+func (r *activityReporter) reportActivity(active bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.active = active
+}
+
+func (r *activityReporter) Poll() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.active
 }
 
 // NewWatcher creates a new Watcher instance.
 func NewFileWatcher(dir string, pollInterval time.Duration) *FileWatcher {
-	return NewFileWatcherWithShim(dir, pollInterval, fsnotify.NewWatcher)
+	return NewFileWatcherWithShim(dir, pollInterval, fsnotify.NewWatcher, nil)
 }
 
 // NewWatcher creates a new Watcher instance.
-func NewFileWatcherWithShim(dir string, pollInterval time.Duration, newFsnotifyWatcherFunc func() (*fsnotify.Watcher, error)) *FileWatcher {
+func NewFileWatcherWithShim(dir string, pollInterval time.Duration, newFsnotifyWatcherFunc func() (*fsnotify.Watcher, error), fsnotifyActivityReporter *activityReporter) *FileWatcher {
 	pollTicker := time.NewTicker(pollInterval)
 
 	return &FileWatcher{
@@ -67,6 +89,7 @@ func NewFileWatcherWithShim(dir string, pollInterval time.Duration, newFsnotifyW
 		stopChan:               make(chan struct{}),
 		pollTicker:             pollTicker,
 		newFsnotifyWatcherFunc: newFsnotifyWatcherFunc,
+		fsnotifyActive:         fsnotifyActivityReporter,
 	}
 }
 
@@ -80,8 +103,8 @@ func (w *FileWatcher) Start() {
 }
 
 func (w *FileWatcher) newFsnotifyWatcher() error {
-	// reset w.fsWatcher
-	w.fsWatcher = nil
+
+	w.closeWatcher()
 
 	watcher, err := w.newFsnotifyWatcherFunc()
 	if err != nil {
@@ -101,10 +124,7 @@ func (w *FileWatcher) newFsnotifyWatcher() error {
 }
 
 func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
-	w.fsnotifyActive = true
-
-	// Get current state of the directory and emit initial events.
-	w.scanDirectory()
+	w.reportFsnotifyActivity(true)
 
 	// Listen for events and loop until error occurs.
 	for {
@@ -138,7 +158,6 @@ func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
 					}
 				}
 			}
-
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				// Stop if channel is closed.
@@ -155,9 +174,7 @@ func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
 // Start begins watching the directory.
 func (w *FileWatcher) runWatcher() {
 	defer func() {
-		if w.fsWatcher != nil {
-			defer w.fsWatcher.Close()
-		}
+		w.closeWatcher()
 	}()
 
 	for {
@@ -167,10 +184,13 @@ func (w *FileWatcher) runWatcher() {
 			log.WithError(err).Info("Error initializing fsnotify. Falling back to polling.")
 		}
 
+		// Get current state of the directory and emit initial events.
+		w.scanDirectory()
+		w.callbacks.OnInSync(true)
 		if w.fsWatcher != nil {
 			// Run fsnotify watcher loop if possible.
 			err := w.runFsnotifyWatcher(w.fsWatcher)
-			w.fsnotifyActive = false
+			w.reportFsnotifyActivity(false)
 			if err != nil {
 				// fall back to polling.
 				log.WithError(err).Info("Start polling directory on updates.")
@@ -182,7 +202,7 @@ func (w *FileWatcher) runWatcher() {
 
 		select {
 		case <-w.pollTicker.C:
-			w.scanDirectory()
+			continue
 		case <-w.stopChan:
 			return
 		}
@@ -244,4 +264,25 @@ func (w *FileWatcher) scanDirectory() {
 // Stop stops the watcher.
 func (w *FileWatcher) Stop() {
 	close(w.stopChan)
+}
+
+// closeWatcher ensures the fsnotify.Watcher cannot be double-closed.
+// Logs & continues if encounters close errors.
+func (w *FileWatcher) closeWatcher() {
+	if w.fsWatcher != nil {
+		err := w.fsWatcher.Close()
+		if err != nil {
+			log.WithError(err).Info("Ignoring error following close of fsWatcher")
+		}
+		// reset.
+		w.fsWatcher = nil
+	}
+}
+
+func (w *FileWatcher) reportFsnotifyActivity(a bool) {
+	if w.fsnotifyActive == nil {
+		return
+	}
+
+	w.fsnotifyActive.reportActivity(a)
 }


### PR DESCRIPTION
## Description

BGP peerings could get generated without waiting for its input

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
