### PR TITLE
fix licenses in apiserver, whisker & ALP images

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -73,6 +73,9 @@ endif
 .PHONY: build
 build: $(BINDIR)/apiserver-$(ARCH)
 
+bin/LICENSE: ../LICENSE.md
+	cp ../LICENSE.md $@
+
 CONTAINER_CREATED=.apiserver.created-$(ARCH)
 CONTAINER_FIPS_CREATED=.apiserver.created-$(ARCH)-fips
 
@@ -85,13 +88,12 @@ sub-image-fips-%:
 	$(MAKE) image FIPS=true ARCH=$*
 
 $(API_SERVER_IMAGE): $(CONTAINER_MARKER)
-$(CONTAINER_CREATED): Dockerfile $(BINDIR)/apiserver-$(ARCH)
-	cp ../LICENSE.md $(BINDIR)/LICENSE
+$(CONTAINER_CREATED): Dockerfile $(BINDIR)/apiserver-$(ARCH) bin/LICENSE
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(API_SERVER_IMAGE):latest-$(ARCH) -f Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
-$(CONTAINER_FIPS_CREATED): Dockerfile $(BINDIR)/apiserver-$(ARCH)
+$(CONTAINER_FIPS_CREATED): Dockerfile $(BINDIR)/apiserver-$(ARCH) bin/LICENSE
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(API_SERVER_IMAGE):latest-fips-$(ARCH) -f Dockerfile .
 	$(MAKE) FIPS=true retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -132,17 +132,18 @@ sub-image-fips-%:
 	$(MAKE) image FIPS=true ARCH=$*
 
 $(DIKASTES_IMAGE): $(CONTAINER_MARKER)
-$(CONTAINER_CREATED): register Dockerfile $(BINDIR)/dikastes-$(ARCH) $(BINDIR)/healthz-$(ARCH)
-	cp ../LICENSE.md $(BINDIR)/LICENSE
+$(CONTAINER_CREATED): register Dockerfile $(BINDIR)/dikastes-$(ARCH) $(BINDIR)/healthz-$(ARCH) bin/LICENSE
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(DIKASTES_IMAGE):latest-$(ARCH) -f Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
-$(CONTAINER_FIPS_CREATED): register Dockerfile $(BINDIR)/dikastes-$(ARCH) $(BINDIR)/healthz-$(ARCH)
-	cp ../LICENSE.md $(BIN)/LICENSE
+$(CONTAINER_FIPS_CREATED): register Dockerfile $(BINDIR)/dikastes-$(ARCH) $(BINDIR)/healthz-$(ARCH) bin/LICENSE
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BINDIR) -t $(DIKASTES_IMAGE):latest-fips-$(ARCH) -f Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
+
+bin/LICENSE: ../LICENSE.md
+	cp ../LICENSE.md $@
 ###############################################################################
 # UTs
 ###############################################################################

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -22,10 +22,14 @@ DOCKER_RUN_RM:=docker run --rm \
 	-v $${PWD}:/code \
 	-w /code
 
-$(IMAGE_BUILD_MARKER): register build
-	$(DOCKER_BUILD) -t whisker:latest-$(ARCH) -f docker-image/Dockerfile .
+$(IMAGE_BUILD_MARKER): register build bin/LICENSE
+	$(DOCKER_BUILD) --build-arg BIN_DIR=bin -t whisker:latest-$(ARCH) -f docker-image/Dockerfile .
 	$(MAKE) retag-build-images-with-registries BUILD_IMAGES=$(BUILD_IMAGES) VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
+
+bin/LICENSE: ../LICENSE.md
+	@mkdir -p bin
+	cp ../LICENSE.md $@
 
 .PHONY: image build
 image: $(IMAGE_BUILD_MARKER)

--- a/whisker/docker-image/Dockerfile
+++ b/whisker/docker-image/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG BIN_DIR
 ARG CALICO_BASE
 
 FROM registry.access.redhat.com/ubi9/ubi:latest AS ubi
@@ -21,7 +22,7 @@ RUN dnf upgrade -y
 COPY docker-image/nginx.repo /etc/yum.repos.d/nginx.repo
 
 RUN dnf --enablerepo=nginx-stable install -y \
-    nginx
+  nginx
 
 FROM scratch AS source
 
@@ -60,7 +61,7 @@ COPY docker-image/nginx.conf /etc/nginx/nginx.conf
 
 COPY dist /usr/share/nginx/html/
 
-COPY LICENSE /licenses/LICENSE
+COPY ${BIN_DIR}LICENSE /licenses/LICENSE
 
 FROM ${CALICO_BASE}
 


### PR DESCRIPTION
## Description

I think this fixes master image build for apiserver, whisker and ALP images failing due to missing license on merge of #10265 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
