### PR TITLE
Update whisker base image to UBI 9

### DIFF
--- a/whisker/docker-image/Dockerfile
+++ b/whisker/docker-image/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG CALICO_BASE
 
-FROM registry.access.redhat.com/ubi8/ubi:latest AS ubi
+FROM registry.access.redhat.com/ubi9/ubi:latest AS ubi
 
 RUN dnf upgrade -y
 
@@ -38,13 +38,11 @@ COPY --from=ubi /usr/bin/sed /usr/bin/sed
 COPY --from=ubi /lib64/libacl.so.1 /lib64/libacl.so.1
 COPY --from=ubi /lib64/libattr.so.1 /lib64/libattr.so.1
 COPY --from=ubi /lib64/libcap.so.2 /lib64/libcap.so.2
-COPY --from=ubi /lib64/libcrypt.so.1 /lib64/libcrypt.so.1
-COPY --from=ubi /lib64/libcrypto.so.1.1 /lib64/libcrypto.so.1.1
-COPY --from=ubi /lib64/libdl.so.2 /lib64/libdl.so.2
+COPY --from=ubi /lib64/libcrypt.so.2 /lib64/libcrypt.so.2
+COPY --from=ubi /lib64/libcrypto.so.3 /lib64/libcrypto.so.3
 COPY --from=ubi /lib64/libpcre2-8.so.0 /lib64/libpcre2-8.so.0
-COPY --from=ubi /lib64/librt.so.1 /lib64/librt.so.1
 COPY --from=ubi /lib64/libselinux.so.1 /lib64/libselinux.so.1
-COPY --from=ubi /lib64/libssl.so.1.1 /lib64/libssl.so.1.1
+COPY --from=ubi /lib64/libssl.so.3 /lib64/libssl.so.3
 COPY --from=ubi /lib64/libtinfo.so.6 /lib64/libtinfo.so.6
 COPY --from=ubi /lib64/libz.so.1 /lib64/libz.so.1
 


### PR DESCRIPTION
## Description

This change updates whisker base image to UBI 9.

## Related issues/PRs

It should be part of https://github.com/projectcalico/calico/pull/10207.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
