### PR TITLE
[release-v3.30] Auto pick #10159: QoS controls: clean up filters and bwp

### DIFF
--- a/felix/dataplane/linux/qos/qos.go
+++ b/felix/dataplane/linux/qos/qos.go
@@ -48,6 +48,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ip"
@@ -227,7 +228,7 @@ func CreateIfb(ifbDeviceName string, mtu int) error {
 }
 
 func TeardownIfb(deviceName string) error {
-	_, err := ip.DelLinkByNameAddr(deviceName)
+	err := ip.DelLinkByName(deviceName)
 	if err != nil {
 		if err == ip.ErrLinkNotFound {
 			return nil
@@ -266,21 +267,24 @@ func CreateEgressQdisc(tbs *TokenBucketState, hostDeviceName string, ifbDeviceNa
 
 	// check if host device has a ingress qdisc
 	hasQdisc := false
+	var qdisc *netlink.Ingress
 	qdiscList, err := netlink.QdiscList(hostDevice)
 	if err != nil {
 		return fmt.Errorf("Failed to list qdiscs on dev %s: %w", hostDeviceName, err)
 	}
 
-	for _, qdisc := range qdiscList {
-		_, isIngress := qdisc.(*netlink.Ingress)
+	for _, qd := range qdiscList {
+		ingressQd, isIngress := qd.(*netlink.Ingress)
 		if isIngress {
+			qdisc = ingressQd
 			hasQdisc = true
+			break
 		}
 	}
 
 	// only add ingress qdisc on host device if it doesn't already exist
 	if !hasQdisc {
-		qdisc := &netlink.Ingress{
+		qdisc = &netlink.Ingress{
 			QdiscAttrs: netlink.QdiscAttrs{
 				LinkIndex: hostDevice.Attrs().Index,
 				Handle:    netlink.MakeHandle(0xffff, 0), // ffff:
@@ -290,7 +294,41 @@ func CreateEgressQdisc(tbs *TokenBucketState, hostDeviceName string, ifbDeviceNa
 
 		err = netlink.QdiscAdd(qdisc)
 		if err != nil {
-			return fmt.Errorf("create ingress qdisc %+v on dev %s: %s", qdisc, hostDeviceName, err)
+			return fmt.Errorf("create ingress qdisc %+v on dev %s: %w", qdisc, hostDeviceName, err)
+		}
+	}
+
+	// List filters on hostDevice to clean up filters and bandwidth plugin ifb devices (those have a "bwp" prefix), if present.
+	filters, err := netlink.FilterList(hostDevice, netlink.HANDLE_INGRESS)
+	if err != nil {
+		return fmt.Errorf("list filters on dev %s: %w", hostDeviceName, err)
+	}
+	log.Debugf("Cleaning up existing filters on dev %s: %+v", hostDeviceName, filters)
+	for _, filter := range filters {
+		u32Filter, ok := filter.(*netlink.U32)
+		if ok {
+			for _, action := range u32Filter.Actions {
+				mirredAction, ok := action.(*netlink.MirredAction)
+				if ok {
+					log.Debugf("Found U32 filter %+v with MirredAction: %+v", u32Filter, mirredAction)
+					filterLink, err := netlink.LinkByIndex(mirredAction.Ifindex)
+					if err != nil {
+						return fmt.Errorf("get link for ifindex %d on dev %s: %w", mirredAction.Ifindex, hostDeviceName, err)
+					}
+					if strings.HasPrefix(filterLink.Attrs().Name, "bwp") {
+						log.Debugf("Cleaning up bandwidth plugin link (bwpXXXX) name %s: %+v", filterLink.Attrs().Name, filterLink)
+						err := netlink.LinkDel(filterLink)
+						if err != nil {
+							return fmt.Errorf("remove 'bwp' ifb link %s: %w", filterLink.Attrs().Name, err)
+						}
+						break
+					}
+				}
+			}
+		}
+		err := netlink.FilterDel(filter)
+		if err != nil {
+			return fmt.Errorf("delete filter %+v on dev %s: %w", filter, hostDeviceName, err)
 		}
 	}
 
@@ -298,7 +336,7 @@ func CreateEgressQdisc(tbs *TokenBucketState, hostDeviceName string, ifbDeviceNa
 	filter := &netlink.U32{
 		FilterAttrs: netlink.FilterAttrs{
 			LinkIndex: hostDevice.Attrs().Index,
-			Parent:    netlink.MakeHandle(0xffff, 0), // ffff:, same as qdisc.Attrs().Handle
+			Parent:    qdisc.Attrs().Handle,
 			Priority:  1,
 			Protocol:  syscall.ETH_P_ALL,
 		},
@@ -307,7 +345,7 @@ func CreateEgressQdisc(tbs *TokenBucketState, hostDeviceName string, ifbDeviceNa
 			netlink.NewMirredAction(ifbDevice.Attrs().Index),
 		},
 	}
-	err = netlink.FilterReplace(filter)
+	err = netlink.FilterAdd(filter)
 	if err != nil {
 		return fmt.Errorf("add egress filter %+v: %s", filter, err)
 	}


### PR DESCRIPTION
Cherry pick of #10159 on release-v3.30.

#10159: QoS controls: clean up filters and bwp

# Original PR Body below

## Description

When upgrading from a calico version that uses the bandwidth plugin (v3.29 and earlier) to a version with built-in QoS controls (v3.30+), the old ifb interface (auxiliary used for egress bandwidth) and related filters would remain configured, breaking the calico-native bandwidth controls for egress.

With these changes, instead of using netlink.FilterReplace(), which wasn't properly replacing the bandwidth plugin filters, calico is now listing and removing all filters, as well as removing corresponding bandwidth plugin ifb interfaces (named "bwpXXXX"), if present, then using netlink.FilterAdd() for the new filter.

Sample `tc` output **WITHOUT** the fix (calico-node v3.29 initially with egress bw limit configured, upgraded to v3.30 hash release, see both `bwp` and `bwcali` devices, as well as their filters):
```
[root@pedro-bz-8e19-kadm-node-1 /]# tc qdisc
qdisc noqueue 0: dev lo root refcnt 2
qdisc mq 0: dev ens4 root
qdisc fq_codel 0: dev ens4 parent :2 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc fq_codel 0: dev ens4 parent :1 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc noqueue 0: dev cali59d28e4e95d root refcnt 2
qdisc noqueue 0: dev vxlan.calico root refcnt 2
qdisc noqueue 0: dev caliad303a2733f root refcnt 2
qdisc ingress ffff: dev caliad303a2733f parent ffff:fff1 ----------------
qdisc tbf 1: dev bwp54203cf43304 root refcnt 2 rate 100Mbit burst 512Mb lat 25ms
qdisc tbf 1: dev bwcali6f298919a root refcnt 2 rate 100Mbit burst 512Mb lat 10.8s
qdisc noqueue 0: dev cali79a19c97c74 root refcnt 2
[root@pedro-bz-8e19-kadm-node-1 /]# tc filter show dev caliad303a2733f root
filter parent ffff: protocol all pref 1 u32 chain 0
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 *flowid 1:1 not_in_hw
  match 00000000/00000000 at 0
        action order 1: mirred (Egress Redirect to device bwp54203cf43304) stolen
        index 1 ref 1 bind 1

        action order 2: mirred (Egress Redirect to device bwp54203cf43304) pass
        index 2 ref 1 bind 1

filter parent ffff: protocol all pref 1 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 *flowid 1:1 not_in_hw
  match 00000000/00000000 at 0
        action order 1: mirred (Egress Redirect to device bwcali6f298919a) stolen
        index 3 ref 1 bind 1
```

Simply removing the ifb interface wasn't enough, as the filter would remain (just a test I did while investigating):
```
[root@pedro-bz-8e19-kadm-node-1 /]# ip link del bwp54203cf43304
[root@pedro-bz-8e19-kadm-node-1 /]# tc filter show dev caliad303a2733f root
filter parent ffff: protocol all pref 1 u32 chain 0
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 *flowid 1:1 not_in_hw
  match 00000000/00000000 at 0
        action order 1: mirred (Egress Redirect to device *) stolen
        index 1 ref 1 bind 1

        action order 2: mirred (Egress Redirect to device *) pass
        index 2 ref 1 bind 1

filter parent ffff: protocol all pref 1 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 *flowid 1:1 not_in_hw
  match 00000000/00000000 at 0
        action order 1: mirred (Egress Redirect to device bwcali6f298919a) stolen
        index 3 ref 1 bind 1

```

Sample output **WITH** the fix:
3.29 with bwp egress annotation for bandwidth limit:
```
[root@pedro-bz-8e19-kadm-node-1 /]# tc qdisc
qdisc noqueue 0: dev lo root refcnt 2
qdisc mq 0: dev ens4 root
qdisc fq_codel 0: dev ens4 parent :2 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc fq_codel 0: dev ens4 parent :1 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc noqueue 0: dev cali9374443f657 root refcnt 2
qdisc noqueue 0: dev caliee13b3b0f91 root refcnt 2
qdisc noqueue 0: dev vxlan.calico root refcnt 2
qdisc noqueue 0: dev cali65425d8647c root refcnt 2
qdisc ingress ffff: dev cali65425d8647c parent ffff:fff1 ----------------
qdisc tbf 1: dev bwp0af31a673038 root refcnt 2 rate 100Mbit burst 512Mb lat 25ms
qdisc noqueue 0: dev calid3bc6f2c336 root refcnt 2
[root@pedro-bz-8e19-kadm-node-1 /]# tc filter show dev cali65425d8647c root
filter parent ffff: protocol all pref 1 u32 chain 0
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 *flowid 1:1 not_in_hw
  match 00000000/00000000 at 0
        action order 1: mirred (Egress Redirect to device bwp0af31a673038) stolen
        index 1 ref 1 bind 1

        action order 2: mirred (Egress Redirect to device bwp0af31a673038) pass
        index 2 ref 1 bind 1
```

After upgrade to custom version with fix (only `bwcali` device, no `bwp`):
```
[root@pedro-bz-8e19-kadm-node-1 /]# tc qdisc
qdisc noqueue 0: dev lo root refcnt 2
qdisc mq 0: dev ens4 root
qdisc fq_codel 0: dev ens4 parent :2 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc fq_codel 0: dev ens4 parent :1 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc noqueue 0: dev caliee13b3b0f91 root refcnt 2
qdisc noqueue 0: dev vxlan.calico root refcnt 2
qdisc noqueue 0: dev cali65425d8647c root refcnt 2
qdisc ingress ffff: dev cali65425d8647c parent ffff:fff1 ----------------
qdisc noqueue 0: dev calid3bc6f2c336 root refcnt 2
qdisc noqueue 0: dev califd90b8dabe7 root refcnt 2
qdisc noqueue 0: dev cali99a04ea0fb9 root refcnt 2
qdisc noqueue 0: dev cali4453721b898 root refcnt 2
qdisc tbf 1: dev bwcali8b3c5d144 root refcnt 2 rate 100Mbit burst 512Mb lat 10.8s
[root@pedro-bz-8e19-kadm-node-1 /]# tc filter show dev cali65425d8647c root
filter parent ffff: protocol all pref 1 u32 chain 0
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1
filter parent ffff: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 *flowid 1:1 not_in_hw
  match 00000000/00000000 at 0
        action order 1: mirred (Egress Redirect to device bwcali8b3c5d144) stolen
        index 3 ref 1 bind 1
```

Finally, validating functionality with iperf:
```
root@iperf3-clients-86cfc4fc98-zzpfj:/# iperf3 -c iperf3-server -O5
Connecting to host iperf3-server, port 5201
[  5] local 192.168.21.3 port 53222 connected to 10.96.170.38 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   170 MBytes  1.43 Gbits/sec    0    915 KBytes       (omitted)
[  5]   1.00-2.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes       (omitted)
[  5]   2.00-3.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes       (omitted)
[  5]   3.00-4.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes       (omitted)
[  5]   4.00-5.00   sec  10.6 MBytes  88.6 Mbits/sec    0    915 KBytes       (omitted)
[  5]   0.00-1.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   1.00-2.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   2.00-3.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   3.00-4.00   sec  10.6 MBytes  88.6 Mbits/sec    0    915 KBytes
[  5]   4.00-5.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   5.00-6.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   6.00-7.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   7.00-8.00   sec  10.6 MBytes  88.6 Mbits/sec    0    915 KBytes
[  5]   8.00-9.00   sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
[  5]   9.00-10.00  sec  11.6 MBytes  97.5 Mbits/sec    0    915 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   114 MBytes  95.7 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   114 MBytes  95.3 Mbits/sec                  receiver

iperf Done.

```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.