### PR TITLE
[release-v3.30] Auto pick #10224: Fix Goldmane history length

### DIFF
--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -35,9 +35,10 @@ import (
 
 const (
 	// numBuckets is the number of buckets to keep in memory.
-	// We keep 240 buckets. Assuming a default window of 15s each, this
-	// gives us a total of 1hr of history.
-	numBuckets = 240
+	// - 1 bucket that covers [now(), now()+15s], currently filling.
+	// - 1 bucket that is 15s into the future, to account for time skew.
+	// - 240 buckets of historical data. This gives us 1hr of history with default settings.
+	numBuckets = 242
 
 	// channelDepth is the depth of the channel to use for flow updates.
 	channelDepth = 5000

--- a/goldmane/pkg/aggregator/aggregator_test.go
+++ b/goldmane/pkg/aggregator/aggregator_test.go
@@ -383,7 +383,7 @@ func TestRotation(t *testing.T) {
 	Expect(flowID).To(BeNumerically(">", 0))
 
 	// Rollover the aggregator until we push the flow out of the window.
-	roller.rolloverAndAdvanceClock(237)
+	roller.rolloverAndAdvanceClock(239)
 
 	// The flow should still be here.
 	Eventually(func() error {

--- a/goldmane/pkg/flowgen/testserver.go
+++ b/goldmane/pkg/flowgen/testserver.go
@@ -150,7 +150,6 @@ func (t *flowGenerator) flowGenWorker(numPairs int) {
 		flowPairs = append(flowPairs, flows)
 	}
 
-	// One hour broken into 15s intervals is 240 intervals.
 	logrus.Info("Backfilling an hour of flow data")
 	for {
 		logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
Cherry pick of #10224 on release-v3.30.

#10224: Fix Goldmane history length

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes a bug where Goldmane was storing an hour of flow data, but the
flow data covered the range of [now()-59m30s, now()+30s]. 

This PR adjusts to [now()-60m, now()+30s].

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.