### PR TITLE
[CORE-11344] Fix whisker multi-arch manifests [master]

### DIFF
--- a/whisker-backend/Makefile
+++ b/whisker-backend/Makefile
@@ -1,6 +1,8 @@
 include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/whisker-backend
+
+# Configure variables used by ci/cd common targets from lib.Makefile.
 IMAGE_BUILD_MARKER = whisker-backend-$(ARCH).created
 BUILD_IMAGES = whisker-backend
 
@@ -10,8 +12,6 @@ BUILD_IMAGES = whisker-backend
 #   that variable is evaluated when we declare DOCKER_RUN and siblings.
 ###############################################################################
 include ../lib.Makefile
-
-# Configure variables used by ci/cd common targets from lib.Makefile.
 
 .PHONY: image build
 image: $(IMAGE_BUILD_MARKER)

--- a/whisker-backend/Makefile
+++ b/whisker-backend/Makefile
@@ -2,6 +2,7 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/whisker-backend
 IMAGE_BUILD_MARKER = whisker-backend-$(ARCH).created
+BUILD_IMAGES = whisker-backend
 
 ###############################################################################
 # include ../lib.Makefile
@@ -11,7 +12,6 @@ IMAGE_BUILD_MARKER = whisker-backend-$(ARCH).created
 include ../lib.Makefile
 
 # Configure variables used by ci/cd common targets from lib.Makefile.
-BUILD_IMAGES=whisker-backend
 
 .PHONY: image build
 image: $(IMAGE_BUILD_MARKER)

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -4,17 +4,16 @@ PACKAGE_NAME = github.com/projectcalico/calico/whisker
 IMAGE_BUILD_MARKER = whisker_container-$(ARCH).created
 EXCLUDEARCH        ?=ppc64le s390x
 
+# Configure variables used by ci/cd common targets from lib.Makefile.
+BUILD_IMAGES=whisker
+BUILD_IMAGE_NAME=node:22.14
+
 ###############################################################################
 # include ../lib.Makefile
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
 #   that variable is evaluated when we declare DOCKER_RUN and siblings.
 ###############################################################################
 include ../lib.Makefile
-
-# Configure variables used by ci/cd common targets from lib.Makefile.
-BUILD_IMAGES=whisker
-
-BUILD_IMAGE_NAME=node:22.14
 
 DOCKER_RUN_RM:=docker run --rm \
 	--env CYPRESS_CACHE_FOLDER=/code/.cache/Cypress \


### PR DESCRIPTION
A subtle bug in our Makefiles.

We set `PUSH_MANIFEST_IMAGES` in `lib.Makefile` using the `:=` syntax; this causes `make` to evaluate the line immediately and store it as a static string, rather than lazily evaluating the entire line every time the variable is accessed.

By setting the value of `BUILD_IMAGES` after `lib.Makefile` is imported, that variable is never picked up; the `push-manifests` target then has nothing to do and exits silently, and no multi-arch manifests are ever pushed.

Solve this by moving the definition of `BUILD_IMAGES` above the import.