### PR TITLE
Use OCI standard labels/annotations

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -27,13 +27,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Aggregated API server which enables calico resources to be managed via kubectl"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico API server"
-LABEL release="1"
-LABEL summary="Calico API server"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Aggregated API server which enables calico resources to be managed via kubectl"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico API server"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/app-policy/Dockerfile
+++ b/app-policy/Dockerfile
@@ -39,13 +39,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico Dikastes enables Application Layer Policy"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico Dikastes"
-LABEL release="1"
-LABEL summary="Calico Dikastes enables Application Layer Policy"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico Dikastes enables Application Layer Policy"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Dikastes"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -25,13 +25,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="calicoctl(1) is a command line tool used to interface with the Calico datastore"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico CLI tool"
-LABEL release="1"
-LABEL summary="Calico CLI tool"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="calicoctl(1) is a command line tool used to interface with the Calico datastore"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico CLI tool"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ENV CALICO_CTL_CONTAINER=TRUE
 

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -25,13 +25,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico Networking for CNI"
-LABEL release="1"
-LABEL summary="Calico Networking for CNI"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Networking for CNI"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ENV PATH=/opt/cni/bin:$PATH
 

--- a/cni-plugin/Dockerfile-windows
+++ b/cni-plugin/Dockerfile-windows
@@ -21,13 +21,13 @@ FROM mcr.microsoft.com/windows/nanoserver:${WINDOWS_VERSION}
 
 ARG GIT_VERSION=unknown
 
-LABEL name="Calico Networking for CNI"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
-LABEL release="1"
-LABEL summary="Calico Networking for CNI"
-LABEL description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin"
-LABEL maintainer="maintainers@tigera.io"
+LABEL org.opencontainers.image.description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Networking for CNI"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version=${GIT_VERSION}
+LABEL org.opencontainers.image.licenses='Apache-2.0'
 
 COPY LICENSE /licenses/LICENSE
 

--- a/kube-controllers/Dockerfile
+++ b/kube-controllers/Dockerfile
@@ -40,13 +40,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico Kubernetes controllers"
-LABEL release="1"
-LABEL summary="Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Kubernetes controllers"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/kube-controllers/docker-image/flannel-migration/Dockerfile
+++ b/kube-controllers/docker-image/flannel-migration/Dockerfile
@@ -37,13 +37,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico Flannel migration controller updates a flannel cluster to Calico"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico Flannel migration controller"
-LABEL release="1"
-LABEL summary="Calico Flannel migration controller updates a flannel cluster to Calico"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico Flannel migration controller updates a flannel cluster to Calico"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Flannel migration controller"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/node/Dockerfile-windows
+++ b/node/Dockerfile-windows
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/nanoserver:${WINDOWS_VERSION}
 ARG GIT_VERSION=unknown
 
 # Required labels for certification
-LABEL description="Calico node handles networking and policy for Calico"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico node"
-LABEL release="1"
-LABEL summary="Calico node handles networking and policy for Calico"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico node handles networking and policy for Calico"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico node"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY LICENSE /licenses/LICENSE
 

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -208,13 +208,13 @@ ARG GIT_VERSION
 ENV SVDIR=/etc/service/enabled
 
 # Required labels for certification
-LABEL description="Calico node handles networking and policy for Calico"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico node"
-LABEL release="1"
-LABEL summary="Calico node handles networking and policy for Calico"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico node handles networking and policy for Calico"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico node"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=ubi / /
 

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -208,13 +208,13 @@ ARG GIT_VERSION
 ENV SVDIR=/etc/service/enabled
 
 # Required labels for certification
-LABEL description="Calico node handles networking and policy for Calico"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico node"
-LABEL release="1"
-LABEL summary="Calico node handles networking and policy for Calico"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico node handles networking and policy for Calico"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico node"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=ubi / /
 

--- a/node/Dockerfile.ppc64le
+++ b/node/Dockerfile.ppc64le
@@ -30,13 +30,13 @@ ENV DOCKER_API_VERSION 1.21
 ENV SVDIR=/etc/service/enabled
 
 # Required labels for certification
-LABEL description="Calico node handles networking and policy for Calico"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico node"
-LABEL release="1"
-LABEL summary="Calico node handles networking and policy for Calico"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico node handles networking and policy for Calico"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico node"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --no-cache bash ip6tables ipset iputils iproute2 conntrack-tools runit file ca-certificates

