### PR TITLE
Plumb watch bookmarks through to clientv3

### DIFF
--- a/libcalico-go/lib/clientv3/resources.go
+++ b/libcalico-go/lib/clientv3/resources.go
@@ -250,7 +250,7 @@ func (c *resources) Watch(ctx context.Context, opts options.ListOptions, kind st
 
 	// Create the backend watcher.  We need to process the results to add revision data etc.
 	ctx, cancel := context.WithCancel(ctx)
-	backend, err := c.backend.Watch(ctx, list, bapi.WatchOptions{Revision: opts.ResourceVersion})
+	backend, err := c.backend.Watch(ctx, list, bapi.WatchOptions{Revision: opts.ResourceVersion, AllowWatchBookmarks: opts.AllowWatchBookmarks})
 	if err != nil {
 		cancel()
 		return nil, err
@@ -394,6 +394,8 @@ func (w *watcher) convertEvent(backendEvent bapi.WatchEvent) watch.Event {
 		apiEvent.Type = watch.Deleted
 	case bapi.WatchModified:
 		apiEvent.Type = watch.Modified
+	case bapi.WatchBookmark:
+		apiEvent.Type = watch.Bookmark
 	}
 
 	if backendEvent.Old != nil {

--- a/libcalico-go/lib/options/listwatch.go
+++ b/libcalico-go/lib/options/listwatch.go
@@ -36,4 +36,8 @@ type ListOptions struct {
 	// as a mechanism for enumerating endpoints within a Pod (since the name construction for a
 	// Workload endpoint is hierarchically constructed).
 	Prefix bool
+
+	// AllowWatchBookmarks indicates whether the watch should support bookmarks. Note that this field is
+	// only used when the watch is backed by the Kubernetes API server.
+	AllowWatchBookmarks bool
 }

--- a/libcalico-go/lib/watch/interface.go
+++ b/libcalico-go/lib/watch/interface.go
@@ -50,6 +50,7 @@ const (
 	Modified EventType = "MODIFIED"
 	Deleted  EventType = "DELETED"
 	Error    EventType = "ERROR"
+	Bookmark EventType = "BOOKMARK"
 
 	DefaultChanSize int32 = 100
 )


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Not sure if we need this yet, but I noticed that the main k8s API server
sets watchBookmarks=true on the watch requests it makes against the
Calico API server, but we aren't respecting that.

Adding this to the clientv3 API would be the first step towards allowing
our apiserver to handle those requests.

I don't think this is causing any problems - clients MUST not expect the
server to generate watch bookmarks anyway, so this would just be a small
optimization if anything.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.