### PR TITLE
Add first pass of quay.io expiry setting tool

### DIFF
--- a/hack/set_quay_expiry.py
+++ b/hack/set_quay_expiry.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+
+# NOTE: This script makes optional use of some modules for 'nicer'
+#       output, and I highly recommend installing them if you're
+#       using this script manually, or testing it; however, the
+#       entire script can run using only modules in the Python 3
+#       standard library, so that no docker container, requirements.txt,
+#       or virtualenv is required.
+#
+#       We also support inline dependencies a la PEP 723, and recommend
+#       using `uv` for this project (and every other project):
+#
+#           https://docs.astral.sh/uv/
+
+"""
+This script takes an expiry time and an image name on
+quay.io and uses the API to set the expiry on that image.
+"""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "rich",
+#     "rich-argparse",
+# ]
+# ///
+
+import os
+import sys
+import json
+import logging
+import argparse
+import datetime
+
+from functools import cache
+from enum import IntEnum, auto
+
+from typing import Optional
+
+import urllib.error
+import urllib.request
+
+try:
+    # Use nicer printing if we have it
+    from rich import print
+except ImportError:
+    pass
+
+try:
+    # Use nicer help formatting if we have it
+    from rich_argparse.contrib import ParagraphRichHelpFormatter as HelpFormatter
+except ImportError:
+    from argparse import HelpFormatter
+
+MONO_FORMAT = "[%(levelname)-8s] %(asctime)s [%(funcName)s:%(lineno)d] %(message)s"
+
+HELP_DESCRIPTION_TEXT = """
+A simple script to add an expiration date to an image tag on quay.io, or to remove the expiration date from one, using the quay.io API.
+
+When removing an expiry it's also possible to un-expire an image thanks to some peculiarities of the quay.io tag API, since the API returns the list of previous tag data for a specific tag even if it's expired.
+"""
+
+HELP_EPILOGUE_TEXT = """
+For prettier logging output, `pip install rich`. For prettier --help output, `pip install rich_argparse`.
+"""
+
+
+try:
+    # Use nicer log formatting if we have it
+    from rich.logging import RichHandler
+
+    handler = RichHandler(rich_tracebacks=True)
+except ImportError:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(MONO_FORMAT))
+
+handler.setLevel(logging.INFO)
+logging.basicConfig(
+    datefmt=r"%Y-%m-%d %H:%M:%S",
+    level=logging.DEBUG,
+    format="%(message)s",
+    handlers=[handler],
+)
+
+log = logging.getLogger(__name__)
+
+GET_TAG_INFO_URL = (
+    "https://quay.io/api/v1/repository/{image_name}/tag?specificTag={image_tag}"
+)
+PUT_TAG_INFO_URL = "https://quay.io/api/v1/repository/{image_name}/tag/{image_tag}"
+DATETIME_FORMAT = "%a, %d %b %Y %X %z"
+
+
+class ReturnCodes(IntEnum):
+    """
+    common return codes used in this module
+    """
+
+    OK = 0
+    NOAPITOKEN = auto()
+    INVALIDIMAGENAME = auto()
+    HTTPSETEXPIRYFORBIDDEN = auto()
+    HTTPIMAGENOTFOUND = auto()
+
+
+class Image:
+    """
+    The Image class represents a docker image on Quay.io, and
+    includes functionality to interact with its API to get information
+    and set expiry times.
+    """
+
+    def __init__(self, image_identifier):
+        if image_identifier.count(":") > 1:
+            log.critical(
+                "Image name needs to be of the format quay.io/image/name:<tag>"
+            )
+            sys.exit(ReturnCodes.INVALIDIMAGENAME)
+        image_uri, image_tag = image_identifier.split(":")
+        self.image_identifier = image_identifier
+        self.image_uri = image_uri
+        self.image_name = image_uri.removeprefix("quay.io/")
+        self.image_tag = image_tag
+
+        self.data = None
+
+        self.fetch_tag_info()
+        self.validate_dates()
+
+    @property
+    def last_modified_datetime(self):
+        return datetime.datetime.strptime(
+            self.latest_tag["last_modified"], DATETIME_FORMAT
+        )
+
+    @property
+    def has_expiry(self):
+        return self.expiry_datetime is not None
+
+    @property
+    def tag_data(self):
+        if self.data is None:
+            self.fetch_tag_info()
+        return self.data
+
+    @property
+    def latest_tag(self):
+        return self.data["tags"][0]
+
+    @property
+    def expiry_datetime(self):
+        try:
+            return datetime.datetime.strptime(
+                self.latest_tag["expiration"], DATETIME_FORMAT
+            )
+        except KeyError:
+            return None
+
+    @property
+    def is_expired(self):
+        if self.expiry_datetime:
+            return self.expiry_datetime < datetime.datetime.now(tz=datetime.UTC)
+        else:
+            return False
+
+    def fetch_tag_info(self):
+        log.debug(
+            "Fetching info for image tag '%s' from quay.io API", self.image_identifier
+        )
+        req = urllib.request.Request(
+            url=GET_TAG_INFO_URL.format(
+                image_name=self.image_name, image_tag=self.image_tag
+            ),
+            headers=auth_header(),
+            method="GET",
+        )
+        log.debug("Fetching tag data for tag '%s'", self.image_identifier)
+        with urllib.request.urlopen(req) as response:
+            data = json.load(response)
+            self.data = data
+
+    def validate_dates(self):
+        log.debug("Last modified date: '%s'", self.last_modified_datetime)
+        log.debug("Expiry date: '%s'", self.last_modified_datetime)
+        if self.expiry_datetime:
+            if self.is_expired:
+                log.error(
+                    (
+                        "Image tag '%s' exists in the API, but is already expired! "
+                        "Further API calls against this tag are likely to fail."
+                    ),
+                    self.image_identifier,
+                )
+            else:
+                log.debug(
+                    "Image tag '%s' has configured expiration '%s'",
+                    self.image_identifier,
+                    self.expiry_datetime,
+                )
+        else:
+            log.debug(
+                "Image tag '%s' has no configured expiration", self.image_identifier
+            )
+
+    def __put_tag_info(self, info):
+        req = urllib.request.Request(
+            url=PUT_TAG_INFO_URL.format(
+                image_name=self.image_name, image_tag=self.image_tag
+            ),
+            headers=auth_header(),
+            data=json.dumps(info).encode(),
+            method="PUT",
+        )
+        req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req) as response:
+                if response.code == 201:
+                    log.debug(
+                        "Successfully updated tag '%s' with data %s",
+                        self.image_identifier,
+                        info,
+                    )
+                else:
+                    log.warning("Got unexpected HTTP response %s", response.status)
+        except urllib.error.HTTPError as http_exc:
+            log.error(
+                "Caught HTTP error setting tag data for '%s': %s",
+                self.image_identifier,
+                http_exc,
+            )
+
+    def remove_expiry(self, restore=False):
+        """
+        Removes the expiry date from an image. Due to a quirk of
+        the API, we can also use this functionality to restore an
+        image that has already expired.
+
+        Args:
+            restore (bool, optional): Whether or not to restore the image if it's expired. Defaults to False.
+        """
+
+        # If the current tag doesn't have an expiry, that means there's nothing
+        # to remove and we don't need to restore it even if we were asked to.
+        if self.has_expiry is False:
+            log.info(
+                "Image tag '%s' has no expiry set, skipping", self.image_identifier
+            )
+            return
+
+        # Setting only the manifest digest creates a "new" entry in the tag's history,
+        # which, by default, has no expiry set. This not only means we can use this
+        # to remove expiry, but we can also use it to restore an already-expired image
+        # to its previous, un-expired version.
+        data = {"manifest_digest": self.latest_tag["manifest_digest"]}
+
+        # Image is expired and we're not trying to restore it - do nothing.
+        if self.is_expired and restore is False:
+            log.error(
+                "Image tag '%s' has expired, skipping (use --restore to restore this image)",
+                self.image_identifier,
+            )
+            return
+
+        # Here we set the tag's manifest_digest but nothing else
+        self.__put_tag_info(data)
+
+        # Do some logic to determine what our log should be like
+        if self.is_expired:
+            log.info(
+                "Restored expired image tag '%s' to manifest '%s' from '%s'",
+                self.image_identifier,
+                self.latest_tag["manifest_digest"],
+                self.last_modified_datetime,
+            )
+        elif self.has_expiry:
+            log.info(
+                "Removed expiry '%s' from image tag '%s'",
+                self.expiry_datetime,
+                self.image_identifier,
+            )
+
+    def set_expiry(self, days: int, relative=False, override=False):
+        if self.has_expiry:
+            if override is False:
+                log.warning(
+                    "Image tag '%s' already has expiry set, skipping",
+                    self.image_identifier,
+                )
+                return
+            log.warning(
+                "Image tag '%s' already has expiry set, but --force-override was set, proceeding anyway",
+                self.image_identifier,
+            )
+
+        if relative:
+            expiry_datetime = make_expiry_datetime(days, self.last_modified_datetime)
+        else:
+            expiry_datetime = make_expiry_datetime(days)
+
+        data = {"expiration": expiry_datetime.timestamp()}
+        self.__put_tag_info(data)
+        log.info(
+            "Set expiry information for image tag '%s' to '%s'",
+            self.image_identifier,
+            expiry_datetime,
+        )
+
+
+@cache
+def auth_header():
+    return {"Authorization": f"Bearer {get_quay_token()}"}
+
+
+def get_quay_token():
+    try:
+        token = os.environ["QUAY_API_TOKEN"]
+        if not token:
+            raise RuntimeError("QUAY_API_TOKEN is unset or empty")
+    except (KeyError, RuntimeError):
+        log.critical(
+            "Please set QUAY_API_TOKEN in the environment before running this script"
+        )
+        sys.exit(ReturnCodes.NOAPITOKEN)
+    return token
+
+
+def make_expiry_datetime(days: int, starting_date: Optional[datetime.datetime] = None):
+    # Create a timedelta from the number of days passed in
+    time_delta = datetime.timedelta(days=days)
+
+    # Get the current timestamp. We'll use this as a default starting_date, but
+    # also use it to validate that our expiration date is in the future.
+    now = datetime.datetime.now(tz=datetime.UTC)
+
+    if starting_date is None:
+        starting_date = now
+
+    # Strip away the time from the datetime so that we're operating at midnight
+    # UTC (which makes things predictable to some extent)
+    expiry_datetime = (
+        starting_date.replace(hour=0, minute=0, second=0, microsecond=0) + time_delta
+    )
+
+    # The API won't let us set dates in the past, so we need to set the expiry
+    # to be 'now' (or, to account for time skew, ten seconds from now)
+    if now > expiry_datetime:
+        log.warning(
+            "Target expiry '%s' is in the past! Setting expiry to ten seconds from now instead.",
+            expiry_datetime,
+        )
+        expiry_datetime = now + datetime.timedelta(minutes=10)
+    return expiry_datetime
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=HelpFormatter,
+        description=HELP_DESCRIPTION_TEXT,
+        epilog=HELP_EPILOGUE_TEXT,
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=False, help="Enable debug logging"
+    )
+
+    subparsers = parser.add_subparsers(dest="action")
+    parser_add_expiry = subparsers.add_parser(
+        "add", help="Add expiry to an image", formatter_class=parser.formatter_class
+    )
+
+    parser_add_expiry.add_argument(
+        "image_names", nargs="+", help="The image to add expiry to"
+    )
+    parser_add_expiry.add_argument(
+        "--expiry-days",
+        type=int,
+        default=90,
+        help="The time (in days from today UTC) to expire the images (default: 90d)",
+    )
+    parser_add_expiry.add_argument(
+        "--relative-date",
+        action="store_true",
+        default=False,
+        help="Set the expiry to days from last image modification instead",
+    )
+    parser_add_expiry.add_argument(
+        "--force-override",
+        action="store_true",
+        default=False,
+        help="Set expiry even if the image has an expiry set already",
+    )
+
+    parser_remove_expiry = subparsers.add_parser(
+        "remove",
+        help="Remove expiry to an image (and optionally un-expire the image)",
+        formatter_class=parser.formatter_class,
+    )
+    parser_remove_expiry.add_argument(
+        "image_names", nargs="+", help="The image to remove expiry from"
+    )
+    parser_remove_expiry.add_argument(
+        "--restore",
+        action="store_true",
+        default=False,
+        help="If the image tag is already expired, restore it to the last known tag",
+    )
+
+    args = parser.parse_args()
+
+    if args.debug:
+        handler.setLevel(logging.DEBUG)
+        log.debug("Executing with args %s", args)
+
+    for image_spec in args.image_names:
+        image_spec = image_spec.removeprefix("https://")
+        if not image_spec.startswith("quay.io"):
+            log.error(
+                "Image '%s' does not appear to be a quay.io image, skipping", image_spec
+            )
+            continue
+        image_obj = Image(image_spec)
+        if args.action == "add":
+            image_obj.set_expiry(args.expiry_days, relative=args.relative_date)
+        elif args.action == "remove":
+            image_obj.remove_expiry(restore=args.restore)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -925,8 +925,10 @@ push-images-to-registry-%:
 # that is.
 push-image-to-registry-%:
 	$(eval BUILD_IMAGE=$(call unescapefs,$*))
