### PR TITLE
Fix duplicate and incomplete flows being streamed

### DIFF
--- a/goldmane/cmd/stream/main.go
+++ b/goldmane/cmd/stream/main.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"github.com/projectcalico/calico/goldmane/pkg/client"
+	"github.com/projectcalico/calico/goldmane/proto"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+var (
+	clientCert = "./tls.crt"
+	clientKey  = "./tls.key"
+	clientCA   = "./ca.crt"
+
+	// The endpoint to connect to. This relies on /etc/hosts or DNS resolution resolving this name
+	// correctly, so that TLS certificate verification passes.
+	endpoint = "goldmane:7443"
+)
+
+var startTime int64
+
+func init() {
+	flag.Int64Var(&startTime, "start", 0, "Start time to use for the stream")
+}
+
+// main is an entrypoint for the stream client utility application, which is helpful for debugging. It initiates a stream
+// connection with Goldmane and prints the received flows to stdout.
+func main() {
+	flag.Parse()
+
+	// Create a stream client.
+	// Generate credentials for the Goldmane client.
+	creds, err := client.ClientCredentials(clientCert, clientKey, clientCA)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to create goldmane TLS credentials.")
+	}
+
+	// Create a client to interact with Flows.
+	c, err := client.NewFlowsAPIClient(endpoint, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		panic(err)
+	}
+
+	// Connect to the stream.
+	stream, err := c.Stream(context.Background(), &proto.FlowStreamRequest{StartTimeGte: startTime})
+	if err != nil {
+		panic(err)
+	}
+
+	// Read from the stream.
+	for {
+		flow, err := stream.Recv()
+		if err != nil {
+			panic(err)
+		}
+
+		// Print the flow.
+		j, err := json.MarshalIndent(flow, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(string(j))
+	}
+}

--- a/goldmane/cmd/stream/main.go
+++ b/goldmane/cmd/stream/main.go
@@ -20,10 +20,11 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/projectcalico/calico/goldmane/pkg/client"
-	"github.com/projectcalico/calico/goldmane/proto"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+
+	"github.com/projectcalico/calico/goldmane/pkg/client"
+	"github.com/projectcalico/calico/goldmane/proto"
 )
 
 var (

--- a/goldmane/pkg/aggregator/aggregator.go
+++ b/goldmane/pkg/aggregator/aggregator.go
@@ -482,9 +482,14 @@ func (a *LogAggregator) backfill(stream *Stream) {
 		backfillLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}()
 
+	logrus.WithFields(logrus.Fields{
+		"streamingBucket": a.buckets.BackfillEndTime(),
+		"now":             a.nowFunc().Unix(),
+	}).Info("Backfilling stream")
+
 	// Go through the bucket ring, generating stream events for each flow that matches the request.
 	// Right now, the stream endpoint only supports aggregation windows of a single bucket interval.
-	err := a.buckets.IterBucketsTime(request.StartTimeGte, a.nowFunc().Unix(), func(bucket *bucketing.AggregationBucket) error {
+	err := a.buckets.IterBucketsTime(request.StartTimeGte, a.buckets.BackfillEndTime(), func(bucket *bucketing.AggregationBucket) error {
 		// Iterate all of the keys in this bucket.
 		stopBucketIteration := false
 		bucket.Flows.Iter(func(d *types.DiachronicFlow) error {

--- a/goldmane/pkg/aggregator/bucketing/bucket_ring.go
+++ b/goldmane/pkg/aggregator/bucketing/bucket_ring.go
@@ -553,6 +553,13 @@ func (r *BucketRing) streamingBucket() *AggregationBucket {
 	return &r.buckets[idx]
 }
 
+// BackfillEndTime returns the time that backfill should complete at. This ensures that backfill doesn't
+// go past the end of the next bucket to be emitted on rollover, which would otherwise result in
+// duplicate and incomplete flows being streamed.
+func (r *BucketRing) BackfillEndTime() int64 {
+	return r.streamingBucket().StartTime
+}
+
 // IterBuckets iterates over the buckets in the ring, from the starting index until the ending index.
 // i.e., i := start; i < end; i++ (but handles wraparound)
 func (r *BucketRing) IterBuckets(start, end int, f func(i int) error) {

--- a/goldmane/pkg/aggregator/stream_test.go
+++ b/goldmane/pkg/aggregator/stream_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator_test
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/calico/goldmane/pkg/types"
+	"github.com/projectcalico/calico/goldmane/proto"
+)
+
+// Make sure we don't receive any duplicate flows. FlowKey is unique within a timeframe, so
+// augment it with time information to get a globally unique ID across time.
+type globalFlowID struct {
+	key       types.FlowKey
+	startTime int64
+	endTime   int64
+}
+
+// enforcedFlowSet is a set of flows. It allows us to ensure that we don't receive duplicate flows.
+type enforcedFlowSet struct {
+	flows map[globalFlowID]struct{}
+}
+
+func newEnforcedFlowSet() *enforcedFlowSet {
+	return &enforcedFlowSet{
+		flows: make(map[globalFlowID]struct{}),
+	}
+}
+
+// add adds a flow to the set. If the flow already exists, it returns an error.
+func (fs *enforcedFlowSet) add(result *proto.FlowResult) error {
+	flow := globalFlowID{
+		key:       *types.ProtoToFlowKey(result.Flow.Key),
+		startTime: result.Flow.StartTime,
+		endTime:   result.Flow.EndTime,
+	}
+	if _, ok := fs.flows[flow]; ok {
+		return fmt.Errorf("duplicate flow: %+v", result.Flow)
+	}
+	fs.flows[flow] = struct{}{}
+	return nil
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes an issue where Goldmane was backfilling streams with too much
data, resulting in duplicate flow emissions on the next rollover. 

This also adds a utility that allows connecting to Goldmane to stream
flows and print them to stdout.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.