### PR TITLE
[release-v3.30] Auto pick #10212: Enable race detector in goldmane uts

### DIFF
--- a/goldmane/Makefile
+++ b/goldmane/Makefile
@@ -64,7 +64,7 @@ gen-files: $(GENERATED_FILES) gen-mocks
 ###############################################################################
 ci: static-checks ut
 ut:
-	$(DOCKER_GO_BUILD) go test ./... -coverprofile coverage.profile -count 1
+	$(DOCKER_GO_BUILD) go test ./... -coverprofile coverage.profile -race -count 1
 
 gen-mocks:
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'mockery'

--- a/goldmane/fv/daemon_test.go
+++ b/goldmane/fv/daemon_test.go
@@ -186,11 +186,12 @@ func TestFlows(t *testing.T) {
 	go func(ctx context.Context) {
 		for {
 			if ctx.Err() != nil {
+				pusher.Close()
 				return
 			}
 			f := testutils.NewRandomFlow(time.Now().Unix())
 			pusher.Push(types.ProtoToFlow(f))
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Millisecond)
 		}
 	}(ctx)
 
@@ -213,14 +214,20 @@ func TestFlows(t *testing.T) {
 	Eventually(emitted.Count, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
 
 	// We should be able to see flows emitted in the stream as well.
-	s, err := cli.Stream(ctx, &proto.FlowStreamRequest{StartTimeGte: -300})
-	require.NoError(t, err)
-
+	streams := []proto.Flows_StreamClient{}
 	for range 10 {
-		// We should receive a flow.
-		f, err := s.Recv()
+		s, err := cli.Stream(ctx, &proto.FlowStreamRequest{StartTimeGte: -300})
 		require.NoError(t, err)
-		require.NotNil(t, f)
+		streams = append(streams, s)
+	}
+
+	for _, s := range streams {
+		for range 10 {
+			// We should receive a flow.
+			f, err := s.Recv()
+			require.NoError(t, err)
+			require.NotNil(t, f)
+		}
 	}
 }
 
@@ -258,6 +265,7 @@ func TestHints(t *testing.T) {
 	go func(ctx context.Context) {
 		for {
 			if ctx.Err() != nil {
+				pusher.Close()
 				return
 			}
 			f := testutils.NewRandomFlow(time.Now().Unix())

--- a/goldmane/pkg/aggregator/stream.go
+++ b/goldmane/pkg/aggregator/stream.go
@@ -26,7 +26,10 @@ type Stream struct {
 
 // Close signals to the stream manager that this stream is done and should be closed.
 func (s *Stream) Close() {
+	// Cancel the stream context - this will trigger any clients writing to the stream to stop.
 	s.cancel()
+
+	// Queue unregistration of the stream, and cleanup of its resources.
 	s.done <- s.id
 }
 

--- a/goldmane/pkg/emitter/emitter_test.go
+++ b/goldmane/pkg/emitter/emitter_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 	"unique"
@@ -119,7 +120,11 @@ func TestEmitterMainline(t *testing.T) {
 
 	// Creat a mock HTTP server to use as our sink.
 	numBucketsEmitted := 0
+	mu := sync.Mutex{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
 		// Verify the request.
 		require.Equal(t, "/path/to/flows", r.URL.Path)
 		require.Equal(t, "POST", r.Method)
@@ -158,6 +163,8 @@ func TestEmitterMainline(t *testing.T) {
 
 	// Wait for the emitter to process the bucket. It should emit the flow to the mock server.
 	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
 		return numBucketsEmitted == 1
 	}, 5*time.Second, 500*time.Millisecond)
 
@@ -228,7 +235,11 @@ func TestEmitterRetry(t *testing.T) {
 	// For this test, we configure the server to fail the first request with a 500 error
 	// and then succeed on subsequent requests. This verifies that the emitter retries in the case
 	// of a failure.
+	mu := sync.Mutex{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
 		if numRequests < 1 {
 			w.WriteHeader(500)
 			numRequests++
@@ -265,9 +276,13 @@ func TestEmitterRetry(t *testing.T) {
 
 	// Wait for the emitter to process the bucket. It should emit the flow to the mock server.
 	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
 		return numRequests >= 2
 	}, 5*time.Second, 500*time.Millisecond, "Didn't retry the request?")
 	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
 		return numBucketsEmitted == 1
 	}, 5*time.Second, 500*time.Millisecond, "Didn't emit the flow?")
 }
@@ -373,7 +388,11 @@ func TestStaleBuckets(t *testing.T) {
 
 	// Creat a mock HTTP server to use as our sink. We don't expect any requests to be made.
 	numBucketsEmitted := 0
+	mu := sync.Mutex{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
 		// Check the body. We don't expect the first flow to be sent.
 		buf := new(bytes.Buffer)
 		_, err := buf.ReadFrom(r.Body)
@@ -418,6 +437,8 @@ func TestStaleBuckets(t *testing.T) {
 
 	// Expect the flow to be sent to the server.
 	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
 		return numBucketsEmitted == 1
 	}, 5*time.Second, 500*time.Millisecond)
 

--- a/goldmane/pkg/flowgen/testserver.go
+++ b/goldmane/pkg/flowgen/testserver.go
@@ -89,6 +89,7 @@ func Start() {
 			for flog := range gen.outChan {
 				flowClient.PushWait(types.ProtoToFlow(flog))
 			}
+			flowClient.Close()
 		}(c)
 	}
 

--- a/goldmane/pkg/types/diachronic_flow.go
+++ b/goldmane/pkg/types/diachronic_flow.go
@@ -61,12 +61,9 @@ func (w *Window) Contains(t int64) bool {
 	return t >= w.start && t <= w.end
 }
 
-var nextID int64
-
-func NewDiachronicFlow(k *FlowKey) *DiachronicFlow {
-	nextID++
+func NewDiachronicFlow(k *FlowKey, id int64) *DiachronicFlow {
 	return &DiachronicFlow{
-		ID:  nextID,
+		ID:  id,
 		Key: *k,
 	}
 }

--- a/goldmane/pkg/types/diachronic_flow_test.go
+++ b/goldmane/pkg/types/diachronic_flow_test.go
@@ -46,7 +46,7 @@ func TestDiachronicFlow(t *testing.T) {
 		&types.FlowKeyMeta{},
 		&proto.PolicyTrace{},
 	)
-	df := types.NewDiachronicFlow(k)
+	df := types.NewDiachronicFlow(k, 0)
 
 	// Add flow data over a bunch of windows.
 	f := types.Flow{

--- a/whisker-backend/test/fv/goldmaneintegration_test.go
+++ b/whisker-backend/test/fv/goldmaneintegration_test.go
@@ -94,6 +94,7 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 
 	cli, err := client.NewFlowClient("localhost:5444", clientCertFile.Name(), clientKeyFile.Name(), certFile.Name())
 	Expect(err).ShouldNot(HaveOccurred())
+	defer cli.Close()
 
 	// Wait for initial connection
 	_, err = chanutil.ReadWithDeadline(ctx, cli.Connect(ctx), time.Minute*20)
@@ -203,6 +204,7 @@ func TestGoldmaneIntegration_FilterHints(t *testing.T) {
 
 	cli, err := client.NewFlowClient("localhost:5444", clientCertFile.Name(), clientKeyFile.Name(), certFile.Name())
 	Expect(err).ShouldNot(HaveOccurred())
+	defer cli.Close()
 
 	// Wait for initial connection
 	_, err = chanutil.ReadWithDeadline(ctx, cli.Connect(ctx), time.Minute*20)


### PR DESCRIPTION
Cherry pick of #10212 on release-v3.30.

#10212: Enable race detector in goldmane uts

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.