### PR TITLE
Reduce log severity on errors in handling endpoint status creation ev…

### DIFF
--- a/confd/pkg/backends/calico/local_bgp_peer_watcher.go
+++ b/confd/pkg/backends/calico/local_bgp_peer_watcher.go
@@ -74,7 +74,8 @@ func (w *LocalBGPPeerWatcher) OnFileCreation(fileName string) {
 	logCxt.Debug("Workload endpoint status file created")
 	epStatus, err := epstatus.GetWorkloadEndpointStatusFromFile(fileName)
 	if err != nil {
-		logCxt.WithError(err).Warn("Failed to read endpoint status from file, it may just be created.")
+		// It's likely fine if reading fails on a creation event as the file might not yet be fully written.
+		logCxt.WithError(err).Debug("Failed to read endpoint status from file, it may just be created and yet to be fully written.")
 		return
 	}
 	if w.updateEpStatus(fileName, epStatus) {

--- a/libcalico-go/lib/epstatusfile/status_file_writer.go
+++ b/libcalico-go/lib/epstatusfile/status_file_writer.go
@@ -215,7 +215,6 @@ func GetWorkloadEndpointStatusFromFile(filePath string) (*WorkloadEndpointStatus
 	var epStatus WorkloadEndpointStatus
 	err = json.Unmarshal(data, &epStatus)
 	if err != nil {
-		logCxt.WithError(err).Error("Failed to unmarshal JSON")
 		return nil, err
 	}
 


### PR DESCRIPTION
…ent (#10326)

* Reduce log severity on errors in handling endpoint status creation event.

(cherry picked from commit 78a23ac23bc0fce2809d37dbbf397b5849b6253a)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
