### PR TITLE
Add clock interface to lib dirctory to allow passing around a clock implementation and shimming it for tests

### DIFF
--- a/lib/std/clock/standard.go
+++ b/lib/std/clock/standard.go
@@ -1,0 +1,49 @@
+package clock
+
+import "time"
+
+type stdClock struct{}
+
+func newStdClock() Clock {
+	return &stdClock{}
+}
+
+func (std *stdClock) Now() Time {
+	return time.Now()
+}
+
+func (std *stdClock) Since(t Time) time.Duration {
+	return time.Since(t)
+}
+
+func (std *stdClock) Until(t Time) time.Duration {
+	return time.Until(t)
+}
+
+func (std *stdClock) After(t Duration) <-chan Time {
+	return time.After(t)
+}
+
+func (std *stdClock) NewTimer(d Duration) Timer {
+	return &stdTimer{Timer: time.NewTimer(d)}
+}
+
+func (std *stdClock) NewTicker(d Duration) Ticker {
+	return &stdTicker{Ticker: time.NewTicker(d)}
+}
+
+type stdTicker struct {
+	*time.Ticker
+}
+
+func (ticker *stdTicker) Chan() <-chan Time {
+	return ticker.C
+}
+
+type stdTimer struct {
+	*time.Timer
+}
+
+func (s stdTimer) Chan() <-chan Time {
+	return s.C
+}

--- a/lib/std/clock/time.go
+++ b/lib/std/clock/time.go
@@ -1,0 +1,66 @@
+package clock
+
+import "time"
+
+func init() {
+	activeClock = newStdClock()
+}
+
+var activeClock Clock
+
+type Time = time.Time
+type Duration = time.Duration
+
+// DoWithClock temporarily sets the shim as the clock and runs the given function. After the function is run, the clock
+// is returned to its original state.
+func DoWithClock(shim Clock, fn func() error) error {
+	defer func(c Clock) { activeClock = c }(activeClock)
+	activeClock = shim
+	return fn()
+}
+
+// Clock is our shim interface to the time package.
+type Clock interface {
+	Now() Time
+	Since(t Time) time.Duration
+	Until(t Time) time.Duration
+	After(t Duration) <-chan Time
+	NewTimer(d Duration) Timer
+	NewTicker(d Duration) Ticker
+}
+
+type Timer interface {
+	Stop() bool
+	Reset(d Duration) bool
+	Chan() <-chan Time
+}
+
+type Ticker interface {
+	Stop()
+	Reset(d Duration)
+	Chan() <-chan Time
+}
+
+func Now() Time {
+	return activeClock.Now()
+}
+
+func Since(t Time) time.Duration {
+	return activeClock.Since(t)
+}
+
+func Until(t Time) time.Duration {
+	return activeClock.Until(t)
+}
+
+func After(t Duration) <-chan Time {
+	return activeClock.After(t)
+}
+
+func NewTimer(d Duration) Timer {
+	return activeClock.NewTimer(d)
+}
+
+func NewTicker(d Duration) Ticker {
+	return activeClock.NewTicker(d)
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
