### PR TITLE
Export cluster IPs for all IP families

### DIFF
--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -245,7 +245,7 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 	routes := make([]string, 0)
 	if rg.client.AdvertiseClusterIPs() {
 		// Only advertise cluster IPs if we've been told to.
-		routes = append(routes, svc.Spec.ClusterIP)
+		routes = append(routes, svc.Spec.ClusterIPs...)
 	}
 	svcID := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
 
@@ -455,9 +455,9 @@ func (rg *routeGenerator) advertiseThisService(svc *v1.Service, ep *v1.Endpoints
 		return false
 	}
 
-	// also do nothing if the clusterIP is empty or None
-	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == "None" {
-		logc.Debug("Skipping service with no cluster IP")
+	// also do nothing if no cluster IPs are assigned
+	if len(svc.Spec.ClusterIPs) == 0 {
+		logc.Debug("Skipping service with no cluster IPs")
 		return false
 	}
 

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -48,7 +48,7 @@ func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
 		ObjectMeta: meta,
 		Spec: v1.ServiceSpec{
 			Type:                  v1.ServiceTypeClusterIP,
-			ClusterIP:             "127.0.0.1",
+			ClusterIPs:            []string{"127.0.0.1", "::1"},
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 			ExternalIPs:           []string{externalIP1, externalIP2},
 		},
@@ -65,7 +65,7 @@ func buildSimpleService2() (svc *v1.Service, ep *v1.Endpoints) {
 		ObjectMeta: meta,
 		Spec: v1.ServiceSpec{
 			Type:                  v1.ServiceTypeClusterIP,
-			ClusterIP:             "127.0.0.5",
+			ClusterIPs:            []string{"127.0.0.5", "::5"},
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 			ExternalIPs:           []string{externalIP1, externalIP2},
 		},
@@ -82,7 +82,7 @@ func buildSimpleService3() (svc *v1.Service, ep *v1.Endpoints) {
 		ObjectMeta: meta,
 		Spec: v1.ServiceSpec{
 			Type:                  v1.ServiceTypeLoadBalancer,
-			ClusterIP:             "127.0.0.10",
+			ClusterIPs:            []string{"127.0.0.10", "::a"},
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 			LoadBalancerIP:        loadBalancerIP1,
 		},
@@ -104,7 +104,7 @@ func buildSimpleService4() (svc *v1.Service, ep *v1.Endpoints) {
 		ObjectMeta: meta,
 		Spec: v1.ServiceSpec{
 			Type:                  v1.ServiceTypeLoadBalancer,
-			ClusterIP:             "127.0.0.11",
+			ClusterIPs:            []string{"127.0.0.11", "::b"},
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 			ExternalIPs:           []string{externalIP3},
 		},
@@ -126,10 +126,12 @@ var _ = Describe("RouteGenerator", func() {
 
 		expectedSvcRouteMap = make(map[string]bool)
 		expectedSvcRouteMap["127.0.0.1/32"] = true
+		expectedSvcRouteMap["::1/128"] = true
 		expectedSvcRouteMap["172.217.3.5/32"] = true
 
 		expectedSvc2RouteMap = make(map[string]bool)
 		expectedSvc2RouteMap["127.0.0.5/32"] = true
+		expectedSvc2RouteMap["::5/128"] = true
 		expectedSvc2RouteMap["172.217.3.5/32"] = true
 
 		rg = &routeGenerator{
@@ -286,11 +288,13 @@ var _ = Describe("RouteGenerator", func() {
 			// Trigger a service add - it should update the cache with its route.
 			initRevision := rg.client.cacheRevision
 			rg.onSvcAdd(svc)
-			Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+			Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
 			Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+			Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+			Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 			// Simulate the remove of the local endpoint. It should withdraw the routes.
@@ -298,15 +302,17 @@ var _ = Describe("RouteGenerator", func() {
 			err := rg.epIndexer.Add(ep)
 			Expect(err).NotTo(HaveOccurred())
 			rg.onEPAdd(ep)
-			Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+			Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 			Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
 			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+			Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal(""))
+			Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal(""))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal(""))
 			Expect(rg.client.cache).To(Equal(map[string]string{}))
 
-			// Add the endpoint back with an IPv6 address.  The service's cluster IP
+			// Add the endpoint back with an IPv6 address.  The service's cluster IPs
 			// should remain non-advertised.
 			ep.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
@@ -317,15 +323,17 @@ var _ = Describe("RouteGenerator", func() {
 			err = rg.epIndexer.Add(ep)
 			Expect(err).NotTo(HaveOccurred())
 			rg.onEPAdd(ep)
-			Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+			Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 			Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
 			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+			Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal(""))
+			Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal(""))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal(""))
 			Expect(rg.client.cache).To(Equal(map[string]string{}))
 
-			// Add the endpoint again with an IPv4 address.  The service's cluster IP
+			// Add the endpoint again with an IPv4 address.  The service's cluster IPs
 			// should now be advertised.
 			ep.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
@@ -336,35 +344,42 @@ var _ = Describe("RouteGenerator", func() {
 			err = rg.epIndexer.Add(ep)
 			Expect(err).NotTo(HaveOccurred())
 			rg.onEPAdd(ep)
-			Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
+			Expect(rg.client.cacheRevision).To(Equal(initRevision + 9))
 			Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+			Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+			Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 		})
 
 		Context("onSvc[Add|Delete]", func() {
-			It("should add the service's cluster IP and approved external IPs into the svcRouteMap", func() {
+			It("should add the service's cluster IPs and approved external IPs into the svcRouteMap", func() {
 				// add
 				initRevision := rg.client.cacheRevision
 				rg.onSvcAdd(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// delete
 				rg.onSvcDelete(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("::1/128"))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutesv6/::1-128"))
 			})
 
 			It("should handle two services advertising the same route correctly, only advertising the route once and only withdrawing the route when both services are removed.", func() {
@@ -372,125 +387,156 @@ var _ = Describe("RouteGenerator", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onSvcAdd(svc)
 				rg.onSvcAdd(svc2)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 5))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.svcRouteMap["foo/rem"]).To(Equal(expectedSvc2RouteMap))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::5/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(2))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.5-32"]).To(Equal("127.0.0.5/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::5-128"]).To(Equal("::5/128"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// We expect the client refcounter to have a single reference for each generated route, as
 				// the route generator deduplicates route updates itself for duplicate service IPs.
 				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/127.0.0.5-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutesv6/::5-128"]).To(Equal(1))
 				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/127.0.0.1-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutesv6/::1-128"]).To(Equal(1))
 				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/172.217.3.5-32"]).To(Equal(1))
 
 				// delete one of the services, and make sure the duplicate route is still advertised
 				// and we handle the counting logic correctly
 				rg.onSvcDelete(svc2)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 7))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["::5-128"]).To(Equal(0))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("127.0.0.5/32"))
+				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("::5/128"))
 				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.5-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutesv6/::5-128"))
 
 				// The client refcount should be updated as well.
 				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/127.0.0.1-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutesv6/::1-128"]).To(Equal(1))
 				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/172.217.3.5-32"]).To(Equal(1))
 				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/127.0.0.5-32"))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutesv6/::5-128"))
 
 				// delete the other service and check that both routes are withdrawn and their counts are 0
 				rg.onSvcDelete(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 10))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("::1/128"))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutesv6/::1-128"))
 
 				// The client refcount should be updated as well.
 				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutesv6/::1-128"))
 				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/127.0.0.5-32"))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutesv6/::5-128"))
 			})
 		})
 
 		Context("onSvcUpdate", func() {
-			It("should add the service's cluster IP and approved external IPs into the svcRouteMap and then remove them for unsupported service type", func() {
+			It("should add the service's cluster IPs and approved external IPs into the svcRouteMap and then remove them for unsupported service type", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onSvcUpdate(nil, svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// set to unsupported service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onSvcUpdate(nil, svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1-32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("::1-128"))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutesv6/::1-128"))
 			})
 		})
 
 		Context("onEp[Add|Delete]", func() {
-			It("should add the service's cluster IP and approved external IPs into the svcRouteMap", func() {
+			It("should add the service's cluster IPs and approved external IPs into the svcRouteMap", func() {
 				// add
 				initRevision := rg.client.cacheRevision
 				rg.onEPAdd(ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// delete
 				rg.onEPDelete(ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutesv6/::1-128"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 			})
 		})
 
 		Context("onEpDelete", func() {
-			It("should add the service's cluster IP and approved external IPs into the svcRouteMap and then remove it for unsupported service type", func() {
+			It("should add the service's cluster IPs and approved external IPs into the svcRouteMap and then remove it for unsupported service type", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onEPUpdate(nil, ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(1))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 
 				// set to unsupported service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onEPUpdate(nil, ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["::1/128"]).To(Equal(0))
 				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutesv6/::1-128"))
 			})
 		})
 
@@ -524,6 +570,7 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onSvcAdd(svc)
 				rg.onEPAdd(ep)
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(Equal("::1/128"))
 
 				// Withdraw the cluster CIDR from the syncer.
 				rg.client.onClusterIPsUpdate([]string{})
@@ -531,6 +578,7 @@ var _ = Describe("RouteGenerator", func() {
 
 				// We should no longer see cluster CIDRs to be advertised.
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(BeEmpty())
+				Expect(rg.client.cache["/calico/staticroutesv6/::1-128"]).To(BeEmpty())
 			})
 
 			// This test simulates a situation where BGPConfiguration has a /32 route that exactly matches


### PR DESCRIPTION
## Description

Previously, only the primary cluster IP for a service was exported. This change exports all cluster IPs for a service. Per the k8s [API spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#servicespec-v1-core), "if clusterIPs is not specified for a service, it will be initialized from the clusterIP field". I expect this is backward compatible with k8s v1.20+ (https://github.com/kubernetes/kubernetes/commit/6675eba3eff1c8e565c4060a9c1396f75da7cc3e).

## Related issues/PRs

Fixes https://github.com/projectcalico/calico/issues/10112

## Release Note

```release-note
Export cluster IPs for all IP families
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
