### PR TITLE
Make node UT diags easier to grok.

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -298,6 +298,7 @@ DOCKER_RUN := mkdir -p $(REPO_ROOT)/.go-pkg-cache bin $(GOMOD_CACHE) && \
 		-e OS=$(BUILDOS) \
 		-e GOOS=$(BUILDOS) \
 		-e GOFLAGS=$(GOFLAGS) \
+		-e ACK_GINKGO_DEPRECATIONS=1.16.5 \
 		-v $(REPO_ROOT):/go/src/github.com/projectcalico/calico:rw \
 		-v $(REPO_ROOT)/.go-pkg-cache:/go-cache:rw \
 		-w /go/src/$(PACKAGE_NAME)

--- a/node/Makefile
+++ b/node/Makefile
@@ -308,6 +308,7 @@ ut fv: run-k8s-apiserver
 	-v $(CERTS_PATH):/home/user/certs \
 	-e KUBECONFIG=/go/src/github.com/projectcalico/calico/hack/test/certs/kubeconfig \
 	-e ETCD_ENDPOINTS=http://$(LOCAL_IP_ENV):2379 \
+	-e GINKGO_ARGS="$(GINKGO_ARGS)" \
 	$(CALICO_BUILD) ./run-uts $(WHAT)
 
 ###############################################################################

--- a/node/run-uts
+++ b/node/run-uts
@@ -16,6 +16,7 @@ echo GINKGO_ARGS: $GINKGO_ARGS
 # We want to run all the tests even if one suite fails. We'll increment this each
 # time a suite fails.
 RC=0
+failed_packages=""
 
 # Go through each package we've been told to test. If there are actually test files present,
 # then run those tests. If the package is included in SKIP, we'll skip them.
@@ -29,10 +30,14 @@ for PKG in "$@"; do
 	HAS_TESTS=$(find ${PKG} -name "*_test.go")
 	if [ ! -z "${HAS_TESTS}" ]; then 
 		echo "Running tests for package: ${PKG}";
-		ginkgo -r -skipPackage=${SKIP} ${GINKGO_ARGS} ${PKG} || ((RC++))
-	else 
+		ginkgo -r -skipPackage=${SKIP} ${GINKGO_ARGS} ${PKG} || {
+			failed_packages+="${PKG} ";
+			((RC++))
+		}
+	else
 		echo "WARNING: No tests to run in ${PKG}, skipping"
 	fi
 done
 
+echo "Failed packages: ${failed_packages}"
 exit ${RC}


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Include names of failed packages.
- Silence Ginkgo deprecation warning.
- Pass through GINKGO_ARGS.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
