### PR TITLE
[release-v3.29] Auto pick #10209: configure arp and rp_filter for bpf nat devices only when

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -170,6 +170,7 @@ type bpfDataplane interface {
 	ensureNoProgram(attachPoint) error
 	ensureQdisc(iface string) (bool, error)
 	ensureBPFDevices() error
+	configureBPFDevices() error
 	updatePolicyProgram(rules polprog.Rules, polDir string, ap attachPoint, ipFamily proto.IPVersion) error
 	removePolicyProgram(ap attachPoint, ipFamily proto.IPVersion) error
 	setAcceptLocal(iface string, val bool) error
@@ -1101,6 +1102,13 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 					delete(m.initAttaches, update.Name)
 				}
 			}
+			if update.Name == dataplanedefs.BPFInDev {
+				m.ifacesLock.Lock()
+				if err := m.reconcileBPFDevices(dataplanedefs.BPFInDev); err != nil {
+					log.WithError(err).Fatal("Failed to configure BPF devices")
+				}
+				defer m.ifacesLock.Unlock()
+			}
 		}
 		if m.initUnknownIfaces != nil {
 			m.initUnknownIfaces.Add(update.Name)
@@ -1205,8 +1213,10 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			// We require host interfaces to be in non-strict RPF mode so that
 			// packets can return straight to host for services bypassing CTLB.
 			switch update.Name {
-			case dataplanedefs.BPFInDev, dataplanedefs.BPFOutDev:
-				// do nothing
+			case dataplanedefs.BPFOutDev:
+				if err := m.reconcileBPFDevices(update.Name); err != nil {
+					log.WithError(err).Fatal("Failed to configure BPF devices")
+				}
 			default:
 				if m.v4 != nil {
 					if err := m.dp.setRPFilter(update.Name, 2); err != nil {
@@ -3297,59 +3307,35 @@ func (m *bpfEndpointManager) ensureStarted() {
 	}
 }
 
-func (m *bpfEndpointManager) ensureBPFDevices() error {
+func (m *bpfEndpointManager) reconcileBPFDevices(iface string) error {
 	if m.hostNetworkedNATMode == hostNetworkedNATDisabled {
 		return nil
 	}
 
-	var bpfout, bpfin netlink.Link
+	vethPeer := dataplanedefs.BPFInDev
+	if iface == dataplanedefs.BPFInDev {
+		vethPeer = dataplanedefs.BPFOutDev
+	}
 
+	// Wait for both bpfin.cali and bpfout.cali to become oper UP
+	// before configuring arp and rp_filter.
+	intf, ok := m.nameToIface[vethPeer]
+	if !ok || !intf.info.ifaceIsUp() {
+		return nil
+	}
+	return m.dp.configureBPFDevices()
+}
+
+func (m *bpfEndpointManager) configureBPFDevices() error {
 	bpfin, err := netlink.LinkByName(dataplanedefs.BPFInDev)
 	if err != nil {
-		la := netlink.NewLinkAttrs()
-		la.Name = dataplanedefs.BPFInDev
-		la.MTU = m.bpfIfaceMTU
-		nat := &netlink.Veth{
-			LinkAttrs: la,
-			PeerName:  dataplanedefs.BPFOutDev,
-		}
-		if err := netlink.LinkAdd(nat); err != nil {
-			return fmt.Errorf("failed to add %s: %w", dataplanedefs.BPFInDev, err)
-		}
-		bpfin, err = netlink.LinkByName(dataplanedefs.BPFInDev)
-		if err != nil {
-			return fmt.Errorf("missing %s after add: %w", dataplanedefs.BPFInDev, err)
-		}
+		return fmt.Errorf("missing %s after add: %w", dataplanedefs.BPFInDev, err)
 	}
 
-	if state := bpfin.Attrs().OperState; state != netlink.OperUp {
-		log.WithField("state", state).Info(dataplanedefs.BPFInDev)
-		if err := netlink.LinkSetUp(bpfin); err != nil {
-			return fmt.Errorf("failed to set %s up: %w", dataplanedefs.BPFInDev, err)
-		}
-	}
-	bpfout, err = netlink.LinkByName(dataplanedefs.BPFOutDev)
+	bpfout, err := netlink.LinkByName(dataplanedefs.BPFOutDev)
 	if err != nil {
 		return fmt.Errorf("missing %s after add: %w", dataplanedefs.BPFOutDev, err)
 	}
-	if state := bpfout.Attrs().OperState; state != netlink.OperUp {
-		log.WithField("state", state).Info(dataplanedefs.BPFOutDev)
-		if err := netlink.LinkSetUp(bpfout); err != nil {
-			return fmt.Errorf("failed to set %s up: %w", dataplanedefs.BPFOutDev, err)
-		}
-	}
-
-	err = netlink.LinkSetMTU(bpfin, m.bpfIfaceMTU)
-	if err != nil {
-		return fmt.Errorf("failed to set MTU to %d on %s: %w", m.bpfIfaceMTU, dataplanedefs.BPFInDev, err)
-	}
-	err = netlink.LinkSetMTU(bpfout, m.bpfIfaceMTU)
-	if err != nil {
-		return fmt.Errorf("failed to set MTU to %d on %s: %w", m.bpfIfaceMTU, dataplanedefs.BPFOutDev, err)
-	}
-
-	m.natInIdx = bpfin.Attrs().Index
-	m.natOutIdx = bpfout.Attrs().Index
 
 	if m.v6 != nil {
 		anyV6, _ := ip.CIDRFromString("::/128")
@@ -3419,6 +3405,65 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 			return fmt.Errorf("failed to configure %s parameters: %w", dataplanedefs.BPFOutDev, err)
 		}
 	}
+
+	return nil
+}
+
+func (m *bpfEndpointManager) ensureBPFDevices() error {
+	if m.hostNetworkedNATMode == hostNetworkedNATDisabled {
+		return nil
+	}
+
+	var bpfout, bpfin netlink.Link
+
+	bpfin, err := netlink.LinkByName(dataplanedefs.BPFInDev)
+	if err != nil {
+		la := netlink.NewLinkAttrs()
+		la.Name = dataplanedefs.BPFInDev
+		la.MTU = m.bpfIfaceMTU
+		nat := &netlink.Veth{
+			LinkAttrs: la,
+			PeerName:  dataplanedefs.BPFOutDev,
+		}
+		if err := netlink.LinkAdd(nat); err != nil {
+			return fmt.Errorf("failed to add %s: %w", dataplanedefs.BPFInDev, err)
+		}
+		bpfin, err = netlink.LinkByName(dataplanedefs.BPFInDev)
+		if err != nil {
+			return fmt.Errorf("missing %s after add: %w", dataplanedefs.BPFInDev, err)
+		}
+	}
+
+	if state := bpfin.Attrs().OperState; state != netlink.OperUp {
+		log.WithField("state", state).Info(dataplanedefs.BPFInDev)
+		if err := netlink.LinkSetUp(bpfin); err != nil {
+			return fmt.Errorf("failed to set %s up: %w", dataplanedefs.BPFInDev, err)
+		}
+	}
+
+	bpfout, err = netlink.LinkByName(dataplanedefs.BPFOutDev)
+	if err != nil {
+		return fmt.Errorf("missing %s after add: %w", dataplanedefs.BPFOutDev, err)
+	}
+	if state := bpfout.Attrs().OperState; state != netlink.OperUp {
+		log.WithField("state", state).Info(dataplanedefs.BPFOutDev)
+		if err := netlink.LinkSetUp(bpfout); err != nil {
+			return fmt.Errorf("failed to set %s up: %w", dataplanedefs.BPFOutDev, err)
+		}
+	}
+
+	err = netlink.LinkSetMTU(bpfin, m.bpfIfaceMTU)
+	if err != nil {
+		return fmt.Errorf("failed to set MTU to %d on %s: %w", m.bpfIfaceMTU, dataplanedefs.BPFInDev, err)
+	}
+
+	err = netlink.LinkSetMTU(bpfout, m.bpfIfaceMTU)
+	if err != nil {
+		return fmt.Errorf("failed to set MTU to %d on %s: %w", m.bpfIfaceMTU, dataplanedefs.BPFOutDev, err)
+	}
+
+	m.natInIdx = bpfin.Attrs().Index
+	m.natOutIdx = bpfout.Attrs().Index
 
 	_, err = m.ensureQdisc(dataplanedefs.BPFInDev)
 	if err != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1107,7 +1107,7 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 				if err := m.reconcileBPFDevices(dataplanedefs.BPFInDev); err != nil {
 					log.WithError(err).Fatal("Failed to configure BPF devices")
 				}
-				defer m.ifacesLock.Unlock()
+				m.ifacesLock.Unlock()
 			}
 		}
 		if m.initUnknownIfaces != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -63,13 +63,14 @@ import (
 )
 
 type mockDataplane struct {
-	mutex       sync.Mutex
-	lastProgID  int
-	progs       map[string]int
-	numAttaches map[string]int
-	policy      map[string]polprog.Rules
-	routes      map[ip.CIDR]struct{}
-	netlinkShim netlinkshim.Interface
+	mutex                sync.Mutex
+	lastProgID           int
+	progs                map[string]int
+	numAttaches          map[string]int
+	policy               map[string]polprog.Rules
+	routes               map[ip.CIDR]struct{}
+	netlinkShim          netlinkshim.Interface
+	natDevicesConfigured bool
 
 	ensureStartedFn    func()
 	ensureQdiscFn      func(string) (bool, error)
@@ -107,6 +108,11 @@ func (m *mockDataplane) interfaceByIndex(ifindex int) (*net.Interface, error) {
 }
 
 func (m *mockDataplane) ensureBPFDevices() error {
+	return nil
+}
+
+func (m *mockDataplane) configureBPFDevices() error {
+	m.natDevicesConfigured = true
 	return nil
 }
 
@@ -660,6 +666,13 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			genWLUpdate("cali12345")()
 			genIfaceUpdate("cali12345", ifacemonitor.StateUp, 15)()
 			genHEPUpdate(allInterfaces, hostEpNorm)()
+		})
+
+		It("should configure NAT devices only when both bpfin and bpfout are oper up", func() {
+			genIfaceUpdate("bpfin.cali", ifacemonitor.StateUp, 1000)()
+			Expect(dp.natDevicesConfigured).To(BeFalse())
+			genIfaceUpdate("bpfout.cali", ifacemonitor.StateUp, 1000)()
+			Expect(dp.natDevicesConfigured).To(BeTrue())
 		})
 
 		It("does not have host-* policy on the workload interface", func() {


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10209 on release-v3.29.

#10209: configure arp and rp_filter for bpf nat devices only when

# Original PR Body below

## Description

In version 242 systemd started setting a persistent MAC address on virtual interfaces. Therefore bpfin.cali and bpfout.cali interfaces MAC changes after creation. As a result, we get a wrong mac when reading it for the first time. This results in a wrong ARP entry programmed. Also, rp_filter setting changes. 

Fix - Configure the dataplane entries for bpfin.cali and bpfout.cali when bpf_ep_mgr gets notified that the interfaces are OPER_UP.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf - Fix configuring arp entries for bpf NAT devices for systemd >= 242
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.