### PR TITLE
Reject policy name with invalid format

### DIFF
--- a/libcalico-go/lib/clientv3/globalnetworkpolicy.go
+++ b/libcalico-go/lib/clientv3/globalnetworkpolicy.go
@@ -63,6 +63,10 @@ func (r globalNetworkPolicies) Create(ctx context.Context, res *apiv3.GlobalNetw
 	if err := validator.Validate(res); err != nil {
 		return nil, err
 	}
+	err := names.ValidateTieredPolicyName(res.Name, tier)
+	if err != nil {
+		return nil, err
+	}
 
 	// Add tier labels to policy for lookup.
 	if tier != "default" {
@@ -94,6 +98,10 @@ func (r globalNetworkPolicies) Update(ctx context.Context, res *apiv3.GlobalNetw
 	defaultPolicyTypesField(res.Spec.Ingress, res.Spec.Egress, &res.Spec.Types)
 
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+	err := names.ValidateTieredPolicyName(res.Name, res.Spec.Tier)
+	if err != nil {
 		return nil, err
 	}
 

--- a/libcalico-go/lib/clientv3/networkpolicy.go
+++ b/libcalico-go/lib/clientv3/networkpolicy.go
@@ -63,6 +63,10 @@ func (r networkPolicies) Create(ctx context.Context, res *apiv3.NetworkPolicy, o
 	if err := validator.Validate(res); err != nil {
 		return nil, err
 	}
+	err := names.ValidateTieredPolicyName(res.Name, tier)
+	if err != nil {
+		return nil, err
+	}
 
 	// Add tier labels to policy for lookup.
 	if tier != "default" {
@@ -94,6 +98,10 @@ func (r networkPolicies) Update(ctx context.Context, res *apiv3.NetworkPolicy, o
 	defaultPolicyTypesField(res.Spec.Ingress, res.Spec.Egress, &res.Spec.Types)
 
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+	err := names.ValidateTieredPolicyName(res.Name, res.Spec.Tier)
+	if err != nil {
 		return nil, err
 	}
 

--- a/libcalico-go/lib/clientv3/networkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/networkpolicy_e2e_test.go
@@ -427,6 +427,44 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 		Entry("NetworkPolicy with default tier prefix", "default.netpol", "netpol"),
 	)
 
+	DescribeTable("NetworkPolicy name validation tests",
+		func(policyName string, tier string, expectError bool) {
+			namespace := "default"
+
+			if tier != "default" {
+				// Create the tier if required before running other tiered policy tests.
+				tierSpec := apiv3.TierSpec{Order: &tierOrder, DefaultAction: &actionPass}
+				By("Creating the tier")
+				_, resErr := c.Tiers().Create(ctx, &apiv3.Tier{
+					ObjectMeta: metav1.ObjectMeta{Name: tier},
+					Spec:       tierSpec,
+				}, options.SetOptions{})
+				Expect(resErr).NotTo(HaveOccurred())
+			}
+
+			_, err := c.NetworkPolicies().Create(ctx,
+				&apiv3.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      policyName,
+						Namespace: namespace},
+					Spec: apiv3.NetworkPolicySpec{
+						Tier: tier,
+					},
+				}, options.SetOptions{})
+
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("NetworkPolicy in default tier without prefix", "netpol", "default", false),
+		Entry("NetworkPolicy in default tier with prefix", "default.netpol", "default", false),
+		Entry("NetworkPolicy in custom tier with correct prefix", "tier1.netpol", "tier1", false),
+		Entry("NetworkPolicy in custom tier without prefix", "netpol", "tier1", true),
+		Entry("NetworkPolicy in custom tier with incorrect prefix", "tier1.netpol", "tier2", true),
+	)
+
 	Describe("NetworkPolicy watch functionality", func() {
 		It("should handle watch events for different resource versions and event types", func() {
 			By("Listing NetworkPolicies with the latest resource version and checking for two results with name1/spec2 and name2/spec2")

--- a/libcalico-go/lib/clientv3/stagedglobalnetworkpolicy.go
+++ b/libcalico-go/lib/clientv3/stagedglobalnetworkpolicy.go
@@ -67,6 +67,10 @@ func (r stagedGlobalNetworkPolicies) Create(ctx context.Context, res *apiv3.Stag
 	if err := validator.Validate(res); err != nil {
 		return nil, err
 	}
+	err := names.ValidateTieredPolicyName(res.Name, tier)
+	if err != nil {
+		return nil, err
+	}
 
 	// Add tier labels to policy for lookup.
 	if tier != "default" {
@@ -102,6 +106,10 @@ func (r stagedGlobalNetworkPolicies) Update(ctx context.Context, res *apiv3.Stag
 	}
 
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+	err := names.ValidateTieredPolicyName(res.Name, res.Spec.Tier)
+	if err != nil {
 		return nil, err
 	}
 

--- a/libcalico-go/lib/clientv3/stagedglobalnetworkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/stagedglobalnetworkpolicy_e2e_test.go
@@ -398,6 +398,41 @@ var _ = testutils.E2eDatastoreDescribe("StagedGlobalNetworkPolicy tests", testut
 		Entry("StagedGlobalNetworkPolicy with default tier prefix", "default.netpol", "netpol"),
 	)
 
+	DescribeTable("StagedGlobalNetworkPolicy name validation tests",
+		func(policyName string, tier string, expectError bool) {
+			if tier != "default" {
+				// Create the tier if required before running other tiered policy tests.
+				tierSpec := apiv3.TierSpec{Order: &tierOrder}
+				By("Creating the tier")
+				_, resErr := c.Tiers().Create(ctx, &apiv3.Tier{
+					ObjectMeta: metav1.ObjectMeta{Name: tier},
+					Spec:       tierSpec,
+				}, options.SetOptions{})
+				Expect(resErr).NotTo(HaveOccurred())
+			}
+
+			_, err := c.StagedGlobalNetworkPolicies().Create(ctx,
+				&apiv3.StagedGlobalNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: policyName},
+					Spec: apiv3.StagedGlobalNetworkPolicySpec{
+						Tier: tier,
+					},
+				}, options.SetOptions{})
+
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("StagedGlobalNetworkPolicy in default tier without prefix", "netpol", "default", false),
+		Entry("StagedGlobalNetworkPolicy in default tier with prefix", "default.netpol", "default", false),
+		Entry("StagedGlobalNetworkPolicy in custom tier with correct prefix", "tier1.netpol", "tier1", false),
+		Entry("StagedGlobalNetworkPolicy in custom tier without prefix", "netpol", "tier1", true),
+		Entry("StagedGlobalNetworkPolicy in custom tier with incorrect prefix", "tier1.netpol", "tier2", true),
+	)
+
 	Describe("StagedGlobalNetworkPolicy watch functionality", func() {
 		It("should handle watch events for different resource versions and event types", func() {
 			By("Listing StagedGlobalNetworkPolicies with the latest resource version and checking for two results with name1/spec2 and name2/spec2")

--- a/libcalico-go/lib/clientv3/stagednetworkpolicy.go
+++ b/libcalico-go/lib/clientv3/stagednetworkpolicy.go
@@ -78,6 +78,10 @@ func (r stagedNetworkPolicies) Create(ctx context.Context, res *apiv3.StagedNetw
 	if err := validator.Validate(res); err != nil {
 		return nil, err
 	}
+	err := names.ValidateTieredPolicyName(res.Name, tier)
+	if err != nil {
+		return nil, err
+	}
 
 	// Add tier labels to policy for lookup.
 	if tier != "default" {
@@ -123,6 +127,10 @@ func (r stagedNetworkPolicies) Update(ctx context.Context, res *apiv3.StagedNetw
 	}
 
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+	err := names.ValidateTieredPolicyName(res.Name, res.Spec.Tier)
+	if err != nil {
 		return nil, err
 	}
 

--- a/libcalico-go/lib/names/policy.go
+++ b/libcalico-go/lib/names/policy.go
@@ -102,6 +102,33 @@ func validateBackendTieredPolicyName(policy, tier string) error {
 	return nil
 }
 
+// ValidateTieredPolicyName validates v3 policy name, policies in the default tier can be named without the default. prefix.
+// Policy names in non default tier have to be in a format of tier.name
+func ValidateTieredPolicyName(policy, tier string) error {
+	if policy == "" {
+		return errors.New("Policy name is empty")
+	}
+	if policyNameIsFormatted(policy) {
+		return nil
+	}
+
+	tier = TierOrDefault(tier)
+	parts := strings.SplitN(policy, ".", 2)
+
+	if len(parts) == 1 && tier == "default" {
+		// Policy in default tier, without the default. prefix
+		return nil
+	}
+
+	if len(parts) == 2 && strings.HasPrefix(policy, tier+".") {
+		// Policy in format of tier.name with tier matching the prefix
+		return nil
+	}
+
+	// If we reached here the policy name is invalid. Either incorrect prefix or with additional . in the name
+	return fmt.Errorf("Incorrectly formatted policy name %s", policy)
+}
+
 func TieredPolicyName(policy string) string {
 	if policy == "" {
 		return ""


### PR DESCRIPTION
Reject policy name with invalid format

cherry pick of:
- #10127

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
