### PR TITLE
Add WatchList support with GenericListWatcher abstraction

### DIFF
--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -157,7 +157,7 @@ type ListAndWatchClient interface {
 	//   - OnError(err): Called when connection timeout or critical error occurs
 	//
 	// The method blocks until the context is cancelled or a terminal error occurs.
-	ListAndWatch(ctx context.Context, list model.ListInterface, handler EventHandler) error
+	ListAndWatch(ctx context.Context, list model.ListInterface, handler EventHandler, opts ...ListWatcherOption) error
 }
 
 // BackendAccessor is implemented by types that provide access to the underlying

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
@@ -114,6 +116,35 @@ type Client interface {
 	// input list options.
 	Watch(ctx context.Context, list model.ListInterface, options WatchOptions) (WatchInterface, error)
 
+	// ListAndWatch provides a unified interface for listing and watching resources.
+	// It runs a continuous loop that performs list-then-watch cycles until the context
+	// is cancelled. The method handles backend-specific logic including:
+	//
+	// Common behavior (via GenericListWatcher):
+	//   - Retry throttling with configurable minimum intervals
+	//   - Revision tracking to resume watches from the last known position
+	//   - Error counting with automatic full resync after repeated failures
+	//   - Connection timeout detection for signaling errors to the handler
+	//
+	// Kubernetes backend:
+	//   - WatchList mode support with automatic fallback to traditional List+Watch
+	//   - CRD installation detection (returns in-sync state if API not installed)
+	//   - Bookmark handling for WatchList sync completion detection
+	//   - Handles resource version expiration and too-large-version errors
+	//
+	// etcd backend:
+	//   - Traditional List+Watch mode
+	//   - Simpler error handling without bookmark or CRD concerns
+	//
+	// The handler receives events through the EventHandler interface:
+	//   - OnResyncStarted(): Called before each resync cycle begins
+	//   - OnAdd/OnUpdate/OnDelete: For resource changes during list and watch
+	//   - OnSync(): Called when initial list completes and watcher is in sync
+	//   - OnError(err): Called when connection timeout or critical error occurs
+	//
+	// The method blocks until the context is cancelled, returning ctx.Err().
+	ListAndWatch(ctx context.Context, list model.ListInterface, handler EventHandler) error
+
 	// EnsureInitialized ensures that the backend is initialized
 	// any ready to be used.
 	EnsureInitialized() error
@@ -144,8 +175,35 @@ type StatusClient interface {
 }
 
 type WatchOptions struct {
-	Revision            string
-	AllowWatchBookmarks bool
+	Revision             string
+	AllowWatchBookmarks  bool
+	SendInitialEvents    *bool
+	ResourceVersionMatch metav1.ResourceVersionMatch
+}
+
+// EventHandler defines the interface for processing list-watch events.
+// Implementations should handle add, update, delete, sync, and error events.
+type EventHandler interface {
+	// OnResyncStarted is called when a resync operation is about to begin.
+	// This allows the handler to prepare for the resync by clearing caches
+	// or updating internal state (e.g., resync epoch tracking).
+	OnResyncStarted()
+
+	// OnAdd is called when a new resource is added.
+	OnAdd(kvp *model.KVPair)
+
+	// OnUpdate is called when an existing resource is modified.
+	OnUpdate(kvp *model.KVPair)
+
+	// OnDelete is called when a resource is deleted.
+	OnDelete(kvp *model.KVPair)
+
+	// OnSync is called when the initial list is complete and the watcher is in sync.
+	OnSync()
+
+	// OnError is called when a critical error occurs that the handler should be aware of.
+	// This includes connection timeouts and other errors that affect data consistency.
+	OnError(err error)
 }
 
 type Syncer interface {

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -131,7 +131,8 @@ type Client interface {
 type ListAndWatchClient interface {
 	// ListAndWatch provides a unified interface for listing and watching resources.
 	// It runs a continuous loop that performs list-then-watch cycles until the context
-	// is cancelled. The method handles backend-specific logic including:
+	// is cancelled or the backend returns a terminal error. The method handles
+	// backend-specific logic including:
 	//
 	// Common behavior (via GenericListWatcher):
 	//   - Retry throttling with configurable minimum intervals
@@ -155,7 +156,7 @@ type ListAndWatchClient interface {
 	//   - OnSync(): Called when initial list completes and watcher is in sync
 	//   - OnError(err): Called when connection timeout or critical error occurs
 	//
-	// The method blocks until the context is cancelled, returning ctx.Err().
+	// The method blocks until the context is cancelled or a terminal error occurs.
 	ListAndWatch(ctx context.Context, list model.ListInterface, handler EventHandler) error
 }
 

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"sync"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
@@ -174,11 +172,19 @@ type StatusClient interface {
 	UpdateStatus(ctx context.Context, object *model.KVPair) (*model.KVPair, error)
 }
 
+// ResourceVersionMatch controls how a watch request interprets its resource version.
+type ResourceVersionMatch string
+
+const (
+	// ResourceVersionMatchNotOlderThan requests data at least as new as the supplied resource version.
+	ResourceVersionMatchNotOlderThan ResourceVersionMatch = "NotOlderThan"
+)
+
 type WatchOptions struct {
 	Revision             string
 	AllowWatchBookmarks  bool
 	SendInitialEvents    *bool
-	ResourceVersionMatch metav1.ResourceVersionMatch
+	ResourceVersionMatch ResourceVersionMatch
 }
 
 // EventHandler defines the interface for processing list-watch events.

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -114,6 +114,21 @@ type Client interface {
 	// input list options.
 	Watch(ctx context.Context, list model.ListInterface, options WatchOptions) (WatchInterface, error)
 
+	// EnsureInitialized ensures that the backend is initialized
+	// any ready to be used.
+	EnsureInitialized() error
+
+	// Clean removes Calico data from the backend datastore.  Used for test purposes.
+	Clean() error
+
+	// Close attempts to close any connections to the datastore.  Using the
+	// client after calling this method may result in undefined behavior.
+	Close() error
+}
+
+// ListAndWatchClient is optionally implemented by backend clients that provide
+// backend-specific list-and-watch behavior.
+type ListAndWatchClient interface {
 	// ListAndWatch provides a unified interface for listing and watching resources.
 	// It runs a continuous loop that performs list-then-watch cycles until the context
 	// is cancelled. The method handles backend-specific logic including:
@@ -142,17 +157,6 @@ type Client interface {
 	//
 	// The method blocks until the context is cancelled, returning ctx.Err().
 	ListAndWatch(ctx context.Context, list model.ListInterface, handler EventHandler) error
-
-	// EnsureInitialized ensures that the backend is initialized
-	// any ready to be used.
-	EnsureInitialized() error
-
-	// Clean removes Calico data from the backend datastore.  Used for test purposes.
-	Clean() error
-
-	// Close attempts to close any connections to the datastore.  Using the
-	// client after calling this method may result in undefined behavior.
-	Close() error
 }
 
 // BackendAccessor is implemented by types that provide access to the underlying

--- a/libcalico-go/lib/backend/api/api.go
+++ b/libcalico-go/lib/backend/api/api.go
@@ -130,9 +130,10 @@ type Client interface {
 // backend-specific list-and-watch behavior.
 type ListAndWatchClient interface {
 	// ListAndWatch provides a unified interface for listing and watching resources.
-	// It runs a continuous loop that performs list-then-watch cycles until the context
-	// is cancelled or the backend returns a terminal error. The method handles
-	// backend-specific logic including:
+	// It runs a continuous loop that performs list-then-watch cycles, generally
+	// retrying transient backend failures internally and signaling connection
+	// failures through EventHandler.OnError. The method handles backend-specific
+	// logic including:
 	//
 	// Common behavior (via GenericListWatcher):
 	//   - Retry throttling with configurable minimum intervals
@@ -156,7 +157,8 @@ type ListAndWatchClient interface {
 	//   - OnSync(): Called when initial list completes and watcher is in sync
 	//   - OnError(err): Called when connection timeout or critical error occurs
 	//
-	// The method blocks until the context is cancelled or a terminal error occurs.
+	// The method blocks until the context is cancelled or until the implementation
+	// cannot start or continue the list-and-watch loop.
 	ListAndWatch(ctx context.Context, list model.ListInterface, handler EventHandler, opts ...ListWatcherOption) error
 }
 

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -103,7 +103,8 @@ type ListWatchBackend interface {
 	HandleListError(err error)
 
 	// HandleWatchError processes errors from the Watch operation.
-	// This is called when CreateWatch fails.
+	// This is called when the regular Watch fails. WatchList creation failures
+	// during initial sync are handled locally by falling back to List+Watch.
 	HandleWatchError(err error)
 
 	// PerformInitialSync executes the initial synchronization.
@@ -384,6 +385,9 @@ func (g *GenericListWatcher) startWatch(ctx context.Context, backend ListWatchBa
 			if ctx.Err() != nil {
 				return nil
 			}
+			// Match client-go reflector behavior: a WatchList create failure falls
+			// back to List+Watch for this sync without treating it as a regular
+			// watch failure.
 			g.Logger.WithError(err).Info(
 				"Data couldn't be fetched in WatchList mode, falling back to List. This is expected if WatchList is not supported or disabled in the backend.")
 		}

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// Default configuration values for list-watch operations.
+// These are variables (not constants) to allow tests to modify them.
+var (
+	MinResyncInterval = 500 * time.Millisecond
+	ListRetryInterval = 1000 * time.Millisecond
+	WatchPollInterval = 5000 * time.Millisecond
+	WatchRetryTimeout = 600 * time.Second
+
+	// MissingAPIRetryTime is the time to wait before retrying when the backing
+	// API is not installed. This is a long interval since missing APIs are expected
+	// to be a stable state.
+	MissingAPIRetryTime = 30 * time.Minute
+
+	// MaxErrorsPerRevision is the maximum number of errors allowed at a single
+	// revision before triggering a full resync.
+	MaxErrorsPerRevision = 5
+)
+
+// closedTimeC is a closed channel that triggers immediately in select statements.
+var closedTimeC <-chan time.Time
+
+func init() {
+	c := make(chan time.Time)
+	close(c)
+	closedTimeC = c
+}
+
+// ListWatchBackend defines the interface for backend-specific list-watch operations.
+// Implementations should provide backend-specific logic for performing list and watch operations.
+type ListWatchBackend interface {
+	// PerformList executes a list operation and returns the results.
+	// It should handle backend-specific error handling and return appropriate errors.
+	PerformList(ctx context.Context) (*model.KVPairList, error)
+
+	// CreateWatch creates a new watch from the current revision.
+	// The implementation should use GenericListWatcher.CurrentRevision for the starting point.
+	// The useWatchList parameter indicates if WatchList semantics should be used.
+	CreateWatch(ctx context.Context, useWatchList bool) (WatchInterface, error)
+
+	// HandleWatchEvent processes a single watch event.
+	// Returns nil to continue processing, or an error to stop the watch loop.
+	HandleWatchEvent(event WatchEvent) error
+
+	// HandleListError processes errors from the List operation.
+	// Implementations should handle all error cases including scheduling retries.
+	HandleListError(err error)
+
+	// HandleWatchError processes errors from the Watch operation.
+	// This is called when CreateWatch fails.
+	HandleWatchError(err error)
+
+	// PerformInitialSync executes the initial synchronization.
+	// For WatchList mode (k8s): notifies resync started, sync completion is via bookmark
+	// For ListThenWatch mode (etcd): performs list, sends events, notifies sync complete
+	// Returns an error if the sync fails and should be retried.
+	PerformInitialSync(ctx context.Context, g *GenericListWatcher) error
+}
+
+// WatchListSupporter is optionally implemented by backends or resource clients
+// that declare their WatchList capability for initial sync.
+type WatchListSupporter interface {
+	SupportsWatchList() bool
+}
+
+func supportsWatchList(backend ListWatchBackend) bool {
+	supporter, ok := backend.(WatchListSupporter)
+	return ok && supporter.SupportsWatchList()
+}
+
+// GenericListWatcher provides common functionality for list-watch implementations.
+// Backend-specific implementations should embed this struct to reuse common logic
+// for retry throttling, revision tracking, and error counting.
+//
+// State management:
+//   - InitialSyncPending: Indicates that initial sync is required. This is set to true
+//     initially and after certain error conditions. It's cleared after successful sync
+//     (either via List completion in fallback mode, or via bookmark in WatchList mode).
+//
+// The relationship between InitialSyncPending and CurrentRevision:
+//   - InitialSyncPending=true, CurrentRevision="": True initial sync, full dataset expected.
+//   - InitialSyncPending=true, CurrentRevision!="": Recovery/reconnection scenario.
+//     In both WatchList and ListThenWatch modes, the full dataset will be received:
+//   - WatchList mode: With SendInitialEvents=true, server re-sends all initial events
+//   - ListThenWatch mode: List API returns full dataset from that revision
+//   - InitialSyncPending=false: Already synced, just watching for changes.
+//
+// In all cases where InitialSyncPending=true, OnResyncStarted() is called to prepare
+// for receiving the full dataset (e.g., increment resync epoch for deletion tracking).
+type GenericListWatcher struct {
+	List    model.ListInterface
+	Handler EventHandler
+	Logger  *log.Entry
+
+	// State tracking
+	CurrentRevision        string
+	ErrorCountAtCurrentRev int
+	LastSuccessfulConnTime time.Time
+	InitialSyncPending     bool // Indicates that initial sync is required
+
+	// Throttling for retries
+	RetryBlockedUntil time.Time
+
+	// Watch management - shared across implementations
+	Watch WatchInterface
+}
+
+// NewGenericListWatcher creates a new GenericListWatcher with the given parameters.
+func NewGenericListWatcher(list model.ListInterface, handler EventHandler) *GenericListWatcher {
+	return &GenericListWatcher{
+		List:                   list,
+		Handler:                handler,
+		Logger:                 log.WithField("list", list),
+		CurrentRevision:        "", // Empty revision to request latest data
+		InitialSyncPending:     true,
+		LastSuccessfulConnTime: time.Now(),
+	}
+}
+
+// RetryThrottleC returns a channel that will be triggered after the retry delay has passed.
+// If no delay is needed, it returns a closed channel that triggers immediately.
+func (g *GenericListWatcher) RetryThrottleC() <-chan time.Time {
+	blockFor := time.Until(g.RetryBlockedUntil)
+	if blockFor > 0 {
+		g.Logger.WithField("delay", blockFor).Debug("Waiting before next retry")
+		return time.After(blockFor)
+	}
+	return closedTimeC // Triggers immediately.
+}
+
+// RetryAfter schedules the next retry attempt after the specified duration.
+func (g *GenericListWatcher) RetryAfter(d time.Duration) {
+	g.RetryBlockedUntil = time.Now().Add(d)
+}
+
+// UpdateRevision updates the current revision and resets the error count.
+func (g *GenericListWatcher) UpdateRevision(revision string) {
+	if revision != "" {
+		g.CurrentRevision = revision
+		g.ErrorCountAtCurrentRev = 0
+	}
+}
+
+// MarkSuccessfulConnection updates the last successful connection time.
+func (g *GenericListWatcher) MarkSuccessfulConnection() {
+	g.LastSuccessfulConnTime = time.Now()
+}
+
+// ResetForFullResync resets the current revision to empty to trigger a full resync.
+func (g *GenericListWatcher) ResetForFullResync() {
+	g.CurrentRevision = ""
+	g.ErrorCountAtCurrentRev = 0
+	g.InitialSyncPending = true
+}
+
+// MarkInitialSyncComplete clears the initial sync pending flag.
+// This should be called after the initial sync is complete (either via List
+// completion in ListThenWatch mode, or via bookmark in WatchList mode).
+func (g *GenericListWatcher) MarkInitialSyncComplete() {
+	g.InitialSyncPending = false
+}
+
+// PerformListSync performs a full list-based synchronization.
+// This is the common implementation for List+Watch mode used by etcd and k8s fallback.
+// It notifies the handler, performs the list, sends events, and marks sync complete.
+func (g *GenericListWatcher) PerformListSync(ctx context.Context, backend ListWatchBackend) error {
+	g.Logger.Info("Full resync is required (ListThenWatch mode)")
+
+	// Notify handler that resync is starting
+	g.Handler.OnResyncStarted()
+
+	// Perform the list operation
+	list, err := backend.PerformList(ctx)
+	if err != nil {
+		backend.HandleListError(err)
+		return err
+	}
+
+	// Successfully listed resources
+	g.MarkSuccessfulConnection()
+
+	if list.Revision == "" || list.Revision == "0" {
+		if len(list.KVPairs) == 0 {
+			g.Logger.Info("List returned no items and an empty/zero revision, reverting to poll.")
+			g.ResetForFullResync()
+			g.RetryAfter(WatchPollInterval)
+			return errors.New("list returned no items and an empty/zero revision")
+		}
+		g.Logger.Panic("BUG: List returned items with empty/zero revision. Watch would be inconsistent.")
+	}
+
+	g.Logger.WithFields(log.Fields{
+		"numKVs":   len(list.KVPairs),
+		"revision": list.Revision,
+	}).Debug("List completed")
+
+	// Send add events for each resource
+	g.SendListAsAddEvents(list)
+
+	// Update revision and notify sync complete
+	g.UpdateRevision(list.Revision)
+	g.Handler.OnSync()
+
+	g.MarkInitialSyncComplete()
+	return nil
+}
+
+// IncrementErrorCount increments the error count at the current revision.
+// Returns true if the error count has exceeded the maximum, indicating
+// a full resync should be triggered.
+func (g *GenericListWatcher) IncrementErrorCount() bool {
+	g.ErrorCountAtCurrentRev++
+	return g.ErrorCountAtCurrentRev >= MaxErrorsPerRevision
+}
+
+// CheckConnectionTimeout checks if the connection has been lost for too long.
+// Returns true if the timeout has been exceeded.
+func (g *GenericListWatcher) CheckConnectionTimeout() bool {
+	return time.Since(g.LastSuccessfulConnTime) > WatchRetryTimeout
+}
+
+// RunLoopWithBackend executes the main list-and-watch loop using the provided backend.
+// This is the preferred method for running list-watch operations as it uses the
+// Backend interface for backend-specific operations while keeping common logic centralized.
+func (g *GenericListWatcher) RunLoopWithBackend(ctx context.Context, backend ListWatchBackend) error {
+	g.Logger.Debug("Starting ListAndWatch loop with backend")
+
+	// Main loop, repeatedly resync with the store and then watch for changes
+	// until our watch fails or context is cancelled.
+	for ctx.Err() == nil {
+		// Wait for any pending retry throttle before proceeding
+		select {
+		case <-ctx.Done():
+			g.Logger.Debug("Context cancelled, stopping ListAndWatch")
+			return ctx.Err()
+		case <-g.RetryThrottleC():
+		}
+
+		// Schedule minimum retry delay to avoid tight loops
+		g.RetryAfter(MinResyncInterval)
+
+		// Perform resync and watch cycle
+		g.resyncAndLoopReadingFromWatcher(ctx, backend)
+	}
+
+	g.Logger.Debug("Context cancelled, stopping ListAndWatch")
+	return ctx.Err()
+}
+
+// resyncAndLoopReadingFromWatcher performs resync if needed, then loops reading from watcher.
+// This is a common implementation used by both k8s and etcd backends.
+func (g *GenericListWatcher) resyncAndLoopReadingFromWatcher(ctx context.Context, backend ListWatchBackend) {
+	defer g.CleanExistingWatcher()
+	g.maybeResyncAndCreateWatcher(ctx, backend)
+	if ctx.Err() != nil {
+		return
+	}
+	// Only loop if watcher was successfully created
+	if g.Watch == nil {
+		return
+	}
+	g.loopReadingFromWatcherWithBackend(ctx, backend)
+}
+
+// CleanExistingWatcher cleans up the current watcher if it exists.
+// This is a common implementation that can be used by all backends.
+func (g *GenericListWatcher) CleanExistingWatcher() {
+	if g.Watch != nil {
+		g.Watch.Stop()
+		g.Watch = nil
+	}
+}
+
+// maybeResyncAndCreateWatcher performs a resync if needed and creates a new watcher.
+func (g *GenericListWatcher) maybeResyncAndCreateWatcher(ctx context.Context, backend ListWatchBackend) {
+	if g.InitialSyncPending {
+		if err := backend.PerformInitialSync(ctx, g); err != nil {
+			// Backend handles error cases including scheduling retries
+			return
+		}
+	}
+
+	// Start watching from the current revision.
+	g.Logger.WithField("revision", g.CurrentRevision).Debug("Starting watch")
+	useWatchList := g.InitialSyncPending && supportsWatchList(backend)
+	watcher, err := backend.CreateWatch(ctx, useWatchList)
+	if err != nil {
+		g.Logger.WithError(err).Info("Failed to start watch")
+		backend.HandleWatchError(err)
+		return
+	}
+
+	g.Watch = watcher
+}
+
+// loopReadingFromWatcherWithBackend reads events from the watcher using the backend's event handler.
+func (g *GenericListWatcher) loopReadingFromWatcherWithBackend(ctx context.Context, backend ListWatchBackend) {
+	g.LoopReadingFromWatcher(ctx, g.Watch, backend.HandleWatchEvent)
+}
+
+// SendListAsAddEvents sends all KVPairs from a list result as Add events to the handler.
+// This is a common operation after performing a List operation during resync.
+func (g *GenericListWatcher) SendListAsAddEvents(list *model.KVPairList) {
+	for _, kvp := range list.KVPairs {
+		g.Handler.OnAdd(kvp)
+	}
+}
+
+// LoopReadingFromWatcher processes events from a watcher until the context is cancelled,
+// the watch channel is closed, or an error occurs. The onEvent callback is called for
+// each event and should return nil to continue processing, or an error to stop.
+func (g *GenericListWatcher) LoopReadingFromWatcher(ctx context.Context, watcher WatchInterface, onEvent func(WatchEvent) error) {
+	for {
+		select {
+		case <-ctx.Done():
+			g.Logger.Debug("Context is done. Returning")
+			return
+
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				// If the channel is closed then resync/recreate the watch.
+				g.Logger.Debug("Watch channel closed by remote - will recreate watcher")
+				return
+			}
+
+			// Handle the event, return if handler returns an error
+			if err := onEvent(event); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// HandleBasicWatchEvent processes a basic watch event (Added, Modified, Deleted).
+// It updates the revision and calls the appropriate handler method.
+// Returns true if the event was handled, false if it requires special handling (e.g., Bookmark, Error).
+func (g *GenericListWatcher) HandleBasicWatchEvent(event WatchEvent) bool {
+	switch event.Type {
+	case WatchAdded:
+		if event.New == nil {
+			g.Logger.Error("Added event without new value, skipping")
+			return true
+		}
+		g.UpdateRevision(event.New.Revision)
+		g.Handler.OnAdd(event.New)
+		g.MarkSuccessfulConnection()
+		return true
+
+	case WatchModified:
+		if event.New == nil {
+			g.Logger.Error("Modified event without new value, skipping")
+			return true
+		}
+		g.UpdateRevision(event.New.Revision)
+		g.Handler.OnUpdate(event.New)
+		g.MarkSuccessfulConnection()
+		return true
+
+	case WatchDeleted:
+		if event.Old == nil {
+			g.Logger.Error("Deletion event without old value, skipping")
+			return true
+		}
+		g.UpdateRevision(event.Old.Revision)
+		g.Handler.OnDelete(event.Old)
+		g.MarkSuccessfulConnection()
+		return true
+
+	default:
+		// Event requires special handling (Bookmark, Error, or unknown)
+		return false
+	}
+}

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -227,12 +227,9 @@ func (g *GenericListWatcher) MarkInitialSyncComplete() {
 
 // PerformListSync performs a full list-based synchronization.
 // This is the common implementation for List+Watch mode used by etcd and k8s fallback.
-// It notifies the handler, performs the list, sends events, and marks sync complete.
+// It performs the list, notifies the handler, sends events, and marks sync complete.
 func (g *GenericListWatcher) PerformListSync(ctx context.Context, backend ListWatchBackend) error {
 	g.Logger.Info("Full resync is required (ListThenWatch mode)")
-
-	// Notify handler that resync is starting
-	g.Handler.OnResyncStarted()
 
 	// Perform the list operation
 	list, err := backend.PerformList(ctx)
@@ -258,6 +255,10 @@ func (g *GenericListWatcher) PerformListSync(ctx context.Context, backend ListWa
 		"numKVs":   len(list.KVPairs),
 		"revision": list.Revision,
 	}).Debug("List completed")
+
+	// Notify handler after a valid list result but before emitting events so
+	// it can prepare resync bookkeeping.
+	g.Handler.OnResyncStarted()
 
 	// Send add events for each resource
 	g.SendListAsAddEvents(list)

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -168,6 +168,9 @@ type GenericListWatcher struct {
 func NewGenericListWatcher(list model.ListInterface, handler EventHandler, opts ...ListWatcherOption) *GenericListWatcher {
 	options := DefaultListWatcherOptions()
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(&options)
 	}
 

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -137,7 +137,8 @@ func supportsWatchList(backend ListWatchBackend) bool {
 //   - InitialSyncPending=true, CurrentRevision!="": Recovery/reconnection scenario.
 //     In both WatchList and ListThenWatch modes, the full dataset will be received:
 //   - WatchList mode: With SendInitialEvents=true, server re-sends all initial events
-//   - ListThenWatch mode: List API returns full dataset from that revision
+//   - ListThenWatch mode: List API returns a fresh full dataset, then watch starts
+//     from the list result revision
 //   - InitialSyncPending=false: Already synced, just watching for changes.
 //
 // In all cases where InitialSyncPending=true, OnResyncStarted() is called to prepare

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
 
 const (
@@ -106,10 +107,10 @@ type ListWatchBackend interface {
 	HandleWatchError(err error)
 
 	// PerformInitialSync executes the initial synchronization.
-	// For WatchList mode (k8s): notifies resync started, sync completion is via bookmark
+	// For WatchList mode (k8s): prepares for initial events, sync completion is via bookmark
 	// For ListThenWatch mode (etcd): performs list, sends events, notifies sync complete
 	// Returns an error if the sync fails and should be retried.
-	PerformInitialSync(ctx context.Context, g *GenericListWatcher) error
+	PerformInitialSync(ctx context.Context, g *GenericListWatcher, useWatchList bool) error
 }
 
 // WatchListSupporter is optionally implemented by backends or resource clients
@@ -282,10 +283,45 @@ func (g *GenericListWatcher) CheckConnectionTimeout() bool {
 	return time.Since(g.LastSuccessfulConnTime) > g.Options.WatchRetryTimeout
 }
 
-// RunLoopWithBackend executes the main list-and-watch loop using the provided backend.
+// HandleListError performs generic list error handling.
+func (g *GenericListWatcher) HandleListError(err error) {
+	g.Logger.WithError(err).Info("Failed to list resources")
+	if g.CheckConnectionTimeout() {
+		g.Logger.Warn("Connection has failed for too long")
+		g.Handler.OnError(err)
+	}
+	g.RetryAfter(g.Options.ListRetryInterval)
+}
+
+// HandleWatchUnavailableError handles errors that indicate watch is not currently usable.
+// Returns true if the error was handled.
+func (g *GenericListWatcher) HandleWatchUnavailableError(err error) bool {
+	var errNotSupp cerrors.ErrorOperationNotSupported
+	var errNotExist cerrors.ErrorResourceDoesNotExist
+	if !errors.As(err, &errNotSupp) && !errors.As(err, &errNotExist) {
+		return false
+	}
+
+	g.Logger.WithError(err).Debug("Watch operation not supported; reverting to poll.")
+	g.RetryAfter(g.Options.WatchPollInterval)
+	g.ResetForFullResync()
+	return true
+}
+
+// HandleWatchError performs generic watch error handling.
+func (g *GenericListWatcher) HandleWatchError(err error) {
+	if g.IncrementErrorCount() {
+		g.Logger.WithError(err).Warn("Watch repeatedly failed without making progress, triggering full resync")
+		g.ResetForFullResync()
+		return
+	}
+	g.Logger.WithError(err).Warn("Watch of resource finished. Attempting to restart it...")
+}
+
+// ListAndWatchWithBackend executes the main list-and-watch loop using the provided backend.
 // This is the preferred method for running list-watch operations as it uses the
 // Backend interface for backend-specific operations while keeping common logic centralized.
-func (g *GenericListWatcher) RunLoopWithBackend(ctx context.Context, backend ListWatchBackend) error {
+func (g *GenericListWatcher) ListAndWatchWithBackend(ctx context.Context, backend ListWatchBackend) error {
 	g.Logger.Debug("Starting ListAndWatch loop with backend")
 
 	// Main loop, repeatedly resync with the store and then watch for changes
@@ -303,62 +339,83 @@ func (g *GenericListWatcher) RunLoopWithBackend(ctx context.Context, backend Lis
 		g.RetryAfter(g.Options.MinResyncInterval)
 
 		// Perform resync and watch cycle
-		g.resyncAndLoopReadingFromWatcher(ctx, backend)
+		g.listAndWatch(ctx, backend)
 	}
 
 	g.Logger.Debug("Context cancelled, stopping ListAndWatch")
 	return ctx.Err()
 }
 
-// resyncAndLoopReadingFromWatcher performs resync if needed, then loops reading from watcher.
-// This is a common implementation used by both k8s and etcd backends.
-func (g *GenericListWatcher) resyncAndLoopReadingFromWatcher(ctx context.Context, backend ListWatchBackend) {
-	defer g.CleanExistingWatcher()
-	g.maybeResyncAndCreateWatcher(ctx, backend)
-	if ctx.Err() != nil {
+// listAndWatch performs an initial sync if needed, then watches for changes.
+func (g *GenericListWatcher) listAndWatch(ctx context.Context, backend ListWatchBackend) {
+	watcher := g.startWatch(ctx, backend)
+	if watcher == nil {
 		return
 	}
-	// Only loop if watcher was successfully created
-	if g.Watch == nil {
-		return
-	}
-	g.loopReadingFromWatcherWithBackend(ctx, backend)
+
+	g.Watch = watcher
+	defer g.stopWatch()
+	g.watch(ctx, backend, watcher)
 }
 
-// CleanExistingWatcher cleans up the current watcher if it exists.
-// This is a common implementation that can be used by all backends.
-func (g *GenericListWatcher) CleanExistingWatcher() {
+func (g *GenericListWatcher) stopWatch() {
 	if g.Watch != nil {
 		g.Watch.Stop()
 		g.Watch = nil
 	}
 }
 
-// maybeResyncAndCreateWatcher performs a resync if needed and creates a new watcher.
-func (g *GenericListWatcher) maybeResyncAndCreateWatcher(ctx context.Context, backend ListWatchBackend) {
+// startWatch performs an initial sync if needed and returns a watcher.
+func (g *GenericListWatcher) startWatch(ctx context.Context, backend ListWatchBackend) WatchInterface {
 	if g.InitialSyncPending {
-		if err := backend.PerformInitialSync(ctx, g); err != nil {
-			// Backend handles error cases including scheduling retries
-			return
+		if supportsWatchList(backend) {
+			// Try WatchList first.  If it is unavailable, fall back to a regular
+			// List+Watch for this sync, matching client-go reflector behavior.
+			g.Logger.WithField("revision", g.CurrentRevision).Debug("Starting WatchList")
+			watcher, err := backend.CreateWatch(ctx, true)
+			if err == nil {
+				if err := backend.PerformInitialSync(ctx, g, true); err != nil {
+					watcher.Stop()
+					return nil
+				}
+				return watcher
+			}
+			stopUnexpectedWatcher(watcher)
+			if ctx.Err() != nil {
+				return nil
+			}
+			g.Logger.WithError(err).Info(
+				"Data couldn't be fetched in WatchList mode, falling back to List. This is expected if WatchList is not supported or disabled in the backend.")
+		}
+
+		if err := backend.PerformInitialSync(ctx, g, false); err != nil {
+			// PerformInitialSync has already recorded the backend-specific retry state.
+			return nil
 		}
 	}
 
 	// Start watching from the current revision.
 	g.Logger.WithField("revision", g.CurrentRevision).Debug("Starting watch")
-	useWatchList := g.InitialSyncPending && supportsWatchList(backend)
-	watcher, err := backend.CreateWatch(ctx, useWatchList)
+	watcher, err := backend.CreateWatch(ctx, false)
 	if err != nil {
+		stopUnexpectedWatcher(watcher)
 		g.Logger.WithError(err).Info("Failed to start watch")
 		backend.HandleWatchError(err)
-		return
+		return nil
 	}
 
-	g.Watch = watcher
+	return watcher
 }
 
-// loopReadingFromWatcherWithBackend reads events from the watcher using the backend's event handler.
-func (g *GenericListWatcher) loopReadingFromWatcherWithBackend(ctx context.Context, backend ListWatchBackend) {
-	g.LoopReadingFromWatcher(ctx, g.Watch, backend.HandleWatchEvent)
+// watch reads events from the watcher using the backend's event handler.
+func (g *GenericListWatcher) watch(ctx context.Context, backend ListWatchBackend, watcher WatchInterface) {
+	g.LoopReadingFromWatcher(ctx, watcher, backend.HandleWatchEvent)
+}
+
+func stopUnexpectedWatcher(watcher WatchInterface) {
+	if watcher != nil {
+		watcher.Stop()
+	}
 }
 
 // SendListAsAddEvents sends all KVPairs from a list result as Add events to the handler.

--- a/libcalico-go/lib/backend/api/listwatcher.go
+++ b/libcalico-go/lib/backend/api/listwatcher.go
@@ -24,23 +24,53 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
-// Default configuration values for list-watch operations.
-// These are variables (not constants) to allow tests to modify them.
-var (
-	MinResyncInterval = 500 * time.Millisecond
-	ListRetryInterval = 1000 * time.Millisecond
-	WatchPollInterval = 5000 * time.Millisecond
-	WatchRetryTimeout = 600 * time.Second
+const (
+	DefaultMinResyncInterval = 500 * time.Millisecond
+	DefaultListRetryInterval = 1000 * time.Millisecond
+	DefaultWatchPollInterval = 5000 * time.Millisecond
+	DefaultWatchRetryTimeout = 600 * time.Second
 
-	// MissingAPIRetryTime is the time to wait before retrying when the backing
-	// API is not installed. This is a long interval since missing APIs are expected
-	// to be a stable state.
-	MissingAPIRetryTime = 30 * time.Minute
+	// DefaultMissingAPIRetryTime is the time to wait before retrying when the
+	// backing API is not installed. This is a long interval since missing APIs
+	// are expected to be a stable state.
+	DefaultMissingAPIRetryTime = 30 * time.Minute
 
-	// MaxErrorsPerRevision is the maximum number of errors allowed at a single
-	// revision before triggering a full resync.
-	MaxErrorsPerRevision = 5
+	// DefaultMaxErrorsPerRevision is the maximum number of errors allowed at a
+	// single revision before triggering a full resync.
+	DefaultMaxErrorsPerRevision = 5
 )
+
+// ListWatcherOptions configures retry and timeout behavior for a GenericListWatcher.
+type ListWatcherOptions struct {
+	MinResyncInterval    time.Duration
+	ListRetryInterval    time.Duration
+	WatchPollInterval    time.Duration
+	WatchRetryTimeout    time.Duration
+	MissingAPIRetryTime  time.Duration
+	MaxErrorsPerRevision int
+}
+
+// ListWatcherOption updates ListWatcherOptions when constructing a GenericListWatcher.
+type ListWatcherOption func(*ListWatcherOptions)
+
+// DefaultListWatcherOptions returns the production defaults for list-watch operations.
+func DefaultListWatcherOptions() ListWatcherOptions {
+	return ListWatcherOptions{
+		MinResyncInterval:    DefaultMinResyncInterval,
+		ListRetryInterval:    DefaultListRetryInterval,
+		WatchPollInterval:    DefaultWatchPollInterval,
+		WatchRetryTimeout:    DefaultWatchRetryTimeout,
+		MissingAPIRetryTime:  DefaultMissingAPIRetryTime,
+		MaxErrorsPerRevision: DefaultMaxErrorsPerRevision,
+	}
+}
+
+// WithListWatcherOptions sets the full ListWatcherOptions for a GenericListWatcher.
+func WithListWatcherOptions(options ListWatcherOptions) ListWatcherOption {
+	return func(o *ListWatcherOptions) {
+		*o = options
+	}
+}
 
 // closedTimeC is a closed channel that triggers immediately in select statements.
 var closedTimeC <-chan time.Time
@@ -116,6 +146,7 @@ type GenericListWatcher struct {
 	List    model.ListInterface
 	Handler EventHandler
 	Logger  *log.Entry
+	Options ListWatcherOptions
 
 	// State tracking
 	CurrentRevision        string
@@ -131,11 +162,17 @@ type GenericListWatcher struct {
 }
 
 // NewGenericListWatcher creates a new GenericListWatcher with the given parameters.
-func NewGenericListWatcher(list model.ListInterface, handler EventHandler) *GenericListWatcher {
+func NewGenericListWatcher(list model.ListInterface, handler EventHandler, opts ...ListWatcherOption) *GenericListWatcher {
+	options := DefaultListWatcherOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	return &GenericListWatcher{
 		List:                   list,
 		Handler:                handler,
 		Logger:                 log.WithField("list", list),
+		Options:                options,
 		CurrentRevision:        "", // Empty revision to request latest data
 		InitialSyncPending:     true,
 		LastSuccessfulConnTime: time.Now(),
@@ -208,7 +245,7 @@ func (g *GenericListWatcher) PerformListSync(ctx context.Context, backend ListWa
 		if len(list.KVPairs) == 0 {
 			g.Logger.Info("List returned no items and an empty/zero revision, reverting to poll.")
 			g.ResetForFullResync()
-			g.RetryAfter(WatchPollInterval)
+			g.RetryAfter(g.Options.WatchPollInterval)
 			return errors.New("list returned no items and an empty/zero revision")
 		}
 		g.Logger.Panic("BUG: List returned items with empty/zero revision. Watch would be inconsistent.")
@@ -235,13 +272,13 @@ func (g *GenericListWatcher) PerformListSync(ctx context.Context, backend ListWa
 // a full resync should be triggered.
 func (g *GenericListWatcher) IncrementErrorCount() bool {
 	g.ErrorCountAtCurrentRev++
-	return g.ErrorCountAtCurrentRev >= MaxErrorsPerRevision
+	return g.ErrorCountAtCurrentRev >= g.Options.MaxErrorsPerRevision
 }
 
 // CheckConnectionTimeout checks if the connection has been lost for too long.
 // Returns true if the timeout has been exceeded.
 func (g *GenericListWatcher) CheckConnectionTimeout() bool {
-	return time.Since(g.LastSuccessfulConnTime) > WatchRetryTimeout
+	return time.Since(g.LastSuccessfulConnTime) > g.Options.WatchRetryTimeout
 }
 
 // RunLoopWithBackend executes the main list-and-watch loop using the provided backend.
@@ -262,7 +299,7 @@ func (g *GenericListWatcher) RunLoopWithBackend(ctx context.Context, backend Lis
 		}
 
 		// Schedule minimum retry delay to avoid tight loops
-		g.RetryAfter(MinResyncInterval)
+		g.RetryAfter(g.Options.MinResyncInterval)
 
 		// Perform resync and watch cycle
 		g.resyncAndLoopReadingFromWatcher(ctx, backend)

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -198,6 +198,23 @@ func TestNewGenericListWatcher(t *testing.T) {
 	assert.Equal(t, "", lw.CurrentRevision)
 	assert.Equal(t, 0, lw.ErrorCountAtCurrentRev)
 	assert.NotNil(t, lw.Logger)
+	assert.Equal(t, DefaultListWatcherOptions(), lw.Options)
+}
+
+func TestNewGenericListWatcher_CustomOptions(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+	options := DefaultListWatcherOptions()
+	options.MinResyncInterval = 10 * time.Millisecond
+	options.ListRetryInterval = 20 * time.Millisecond
+	options.WatchPollInterval = 30 * time.Millisecond
+	options.WatchRetryTimeout = 40 * time.Millisecond
+	options.MissingAPIRetryTime = 50 * time.Millisecond
+	options.MaxErrorsPerRevision = 2
+
+	lw := NewGenericListWatcher(list, handler, WithListWatcherOptions(options))
+
+	assert.Equal(t, options, lw.Options)
 }
 
 func TestGenericListWatcher_UpdateRevision(t *testing.T) {
@@ -221,7 +238,7 @@ func TestGenericListWatcher_IncrementErrorCount_Threshold(t *testing.T) {
 	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
 
 	// Increment errors up to threshold
-	for i := 1; i < MaxErrorsPerRevision; i++ {
+	for i := 1; i < lw.Options.MaxErrorsPerRevision; i++ {
 		exceeded := lw.IncrementErrorCount()
 		assert.False(t, exceeded, "Should not exceed at count %d", i)
 	}
@@ -229,7 +246,7 @@ func TestGenericListWatcher_IncrementErrorCount_Threshold(t *testing.T) {
 	// Next increment should exceed threshold
 	exceeded := lw.IncrementErrorCount()
 	assert.True(t, exceeded)
-	assert.Equal(t, MaxErrorsPerRevision, lw.ErrorCountAtCurrentRev)
+	assert.Equal(t, lw.Options.MaxErrorsPerRevision, lw.ErrorCountAtCurrentRev)
 }
 
 func TestGenericListWatcher_ResetForFullResync(t *testing.T) {
@@ -279,7 +296,7 @@ func TestGenericListWatcher_ConnectionTracking(t *testing.T) {
 	assert.False(t, lw.CheckConnectionTimeout())
 
 	// Set last connection to past timeout
-	lw.LastSuccessfulConnTime = time.Now().Add(-WatchRetryTimeout - time.Second)
+	lw.LastSuccessfulConnTime = time.Now().Add(-lw.Options.WatchRetryTimeout - time.Second)
 	assert.True(t, lw.CheckConnectionTimeout())
 
 	// Mark successful connection should reset

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -650,57 +650,62 @@ func TestPerformListSync_ListError(t *testing.T) {
 	assert.Empty(t, handler.calls)
 }
 
-func TestPerformListSync_EmptyRevisionNoItems(t *testing.T) {
-	handler := newMockEventHandler()
-	lw := NewGenericListWatcher(testListOptions(), handler)
-
-	backend := newMockListWatchBackend()
-	backend.listResult = &model.KVPairList{
-		KVPairs:  []*model.KVPair{}, // No items
-		Revision: "",                // Empty revision
+func TestPerformListSync_EmptyOrZeroRevisionNoItems(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+	}{
+		{name: "empty revision", revision: ""},
+		{name: "zero revision", revision: "0"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newMockEventHandler()
+			lw := NewGenericListWatcher(testListOptions(), handler)
 
-	err := lw.PerformListSync(context.Background(), backend)
+			backend := newMockListWatchBackend()
+			backend.listResult = &model.KVPairList{
+				KVPairs:  []*model.KVPair{}, // No items
+				Revision: tt.revision,
+			}
 
-	// Should return error and schedule retry (poll mode)
-	assert.Error(t, err)
-	assert.Equal(t, "", lw.CurrentRevision) // Should reset for resync
-	assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
+			err := lw.PerformListSync(context.Background(), backend)
+
+			// Should return error and schedule retry (poll mode)
+			assert.Error(t, err)
+			assert.Equal(t, "", lw.CurrentRevision) // Should reset for resync
+			assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
+		})
+	}
 }
 
-func TestPerformListSync_ZeroRevisionNoItems(t *testing.T) {
-	handler := newMockEventHandler()
-	lw := NewGenericListWatcher(testListOptions(), handler)
-
-	backend := newMockListWatchBackend()
-	backend.listResult = &model.KVPairList{
-		KVPairs:  []*model.KVPair{}, // No items
-		Revision: "",                // Zero revision
+func TestPerformListSync_EmptyOrZeroRevisionWithItems_Panics(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+	}{
+		{name: "empty revision", revision: ""},
+		{name: "zero revision", revision: "0"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newMockEventHandler()
+			lw := NewGenericListWatcher(testListOptions(), handler)
 
-	err := lw.PerformListSync(context.Background(), backend)
+			backend := newMockListWatchBackend()
+			backend.listResult = &model.KVPairList{
+				KVPairs: []*model.KVPair{
+					{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+				},
+				Revision: tt.revision,
+			}
 
-	// Should return error and schedule retry (poll mode)
-	assert.Error(t, err)
-	assert.Equal(t, "", lw.CurrentRevision)
-}
-
-func TestPerformListSync_ZeroRevisionWithItems_Panics(t *testing.T) {
-	handler := newMockEventHandler()
-	lw := NewGenericListWatcher(testListOptions(), handler)
-
-	backend := newMockListWatchBackend()
-	backend.listResult = &model.KVPairList{
-		KVPairs: []*model.KVPair{
-			{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
-		},
-		Revision: "", // Zero revision with items - BUG condition
+			// Should panic due to inconsistent state
+			assert.Panics(t, func() {
+				lw.PerformListSync(context.Background(), backend)
+			})
+		})
 	}
-
-	// Should panic due to inconsistent state
-	assert.Panics(t, func() {
-		lw.PerformListSync(context.Background(), backend)
-	})
 }
 
 // ============================================================================

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -242,6 +242,16 @@ func TestNewGenericListWatcher_CustomOptions(t *testing.T) {
 	assert.Equal(t, options, lw.Options)
 }
 
+func TestNewGenericListWatcher_NilOption(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	assert.NotPanics(t, func() {
+		lw := NewGenericListWatcher(list, handler, nil)
+		assert.Equal(t, DefaultListWatcherOptions(), lw.Options)
+	})
+}
+
 func TestGenericListWatcher_UpdateRevision(t *testing.T) {
 	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
 

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -38,6 +38,7 @@ type mockEventHandler struct {
 	syncCount       int
 	resyncStartedCt int
 	errors          []error
+	calls           []string
 }
 
 func newMockEventHandler() *mockEventHandler {
@@ -51,26 +52,32 @@ func newMockEventHandler() *mockEventHandler {
 
 func (m *mockEventHandler) OnResyncStarted() {
 	m.resyncStartedCt++
+	m.calls = append(m.calls, "resync-started")
 }
 
 func (m *mockEventHandler) OnAdd(kvp *model.KVPair) {
 	m.addEvents = append(m.addEvents, kvp)
+	m.calls = append(m.calls, "add")
 }
 
 func (m *mockEventHandler) OnUpdate(kvp *model.KVPair) {
 	m.updateEvents = append(m.updateEvents, kvp)
+	m.calls = append(m.calls, "update")
 }
 
 func (m *mockEventHandler) OnDelete(kvp *model.KVPair) {
 	m.deleteEvents = append(m.deleteEvents, kvp)
+	m.calls = append(m.calls, "delete")
 }
 
 func (m *mockEventHandler) OnSync() {
 	m.syncCount++
+	m.calls = append(m.calls, "sync")
 }
 
 func (m *mockEventHandler) OnError(err error) {
 	m.errors = append(m.errors, err)
+	m.calls = append(m.calls, "error")
 }
 
 // mockWatcher implements WatchInterface for testing
@@ -617,6 +624,7 @@ func TestPerformListSync_Success(t *testing.T) {
 	assert.Equal(t, 1, handler.resyncStartedCt)
 	assert.Equal(t, 1, handler.syncCount)
 	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, []string{"resync-started", "add", "sync"}, handler.calls)
 	assert.Equal(t, "100", lw.CurrentRevision)
 	assert.False(t, lw.InitialSyncPending) // Should be cleared after successful sync
 }
@@ -637,8 +645,9 @@ func TestPerformListSync_ListError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.True(t, listErrorCalled)
-	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 0, handler.resyncStartedCt)
 	assert.Equal(t, 0, handler.syncCount) // Sync should not be called on error
+	assert.Empty(t, handler.calls)
 }
 
 func TestPerformListSync_EmptyRevisionNoItems(t *testing.T) {

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -1,0 +1,860 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// ============================================================================
+// Test Mocks
+// ============================================================================
+
+// mockEventHandler implements EventHandler for testing
+type mockEventHandler struct {
+	addEvents       []*model.KVPair
+	updateEvents    []*model.KVPair
+	deleteEvents    []*model.KVPair
+	syncCount       int
+	resyncStartedCt int
+	errors          []error
+}
+
+func newMockEventHandler() *mockEventHandler {
+	return &mockEventHandler{
+		addEvents:    make([]*model.KVPair, 0),
+		updateEvents: make([]*model.KVPair, 0),
+		deleteEvents: make([]*model.KVPair, 0),
+		errors:       make([]error, 0),
+	}
+}
+
+func (m *mockEventHandler) OnResyncStarted() {
+	m.resyncStartedCt++
+}
+
+func (m *mockEventHandler) OnAdd(kvp *model.KVPair) {
+	m.addEvents = append(m.addEvents, kvp)
+}
+
+func (m *mockEventHandler) OnUpdate(kvp *model.KVPair) {
+	m.updateEvents = append(m.updateEvents, kvp)
+}
+
+func (m *mockEventHandler) OnDelete(kvp *model.KVPair) {
+	m.deleteEvents = append(m.deleteEvents, kvp)
+}
+
+func (m *mockEventHandler) OnSync() {
+	m.syncCount++
+}
+
+func (m *mockEventHandler) OnError(err error) {
+	m.errors = append(m.errors, err)
+}
+
+// mockWatcher implements WatchInterface for testing
+type mockWatcher struct {
+	events     chan WatchEvent
+	stopped    bool
+	terminated bool
+}
+
+func newMockWatcher() *mockWatcher {
+	return &mockWatcher{
+		events: make(chan WatchEvent, 10),
+	}
+}
+
+func (w *mockWatcher) Stop() {
+	if !w.stopped {
+		w.stopped = true
+		close(w.events)
+	}
+}
+
+func (w *mockWatcher) ResultChan() <-chan WatchEvent {
+	return w.events
+}
+
+func (w *mockWatcher) HasTerminated() bool {
+	return w.terminated
+}
+
+func (w *mockWatcher) SendEvent(event WatchEvent) {
+	w.events <- event
+}
+
+// mockListWatchBackend implements ListWatchBackend for testing
+type mockListWatchBackend struct {
+	listResult           *model.KVPairList
+	listError            error
+	watchResult          WatchInterface
+	watchError           error
+	listErrorHandler     func(error)
+	watchErrorCalls      int
+	createWatchArguments []bool
+}
+
+func newMockListWatchBackend() *mockListWatchBackend {
+	return &mockListWatchBackend{
+		listResult: &model.KVPairList{
+			KVPairs: []*model.KVPair{
+				{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+			},
+			Revision: "100",
+		},
+	}
+}
+
+func (m *mockListWatchBackend) PerformList(ctx context.Context) (*model.KVPairList, error) {
+	return m.listResult, m.listError
+}
+
+func (m *mockListWatchBackend) CreateWatch(ctx context.Context, useWatchList bool) (WatchInterface, error) {
+	m.createWatchArguments = append(m.createWatchArguments, useWatchList)
+	return m.watchResult, m.watchError
+}
+
+func (m *mockListWatchBackend) HandleWatchEvent(event WatchEvent) error {
+	return nil
+}
+
+func (m *mockListWatchBackend) HandleListError(err error) {
+	if m.listErrorHandler != nil {
+		m.listErrorHandler(err)
+	}
+}
+
+func (m *mockListWatchBackend) HandleWatchError(err error) {
+	m.watchErrorCalls++
+}
+
+func (m *mockListWatchBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher) error {
+	return g.PerformListSync(ctx, m)
+}
+
+type mockWatchListBackend struct {
+	*mockListWatchBackend
+	supportsWatchList bool
+}
+
+func (m *mockWatchListBackend) SupportsWatchList() bool {
+	return m.supportsWatchList
+}
+
+func (m *mockWatchListBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher) error {
+	g.Handler.OnResyncStarted()
+	return nil
+}
+
+type mockInitialSyncPendingBackend struct {
+	*mockListWatchBackend
+}
+
+func (m *mockInitialSyncPendingBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher) error {
+	g.Handler.OnResyncStarted()
+	return nil
+}
+
+// testListOptions returns a real ListInterface for testing
+func testListOptions() model.ListInterface {
+	return model.GlobalConfigListOptions{}
+}
+
+// ============================================================================
+// GenericListWatcher Creation and State Management Tests
+// ============================================================================
+
+func TestNewGenericListWatcher(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewGenericListWatcher(list, handler)
+
+	assert.NotNil(t, lw)
+	assert.Equal(t, list, lw.List)
+	assert.Equal(t, handler, lw.Handler)
+	assert.Equal(t, "", lw.CurrentRevision)
+	assert.Equal(t, 0, lw.ErrorCountAtCurrentRev)
+	assert.NotNil(t, lw.Logger)
+}
+
+func TestGenericListWatcher_UpdateRevision(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// Update revision should set CurrentRevision and reset error count
+	lw.IncrementErrorCount()
+	lw.IncrementErrorCount()
+	assert.Equal(t, 2, lw.ErrorCountAtCurrentRev)
+
+	lw.UpdateRevision("100")
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.Equal(t, 0, lw.ErrorCountAtCurrentRev)
+
+	// Empty revision should not update
+	lw.UpdateRevision("")
+	assert.Equal(t, "100", lw.CurrentRevision)
+}
+
+func TestGenericListWatcher_IncrementErrorCount_Threshold(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// Increment errors up to threshold
+	for i := 1; i < MaxErrorsPerRevision; i++ {
+		exceeded := lw.IncrementErrorCount()
+		assert.False(t, exceeded, "Should not exceed at count %d", i)
+	}
+
+	// Next increment should exceed threshold
+	exceeded := lw.IncrementErrorCount()
+	assert.True(t, exceeded)
+	assert.Equal(t, MaxErrorsPerRevision, lw.ErrorCountAtCurrentRev)
+}
+
+func TestGenericListWatcher_ResetForFullResync(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	lw.UpdateRevision("500")
+	lw.IncrementErrorCount()
+	lw.MarkInitialSyncComplete() // Clear initial sync pending
+
+	lw.ResetForFullResync()
+
+	assert.Equal(t, "", lw.CurrentRevision)
+	assert.Equal(t, 0, lw.ErrorCountAtCurrentRev)
+	assert.True(t, lw.InitialSyncPending) // Should be set back to true
+}
+
+func TestGenericListWatcher_MarkInitialSyncComplete(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// Initially pending
+	assert.True(t, lw.InitialSyncPending)
+
+	lw.MarkInitialSyncComplete()
+
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestGenericListWatcher_InitialSyncPending(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// Initial state: InitialSyncPending=true
+	assert.True(t, lw.InitialSyncPending)
+
+	// Clear InitialSyncPending
+	lw.MarkInitialSyncComplete()
+	assert.False(t, lw.InitialSyncPending)
+
+	// Reset should set InitialSyncPending=true
+	lw.ResetForFullResync()
+	assert.True(t, lw.InitialSyncPending)
+}
+
+func TestGenericListWatcher_ConnectionTracking(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// Just connected, should not timeout
+	assert.False(t, lw.CheckConnectionTimeout())
+
+	// Set last connection to past timeout
+	lw.LastSuccessfulConnTime = time.Now().Add(-WatchRetryTimeout - time.Second)
+	assert.True(t, lw.CheckConnectionTimeout())
+
+	// Mark successful connection should reset
+	lw.MarkSuccessfulConnection()
+	assert.False(t, lw.CheckConnectionTimeout())
+}
+
+// ============================================================================
+// Retry Throttling Tests
+// ============================================================================
+
+func TestGenericListWatcher_RetryThrottling(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// No pending delay, should trigger immediately
+	select {
+	case <-lw.RetryThrottleC():
+		// Success
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("RetryThrottleC should have triggered immediately")
+	}
+
+	// Schedule retry for 50ms in future
+	lw.RetryAfter(50 * time.Millisecond)
+
+	start := time.Now()
+	<-lw.RetryThrottleC()
+	elapsed := time.Since(start)
+
+	assert.True(t, elapsed >= 40*time.Millisecond, "Should wait for scheduled time")
+}
+
+// ============================================================================
+// Watch Event Handling Tests
+// ============================================================================
+
+func TestGenericListWatcher_HandleBasicWatchEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		event          WatchEvent
+		expectHandled  bool
+		expectAdds     int
+		expectUpdates  int
+		expectDeletes  int
+		expectRevision string
+	}{
+		{
+			name: "Added event",
+			event: WatchEvent{
+				Type: WatchAdded,
+				New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "val", Revision: "10"},
+			},
+			expectHandled:  true,
+			expectAdds:     1,
+			expectRevision: "10",
+		},
+		{
+			name: "Modified event",
+			event: WatchEvent{
+				Type: WatchModified,
+				New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "new", Revision: "20"},
+			},
+			expectHandled:  true,
+			expectUpdates:  1,
+			expectRevision: "20",
+		},
+		{
+			name: "Deleted event",
+			event: WatchEvent{
+				Type: WatchDeleted,
+				Old:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "val", Revision: "30"},
+			},
+			expectHandled:  true,
+			expectDeletes:  1,
+			expectRevision: "30",
+		},
+		{
+			name: "Error event - not handled by basic handler",
+			event: WatchEvent{
+				Type:  WatchError,
+				Error: errors.New("test error"),
+			},
+			expectHandled:  false,
+			expectRevision: "",
+		},
+		{
+			name: "Bookmark event - not handled by basic handler",
+			event: WatchEvent{
+				Type: WatchBookmark,
+				New:  &model.KVPair{Revision: "100"},
+			},
+			expectHandled:  false,
+			expectRevision: "",
+		},
+		{
+			name: "Unknown event type - not handled",
+			event: WatchEvent{
+				Type: WatchEventType("unknown"),
+			},
+			expectHandled:  false,
+			expectRevision: "",
+		},
+		{
+			name:           "Added without New value - handled with error log",
+			event:          WatchEvent{Type: WatchAdded, New: nil},
+			expectHandled:  true,
+			expectAdds:     0,
+			expectRevision: "",
+		},
+		{
+			name:           "Modified without New value - handled with error log",
+			event:          WatchEvent{Type: WatchModified, New: nil},
+			expectHandled:  true,
+			expectUpdates:  0,
+			expectRevision: "",
+		},
+		{
+			name:           "Deleted without Old value - handled with error log",
+			event:          WatchEvent{Type: WatchDeleted, Old: nil},
+			expectHandled:  true,
+			expectDeletes:  0,
+			expectRevision: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newMockEventHandler()
+			lw := NewGenericListWatcher(testListOptions(), handler)
+
+			handled := lw.HandleBasicWatchEvent(tt.event)
+
+			assert.Equal(t, tt.expectHandled, handled)
+			assert.Len(t, handler.addEvents, tt.expectAdds)
+			assert.Len(t, handler.updateEvents, tt.expectUpdates)
+			assert.Len(t, handler.deleteEvents, tt.expectDeletes)
+			assert.Equal(t, tt.expectRevision, lw.CurrentRevision)
+		})
+	}
+}
+
+func TestGenericListWatcher_SendListAsAddEvents(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	kvpList := &model.KVPairList{
+		KVPairs: []*model.KVPair{
+			{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+			{Key: model.GlobalConfigKey{Name: "key2"}, Value: "value2", Revision: "2"},
+			{Key: model.GlobalConfigKey{Name: "key3"}, Value: "value3", Revision: "3"},
+		},
+		Revision: "3",
+	}
+
+	lw.SendListAsAddEvents(kvpList)
+
+	assert.Len(t, handler.addEvents, 3)
+	assert.Equal(t, "value1", handler.addEvents[0].Value)
+	assert.Equal(t, "value2", handler.addEvents[1].Value)
+	assert.Equal(t, "value3", handler.addEvents[2].Value)
+}
+
+// ============================================================================
+// Watch Loop Tests
+// ============================================================================
+
+func TestGenericListWatcher_LoopReadingFromWatcher(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	watcher := newMockWatcher()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		watcher.SendEvent(WatchEvent{
+			Type: WatchAdded,
+			New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "k1"}, Value: "v1", Revision: "1"},
+		})
+		watcher.SendEvent(WatchEvent{
+			Type: WatchModified,
+			New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "k1"}, Value: "v2", Revision: "2"},
+		})
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	eventHandler := func(event WatchEvent) error {
+		lw.HandleBasicWatchEvent(event)
+		return nil
+	}
+
+	lw.LoopReadingFromWatcher(ctx, watcher, eventHandler)
+
+	assert.Len(t, handler.addEvents, 1)
+	assert.Len(t, handler.updateEvents, 1)
+	assert.Equal(t, "2", lw.CurrentRevision)
+}
+
+func TestGenericListWatcher_LoopReadingFromWatcher_ChannelClosed(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	watcher := newMockWatcher()
+	ctx := context.Background()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		watcher.SendEvent(WatchEvent{
+			Type: WatchAdded,
+			New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "k1"}, Value: "v1", Revision: "1"},
+		})
+		time.Sleep(10 * time.Millisecond)
+		watcher.Stop()
+	}()
+
+	eventHandler := func(event WatchEvent) error {
+		lw.HandleBasicWatchEvent(event)
+		return nil
+	}
+
+	lw.LoopReadingFromWatcher(ctx, watcher, eventHandler)
+
+	assert.Len(t, handler.addEvents, 1)
+}
+
+func TestGenericListWatcher_LoopReadingFromWatcher_ErrorStopsLoop(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	watcher := newMockWatcher()
+	ctx := context.Background()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		watcher.SendEvent(WatchEvent{
+			Type: WatchAdded,
+			New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "k1"}, Value: "v1", Revision: "1"},
+		})
+		watcher.SendEvent(WatchEvent{
+			Type:  WatchError,
+			Error: errors.New("watch error"),
+		})
+		// This event should not be processed
+		watcher.SendEvent(WatchEvent{
+			Type: WatchAdded,
+			New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "k2"}, Value: "v2", Revision: "2"},
+		})
+	}()
+
+	eventHandler := func(event WatchEvent) error {
+		if event.Type == WatchError {
+			return event.Error
+		}
+		lw.HandleBasicWatchEvent(event)
+		return nil
+	}
+
+	lw.LoopReadingFromWatcher(ctx, watcher, eventHandler)
+
+	// Only first event should be processed
+	assert.Len(t, handler.addEvents, 1)
+}
+
+// ============================================================================
+// Watcher Cleanup Tests
+// ============================================================================
+
+func TestGenericListWatcher_CleanExistingWatcher(t *testing.T) {
+	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
+
+	// With watcher - should stop and nil it
+	watcher := newMockWatcher()
+	lw.Watch = watcher
+	assert.False(t, watcher.stopped)
+
+	lw.CleanExistingWatcher()
+	assert.True(t, watcher.stopped)
+	assert.Nil(t, lw.Watch)
+
+	// With nil watcher - should not panic
+	lw.Watch = nil
+	lw.CleanExistingWatcher()
+	assert.Nil(t, lw.Watch)
+}
+
+// ============================================================================
+// PerformListSync Tests
+// ============================================================================
+
+func TestPerformListSync_Success(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+
+	err := lw.PerformListSync(context.Background(), backend)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 1, handler.syncCount)
+	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.False(t, lw.InitialSyncPending) // Should be cleared after successful sync
+}
+
+func TestPerformListSync_ListError(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+	backend.listError = errors.New("list failed")
+
+	listErrorCalled := false
+	backend.listErrorHandler = func(err error) {
+		listErrorCalled = true
+	}
+
+	err := lw.PerformListSync(context.Background(), backend)
+
+	assert.Error(t, err)
+	assert.True(t, listErrorCalled)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 0, handler.syncCount) // Sync should not be called on error
+}
+
+func TestPerformListSync_EmptyRevisionNoItems(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+	backend.listResult = &model.KVPairList{
+		KVPairs:  []*model.KVPair{}, // No items
+		Revision: "",                // Empty revision
+	}
+
+	err := lw.PerformListSync(context.Background(), backend)
+
+	// Should return error and schedule retry (poll mode)
+	assert.Error(t, err)
+	assert.Equal(t, "", lw.CurrentRevision) // Should reset for resync
+	assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
+}
+
+func TestPerformListSync_ZeroRevisionNoItems(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+	backend.listResult = &model.KVPairList{
+		KVPairs:  []*model.KVPair{}, // No items
+		Revision: "",                // Zero revision
+	}
+
+	err := lw.PerformListSync(context.Background(), backend)
+
+	// Should return error and schedule retry (poll mode)
+	assert.Error(t, err)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestPerformListSync_ZeroRevisionWithItems_Panics(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+	backend.listResult = &model.KVPairList{
+		KVPairs: []*model.KVPair{
+			{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+		},
+		Revision: "", // Zero revision with items - BUG condition
+	}
+
+	// Should panic due to inconsistent state
+	assert.Panics(t, func() {
+		lw.PerformListSync(context.Background(), backend)
+	})
+}
+
+// ============================================================================
+// RunLoopWithBackend Integration Tests
+// ============================================================================
+
+func TestGenericListWatcher_RunLoopWithBackend_SuccessfulSync(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+	watcher := newMockWatcher()
+	backend.watchResult = watcher
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error)
+	go func() {
+		done <- lw.RunLoopWithBackend(ctx, backend)
+	}()
+
+	// Wait a bit for initial sync to complete
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a watch event
+	watcher.SendEvent(WatchEvent{
+		Type: WatchAdded,
+		New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "new-key"}, Value: "new-value", Revision: "101"},
+	})
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	assert.Equal(t, context.Canceled, err)
+
+	// Verify initial sync occurred
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 1, handler.syncCount)
+	assert.GreaterOrEqual(t, len(handler.addEvents), 1)
+}
+
+func TestGenericListWatcher_RunLoopWithBackend_WatchCreationFails(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	backend := newMockListWatchBackend()
+	backend.watchError = errors.New("watch creation failed")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := lw.RunLoopWithBackend(ctx, backend)
+
+	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.GreaterOrEqual(t, backend.watchErrorCalls, 1)
+}
+
+func TestGenericListWatcher_RunLoopWithBackend_NoResyncNeeded(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+	lw.UpdateRevision("100")     // Already has a revision
+	lw.MarkInitialSyncComplete() // No resync needed
+
+	backend := newMockListWatchBackend()
+	watcher := newMockWatcher()
+	backend.watchResult = watcher
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error)
+	go func() {
+		done <- lw.RunLoopWithBackend(ctx, backend)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	assert.Equal(t, context.Canceled, err)
+
+	// No resync should occur
+	assert.Equal(t, 0, handler.resyncStartedCt)
+}
+
+func TestGenericListWatcher_CreateWatchUsesWatchListOnlyWhenInitialSyncPendingAndSupported(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialSyncPending bool
+		supportsWatchList  bool
+		omitSupporter      bool
+		expected           bool
+	}{
+		{
+			name:               "initial sync and WatchList supported",
+			initialSyncPending: true,
+			supportsWatchList:  true,
+			expected:           true,
+		},
+		{
+			name:               "initial sync but WatchList not supported",
+			initialSyncPending: true,
+			supportsWatchList:  false,
+			expected:           false,
+		},
+		{
+			name:               "initial sync and backend does not implement WatchListSupporter",
+			initialSyncPending: true,
+			omitSupporter:      true,
+			expected:           false,
+		},
+		{
+			name:               "incremental watch",
+			initialSyncPending: false,
+			supportsWatchList:  true,
+			expected:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newMockEventHandler()
+			lw := NewGenericListWatcher(testListOptions(), handler)
+			lw.InitialSyncPending = tt.initialSyncPending
+			if !tt.initialSyncPending {
+				lw.UpdateRevision("100")
+			}
+
+			baseBackend := newMockListWatchBackend()
+			baseBackend.watchResult = newMockWatcher()
+			var backend ListWatchBackend = &mockWatchListBackend{
+				mockListWatchBackend: baseBackend,
+				supportsWatchList:    tt.supportsWatchList,
+			}
+			if tt.omitSupporter {
+				backend = &mockInitialSyncPendingBackend{
+					mockListWatchBackend: baseBackend,
+				}
+			}
+
+			lw.maybeResyncAndCreateWatcher(context.Background(), backend)
+
+			require.Len(t, baseBackend.createWatchArguments, 1)
+			assert.Equal(t, tt.expected, baseBackend.createWatchArguments[0])
+		})
+	}
+}
+
+func TestGenericListWatcher_RunLoopWithBackend_WatchChannelClosed_Recreates(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	watcherCount := 0
+	backend := newMockListWatchBackend()
+
+	// Create multiple watchers to simulate reconnection
+	originalCreateWatch := backend.CreateWatch
+	_ = originalCreateWatch
+	backend.watchResult = nil
+
+	// Custom mock that creates new watchers
+	var currentWatcher *mockWatcher
+	backend = &mockListWatchBackend{
+		listResult: &model.KVPairList{
+			KVPairs:  []*model.KVPair{{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"}},
+			Revision: "100",
+		},
+	}
+
+	// Override watch creation to track calls
+	createWatchCalls := 0
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		for ctx.Err() == nil {
+			createWatchCalls++
+			currentWatcher = newMockWatcher()
+			// Close the watcher after a short time to trigger reconnection
+			go func(w *mockWatcher) {
+				time.Sleep(50 * time.Millisecond)
+				w.Stop()
+			}(currentWatcher)
+
+			lw.Watch = currentWatcher
+			lw.loopReadingFromWatcherWithBackend(ctx, backend)
+			watcherCount++
+			if watcherCount >= 2 {
+				cancel()
+				break
+			}
+		}
+		done <- nil
+	}()
+
+	<-done
+
+	// Verify multiple watchers were created due to channel close
+	require.GreaterOrEqual(t, watcherCount, 1)
+}

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -859,6 +859,7 @@ func TestGenericListWatcher_WatchListCreateFailureFallsBackToList(t *testing.T) 
 
 	require.Equal(t, []bool{true, false}, baseBackend.createWatchArguments)
 	require.Equal(t, []bool{false}, baseBackend.performInitialSyncArguments)
+	assert.Equal(t, 0, baseBackend.watchErrorCalls)
 	assert.Equal(t, fallbackWatcher, createdWatcher)
 	assert.True(t, watchListWatcher.stopped)
 	assert.False(t, fallbackWatcher.stopped)

--- a/libcalico-go/lib/backend/api/listwatcher_test.go
+++ b/libcalico-go/lib/backend/api/listwatcher_test.go
@@ -107,13 +107,16 @@ func (w *mockWatcher) SendEvent(event WatchEvent) {
 
 // mockListWatchBackend implements ListWatchBackend for testing
 type mockListWatchBackend struct {
-	listResult           *model.KVPairList
-	listError            error
-	watchResult          WatchInterface
-	watchError           error
-	listErrorHandler     func(error)
-	watchErrorCalls      int
-	createWatchArguments []bool
+	listResult                  *model.KVPairList
+	listError                   error
+	watchResult                 WatchInterface
+	watchResults                []WatchInterface
+	watchError                  error
+	watchErrors                 []error
+	listErrorHandler            func(error)
+	watchErrorCalls             int
+	createWatchArguments        []bool
+	performInitialSyncArguments []bool
 }
 
 func newMockListWatchBackend() *mockListWatchBackend {
@@ -133,7 +136,17 @@ func (m *mockListWatchBackend) PerformList(ctx context.Context) (*model.KVPairLi
 
 func (m *mockListWatchBackend) CreateWatch(ctx context.Context, useWatchList bool) (WatchInterface, error) {
 	m.createWatchArguments = append(m.createWatchArguments, useWatchList)
-	return m.watchResult, m.watchError
+	watchResult := m.watchResult
+	if len(m.watchResults) > 0 {
+		watchResult = m.watchResults[0]
+		m.watchResults = m.watchResults[1:]
+	}
+	if len(m.watchErrors) > 0 {
+		err := m.watchErrors[0]
+		m.watchErrors = m.watchErrors[1:]
+		return watchResult, err
+	}
+	return watchResult, m.watchError
 }
 
 func (m *mockListWatchBackend) HandleWatchEvent(event WatchEvent) error {
@@ -150,7 +163,8 @@ func (m *mockListWatchBackend) HandleWatchError(err error) {
 	m.watchErrorCalls++
 }
 
-func (m *mockListWatchBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher) error {
+func (m *mockListWatchBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher, useWatchList bool) error {
+	m.performInitialSyncArguments = append(m.performInitialSyncArguments, useWatchList)
 	return g.PerformListSync(ctx, m)
 }
 
@@ -163,7 +177,11 @@ func (m *mockWatchListBackend) SupportsWatchList() bool {
 	return m.supportsWatchList
 }
 
-func (m *mockWatchListBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher) error {
+func (m *mockWatchListBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher, useWatchList bool) error {
+	m.performInitialSyncArguments = append(m.performInitialSyncArguments, useWatchList)
+	if !useWatchList {
+		return g.PerformListSync(ctx, m.mockListWatchBackend)
+	}
 	g.Handler.OnResyncStarted()
 	return nil
 }
@@ -172,9 +190,9 @@ type mockInitialSyncPendingBackend struct {
 	*mockListWatchBackend
 }
 
-func (m *mockInitialSyncPendingBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher) error {
-	g.Handler.OnResyncStarted()
-	return nil
+func (m *mockInitialSyncPendingBackend) PerformInitialSync(ctx context.Context, g *GenericListWatcher, useWatchList bool) error {
+	m.performInitialSyncArguments = append(m.performInitialSyncArguments, useWatchList)
+	return g.PerformListSync(ctx, m.mockListWatchBackend)
 }
 
 // testListOptions returns a real ListInterface for testing
@@ -565,7 +583,7 @@ func TestGenericListWatcher_LoopReadingFromWatcher_ErrorStopsLoop(t *testing.T) 
 // Watcher Cleanup Tests
 // ============================================================================
 
-func TestGenericListWatcher_CleanExistingWatcher(t *testing.T) {
+func TestGenericListWatcher_StopWatch(t *testing.T) {
 	lw := NewGenericListWatcher(testListOptions(), newMockEventHandler())
 
 	// With watcher - should stop and nil it
@@ -573,13 +591,13 @@ func TestGenericListWatcher_CleanExistingWatcher(t *testing.T) {
 	lw.Watch = watcher
 	assert.False(t, watcher.stopped)
 
-	lw.CleanExistingWatcher()
+	lw.stopWatch()
 	assert.True(t, watcher.stopped)
 	assert.Nil(t, lw.Watch)
 
 	// With nil watcher - should not panic
 	lw.Watch = nil
-	lw.CleanExistingWatcher()
+	lw.stopWatch()
 	assert.Nil(t, lw.Watch)
 }
 
@@ -677,10 +695,10 @@ func TestPerformListSync_ZeroRevisionWithItems_Panics(t *testing.T) {
 }
 
 // ============================================================================
-// RunLoopWithBackend Integration Tests
+// ListAndWatchWithBackend Integration Tests
 // ============================================================================
 
-func TestGenericListWatcher_RunLoopWithBackend_SuccessfulSync(t *testing.T) {
+func TestGenericListWatcher_ListAndWatchWithBackend_SuccessfulSync(t *testing.T) {
 	handler := newMockEventHandler()
 	lw := NewGenericListWatcher(testListOptions(), handler)
 
@@ -692,7 +710,7 @@ func TestGenericListWatcher_RunLoopWithBackend_SuccessfulSync(t *testing.T) {
 
 	done := make(chan error)
 	go func() {
-		done <- lw.RunLoopWithBackend(ctx, backend)
+		done <- lw.ListAndWatchWithBackend(ctx, backend)
 	}()
 
 	// Wait a bit for initial sync to complete
@@ -716,7 +734,7 @@ func TestGenericListWatcher_RunLoopWithBackend_SuccessfulSync(t *testing.T) {
 	assert.GreaterOrEqual(t, len(handler.addEvents), 1)
 }
 
-func TestGenericListWatcher_RunLoopWithBackend_WatchCreationFails(t *testing.T) {
+func TestGenericListWatcher_ListAndWatchWithBackend_WatchCreationFails(t *testing.T) {
 	handler := newMockEventHandler()
 	lw := NewGenericListWatcher(testListOptions(), handler)
 
@@ -726,13 +744,13 @@ func TestGenericListWatcher_RunLoopWithBackend_WatchCreationFails(t *testing.T) 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := lw.RunLoopWithBackend(ctx, backend)
+	err := lw.ListAndWatchWithBackend(ctx, backend)
 
 	assert.Equal(t, context.DeadlineExceeded, err)
 	assert.GreaterOrEqual(t, backend.watchErrorCalls, 1)
 }
 
-func TestGenericListWatcher_RunLoopWithBackend_NoResyncNeeded(t *testing.T) {
+func TestGenericListWatcher_ListAndWatchWithBackend_NoResyncNeeded(t *testing.T) {
 	handler := newMockEventHandler()
 	lw := NewGenericListWatcher(testListOptions(), handler)
 	lw.UpdateRevision("100")     // Already has a revision
@@ -746,7 +764,7 @@ func TestGenericListWatcher_RunLoopWithBackend_NoResyncNeeded(t *testing.T) {
 
 	done := make(chan error)
 	go func() {
-		done <- lw.RunLoopWithBackend(ctx, backend)
+		done <- lw.ListAndWatchWithBackend(ctx, backend)
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -814,15 +832,44 @@ func TestGenericListWatcher_CreateWatchUsesWatchListOnlyWhenInitialSyncPendingAn
 				}
 			}
 
-			lw.maybeResyncAndCreateWatcher(context.Background(), backend)
+			watcher := lw.startWatch(context.Background(), backend)
 
 			require.Len(t, baseBackend.createWatchArguments, 1)
 			assert.Equal(t, tt.expected, baseBackend.createWatchArguments[0])
+			assert.NotNil(t, watcher)
 		})
 	}
 }
 
-func TestGenericListWatcher_RunLoopWithBackend_WatchChannelClosed_Recreates(t *testing.T) {
+func TestGenericListWatcher_WatchListCreateFailureFallsBackToList(t *testing.T) {
+	handler := newMockEventHandler()
+	lw := NewGenericListWatcher(testListOptions(), handler)
+
+	watchListWatcher := newMockWatcher()
+	fallbackWatcher := newMockWatcher()
+	baseBackend := newMockListWatchBackend()
+	baseBackend.watchResults = []WatchInterface{watchListWatcher, fallbackWatcher}
+	baseBackend.watchErrors = []error{errors.New("watchlist failed"), nil}
+	backend := &mockWatchListBackend{
+		mockListWatchBackend: baseBackend,
+		supportsWatchList:    true,
+	}
+
+	createdWatcher := lw.startWatch(context.Background(), backend)
+
+	require.Equal(t, []bool{true, false}, baseBackend.createWatchArguments)
+	require.Equal(t, []bool{false}, baseBackend.performInitialSyncArguments)
+	assert.Equal(t, fallbackWatcher, createdWatcher)
+	assert.True(t, watchListWatcher.stopped)
+	assert.False(t, fallbackWatcher.stopped)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 1, handler.syncCount)
+	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestGenericListWatcher_WatchChannelClosed_Recreates(t *testing.T) {
 	handler := newMockEventHandler()
 	lw := NewGenericListWatcher(testListOptions(), handler)
 
@@ -859,8 +906,7 @@ func TestGenericListWatcher_RunLoopWithBackend_WatchChannelClosed_Recreates(t *t
 				w.Stop()
 			}(currentWatcher)
 
-			lw.Watch = currentWatcher
-			lw.loopReadingFromWatcherWithBackend(ctx, backend)
+			lw.watch(ctx, backend, currentWatcher)
 			watcherCount++
 			if watcherCount >= 2 {
 				cancel()

--- a/libcalico-go/lib/backend/etcdv3/listwatcher.go
+++ b/libcalico-go/lib/backend/etcdv3/listwatcher.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdv3
+
+import (
+	"context"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// ListWatcher encapsulates the list-watch logic for etcd backend.
+// It embeds GenericListWatcher for common functionality and implements
+// the ListWatchBackend interface for etcd-specific logic.
+type ListWatcher struct {
+	*api.GenericListWatcher
+	client *etcdV3Client
+}
+
+// Ensure ListWatcher implements ListWatchBackend
+var _ api.ListWatchBackend = (*ListWatcher)(nil)
+
+// ListAndWatch implements the list-and-watch pattern for etcd resources.
+// For etcd, this uses the existing watcher implementation which already handles
+// both list and watch operations internally. Unlike kubernetes, etcd doesn't need
+// separate handling for bookmarks, CRD installation, or WatchList fallbacks.
+func (c *etcdV3Client) ListAndWatch(ctx context.Context, l model.ListInterface, handler api.EventHandler) error {
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(l, handler),
+		client:             c,
+	}
+	return lw.RunLoopWithBackend(ctx, lw)
+}
+
+// PerformList implements ListWatchBackend.PerformList for etcd.
+func (lw *ListWatcher) PerformList(ctx context.Context) (*model.KVPairList, error) {
+	return lw.client.List(ctx, lw.List, "")
+}
+
+// CreateWatch implements ListWatchBackend.CreateWatch for etcd.
+func (lw *ListWatcher) CreateWatch(ctx context.Context, useWatchList bool) (api.WatchInterface, error) {
+	return lw.client.Watch(ctx, lw.List, api.WatchOptions{
+		Revision: lw.CurrentRevision,
+	})
+}
+
+// HandleWatchEvent implements ListWatchBackend.HandleWatchEvent for etcd.
+func (lw *ListWatcher) HandleWatchEvent(event api.WatchEvent) error {
+	// Try to handle basic events (Added, Modified, Deleted) using common method
+	if lw.HandleBasicWatchEvent(event) {
+		return nil // continue processing
+	}
+
+	// Handle etcd-specific events
+	switch event.Type {
+	case api.WatchError:
+		lw.Logger.WithError(event.Error).Warn("Received watch error from etcd")
+
+		// Increment error count and check if we need a full resync
+		if lw.IncrementErrorCount() {
+			lw.Logger.Warn("Too many errors at current revision, triggering full resync")
+			lw.ResetForFullResync()
+		} else {
+			// Not yet hit the error threshold, just log and retry
+			lw.Logger.Info("Watch of resource finished. Attempting to restart it...")
+		}
+
+		return event.Error // stop processing, will recreate watcher
+
+	default:
+		lw.Logger.WithField("eventType", event.Type).Warn("Unexpected watch event type")
+	}
+
+	return nil
+}
+
+// HandleListError implements ListWatchBackend.HandleListError for etcd.
+// etcd uses generic error handling for all list errors.
+func (lw *ListWatcher) HandleListError(err error) {
+	lw.Logger.WithError(err).Info("Failed to list resources")
+
+	// Check if we've been disconnected too long
+	if lw.CheckConnectionTimeout() {
+		lw.Logger.Warn("Connection has failed for too long")
+		lw.Handler.OnError(err)
+	}
+
+	// Schedule retry with delay
+	lw.RetryAfter(api.ListRetryInterval)
+}
+
+// HandleWatchError implements ListWatchBackend.HandleWatchError for etcd.
+func (lw *ListWatcher) HandleWatchError(err error) {
+	// None of our expected errors, retry a few times before we give up
+	if lw.IncrementErrorCount() {
+		// Too many errors at the current revision, trigger a full resync
+		lw.Logger.WithError(err).Warn("Watch repeatedly failed without making progress, triggering full resync")
+		lw.ResetForFullResync()
+		return
+	}
+
+	lw.Logger.WithError(err).Warn("Watch of resource finished. Attempting to restart it...")
+}
+
+// PerformInitialSync implements ListWatchBackend.PerformInitialSync for etcd.
+// etcd uses traditional List+Watch mode: list all resources first, then watch for changes.
+func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher) error {
+	return g.PerformListSync(ctx, lw)
+}

--- a/libcalico-go/lib/backend/etcdv3/listwatcher.go
+++ b/libcalico-go/lib/backend/etcdv3/listwatcher.go
@@ -41,7 +41,7 @@ func (c *etcdV3Client) ListAndWatch(ctx context.Context, l model.ListInterface, 
 		GenericListWatcher: api.NewGenericListWatcher(l, handler),
 		client:             c,
 	}
-	return lw.RunLoopWithBackend(ctx, lw)
+	return lw.ListAndWatchWithBackend(ctx, lw)
 }
 
 // PerformList implements ListWatchBackend.PerformList for etcd.
@@ -89,33 +89,16 @@ func (lw *ListWatcher) HandleWatchEvent(event api.WatchEvent) error {
 // HandleListError implements ListWatchBackend.HandleListError for etcd.
 // etcd uses generic error handling for all list errors.
 func (lw *ListWatcher) HandleListError(err error) {
-	lw.Logger.WithError(err).Info("Failed to list resources")
-
-	// Check if we've been disconnected too long
-	if lw.CheckConnectionTimeout() {
-		lw.Logger.Warn("Connection has failed for too long")
-		lw.Handler.OnError(err)
-	}
-
-	// Schedule retry with delay
-	lw.RetryAfter(lw.Options.ListRetryInterval)
+	lw.GenericListWatcher.HandleListError(err)
 }
 
 // HandleWatchError implements ListWatchBackend.HandleWatchError for etcd.
 func (lw *ListWatcher) HandleWatchError(err error) {
-	// None of our expected errors, retry a few times before we give up
-	if lw.IncrementErrorCount() {
-		// Too many errors at the current revision, trigger a full resync
-		lw.Logger.WithError(err).Warn("Watch repeatedly failed without making progress, triggering full resync")
-		lw.ResetForFullResync()
-		return
-	}
-
-	lw.Logger.WithError(err).Warn("Watch of resource finished. Attempting to restart it...")
+	lw.GenericListWatcher.HandleWatchError(err)
 }
 
 // PerformInitialSync implements ListWatchBackend.PerformInitialSync for etcd.
 // etcd uses traditional List+Watch mode: list all resources first, then watch for changes.
-func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher) error {
+func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher, useWatchList bool) error {
 	return g.PerformListSync(ctx, lw)
 }

--- a/libcalico-go/lib/backend/etcdv3/listwatcher.go
+++ b/libcalico-go/lib/backend/etcdv3/listwatcher.go
@@ -36,9 +36,9 @@ var _ api.ListWatchBackend = (*ListWatcher)(nil)
 // For etcd, this uses the existing watcher implementation which already handles
 // both list and watch operations internally. Unlike kubernetes, etcd doesn't need
 // separate handling for bookmarks, CRD installation, or WatchList fallbacks.
-func (c *etcdV3Client) ListAndWatch(ctx context.Context, l model.ListInterface, handler api.EventHandler) error {
+func (c *etcdV3Client) ListAndWatch(ctx context.Context, l model.ListInterface, handler api.EventHandler, opts ...api.ListWatcherOption) error {
 	lw := &ListWatcher{
-		GenericListWatcher: api.NewGenericListWatcher(l, handler),
+		GenericListWatcher: api.NewGenericListWatcher(l, handler, opts...),
 		client:             c,
 	}
 	return lw.ListAndWatchWithBackend(ctx, lw)

--- a/libcalico-go/lib/backend/etcdv3/listwatcher.go
+++ b/libcalico-go/lib/backend/etcdv3/listwatcher.go
@@ -98,7 +98,7 @@ func (lw *ListWatcher) HandleListError(err error) {
 	}
 
 	// Schedule retry with delay
-	lw.RetryAfter(api.ListRetryInterval)
+	lw.RetryAfter(lw.Options.ListRetryInterval)
 }
 
 // HandleWatchError implements ListWatchBackend.HandleWatchError for etcd.

--- a/libcalico-go/lib/backend/etcdv3/listwatcher_test.go
+++ b/libcalico-go/lib/backend/etcdv3/listwatcher_test.go
@@ -1,0 +1,550 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdv3
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+// mockEventHandler implements api.EventHandler for testing
+type mockEventHandler struct {
+	addEvents       []*model.KVPair
+	updateEvents    []*model.KVPair
+	deleteEvents    []*model.KVPair
+	syncCount       int
+	resyncStartedCt int
+	errors          []error
+}
+
+func newMockEventHandler() *mockEventHandler {
+	return &mockEventHandler{
+		addEvents:    make([]*model.KVPair, 0),
+		updateEvents: make([]*model.KVPair, 0),
+		deleteEvents: make([]*model.KVPair, 0),
+		errors:       make([]error, 0),
+	}
+}
+
+func (m *mockEventHandler) OnResyncStarted() {
+	m.resyncStartedCt++
+}
+
+func (m *mockEventHandler) OnAdd(kvp *model.KVPair) {
+	m.addEvents = append(m.addEvents, kvp)
+}
+
+func (m *mockEventHandler) OnUpdate(kvp *model.KVPair) {
+	m.updateEvents = append(m.updateEvents, kvp)
+}
+
+func (m *mockEventHandler) OnDelete(kvp *model.KVPair) {
+	m.deleteEvents = append(m.deleteEvents, kvp)
+}
+
+func (m *mockEventHandler) OnSync() {
+	m.syncCount++
+}
+
+func (m *mockEventHandler) OnError(err error) {
+	m.errors = append(m.errors, err)
+}
+
+// mockWatcher implements api.WatchInterface for testing
+type mockWatcher struct {
+	events     chan api.WatchEvent
+	stopped    bool
+	terminated bool
+}
+
+func newMockWatcher() *mockWatcher {
+	return &mockWatcher{
+		events: make(chan api.WatchEvent, 10),
+	}
+}
+
+func (w *mockWatcher) Stop() {
+	if !w.stopped {
+		w.stopped = true
+		close(w.events)
+	}
+}
+
+func (w *mockWatcher) ResultChan() <-chan api.WatchEvent {
+	return w.events
+}
+
+func (w *mockWatcher) HasTerminated() bool {
+	return w.terminated
+}
+
+func (w *mockWatcher) SendEvent(event api.WatchEvent) {
+	w.events <- event
+}
+
+// testListOptions returns a real ListInterface for testing
+func testListOptions() model.ListInterface {
+	return model.GlobalConfigListOptions{}
+}
+
+// ============================================================================
+// ListWatcher Creation Tests
+// ============================================================================
+
+func TestListWatcher_Creation(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil, // We don't need a real client for this test
+	}
+
+	assert.NotNil(t, lw)
+	assert.NotNil(t, lw.GenericListWatcher)
+	assert.Equal(t, list, lw.List)
+	assert.Equal(t, handler, lw.Handler)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+// ============================================================================
+// HandleWatchEvent Tests
+// ============================================================================
+
+func TestListWatcher_HandleWatchEvent_Added(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	event := api.WatchEvent{
+		Type: api.WatchAdded,
+		New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "val", Revision: "10"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, "10", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Modified(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	event := api.WatchEvent{
+		Type: api.WatchModified,
+		Old:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "old", Revision: "5"},
+		New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "new", Revision: "20"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Len(t, handler.updateEvents, 1)
+	assert.Equal(t, "new", handler.updateEvents[0].Value)
+	assert.Equal(t, "20", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Deleted(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	event := api.WatchEvent{
+		Type: api.WatchDeleted,
+		Old:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "val", Revision: "30"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Len(t, handler.deleteEvents, 1)
+	assert.Equal(t, "30", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Error_BelowThreshold(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	lw.CurrentRevision = "100"
+
+	testErr := errors.New("watch error")
+	event := api.WatchEvent{
+		Type:  api.WatchError,
+		Error: testErr,
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	// Should return the error to stop processing
+	assert.Error(t, err)
+	assert.Equal(t, testErr, err)
+	// Should not reset revision (below error threshold)
+	assert.Equal(t, "100", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Error_ExceedsThreshold(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	lw.CurrentRevision = "100"
+
+	// Set error count close to threshold
+	for i := 0; i < api.MaxErrorsPerRevision-1; i++ {
+		lw.IncrementErrorCount()
+	}
+
+	testErr := errors.New("watch error")
+	event := api.WatchEvent{
+		Type:  api.WatchError,
+		Error: testErr,
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	// Should return the error to stop processing
+	assert.Error(t, err)
+	// Should reset for full resync after exceeding threshold
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_UnknownType(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	event := api.WatchEvent{
+		Type: api.WatchEventType("UNKNOWN"),
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	// Should return nil (just log warning)
+	assert.NoError(t, err)
+}
+
+// ============================================================================
+// HandleListError Tests
+// ============================================================================
+
+func TestListWatcher_HandleListError_GenericError(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	genericErr := errors.New("list failed")
+
+	lw.HandleListError(genericErr)
+
+	// Should schedule a retry
+	assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
+}
+
+func TestListWatcher_HandleListError_ConnectionTimeout(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	// Set last connection to past timeout
+	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+
+	genericErr := errors.New("connection error")
+
+	lw.HandleListError(genericErr)
+
+	// Should call OnError due to timeout
+	assert.Len(t, handler.errors, 1)
+}
+
+// ============================================================================
+// HandleWatchError Tests
+// ============================================================================
+
+func TestListWatcher_HandleWatchError_BelowThreshold(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	lw.CurrentRevision = "100"
+
+	genericErr := errors.New("watch error")
+
+	lw.HandleWatchError(genericErr)
+
+	// Should not reset revision (below threshold)
+	assert.Equal(t, "100", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchError_ExceedsThreshold(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	lw.CurrentRevision = "100"
+
+	// Set error count close to threshold
+	for i := 0; i < api.MaxErrorsPerRevision-1; i++ {
+		lw.IncrementErrorCount()
+	}
+
+	genericErr := errors.New("watch error")
+
+	lw.HandleWatchError(genericErr)
+
+	// Should reset for full resync after exceeding threshold
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+// ============================================================================
+// InitialSyncPending Tests
+// ============================================================================
+
+func TestListWatcher_InitialSyncPending_Initial(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// Initial state: InitialSyncPending=true
+	assert.True(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_InitialSyncPending_AfterSync(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	lw.CurrentRevision = "100"
+	lw.MarkInitialSyncComplete() // Clear the initial sync flag
+
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_InitialSyncPending_AfterReset(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+	lw.CurrentRevision = "100"
+	lw.MarkInitialSyncComplete()
+	lw.ResetForFullResync()
+
+	assert.True(t, lw.InitialSyncPending)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+// ============================================================================
+// PerformInitialSync Tests
+// ============================================================================
+
+func TestListWatcher_PerformInitialSync(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// etcd uses PerformListSync internally, which requires a working client
+	// We can verify the method exists and the ListWatcher implements ListWatchBackend
+	var _ api.ListWatchBackend = lw
+
+	// Verify initial state
+	assert.True(t, lw.InitialSyncPending)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+// ============================================================================
+// Boundary and Edge Case Tests
+// ============================================================================
+
+func TestListWatcher_HandleWatchEvent_MissingValue(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// Added without New value
+	event := api.WatchEvent{Type: api.WatchAdded, New: nil}
+	err := lw.HandleWatchEvent(event)
+	assert.NoError(t, err)              // Handled (with error log)
+	assert.Len(t, handler.addEvents, 0) // No event added
+
+	// Modified without New value
+	event = api.WatchEvent{Type: api.WatchModified, New: nil}
+	err = lw.HandleWatchEvent(event)
+	assert.NoError(t, err)
+	assert.Len(t, handler.updateEvents, 0)
+
+	// Deleted without Old value
+	event = api.WatchEvent{Type: api.WatchDeleted, Old: nil}
+	err = lw.HandleWatchEvent(event)
+	assert.NoError(t, err)
+	assert.Len(t, handler.deleteEvents, 0)
+}
+
+func TestListWatcher_MultipleRevisionsInSequence(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// Simulate a sequence of revisions
+	revisions := []string{"10", "20", "30", "40", "50"}
+
+	for _, rev := range revisions {
+		event := api.WatchEvent{
+			Type: api.WatchAdded,
+			New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "key"}, Value: "val", Revision: rev},
+		}
+		err := lw.HandleWatchEvent(event)
+		assert.NoError(t, err)
+		assert.Equal(t, rev, lw.CurrentRevision)
+	}
+
+	assert.Equal(t, "50", lw.CurrentRevision)
+	assert.Len(t, handler.addEvents, 5)
+}
+
+func TestListWatcher_ErrorCountResetOnNewRevision(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// Accumulate errors at revision "100"
+	lw.UpdateRevision("100")
+	for i := 0; i < 3; i++ {
+		lw.IncrementErrorCount()
+	}
+	assert.Equal(t, 3, lw.ErrorCountAtCurrentRev)
+
+	// Update to new revision - errors should reset
+	lw.UpdateRevision("200")
+	assert.Equal(t, 0, lw.ErrorCountAtCurrentRev)
+
+	// Accumulate more errors
+	for i := 0; i < 2; i++ {
+		lw.IncrementErrorCount()
+	}
+	assert.Equal(t, 2, lw.ErrorCountAtCurrentRev)
+}
+
+func TestListWatcher_ConnectionTimeoutBoundary(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// Just under timeout
+	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout + time.Second)
+	assert.False(t, lw.CheckConnectionTimeout())
+
+	// Just over timeout
+	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+	assert.True(t, lw.CheckConnectionTimeout())
+}
+
+// ============================================================================
+// Watch Bookmark Tests (etcd doesn't use bookmarks, but verify handling)
+// ============================================================================
+
+func TestListWatcher_HandleWatchEvent_Bookmark(t *testing.T) {
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             nil,
+	}
+
+	// etcd doesn't use bookmarks, but HandleBasicWatchEvent will return false
+	event := api.WatchEvent{
+		Type: api.WatchBookmark,
+		New:  &model.KVPair{Revision: "100"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	// Bookmark is not a basic watch event, so it falls through to unknown type warning
+	assert.NoError(t, err)
+}

--- a/libcalico-go/lib/backend/etcdv3/listwatcher_test.go
+++ b/libcalico-go/lib/backend/etcdv3/listwatcher_test.go
@@ -230,7 +230,7 @@ func TestListWatcher_HandleWatchEvent_Error_ExceedsThreshold(t *testing.T) {
 	lw.CurrentRevision = "100"
 
 	// Set error count close to threshold
-	for i := 0; i < api.MaxErrorsPerRevision-1; i++ {
+	for i := 0; i < lw.Options.MaxErrorsPerRevision-1; i++ {
 		lw.IncrementErrorCount()
 	}
 
@@ -297,7 +297,7 @@ func TestListWatcher_HandleListError_ConnectionTimeout(t *testing.T) {
 		client:             nil,
 	}
 	// Set last connection to past timeout
-	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+	lw.LastSuccessfulConnTime = time.Now().Add(-lw.Options.WatchRetryTimeout - time.Second)
 
 	genericErr := errors.New("connection error")
 
@@ -340,7 +340,7 @@ func TestListWatcher_HandleWatchError_ExceedsThreshold(t *testing.T) {
 	lw.CurrentRevision = "100"
 
 	// Set error count close to threshold
-	for i := 0; i < api.MaxErrorsPerRevision-1; i++ {
+	for i := 0; i < lw.Options.MaxErrorsPerRevision-1; i++ {
 		lw.IncrementErrorCount()
 	}
 
@@ -516,11 +516,11 @@ func TestListWatcher_ConnectionTimeoutBoundary(t *testing.T) {
 	}
 
 	// Just under timeout
-	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout + time.Second)
+	lw.LastSuccessfulConnTime = time.Now().Add(-lw.Options.WatchRetryTimeout + time.Second)
 	assert.False(t, lw.CheckConnectionTimeout())
 
 	// Just over timeout
-	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+	lw.LastSuccessfulConnTime = time.Now().Add(-lw.Options.WatchRetryTimeout - time.Second)
 	assert.True(t, lw.CheckConnectionTimeout())
 }
 

--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -759,7 +759,7 @@ func (c *KubeClient) Watch(ctx context.Context, l model.ListInterface, options a
 // - WatchList support with fallback to List+Watch
 // - Error handling for k8s-specific errors (NotFound, ResourceExpired, etc.)
 // - Connection failure detection and recovery
-func (c *KubeClient) ListAndWatch(ctx context.Context, l model.ListInterface, handler api.EventHandler) error {
+func (c *KubeClient) ListAndWatch(ctx context.Context, l model.ListInterface, handler api.EventHandler, opts ...api.ListWatcherOption) error {
 	log.Debugf("Performing 'ListAndWatch' for %+v %v", l, reflect.TypeOf(l))
 
 	// Get the resource client
@@ -773,6 +773,6 @@ func (c *KubeClient) ListAndWatch(ctx context.Context, l model.ListInterface, ha
 	}
 
 	// Create a list-watcher that handles k8s-specific logic
-	lw := NewListWatcher(client, l, handler)
+	lw := NewListWatcher(client, l, handler, opts...)
 	return lw.ListAndWatchWithBackend(ctx, lw)
 }

--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -774,5 +774,5 @@ func (c *KubeClient) ListAndWatch(ctx context.Context, l model.ListInterface, ha
 
 	// Create a list-watcher that handles k8s-specific logic
 	lw := NewListWatcher(client, l, handler)
-	return lw.RunLoopWithBackend(ctx, lw)
+	return lw.ListAndWatchWithBackend(ctx, lw)
 }

--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -751,3 +751,28 @@ func (c *KubeClient) Watch(ctx context.Context, l model.ListInterface, options a
 	}
 	return client.Watch(ctx, l, options)
 }
+
+// ListAndWatch implements the list-and-watch pattern for Kubernetes resources.
+// This method handles k8s-specific logic including:
+// - CRD installation detection and retry logic
+// - Bookmark event handling
+// - WatchList support with fallback to List+Watch
+// - Error handling for k8s-specific errors (NotFound, ResourceExpired, etc.)
+// - Connection failure detection and recovery
+func (c *KubeClient) ListAndWatch(ctx context.Context, l model.ListInterface, handler api.EventHandler) error {
+	log.Debugf("Performing 'ListAndWatch' for %+v %v", l, reflect.TypeOf(l))
+
+	// Get the resource client
+	client := c.getResourceClientFromList(l)
+	if client == nil {
+		log.Debug("ListAndWatch operation not supported for this resource type")
+		return cerrors.ErrorOperationNotSupported{
+			Identifier: l,
+			Operation:  "ListAndWatch",
+		}
+	}
+
+	// Create a list-watcher that handles k8s-specific logic
+	lw := NewListWatcher(client, l, handler)
+	return lw.RunLoopWithBackend(ctx, lw)
+}

--- a/libcalico-go/lib/backend/k8s/listwatcher.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher.go
@@ -190,6 +190,11 @@ func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericLis
 
 // handleBookmark processes a bookmark event
 func (lw *ListWatcher) handleBookmark(event api.WatchEvent) {
+	if event.New == nil {
+		lw.Logger.Warn("Watch bookmark received without revision")
+		return
+	}
+
 	lw.Logger.WithField("newRevision", event.New.Revision).Debug("Watch bookmark received")
 	lw.UpdateRevision(event.New.Revision)
 

--- a/libcalico-go/lib/backend/k8s/listwatcher.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"context"
-	"errors"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +25,6 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
 
 // ListWatcher implements the ListAndWatch logic for Kubernetes backends.
@@ -37,8 +35,7 @@ import (
 // - k8s-specific error handling
 type ListWatcher struct {
 	*api.GenericListWatcher
-	client         resources.K8sResourceClient
-	fallbackToList bool
+	client resources.K8sResourceClient
 }
 
 // Ensure ListWatcher implements ListWatchBackend
@@ -54,9 +51,6 @@ func NewListWatcher(client resources.K8sResourceClient, list model.ListInterface
 
 // SupportsWatchList implements api.WatchListSupporter for k8s.
 func (lw *ListWatcher) SupportsWatchList() bool {
-	if lw.fallbackToList {
-		return false
-	}
 	if supporter, ok := lw.client.(api.WatchListSupporter); ok {
 		return supporter.SupportsWatchList()
 	}
@@ -101,11 +95,9 @@ func (lw *ListWatcher) HandleListError(err error) {
 		return
 	}
 
-	lw.Logger.WithError(err).Info("Failed to perform list of current data")
-
 	if kerrors.IsResourceExpired(err) || isTooLargeResourceVersionError(err) {
 		// Our current watch revision is out of sync, start again without a revision
-		lw.Logger.Info("Resource too old/new error from server, clearing cached watch revision")
+		lw.Logger.WithError(err).Info("Resource too old/new error from server, clearing cached watch revision")
 		lw.ResetForFullResync()
 		// Error is a "layer 7" error; so connection is good!
 		lw.MarkSuccessfulConnection()
@@ -114,28 +106,13 @@ func (lw *ListWatcher) HandleListError(err error) {
 		return
 	}
 
-	// Generic error handling
-	// Check if we've been disconnected too long
-	if lw.CheckConnectionTimeout() {
-		lw.Logger.Warn("Connection has failed for too long")
-		lw.Handler.OnError(err)
-	}
-
-	// Schedule retry with delay
-	lw.RetryAfter(lw.Options.ListRetryInterval)
+	lw.GenericListWatcher.HandleListError(err)
 }
 
 // HandleWatchError implements ListWatchBackend.HandleWatchError for k8s.
 func (lw *ListWatcher) HandleWatchError(err error) {
 	if kerrors.IsNotFound(err) {
 		lw.HandleListError(err)
-		return
-	}
-
-	// Check if WatchList is not supported
-	if lw.InitialSyncPending && kerrors.IsInvalid(err) {
-		lw.Logger.WithError(err).Warn("Backend does not support WatchList, falling back to List")
-		lw.fallbackToList = true
 		return
 	}
 
@@ -162,33 +139,11 @@ func (lw *ListWatcher) HandleWatchError(err error) {
 		return
 	}
 
-	var errNotSupp cerrors.ErrorOperationNotSupported
-	var errNotExist cerrors.ErrorResourceDoesNotExist
-	if errors.As(err, &errNotSupp) ||
-		errors.As(err, &errNotExist) {
-		// Watch is not supported on this resource type, either because the type fundamentally
-		// doesn't support it, or because there are no resources to watch yet (and Kubernetes won't
-		// let us watch if there are no resources yet). Pause for the watch poll interval.
-		// This loop effectively becomes a poll loop for this resource type.
-		lw.Logger.Debug("Watch operation not supported; reverting to poll.")
-		lw.RetryAfter(lw.Options.WatchPollInterval)
-
-		// Make sure we force a re-list of the resource even if the watch previously succeeded
-		// but now cannot.
-		lw.fallbackToList = true
-		lw.ResetForFullResync()
+	if lw.HandleWatchUnavailableError(err) {
 		return
 	}
 
-	// None of our expected errors, retry a few times before we give up
-	if lw.IncrementErrorCount() {
-		// Too many errors at the current revision, trigger a full resync
-		lw.Logger.WithError(err).Warn("Watch repeatedly failed without making progress, triggering full resync")
-		lw.ResetForFullResync()
-		return
-	}
-
-	lw.Logger.WithError(err).Warn("Watch of resource finished. Attempting to restart it...")
+	lw.GenericListWatcher.HandleWatchError(err)
 }
 
 // HandleWatchEvent implements ListWatchBackend.HandleWatchEvent for k8s.
@@ -221,8 +176,8 @@ func (lw *ListWatcher) HandleWatchEvent(event api.WatchEvent) error {
 //   - WatchList mode (default): Initial data comes through watch events with
 //     SendInitialEvents=true. Sync completion is signaled by a bookmark.
 //   - List+Watch mode (fallback): Performs a traditional List operation first.
-func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher) error {
-	if !lw.SupportsWatchList() {
+func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher, useWatchList bool) error {
+	if !useWatchList {
 		// Fall back to traditional List+Watch mode, use common implementation.
 		return g.PerformListSync(ctx, lw)
 	}

--- a/libcalico-go/lib/backend/k8s/listwatcher.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher.go
@@ -45,9 +45,9 @@ type ListWatcher struct {
 var _ api.ListWatchBackend = (*ListWatcher)(nil)
 
 // NewListWatcher creates a new k8sListWatcher instance
-func NewListWatcher(client resources.K8sResourceClient, list model.ListInterface, handler api.EventHandler) *ListWatcher {
+func NewListWatcher(client resources.K8sResourceClient, list model.ListInterface, handler api.EventHandler, opts ...api.ListWatcherOption) *ListWatcher {
 	return &ListWatcher{
-		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		GenericListWatcher: api.NewGenericListWatcher(list, handler, opts...),
 		client:             client,
 	}
 }
@@ -97,7 +97,7 @@ func (lw *ListWatcher) HandleListError(err error) {
 		lw.Handler.OnSync()
 
 		// Schedule retry for a long time later
-		lw.RetryAfter(api.MissingAPIRetryTime)
+		lw.RetryAfter(lw.Options.MissingAPIRetryTime)
 		return
 	}
 
@@ -110,7 +110,7 @@ func (lw *ListWatcher) HandleListError(err error) {
 		// Error is a "layer 7" error; so connection is good!
 		lw.MarkSuccessfulConnection()
 		// Schedule a retry to avoid tight loop
-		lw.RetryAfter(api.ListRetryInterval)
+		lw.RetryAfter(lw.Options.ListRetryInterval)
 		return
 	}
 
@@ -122,7 +122,7 @@ func (lw *ListWatcher) HandleListError(err error) {
 	}
 
 	// Schedule retry with delay
-	lw.RetryAfter(api.ListRetryInterval)
+	lw.RetryAfter(lw.Options.ListRetryInterval)
 }
 
 // HandleWatchError implements ListWatchBackend.HandleWatchError for k8s.
@@ -171,7 +171,7 @@ func (lw *ListWatcher) HandleWatchError(err error) {
 		// let us watch if there are no resources yet). Pause for the watch poll interval.
 		// This loop effectively becomes a poll loop for this resource type.
 		lw.Logger.Debug("Watch operation not supported; reverting to poll.")
-		lw.RetryAfter(api.WatchPollInterval)
+		lw.RetryAfter(lw.Options.WatchPollInterval)
 
 		// Make sure we force a re-list of the resource even if the watch previously succeeded
 		// but now cannot.

--- a/libcalico-go/lib/backend/k8s/listwatcher.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher.go
@@ -86,6 +86,11 @@ func (lw *ListWatcher) HandleListError(err error) {
 		// This is a valid long-term state, so we don't want to keep retrying rapidly
 		lw.Logger.Info("Backing API not installed, marking as in-sync and retrying later")
 
+		// Treat the response as healthy, but force a full resync if the API
+		// becomes available later.
+		lw.ResetForFullResync()
+		lw.MarkSuccessfulConnection()
+
 		// Notify handler that we're in sync (even though API is not installed)
 		// This allows the syncer to proceed without this resource type
 		lw.Handler.OnSync()

--- a/libcalico-go/lib/backend/k8s/listwatcher.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"errors"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/utils/pointer"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+)
+
+// ListWatcher implements the ListAndWatch logic for Kubernetes backends.
+// It embeds GenericListWatcher for common functionality and implements
+// the ListWatchBackend interface for k8s-specific logic:
+// - Bookmark handling
+// - WatchList support with fallback
+// - k8s-specific error handling
+type ListWatcher struct {
+	*api.GenericListWatcher
+	client         resources.K8sResourceClient
+	fallbackToList bool
+}
+
+// Ensure ListWatcher implements ListWatchBackend
+var _ api.ListWatchBackend = (*ListWatcher)(nil)
+
+// NewListWatcher creates a new k8sListWatcher instance
+func NewListWatcher(client resources.K8sResourceClient, list model.ListInterface, handler api.EventHandler) *ListWatcher {
+	return &ListWatcher{
+		GenericListWatcher: api.NewGenericListWatcher(list, handler),
+		client:             client,
+	}
+}
+
+// SupportsWatchList implements api.WatchListSupporter for k8s.
+func (lw *ListWatcher) SupportsWatchList() bool {
+	if lw.fallbackToList {
+		return false
+	}
+	if supporter, ok := lw.client.(api.WatchListSupporter); ok {
+		return supporter.SupportsWatchList()
+	}
+	return true
+}
+
+// PerformList implements ListWatchBackend.PerformList for k8s.
+func (lw *ListWatcher) PerformList(ctx context.Context) (*model.KVPairList, error) {
+	return lw.client.List(ctx, lw.List, "")
+}
+
+// CreateWatch implements ListWatchBackend.CreateWatch for k8s.
+func (lw *ListWatcher) CreateWatch(ctx context.Context, useWatchList bool) (api.WatchInterface, error) {
+	watchOptions := api.WatchOptions{
+		AllowWatchBookmarks: true,
+		Revision:            lw.CurrentRevision,
+	}
+
+	// Configure WatchList options when requested by the generic list watcher.
+	if useWatchList {
+		watchOptions.Revision = ""
+		watchOptions.SendInitialEvents = pointer.Bool(true)
+		watchOptions.ResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
+	}
+
+	return lw.client.Watch(ctx, lw.List, watchOptions)
+}
+
+// HandleListError implements ListWatchBackend.HandleListError for k8s.
+func (lw *ListWatcher) HandleListError(err error) {
+	if kerrors.IsNotFound(err) {
+		// The resource type doesn't exist yet (CRD not installed)
+		// This is a valid long-term state, so we don't want to keep retrying rapidly
+		lw.Logger.Info("Backing API not installed, marking as in-sync and retrying later")
+
+		// Notify handler that we're in sync (even though API is not installed)
+		// This allows the syncer to proceed without this resource type
+		lw.Handler.OnSync()
+
+		// Schedule retry for a long time later
+		lw.RetryAfter(api.MissingAPIRetryTime)
+		return
+	}
+
+	lw.Logger.WithError(err).Info("Failed to perform list of current data")
+
+	if kerrors.IsResourceExpired(err) || isTooLargeResourceVersionError(err) {
+		// Our current watch revision is out of sync, start again without a revision
+		lw.Logger.Info("Resource too old/new error from server, clearing cached watch revision")
+		lw.ResetForFullResync()
+		// Error is a "layer 7" error; so connection is good!
+		lw.MarkSuccessfulConnection()
+		// Schedule a retry to avoid tight loop
+		lw.RetryAfter(api.ListRetryInterval)
+		return
+	}
+
+	// Generic error handling
+	// Check if we've been disconnected too long
+	if lw.CheckConnectionTimeout() {
+		lw.Logger.Warn("Connection has failed for too long")
+		lw.Handler.OnError(err)
+	}
+
+	// Schedule retry with delay
+	lw.RetryAfter(api.ListRetryInterval)
+}
+
+// HandleWatchError implements ListWatchBackend.HandleWatchError for k8s.
+func (lw *ListWatcher) HandleWatchError(err error) {
+	if kerrors.IsNotFound(err) {
+		lw.HandleListError(err)
+		return
+	}
+
+	// Check if WatchList is not supported
+	if lw.InitialSyncPending && kerrors.IsInvalid(err) {
+		lw.Logger.WithError(err).Warn("Backend not support WatchList, falling back to List")
+		lw.fallbackToList = true
+		return
+	}
+
+	// Check for revision-related errors
+	if kerrors.IsResourceExpired(err) || kerrors.IsGone(err) || isTooLargeResourceVersionError(err) {
+		// Our current watch revision is too old (or too new!), start again
+		lw.Logger.Info("Watch has expired, queueing full resync")
+		lw.ResetForFullResync()
+		// Error is a "layer 7" error; so connection is good!
+		lw.MarkSuccessfulConnection()
+		return
+	}
+
+	// Check for connection-related errors
+	if utilnet.IsConnectionRefused(err) || kerrors.IsTooManyRequests(err) {
+		// Connection-related error, we can just retry without resetting the watch
+		if lw.CheckConnectionTimeout() {
+			// Too long since we were connected
+			lw.Logger.WithError(err).Warn("Timed out waiting for connection to be restored, forcing resync")
+			lw.ResetForFullResync()
+			return
+		}
+		lw.Logger.WithError(err).Warn("API server refused connection, will retry")
+		return
+	}
+
+	var errNotSupp cerrors.ErrorOperationNotSupported
+	var errNotExist cerrors.ErrorResourceDoesNotExist
+	if errors.As(err, &errNotSupp) ||
+		errors.As(err, &errNotExist) {
+		// Watch is not supported on this resource type, either because the type fundamentally
+		// doesn't support it, or because there are no resources to watch yet (and Kubernetes won't
+		// let us watch if there are no resources yet). Pause for the watch poll interval.
+		// This loop effectively becomes a poll loop for this resource type.
+		lw.Logger.Debug("Watch operation not supported; reverting to poll.")
+		lw.RetryAfter(api.WatchPollInterval)
+
+		// Make sure we force a re-list of the resource even if the watch previously succeeded
+		// but now cannot.
+		lw.fallbackToList = true
+		lw.ResetForFullResync()
+		return
+	}
+
+	// None of our expected errors, retry a few times before we give up
+	if lw.IncrementErrorCount() {
+		// Too many errors at the current revision, trigger a full resync
+		lw.Logger.WithError(err).Warn("Watch repeatedly failed without making progress, triggering full resync")
+		lw.ResetForFullResync()
+		return
+	}
+
+	lw.Logger.WithError(err).Warn("Watch of resource finished. Attempting to restart it...")
+}
+
+// HandleWatchEvent implements ListWatchBackend.HandleWatchEvent for k8s.
+func (lw *ListWatcher) HandleWatchEvent(event api.WatchEvent) error {
+	// Try to handle basic events (Added, Modified, Deleted) using common method
+	if lw.HandleBasicWatchEvent(event) {
+		return nil // continue processing
+	}
+
+	// Handle k8s-specific events
+	switch event.Type {
+	case api.WatchBookmark:
+		lw.handleBookmark(event)
+		lw.MarkSuccessfulConnection()
+		return nil
+
+	case api.WatchError:
+		lw.HandleWatchError(event.Error)
+		return event.Error // stop processing, will recreate watcher
+
+	default:
+		lw.Logger.Errorf("Unknown event type received from the datastore: %v", event.Type)
+	}
+
+	return nil
+}
+
+// PerformInitialSync implements ListWatchBackend.PerformInitialSync for k8s.
+// k8s supports two modes:
+//   - WatchList mode (default): Initial data comes through watch events with
+//     SendInitialEvents=true. Sync completion is signaled by a bookmark.
+//   - List+Watch mode (fallback): Performs a traditional List operation first.
+func (lw *ListWatcher) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher) error {
+	if !lw.SupportsWatchList() {
+		// Fall back to traditional List+Watch mode, use common implementation.
+		return g.PerformListSync(ctx, lw)
+	}
+
+	// WatchList mode: initial data comes through watch events
+	g.Logger.Info("Using WatchList mode for initial sync")
+	g.Handler.OnResyncStarted()
+	return nil
+}
+
+// handleBookmark processes a bookmark event
+func (lw *ListWatcher) handleBookmark(event api.WatchEvent) {
+	lw.Logger.WithField("newRevision", event.New.Revision).Debug("Watch bookmark received")
+	lw.UpdateRevision(event.New.Revision)
+
+	// Check if this bookmark indicates sync completion (for WatchList)
+	k8sRes, ok := event.New.Value.(resources.Resource)
+	if ok && k8sRes.GetObjectMeta().GetAnnotations()[metav1.InitialEventsAnnotationKey] == "true" {
+		// This bookmark indicates we've received all initial events
+		lw.Handler.OnSync()
+		// Clear the initial sync flag after WatchList sync completion
+		lw.MarkInitialSyncComplete()
+	}
+}

--- a/libcalico-go/lib/backend/k8s/listwatcher.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher.go
@@ -79,7 +79,7 @@ func (lw *ListWatcher) CreateWatch(ctx context.Context, useWatchList bool) (api.
 	if useWatchList {
 		watchOptions.Revision = ""
 		watchOptions.SendInitialEvents = pointer.Bool(true)
-		watchOptions.ResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
+		watchOptions.ResourceVersionMatch = api.ResourceVersionMatchNotOlderThan
 	}
 
 	return lw.client.Watch(ctx, lw.List, watchOptions)
@@ -134,7 +134,7 @@ func (lw *ListWatcher) HandleWatchError(err error) {
 
 	// Check if WatchList is not supported
 	if lw.InitialSyncPending && kerrors.IsInvalid(err) {
-		lw.Logger.WithError(err).Warn("Backend not support WatchList, falling back to List")
+		lw.Logger.WithError(err).Warn("Backend does not support WatchList, falling back to List")
 		lw.fallbackToList = true
 		return
 	}

--- a/libcalico-go/lib/backend/k8s/listwatcher_test.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher_test.go
@@ -870,6 +870,25 @@ func TestListWatcher_HandleBookmark_WithoutInitialEventsAnnotation(t *testing.T)
 	assert.True(t, lw.InitialSyncPending) // Still needs initial sync
 }
 
+func TestListWatcher_HandleBookmark_WithNilNew(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	event := api.WatchEvent{
+		Type: api.WatchBookmark,
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Empty(t, lw.CurrentRevision)
+	assert.Equal(t, 0, handler.syncCount)
+	assert.True(t, lw.InitialSyncPending)
+}
+
 // ============================================================================
 // Integration-like Tests
 // ============================================================================

--- a/libcalico-go/lib/backend/k8s/listwatcher_test.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher_test.go
@@ -336,12 +336,21 @@ func TestListWatcher_HandleListError_NotFound(t *testing.T) {
 	handler := newMockEventHandler()
 
 	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+	lw.ErrorCountAtCurrentRev = 3
+	lw.MarkInitialSyncComplete()
 
 	// Create a NotFound error
 	notFoundErr := kerrors.NewNotFound(schema.GroupResource{Group: "test", Resource: "test"}, "test")
+	before := time.Now()
 
 	lw.HandleListError(notFoundErr)
 
+	// Should reset for a full resync if the API becomes available later.
+	assert.Equal(t, "", lw.CurrentRevision)
+	assert.Equal(t, 0, lw.ErrorCountAtCurrentRev)
+	assert.True(t, lw.InitialSyncPending)
+	assert.False(t, lw.LastSuccessfulConnTime.Before(before))
 	// Should call OnSync to mark as in-sync even though API is not installed
 	assert.Equal(t, 1, handler.syncCount)
 	// Should schedule a long retry

--- a/libcalico-go/lib/backend/k8s/listwatcher_test.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher_test.go
@@ -185,7 +185,6 @@ func TestNewListWatcher(t *testing.T) {
 	assert.Equal(t, list, lw.List)
 	assert.Equal(t, handler, lw.Handler)
 	assert.True(t, lw.InitialSyncPending)
-	assert.False(t, lw.fallbackToList)
 	assert.Equal(t, "", lw.CurrentRevision)
 }
 
@@ -194,12 +193,10 @@ func TestListWatcher_SupportsWatchList(t *testing.T) {
 
 	assert.True(t, lw.SupportsWatchList())
 
-	lw.fallbackToList = true
-	assert.False(t, lw.SupportsWatchList())
-
 	supportsWatchList := false
 	lw = NewListWatcher(&mockK8sResourceClient{supportsWatchList: &supportsWatchList}, testListOptions(), newMockEventHandler())
 	assert.False(t, lw.SupportsWatchList())
+
 }
 
 // ============================================================================
@@ -406,22 +403,6 @@ func TestListWatcher_HandleListError_ConnectionTimeout(t *testing.T) {
 // HandleWatchError Tests
 // ============================================================================
 
-func TestListWatcher_HandleWatchError_WatchListNotSupported(t *testing.T) {
-	client := &mockK8sResourceClient{}
-	list := testListOptions()
-	handler := newMockEventHandler()
-
-	lw := NewListWatcher(client, list, handler)
-
-	// Create an Invalid error (indicates WatchList not supported)
-	invalidErr := kerrors.NewInvalid(schema.GroupKind{Group: "test", Kind: "test"}, "test", nil)
-
-	lw.HandleWatchError(invalidErr)
-
-	// Should fall back to list mode
-	assert.True(t, lw.fallbackToList)
-}
-
 func TestListWatcher_HandleWatchError_NotFound(t *testing.T) {
 	client := &mockK8sResourceClient{}
 	list := testListOptions()
@@ -437,7 +418,6 @@ func TestListWatcher_HandleWatchError_NotFound(t *testing.T) {
 	lw.HandleWatchError(notFoundErr)
 
 	assert.Equal(t, 1, handler.syncCount)
-	assert.False(t, lw.fallbackToList)
 	assert.True(t, lw.RetryBlockedUntil.After(time.Now().Add(29*time.Minute)))
 }
 
@@ -528,8 +508,7 @@ func TestListWatcher_HandleWatchError_OperationNotSupported(t *testing.T) {
 
 	lw.HandleWatchError(notSuppErr)
 
-	// Should fall back to list mode and need initial sync
-	assert.True(t, lw.fallbackToList)
+	// Should force a resync without permanently disabling WatchList.
 	assert.True(t, lw.InitialSyncPending)
 	// Should schedule a poll interval retry
 	assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
@@ -550,8 +529,7 @@ func TestListWatcher_HandleWatchError_ResourceDoesNotExist(t *testing.T) {
 
 	lw.HandleWatchError(notExistErr)
 
-	// Should fall back to list mode and need initial sync
-	assert.True(t, lw.fallbackToList)
+	// Should force a resync without permanently disabling WatchList.
 	assert.True(t, lw.InitialSyncPending)
 }
 
@@ -747,7 +725,7 @@ func TestListWatcher_PerformInitialSync_WatchListMode(t *testing.T) {
 	lw := NewListWatcher(client, list, handler)
 
 	// WatchList mode (default)
-	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher, true)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, handler.resyncStartedCt)
@@ -767,10 +745,9 @@ func TestListWatcher_PerformInitialSync_FallbackMode(t *testing.T) {
 	handler := newMockEventHandler()
 
 	lw := NewListWatcher(client, list, handler)
-	lw.fallbackToList = true
 
 	// Fallback to List+Watch mode
-	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, handler.resyncStartedCt)
@@ -798,7 +775,7 @@ func TestListWatcher_PerformInitialSync_ResourceDisablesWatchList(t *testing.T) 
 
 	lw := NewListWatcher(client, list, handler)
 
-	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher, lw.SupportsWatchList())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, client.listCalls)
 	assert.Equal(t, "", client.lastListRevision)
@@ -913,10 +890,9 @@ func TestListWatcher_FullListThenWatch_Flow(t *testing.T) {
 	handler := newMockEventHandler()
 
 	lw := NewListWatcher(client, list, handler)
-	lw.fallbackToList = true // Force list-then-watch mode
 
 	// Perform the initial sync using PerformInitialSync
-	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, handler.resyncStartedCt)
@@ -934,7 +910,7 @@ func TestListWatcher_WatchListMode_Flow(t *testing.T) {
 	lw := NewListWatcher(client, list, handler)
 
 	// Perform the initial sync using WatchList mode
-	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher, true)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, handler.resyncStartedCt)

--- a/libcalico-go/lib/backend/k8s/listwatcher_test.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher_test.go
@@ -392,7 +392,7 @@ func TestListWatcher_HandleListError_ConnectionTimeout(t *testing.T) {
 
 	lw := NewListWatcher(client, list, handler)
 	// Set last connection to past timeout
-	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+	lw.LastSuccessfulConnTime = time.Now().Add(-lw.Options.WatchRetryTimeout - time.Second)
 
 	genericErr := errors.New("connection error")
 
@@ -502,7 +502,7 @@ func TestListWatcher_HandleWatchError_TooManyRequests_ConnectionTimeout(t *testi
 	lw := NewListWatcher(client, list, handler)
 	lw.CurrentRevision = "100"
 	// Set last connection to past timeout
-	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+	lw.LastSuccessfulConnTime = time.Now().Add(-lw.Options.WatchRetryTimeout - time.Second)
 
 	// Create a TooManyRequests error
 	tooManyErr := kerrors.NewTooManyRequests("too many requests", 10)
@@ -564,7 +564,7 @@ func TestListWatcher_HandleWatchError_UnknownError_ExceedsThreshold(t *testing.T
 	lw.CurrentRevision = "100"
 
 	// Set error count close to threshold
-	for i := 0; i < api.MaxErrorsPerRevision-1; i++ {
+	for i := 0; i < lw.Options.MaxErrorsPerRevision-1; i++ {
 		lw.IncrementErrorCount()
 	}
 

--- a/libcalico-go/lib/backend/k8s/listwatcher_test.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher_test.go
@@ -288,7 +288,7 @@ func TestListWatcher_CreateWatch_WatchListMode(t *testing.T) {
 	assert.True(t, client.lastWatchOptions.AllowWatchBookmarks)
 	assert.NotNil(t, client.lastWatchOptions.SendInitialEvents)
 	assert.True(t, *client.lastWatchOptions.SendInitialEvents)
-	assert.Equal(t, metav1.ResourceVersionMatchNotOlderThan, client.lastWatchOptions.ResourceVersionMatch)
+	assert.Equal(t, api.ResourceVersionMatchNotOlderThan, client.lastWatchOptions.ResourceVersionMatch)
 }
 
 func TestListWatcher_CreateWatch_ListWatchMode(t *testing.T) {

--- a/libcalico-go/lib/backend/k8s/listwatcher_test.go
+++ b/libcalico-go/lib/backend/k8s/listwatcher_test.go
@@ -1,0 +1,943 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+)
+
+// mockK8sResourceClient implements resources.K8sResourceClient for testing
+type mockK8sResourceClient struct {
+	listResult        *model.KVPairList
+	listError         error
+	watchResult       api.WatchInterface
+	watchError        error
+	lastWatchOptions  api.WatchOptions
+	watchCalls        int
+	listCalls         int
+	lastListRevision  string
+	supportsWatchList *bool
+}
+
+func (m *mockK8sResourceClient) Create(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return nil, nil
+}
+
+func (m *mockK8sResourceClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return nil, nil
+}
+
+func (m *mockK8sResourceClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
+	return nil, nil
+}
+
+func (m *mockK8sResourceClient) DeleteKVP(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return nil, nil
+}
+
+func (m *mockK8sResourceClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	return nil, nil
+}
+
+func (m *mockK8sResourceClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	m.listCalls++
+	m.lastListRevision = revision
+	return m.listResult, m.listError
+}
+
+func (m *mockK8sResourceClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
+	m.lastWatchOptions = options
+	m.watchCalls++
+	return m.watchResult, m.watchError
+}
+
+func (m *mockK8sResourceClient) EnsureInitialized() error {
+	return nil
+}
+
+func (m *mockK8sResourceClient) SupportsWatchList() bool {
+	if m.supportsWatchList == nil {
+		return true
+	}
+	return *m.supportsWatchList
+}
+
+// mockEventHandler implements api.EventHandler for testing
+type mockEventHandler struct {
+	addEvents       []*model.KVPair
+	updateEvents    []*model.KVPair
+	deleteEvents    []*model.KVPair
+	syncCount       int
+	resyncStartedCt int
+	errors          []error
+}
+
+func newMockEventHandler() *mockEventHandler {
+	return &mockEventHandler{
+		addEvents:    make([]*model.KVPair, 0),
+		updateEvents: make([]*model.KVPair, 0),
+		deleteEvents: make([]*model.KVPair, 0),
+		errors:       make([]error, 0),
+	}
+}
+
+func (m *mockEventHandler) OnResyncStarted() {
+	m.resyncStartedCt++
+}
+
+func (m *mockEventHandler) OnAdd(kvp *model.KVPair) {
+	m.addEvents = append(m.addEvents, kvp)
+}
+
+func (m *mockEventHandler) OnUpdate(kvp *model.KVPair) {
+	m.updateEvents = append(m.updateEvents, kvp)
+}
+
+func (m *mockEventHandler) OnDelete(kvp *model.KVPair) {
+	m.deleteEvents = append(m.deleteEvents, kvp)
+}
+
+func (m *mockEventHandler) OnSync() {
+	m.syncCount++
+}
+
+func (m *mockEventHandler) OnError(err error) {
+	m.errors = append(m.errors, err)
+}
+
+// mockWatcher implements api.WatchInterface for testing
+type mockWatcher struct {
+	events     chan api.WatchEvent
+	stopped    bool
+	terminated bool
+}
+
+func newMockWatcher() *mockWatcher {
+	return &mockWatcher{
+		events: make(chan api.WatchEvent, 10),
+	}
+}
+
+func (w *mockWatcher) Stop() {
+	if !w.stopped {
+		w.stopped = true
+		close(w.events)
+	}
+}
+
+func (w *mockWatcher) ResultChan() <-chan api.WatchEvent {
+	return w.events
+}
+
+func (w *mockWatcher) HasTerminated() bool {
+	return w.terminated
+}
+
+func (w *mockWatcher) SendEvent(event api.WatchEvent) {
+	w.events <- event
+}
+
+// testListOptions returns a real ListInterface for testing
+func testListOptions() model.ListInterface {
+	return model.GlobalConfigListOptions{}
+}
+
+// ============================================================================
+// ListWatcher Creation Tests
+// ============================================================================
+
+func TestNewListWatcher(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	assert.NotNil(t, lw)
+	assert.NotNil(t, lw.GenericListWatcher)
+	assert.Equal(t, list, lw.List)
+	assert.Equal(t, handler, lw.Handler)
+	assert.True(t, lw.InitialSyncPending)
+	assert.False(t, lw.fallbackToList)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestListWatcher_SupportsWatchList(t *testing.T) {
+	lw := NewListWatcher(&mockK8sResourceClient{}, testListOptions(), newMockEventHandler())
+
+	assert.True(t, lw.SupportsWatchList())
+
+	lw.fallbackToList = true
+	assert.False(t, lw.SupportsWatchList())
+
+	supportsWatchList := false
+	lw = NewListWatcher(&mockK8sResourceClient{supportsWatchList: &supportsWatchList}, testListOptions(), newMockEventHandler())
+	assert.False(t, lw.SupportsWatchList())
+}
+
+// ============================================================================
+// PerformList Tests
+// ============================================================================
+
+func TestListWatcher_PerformList_Success(t *testing.T) {
+	client := &mockK8sResourceClient{
+		listResult: &model.KVPairList{
+			KVPairs: []*model.KVPair{
+				{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+			},
+			Revision: "100",
+		},
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	result, err := lw.PerformList(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.KVPairs, 1)
+	assert.Equal(t, "100", result.Revision)
+}
+
+func TestListWatcher_PerformList_Error(t *testing.T) {
+	client := &mockK8sResourceClient{
+		listError: errors.New("list failed"),
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	result, err := lw.PerformList(context.Background())
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// ============================================================================
+// CreateWatch Tests
+// ============================================================================
+
+func TestListWatcher_CreateWatch_NormalMode(t *testing.T) {
+	watcher := newMockWatcher()
+	client := &mockK8sResourceClient{
+		watchResult: watcher,
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Not initial sync
+	result, err := lw.CreateWatch(context.Background(), false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, watcher, result)
+	assert.Equal(t, 1, client.watchCalls)
+	assert.Equal(t, "100", client.lastWatchOptions.Revision)
+	assert.True(t, client.lastWatchOptions.AllowWatchBookmarks)
+	assert.Nil(t, client.lastWatchOptions.SendInitialEvents)
+	assert.Empty(t, client.lastWatchOptions.ResourceVersionMatch)
+}
+
+func TestListWatcher_CreateWatch_WatchListMode(t *testing.T) {
+	watcher := newMockWatcher()
+	client := &mockK8sResourceClient{
+		watchResult: watcher,
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// WatchList mode should use SendInitialEvents.
+	result, err := lw.CreateWatch(context.Background(), true)
+
+	assert.NoError(t, err)
+	assert.Equal(t, watcher, result)
+	assert.Equal(t, 1, client.watchCalls)
+	assert.Equal(t, "", client.lastWatchOptions.Revision)
+	assert.True(t, client.lastWatchOptions.AllowWatchBookmarks)
+	assert.NotNil(t, client.lastWatchOptions.SendInitialEvents)
+	assert.True(t, *client.lastWatchOptions.SendInitialEvents)
+	assert.Equal(t, metav1.ResourceVersionMatchNotOlderThan, client.lastWatchOptions.ResourceVersionMatch)
+}
+
+func TestListWatcher_CreateWatch_ListWatchMode(t *testing.T) {
+	watcher := newMockWatcher()
+	client := &mockK8sResourceClient{
+		watchResult: watcher,
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// List+Watch mode should not use WatchList options.
+	result, err := lw.CreateWatch(context.Background(), false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, watcher, result)
+	assert.Equal(t, 1, client.watchCalls)
+	assert.Equal(t, "100", client.lastWatchOptions.Revision)
+	assert.True(t, client.lastWatchOptions.AllowWatchBookmarks)
+	assert.Nil(t, client.lastWatchOptions.SendInitialEvents)
+	assert.Empty(t, client.lastWatchOptions.ResourceVersionMatch)
+}
+
+func TestListWatcher_CreateWatch_Error(t *testing.T) {
+	client := &mockK8sResourceClient{
+		watchError: errors.New("watch failed"),
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	result, err := lw.CreateWatch(context.Background(), false)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// ============================================================================
+// HandleListError Tests
+// ============================================================================
+
+func TestListWatcher_HandleListError_NotFound(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// Create a NotFound error
+	notFoundErr := kerrors.NewNotFound(schema.GroupResource{Group: "test", Resource: "test"}, "test")
+
+	lw.HandleListError(notFoundErr)
+
+	// Should call OnSync to mark as in-sync even though API is not installed
+	assert.Equal(t, 1, handler.syncCount)
+	// Should schedule a long retry
+	assert.True(t, lw.RetryBlockedUntil.After(time.Now().Add(29*time.Minute)))
+}
+
+func TestListWatcher_HandleListError_ResourceExpired(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Create a ResourceExpired error
+	expiredErr := kerrors.NewResourceExpired("resource expired")
+
+	lw.HandleListError(expiredErr)
+
+	// Should reset for full resync
+	assert.Equal(t, "", lw.CurrentRevision)
+	// Should mark successful connection (layer 7 error)
+	assert.True(t, lw.LastSuccessfulConnTime.After(time.Now().Add(-1*time.Second)))
+}
+
+func TestListWatcher_HandleListError_GenericError(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	genericErr := errors.New("generic error")
+
+	lw.HandleListError(genericErr)
+
+	// Should schedule a retry
+	assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
+}
+
+func TestListWatcher_HandleListError_ConnectionTimeout(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	// Set last connection to past timeout
+	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+
+	genericErr := errors.New("connection error")
+
+	lw.HandleListError(genericErr)
+
+	// Should call OnError due to timeout
+	assert.Len(t, handler.errors, 1)
+}
+
+// ============================================================================
+// HandleWatchError Tests
+// ============================================================================
+
+func TestListWatcher_HandleWatchError_WatchListNotSupported(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// Create an Invalid error (indicates WatchList not supported)
+	invalidErr := kerrors.NewInvalid(schema.GroupKind{Group: "test", Kind: "test"}, "test", nil)
+
+	lw.HandleWatchError(invalidErr)
+
+	// Should fall back to list mode
+	assert.True(t, lw.fallbackToList)
+}
+
+func TestListWatcher_HandleWatchError_NotFound(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	notFoundErr := cerrors.ErrorResourceDoesNotExist{
+		Err:        kerrors.NewNotFound(schema.GroupResource{Group: "test", Resource: "test"}, "test"),
+		Identifier: "test-resource",
+	}
+
+	lw.HandleWatchError(notFoundErr)
+
+	assert.Equal(t, 1, handler.syncCount)
+	assert.False(t, lw.fallbackToList)
+	assert.True(t, lw.RetryBlockedUntil.After(time.Now().Add(29*time.Minute)))
+}
+
+func TestListWatcher_HandleWatchError_ResourceExpired(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Create a ResourceExpired error
+	expiredErr := kerrors.NewResourceExpired("resource expired")
+
+	lw.HandleWatchError(expiredErr)
+
+	// Should reset for full resync
+	assert.Equal(t, "", lw.CurrentRevision)
+	// Should mark successful connection (layer 7 error)
+	assert.True(t, lw.LastSuccessfulConnTime.After(time.Now().Add(-1*time.Second)))
+}
+
+func TestListWatcher_HandleWatchError_Gone(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Create a Gone error
+	goneErr := kerrors.NewGone("resource gone")
+
+	lw.HandleWatchError(goneErr)
+
+	// Should reset for full resync
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchError_TooManyRequests(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Create a TooManyRequests error
+	tooManyErr := kerrors.NewTooManyRequests("too many requests", 10)
+
+	lw.HandleWatchError(tooManyErr)
+
+	// Should not reset revision (just retry)
+	assert.Equal(t, "100", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchError_TooManyRequests_ConnectionTimeout(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+	// Set last connection to past timeout
+	lw.LastSuccessfulConnTime = time.Now().Add(-api.WatchRetryTimeout - time.Second)
+
+	// Create a TooManyRequests error
+	tooManyErr := kerrors.NewTooManyRequests("too many requests", 10)
+
+	lw.HandleWatchError(tooManyErr)
+
+	// Should reset for full resync due to timeout
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchError_OperationNotSupported(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Create an OperationNotSupported error
+	notSuppErr := cerrors.ErrorOperationNotSupported{
+		Operation: "watch",
+	}
+
+	lw.HandleWatchError(notSuppErr)
+
+	// Should fall back to list mode and need initial sync
+	assert.True(t, lw.fallbackToList)
+	assert.True(t, lw.InitialSyncPending)
+	// Should schedule a poll interval retry
+	assert.True(t, lw.RetryBlockedUntil.After(time.Now()))
+}
+
+func TestListWatcher_HandleWatchError_ResourceDoesNotExist(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Create a ResourceDoesNotExist error
+	notExistErr := cerrors.ErrorResourceDoesNotExist{
+		Identifier: "test-resource",
+	}
+
+	lw.HandleWatchError(notExistErr)
+
+	// Should fall back to list mode and need initial sync
+	assert.True(t, lw.fallbackToList)
+	assert.True(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_HandleWatchError_UnknownError_ExceedsThreshold(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	// Set error count close to threshold
+	for i := 0; i < api.MaxErrorsPerRevision-1; i++ {
+		lw.IncrementErrorCount()
+	}
+
+	genericErr := errors.New("unknown error")
+
+	lw.HandleWatchError(genericErr)
+
+	// Should reset for full resync after exceeding threshold
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchError_UnknownError_BelowThreshold(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	genericErr := errors.New("unknown error")
+
+	lw.HandleWatchError(genericErr)
+
+	// Should not reset revision (below threshold)
+	assert.Equal(t, "100", lw.CurrentRevision)
+}
+
+// ============================================================================
+// HandleWatchEvent Tests
+// ============================================================================
+
+func TestListWatcher_HandleWatchEvent_Added(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	event := api.WatchEvent{
+		Type: api.WatchAdded,
+		New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "val", Revision: "10"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, "10", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Modified(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	event := api.WatchEvent{
+		Type: api.WatchModified,
+		Old:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "old", Revision: "5"},
+		New:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "new", Revision: "20"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Len(t, handler.updateEvents, 1)
+	assert.Equal(t, "20", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Deleted(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	event := api.WatchEvent{
+		Type: api.WatchDeleted,
+		Old:  &model.KVPair{Key: model.GlobalConfigKey{Name: "test"}, Value: "val", Revision: "30"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Len(t, handler.deleteEvents, 1)
+	assert.Equal(t, "30", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Bookmark(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	event := api.WatchEvent{
+		Type: api.WatchBookmark,
+		New:  &model.KVPair{Revision: "100"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "100", lw.CurrentRevision)
+}
+
+func TestListWatcher_HandleWatchEvent_Error(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+
+	testErr := errors.New("watch error")
+	event := api.WatchEvent{
+		Type:  api.WatchError,
+		Error: testErr,
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	// Should return the error to stop processing
+	assert.Error(t, err)
+	assert.Equal(t, testErr, err)
+}
+
+// ============================================================================
+// InitialSyncPending Tests
+// ============================================================================
+
+func TestListWatcher_InitialSyncPending_Initial(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// Initial state: InitialSyncPending=true, CurrentRevision=""
+	assert.True(t, lw.InitialSyncPending)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+func TestListWatcher_InitialSyncPending_AfterSync(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+	lw.MarkInitialSyncComplete()
+
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_InitialSyncPending_AfterReset(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.CurrentRevision = "100"
+	lw.MarkInitialSyncComplete()
+	lw.ResetForFullResync()
+
+	assert.True(t, lw.InitialSyncPending)
+	assert.Equal(t, "", lw.CurrentRevision)
+}
+
+// ============================================================================
+// PerformInitialSync Tests
+// ============================================================================
+
+func TestListWatcher_PerformInitialSync_WatchListMode(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// WatchList mode (default)
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 0, handler.syncCount) // Sync is signaled by bookmark, not here
+}
+
+func TestListWatcher_PerformInitialSync_FallbackMode(t *testing.T) {
+	client := &mockK8sResourceClient{
+		listResult: &model.KVPairList{
+			KVPairs: []*model.KVPair{
+				{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+			},
+			Revision: "100",
+		},
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.fallbackToList = true
+
+	// Fallback to List+Watch mode
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 1, handler.syncCount)
+	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_PerformInitialSync_ResourceDisablesWatchList(t *testing.T) {
+	supportsWatchList := false
+	watcher := newMockWatcher()
+	client := &mockK8sResourceClient{
+		listResult: &model.KVPairList{
+			KVPairs: []*model.KVPair{
+				{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+			},
+			Revision: "100",
+		},
+		watchResult:       watcher,
+		supportsWatchList: &supportsWatchList,
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, client.listCalls)
+	assert.Equal(t, "", client.lastListRevision)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 1, handler.syncCount)
+	assert.Len(t, handler.addEvents, 1)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.False(t, lw.InitialSyncPending)
+
+	result, err := lw.CreateWatch(context.Background(), lw.InitialSyncPending && lw.SupportsWatchList())
+	assert.NoError(t, err)
+	assert.Equal(t, watcher, result)
+	assert.Equal(t, "100", client.lastWatchOptions.Revision)
+	assert.Nil(t, client.lastWatchOptions.SendInitialEvents)
+	assert.Empty(t, client.lastWatchOptions.ResourceVersionMatch)
+}
+
+// ============================================================================
+// Bookmark Handling Tests
+// ============================================================================
+
+// mockResource implements resources.Resource for testing bookmark handling
+type mockResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+// Ensure mockResource implements resources.Resource
+var _ resources.Resource = (*mockResource)(nil)
+
+func (m *mockResource) GetObjectKind() schema.ObjectKind {
+	return &m.TypeMeta
+}
+
+func (m *mockResource) DeepCopyObject() runtime.Object {
+	if m == nil {
+		return nil
+	}
+	out := new(mockResource)
+	m.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.TypeMeta = m.TypeMeta
+	return out
+}
+
+func TestListWatcher_HandleBookmark_WithInitialEventsAnnotation(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// Create a bookmark event with InitialEventsAnnotationKey
+	resource := &mockResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				metav1.InitialEventsAnnotationKey: "true",
+			},
+		},
+	}
+
+	event := api.WatchEvent{
+		Type: api.WatchBookmark,
+		New:  &model.KVPair{Revision: "100", Value: resource},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.Equal(t, 1, handler.syncCount) // OnSync should be called
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_HandleBookmark_WithoutInitialEventsAnnotation(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// Create a bookmark event without InitialEventsAnnotationKey
+	event := api.WatchEvent{
+		Type: api.WatchBookmark,
+		New:  &model.KVPair{Revision: "100"},
+	}
+
+	err := lw.HandleWatchEvent(event)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.Equal(t, 0, handler.syncCount) // OnSync should NOT be called
+	assert.True(t, lw.InitialSyncPending) // Still needs initial sync
+}
+
+// ============================================================================
+// Integration-like Tests
+// ============================================================================
+
+func TestListWatcher_FullListThenWatch_Flow(t *testing.T) {
+	watcher := newMockWatcher()
+	client := &mockK8sResourceClient{
+		listResult: &model.KVPairList{
+			KVPairs: []*model.KVPair{
+				{Key: model.GlobalConfigKey{Name: "key1"}, Value: "value1", Revision: "1"},
+				{Key: model.GlobalConfigKey{Name: "key2"}, Value: "value2", Revision: "2"},
+			},
+			Revision: "100",
+		},
+		watchResult: watcher,
+	}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+	lw.fallbackToList = true // Force list-then-watch mode
+
+	// Perform the initial sync using PerformInitialSync
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 1, handler.syncCount)
+	assert.Len(t, handler.addEvents, 2)
+	assert.Equal(t, "100", lw.CurrentRevision)
+	assert.False(t, lw.InitialSyncPending)
+}
+
+func TestListWatcher_WatchListMode_Flow(t *testing.T) {
+	client := &mockK8sResourceClient{}
+	list := testListOptions()
+	handler := newMockEventHandler()
+
+	lw := NewListWatcher(client, list, handler)
+
+	// Perform the initial sync using WatchList mode
+	err := lw.PerformInitialSync(context.Background(), lw.GenericListWatcher)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, handler.resyncStartedCt)
+	assert.Equal(t, 0, handler.syncCount) // Sync is signaled by bookmark, not here
+	assert.True(t, lw.InitialSyncPending) // Still true until bookmark received
+}

--- a/libcalico-go/lib/backend/k8s/reflector_ports.go
+++ b/libcalico-go/lib/backend/k8s/reflector_ports.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package watchersyncer
+package k8s
 
 import (
 	"strings"

--- a/libcalico-go/lib/backend/k8s/resources/profile.go
+++ b/libcalico-go/lib/backend/k8s/resources/profile.go
@@ -266,6 +266,13 @@ func (c *profileClient) EnsureInitialized() error {
 	return nil
 }
 
+func (c *profileClient) SupportsWatchList() bool {
+	// Profile watches merge Namespace and ServiceAccount watches. The merged
+	// watcher needs to wait for both initial-events bookmarks before WatchList
+	// can safely signal sync completion.
+	return false
+}
+
 func (c *profileClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
 	// Build watch options to pass to k8s.
 	rlo, ok := list.(model.ResourceListOptions)

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -360,9 +360,11 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 
 func watchOptionsToK8sListOptions(wo api.WatchOptions) metav1.ListOptions {
 	return metav1.ListOptions{
-		ResourceVersion:     wo.Revision,
-		Watch:               true,
-		AllowWatchBookmarks: wo.AllowWatchBookmarks,
+		ResourceVersion:      wo.Revision,
+		Watch:                true,
+		AllowWatchBookmarks:  wo.AllowWatchBookmarks,
+		SendInitialEvents:    wo.SendInitialEvents,
+		ResourceVersionMatch: wo.ResourceVersionMatch,
 	}
 }
 

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -364,7 +364,16 @@ func watchOptionsToK8sListOptions(wo api.WatchOptions) metav1.ListOptions {
 		Watch:                true,
 		AllowWatchBookmarks:  wo.AllowWatchBookmarks,
 		SendInitialEvents:    wo.SendInitialEvents,
-		ResourceVersionMatch: wo.ResourceVersionMatch,
+		ResourceVersionMatch: watchResourceVersionMatchToK8s(wo.ResourceVersionMatch),
+	}
+}
+
+func watchResourceVersionMatchToK8s(match api.ResourceVersionMatch) metav1.ResourceVersionMatch {
+	switch match {
+	case api.ResourceVersionMatchNotOlderThan:
+		return metav1.ResourceVersionMatchNotOlderThan
+	default:
+		return metav1.ResourceVersionMatch(match)
 	}
 }
 

--- a/libcalico-go/lib/backend/k8s/resources/watcher.go
+++ b/libcalico-go/lib/backend/k8s/resources/watcher.go
@@ -175,6 +175,7 @@ func (crw *k8sWatcherConverter) convertEvent(kevent kwatch.Event) []*api.WatchEv
 		return []*api.WatchEvent{{
 			Type: api.WatchBookmark,
 			New: &model.KVPair{
+				Value:    k8sRes,
 				Revision: revision,
 			},
 		}}

--- a/libcalico-go/lib/backend/k8s/resources/watcher.go
+++ b/libcalico-go/lib/backend/k8s/resources/watcher.go
@@ -168,8 +168,9 @@ func (crw *k8sWatcherConverter) convertEvent(kevent kwatch.Event) []*api.WatchEv
 
 		return crw.buildEventsFromKVPs(kvps, kevent.Type)
 	case kwatch.Bookmark:
-		// For bookmarks we send an empty KVPair with the current resource
-		// version only.
+		// For bookmarks we send a KVPair with the current resource version.
+		// Keep the k8s resource as Value so WatchList can detect the final
+		// initial-events bookmark annotation.
 		k8sRes := kevent.Object.(Resource)
 		revision := k8sRes.GetObjectMeta().GetResourceVersion()
 		return []*api.WatchEvent{{

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -211,7 +211,7 @@ func (wc *watcherCache) OnSync() {
 	if wc.resyncEpoch != wc.lastHandledResyncEpoch {
 		// We just completed a resync with a non-empty cache, we need to scan
 		// the cache to look for resources that were deleted during the resync.
-		updates := make([]api.Update, 0)
+		updates := make([]api.Update, 0, len(wc.resources))
 		for k, r := range wc.resources {
 			if r.resyncEpoch == wc.resyncEpoch {
 				// This resource was validated during the resync.

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -214,6 +214,10 @@ func (wc *watcherCache) OnUpdate(kvp *model.KVPair) {
 
 // OnDelete handles delete events from ListAndWatch
 func (wc *watcherCache) OnDelete(kvp *model.KVPair) {
+	if kvp == nil {
+		wc.logger.Warn("Received delete event without KVPair, skipping")
+		return
+	}
 	kvp.Value = nil
 	wc.handleWatchListEvent(kvp)
 }

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -49,7 +49,7 @@ type watcherCache struct {
 	listWatcherOptions     api.ListWatcherOptions
 }
 
-// cacheEntry is an entry in our cache.  It groups the a key with the last known
+// cacheEntry is an entry in our cache.  It groups a key with the last known
 // revision that we processed.  We store the revision so that we can determine
 // if an entry has been updated (and therefore whether we need to send an update
 // event in the syncer callback).

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -46,6 +46,7 @@ type watcherCache struct {
 	results                chan<- any
 	hasSynced              bool
 	resourceType           ResourceType
+	listWatcherOptions     api.ListWatcherOptions
 }
 
 // cacheEntry is an entry in our cache.  It groups the a key with the last known
@@ -59,13 +60,14 @@ type cacheEntry struct {
 }
 
 // Create a new watcherCache.
-func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- any) *watcherCache {
+func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- any, options api.ListWatcherOptions) *watcherCache {
 	return &watcherCache{
-		logger:       logrus.WithField("ListRoot", listRootForLog(resourceType.ListInterface)),
-		client:       client,
-		resourceType: resourceType,
-		results:      results,
-		resources:    make(map[string]cacheEntry),
+		logger:             logrus.WithField("ListRoot", listRootForLog(resourceType.ListInterface)),
+		client:             client,
+		resourceType:       resourceType,
+		results:            results,
+		resources:          make(map[string]cacheEntry),
+		listWatcherOptions: options,
 	}
 }
 
@@ -96,10 +98,10 @@ func (wc *watcherCache) run(ctx context.Context) {
 
 func (wc *watcherCache) listAndWatch(ctx context.Context) error {
 	if client, ok := wc.client.(api.ListAndWatchClient); ok {
-		return client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc)
+		return client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc, api.WithListWatcherOptions(wc.listWatcherOptions))
 	}
 
-	lw := api.NewGenericListWatcher(wc.resourceType.ListInterface, wc)
+	lw := api.NewGenericListWatcher(wc.resourceType.ListInterface, wc, api.WithListWatcherOptions(wc.listWatcherOptions))
 	backend := &clientListWatchBackend{
 		client:      wc.client,
 		list:        wc.resourceType.ListInterface,

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -129,12 +129,27 @@ func (b *clientListWatchBackend) HandleWatchEvent(event api.WatchEvent) error {
 	if b.listWatcher.HandleBasicWatchEvent(event) {
 		return nil
 	}
-	if event.Type == api.WatchError {
+
+	switch event.Type {
+	case api.WatchBookmark:
+		b.handleBookmark(event)
+		return nil
+	case api.WatchError:
 		b.HandleWatchError(event.Error)
 		return event.Error
+	default:
+		b.listWatcher.Logger.WithField("eventType", event.Type).Warn("Unexpected watch event type")
+		return nil
 	}
-	b.listWatcher.Logger.WithField("eventType", event.Type).Warn("Unexpected watch event type")
-	return nil
+}
+
+func (b *clientListWatchBackend) handleBookmark(event api.WatchEvent) {
+	if event.New == nil {
+		b.listWatcher.Logger.Warn("Watch bookmark received without revision")
+		return
+	}
+	b.listWatcher.UpdateRevision(event.New.Revision)
+	b.listWatcher.MarkSuccessfulConnection()
 }
 
 func (b *clientListWatchBackend) HandleListError(err error) {

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -91,6 +91,7 @@ func (wc *watcherCache) run(ctx context.Context) {
 			return
 		}
 		wc.logger.WithError(err).Error("ListAndWatch failed")
+		wc.results <- errorSyncBackendError{Err: err}
 	}
 }
 

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -83,9 +83,8 @@ func (wc *watcherCache) run(ctx context.Context) {
 	// On shutdown, send deletions for all the objects we're tracking.
 	defer wc.sendDeletionsForAllResources()
 
-	// Run ListAndWatch - this will block until context is cancelled or an error occurs
-	// watcherCache directly implements the EventHandler interface
-	if err := wc.client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc); err != nil {
+	// Run ListAndWatch - this will block until context is cancelled or an error occurs.
+	if err := wc.listAndWatch(ctx); err != nil {
 		if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			wc.logger.WithError(err).Debug("ListAndWatch stopped")
 			return
@@ -93,6 +92,64 @@ func (wc *watcherCache) run(ctx context.Context) {
 		wc.logger.WithError(err).Error("ListAndWatch failed")
 		wc.results <- errorSyncBackendError{Err: err}
 	}
+}
+
+func (wc *watcherCache) listAndWatch(ctx context.Context) error {
+	if client, ok := wc.client.(api.ListAndWatchClient); ok {
+		return client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc)
+	}
+
+	lw := api.NewGenericListWatcher(wc.resourceType.ListInterface, wc)
+	backend := &clientListWatchBackend{
+		client:      wc.client,
+		list:        wc.resourceType.ListInterface,
+		listWatcher: lw,
+	}
+	return lw.ListAndWatchWithBackend(ctx, backend)
+}
+
+type clientListWatchBackend struct {
+	client      api.Client
+	list        model.ListInterface
+	listWatcher *api.GenericListWatcher
+}
+
+func (b *clientListWatchBackend) PerformList(ctx context.Context) (*model.KVPairList, error) {
+	return b.client.List(ctx, b.list, "")
+}
+
+func (b *clientListWatchBackend) CreateWatch(ctx context.Context, useWatchList bool) (api.WatchInterface, error) {
+	return b.client.Watch(ctx, b.list, api.WatchOptions{
+		AllowWatchBookmarks: true,
+		Revision:            b.listWatcher.CurrentRevision,
+	})
+}
+
+func (b *clientListWatchBackend) HandleWatchEvent(event api.WatchEvent) error {
+	if b.listWatcher.HandleBasicWatchEvent(event) {
+		return nil
+	}
+	if event.Type == api.WatchError {
+		b.HandleWatchError(event.Error)
+		return event.Error
+	}
+	b.listWatcher.Logger.WithField("eventType", event.Type).Warn("Unexpected watch event type")
+	return nil
+}
+
+func (b *clientListWatchBackend) HandleListError(err error) {
+	b.listWatcher.HandleListError(err)
+}
+
+func (b *clientListWatchBackend) HandleWatchError(err error) {
+	if b.listWatcher.HandleWatchUnavailableError(err) {
+		return
+	}
+	b.listWatcher.HandleWatchError(err)
+}
+
+func (b *clientListWatchBackend) PerformInitialSync(ctx context.Context, g *api.GenericListWatcher, useWatchList bool) error {
+	return g.PerformListSync(ctx, b)
 }
 
 // OnResyncStarted implements api.EventHandler interface.
@@ -197,9 +254,8 @@ func (wc *watcherCache) handleWatchListEvent(kvp *model.KVPair) {
 	}
 }
 
-// handleWatchBookmark handles a bookmark event from the API server, these
-// update the revision that we should be watching from without sending
-// a KVP.  This prevents datastore compactions from invalidating our watches.
+// handleConvertedWatchEvent handles one converted watch event and sends the
+// appropriate update type to the main watcherSyncer.
 func (wc *watcherCache) handleConvertedWatchEvent(kvp *model.KVPair) {
 	if kvp.Value == nil {
 		wc.handleDeletedUpdate(kvp.Key)

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -18,16 +18,15 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
+
+// Compile-time check that watcherCache implements api.EventHandler interface
+var _ api.EventHandler = (*watcherCache)(nil)
 
 // The watcherCache provides watcher/syncer support for a single key type in the
 // backend.  These results are sent to the main WatcherSyncer on a buffered "results"
@@ -41,60 +40,32 @@ import (
 type watcherCache struct {
 	logger                 *logrus.Entry
 	client                 api.Client
-	watch                  api.WatchInterface
 	resources              map[string]cacheEntry
-	oldResources           map[string]cacheEntry
+	resyncEpoch            uint64
+	lastHandledResyncEpoch uint64
 	results                chan<- any
 	hasSynced              bool
 	resourceType           ResourceType
-	currentWatchRevision   string
-	errorCountAtCurrentRev int
-	resyncBlockedUntil     time.Time
-	lastSuccessfulConnTime time.Time
-	watchRetryTimeout      time.Duration
-
-	// crdInstalled tracks whether or not we've detected that the backing API for this
-	// resource type is installed in the cluster.
-	crdInstalled bool
 }
-
-const (
-	MaxErrorsPerRevision = 5
-)
-
-var (
-	MinResyncInterval        = 500 * time.Millisecond
-	ListRetryInterval        = 1000 * time.Millisecond
-	WatchPollInterval        = 5000 * time.Millisecond
-	DefaultWatchRetryTimeout = 600 * time.Second
-
-	// If the backing API is not installed, we consider ourselves in-sync but retry
-	// infrequently. If the API is eventually installed, we will resync after this timer pops.
-	// However, it's good practice to restart Calico when installing a new API to expedite this.
-	MissingAPIRetryTime = 30 * time.Minute
-)
 
 // cacheEntry is an entry in our cache.  It groups the a key with the last known
 // revision that we processed.  We store the revision so that we can determine
 // if an entry has been updated (and therefore whether we need to send an update
 // event in the syncer callback).
 type cacheEntry struct {
-	revision string
-	key      model.Key
+	revision    string
+	key         model.Key
+	resyncEpoch uint64
 }
 
 // Create a new watcherCache.
-func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- any, watchTimeout time.Duration) *watcherCache {
+func newWatcherCache(client api.Client, resourceType ResourceType, results chan<- any) *watcherCache {
 	return &watcherCache{
-		logger:               logrus.WithField("ListRoot", listRootForLog(resourceType.ListInterface)),
-		client:               client,
-		resourceType:         resourceType,
-		results:              results,
-		resources:            make(map[string]cacheEntry, 0),
-		currentWatchRevision: "0",
-		resyncBlockedUntil:   time.Now(),
-		watchRetryTimeout:    watchTimeout,
-		crdInstalled:         true, // Assume true until we detect otherwise.
+		logger:       logrus.WithField("ListRoot", listRootForLog(resourceType.ListInterface)),
+		client:       client,
+		resourceType: resourceType,
+		results:      results,
+		resources:    make(map[string]cacheEntry),
 	}
 }
 
@@ -112,336 +83,82 @@ func (wc *watcherCache) run(ctx context.Context) {
 	// On shutdown, send deletions for all the objects we're tracking.
 	defer wc.sendDeletionsForAllResources()
 
-	// Main loop, repeatedly resync with the store and then watch for changes
-	// until our watch fails.
-	for ctx.Err() == nil {
-		wc.resyncAndLoopReadingFromWatcher(ctx)
-	}
-}
-
-func (wc *watcherCache) resyncAndLoopReadingFromWatcher(ctx context.Context) {
-	defer wc.cleanExistingWatcher()
-	wc.maybeResyncAndCreateWatcher(ctx)
-	if ctx.Err() != nil {
-		// maybeResyncAndCreateWatcher may have returned early with no watcher,
-		// in which case it's not safe to call loopReadingFromWatcher.
-		return
-	}
-	wc.loopReadingFromWatcher(ctx)
-}
-
-func (wc *watcherCache) loopReadingFromWatcher(ctx context.Context) {
-	eventLogger := wc.logger.WithField("event", nil)
-
-	for {
-		select {
-		case <-ctx.Done():
-			wc.logger.Debug("Context is done. Returning")
+	// Run ListAndWatch - this will block until context is cancelled or an error occurs
+	// watcherCache directly implements the EventHandler interface
+	if err := wc.client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc); err != nil {
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			wc.logger.WithError(err).Debug("ListAndWatch stopped")
 			return
-		case event, ok := <-wc.watch.ResultChan():
-			if !ok {
-				// If the channel is closed then resync/recreate the watch.
-				wc.logger.Debug("Watch channel closed by remote - recreate watcher")
-				return
-			}
-
-			// Re-use this log event so that we don't allocate every time.
-			eventLogger.Data["event"] = event
-			eventLogger.Debug("Got event from results channel")
-
-			// Handle the specific event type.
-			switch event.Type {
-			case api.WatchAdded, api.WatchModified:
-				kvp := event.New
-				wc.handleWatchListEvent(kvp)
-				wc.lastSuccessfulConnTime = time.Now()
-			case api.WatchDeleted:
-				// Nil out the value to indicate a delete.
-				kvp := event.Old
-				if kvp == nil {
-					// Bug, we're about to panic when we hit the nil pointer, log something useful.
-					eventLogger.Panic("Deletion event without old value")
-				}
-				kvp.Value = nil
-				wc.handleWatchListEvent(kvp)
-				wc.lastSuccessfulConnTime = time.Now()
-			case api.WatchBookmark:
-				wc.handleWatchBookmark(event)
-				wc.lastSuccessfulConnTime = time.Now()
-			case api.WatchError:
-				if kerrors.IsResourceExpired(event.Error) {
-					// Our current watch revision is too old.  Even with watch bookmarks, we hit this path after the
-					// API server restarts (and presumably does an immediate compaction).
-					eventLogger.Info("Watch has expired, triggering full resync.")
-					wc.resetWatchRevisionForFullResync()
-					// "Layer 7" error so the connection is good.
-					wc.lastSuccessfulConnTime = time.Now()
-				} else {
-					// Unknown error, default is to just try restarting the watch on assumption that it's
-					// a connectivity issue.  Note that, if the error recurs when recreating the watch, we will
-					// check for various expected connectivity failure conditions and handle them there.
-					wc.errorCountAtCurrentRev++
-					if wc.errorCountAtCurrentRev >= MaxErrorsPerRevision {
-						// Too many errors at the current revision, trigger a full resync.
-						eventLogger.Warn("Watch repeatedly failed without making progress, triggering full resync")
-						wc.resetWatchRevisionForFullResync()
-					} else {
-						eventLogger.Info("Watch of resource finished. Attempting to restart it...")
-					}
-				}
-				return
-			default:
-				// Unknown event type - not much we can do other than log.
-				eventLogger.Errorf("Unknown event type received from the datastore")
-			}
 		}
+		wc.logger.WithError(err).Error("ListAndWatch failed")
 	}
 }
 
-func (wc *watcherCache) markInstalled() {
-	if !wc.crdInstalled {
-		wc.logger.Info("Backing API has been installed")
-		wc.crdInstalled = true
+// OnResyncStarted implements api.EventHandler interface.
+// It is called when a resync operation is about to begin.
+func (wc *watcherCache) OnResyncStarted() {
+	wc.logger.Debug("Resync started notification received")
+	// Notify the converter that we are resyncing.
+	if wc.resourceType.UpdateProcessor != nil {
+		wc.logger.Debug("Trigger converter resync notification")
+		wc.resourceType.UpdateProcessor.OnSyncerStarting()
 	}
-}
-
-// maybeResyncAndCreateWatcher loops performing resync processing until it successfully
-// completes a resync and starts a watcher.
-func (wc *watcherCache) maybeResyncAndCreateWatcher(ctx context.Context) {
-	// The passed in context allows a resync to be stopped mid-resync. The resync should be stopped as quickly as
-	// possible, but there should be usable data available in wc.resources so that delete events can be sent.
-	// The strategy is to
-	// - cancel any long running functions calls made from here, i.e. pass ctx to the client.list() calls
-	//    - but if it finishes, then ensure that the listing gets processed.
-	// - cancel any sleeps if the context is cancelled
-
-	// Make sure any previous watcher is stopped.
-	wc.logger.Debug("Starting watch sync/resync processing")
-	wc.cleanExistingWatcher()
-
-	// If we don't have a currentWatchRevision then we need to perform a full resync.
-	var performFullResync bool
-	for {
-		start := time.Now()
-		select {
-		case <-ctx.Done():
-			wc.logger.Debug("Context is done. Returning")
-			return
-		case <-wc.resyncThrottleC():
-			// Start the resync.  This processing loops until we create the watcher.  If the
-			// watcher continuously fails then this loop effectively becomes a polling based
-			// syncer.
-			wc.logger.Debugf("Starting main resync loop after delay %v", time.Since(start))
-		}
-
-		// Avoid tight loop in unexpected failure scenarios.  For example, if creating the watch succeeds but the
-		// watch immediately ends.
-		wc.resyncBlockedUntil = time.Now().Add(MinResyncInterval)
-
-		performFullResync = performFullResync || wc.currentWatchRevision == "0"
-		if performFullResync {
-			wc.logger.Info("Full resync is required")
-
-			// Notify the converter that we are resyncing.
-			if wc.resourceType.UpdateProcessor != nil {
-				wc.logger.Debug("Trigger converter resync notification")
-				wc.resourceType.UpdateProcessor.OnSyncerStarting()
-			}
-
-			// Start the sync by Listing the current resources. Start from the current watch revision, which will
-			// be 0 at start of day or the latest received revision.
-			l, err := wc.client.List(ctx, wc.resourceType.ListInterface, wc.currentWatchRevision)
-			if err != nil {
-				if kerrors.IsNotFound(err) {
-					// The resource type doesn't exist yet.  This is possible if the CRD backing this API has not been installed.
-					// This is a valid long-term state, so we don't want to keep retrying rapidly.
-					// Consider ourselves in sync, and then sleep for a long time.
-					if !wc.hasSynced {
-						wc.logger.Info("Backing API not installed, marking as in-sync and retrying later.")
-						wc.finishResync()
-					} else {
-						wc.logger.Debug("Backing API still not installed, retrying later.")
-					}
-					wc.resyncBlockedUntil = time.Now().Add(MissingAPIRetryTime)
-					wc.crdInstalled = false
-					continue
-				}
-
-				// If we get this far, we know the API is installed even if we got an error.
-				wc.markInstalled()
-
-				// Failed to perform the list.  Pause briefly (so we don't tight loop) and retry.
-				wc.logger.WithError(err).Info("Failed to perform list of current data during resync")
-
-				if kerrors.IsResourceExpired(err) || isTooLargeResourceVersionError(err) {
-					// Our current watch revision is out of sync. Start again without a revision.
-					wc.logger.Info("Resource too old/new error from server, clearing cached watch revision.")
-					wc.resetWatchRevisionForFullResync()
-					// Error is a "layer 7" error; so connection is good!
-					wc.lastSuccessfulConnTime = time.Now()
-				} else if time.Since(wc.lastSuccessfulConnTime) > wc.watchRetryTimeout {
-					// Need to send back an error here for handling. Only callbacks with connection failure handling should actually kick off anything.
-					wc.logger.Warn("Connection to datastore has failed - signaling error to client.")
-					wc.results <- errorSyncBackendError{
-						Err: err,
-					}
-
-					if wc.resourceType.SendDeletesOnConnFail {
-						// Unable to List, and we need to send deletes on connection failure. Send them now.
-						// Note: We do not need to check if the context is done since we will send deletes during exit
-						// processing anyway.
-						wc.logger.Info("connection failed, sending deletion events for all resources.")
-						wc.sendDeletionsForAllResources()
-					}
-				}
-
-				wc.resyncBlockedUntil = time.Now().Add(ListRetryInterval)
-				continue
-			}
-			wc.logger.WithField("numKVs", len(l.KVPairs)).Debug("List completed.")
-			wc.lastSuccessfulConnTime = time.Now()
-			wc.markInstalled()
-
-			// Once this point is reached, it's important not to drop out if the context is cancelled.
-			// Move the current resources over to the oldResources
-			wc.oldResources = wc.resources
-			wc.resources = make(map[string]cacheEntry, 0)
-
-			// Send updates for each of the resources we listed - this will revalidate entries in
-			// the oldResources map.
-			for _, kvp := range l.KVPairs {
-				wc.handleWatchListEvent(kvp)
-			}
-
-			// We've listed the current settings.  Complete the sync by notifying the main WatcherSyncer
-			// go routine (if we haven't already) and by sending deletes for the old resources that were
-			// not acknowledged by the List.  The oldResources will be empty after this call.
-			wc.finishResync()
-
-			// Store the current watch revision.  This gets updated on any new add/modified event.
-			wc.logger.Logger.WithField("revision", l.Revision).Debug("List completed.")
-			if l.Revision == "" || l.Revision == "0" {
-				if len(l.KVPairs) == 0 {
-					// Got a bad revision but there are no items.  This may mean that the datastore
-					// returns an unhelpful "not found" error instead of an empty list.  Revert to a
-					// poll until some items show up.
-					wc.logger.Info("List returned no items and an empty/zero revision, reverting to poll.")
-					wc.currentWatchRevision = "0"
-					performFullResync = true
-					wc.resyncBlockedUntil = time.Now().Add(WatchPollInterval)
-					continue
-				}
-				wc.logger.Panic("BUG: List returned items with empty/zero revision.  Watch would be inconsistent.")
-			}
-			wc.currentWatchRevision = l.Revision
-			wc.errorCountAtCurrentRev = 0
-
-			// Mark the resync as complete.
-			performFullResync = false
-		}
-
-		// And now start watching from the revision returned by the List, or from a previous watch event
-		// (depending on whether we were performing a full resync).
-		wc.logger.WithField("revision", wc.currentWatchRevision).Debug("Starting watch from revision")
-		w, err := wc.client.Watch(ctx, wc.resourceType.ListInterface, api.WatchOptions{
-			Revision:            wc.currentWatchRevision,
-			AllowWatchBookmarks: true,
-		})
-		if err != nil {
-			if kerrors.IsResourceExpired(err) || kerrors.IsGone(err) || isTooLargeResourceVersionError(err) {
-				// Our current watch revision is too old (or too new!). Start again
-				// without a revision. Condition cribbed from client-go's reflector.
-				wc.logger.Info("Watch has expired, queueing full resync.")
-				wc.resetWatchRevisionForFullResync()
-				// Error is a "layer 7" error; so connection is good!
-				wc.lastSuccessfulConnTime = time.Now()
-				continue
-			}
-
-			if utilnet.IsConnectionRefused(err) || kerrors.IsTooManyRequests(err) {
-				// Connection-related error, we can just retry without resetting
-				// the watch. Condition cribbed from client-go's reflector
-				if time.Since(wc.lastSuccessfulConnTime) > wc.watchRetryTimeout {
-					// Too long since we were connected, and we may need to signal an error to the client.
-					// The signalling is done as part of the resync machinery so trigger a resync now.
-					wc.logger.WithError(err).Warn("Timed out waiting for connection to be restored, forcing a resync.")
-					wc.resetWatchRevisionForFullResync()
-				}
-				wc.logger.WithError(err).Warn("API server refused connection, will retry.")
-				continue
-			}
-
-			var errNotSupp cerrors.ErrorOperationNotSupported
-			var errNotExist cerrors.ErrorResourceDoesNotExist
-			if errors.As(err, &errNotSupp) ||
-				errors.As(err, &errNotExist) {
-				// Watch is not supported on this resource type, either because the type fundamentally
-				// doesn't support it, or because there are no resources to watch yet (and Kubernetes won't
-				// let us watch if there are no resources yet). Pause for the watch poll interval.
-				// This loop effectively becomes a poll loop for this resource type.
-				wc.logger.Debug("Watch operation not supported; reverting to poll.")
-				wc.resyncBlockedUntil = time.Now().Add(WatchPollInterval)
-
-				// Make sure we force a re-list of the resource even if the watch previously succeeded
-				// but now cannot.
-				performFullResync = true
-				continue
-			}
-
-			// None of our expected errors, retry a few times before we give up and try a full resync.
-			wc.errorCountAtCurrentRev++
-			wc.logger.WithError(err).WithField("performFullResync", performFullResync).WithField("errorsWithoutProgress", wc.errorCountAtCurrentRev).Warn(
-				"Failed to create watcher; will retry.")
-			if wc.errorCountAtCurrentRev >= MaxErrorsPerRevision {
-				// Hitting repeated errors, try a full resync next time.
-				performFullResync = true
-			}
-			continue
-		}
-
-		// Store the watcher and exit back to the main event loop.
-		wc.logger.Debug("Resync completed, now watching for change events")
-		wc.watch = w
-		return
-	}
-}
-
-func (wc *watcherCache) resetWatchRevisionForFullResync() {
-	wc.currentWatchRevision = "0"
-	wc.errorCountAtCurrentRev = 0
-}
-
-var closedTimeC = make(chan time.Time)
-
-func init() {
-	close(closedTimeC)
-}
-
-func (wc *watcherCache) resyncThrottleC() <-chan time.Time {
-	blockFor := time.Until(wc.resyncBlockedUntil)
-	var blockC <-chan time.Time
-	if blockFor > 0 {
-		wc.logger.WithField("delay", blockFor).Debug("Sleeping before next resync")
-		blockC = time.After(blockFor)
+	if len(wc.resources) > 0 {
+		// Our cache isn't empty, so we need to use the resync epoch to detect
+		// deletes during the resync.
+		wc.resyncEpoch++
 	} else {
-		blockC = closedTimeC // Triggers immediately.
-	}
-	return blockC
-}
-
-func (wc *watcherCache) cleanExistingWatcher() {
-	if wc.watch != nil {
-		wc.logger.Debug("Stopping previous watcher")
-		wc.watch.Stop()
-		wc.watch = nil
+		// Cache empty, reset the resync epoch so we can skip the post-resync scan.
+		wc.resyncEpoch = 0
+		wc.lastHandledResyncEpoch = 0
 	}
 }
 
-// finishResync handles processing to finish synchronization.
+// OnAdd handles add events from ListAndWatch
+func (wc *watcherCache) OnAdd(kvp *model.KVPair) {
+	wc.handleWatchListEvent(kvp)
+}
+
+// OnUpdate handles update events from ListAndWatch
+func (wc *watcherCache) OnUpdate(kvp *model.KVPair) {
+	wc.handleWatchListEvent(kvp)
+}
+
+// OnDelete handles delete events from ListAndWatch
+func (wc *watcherCache) OnDelete(kvp *model.KVPair) {
+	kvp.Value = nil
+	wc.handleWatchListEvent(kvp)
+}
+
+// OnSync handles processing to finish synchronization.
 // If this watcher has never been synced then notify the main watcherSyncer that we've synced.
 // We may also need to send deleted messages for old resources that were not validated in the
 // resync (i.e. they must have since been deleted).
-func (wc *watcherCache) finishResync() {
+func (wc *watcherCache) OnSync() {
+	if wc.resyncEpoch != wc.lastHandledResyncEpoch {
+		// We just completed a resync with a non-empty cache, we need to scan
+		// the cache to look for resources that were deleted during the resync.
+		updates := make([]api.Update, 0)
+		for k, r := range wc.resources {
+			if r.resyncEpoch == wc.resyncEpoch {
+				// This resource was validated during the resync.
+				continue
+			}
+			updates = append(updates, api.Update{
+				UpdateType: api.UpdateTypeKVDeleted,
+				KVPair: model.KVPair{
+					Key: r.key,
+				},
+			})
+			delete(wc.resources, k)
+		}
+		if len(updates) > 0 {
+			wc.logger.WithField("Num", len(updates)).Debug("Sending resync deletes")
+			wc.results <- updates
+		}
+		wc.lastHandledResyncEpoch = wc.resyncEpoch
+	}
+
 	// If we haven't already sent an InSync event then send a synced notification.  The watcherSyncer will send a Synced
 	// event when it has received synced events from each cache. Once in-sync the cache remains in-sync.
 	if !wc.hasSynced {
@@ -449,35 +166,18 @@ func (wc *watcherCache) finishResync() {
 		wc.results <- api.InSync
 		wc.hasSynced = true
 	}
+}
 
-	// If the watcher failed at any time, we end up recreating a watcher and storing off
-	// the current known resources for revalidation.  Now that we have finished the sync,
-	// any of the remaining resources that were not accounted for must have been deleted
-	// and we need to send deleted events for them.
-	numOldResources := len(wc.oldResources)
-	if numOldResources > 0 {
-		wc.logger.WithField("Num", numOldResources).Debug("Sending resync deletes")
-		updates := make([]api.Update, 0, len(wc.oldResources))
-		for _, r := range wc.oldResources {
-			updates = append(updates, api.Update{
-				UpdateType: api.UpdateTypeKVDeleted,
-				KVPair: model.KVPair{
-					Key: r.key,
-				},
-			})
-		}
-		wc.results <- updates
-	}
-	wc.oldResources = nil
+// OnError handles error events from ListAndWatch.
+// It forwards the error to the results channel for the main watcherSyncer to handle.
+func (wc *watcherCache) OnError(err error) {
+	wc.logger.WithError(err).Warn("Received error from ListAndWatch")
+	wc.results <- errorSyncBackendError{Err: err}
 }
 
 // handleWatchListEvent handles a watch event converting it if required and passing to
 // handleConvertedWatchEvent to send the appropriate update types.
 func (wc *watcherCache) handleWatchListEvent(kvp *model.KVPair) {
-	// Track the resource version from this watch/list event.
-	wc.currentWatchRevision = kvp.Revision
-	wc.errorCountAtCurrentRev = 0
-
 	if wc.resourceType.UpdateProcessor == nil {
 		// No update processor - handle immediately.
 		wc.handleConvertedWatchEvent(kvp)
@@ -499,14 +199,6 @@ func (wc *watcherCache) handleWatchListEvent(kvp *model.KVPair) {
 // handleWatchBookmark handles a bookmark event from the API server, these
 // update the revision that we should be watching from without sending
 // a KVP.  This prevents datastore compactions from invalidating our watches.
-func (wc *watcherCache) handleWatchBookmark(event api.WatchEvent) {
-	wc.logger.WithField("newRevision", event.New.Revision).Debug("Watch bookmark received")
-	wc.currentWatchRevision = event.New.Revision
-	wc.errorCountAtCurrentRev = 0
-}
-
-// handleConvertedWatchEvent handles a converted watch event fanning out
-// to the add/mod or delete processing as necessary.
 func (wc *watcherCache) handleConvertedWatchEvent(kvp *model.KVPair) {
 	if kvp.Value == nil {
 		wc.handleDeletedUpdate(kvp.Key)
@@ -522,23 +214,28 @@ func (wc *watcherCache) handleAddedOrModifiedUpdate(kvp *model.KVPair) {
 	thisKey := kvp.Key
 	thisKeyString := thisKey.String()
 	thisRevision := kvp.Revision
-	wc.markAsValid(thisKeyString)
 
 	// If the resource is already in our map, then this is a modified event.  Check the
 	// revision to see if we actually need to send an update.
+	send := true
+
 	if resource, ok := wc.resources[thisKeyString]; ok {
 		if resource.revision == thisRevision {
 			// No update to revision, so no event to send.
 			wc.logger.WithField("Key", thisKeyString).Debug("Swallowing event update from datastore because entry is same as cached entry")
-			return
+			send = false
+		} else {
+			// Resource is modified, send an update event and store the latest revision.
+			wc.logger.WithField("Key", thisKeyString).Debug("Datastore entry modified, sending syncer update")
 		}
-		// Resource is modified, send an update event and store the latest revision.
-		wc.logger.WithField("Key", thisKeyString).Debug("Datastore entry modified, sending syncer update")
-		wc.results <- []api.Update{{
-			UpdateType: api.UpdateTypeKVUpdated,
-			KVPair:     *kvp,
-		}}
+		if send {
+			wc.results <- []api.Update{{
+				UpdateType: api.UpdateTypeKVUpdated,
+				KVPair:     *kvp,
+			}}
+		}
 		resource.revision = thisRevision
+		resource.resyncEpoch = wc.resyncEpoch
 		wc.resources[thisKeyString] = resource
 		return
 	}
@@ -551,15 +248,15 @@ func (wc *watcherCache) handleAddedOrModifiedUpdate(kvp *model.KVPair) {
 		KVPair:     *kvp,
 	}}
 	wc.resources[thisKeyString] = cacheEntry{
-		revision: thisRevision,
-		key:      thisKey,
+		revision:    thisRevision,
+		key:         thisKey,
+		resyncEpoch: wc.resyncEpoch,
 	}
 }
 
 // handleDeletedWatchEvent sends a deleted event and removes the resource key from our cache.
 func (wc *watcherCache) handleDeletedUpdate(key model.Key) {
 	thisKeyString := key.String()
-	wc.markAsValid(thisKeyString)
 
 	// If we have seen an added event for this key then send a deleted event and remove
 	// from the cache.
@@ -575,20 +272,6 @@ func (wc *watcherCache) handleDeletedUpdate(key model.Key) {
 	}
 }
 
-// markAsValid marks a resource that we have just seen as valid, by moving it from the set of
-// "oldResources" that were stored during the resync back into the main "resources" set.  Any entries
-// remaining in the oldResources map once the current snapshot events have been processed, indicates
-// entries that were deleted during the resync - see corresponding code in finishResync().
-func (wc *watcherCache) markAsValid(resourceKey string) {
-	if wc.oldResources != nil {
-		if oldResource, ok := wc.oldResources[resourceKey]; ok {
-			wc.logger.WithField("Key", resourceKey).Debug("Marking key as re-processed")
-			wc.resources[resourceKey] = oldResource
-			delete(wc.oldResources, resourceKey)
-		}
-	}
-}
-
 func (wc *watcherCache) sendDeletionsForAllResources() {
 	for _, value := range wc.resources {
 		wc.results <- []api.Update{{
@@ -599,7 +282,4 @@ func (wc *watcherCache) sendDeletionsForAllResources() {
 		}}
 	}
 	clear(wc.resources)
-
-	// Just signaled deletion of all resources, must perform a full resync to restore them.
-	wc.resetWatchRevisionForFullResync()
 }

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
 
 // Compile-time check that watcherCache implements api.EventHandler interface
@@ -98,9 +99,21 @@ func (wc *watcherCache) run(ctx context.Context) {
 
 func (wc *watcherCache) listAndWatch(ctx context.Context) error {
 	if client, ok := wc.client.(api.ListAndWatchClient); ok {
-		return client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc, api.WithListWatcherOptions(wc.listWatcherOptions))
+		err := client.ListAndWatch(ctx, wc.resourceType.ListInterface, wc, api.WithListWatcherOptions(wc.listWatcherOptions))
+		if err == nil {
+			return nil
+		}
+		var errNotSupported cerrors.ErrorOperationNotSupported
+		if !errors.As(err, &errNotSupported) {
+			return err
+		}
+		wc.logger.WithError(err).Debug("Backend-specific ListAndWatch is not supported; falling back to generic List+Watch")
 	}
 
+	return wc.genericListAndWatch(ctx)
+}
+
+func (wc *watcherCache) genericListAndWatch(ctx context.Context) error {
 	lw := api.NewGenericListWatcher(wc.resourceType.ListInterface, wc, api.WithListWatcherOptions(wc.listWatcherOptions))
 	backend := &clientListWatchBackend{
 		client:      wc.client,

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -17,7 +17,6 @@ package watchersyncer
 import (
 	"context"
 	"sync"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -39,10 +38,6 @@ type ResourceType struct {
 	// UpdateProcessor converts the raw KVPairs returned from the datastore into the appropriate
 	// KVPairs required for the syncer.  This is optional.
 	UpdateProcessor SyncerUpdateProcessor
-
-	// SendDeletesOnConnFail will send deletes for all resources (and therefore do a full resync) if
-	// the connection fails at any point.
-	SendDeletesOnConnFail bool
 }
 
 // Error indicating a problem with a watcher communicating with the backend.
@@ -76,42 +71,32 @@ type SyncerUpdateProcessor interface {
 
 type Option func(*watcherSyncer)
 
-func WithWatchRetryTimeout(t time.Duration) Option {
-	return func(ws *watcherSyncer) {
-		ws.watchRetryTimeout = t
-	}
-}
-
-var _ = WithWatchRetryTimeout
-
 // New creates a new multiple Watcher-backed api.Syncer.
 func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
 	rs := &watcherSyncer{
-		watcherCaches:     make([]*watcherCache, len(resourceTypes)),
-		results:           make(chan any, 2000),
-		callbacks:         callbacks,
-		watchRetryTimeout: DefaultWatchRetryTimeout,
+		watcherCaches: make([]*watcherCache, len(resourceTypes)),
+		results:       make(chan any, 2000),
+		callbacks:     callbacks,
 	}
 	for _, o := range options {
 		o(rs)
 	}
 	for i, r := range resourceTypes {
-		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results, rs.watchRetryTimeout)
+		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results)
 	}
 	return rs
 }
 
 // watcherSyncer implements the api.Syncer interface.
 type watcherSyncer struct {
-	status            api.SyncStatus
-	watcherCaches     []*watcherCache
-	results           chan any
-	numSynced         int
-	callbacks         api.SyncerCallbacks
-	wgwc              *sync.WaitGroup
-	wgws              *sync.WaitGroup
-	cancel            context.CancelFunc
-	watchRetryTimeout time.Duration
+	status        api.SyncStatus
+	watcherCaches []*watcherCache
+	results       chan any
+	numSynced     int
+	callbacks     api.SyncerCallbacks
+	wgwc          *sync.WaitGroup
+	wgws          *sync.WaitGroup
+	cancel        context.CancelFunc
 }
 
 func (ws *watcherSyncer) Start() {

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -38,6 +38,13 @@ type ResourceType struct {
 	// UpdateProcessor converts the raw KVPairs returned from the datastore into the appropriate
 	// KVPairs required for the syncer.  This is optional.
 	UpdateProcessor SyncerUpdateProcessor
+
+	// SendDeletesOnConnFail will send deletes for all resources (and therefore do a full resync) if
+	// the connection fails at any point.
+	//
+	// Deprecated: watcher caches now resync through GenericListWatcher and
+	// delete stale entries after successful full resyncs.
+	SendDeletesOnConnFail bool
 }
 
 // Error indicating a problem with a watcher communicating with the backend.
@@ -69,29 +76,46 @@ type SyncerUpdateProcessor interface {
 	OnSyncerStarting()
 }
 
+type Option func(*watcherSyncer)
+
+// WithListWatcherOptions sets the list-watch retry and timeout options used by
+// watcher caches.
+func WithListWatcherOptions(options api.ListWatcherOptions) Option {
+	return func(ws *watcherSyncer) {
+		ws.listWatcherOptions = options
+	}
+}
+
 // New creates a new multiple Watcher-backed api.Syncer.
-func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks) api.Syncer {
+func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
 	rs := &watcherSyncer{
-		watcherCaches: make([]*watcherCache, len(resourceTypes)),
-		results:       make(chan any, 2000),
-		callbacks:     callbacks,
+		watcherCaches:      make([]*watcherCache, len(resourceTypes)),
+		results:            make(chan any, 2000),
+		callbacks:          callbacks,
+		listWatcherOptions: api.DefaultListWatcherOptions(),
+	}
+	for _, o := range options {
+		if o != nil {
+			o(rs)
+		}
 	}
 	for i, r := range resourceTypes {
-		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results)
+		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results, rs.listWatcherOptions)
 	}
 	return rs
 }
 
 // watcherSyncer implements the api.Syncer interface.
 type watcherSyncer struct {
-	status        api.SyncStatus
-	watcherCaches []*watcherCache
-	results       chan any
-	numSynced     int
-	callbacks     api.SyncerCallbacks
-	wgwc          *sync.WaitGroup
-	wgws          *sync.WaitGroup
-	cancel        context.CancelFunc
+	status             api.SyncStatus
+	watcherCaches      []*watcherCache
+	results            chan any
+	numSynced          int
+	callbacks          api.SyncerCallbacks
+	wgwc               *sync.WaitGroup
+	wgws               *sync.WaitGroup
+	cancel             context.CancelFunc
+	listWatcherOptions api.ListWatcherOptions
 }
 
 func (ws *watcherSyncer) Start() {

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -17,6 +17,7 @@ package watchersyncer
 import (
 	"context"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -83,6 +84,17 @@ type Option func(*watcherSyncer)
 func WithListWatcherOptions(options api.ListWatcherOptions) Option {
 	return func(ws *watcherSyncer) {
 		ws.listWatcherOptions = options
+	}
+}
+
+// WithWatchRetryTimeout sets the maximum time a watch can fail to reconnect
+// before reporting a connection error.
+//
+// Deprecated: use WithListWatcherOptions to set
+// api.ListWatcherOptions.WatchRetryTimeout instead.
+func WithWatchRetryTimeout(t time.Duration) Option {
+	return func(ws *watcherSyncer) {
+		ws.listWatcherOptions.WatchRetryTimeout = t
 	}
 }
 

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -69,17 +69,12 @@ type SyncerUpdateProcessor interface {
 	OnSyncerStarting()
 }
 
-type Option func(*watcherSyncer)
-
 // New creates a new multiple Watcher-backed api.Syncer.
-func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks, options ...Option) api.Syncer {
+func New(client api.Client, resourceTypes []ResourceType, callbacks api.SyncerCallbacks) api.Syncer {
 	rs := &watcherSyncer{
 		watcherCaches: make([]*watcherCache, len(resourceTypes)),
 		results:       make(chan any, 2000),
 		callbacks:     callbacks,
-	}
-	for _, o := range options {
-		o(rs)
 	}
 	for i, r := range resourceTypes {
 		rs.watcherCaches[i] = newWatcherCache(client, r, rs.results)

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -217,6 +217,23 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectConnErrors([]error{genError})
 	})
 
+	It("should ignore nil delete events from backend ListAndWatch implementations", func() {
+		onDeleteCalled := make(chan struct{})
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs.fc.listAndWatchFunc = func(ctx context.Context, list model.ListInterface, handler api.EventHandler, opts ...api.ListWatcherOption) error {
+			handler.OnDelete(nil)
+			close(onDeleteCalled)
+			<-ctx.Done()
+			return ctx.Err()
+		}
+
+		rs.watcherSyncer.Start()
+		defer rs.watcherSyncer.Stop()
+
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		Eventually(onDeleteCalled).Should(BeClosed())
+	})
+
 	It("should fall back to generic ListAndWatch if backend-specific ListAndWatch is unsupported", func() {
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.fc.listAndWatchError = cerrors.ErrorOperationNotSupported{
@@ -1250,6 +1267,7 @@ func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType
 type fakeClient struct {
 	lws               map[string]*listWatchSource
 	listAndWatchError error
+	listAndWatchFunc  func(context.Context, model.ListInterface, api.EventHandler, ...api.ListWatcherOption) error
 
 	// Allows us to track the revision that the syncer is using.
 	latestListRevision  string
@@ -1390,6 +1408,9 @@ func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface,
 	log.WithField("Name", name).Info("ListAndWatch request")
 	if c.listAndWatchError != nil {
 		return c.listAndWatchError
+	}
+	if c.listAndWatchFunc != nil {
+		return c.listAndWatchFunc(ctx, list, handler, opts...)
 	}
 
 	client := &fakeK8sClient{fakeClient: c}

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -203,6 +203,21 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectConnErrors([]error{listAndWatchErr})
 	})
 
+	It("should fall back to generic ListAndWatch if backend-specific ListAndWatch is unsupported", func() {
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs.fc.listAndWatchError = cerrors.ErrorOperationNotSupported{
+			Operation:  "ListAndWatch",
+			Identifier: r1.ListInterface,
+		}
+
+		rs.watcherSyncer.Start()
+
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.ExpectStatusUpdate(api.InSync)
+	})
+
 	It("should handle reconnection if watchers fail to be created", func() {
 		// Since we are timing the processing, keep the interval sufficiently large
 		// to make the measurements more accurate.

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -80,7 +80,7 @@ var (
 	notSupported = cerrors.ErrorOperationNotSupported{}
 	notExists    = cerrors.ErrorResourceDoesNotExist{}
 	k8sTooOldRV  = kerrors.NewResourceExpired("test error")
-	caliTooOldRV = kerrors.FromObject(&k8sTooOldRV.ErrStatus) // Our wrapper around above error.
+	caliTooOldRV = kerrors.FromObject(&k8sTooOldRV.ErrStatus)
 	genError     = errors.New("Generic error")
 )
 

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1266,7 +1266,7 @@ func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, option
 	}
 }
 
-// ListAndWatch implements the api.Client interface by using k8s.NewListWatcher.
+// ListAndWatch implements the optional api.ListAndWatchClient interface by using k8s.NewListWatcher.
 // We use a fakeK8sClient to adapt fakeClient to K8sResourceClient interface.
 // The fakeK8sClient.Watch returns an Invalid error for WatchList mode to trigger
 // fallback to traditional List+Watch mode.
@@ -1279,7 +1279,7 @@ func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface,
 
 	client := &fakeK8sClient{fakeClient: c}
 	lw := k8s.NewListWatcher(client, list, handler, api.WithListWatcherOptions(c.listWatcherOptions))
-	return lw.RunLoopWithBackend(ctx, lw)
+	return lw.ListAndWatchWithBackend(ctx, lw)
 }
 
 // fakeK8sClient adapts fakeClient to K8sResourceClient interface

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -24,13 +24,14 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/watchersyncer"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
@@ -79,7 +80,7 @@ var (
 	notSupported = cerrors.ErrorOperationNotSupported{}
 	notExists    = cerrors.ErrorResourceDoesNotExist{}
 	k8sTooOldRV  = kerrors.NewResourceExpired("test error")
-	caliTooOldRV = apierrors.FromObject(&k8sTooOldRV.ErrStatus) // Our wrapper around above error.
+	caliTooOldRV = kerrors.FromObject(&k8sTooOldRV.ErrStatus) // Our wrapper around above error.
 	genError     = errors.New("Generic error")
 )
 
@@ -146,8 +147,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently
 		// large to make the measurements more accurate.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		By("Getting to the initial in-sync")
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
@@ -157,15 +158,16 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
 		rs.ExpectStatusUpdate(api.InSync)
 
-		// Send a watch error. This will trigger a re-list from the revision
-		// the watcher cache has stored.
+		// Send a watch error. This will trigger fallback to List+Watch mode and a re-list.
+		// With the current design, List always starts from empty revision to get fresh data.
 		By("Sending watch error but no too-old error")
 		rs.clientWatchResponse(r1, notSupported)
 		rs.clientListResponse(r1, emptyList)
 
-		// Expect List and watch be called with the emptylist revision.
-		Eventually(rs.fc.getLatestListRevision, 2*time.Second, 10*time.Millisecond).Should(Equal(emptyList.Revision))
-		Eventually(rs.fc.getLatestWatchRevision, 2*time.Second, 10*time.Millisecond).Should(Equal(emptyList.Revision))
+		// List is always called with empty revision (to get latest data).
+		// Watch is called with the revision from the previous successful list.
+		Eventually(rs.fc.getLatestListRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(""))
+		Eventually(rs.fc.getLatestWatchRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(emptyList.Revision))
 
 		// Send a watch error, followed by a resource version too old error
 		// on the list. This should trigger the watcher cache to retry the list
@@ -173,7 +175,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		By("Sending watch error and too-old error")
 		rs.clientWatchResponse(r1, k8sTooOldRV)
 		rs.clientListResponse(r1, k8sTooOldRV)
-		Eventually(rs.fc.getLatestListRevision, 2*time.Second, 10*time.Millisecond).Should(Equal("0"))
+		// List is always called with empty revision (to get latest data)
+		Eventually(rs.fc.getLatestListRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(""))
 
 		// Simulate a successful list using the 0 revision - we should see the watch started from the correct
 		// revision again.
@@ -185,7 +188,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// If an API isn't installed, the List will return a NotFound error. We expect the watcher cache to handle this gracefully,
 		// makring itself in sync and not retrying for an extended period.
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
-		rs.clientListResponse(r1, apierrors.NewNotFound(apiv3.Resource("networkpolicies"), ""))
+		rs.clientListResponse(r1, kerrors.NewNotFound(apiv3.Resource("networkpolicies"), ""))
 		rs.watcherSyncer.Start()
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
@@ -196,8 +199,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently
 		// large to make the measurements more accurate.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
@@ -223,7 +226,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// The longest of these is resource 2 (since the watcher poll timer is longer).  We'll
 		// check that connection succeeds within -30% and +50% of the expected interval.
 		By("Driving a bunch of List complete, Watch fail events for 2/3 resource types")
-		expectedDuration := watchersyncer.WatchPollInterval * 2
+		expectedDuration := api.WatchPollInterval * 2
 		minDuration := 70 * expectedDuration / 100
 		maxDuration := 250 * expectedDuration / 100
 		before := time.Now()
@@ -261,7 +264,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// - list succeeds
 		// - watch succeeds ... total 6s
 		By("Driving a bunch of List complete, Watch fail events for the 3rd resource type")
-		expectedDuration = watchersyncer.WatchPollInterval + watchersyncer.ListRetryInterval
+		expectedDuration = api.WatchPollInterval + api.ListRetryInterval
 		minDuration = 70 * expectedDuration / 100
 		maxDuration = 130 * expectedDuration / 100
 		before = time.Now()
@@ -292,8 +295,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently
 		// large to make the measurements more accurate.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
@@ -307,7 +310,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// - list succeeds
 		// - watch succeeds ...
 		By("Failing watch with an unknown error repeatedly.")
-		expectedDuration := watchersyncer.MinResyncInterval * 5
+		expectedDuration := api.MinResyncInterval * 5
 		minDuration := 70 * expectedDuration / 100
 		maxDuration := 150 * expectedDuration / 100
 		before := time.Now()
@@ -315,7 +318,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
 		rs.ExpectStatusUpdate(api.InSync)
 		// Expect MaxErrorsPerRevision unknown errors before triggering a re-list.
-		for range watchersyncer.MaxErrorsPerRevision {
+		for range api.MaxErrorsPerRevision {
 			rs.clientWatchResponse(r1, genError)
 		}
 		rs.ExpectStatusUnchanged()
@@ -341,8 +344,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently
 		// large to make the measurements more accurate.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
@@ -357,7 +360,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUnchanged()
 		rs.clientListResponse(r3, emptyList)
 		rs.ExpectStatusUpdate(api.InSync)
-		for range watchersyncer.MaxErrorsPerRevision {
+		for range api.MaxErrorsPerRevision {
 			By("Starting a watch and then sending a terminating error.")
 			rs.clientWatchResponse(r3, nil)
 			rs.sendEvent(r3, api.WatchEvent{
@@ -372,9 +375,12 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUnchanged()
 
 		By("Expecting the time for all events to be handled is within a sensible window")
-		expectedDuration := watchersyncer.MinResyncInterval * 5
+		expectedDuration := api.MinResyncInterval * 5
 		minDuration := 70 * expectedDuration / 100
-		maxDuration := 300 * expectedDuration / 100
+		// Note: maxDuration is set to 200% to account for WatchList fallback delay.
+		// When the fake client returns an Invalid error for WatchList mode, it triggers
+		// a fallback to List+Watch mode which adds an extra retry delay.
+		maxDuration := 200 * expectedDuration / 100
 		for time.Since(before) < maxDuration {
 			if rs.allEventsHandled() {
 				break
@@ -394,8 +400,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently
 		// large to make the measurements more accurate.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
@@ -421,7 +427,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.clientWatchResponse(r1, nil)
 		rs.ExpectStatusUnchanged()
 
-		Eventually(rs.fc.getLatestWatchRevision, watchersyncer.MinResyncInterval*2, 10*time.Millisecond).Should(
+		Eventually(rs.fc.getLatestWatchRevision, api.MinResyncInterval*2, 10*time.Millisecond).Should(
 			Equal("bookmarkRevision"))
 	})
 
@@ -429,8 +435,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently
 		// large to make the measurements more accurate.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
@@ -453,23 +459,23 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 			Error: dsError,
 		})
 
-		for range watchersyncer.MaxErrorsPerRevision * 2 {
+		for range api.MaxErrorsPerRevision * 2 {
 			rs.clientWatchResponse(r1, cerrors.ErrorDatastoreError{
 				Err: unix.ECONNREFUSED,
 			})
-			Eventually(rs.allEventsHandled, watchersyncer.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
+			Eventually(rs.allEventsHandled, api.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
 		}
 		rs.clientWatchResponse(r1, nil)
 		rs.ExpectStatusUnchanged()
-		Eventually(rs.allEventsHandled, watchersyncer.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
+		Eventually(rs.allEventsHandled, api.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
 
 		Expect(rs.fc.getLatestWatchRevision()).To(Equal("bookmarkRevision"))
 	})
 
 	It("Should handle receiving events while one watcher fails and fails to recreate", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 50*time.Millisecond, 200*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		eventL1Added1 := addEvent(l1Key1)
@@ -498,7 +504,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.clientWatchResponse(r2, genError)
 		rs.ExpectStatusUnchanged()
 		rs.clientWatchResponse(r2, nil)
-		time.Sleep(130 * watchersyncer.WatchPollInterval / 100)
+		time.Sleep(130 * api.WatchPollInterval / 100)
 		rs.expectAllEventsHandled()
 
 		By("Sending two watch events for resource 2.")
@@ -551,8 +557,8 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 
 	It("Should not resend add events during a resync and should delete stale entries", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
-		setWatchIntervals(50*time.Millisecond, 50*time.Millisecond, 200*time.Millisecond)
+		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
+		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
 
 		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		eventL1Added1 := addEvent(l1Key1)
@@ -579,7 +585,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// The retry thread will be blocked for the watch poll interval.
 		// Need to use a too-old error to trigger re-List.
 		rs.clientWatchResponse(r1, caliTooOldRV)
-		time.Sleep(watchersyncer.WatchPollInterval)
+		time.Sleep(api.WatchPollInterval)
 		rs.ExpectStatusUnchanged()
 
 		By("returning a sync list with one entry removed and a new one added")
@@ -907,9 +913,9 @@ var (
 // Set the list interval and watch interval in the WatcherSyncer.  We do this to reduce
 // the test time.
 func setWatchIntervals(minRetryInterval, listRetryInterval, watchPollInterval time.Duration) {
-	watchersyncer.MinResyncInterval = minRetryInterval
-	watchersyncer.ListRetryInterval = listRetryInterval
-	watchersyncer.WatchPollInterval = watchPollInterval
+	api.MinResyncInterval = minRetryInterval
+	api.ListRetryInterval = listRetryInterval
+	api.WatchPollInterval = watchPollInterval
 }
 
 // Fake converter used to cover error and update handling paths.
@@ -1251,6 +1257,42 @@ func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, option
 		c.latestWatchRevision = options.Revision
 		return l.watch()
 	}
+}
+
+// ListAndWatch implements the api.Client interface by using k8s.NewListWatcher.
+// We use a fakeK8sClient to adapt fakeClient to K8sResourceClient interface.
+// The fakeK8sClient.Watch returns an Invalid error for WatchList mode to trigger
+// fallback to traditional List+Watch mode.
+func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface, handler api.EventHandler) error {
+	name := model.ListOptionsToDefaultPathRoot(list)
+	log.WithField("Name", name).Info("ListAndWatch request")
+
+	client := &fakeK8sClient{fakeClient: c}
+	lw := k8s.NewListWatcher(client, list, handler)
+	return lw.RunLoopWithBackend(ctx, lw)
+}
+
+// fakeK8sClient adapts fakeClient to K8sResourceClient interface
+type fakeK8sClient struct {
+	*fakeClient
+}
+
+func (c *fakeK8sClient) Delete(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
+	// K8sResourceClient.Delete has uid parameter, but we ignore it in tests
+	return c.fakeClient.Delete(ctx, key, revision)
+}
+
+// Watch overrides fakeClient.Watch to return an Invalid error when WatchList mode is detected.
+// This triggers the k8s.ListWatcher to fall back to traditional List+Watch mode.
+func (c *fakeK8sClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
+	// Check if this is a WatchList mode request (SendInitialEvents is set to true)
+	if options.SendInitialEvents != nil && *options.SendInitialEvents {
+		log.WithField("list", list).Info("WatchList mode detected, returning Invalid error to trigger fallback")
+		// Return an Invalid error to trigger fallback to List+Watch mode
+		return nil, kerrors.NewInvalid(apiv3.SchemeGroupVersion.WithKind("NetworkPolicy").GroupKind(), "", nil)
+	}
+	// Otherwise, delegate to the underlying fakeClient.Watch
+	return c.fakeClient.Watch(ctx, list, options)
 }
 
 // listWatchSource provides the resource type specific control of the client List and Watch response,

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 
 	It("should handle when an API is not installed", func() {
 		// If an API isn't installed, the List will return a NotFound error. We expect the watcher cache to handle this gracefully,
-		// makring itself in sync and not retrying for an extended period.
+		// marking itself in sync and not retrying for an extended period.
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.clientListResponse(r1, kerrors.NewNotFound(apiv3.Resource("networkpolicies"), ""))
 		rs.watcherSyncer.Start()
@@ -1065,7 +1065,7 @@ func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester
 }
 
 func newWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options api.ListWatcherOptions) *watcherSyncerTester {
-	// Create the required watchers.  This hs methods that we use to drive
+	// Create the required watchers.  This has methods that we use to drive
 	// responses.
 	lws := map[string]*listWatchSource{}
 	for _, r := range l {

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -431,6 +431,35 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 			Equal("bookmarkRevision"))
 	})
 
+	It("Should restart from the most recent watch bookmark with the fallback ListWatch backend", func() {
+		rs := newStartedPlainWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.ExpectStatusUpdate(api.InSync)
+		rs.clientWatchResponse(r1, nil)
+
+		By("Sending a bookmark.")
+		rs.sendEvent(r1, api.WatchEvent{
+			Type: api.WatchBookmark,
+			New: &model.KVPair{
+				Revision: "fallbackBookmarkRevision",
+			},
+		})
+		By("Sending a watch terminated error.")
+		rs.sendEvent(r1, api.WatchEvent{
+			Type:  api.WatchError,
+			Error: dsError,
+		})
+
+		rs.clientWatchResponse(r1, nil)
+		rs.ExpectStatusUnchanged()
+
+		Eventually(rs.fc.getLatestWatchRevision, api.DefaultMinResyncInterval*2, 10*time.Millisecond).Should(
+			Equal("fallbackBookmarkRevision"))
+	})
+
 	It("Should retry the same revision on connection refused", func() {
 		// Since we are timing the processing, keep the interval sufficiently large
 		// to make the measurements more accurate.
@@ -1024,6 +1053,13 @@ func newStartedWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, op
 	return rst
 }
 
+func newStartedPlainWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
+	rst := newWatcherSyncerTester(l)
+	rst.watcherSyncer = watchersyncer.New(&plainFakeClient{fc: rst.fc}, l, rst.SyncerTester)
+	rst.watcherSyncer.Start()
+	return rst
+}
+
 func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
 	return newWatcherSyncerTesterWithOptions(l, api.DefaultListWatcherOptions())
 }
@@ -1264,6 +1300,54 @@ func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, option
 		c.latestWatchRevision = options.Revision
 		return l.watch()
 	}
+}
+
+type plainFakeClient struct {
+	fc *fakeClient
+}
+
+func (c *plainFakeClient) Create(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return c.fc.Create(ctx, object)
+}
+
+func (c *plainFakeClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return c.fc.Update(ctx, object)
+}
+
+func (c *plainFakeClient) Apply(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return c.fc.Apply(ctx, object)
+}
+
+func (c *plainFakeClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	return c.fc.Delete(ctx, key, revision)
+}
+
+func (c *plainFakeClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	return c.fc.DeleteKVP(ctx, kvp)
+}
+
+func (c *plainFakeClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	return c.fc.Get(ctx, key, revision)
+}
+
+func (c *plainFakeClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	return c.fc.List(ctx, list, revision)
+}
+
+func (c *plainFakeClient) Watch(ctx context.Context, list model.ListInterface, options api.WatchOptions) (api.WatchInterface, error) {
+	return c.fc.Watch(ctx, list, options)
+}
+
+func (c *plainFakeClient) EnsureInitialized() error {
+	return c.fc.EnsureInitialized()
+}
+
+func (c *plainFakeClient) Clean() error {
+	return c.fc.Clean()
+}
+
+func (c *plainFakeClient) Close() error {
+	return c.fc.Close()
 }
 
 // ListAndWatch implements the optional api.ListAndWatchClient interface by using k8s.NewListWatcher.

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -1082,8 +1082,7 @@ func newWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options a
 	}
 
 	fc := &fakeClient{
-		lws:                lws,
-		listWatcherOptions: options,
+		lws: lws,
 	}
 
 	// Create the syncer tester.
@@ -1091,7 +1090,7 @@ func newWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options a
 	rst := &watcherSyncerTester{
 		SyncerTester:  st,
 		fc:            fc,
-		watcherSyncer: watchersyncer.New(fc, l, st),
+		watcherSyncer: watchersyncer.New(fc, l, st, watchersyncer.WithListWatcherOptions(options)),
 		lws:           lws,
 	}
 	return rst
@@ -1216,9 +1215,8 @@ func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType
 // fakeClient implements the api.Client interface.  We mock this out so that we can control
 // the events
 type fakeClient struct {
-	lws                map[string]*listWatchSource
-	listWatcherOptions api.ListWatcherOptions
-	listAndWatchError  error
+	lws               map[string]*listWatchSource
+	listAndWatchError error
 
 	// Allows us to track the revision that the syncer is using.
 	latestListRevision  string
@@ -1354,7 +1352,7 @@ func (c *plainFakeClient) Close() error {
 // We use a fakeK8sClient to adapt fakeClient to K8sResourceClient interface.
 // The fakeK8sClient.Watch returns an Invalid error for WatchList mode to trigger
 // fallback to traditional List+Watch mode.
-func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface, handler api.EventHandler) error {
+func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface, handler api.EventHandler, opts ...api.ListWatcherOption) error {
 	name := model.ListOptionsToDefaultPathRoot(list)
 	log.WithField("Name", name).Info("ListAndWatch request")
 	if c.listAndWatchError != nil {
@@ -1362,7 +1360,7 @@ func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface,
 	}
 
 	client := &fakeK8sClient{fakeClient: c}
-	lw := k8s.NewListWatcher(client, list, handler, api.WithListWatcherOptions(c.listWatcherOptions))
+	lw := k8s.NewListWatcher(client, list, handler, opts...)
 	return lw.ListAndWatchWithBackend(ctx, lw)
 }
 

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -203,6 +203,20 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectConnErrors([]error{listAndWatchErr})
 	})
 
+	It("should support deprecated WithWatchRetryTimeout option", func() {
+		rs := newWatcherSyncerTesterWithWatchersyncerOptions(
+			[]watchersyncer.ResourceType{r1},
+			watchersyncer.WithWatchRetryTimeout(time.Nanosecond),
+		)
+		rs.clientListResponse(r1, genError)
+
+		rs.watcherSyncer.Start()
+		defer rs.watcherSyncer.Stop()
+
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.ExpectConnErrors([]error{genError})
+	})
+
 	It("should fall back to generic ListAndWatch if backend-specific ListAndWatch is unsupported", func() {
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.fc.listAndWatchError = cerrors.ErrorOperationNotSupported{
@@ -1080,6 +1094,10 @@ func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester
 }
 
 func newWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options api.ListWatcherOptions) *watcherSyncerTester {
+	return newWatcherSyncerTesterWithWatchersyncerOptions(l, watchersyncer.WithListWatcherOptions(options))
+}
+
+func newWatcherSyncerTesterWithWatchersyncerOptions(l []watchersyncer.ResourceType, options ...watchersyncer.Option) *watcherSyncerTester {
 	// Create the required watchers.  This has methods that we use to drive
 	// responses.
 	lws := map[string]*listWatchSource{}
@@ -1105,7 +1123,7 @@ func newWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options a
 	rst := &watcherSyncerTester{
 		SyncerTester:  st,
 		fc:            fc,
-		watcherSyncer: watchersyncer.New(fc, l, st, watchersyncer.WithListWatcherOptions(options)),
+		watcherSyncer: watchersyncer.New(fc, l, st, options...),
 		lws:           lws,
 	}
 	return rst

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -191,6 +191,18 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUpdate(api.InSync)
 	})
 
+	It("should report ListAndWatch failures", func() {
+		listAndWatchErr := errors.New("list and watch failed")
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs.fc.listAndWatchError = listAndWatchErr
+
+		rs.watcherSyncer.Start()
+		defer rs.watcherSyncer.Stop()
+
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.ExpectConnErrors([]error{listAndWatchErr})
+	})
+
 	It("should handle reconnection if watchers fail to be created", func() {
 		// Since we are timing the processing, keep the interval sufficiently large
 		// to make the measurements more accurate.
@@ -1170,6 +1182,7 @@ func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType
 type fakeClient struct {
 	lws                map[string]*listWatchSource
 	listWatcherOptions api.ListWatcherOptions
+	listAndWatchError  error
 
 	// Allows us to track the revision that the syncer is using.
 	latestListRevision  string
@@ -1260,6 +1273,9 @@ func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, option
 func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface, handler api.EventHandler) error {
 	name := model.ListOptionsToDefaultPathRoot(list)
 	log.WithField("Name", name).Info("ListAndWatch request")
+	if c.listAndWatchError != nil {
+		return c.listAndWatchError
+	}
 
 	client := &fakeK8sClient{fakeClient: c}
 	lw := k8s.NewListWatcher(client, list, handler, api.WithListWatcherOptions(c.listWatcherOptions))

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -144,14 +144,10 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 
 	// Tests the scenario found in this issue: https://github.com/projectcalico/calico/issues/6032
 	It("should handle resourceVersion expired errors", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		// Since we are timing the processing, we still need the interval to be sufficiently
-		// large to make the measurements more accurate.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
+		options := testListWatcherOptions(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		By("Getting to the initial in-sync")
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1}, options)
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, k8sTooOldRV)
 		rs.clientListResponse(r1, emptyList)
@@ -196,13 +192,11 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("should handle reconnection if watchers fail to be created", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		// Since we are timing the processing, we still need the interval to be sufficiently
-		// large to make the measurements more accurate.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
+		// Since we are timing the processing, keep the interval sufficiently large
+		// to make the measurements more accurate.
+		options := testListWatcherOptions(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1, r2, r3}, options)
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		// All of the events should have been consumed within a time frame dictated by the
@@ -226,7 +220,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// The longest of these is resource 2 (since the watcher poll timer is longer).  We'll
 		// check that connection succeeds within -30% and +50% of the expected interval.
 		By("Driving a bunch of List complete, Watch fail events for 2/3 resource types")
-		expectedDuration := api.WatchPollInterval * 2
+		expectedDuration := options.WatchPollInterval * 2
 		minDuration := 70 * expectedDuration / 100
 		maxDuration := 250 * expectedDuration / 100
 		before := time.Now()
@@ -264,7 +258,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// - list succeeds
 		// - watch succeeds ... total 6s
 		By("Driving a bunch of List complete, Watch fail events for the 3rd resource type")
-		expectedDuration = api.WatchPollInterval + api.ListRetryInterval
+		expectedDuration = options.WatchPollInterval + options.ListRetryInterval
 		minDuration = 70 * expectedDuration / 100
 		maxDuration = 130 * expectedDuration / 100
 		before = time.Now()
@@ -292,13 +286,11 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("should require several unknown watch failures to trigger re-List()", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		// Since we are timing the processing, we still need the interval to be sufficiently
-		// large to make the measurements more accurate.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
+		// Since we are timing the processing, keep the interval sufficiently large
+		// to make the measurements more accurate.
+		options := testListWatcherOptions(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1}, options)
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		// All of the events should have been consumed within a time frame dictated by the
@@ -310,7 +302,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// - list succeeds
 		// - watch succeeds ...
 		By("Failing watch with an unknown error repeatedly.")
-		expectedDuration := api.MinResyncInterval * 5
+		expectedDuration := options.MinResyncInterval * time.Duration(options.MaxErrorsPerRevision)
 		minDuration := 70 * expectedDuration / 100
 		maxDuration := 150 * expectedDuration / 100
 		before := time.Now()
@@ -318,7 +310,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
 		rs.ExpectStatusUpdate(api.InSync)
 		// Expect MaxErrorsPerRevision unknown errors before triggering a re-list.
-		for range api.MaxErrorsPerRevision {
+		for range options.MaxErrorsPerRevision {
 			rs.clientWatchResponse(r1, genError)
 		}
 		rs.ExpectStatusUnchanged()
@@ -341,13 +333,11 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should handle reconnection and syncing when the watcher sends a watch terminated error", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		// Since we are timing the processing, we still need the interval to be sufficiently
-		// large to make the measurements more accurate.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
+		// Since we are timing the processing, keep the interval sufficiently large
+		// to make the measurements more accurate.
+		options := testListWatcherOptions(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1, r2, r3}, options)
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		before := time.Now()
@@ -360,7 +350,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUnchanged()
 		rs.clientListResponse(r3, emptyList)
 		rs.ExpectStatusUpdate(api.InSync)
-		for range api.MaxErrorsPerRevision {
+		for range options.MaxErrorsPerRevision {
 			By("Starting a watch and then sending a terminating error.")
 			rs.clientWatchResponse(r3, nil)
 			rs.sendEvent(r3, api.WatchEvent{
@@ -375,7 +365,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUnchanged()
 
 		By("Expecting the time for all events to be handled is within a sensible window")
-		expectedDuration := api.MinResyncInterval * 5
+		expectedDuration := options.MinResyncInterval * time.Duration(options.MaxErrorsPerRevision)
 		minDuration := 70 * expectedDuration / 100
 		// Note: maxDuration is set to 200% to account for WatchList fallback delay.
 		// When the fake client returns an Invalid error for WatchList mode, it triggers
@@ -397,13 +387,11 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should restart from the most recent watch bookmark after a watch failure", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		// Since we are timing the processing, we still need the interval to be sufficiently
-		// large to make the measurements more accurate.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
+		// Since we are timing the processing, keep the interval sufficiently large
+		// to make the measurements more accurate.
+		options := testListWatcherOptions(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1}, options)
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		rs.clientListResponse(r1, emptyList)
@@ -427,18 +415,16 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.clientWatchResponse(r1, nil)
 		rs.ExpectStatusUnchanged()
 
-		Eventually(rs.fc.getLatestWatchRevision, api.MinResyncInterval*2, 10*time.Millisecond).Should(
+		Eventually(rs.fc.getLatestWatchRevision, options.MinResyncInterval*2, 10*time.Millisecond).Should(
 			Equal("bookmarkRevision"))
 	})
 
 	It("Should retry the same revision on connection refused", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		// Since we are timing the processing, we still need the interval to be sufficiently
-		// large to make the measurements more accurate.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
+		// Since we are timing the processing, keep the interval sufficiently large
+		// to make the measurements more accurate.
+		options := testListWatcherOptions(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1}, options)
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		rs.clientListResponse(r1, emptyList)
@@ -459,25 +445,23 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 			Error: dsError,
 		})
 
-		for range api.MaxErrorsPerRevision * 2 {
+		for range options.MaxErrorsPerRevision * 2 {
 			rs.clientWatchResponse(r1, cerrors.ErrorDatastoreError{
 				Err: unix.ECONNREFUSED,
 			})
-			Eventually(rs.allEventsHandled, api.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
+			Eventually(rs.allEventsHandled, options.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
 		}
 		rs.clientWatchResponse(r1, nil)
 		rs.ExpectStatusUnchanged()
-		Eventually(rs.allEventsHandled, api.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
+		Eventually(rs.allEventsHandled, options.MinResyncInterval*2, time.Millisecond).Should(BeTrue())
 
 		Expect(rs.fc.getLatestWatchRevision()).To(Equal("bookmarkRevision"))
 	})
 
 	It("Should handle receiving events while one watcher fails and fails to recreate", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		options := testListWatcherOptions(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1, r2, r3}, options)
 		eventL1Added1 := addEvent(l1Key1)
 		eventL2Added1 := addEvent(l2Key1)
 		eventL2Added2 := addEvent(l2Key2)
@@ -504,7 +488,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.clientWatchResponse(r2, genError)
 		rs.ExpectStatusUnchanged()
 		rs.clientWatchResponse(r2, nil)
-		time.Sleep(130 * api.WatchPollInterval / 100)
+		time.Sleep(130 * options.WatchPollInterval / 100)
 		rs.expectAllEventsHandled()
 
 		By("Sending two watch events for resource 2.")
@@ -556,11 +540,9 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should not resend add events during a resync and should delete stale entries", func() {
-		// Temporarily reduce the watch and list poll interval to make the tests faster.
-		defer setWatchIntervals(api.MinResyncInterval, api.ListRetryInterval, api.WatchPollInterval)
-		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
+		options := testListWatcherOptions(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
 
-		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTesterWithOptions([]watchersyncer.ResourceType{r1}, options)
 		eventL1Added1 := addEvent(l1Key1)
 		eventL1Deleted1 := deleteEvent(l1Key1)
 		eventL1Added2 := addEvent(l1Key2)
@@ -585,7 +567,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// The retry thread will be blocked for the watch poll interval.
 		// Need to use a too-old error to trigger re-List.
 		rs.clientWatchResponse(r1, caliTooOldRV)
-		time.Sleep(api.WatchPollInterval)
+		time.Sleep(options.WatchPollInterval)
 		rs.ExpectStatusUnchanged()
 
 		By("returning a sync list with one entry removed and a new one added")
@@ -910,12 +892,12 @@ var (
 	}
 )
 
-// Set the list interval and watch interval in the WatcherSyncer.  We do this to reduce
-// the test time.
-func setWatchIntervals(minRetryInterval, listRetryInterval, watchPollInterval time.Duration) {
-	api.MinResyncInterval = minRetryInterval
-	api.ListRetryInterval = listRetryInterval
-	api.WatchPollInterval = watchPollInterval
+func testListWatcherOptions(minRetryInterval, listRetryInterval, watchPollInterval time.Duration) api.ListWatcherOptions {
+	options := api.DefaultListWatcherOptions()
+	options.MinResyncInterval = minRetryInterval
+	options.ListRetryInterval = listRetryInterval
+	options.WatchPollInterval = watchPollInterval
+	return options
 }
 
 // Fake converter used to cover error and update handling paths.
@@ -1024,7 +1006,17 @@ func newStartedWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSynce
 	return rst
 }
 
+func newStartedWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options api.ListWatcherOptions) *watcherSyncerTester {
+	rst := newWatcherSyncerTesterWithOptions(l, options)
+	rst.watcherSyncer.Start()
+	return rst
+}
+
 func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
+	return newWatcherSyncerTesterWithOptions(l, api.DefaultListWatcherOptions())
+}
+
+func newWatcherSyncerTesterWithOptions(l []watchersyncer.ResourceType, options api.ListWatcherOptions) *watcherSyncerTester {
 	// Create the required watchers.  This hs methods that we use to drive
 	// responses.
 	lws := map[string]*listWatchSource{}
@@ -1042,7 +1034,8 @@ func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester
 	}
 
 	fc := &fakeClient{
-		lws: lws,
+		lws:                lws,
+		listWatcherOptions: options,
 	}
 
 	// Create the syncer tester.
@@ -1175,7 +1168,8 @@ func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType
 // fakeClient implements the api.Client interface.  We mock this out so that we can control
 // the events
 type fakeClient struct {
-	lws map[string]*listWatchSource
+	lws                map[string]*listWatchSource
+	listWatcherOptions api.ListWatcherOptions
 
 	// Allows us to track the revision that the syncer is using.
 	latestListRevision  string
@@ -1268,7 +1262,7 @@ func (c *fakeClient) ListAndWatch(ctx context.Context, list model.ListInterface,
 	log.WithField("Name", name).Info("ListAndWatch request")
 
 	client := &fakeK8sClient{fakeClient: c}
-	lw := k8s.NewListWatcher(client, list, handler)
+	lw := k8s.NewListWatcher(client, list, handler, api.WithListWatcherOptions(c.listWatcherOptions))
 	return lw.RunLoopWithBackend(ctx, lw)
 }
 


### PR DESCRIPTION
## Description

This PR adds WatchList-aware synchronization support for the Kubernetes backend and refactors shared list/watch behavior into a reusable `GenericListWatcher`.

Kubernetes resources that support WatchList can stream initial data through watch events using `SendInitialEvents=true`, watch bookmarks, and `ResourceVersionMatch=NotOlderThan`. Resources that do not support WatchList, older apiservers, and non-Kubernetes backends continue to use List+Watch.

## Motivation

The previous `watcherCache` implementation owned list calls, watch creation, retry throttling, revision tracking, stale-entry detection, and event processing in one place. That made it difficult to add Kubernetes WatchList support without duplicating list/watch behavior or changing etcd semantics.

This change separates the shared state machine from backend-specific behavior:

- `GenericListWatcher` owns common retry, revision, initial sync, and event-loop logic.
- Kubernetes and etcd provide backend-specific `ListWatchBackend` implementations.
- `watcherCache` focuses on converting `EventHandler` callbacks into syncer updates.

WatchList reduces initial-sync memory pressure on Kubernetes clusters that support it because initial objects can be streamed through watch events instead of first materializing a full List response in the watcher cache.

## Refactoring Summary

### Before

```text
watcherCache
|-- List/Watch logic embedded
|-- Error handling mixed with event processing
|-- Retry/throttle logic embedded
|-- Revision tracking embedded
|-- oldResources map copied for deletion detection
`-- Tightly coupled to concrete backend watch behavior
```

### After

```text
watcherCache
|-- Implements api.EventHandler
|-- Handles OnAdd / OnUpdate / OnDelete / OnSync / OnError
|-- Uses resyncEpoch for stale-entry deletion detection
`-- Delegates list/watch mechanics to backend ListAndWatch or generic fallback

GenericListWatcher
|-- Common retry/throttle logic
|-- Current revision tracking
|-- Repeated error counting
|-- Initial sync state
`-- Shared event loop and basic watch event handling

k8s.ListWatcher
|-- WatchList initial sync when supported
|-- Bookmark handling
|-- Fallback to List+Watch
`-- Kubernetes-specific error handling

etcdv3.ListWatcher
|-- Traditional List+Watch
`-- etcd-specific watch error handling
```

## Design

### Architecture

```mermaid
flowchart TB
    subgraph WatcherSyncer["WatcherSyncer Layer"]
        WS[WatcherSyncer<br/>Coordinates watcher caches]
        WC1[watcherCache #1]
        WC2[watcherCache #2]
        WC3[watcherCache #N]
        WS --> WC1
        WS --> WC2
        WS --> WC3
    end

    subgraph EventHandling["Event Handling"]
        EH{{api.EventHandler}}
        EH1[OnResyncStarted]
        EH2[OnAdd / OnUpdate / OnDelete]
        EH3[OnSync]
        EH4[OnError]
        EH --> EH1
        EH --> EH2
        EH --> EH3
        EH --> EH4
    end

    subgraph ClientInterfaces["Client Interfaces"]
        APIClient[api.Client<br/>List + Watch]
        OptionalLAW[api.ListAndWatchClient<br/>optional ListAndWatch]
        WatchListSupport[api.WatchListSupporter<br/>optional capability]
    end

    subgraph Backends["Backend Implementations"]
        K8SC[k8s.KubeClient]
        ETCDC[etcdv3.Client]
        GenericFallback[clientListWatchBackend<br/>generic List+Watch fallback]
        K8SC -. implements .-> OptionalLAW
        ETCDC -. implements .-> OptionalLAW
        GenericFallback --> APIClient
    end

    subgraph ListWatchers["ListWatcher Implementations"]
        GLW[api.GenericListWatcher]
        K8SLW[k8s.ListWatcher]
        ETCDLW[etcdv3.ListWatcher]
        K8SLW --> GLW
        ETCDLW --> GLW
        GenericFallback --> GLW
    end

    subgraph K8sModes["Kubernetes Sync Modes"]
        WLM[WatchList mode<br/>SendInitialEvents + bookmark]
        LWM[List+Watch fallback]
        K8SLW --> WLM
        K8SLW -. fallback .-> LWM
        WatchListSupport -. controls .-> WLM
    end

    subgraph DataSources["Data Sources"]
        APIServer[(Kubernetes API server)]
        ETCD[(etcd)]
    end

    WC1 -. implements .-> EH
    WC2 -. implements .-> EH
    WC3 -. implements .-> EH

    WC1 -->|prefer optional ListAndWatch| OptionalLAW
    WC2 -->|fallback if unsupported| GenericFallback
    WC3 -->|fallback if unsupported| GenericFallback

    OptionalLAW --> K8SC
    OptionalLAW --> ETCDC

    WLM --> APIServer
    LWM --> APIServer
    ETCDLW --> ETCD

    style OptionalLAW fill:#9f9,stroke:#393
    style WLM fill:#9cf,stroke:#369
    style GLW fill:#fc9,stroke:#963
```

### Data Flow

```mermaid
sequenceDiagram
    participant WS as WatcherSyncer
    participant WC as watcherCache
    participant Client as backend client
    participant LW as backend ListWatcher
    participant GLW as GenericListWatcher
    participant Server as K8s API / etcd

    WS->>WC: run(ctx)

    alt Client implements api.ListAndWatchClient
        WC->>Client: ListAndWatch(ctx, list, handler, options)
        Client->>LW: create backend ListWatcher
    else Client only implements api.Client
        WC->>GLW: create GenericListWatcher
        WC->>LW: create generic clientListWatchBackend
    end

    loop ListAndWatch loop
        GLW->>GLW: RetryThrottleC()

        alt InitialSyncPending and WatchList supported
            GLW->>LW: CreateWatch(useWatchList=true)
            alt WatchList create succeeds
                GLW->>LW: PerformInitialSync(useWatchList=true)
                LW->>WC: OnResyncStarted()
                loop Stream initial events
                    Server-->>LW: Added / Modified / Deleted
                    LW->>GLW: UpdateRevision()
                    LW->>WC: OnAdd / OnUpdate / OnDelete
                end
                Server-->>LW: Bookmark(initial-events=true)
                LW->>GLW: UpdateRevision()
                LW->>WC: OnSync()
            else WatchList unavailable
                GLW->>LW: PerformInitialSync(useWatchList=false)
                LW->>Server: List(empty revision)
                Server-->>LW: KVPairList(revision)
                LW->>WC: OnResyncStarted()
                LW->>WC: OnAdd(kvp) for each result
                LW->>WC: OnSync()
                GLW->>LW: CreateWatch(useWatchList=false)
            end
        else List+Watch mode
            GLW->>LW: PerformInitialSync(useWatchList=false)
            LW->>Server: List(empty revision)
            Server-->>LW: KVPairList(revision)
            LW->>WC: OnResyncStarted()
            LW->>WC: OnAdd(kvp) for each result
            LW->>WC: OnSync()
            GLW->>LW: CreateWatch(useWatchList=false)
        end

        loop Watch events
            Server-->>LW: Watch event / bookmark / error
            LW->>GLW: HandleBasicWatchEvent or backend-specific handling
            GLW->>WC: OnAdd / OnUpdate / OnDelete
        end

        alt Backend-specific ListAndWatch unsupported
            Client-->>WC: ErrorOperationNotSupported
            WC->>GLW: fall back to generic List+Watch
        else Non-context terminal error
            Client-->>WC: error
            WC->>WS: errorSyncBackendError
        end
    end
```

### Key Interfaces

#### Optional backend ListAndWatch

```go
type ListAndWatchClient interface {
    ListAndWatch(
        ctx context.Context,
        list model.ListInterface,
        handler EventHandler,
        opts ...ListWatcherOption,
    ) error
}
```

This is intentionally optional. `api.Client` remains compatible with implementations that only provide `List` and `Watch`.

#### EventHandler

```go
type EventHandler interface {
    OnResyncStarted()
    OnAdd(kvp *model.KVPair)
    OnUpdate(kvp *model.KVPair)
    OnDelete(kvp *model.KVPair)
    OnSync()
    OnError(err error)
}
```

#### ListWatchBackend

```go
type ListWatchBackend interface {
    PerformList(ctx context.Context) (*model.KVPairList, error)
    CreateWatch(ctx context.Context, useWatchList bool) (WatchInterface, error)
    HandleWatchEvent(event WatchEvent) error
    HandleListError(err error)
    HandleWatchError(err error)
    PerformInitialSync(ctx context.Context, g *GenericListWatcher, useWatchList bool) error
}
```

#### WatchListSupporter

```go
type WatchListSupporter interface {
    SupportsWatchList() bool
}
```

Backends or resource clients can implement this to disable WatchList for resources that need special sync semantics.

## Implementation Details

### 1. GenericListWatcher (`api/listwatcher.go`)

`GenericListWatcher` provides the common list/watch state machine:

- retry throttling through `MinResyncInterval`, `ListRetryInterval`, and `WatchPollInterval`
- connection timeout detection through `WatchRetryTimeout`
- current revision tracking
- repeated error counting through `MaxErrorsPerRevision`
- full resync reset through `ResetForFullResync`
- initial sync tracking through `InitialSyncPending`
- basic add/update/delete watch event handling

The constructor accepts `ListWatcherOption` values and ignores nil options defensively.

### 2. Kubernetes ListWatcher (`k8s/listwatcher.go`)

Kubernetes uses `k8s.ListWatcher`, which embeds `GenericListWatcher`.

WatchList mode:

- uses `SendInitialEvents=true`
- uses empty revision plus `ResourceVersionMatch=NotOlderThan`
- requests bookmarks
- identifies sync completion from the initial-events bookmark
- keeps the Kubernetes object in bookmark events so the final bookmark annotation can be inspected

Fallback behavior:

- if WatchList creation fails, the code falls back to List+Watch for that sync, matching client-go reflector behavior
- if a resource client reports `SupportsWatchList() == false`, initial sync uses List+Watch directly
- if `KubeClient.ListAndWatch` is unsupported for a resource type, `watcherCache` falls back to the generic `api.Client.List` plus `api.Client.Watch` path

Kubernetes-specific error handling:

- missing API / CRD: mark in sync, reset for future full resync, retry later
- resource expired / gone / too-large resource version: reset for full resync
- connection refused / too many requests: retry and reset if the connection timeout is exceeded

### 3. Profile resources

Profile resources explicitly disable WatchList:

```go
func (c *profileClient) SupportsWatchList() bool {
    return false
}
```

Profiles merge Namespace and ServiceAccount watches. The merged watcher must wait for both underlying streams to complete initial events before it can safely report sync completion, so the PR keeps Profiles on List+Watch for now.

### 4. etcd ListWatcher (`etcdv3/listwatcher.go`)

etcd uses `etcdv3.ListWatcher` with traditional List+Watch. It shares `GenericListWatcher` for retry, revision, error-count, connection-timeout, and full-resync behavior, but it does not use WatchList or bookmark sync completion.

### 5. watcherCache (`watchersyncer/watchercache.go`)

`watcherCache` now implements `api.EventHandler` and delegates list/watch mechanics:

- prefer backend-specific `api.ListAndWatchClient`
- fall back to generic List+Watch when backend-specific ListAndWatch returns `ErrorOperationNotSupported`
- forward non-context ListAndWatch errors to the syncer
- handle bookmarks in the generic fallback backend to advance the current revision
- skip malformed nil delete events instead of panicking

#### Resync Epoch Mechanism

```go
type cacheEntry struct {
    revision    string
    key         model.Key
    resyncEpoch uint64
}

type watcherCache struct {
    resyncEpoch            uint64
    lastHandledResyncEpoch uint64
    resources              map[string]cacheEntry
}
```

On resync start:

1. Increment `resyncEpoch` when the cache is non-empty.
2. Process incoming full-resync events, updating entries to the current epoch.
3. After sync, delete entries whose epoch was not refreshed.

```mermaid
sequenceDiagram
    participant Cache as watcherCache
    participant Resources as resources map
    participant Syncer as WatcherSyncer

    Note over Resources: Initial state<br/>pod-a epoch=1<br/>pod-b epoch=1<br/>pod-c epoch=1

    Cache->>Cache: OnResyncStarted()<br/>resyncEpoch = 2

    Note over Cache: Full resync receives pod-a and pod-c<br/>pod-b was deleted while disconnected

    Cache->>Resources: OnAdd(pod-a) sets epoch=2
    Cache->>Resources: OnAdd(pod-c) sets epoch=2
    Note over Resources: pod-a epoch=2<br/>pod-b epoch=1 stale<br/>pod-c epoch=2

    Cache->>Cache: OnSync()
    Cache->>Resources: scan entries with epoch < 2
    Resources-->>Cache: pod-b is stale
    Cache->>Syncer: send delete for pod-b
    Cache->>Resources: remove pod-b

    Note over Resources: Final state<br/>pod-a epoch=2<br/>pod-c epoch=2
```

This avoids copying all cached entries into a separate `oldResources` map for every resync.

### 6. watchersyncer options compatibility

`watchersyncer.New` accepts options again and passes `api.ListWatcherOptions` down into watcher caches and backend list watchers.

The previous exported option remains available:

```go
// Deprecated: use WithListWatcherOptions to set
// api.ListWatcherOptions.WatchRetryTimeout instead.
func WithWatchRetryTimeout(t time.Duration) Option
```

`ResourceType.SendDeletesOnConnFail` is also retained as a deprecated field for external API compatibility.

## Resource Version Management

### Overview

This PR uses empty revision for full resync List calls. That is intentional: fallback List+Watch should list the latest consistent data, then start the following watch from the returned list revision.

WatchList also starts with empty revision and sets `ResourceVersionMatch=NotOlderThan`, allowing Kubernetes to stream initial events and signal completion with a bookmark.

### Revision Lifecycle

```mermaid
stateDiagram-v2
    [*] --> Empty: NewGenericListWatcher
    Empty --> Syncing: InitialSyncPending

    state Syncing {
        [*] --> WatchList: Kubernetes and SupportsWatchList
        [*] --> ListWatch: etcd / fallback / unsupported WatchList

        WatchList --> CreateWatchList: CreateWatch(useWatchList=true)
        CreateWatchList --> ReceiveInitialEvents: watch created
        CreateWatchList --> ListWatch: WatchList create failed
        ReceiveInitialEvents --> UpdateRev: Each event updates revision
        UpdateRev --> ReceiveInitialEvents
        ReceiveInitialEvents --> Synced: initial-events bookmark

        ListWatch --> ListAll: PerformList(empty revision)
        ListAll --> UpdateRevFromList: Use list revision
        UpdateRevFromList --> Synced: OnSync
    }

    Synced --> Watching: CreateWatch(useWatchList=false)

    state Watching {
        [*] --> WaitEvent
        WaitEvent --> ProcessEvent: Event received
        ProcessEvent --> UpdateRevision: Update CurrentRevision
        UpdateRevision --> WaitEvent
    }

    Watching --> Empty: full resync required
    Watching --> Syncing: watch recreated
```

### Revision Update Points

| Scenario | Revision source | Action |
| --- | --- | --- |
| Initial state | `""` | Request latest data |
| List+Watch list completion | `list.Revision` | `UpdateRevision()` |
| WatchList added/modified/deleted event | `event.New.Revision` or `event.Old.Revision` | `UpdateRevision()` |
| WatchList bookmark | `event.New.Revision` | `UpdateRevision()` |
| Generic fallback bookmark | `event.New.Revision` | `UpdateRevision()` |
| ResourceExpired / Gone / too-large RV | none | `ResetForFullResync()` |
| Repeated watch errors | none | `ResetForFullResync()` |

### Revision Flow

```mermaid
sequenceDiagram
    participant GLW as GenericListWatcher
    participant Backend as backend ListWatcher
    participant Server as K8s API / etcd

    Note over GLW: CurrentRevision is empty

    alt WatchList initial sync
        GLW->>Backend: CreateWatch(useWatchList=true)
        Backend->>Server: Watch(empty revision, SendInitialEvents=true, ResourceVersionMatch=NotOlderThan)
        Server-->>Backend: WatchAdded(rev=100)
        Backend->>GLW: UpdateRevision("100")
        Server-->>Backend: WatchAdded(rev=101)
        Backend->>GLW: UpdateRevision("101")
        Server-->>Backend: Bookmark(rev=101, initial-events=true)
        Backend->>GLW: UpdateRevision("101")
        Backend->>GLW: MarkInitialSyncComplete()
    else List+Watch initial sync
        Backend->>Server: List(empty revision)
        Server-->>Backend: KVPairList(rev=102)
        Backend->>GLW: UpdateRevision("102")
        Backend->>GLW: MarkInitialSyncComplete()
        GLW->>Backend: CreateWatch(useWatchList=false)
        Backend->>Server: Watch(revision=102)
    end

    loop Watch events
        Server-->>Backend: WatchModified(rev=103)
        Backend->>GLW: UpdateRevision("103")
        Server-->>Backend: Bookmark(rev=110)
        Backend->>GLW: UpdateRevision("110")
    end

    alt Full resync needed
        Backend-->>GLW: ResourceExpired / too many errors
        GLW->>GLW: ResetForFullResync()
        Note over GLW: CurrentRevision is empty<br/>InitialSyncPending = true
    end
```

## Why Empty Revision Instead of `"0"`

The fallback List+Watch path always lists with an empty revision. This keeps full resync behavior simple and consistent: List asks for the latest data, then Watch starts from the list result revision.

For Kubernetes, empty revision is also the right shape for modern apiservers that support consistent list-from-cache behavior. The implementation does not force `resourceVersion=0` for fallback lists.

For etcd, empty revision means no explicit `WithRev` is passed, so the latest data is returned.

## Compatibility Notes

- `api.Client` remains backward compatible. Backend-specific list/watch support is provided by optional `api.ListAndWatchClient`.
- Existing clients that only implement `List` and `Watch` continue through the generic List+Watch fallback.
- `backend/api.WatchOptions` uses a backend-api-defined `ResourceVersionMatch` type and translates to Kubernetes `metav1.ResourceVersionMatch` in the k8s resource layer.
- `watchersyncer.WithWatchRetryTimeout` remains as a deprecated compatibility wrapper.
- `ResourceType.SendDeletesOnConnFail` remains as a deprecated compatibility field.


## Todos

- [x] Tests
- [x] Documentation not required
- [x] Release note

## Release Note

```release-note
Add WatchList-aware synchronization support for Kubernetes backend watchers. Kubernetes resources that support WatchList can stream initial data through watch events with automatic fallback to List+Watch, while etcd and unsupported resources continue using List+Watch behavior.
```
