### PR TITLE
Remove gatewayapis/status from RBAC

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -158,7 +158,6 @@ rules:
       - apiservers/status
       - gatewayapis
       - gatewayapis/finalizers
-      - gatewayapis/status
       - goldmanes
       - goldmanes/finalizers
       - goldmanes/status

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -158,7 +158,6 @@ rules:
       - apiservers/status
       - gatewayapis
       - gatewayapis/finalizers
-      - gatewayapis/status
       - goldmanes
       - goldmanes/finalizers
       - goldmanes/status

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -242,7 +242,6 @@ rules:
       - apiservers/status
       - gatewayapis
       - gatewayapis/finalizers
-      - gatewayapis/status
       - goldmanes
       - goldmanes/finalizers
       - goldmanes/status

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -196,7 +196,6 @@ rules:
       - apiservers/status
       - gatewayapis
       - gatewayapis/finalizers
-      - gatewayapis/status
       - goldmanes
       - goldmanes/finalizers
       - goldmanes/status


### PR DESCRIPTION
As GatewayAPI doesn't have a status subresource yet.