### PR TITLE
Update calico/base pin to fix s390x loader symlink

### DIFF
--- a/metadata.mk
+++ b/metadata.mk
@@ -4,9 +4,9 @@
 
 # The version of calico/go-build and calico/base to use.
 GO_BUILD_VER=1.24.2-llvm18.1.8-k8s1.32.3
-CALICO_BASE_VER=ubi8-1743740882
+CALICO_BASE_VER=ubi8-1744398299
 # TODO Remove once CALICO_BASE is updated to UBI9
-CALICO_BASE_UBI9_VER=ubi9-1743740882
+CALICO_BASE_UBI9_VER=ubi9-1744398299
 
 # Env var to ACK Ginkgo deprecation warnings, may need updating with go-build.
 ACK_GINKGO=ACK_GINKGO_DEPRECATIONS=1.16.5


### PR DESCRIPTION
## Description

This change updates calico/base image for s390x to fix a dangling symlink issue that prevents programs from loading. See changes in https://github.com/projectcalico/go-build/pull/672.

## Related issues/PRs

https://github.com/projectcalico/go-build/pull/672

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Resolved an issue preventing the program from launching on the s390x architecture.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
