### PR TITLE
[v3.30] Fix confd log spam

### DIFF
--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -365,7 +365,7 @@ type client struct {
 	secretWatcher *secretWatcher
 
 	// Subcomponent for accessing and watching local BGP peers.
-	localBGPPeerWatcher *localBGPPeerWatcher
+	localBGPPeerWatcher *LocalBGPPeerWatcher
 
 	// Channels used to decouple update and status processing.
 	syncerC  chan interface{}
@@ -1632,12 +1632,12 @@ func (c *client) onNewUpdates() {
 	}
 }
 
-func (c *client) recheckPeerConfig() {
-	log.Info("Trigger to recheck BGP peers following possible password or local BGP peer update")
+func (c *client) recheckPeerConfig(reason string) {
 	select {
 	// Non-blocking write into the recheckC channel.  The idea here is that we don't need to add
 	// a second trigger if there is already one pending.
 	case c.recheckC <- struct{}{}:
+		log.WithField("trigger", reason).Info("Triggered recheck of BGP peers.")
 	default:
 	}
 }

--- a/confd/pkg/backends/calico/secret_watcher.go
+++ b/confd/pkg/backends/calico/secret_watcher.go
@@ -177,19 +177,19 @@ func (sw *secretWatcher) SweepStale() {
 func (sw *secretWatcher) OnAdd(obj interface{}, isInInitialList bool) {
 	log.Debug("Secret added")
 	sw.updateSecret(obj.(*v1.Secret))
-	sw.client.recheckPeerConfig()
+	sw.client.recheckPeerConfig("secret added")
 }
 
 func (sw *secretWatcher) OnUpdate(oldObj, newObj interface{}) {
 	log.Debug("Secret updated")
 	sw.updateSecret(newObj.(*v1.Secret))
-	sw.client.recheckPeerConfig()
+	sw.client.recheckPeerConfig("secret updated")
 }
 
 func (sw *secretWatcher) OnDelete(obj interface{}) {
 	log.Debug("Secret deleted")
 	sw.deleteSecret(obj.(*v1.Secret))
-	sw.client.recheckPeerConfig()
+	sw.client.recheckPeerConfig("secret deleted")
 }
 
 func (sw *secretWatcher) updateSecret(secret *v1.Secret) {

--- a/felix/statusrep/status_file_reporter.go
+++ b/felix/statusrep/status_file_reporter.go
@@ -318,6 +318,7 @@ func (fr *EndpointStatusFileReporter) reconcileStatusFiles() error {
 	logrus.Debug("Start reconcile status file")
 
 	fr.statusDirDeltaTracker.PendingUpdates().Iter(func(k string, v epstatus.WorkloadEndpointStatus) deltatracker.IterAction {
+		logrus.WithField("file", k).Debug("Applying update to status file.")
 		itemJSON, err := json.Marshal(v)
 		if err != nil {
 			logrus.WithError(err).WithField("file", k).Error("error json Marshal on endpoint status")
@@ -336,8 +337,9 @@ func (fr *EndpointStatusFileReporter) reconcileStatusFiles() error {
 	})
 
 	fr.statusDirDeltaTracker.PendingDeletions().Iter(func(k string) deltatracker.IterAction {
+		logrus.WithField("file", k).Debug("Deleting status file.")
 		err := fr.epStatusWriter.DeleteStatusFile(k)
-		if err != nil {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			logrus.WithError(err).WithField("file", k).Error("error on deleting file")
 			lastError = err
 			return deltatracker.IterActionNoOp


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
* Tweak logs for better diags.

* Fix incorrect round tripping of endpoint status files.

When an empty slice was marshalled, it gets read back as nil, resulting in a persistent diff.

* Add UT with empty endpoint slices.

Fix permissions on endpoint status dir.

* Ignore non-BGPPeer local endpoints

Only trigger BGPPeer calculation from endpoint status change if the endpoint is actually a BGPPeer (or was a BGPPeer).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Pick of #10178 
CORE-11263
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
