### PR TITLE
Improve memory accounting in calc graph benchmarks

### DIFF
--- a/felix/calc/calc_graph_bench_test.go
+++ b/felix/calc/calc_graph_bench_test.go
@@ -16,6 +16,7 @@ package calc
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"net"
 	"runtime"
@@ -35,31 +36,45 @@ import (
 
 const numNamespaces = 100
 
-func BenchmarkInitialSnapshot200Local250kTotal10000TagPols(b *testing.B) {
-	benchInitialSnap(b, 250_000, 200, 10000, 0)
+func BenchmarkSnapshot200Local250kTotal10000TagPols(b *testing.B) {
+	benchInitialSnap(b, 250_000, 200, 0, 10000, 0)
 }
 
-func BenchmarkInitialSnapshot200Local10kTotal1000NetsetPols(b *testing.B) {
-	benchInitialSnap(b, 10000, 200, 0, 1000)
+func BenchmarkSnapshot200Local10kTotal1000NetsetPols(b *testing.B) {
+	benchInitialSnap(b, 10000, 200, 0, 0, 1000)
 }
 
-func BenchmarkInitialSnapshot200Local10kTotal10000NetsetPols(b *testing.B) {
-	benchInitialSnap(b, 10000, 200, 0, 10000)
+func BenchmarkSnapshot200Local10kTotal10000NetsetPols(b *testing.B) {
+	benchInitialSnap(b, 10000, 200, 0, 0, 10000)
 }
 
-var (
-	keepAlive any
-	_         = keepAlive
-)
+func BenchmarkSnapshotThenDeleteLocal200Local250kTotal10000TagPols(b *testing.B) {
+	benchInitialSnap(b, 250_000, 200, 200, 10000, 0)
+}
 
-func benchInitialSnap(b *testing.B, numEndpoints int, numLocalEndpoints int, numTagPols int, netSetsAndPols int) {
+func BenchmarkSnapshotThenDeleteLocal200Local10kTotal1000NetsetPols(b *testing.B) {
+	benchInitialSnap(b, 10000, 200, 200, 0, 1000)
+}
+
+func BenchmarkSnapshotThenDeleteLocal200Local10kTotal10000NetsetPols(b *testing.B) {
+	benchInitialSnap(b, 10000, 200, 200, 0, 10000)
+}
+
+func benchInitialSnap(
+	b *testing.B,
+	numEndpoints int,
+	numLocalEndpoints int,
+	numLocalEndpointsToDelete int,
+	numTagPols int,
+	netSetsAndPols int,
+) {
 	RegisterTestingT(b)
 	defer logrus.SetLevel(logrus.GetLevel())
 	logrus.SetLevel(logrus.ErrorLevel)
 
 	epUpdates := makeEndpointUpdates(numEndpoints, "remotehost")
 	localUpdates := makeEndpointUpdates(numLocalEndpoints, "localhost")
-	localDeletes := makeEndpointDeletes(numLocalEndpoints, "localhost")
+	localDeletes := makeEndpointDeletes(numLocalEndpointsToDelete, "localhost")
 	polUpdates := makeTagPolicies(numTagPols)
 	profUpdates := makeNamespaceUpdates(numNamespaces)
 	netSetUpdates := makeNetSetAndPolUpdates(netSetsAndPols)
@@ -79,7 +94,6 @@ func benchInitialSnap(b *testing.B, numEndpoints int, numLocalEndpoints int, num
 			numMessages++
 		}
 		cg = NewCalculationGraph(es, nil, conf, func() {})
-		keepAlive = cg // Keep CG alive after run so that memory profile shows its usage
 
 		logrus.SetLevel(logrus.WarnLevel)
 		b.StartTimer()
@@ -106,11 +120,17 @@ func benchInitialSnap(b *testing.B, numEndpoints int, numLocalEndpoints int, num
 		b.ReportMetric(float64(numMessages), "Msgs")
 	}
 	b.StopTimer()
+
+	// Add the size of the heap to the benchmark output.  Trigger a GC and then
+	// sleep to allow any runtime.Cleanup()s to finish.
 	runtime.GC()
 	time.Sleep(time.Second)
+	// Read the stats.
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	b.ReportMetric(float64(m.HeapAlloc/(1024*1024)), "HeapAllocMB")
+	b.ReportMetric(float64(m.HeapAlloc)/(1024*1024), "HeapAllocMB")
+
+	// Make sure the CalcGraph doesn't get GCed before we collect stats.
 	runtime.KeepAlive(cg)
 }
 
@@ -352,6 +372,19 @@ func generateLabels() map[string]string {
 	for _, n := range []int{10, 11, 20, 30, 40} {
 		labels[fmt.Sprintf("one-in-%d", n)] = fmt.Sprintf("value-%d", labelSeed%n)
 	}
-	labels[markerLabels[labelSeed%len(markerLabels)]] = "true"
+	labels[markerLabels[(labelSeed)%len(markerLabels)]] = "true"
+
+	// Round trip through JSON; this makes every string unique, simulating
+	// what happens when we decode strings for real in felix.
+	buf, err := json.Marshal(labels)
+	if err != nil {
+		panic(err)
+	}
+	labels = nil
+	err = json.Unmarshal(buf, &labels)
+	if err != nil {
+		panic(err)
+	}
+
 	return labels
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

- Report heap size as part of benchmark output.
- Split benchmarks into variants that do and do not delete the local pods.
- Round trip labels through JSON to simulate receiving them on the wire (which results in them using a lot more memory  due to allocating copies of each string).

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
