### PR TITLE
Revert envoybinary bump

### DIFF
--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -5,7 +5,7 @@ PACKAGE_NAME ?= github.com/projectcalico/calico/third_party/envoy-gateway
 ENVOY_GATEWAY_IMAGE ?= envoy-gateway
 BUILD_IMAGES ?= $(ENVOY_GATEWAY_IMAGE)
 
-ENVOY_GATEWAY_VERSION=v1.3.2
+ENVOY_GATEWAY_VERSION=v1.2.6
 
 ##############################################################################
 # Include lib.Makefile before anything else
@@ -24,6 +24,7 @@ init-source:: $(ENVOY_GATEWAY_DOWNLOADED)
 $(ENVOY_GATEWAY_DOWNLOADED):
 	mkdir -p envoy-gateway
 	curl -sfL https://github.com/envoyproxy/gateway/archive/refs/tags/$(ENVOY_GATEWAY_VERSION).tar.gz | tar xz --strip-components 1 -C envoy-gateway
+	patch -d envoy-gateway -p1 < patches/0001-Bump-golang.org-x-net-to-v0.34.0-to-fix-CVE-2024-453.patch
 	touch $@
 
 .PHONY: build

--- a/third_party/envoy-gateway/patches/0001-Bump-golang.org-x-net-to-v0.34.0-to-fix-CVE-2024-453.patch
+++ b/third_party/envoy-gateway/patches/0001-Bump-golang.org-x-net-to-v0.34.0-to-fix-CVE-2024-453.patch
@@ -1,0 +1,131 @@
+From 930ef60512ee025761c1cd77660d1e1b494f2112 Mon Sep 17 00:00:00 2001
+From: Nell Jerram <nell@tigera.io>
+Date: Fri, 31 Jan 2025 11:54:48 +0000
+Subject: [PATCH] Bump golang.org/x/net to v0.34.0, to fix CVE-2024-45338
+
+---
+ examples/extension-server/go.mod |  4 ++--
+ examples/extension-server/go.sum |  8 ++++----
+ go.mod                           |  8 ++++----
+ go.sum                           | 16 ++++++++--------
+ 4 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/examples/extension-server/go.mod b/examples/extension-server/go.mod
+index 2ae1badd..0bb40554 100644
+--- a/examples/extension-server/go.mod
++++ b/examples/extension-server/go.mod
+@@ -31,8 +31,8 @@ require (
+ 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+ 	github.com/x448/float16 v0.8.4 // indirect
+ 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+-	golang.org/x/net v0.30.0 // indirect
+-	golang.org/x/sys v0.28.0 // indirect
++	golang.org/x/net v0.34.0 // indirect
++	golang.org/x/sys v0.29.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 // indirect
+diff --git a/examples/extension-server/go.sum b/examples/extension-server/go.sum
+index 960a9ee8..7272f43e 100644
+--- a/examples/extension-server/go.sum
++++ b/examples/extension-server/go.sum
+@@ -81,16 +81,16 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
+-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+diff --git a/go.mod b/go.mod
+index 103a5e7f..a22ee7fb 100644
+--- a/go.mod
++++ b/go.mod
+@@ -44,7 +44,7 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.3.1
+ 	go.uber.org/zap v1.27.0
+ 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
+-	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.29.0
+ 	google.golang.org/protobuf v1.35.1
+ 	gopkg.in/yaml.v3 v3.0.1
+ 	helm.sh/helm/v3 v3.16.2
+@@ -208,7 +208,7 @@ require (
+ 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 // indirect
+-	golang.org/x/crypto v0.31.0 // indirect
++	golang.org/x/crypto v0.32.0 // indirect
+ 	golang.org/x/crypto/x509roots/fallback v0.0.0-20240904212608-c9da6b9a4008 // indirect
+ 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+ 	gopkg.in/ini.v1 v1.67.0 // indirect
+@@ -277,10 +277,10 @@ require (
+ 	go.starlark.net v0.0.0-20240520160348-046347dcd104 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	golang.org/x/mod v0.21.0 // indirect
+-	golang.org/x/net v0.30.0
++	golang.org/x/net v0.34.0
+ 	golang.org/x/oauth2 v0.23.0 // indirect
+ 	golang.org/x/sync v0.10.0 // indirect
+-	golang.org/x/term v0.27.0 // indirect
++	golang.org/x/term v0.28.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.24.0 // indirect
+diff --git a/go.sum b/go.sum
+index 12cc6d68..f73db345 100644
+--- a/go.sum
++++ b/go.sum
+@@ -944,8 +944,8 @@ golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
++golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
++golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
+ golang.org/x/crypto/x509roots/fallback v0.0.0-20240904212608-c9da6b9a4008 h1:vKHSxFhPLnBEYu9R8DcQ4gXq9EqU0VVhC9pq9wmtYsg=
+ golang.org/x/crypto/x509roots/fallback v0.0.0-20240904212608-c9da6b9a4008/go.mod h1:kNa9WdvYnzFwC79zRpLRMJbdEFlhyM5RPFBBZp/wWH8=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+@@ -982,8 +982,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
+-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -1035,10 +1035,10 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+-golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
++golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=
+ golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+-- 
+2.34.1
+

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -5,7 +5,7 @@ PACKAGE_NAME ?= github.com/projectcalico/calico/third_party/envoy-proxy
 ENVOY_PROXY_IMAGE ?= envoy-proxy
 BUILD_IMAGES ?= $(ENVOY_PROXY_IMAGE)
 
-ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.33.1
+ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.31.5
 
 EXCLUDEARCH ?= ppc64le s390x
 

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -5,7 +5,7 @@ PACKAGE_NAME ?= github.com/projectcalico/calico/third_party/envoy-ratelimit
 ENVOY_RATELIMIT_IMAGE ?= envoy-ratelimit
 BUILD_IMAGES ?= $(ENVOY_RATELIMIT_IMAGE)
 
-ENVOY_RATELIMIT_VERSION=0141a24f
+ENVOY_RATELIMIT_VERSION=49af5cca
 
 ##############################################################################
 # Include lib.Makefile before anything else
@@ -24,6 +24,7 @@ init-source:: $(ENVOY_RATELIMIT_DOWNLOADED)
 $(ENVOY_RATELIMIT_DOWNLOADED):
 	git clone -n https://github.com/envoyproxy/ratelimit.git envoy-ratelimit
 	cd envoy-ratelimit && git checkout $(ENVOY_RATELIMIT_VERSION)
+	patch -d envoy-ratelimit -p1 < patches/0001-Bump-golang.org-x-net-to-v0.34.0-to-fix-CVE-2024-453.patch
 	touch $@
 
 .PHONY: build

--- a/third_party/envoy-ratelimit/patches/0001-Bump-golang.org-x-net-to-v0.34.0-to-fix-CVE-2024-453.patch
+++ b/third_party/envoy-ratelimit/patches/0001-Bump-golang.org-x-net-to-v0.34.0-to-fix-CVE-2024-453.patch
@@ -1,0 +1,101 @@
+From 2cb3bff52ab2459730294ca1fbf50c1a1ec9535a Mon Sep 17 00:00:00 2001
+From: Nell Jerram <nell@tigera.io>
+Date: Fri, 31 Jan 2025 14:45:11 +0000
+Subject: [PATCH] Bump golang.org/x/net to v0.34.0, to fix CVE-2024-45338
+
+---
+ go.mod | 10 +++++-----
+ go.sum | 12 ++++++------
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index b7b3051..f845ff3 100644
+--- a/go.mod
++++ b/go.mod
+@@ -8,6 +8,7 @@ require (
+ 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
+ 	github.com/coocood/freecache v1.2.4
+ 	github.com/envoyproxy/go-control-plane v0.12.1-0.20240123181358-841e293a220b
++	github.com/go-kit/log v0.2.1
+ 	github.com/golang/mock v1.6.0
+ 	github.com/google/uuid v1.6.0
+ 	github.com/gorilla/mux v1.8.1
+@@ -19,6 +20,7 @@ require (
+ 	github.com/lyft/gostats v0.4.14
+ 	github.com/mediocregopher/radix/v3 v3.8.1
+ 	github.com/prometheus/client_golang v1.19.1
++	github.com/prometheus/client_model v0.6.0
+ 	github.com/prometheus/statsd_exporter v0.26.1
+ 	github.com/sirupsen/logrus v1.9.3
+ 	github.com/stretchr/testify v1.9.0
+@@ -29,7 +31,7 @@ require (
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
+ 	go.opentelemetry.io/otel/sdk v1.28.0
+ 	go.opentelemetry.io/otel/trace v1.28.0
+-	golang.org/x/net v0.26.0
++	golang.org/x/net v0.34.0
+ 	google.golang.org/grpc v1.65.0
+ 	google.golang.org/protobuf v1.34.2
+ 	gopkg.in/yaml.v2 v2.4.0
+@@ -47,7 +49,6 @@ require (
+ 	github.com/davecgh/go-spew v1.1.1 // indirect
+ 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
+ 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+-	github.com/go-kit/log v0.2.1 // indirect
+ 	github.com/go-logfmt/logfmt v0.6.0 // indirect
+ 	github.com/go-logr/logr v1.4.2 // indirect
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+@@ -55,15 +56,14 @@ require (
+ 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
+ 	github.com/planetscale/vtprotobuf v0.5.1-0.20231212170721-e7d721933795 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+-	github.com/prometheus/client_model v0.6.0 // indirect
+ 	github.com/prometheus/common v0.48.0 // indirect
+ 	github.com/prometheus/procfs v0.12.0 // indirect
+ 	github.com/stretchr/objx v0.5.2 // indirect
+ 	github.com/yuin/gopher-lua v1.1.1 // indirect
+ 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+ 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+-	golang.org/x/sys v0.21.0 // indirect
+-	golang.org/x/text v0.16.0 // indirect
++	golang.org/x/sys v0.29.0 // indirect
++	golang.org/x/text v0.21.0 // indirect
+ 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20240701130421-f6361c86f094 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
+diff --git a/go.sum b/go.sum
+index b54c5c8..c57a647 100644
+--- a/go.sum
++++ b/go.sum
+@@ -191,8 +191,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
+-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -214,13 +214,13 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
+-golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
++golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
++golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description

This reverts #10250 which was not ready to be merged and currently causing hashreleases to fail on master

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
