### PR TITLE
Expose the Selector AST and other clean-ups

### DIFF
--- a/felix/calc/active_bpgpeer_calculator.go
+++ b/felix/calc/active_bpgpeer_calculator.go
@@ -177,7 +177,7 @@ func (abp *ActiveBGPPeerCalculator) bgpPeerSelectsLocalNode(bgpPeer *v3.BGPPeer)
 }
 
 func (abp *ActiveBGPPeerCalculator) onPeerActive(bgpPeer *v3.BGPPeer) {
-	var newSelector sel.Selector
+	var newSelector *sel.Selector
 	var err error
 
 	logrus.WithField("bgppeer", bgpPeer).Debugf("BGPPeer is active.")

--- a/felix/labelindex/label_inherit_index_test.go
+++ b/felix/labelindex/label_inherit_index_test.go
@@ -45,9 +45,9 @@ var _ = Describe("Index", func() {
 	var (
 		updates []update
 		idx     *InheritIndex
-		a_eq_a1 selector.Selector
-		a_eq_b  selector.Selector
-		c_eq_d  selector.Selector
+		a_eq_a1 *selector.Selector
+		a_eq_b  *selector.Selector
+		c_eq_d  *selector.Selector
 		err     error
 	)
 

--- a/felix/labelindex/labelrestrictionindex/label_restriction_index.go
+++ b/felix/labelindex/labelrestrictionindex/label_restriction_index.go
@@ -29,7 +29,7 @@ import (
 // find a small subset of selectors that are candidate matches.
 type LabelRestrictionIndex[SelID comparable] struct {
 	// selectorsByID stores all selectors that we know about by their ID.
-	selectorsByID map[SelID]selector.Selector
+	selectorsByID map[SelID]*selector.Selector
 
 	// labelToValueToIDs stores a sub-index for each label name that occurs in
 	// a selector.  This is the main lookup datastructure.  The valuesSubIndex
@@ -62,7 +62,7 @@ type Gauge interface {
 
 func New[SelID comparable](opts ...Option[SelID]) *LabelRestrictionIndex[SelID] {
 	idx := &LabelRestrictionIndex[SelID]{
-		selectorsByID:     map[SelID]selector.Selector{},
+		selectorsByID:     map[SelID]*selector.Selector{},
 		labelToValueToIDs: map[string]*valuesSubIndex[SelID]{},
 		unoptimizedIDs:    set.New[SelID](),
 	}
@@ -72,7 +72,7 @@ func New[SelID comparable](opts ...Option[SelID]) *LabelRestrictionIndex[SelID] 
 	return idx
 }
 
-func (s *LabelRestrictionIndex[SelID]) AddSelector(id SelID, selector selector.Selector) {
+func (s *LabelRestrictionIndex[SelID]) AddSelector(id SelID, selector *selector.Selector) {
 	defer s.updateGauges()
 
 	// In case of changes with the same ID, delete it first to clean up the
@@ -230,7 +230,7 @@ type Labeled interface {
 	IterOwnAndParentLabels(func(k, v string))
 }
 
-func (s *LabelRestrictionIndex[SelID]) IterPotentialMatches(item Labeled, f func(SelID, selector.Selector)) {
+func (s *LabelRestrictionIndex[SelID]) IterPotentialMatches(item Labeled, f func(SelID, *selector.Selector)) {
 	emit := func(id SelID) error {
 		f(id, s.selectorsByID[id])
 		return nil

--- a/felix/labelindex/labelrestrictionindex/label_restriction_index_test.go
+++ b/felix/labelindex/labelrestrictionindex/label_restriction_index_test.go
@@ -70,7 +70,7 @@ func TestLabelRestrictionIndex(t *testing.T) {
 	t.Log("Checking that the correct selectors are found...")
 	potentialMatches := func(labels map[string]string) []string {
 		var out []string
-		idx.IterPotentialMatches(labeledAdapter(labels), func(s string, s2 selector.Selector) {
+		idx.IterPotentialMatches(labeledAdapter(labels), func(s string, s2 *selector.Selector) {
 			Expect(out).NotTo(ContainElement(s), "IterPotentialMatches produced duplicate: "+s)
 			out = append(out, s)
 			Expect(s2).NotTo(BeNil())
@@ -228,7 +228,7 @@ func TestFindMostRestrictedLabel(t *testing.T) {
 		"findMostRestrictedLabel should handle >10k values when comparing to MustBePresent (edge case)")
 }
 
-func mustParseSelector(s string) selector.Selector {
+func mustParseSelector(s string) *selector.Selector {
 	sel, err := selector.Parse(s)
 	Expect(err).NotTo(HaveOccurred())
 	return sel

--- a/felix/labelindex/named_port_bench_test.go
+++ b/felix/labelindex/named_port_bench_test.go
@@ -232,7 +232,7 @@ func benchmarkSelectorUpdates(b *testing.B, numEndpoints int) {
 	}
 
 	// Pre-calculate the selectors.
-	var sels []selector.Selector
+	var sels []*selector.Selector
 	for i := 0; i < b.N; i++ {
 		sel, err := selector.Parse(fmt.Sprintf(`alpha == "beta" && has(ipset-%d)`, i%10))
 		if err != nil {

--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -1035,7 +1035,7 @@ type ipSet struct {
 	Port     string
 }
 
-func (s ipSet) ParsedSelector() selector.Selector {
+func (s ipSet) ParsedSelector() *selector.Selector {
 	sel, err := selector.Parse(s.Selector)
 	Expect(err).NotTo(HaveOccurred())
 	return sel

--- a/hack/cmd/calico-selector/calico-selector.go
+++ b/hack/cmd/calico-selector/calico-selector.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/libcalico-go/lib/selector"
+	"github.com/projectcalico/calico/libcalico-go/lib/selector/parser"
+)
+
+func main() {
+	logutils.ConfigureEarlyLogging()
+	// We use stdout for the parseable output of the tool so we _do_ want
+	// logging to go to stderr.
+	logrus.SetOutput(os.Stderr)
+	logrus.SetLevel(logrus.WarnLevel)
+
+	if len(os.Args) != 3 {
+		logrus.Fatalln("Usage: calico-selector id|set-name|print-tree <selector>")
+		os.Exit(1)
+	}
+
+	selStr := os.Args[2]
+	sel, err := selector.Parse(selStr)
+	if err != nil {
+		logrus.Fatalln("Failed to parse selector:", err)
+		os.Exit(1)
+	}
+	logrus.Info("Parsed selector:", sel.String())
+	logrus.Info("Unique ID:", sel.UniqueID())
+
+	switch os.Args[1] {
+	case "id":
+		fmt.Println(sel.UniqueID())
+	case "set-name":
+		// cali40s:buYu-wdtmS21f_KbIqrPSoG
+		fmt.Println("cali40" + sel.UniqueID()[:25])
+	case "print-tree":
+		printTree("", sel.Root(), false)
+	default:
+		logrus.Fatalln("Usage: calico-selector id|set-name|print-tree <selector>")
+	}
+}
+
+func printTree(indent string, n parser.Node, continueLine bool) {
+	p := func(v string, args ...any) {
+		fmt.Printf(indent+v+"\n", args...)
+	}
+	nextIndent := strings.ReplaceAll(indent, "-", " ")
+	if continueLine {
+		nextIndent = strings.ReplaceAll(nextIndent, "+", "|")
+	} else {
+		nextIndent = strings.ReplaceAll(nextIndent, "+", " ")
+	}
+	nextIndent += "+-"
+	switch n := n.(type) {
+	case *parser.AllNode:
+		p("all()")
+	case *parser.GlobalNode:
+		p("global()")
+	case *parser.LabelEqValueNode:
+		p("(%s == %q)", n.LabelName, n.Value)
+	case *parser.LabelNeValueNode:
+		p("(%s != %q)", n.LabelName, n.Value)
+	case *parser.LabelInSetNode:
+		p("(%s in {%s})", n.LabelName, strings.Join(n.Value, ","))
+	case *parser.LabelNotInSetNode:
+		p("(%s not in {%s})", n.LabelName, strings.Join(n.Value, ","))
+	case *parser.LabelStartsWithValueNode:
+		p("(%s starts with %q)", n.LabelName, n.Value)
+	case *parser.LabelEndsWithValueNode:
+		p("(%s ends with %q)", n.LabelName, n.Value)
+	case *parser.LabelContainsValueNode:
+		p("(%s contains %q)", n.LabelName, n.Value)
+	case *parser.HasNode:
+		p("has(%s)", n.LabelName)
+	case *parser.NotNode:
+		p("NOT")
+		printTree(nextIndent, n.Operand, false)
+	case *parser.AndNode:
+		p("AND")
+		for i, op := range n.Operands {
+			printTree(nextIndent, op, i < len(n.Operands)-1)
+		}
+	case *parser.OrNode:
+		p("OR")
+		for i, op := range n.Operands {
+			printTree(nextIndent, op, i < len(n.Operands)-1)
+		}
+	default:
+		p("unknown node type: %v", n)
+	}
+}

--- a/libcalico-go/lib/selector/parser/ast.go
+++ b/libcalico-go/lib/selector/parser/ast.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/hash"
 )
 
 // Labels defines the interface of labels that can be used by selector
@@ -115,6 +117,7 @@ func (sel *Selector) EvaluateLabels(labels Labels) bool {
 
 func (sel *Selector) AcceptVisitor(v Visitor) {
 	sel.root.AcceptVisitor(v)
+	sel.updateFields()
 }
 
 func (sel *Selector) String() string {
@@ -138,6 +141,14 @@ func (sel *Selector) Equal(other *Selector) bool {
 
 func (sel *Selector) Root() Node {
 	return sel.root
+}
+
+func (sel *Selector) updateFields() {
+	fragments := sel.root.collectFragments([]string{})
+	str := strings.Join(fragments, "")
+	sel.stringRep = str
+	sel.hash = hash.MakeUniqueID("s", str)
+	sel.labelRestrictions = sel.root.LabelRestrictions()
 }
 
 type Node interface {

--- a/libcalico-go/lib/selector/parser/parser.go
+++ b/libcalico-go/lib/selector/parser/parser.go
@@ -17,10 +17,12 @@ package parser
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/hash"
 	"github.com/projectcalico/calico/libcalico-go/lib/selector/tokenizer"
 )
 
@@ -32,7 +34,7 @@ var (
 )
 
 // Parse parses a string representation of a selector expression into a Selector.
-func Parse(selector string) (sel Selector, err error) {
+func Parse(selector string) (sel *Selector, err error) {
 	sharedParserLock.Lock()
 	defer sharedParserLock.Unlock()
 
@@ -61,7 +63,7 @@ type Parser struct {
 	tokBuf []tokenizer.Token
 }
 
-func (p *Parser) Parse(selector string) (sel Selector, err error) {
+func (p *Parser) Parse(selector string) (sel *Selector, err error) {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("Parsing %q", selector)
 	}
@@ -76,7 +78,7 @@ func (p *Parser) Validate(selector string) (err error) {
 	return
 }
 
-func (p *Parser) parseRoot(selector string, validateOnly bool) (sel Selector, err error) {
+func (p *Parser) parseRoot(selector string, validateOnly bool) (sel *Selector, err error) {
 	// Tokenize the input.  We re-use the same shared buffer to avoid
 	// allocations.
 	tokens, err := tokenizer.AppendTokens(p.tokBuf[:0], selector)
@@ -92,7 +94,7 @@ func (p *Parser) parseRoot(selector string, validateOnly bool) (sel Selector, er
 		if validateOnly {
 			return nil, nil
 		}
-		return &selectorRoot{root: &AllNode{}}, nil
+		return &Selector{root: &AllNode{}}, nil
 	}
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("Tokens %v", tokens)
@@ -110,17 +112,29 @@ func (p *Parser) parseRoot(selector string, validateOnly bool) (sel Selector, er
 	if validateOnly {
 		return
 	}
-	sel = &selectorRoot{root: node}
+
+	fragments := node.collectFragments([]string{})
+	str := strings.Join(fragments, "")
+	sel = &Selector{
+		root: node,
+
+		// We used to calculate these on first use but that leads to problems
+		// with comparing parsed selectors.
+		stringRep:         str,
+		hash:              hash.MakeUniqueID("s", str),
+		labelRestrictions: node.LabelRestrictions(),
+	}
+
 	return
 }
 
 // parseOrExpression parses a one or more "&&" terms, separated by "||" operators.
-func (p *Parser) parseOrExpression(tokens []tokenizer.Token, validateOnly bool) (sel node, remTokens []tokenizer.Token, err error) {
+func (p *Parser) parseOrExpression(tokens []tokenizer.Token, validateOnly bool) (sel Node, remTokens []tokenizer.Token, err error) {
 	if parserDebug {
 		log.Debugf("Parsing ||s from %v", tokens)
 	}
 	// Look for the first expression.
-	var andNodes []node
+	var andNodes []Node
 	sel, remTokens, err = p.parseAndExpression(tokens, validateOnly)
 	if err != nil {
 		return
@@ -160,12 +174,12 @@ func (p *Parser) parseOrExpression(tokens []tokenizer.Token, validateOnly bool) 
 func (p *Parser) parseAndExpression(
 	tokens []tokenizer.Token,
 	validateOnly bool,
-) (sel node, remTokens []tokenizer.Token, err error) {
+) (sel Node, remTokens []tokenizer.Token, err error) {
 	if parserDebug {
 		log.Debugf("Parsing &&s from %v", tokens)
 	}
 	// Look for the first operation.
-	var opNodes []node
+	var opNodes []Node
 	sel, remTokens, err = p.parseOperation(tokens, validateOnly)
 	if err != nil {
 		return
@@ -211,7 +225,7 @@ var (
 
 // parseOperations parses a single, possibly negated operation (i.e. ==, !=, has()).
 // It also handles calling parseOrExpression recursively for parenthesized expressions.
-func (p *Parser) parseOperation(tokens []tokenizer.Token, validateOnly bool) (sel node, remTokens []tokenizer.Token, err error) {
+func (p *Parser) parseOperation(tokens []tokenizer.Token, validateOnly bool) (sel Node, remTokens []tokenizer.Token, err error) {
 	if parserDebug {
 		log.Debugf("Parsing op from %v", tokens)
 	}

--- a/libcalico-go/lib/selector/parser/parser_test.go
+++ b/libcalico-go/lib/selector/parser/parser_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Parser", func() {
 	for _, test := range selectorTests {
 		var test = test // Take copy of variable for the closure.
 		Context(fmt.Sprintf("selector %#v", test.sel), func() {
-			var sel parser.Selector
+			var sel *parser.Selector
 			var err error
 			BeforeEach(func() {
 				sel, err = parser.Parse(test.sel)

--- a/libcalico-go/lib/selector/selector.go
+++ b/libcalico-go/lib/selector/selector.go
@@ -21,7 +21,13 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/selector/parser"
 )
 
-var NoMatch Selector
+// NoMatch is a pre-calculated selector that always evaluates to false.
+// It matches nothing.
+var NoMatch *Selector
+
+// All is a pre-calculated selector that always evaluates to true. It matches
+// everything.
+var All *Selector
 
 func init() {
 	var err error
@@ -29,32 +35,17 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse !all(): %v", err))
 	}
-
-	// Initialise NoMatch's cached fields.
-	_ = NoMatch.UniqueID()
-	_ = NoMatch.LabelRestrictions()
+	All, err = Parse("all()")
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse all(): %v", err))
+	}
 }
 
 // Selector represents a label selector.
-type Selector interface {
-	// Evaluate evaluates the selector against the given labels expressed as a concrete map.
-	Evaluate(labels map[string]string) bool
-
-	// EvaluateLabels evaluates the selector against the given labels expressed as an interface.
-	// This allows for labels that are calculated on the fly.
-	EvaluateLabels(labels parser.Labels) bool
-
-	// String returns a string that represents this selector.
-	String() string
-
-	// UniqueID returns the unique ID that represents this selector.
-	UniqueID() string
-
-	LabelRestrictions() map[string]parser.LabelRestriction
-}
+type Selector = parser.Selector
 
 // Parse a string representation of a selector expression into a Selector.
-func Parse(selector string) (sel Selector, err error) {
+func Parse(selector string) (sel *Selector, err error) {
 	return parser.Parse(selector)
 }
 

--- a/libcalico-go/lib/selector/selector_benchmarks_test.go
+++ b/libcalico-go/lib/selector/selector_benchmarks_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/selector/parser"
 )
 
-var sel Selector
+var sel *Selector
 
 func BenchmarkParse(b *testing.B) {
 	logrus.SetLevel(logrus.InfoLevel)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Expose the selector AST nodes to allow the tree to be walked for external processing.
- Tidy up the types use for selectors, return the concrete type; the interface just adds indirection (and makes maps/slices of selectors bigger).
- Eagerly calculate the Selector's fields.  I've seen a few instances recently where the lazy init tripped folks up.  Either because reflect.DeepEqual failed, or because there was a race when using selectors across goroutines.  We have Validate() now and we almost always want all the fields so there's not a lot to be gained. Ha, and I found another latent bug while making this change AcceptVisitor didn't refresh the fields.
- Add a demo app that pretty-print's selectors in various ways.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
