### PR TITLE
flowlogs: cleanup socket when creating local reporter

### DIFF
--- a/felix/collector/local/server.go
+++ b/felix/collector/local/server.go
@@ -110,7 +110,7 @@ func (s *FlowServer) Run() error {
 	// Try to clean up socket if it exists. Simply continue with any error. It might work fine to use the same socket.
 	err = cleanupLocalSocket(addr)
 	if err != nil {
-		logrus.WithError(err).WithField("address", addr).Errorf("Failed to clean up local socket")
+		logrus.WithError(err).WithField("address", addr).Debug("Failed to clean up local socket")
 	}
 
 	s.once.Do(func() {

--- a/felix/collector/local/server.go
+++ b/felix/collector/local/server.go
@@ -105,16 +105,22 @@ func (s *FlowServer) Run() error {
 		logrus.WithError(err).Error("Failed to create local socket")
 		return err
 	}
+	addr := s.Address()
+
+	// Try to clean up socket if it exists. Simply continue with any error. It might work fine to use the same socket.
+	err = cleanupLocalSocket(addr)
+	if err != nil {
+		logrus.WithError(err).WithField("address", addr).Errorf("Failed to clean up local socket")
+	}
 
 	s.once.Do(func() {
 		var l net.Listener
-		sockAddr := s.Address()
-		l, err = net.Listen("unix", sockAddr)
+		l, err = net.Listen("unix", addr)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to listen on local socket")
 			return
 		}
-		logrus.WithField("address", sockAddr).Info("Running local server")
+		logrus.WithField("address", addr).Info("Running local server")
 		go func() {
 			err = s.grpcServer.Serve(l)
 			if err != nil {
@@ -152,7 +158,10 @@ func (s *FlowServer) Watch(
 }
 
 func (s *FlowServer) Stop() {
-	cleanupLocalSocket(s.Address())
+	addr := s.Address()
+	if err := cleanupLocalSocket(addr); err != nil {
+		logrus.WithError(err).WithField("address", addr).Errorf("Failed to clean up local socket")
+	}
 	s.grpcServer.Stop()
 }
 
@@ -173,7 +182,7 @@ func (s *FlowServer) Address() string {
 }
 
 func ensureLocalSocketDirExists(dir string) error {
-	logrus.Debug("Checking if local socket exists.")
+	logrus.Debug("Checking if local socket directory exists.")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		logrus.WithField("directory", dir).Debug("Local socket directory does not exist")
 		err := os.MkdirAll(dir, 0o600)
@@ -186,13 +195,10 @@ func ensureLocalSocketDirExists(dir string) error {
 	return nil
 }
 
-func cleanupLocalSocket(addr string) {
+func cleanupLocalSocket(addr string) error {
 	_, err := os.Stat(addr)
 	if err != nil && os.IsNotExist(err) {
-		return
+		return nil
 	}
-	err = os.Remove(addr)
-	if err != nil {
-		logrus.WithError(err).WithField("address", addr).Errorf("Failed to remove local socket")
-	}
+	return os.Remove(addr)
 }

--- a/node/pkg/flowlogs/flowlogs.go
+++ b/node/pkg/flowlogs/flowlogs.go
@@ -65,7 +65,7 @@ func flowToString(f *types.Flow) string {
 		startTime.Local(), f.Key.Reporter(), f.Key.Action(),
 		endpointTypeToString(f.Key.SourceType()), f.Key.SourceNamespace(), f.Key.SourceName(),
 		endpointTypeToString(f.Key.DestType()), f.Key.DestNamespace(), f.Key.DestName(),
-		f.Key.DestServiceName(), f.Key.DestServiceNamespace(),
+		f.Key.DestServiceNamespace(), f.Key.DestServiceName(),
 		f.Key.Proto(), f.Key.DestPort(), f.Key.DestServicePortName(), f.Key.DestServicePort(),
 		f.PacketsIn, f.BytesIn, f.PacketsOut, f.BytesOut,
 		f.NumConnectionsStarted, f.NumConnectionsCompleted, f.NumConnectionsLive,


### PR DESCRIPTION
## Description

Always try to clean up local socket when starting up flowlogs local flow server. This prevents cases where local socket is not cleaned up from previous runs, which leads to this error:

```
2025-04-22 21:03:05.728 [ERROR][290] node/server.go 114: Failed to listen on local socket error=listen unix /var/run/calico/flows/flows.sock: bind: address already in use
2025-04-22 21:03:05.729 [ERROR][290] node/flowlogs.go 46: Failed to start local flow server error=listen unix /var/run/calico/flows/flows.sock: bind: address already in use
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Related to https://github.com/projectcalico/calico/pull/10144

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
