### PR TITLE
Migrate to UBI 9 base and tune GOAMD64=v2

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -200,12 +200,7 @@ ifeq ($(BUILDARCH),amd64)
 	ETCD_IMAGE = quay.io/coreos/etcd:$(ETCD_VERSION)
 endif
 
-# calico/node continues to use UBI 8 as its base, and our toolchain is also built on RHEL/UBI 8.
-# Meanwhile other components (e.g. third_party/envoy-proxy) use UBI 9.  While it may be possible to
-# update calico/base to UBI 9, fully transitioning to UBI 9 would require dropping support for RHEL
-# 8.
-UBI_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal:latest
-UBI9_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:latest
+UBI_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ifeq ($(GIT_USE_SSH),true)
 	GIT_CONFIG_SSH ?= git config --global url."ssh://git@github.com/".insteadOf "https://github.com/";
@@ -260,8 +255,12 @@ endif
 
 EXTRA_DOCKER_ARGS += -v $(GOMOD_CACHE):/go/pkg/mod:rw
 
-# Define go architecture flags to support arm variants
+# Define go architecture flags
 GOARCH_FLAGS :=-e GOARCH=$(ARCH)
+
+ifeq ($(ARCH),amd64)
+GOARCH_FLAGS += -e GOAMD64=v2
+endif
 
 # Location of certificates used in UTs.
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -273,8 +272,6 @@ CALICO_BASE ?= $(UBI_IMAGE)
 else
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)
 endif
-# TODO Remove once CALICO_BASE is updated to UBI9
-CALICO_BASE_UBI9 ?= calico/base:$(CALICO_BASE_UBI9_VER)
 
 ifndef NO_DOCKER_PULL
 DOCKER_PULL = --pull
@@ -285,10 +282,8 @@ endif
 # DOCKER_BUILD is the base build command used for building all images.
 DOCKER_BUILD=docker buildx build --load --platform=linux/$(ARCH) $(DOCKER_PULL)\
 	--build-arg UBI_IMAGE=$(UBI_IMAGE) \
-	--build-arg UBI9_IMAGE=$(UBI9_IMAGE) \
 	--build-arg GIT_VERSION=$(GIT_VERSION) \
 	--build-arg CALICO_BASE=$(CALICO_BASE) \
-	--build-arg CALICO_BASE_UBI9=$(CALICO_BASE_UBI9) \
 	--build-arg BPFTOOL_IMAGE=$(BPFTOOL_IMAGE)
 
 DOCKER_RUN := mkdir -p $(REPO_ROOT)/.go-pkg-cache bin $(GOMOD_CACHE) && \
@@ -386,7 +381,7 @@ endef
 
 # update_calico_base_pin updates the CALICO_BASE_VER in metadata.mk.
 define update_calico_base_pin
-	$(eval new_ver := $(shell curl -s "https://hub.docker.com/v2/repositories/calico/base/tags/?page_size=100" | jq -r '.results[].name' | grep -E "^ubi8-[0-9]+$$" | sort -r | head -n 1))
+	$(eval new_ver := $(shell curl -s "https://hub.docker.com/v2/repositories/calico/base/tags/?page_size=100" | jq -r '.results[].name' | grep -E "^ubi9-[0-9]+$$" | sort -r | head -n 1))
 	$(eval old_ver := $(shell grep -E "^CALICO_BASE_VER" $(1) | cut -d'=' -f2 | xargs))
 
 	@echo "current CALICO_BASE_VER=$(old_ver)"
@@ -395,7 +390,6 @@ define update_calico_base_pin
 	bash -c '\
 		if [[ "$(new_ver)" > "$(old_ver)" ]]; then \
 			sed -i "s/^CALICO_BASE_VER[[:space:]]*=.*/CALICO_BASE_VER=$(new_ver)/" $(1); \
-			sed -i "s/^CALICO_BASE_UBI9_VER[[:space:]]*=.*/CALICO_BASE_UBI9_VER=$(subst ubi8,ubi9,$(new_ver))/" $(1); \
 			echo "CALICO_BASE_VER is updated to $(new_ver)"; \
 		else \
 			echo "no need to update CALICO_BASE_VER"; \

--- a/metadata.mk
+++ b/metadata.mk
@@ -4,9 +4,7 @@
 
 # The version of calico/go-build and calico/base to use.
 GO_BUILD_VER=1.24.2-llvm18.1.8-k8s1.32.3
