### PR TITLE
Revert "Add CEL validation for IPPools."

### DIFF
--- a/api/pkg/apis/projectcalico/v3/ippool.go
+++ b/api/pkg/apis/projectcalico/v3/ippool.go
@@ -48,7 +48,6 @@ type IPPool struct {
 // IPPoolSpec contains the specification for an IPPool resource.
 type IPPoolSpec struct {
 	// The pool CIDR.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="CIDR cannot be changed; follow IP pool migration guide to avoid corruption."
 	CIDR string `json:"cidr" validate:"net"`
 
 	// Contains configuration for VXLAN tunneling for this pool. If not specified,
@@ -70,7 +69,6 @@ type IPPoolSpec struct {
 	DisableBGPExport bool `json:"disableBGPExport,omitempty" validate:"omitempty"`
 
 	// The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 122 for IPv6.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Block size cannot be changed; follow IP pool migration guide to avoid corruption."
 	BlockSize int `json:"blockSize,omitempty"`
 
 	// Allows IPPool to allocate for a specific node by label selector.

--- a/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
@@ -58,19 +58,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -3691,19 +3691,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -3701,19 +3701,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -3702,19 +3702,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -3686,19 +3686,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -3686,19 +3686,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -3703,19 +3703,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -3600,19 +3600,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -3686,19 +3686,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -30305,19 +30305,9 @@ spec:
                     The block size to use for IP address assignments from
                     this pool. Defaults to 26 for IPv4 and 122 for IPv6.
                   type: integer
-                  x-kubernetes-validations:
-                    - message:
-                        Block size cannot be changed; follow IP pool migration
-                        guide to avoid corruption.
-                      rule: self == oldSelf
                 cidr:
                   description: The pool CIDR.
                   type: string
-                  x-kubernetes-validations:
-                    - message:
-                        CIDR cannot be changed; follow IP pool migration guide
-                        to avoid corruption.
-                      rule: self == oldSelf
                 disableBGPExport:
                   description:
                     "Disable exporting routes from this IP Pool's CIDR over


### PR DESCRIPTION
Revert projectcalico/calico#10135, some platforms don't support CEL yet (MKE) and they reject the CRDs in that case.