--- a/node/Dockerfile.s390x
+++ b/node/Dockerfile.s390x
@@ -27,13 +27,13 @@ ARG GIT_VERSION
 ENV SVDIR=/etc/service/enabled
 
 # Required labels for certification
-LABEL description="Calico node handles networking and policy for Calico"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico node"
-LABEL release="1"
-LABEL summary="Calico node handles networking and policy for Calico"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico node handles networking and policy for Calico"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico node"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --no-cache bash ip6tables ipset iputils iproute2 conntrack-tools runit file ca-certificates

--- a/pod2daemon/csidriver/Dockerfile
+++ b/pod2daemon/csidriver/Dockerfile
@@ -25,13 +25,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico CSI driver to setup secure connections from Kubernetes pods to local daemons"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico CSI Driver"
-LABEL release="1"
-LABEL summary="Calico CSI driver to setup secure connections from Kubernetes pods to local daemons"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico CSI driver to setup secure connections from Kubernetes pods to local daemons"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico CSI Driver"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/pod2daemon/flexvol/docker-image/Dockerfile
+++ b/pod2daemon/flexvol/docker-image/Dockerfile
@@ -49,13 +49,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico FlexVolume driver installer to setup secure connections from Kubernetes pods to local daemons"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico FlexVolume driver installer"
-LABEL release="1"
-LABEL summary="Calico FlexVolume driver installer to setup secure connections from Kubernetes pods to local daemons"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico FlexVolume driver installer to setup secure connections from Kubernetes pods to local daemons"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico FlexVolume driver installer"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/pod2daemon/node-driver-registrar-docker/Dockerfile
+++ b/pod2daemon/node-driver-registrar-docker/Dockerfile
@@ -26,13 +26,14 @@ FROM ${CALICO_BASE}
 ARG GIT_VERSION=unknown
 ARG UPSTREAM_VER=unknown
 
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="CSI Node driver registrar"
-LABEL release="1"
-LABEL summary="CSI Node driver registrar (repackaged for Calico)"
-LABEL description="CSI Node driver registrar handles registration of CSI drivers with the kubelet. This is the upstream version repackaged for Calico."
-LABEL vendor="Project Calico"
-LABEL version="${UPSTREAM_VER}+calico-${GIT_VERSION}"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.title="CSI Node driver registrar"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.description="CSI Node driver registrar handles registration of CSI drivers with the kubelet. This is the upstream version repackaged for Calico."
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${UPSTREAM_VER}+calico-${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 
 COPY --from=source / /
 

--- a/test-tools/mocknode/Dockerfile
+++ b/test-tools/mocknode/Dockerfile
@@ -26,13 +26,13 @@ FROM ${CALICO_BASE}
 ARG GIT_VERSION=unknown
 
 # Required labels for certification
-LABEL description="Calico mock node for scale testing"
-LABEL maintainer="shaun@tigera.io"
-LABEL name="Calico mock node"
-LABEL release="1"
-LABEL summary="Calico mock node for scale testing"
-LABEL vendor="Tigera"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico mock node for scale testing"
+LABEL org.opencontainers.image.authors="shaun@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico mock node"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 

--- a/typha/docker-image/Dockerfile
+++ b/typha/docker-image/Dockerfile
@@ -27,13 +27,13 @@ FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 
-LABEL description="Calico Typha is a fan-out datastore proxy"
-LABEL maintainer="maintainers@tigera.io"
-LABEL name="Calico Typha"
-LABEL release="1"
-LABEL summary="Calico Typha is a fan-out datastore proxy"
-LABEL vendor="Project Calico"
-LABEL version=${GIT_VERSION}
+LABEL org.opencontainers.image.description="Calico Typha is a fan-out datastore proxy"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Typha"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=source / /
 


### PR DESCRIPTION
## Description

This change replaces all custom LABEL expression used in all Dockerfiles referenced by the `image` Make target. Additionally, it adds the `org.opencontainers.image.source` label as requested in #9625 as well as `org.opencontainers.image.licenses`

See https://github.com/opencontainers/image-spec/blob/main/annotations.md for a description of all standard annotations.

Some existing labels were removed entirely, e.g. `release` is no matching OCI annotation and seems to be always set to `1`? The existing `name` and `summary` labels were merged into `org.opencontainers.image.title` since they contain the same value.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes #9625

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
All Docker images now use standard OCI labels
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