-CALICO_BASE_VER=ubi8-1744398299
-# TODO Remove once CALICO_BASE is updated to UBI9
-CALICO_BASE_UBI9_VER=ubi9-1744398299
+CALICO_BASE_VER=ubi9-1744398299
 
 # Env var to ACK Ginkgo deprecation warnings, may need updating with go-build.
 ACK_GINKGO=ACK_GINKGO_DEPRECATIONS=1.16.5

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -17,7 +17,6 @@ ARG LIBNFTNL_VER=1.2.2-1
 ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
-ARG UBI_IMAGE
 ARG BPFTOOL_IMAGE
 FROM ${BPFTOOL_IMAGE} AS bpftool
 FROM ${BIRD_IMAGE} AS bird
@@ -79,7 +78,7 @@ RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}
     cd /root/admin/runit-${RUNIT_VER} && \
     package/compile
 
-FROM ${UBI_IMAGE} AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS ubi
 
 ARG GIT_VERSION
 ARG IPTABLES_VER

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -17,7 +17,6 @@ ARG LIBNFTNL_VER=1.2.2-1
 ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
-ARG UBI_IMAGE
 
 FROM calico/bpftool:v7.4.0 AS bpftool
 FROM ${BIRD_IMAGE} AS bird
@@ -79,7 +78,7 @@ RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}
     cd /root/admin/runit-${RUNIT_VER} && \
     package/compile
 
-FROM ${UBI_IMAGE} AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS ubi
 
 ARG GIT_VERSION
 ARG IPTABLES_VER

--- a/third_party/envoy-proxy/Dockerfile
+++ b/third_party/envoy-proxy/Dockerfile
@@ -1,15 +1,15 @@
 # Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
-ARG CALICO_BASE_UBI9
+ARG CALICO_BASE
 ARG ENVOYBINARY_IMAGE
 ARG THIRD_PARTY_REGISTRY
-ARG UBI9_IMAGE
+ARG UBI_IMAGE
 
 FROM ${ENVOYBINARY_IMAGE} AS envoybinary
 
-FROM ${UBI9_IMAGE} AS ubi
+FROM ${UBI_IMAGE} AS ubi
 
-FROM scratch as source
+FROM scratch AS source
 
 # dependencies
 COPY --from=ubi /bin/sh /bin/sh
@@ -23,6 +23,7 @@ COPY --from=ubi /usr/sbin/usermod /usr/sbin/usermod
 COPY --from=ubi /lib64/libacl.so.1 /lib64/libacl.so.1
 COPY --from=ubi /lib64/libattr.so.1 /lib64/libattr.so.1
 COPY --from=ubi /lib64/libaudit.so.1 /lib64/libaudit.so.1
+COPY --from=ubi /lib64/libbz2.so.1 /lib64/libbz2.so.1
 COPY --from=ubi /lib64/libcap-ng.so.0 /lib64/libcap-ng.so.0
 COPY --from=ubi /lib64/libcap.so.2 /lib64/libcap.so.2
 COPY --from=ubi /lib64/libdl.so.2 /lib64/libdl.so.2
@@ -30,14 +31,16 @@ COPY --from=ubi /lib64/libm.so.6 /lib64/libm.so.6
 COPY --from=ubi /lib64/libpcre2-8.so.0 /lib64/libpcre2-8.so.0
 COPY --from=ubi /lib64/librt.so.1 /lib64/librt.so.1
 COPY --from=ubi /lib64/libselinux.so.1 /lib64/libselinux.so.1
+COPY --from=ubi /lib64/libsemanage.so.2 /lib64/libsemanage.so.2
+COPY --from=ubi /lib64/libsepol.so.2 /lib64/libsepol.so.2
 COPY --from=ubi /lib64/libtinfo.so.6 /lib64/libtinfo.so.6
 
 COPY --from=envoybinary --chown=0:0 --chmod=644 \
     /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
 COPY --from=envoybinary --chown=0:0 --chmod=755 \
-    /usr/local/bin/envoy /usr/local/bin/
+    /usr/local/bin/envoy /usr/local/bin/envoy
 
-FROM ${CALICO_BASE_UBI9}
+FROM ${CALICO_BASE}
 
 COPY --from=source / /
 


### PR DESCRIPTION
## Description

This change updates `calico/base` image to UBI 9. It also sets GOAMD64=v2 environment variable for amd64 builds. Calico node image is unchanged and is still using UBI8 as the base. Most of the Calico components are statically linked so they shouldn't be affected by this change. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update calico/base image to utilize the minimum glibc runtime from UBI 9.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