-	$(MAKE) -j6 $(addprefix push-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(BUILD_IMAGE)
 	$(eval EXPIRY_IMAGES_LIST=$(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG) $(addprefix $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG)-,$(VALIDARCHES)))
+
+	$(MAKE) -j6 $(addprefix push-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(BUILD_IMAGE)
+
 ifeq ($(findstring quay.io,$(REGISTRY)),quay.io)
 	$(if $(RELEASE), \
 		$(RELEASE_PY3) $(QUAY_SET_EXPIRY_SCRIPT) remove $(EXPIRY_IMAGES_LIST), \

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -493,16 +493,24 @@ endif
 
 GIT_CMD           = git
 DOCKER_CMD        = docker
+PYTHON3_CMD       = python3
 
+
+# RELEASE_PY3 is for Python invocations used for releasing,
+# where we want to be able to DRY_RUN them.
 ifdef CONFIRM
 CRANE         = $(CRANE_CMD)
 GIT           = $(GIT_CMD)
 DOCKER        = $(DOCKER_CMD)
+RELEASE_PY3   = $(PYTHON3_CMD)
 else
-CRANE         = echo [DRY RUN] $(CRANE_CMD)
-GIT           = echo [DRY RUN] $(GIT_CMD)
-DOCKER        = echo [DRY RUN] $(DOCKER_CMD)
+CRANE         = @echo [DRY RUN] $(CRANE_CMD)
+GIT           = @echo [DRY RUN] $(GIT_CMD)
+DOCKER        = @echo [DRY RUN] $(DOCKER_CMD)
+RELEASE_PY3   = @echo [DRY RUN] $(PYTHON3_CMD)
 endif
+
+QUAY_SET_EXPIRY_SCRIPT = $(REPO_ROOT)/hack/set_quay_expiry.py
 
 commit-and-push-pr:
 	$(GIT) add $(GIT_COMMIT_FILES)
@@ -911,8 +919,20 @@ push-images-to-registry-%:
 
 # push-image-to-registry-% pushes the build / arch images specified by $* and VALIDARCHES to the registry
 # specified by REGISTRY.
+#
+# We also build a list of all of the iamges we're going to be pushing and then, once we're done, we set the expiry
+# on those images, either adding an expiry for normal pushes or removing it for releases, if we're pushing to quay.io
+# that is.
 push-image-to-registry-%:
-	$(MAKE) -j6 $(addprefix push-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(call unescapefs,$*)
+	$(eval BUILD_IMAGE=$(call unescapefs,$*))
+	$(MAKE) -j6 $(addprefix push-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(BUILD_IMAGE)
+	$(eval EXPIRY_IMAGES_LIST=$(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG) $(addprefix $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG)-,$(VALIDARCHES)))
+ifeq ($(findstring quay.io,$(REGISTRY)),quay.io)
+	$(if $(RELEASE), \
+		$(RELEASE_PY3) $(QUAY_SET_EXPIRY_SCRIPT) remove $(EXPIRY_IMAGES_LIST), \
+		$(RELEASE_PY3) $(QUAY_SET_EXPIRY_SCRIPT) add --expiry-days=$(QUAY_EXPIRE_DAYS) $(EXPIRY_IMAGES_LIST) \
+	)
+endif
 
 # push-image-arch-to-registry-% pushes the build / arch image specified by $* and BUILD_IMAGE to the registry
 # specified by REGISTRY.

--- a/metadata.mk
+++ b/metadata.mk
@@ -66,3 +66,6 @@ BPFTOOL_IMAGE=calico/bpftool:v7.5.0
 
 # The operator branch corresponding to this branch.
 OPERATOR_BRANCH=master
+
+# quay.io expiry time for hashrelease/dev images
+QUAY_EXPIRE_DAYS=90


### PR DESCRIPTION
Add a new tool to set expiry times on quay.io images by updating a tag's information.

## Adding expiry to an image tag

```plain
Usage: set_quay_expiry.py add [-h] [--expiry-days EXPIRY_DAYS] [--relative-date] [--force-override] image_names [image_names ...]

Positional Arguments:
  image_names           The image to add expiry to

Options:
  -h, --help            show this help message and exit
  --expiry-days EXPIRY_DAYS
                        The time (in days from today UTC) to expire the images (default: 90d)
  --relative-date       Set the expiry to days from last image modification instead
  --force-override      Set expiry even if the image has an expiry set already
```

### How it works

Adding the expiry is fairly straightforward. If no options are specified, the tool goes through each image tag in `image_names` and sets the expiry date to 90 days from the previous midnight UTC if the image doesn't have an expiry set already.

Options:
* With `--expiry-days`, change the number of days from now the image should expire
* With `--relative-date`, expire the image `expiry-days` days from when the image was last modified (i.e. uploaded, usually) instead of from today
* With `--force-override`, overwrite the existing expiry if there is one; otherwise, skip it and move on.

### Caveats

In order to simplify things (but did we, though?) we do the following:

1. Check to see if the image already has an expiry; if so, and `--force-override` is not set, just skip it.
2. Decide which datetime to use as the 'base' for our expiry; this is either the current datetime in UTC, or the datetime when the latest image tag version was last modified (which is almost always going to be the date the image was originally pushed).
3. We then remove the time component from this datetime (setting hour, minute, second, microsecond to zero), and add our time delta (90 days by default), giving us an expiration timestamp of midnight UTC _some day_. This could potentially be between 89 and 91 days from now if 'midnight UTC' is yesterday or tomorrow for you, but timezones suck so we're doing it this way.

The quay.io API won't accept dates in the past, so if you're trying to expire image tags which have existed for more than 90 days using `--relative-date` the API call would fail. Instead, if the new expiration datetime is in the past, we set an expiration datetime of (now + 10 seconds) to provide a buffer for time skew, and then set the expiry to that value. This means that the image will expire roughly ten seconds from the time the script is run.

Expiration can be seen in the quay.io dashboard or queried via the API.

## Removing expiry from an image tag

```plain
Usage: set_quay_expiry.py remove [-h] [--restore] image_names [image_names ...]

Positional Arguments:
  image_names  The image to remove expiry from

Options:
  -h, --help   show this help message and exit
  --restore    If the image tag is already expired, restore it to the last known tag
```

Removing expiry is also straightforward; go through each image in `image_names` and remove the expiry date from the image if it has one; if it doesn't, skip it.

Removing the expiry is done by getting the current tag's `manifest_digest`, and then overwriting the tag with 'new' information containing only the `manifest_digest` field and not an `expiration` field. This creates effectively a new 'version' of the tag; this version points to the same actual image data (`manifest_digest`), but has no `expiration` set, meaning it won't expire.

### Restoring an expired image

The `quay.io` API has an interesting peculiarity: if an image tag has expired, it's no longer accessible _in most cases_, but you can still make API calls to get the image tag details. These details are effectively a log of each 'version' of the tag up until the most recent. Each 'version' of the tag includes a modification date, expiry date (if present), timestamp when the tag started being that version, timestamp when the tag stopped being that version, and manifest digest. You can fetch this information _even if an image has expired_, and the most recent 'version' will contain the details for what the tag was configured as before it expires.

This means that, _even if an image has expired_, we can fetch the historical tag information, find the `manifest_digest` from the most recent tag 'version', and create a 'new' tag using that digest. This  recreates the tag as it was before it expired, effectively un-expiring it.

## Python-related meta-commentary

### Third-party libraries

To simplify running the script in CI, the script relies solely on the Python 3 standard library, and should run in any currently supported Python 3 version. To ease the eyes, however, it makes optional use of the [rich](https://pypi.org/project/rich/) and [rich_argparse](https://pypi.org/project/rich-argparse/) modules, which I highly recommend installing if you're going to test or modify the script.

### Using `uv` to run the script

The [uv](https://docs.astral.sh/uv/) tool is a rust-based program which is a replacement for almost every piece of tooling out there in the Python ecosystem, and it supports PEP 723 inline metadata which this script makes use of. Thus, after installing `uv`, you can run this script with all of its dependencies by doing `uv run <script> <args>` instead of `python3 <script> <args>`; this will automatically download the optional dependencies, store them in a cache, create a temporary venv, and run the script using that venv and those dependencies. It will also ensure that it runs with the Python version specified (in this case, >= 3.11); if your local system doesn't provide that version, it will download it and install that into the venv as well.

### Golang in the future

I may rewrite this in Golang, but for now it's written in Python for two reasons:

1. I could write it 20-30 times faster in Python than in Golang, which made prototyping a lot faster
2. It can run without any external dependencies, so it doesn't need `go-build`, a compiler, modules downloading, etc., making it a lot easier and faster to deploy and run in CI. It doesn't even need to run in a docker container, though in the future I'll likely add support for downloading `uv` and running it in a venv with a specific Python version.