### PR TITLE
Allow tigera-operator to delete whisker and goldmane when uninstalling

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -194,6 +194,8 @@ rules:
     resources:
       - installations
       - apiservers
+      - whiskers
+      - goldmanes
     verbs:
       - delete
   - apiGroups:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -194,6 +194,8 @@ rules:
     resources:
       - installations
       - apiservers
+      - whiskers
+      - goldmanes
     verbs:
       - delete
   - apiGroups:

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -278,6 +278,8 @@ rules:
     resources:
       - installations
       - apiservers
+      - whiskers
+      - goldmanes
     verbs:
       - delete
   - apiGroups:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -232,6 +232,8 @@ rules:
     resources:
       - installations
       - apiservers
+      - whiskers
+      - goldmanes
     verbs:
       - delete
   - apiGroups:


### PR DESCRIPTION
## Description

Alter clusterrole for deleting whisker and goldmane. 

Needed for https://github.com/tigera/operator/pull/3886

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
