### PR TITLE
Use kubebuilder validation to verify the length of generateName in KubeControllersConfig

### DIFF
--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -126,6 +126,7 @@ const (
 
 type Template struct {
 	// GenerateName is appended to the end of the generated AutoHostEndpoint name
+	// +kubebuilder:validation:MaxLength=253
 	GenerateName string `json:"generateName,omitempty" validate:"omitempty,name"`
 
 	// InterfaceCIDRs contains a list of CIRDs used for matching nodeIPs to the AutoHostEndpoint

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -825,7 +825,7 @@ func (c *IPAMController) checkAllocations() ([]string, error) {
 		// Clear the full sync flag.
 		c.fullSyncRequired = false
 	} else {
-		log.Info("Checking dirty nodes for leaks and redundant affinities")
+		log.Debug("Checking dirty nodes for leaks and redundant affinities")
 
 		// Collect allocation state for all nodes that have changed since the last sync.
 		c.allocationState.iterDirty(func(node string, allocations map[string]*allocation) {

--- a/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -91,6 +91,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -265,6 +266,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -3904,6 +3904,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4078,6 +4079,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -3914,6 +3914,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4088,6 +4089,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -3915,6 +3915,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4089,6 +4090,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -3899,6 +3899,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4073,6 +4074,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -3899,6 +3899,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4073,6 +4074,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -3916,6 +3916,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4090,6 +4091,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -3813,6 +3813,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -3987,6 +3988,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -3899,6 +3899,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -4073,6 +4074,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -30518,6 +30518,7 @@ spec:
                                     description:
                                       GenerateName is appended to the end
                                       of the generated AutoHostEndpoint name
+                                    maxLength: 253
                                     type: string
                                   interfaceCIDRs:
                                     description:
@@ -30692,6 +30693,7 @@ spec:
                                         description:
                                           GenerateName is appended to the
                                           end of the generated AutoHostEndpoint name
+                                        maxLength: 253
                                         type: string
                                       interfaceCIDRs:
                                         description:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Defense in depth! just in case the crd.projectcalico.org/v1 API is hit instead.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.