### PR TITLE
Fix confd status file churn

### DIFF
--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -365,7 +365,7 @@ type client struct {
 	secretWatcher *secretWatcher
 
 	// Subcomponent for accessing and watching local BGP peers.
-	localBGPPeerWatcher *localBGPPeerWatcher
+	localBGPPeerWatcher *LocalBGPPeerWatcher
 
 	// Channels used to decouple update and status processing.
 	syncerC  chan interface{}
@@ -1633,11 +1633,11 @@ func (c *client) onNewUpdates() {
 }
 
 func (c *client) recheckPeerConfig(reason string) {
-	log.WithField("trigger", reason).Info("Trigger to recheck BGP peers following possible password or local BGP peer update")
 	select {
 	// Non-blocking write into the recheckC channel.  The idea here is that we don't need to add
 	// a second trigger if there is already one pending.
 	case c.recheckC <- struct{}{}:
+		log.WithField("trigger", reason).Info("Triggered recheck of BGP peers.")
 	default:
 	}
 }

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1632,8 +1632,8 @@ func (c *client) onNewUpdates() {
 	}
 }
 
-func (c *client) recheckPeerConfig() {
-	log.Info("Trigger to recheck BGP peers following possible password or local BGP peer update")
+func (c *client) recheckPeerConfig(reason string) {
+	log.WithField("trigger", reason).Info("Trigger to recheck BGP peers following possible password or local BGP peer update")
 	select {
 	// Non-blocking write into the recheckC channel.  The idea here is that we don't need to add
 	// a second trigger if there is already one pending.

--- a/confd/pkg/backends/calico/local_bgp_peer_watcher.go
+++ b/confd/pkg/backends/calico/local_bgp_peer_watcher.go
@@ -76,7 +76,7 @@ func (w *localBGPPeerWatcher) OnFileCreation(fileName string) {
 		return
 	}
 	w.updateEpStatus(fileName, epStatus)
-	w.client.recheckPeerConfig()
+	w.client.recheckPeerConfig("file created")
 }
 
 func (w *localBGPPeerWatcher) OnFileUpdate(fileName string) {
@@ -89,14 +89,14 @@ func (w *localBGPPeerWatcher) OnFileUpdate(fileName string) {
 		return
 	}
 	w.updateEpStatus(fileName, epStatus)
-	w.client.recheckPeerConfig()
+	w.client.recheckPeerConfig("file updated")
 }
 
 func (w *localBGPPeerWatcher) OnFileDeletion(fileName string) {
 	log.WithField("file", fileName).Debug("Workload endpoint status file deleted")
 
 	w.deleteEpStatus(fileName)
-	w.client.recheckPeerConfig()
+	w.client.recheckPeerConfig("file deleted")
 }
 
 func (w *localBGPPeerWatcher) updateEpStatus(fileName string, epStatus *epstatus.WorkloadEndpointStatus) {

--- a/confd/pkg/backends/calico/local_bgp_peer_watcher.go
+++ b/confd/pkg/backends/calico/local_bgp_peer_watcher.go
@@ -16,6 +16,7 @@ package calico
 import (
 	"net"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -30,24 +31,24 @@ const (
 
 // LocalBGPPeerWatcher watches endpoint status files and maintain
 // a cache to store active workload endpoint status.
-type localBGPPeerWatcher struct {
-	client                   *client
-	mutex                    sync.Mutex
-	activeFileNameToEpStatus map[string]epstatus.WorkloadEndpointStatus
-	fileWatcher              *epstatus.FileWatcher
+type LocalBGPPeerWatcher struct {
+	client                               *client
+	mutex                                sync.Mutex
+	activeLocalBGPPeerFileNameToEpStatus map[string]epstatus.WorkloadEndpointStatus
+	fileWatcher                          *epstatus.FileWatcher
 }
 
-func NewLocalBGPPeerWatcher(client *client, prefix string, pollIntervalSeconds int) (*localBGPPeerWatcher, error) {
+func NewLocalBGPPeerWatcher(client *client, prefix string, pollIntervalSeconds int) (*LocalBGPPeerWatcher, error) {
 	if pollIntervalSeconds == 0 {
 		pollIntervalSeconds = defaultPollIntervalSeconds
 	}
 
 	dir := filepath.Join(prefix, epstatus.GetDirStatus())
 
-	w := &localBGPPeerWatcher{
-		client:                   client,
-		activeFileNameToEpStatus: map[string]epstatus.WorkloadEndpointStatus{},
-		fileWatcher:              epstatus.NewFileWatcher(dir, time.Duration(pollIntervalSeconds)*time.Second),
+	w := &LocalBGPPeerWatcher{
+		client:                               client,
+		activeLocalBGPPeerFileNameToEpStatus: map[string]epstatus.WorkloadEndpointStatus{},
+		fileWatcher:                          epstatus.NewFileWatcher(dir, time.Duration(pollIntervalSeconds)*time.Second),
 	}
 	w.fileWatcher.SetCallbacks(epstatus.Callbacks{
 		OnFileCreation: w.OnFileCreation,
@@ -58,15 +59,15 @@ func NewLocalBGPPeerWatcher(client *client, prefix string, pollIntervalSeconds i
 	return w, nil
 }
 
-func (w *localBGPPeerWatcher) Start() {
+func (w *LocalBGPPeerWatcher) Start() {
 	w.fileWatcher.Start()
 }
 
-func (w *localBGPPeerWatcher) Stop() {
+func (w *LocalBGPPeerWatcher) Stop() {
 	w.fileWatcher.Stop()
 }
 
-func (w *localBGPPeerWatcher) OnFileCreation(fileName string) {
+func (w *LocalBGPPeerWatcher) OnFileCreation(fileName string) {
 	logCxt := log.WithField("file", fileName)
 
 	logCxt.Debug("Workload endpoint status file created")
@@ -75,40 +76,63 @@ func (w *localBGPPeerWatcher) OnFileCreation(fileName string) {
 		logCxt.WithError(err).Warn("Failed to read endpoint status from file, it may just be created.")
 		return
 	}
-	w.updateEpStatus(fileName, epStatus)
-	w.client.recheckPeerConfig("file created")
+	if w.updateEpStatus(fileName, epStatus) {
+		w.client.recheckPeerConfig("endpoint status file created")
+	}
 }
 
-func (w *localBGPPeerWatcher) OnFileUpdate(fileName string) {
+func (w *LocalBGPPeerWatcher) OnFileUpdate(fileName string) {
 	logCxt := log.WithField("file", fileName)
 
 	logCxt.Debug("Workload endpoint status file updated")
 	epStatus, err := epstatus.GetWorkloadEndpointStatusFromFile(fileName)
 	if err != nil {
-		logCxt.WithError(err).Error("Failed to read endpoint status from file")
-		return
+		// Avoid spurious error messages when the file is mid-update.
+		time.Sleep(50 * time.Millisecond)
+		epStatus, err = epstatus.GetWorkloadEndpointStatusFromFile(fileName)
+		if err != nil {
+			logCxt.WithError(err).Error("Failed to read endpoint status from file")
+			return
+		}
 	}
-	w.updateEpStatus(fileName, epStatus)
-	w.client.recheckPeerConfig("file updated")
+	if w.updateEpStatus(fileName, epStatus) {
+		w.client.recheckPeerConfig("endpoint status file updated")
+	}
 }
 
-func (w *localBGPPeerWatcher) OnFileDeletion(fileName string) {
+func (w *LocalBGPPeerWatcher) OnFileDeletion(fileName string) {
 	log.WithField("file", fileName).Debug("Workload endpoint status file deleted")
 
-	w.deleteEpStatus(fileName)
-	w.client.recheckPeerConfig("file deleted")
+	if w.deleteEpStatus(fileName) {
+		w.client.recheckPeerConfig("endpoint status file deleted")
+	}
 }
 
-func (w *localBGPPeerWatcher) updateEpStatus(fileName string, epStatus *epstatus.WorkloadEndpointStatus) {
+func (w *LocalBGPPeerWatcher) updateEpStatus(fileName string, epStatus *epstatus.WorkloadEndpointStatus) (changed bool) {
+	if epStatus.BGPPeerName == "" {
+		return w.deleteEpStatus(fileName)
+	}
+
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-	w.activeFileNameToEpStatus[fileName] = *epStatus
+	old, ok := w.activeLocalBGPPeerFileNameToEpStatus[fileName]
+	if ok && reflect.DeepEqual(old, *epStatus) {
+		log.WithField("file", fileName).Debug("Workload endpoint status file unchanged")
+		return false
+	}
+	w.activeLocalBGPPeerFileNameToEpStatus[fileName] = *epStatus
+	return true
 }
 
-func (w *localBGPPeerWatcher) deleteEpStatus(fileName string) {
+func (w *LocalBGPPeerWatcher) deleteEpStatus(fileName string) (changed bool) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-	delete(w.activeFileNameToEpStatus, fileName)
+	if _, ok := w.activeLocalBGPPeerFileNameToEpStatus[fileName]; !ok {
+		log.WithField("file", fileName).Debug("Endpoint status already gone.")
+		return false
+	}
+	delete(w.activeLocalBGPPeerFileNameToEpStatus, fileName)
+	return true
 }
 
 type localBGPPeerData struct {
@@ -118,13 +142,13 @@ type localBGPPeerData struct {
 	ipv6        string
 }
 
-func (w *localBGPPeerWatcher) GetActiveLocalBGPPeers() []localBGPPeerData {
+func (w *LocalBGPPeerWatcher) GetActiveLocalBGPPeers() []localBGPPeerData {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	peerData := []localBGPPeerData{}
+	var peerData []localBGPPeerData
 
-	for name, epStatus := range w.activeFileNameToEpStatus {
+	for name, epStatus := range w.activeLocalBGPPeerFileNameToEpStatus {
 		var ipv4, ipv6 string
 		if len(epStatus.Ipv4Nets) != 0 {
 			ip, _, err := net.ParseCIDR(epStatus.Ipv4Nets[0])

--- a/confd/pkg/backends/calico/secret_watcher.go
+++ b/confd/pkg/backends/calico/secret_watcher.go
@@ -177,19 +177,19 @@ func (sw *secretWatcher) SweepStale() {
 func (sw *secretWatcher) OnAdd(obj interface{}, isInInitialList bool) {
 	log.Debug("Secret added")
 	sw.updateSecret(obj.(*v1.Secret))
-	sw.client.recheckPeerConfig()
+	sw.client.recheckPeerConfig("secret added")
 }
 
 func (sw *secretWatcher) OnUpdate(oldObj, newObj interface{}) {
 	log.Debug("Secret updated")
 	sw.updateSecret(newObj.(*v1.Secret))
-	sw.client.recheckPeerConfig()
+	sw.client.recheckPeerConfig("secret updated")
 }
 
 func (sw *secretWatcher) OnDelete(obj interface{}) {
 	log.Debug("Secret deleted")
 	sw.deleteSecret(obj.(*v1.Secret))
-	sw.client.recheckPeerConfig()
+	sw.client.recheckPeerConfig("secret deleted")
 }
 
 func (sw *secretWatcher) updateSecret(secret *v1.Secret) {

--- a/felix/statusrep/status_file_reporter.go
+++ b/felix/statusrep/status_file_reporter.go
@@ -318,6 +318,7 @@ func (fr *EndpointStatusFileReporter) reconcileStatusFiles() error {
 	logrus.Debug("Start reconcile status file")
 
 	fr.statusDirDeltaTracker.PendingUpdates().Iter(func(k string, v epstatus.WorkloadEndpointStatus) deltatracker.IterAction {
+		logrus.WithField("file", k).Debug("Applying update to status file.")
 		itemJSON, err := json.Marshal(v)
 		if err != nil {
 			logrus.WithError(err).WithField("file", k).Error("error json Marshal on endpoint status")
@@ -336,8 +337,9 @@ func (fr *EndpointStatusFileReporter) reconcileStatusFiles() error {
 	})
 
 	fr.statusDirDeltaTracker.PendingDeletions().Iter(func(k string) deltatracker.IterAction {
+		logrus.WithField("file", k).Debug("Deleting status file.")
 		err := fr.epStatusWriter.DeleteStatusFile(k)
-		if err != nil {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			logrus.WithError(err).WithField("file", k).Error("error on deleting file")
 			lastError = err
 			return deltatracker.IterActionNoOp

--- a/libcalico-go/lib/epstatusfile/status_file_writer.go
+++ b/libcalico-go/lib/epstatusfile/status_file_writer.go
@@ -181,13 +181,22 @@ func WorkloadEndpointToWorkloadEndpointStatus(ep *proto.WorkloadEndpoint) *Workl
 		peerName = ep.LocalBgpPeer.BgpPeerName
 	}
 	epStatus := &WorkloadEndpointStatus{
-		IfaceName:   ep.Name,
-		Mac:         ep.Mac,
-		Ipv4Nets:    ep.Ipv4Nets,
-		Ipv6Nets:    ep.Ipv6Nets,
+		IfaceName: ep.Name,
+		Mac:       ep.Mac,
+		// Make sure that zero length slice is nilled out so that it compares
+		// equal after round-tripping through JSON.
+		Ipv4Nets:    normaliseZeroLenSlice(ep.Ipv4Nets),
+		Ipv6Nets:    normaliseZeroLenSlice(ep.Ipv6Nets),
 		BGPPeerName: peerName,
 	}
 	return epStatus
+}
+
+func normaliseZeroLenSlice[T any](nets []T) []T {
+	if len(nets) == 0 {
+		return nil
+	}
+	return nets
 }
 
 func GetWorkloadEndpointStatusFromFile(filePath string) (*WorkloadEndpointStatus, error) {

--- a/libcalico-go/lib/epstatusfile/status_file_writer.go
+++ b/libcalico-go/lib/epstatusfile/status_file_writer.go
@@ -115,15 +115,15 @@ func (w *EndpointStatusFileWriter) DeleteStatusFile(name string) error {
 // the parent dir specified by prefix. Attempts to create the dir if it doesn't exist.
 // Returns all entries along with their unmarshaled WorkloadEndpointStatus structs within the dir if any exist.
 func (w *EndpointStatusFileWriter) EnsureStatusDir(prefix string) ([]fs.DirEntry, []WorkloadEndpointStatus, error) {
-	validEntries := []fs.DirEntry{}
-	epStatuses := []WorkloadEndpointStatus{}
+	var presentFiles []fs.DirEntry
+	var epStatuses []WorkloadEndpointStatus
 
 	path := filepath.Join(prefix, dirStatus)
 
 	entries, err := w.Filesys.ReadDir(path)
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		// Discard ErrNotExist and return the result of attempting to create it.
-		return validEntries, epStatuses, w.Filesys.Mkdir(path, fs.FileMode(0655))
+		return presentFiles, epStatuses, w.Filesys.Mkdir(path, fs.FileMode(0655))
 	}
 
 	// Iterate over each file entry.
@@ -153,13 +153,13 @@ func (w *EndpointStatusFileWriter) EnsureStatusDir(prefix string) ([]fs.DirEntry
 		}
 
 		// Append entry to the slice.
-		validEntries = append(validEntries, entry)
+		presentFiles = append(presentFiles, entry)
 
 		// Append the parsed struct to the slice.
 		epStatuses = append(epStatuses, epStatus)
 	}
 
-	return validEntries, epStatuses, err
+	return presentFiles, epStatuses, err
 }
 
 type WorkloadEndpointStatus struct {

--- a/libcalico-go/lib/epstatusfile/status_file_writer.go
+++ b/libcalico-go/lib/epstatusfile/status_file_writer.go
@@ -123,7 +123,7 @@ func (w *EndpointStatusFileWriter) EnsureStatusDir(prefix string) ([]fs.DirEntry
 	entries, err := w.Filesys.ReadDir(path)
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		// Discard ErrNotExist and return the result of attempting to create it.
-		return presentFiles, epStatuses, w.Filesys.Mkdir(path, fs.FileMode(0655))
+		return presentFiles, epStatuses, w.Filesys.Mkdir(path, fs.FileMode(0755))
 	}
 
 	// Iterate over each file entry.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Fix that felix would rewrite endpoints status files every resync because the JSON didn't round trip (empty slice returned as nil slice).
- Let confd retry reading the endpoint status file once after 50ms to avoid spurious errors caused by felix being mid-write.
- In confd, only store local endpoints if they actually have a BGPPeer name populated.  Suppress BGPPeer recalculation if the changed endpoint wasn't actually a BGP peer.
- Tweak tests to use a random temp dir so that they can be run outside of the UT container.
- Fix file permissions on the endpoint-status dir.  655 should be 755 (need the execute bit to allow for access to files within the directory).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-11263

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
