### PR TITLE
Improve performance of IPAM GC controller

### DIFF
--- a/calicoctl/calicoctl/commands/ipam/release.go
+++ b/calicoctl/calicoctl/commands/ipam/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/calicoctl/calicoctl/commands/ipam/release.go
+++ b/calicoctl/calicoctl/commands/ipam/release.go
@@ -50,8 +50,8 @@ Options:
   -h --help                    Show this screen.
      --ip=<IP>                 IP address to release.
      --from-report=<REPORT>    Release all leaked addresses from the report.  If multiple reports are specified then
-                               only leaked IPs common to all reports will be released - by generating reports at 
-                               different times, e.g. separated by an hour, this can be used to provide additional 
+                               only leaked IPs common to all reports will be released - by generating reports at
+                               different times, e.g. separated by an hour, this can be used to provide additional
                                certainty that the IPs are truly leaked rather than in a transient state of assignment.
                                At least one of the reports should be newly generated.
      --force                   Force release of leaked addresses.
@@ -130,7 +130,7 @@ Description:
 
 		// Call ReleaseIPs releases the IP and returns an empty slice as unallocatedIPs if
 		// release was successful else it returns back the slice with the IP passed in.
-		unallocatedIPs, err := ipamClient.ReleaseIPs(ctx, opt)
+		unallocatedIPs, _, err := ipamClient.ReleaseIPs(ctx, opt)
 		if err != nil {
 			return fmt.Errorf("Error: %v", err)
 		}
@@ -231,7 +231,7 @@ func releaseIPs(ctx context.Context, c clientv3.Interface, notInUseIPs map[strin
 	}
 	fmt.Printf("Releasing %d old IPs...\n", len(ipsToRelease))
 
-	unallocated, err := c.IPAM().ReleaseIPs(ctx, ipsToRelease...)
+	unallocated, _, err := c.IPAM().ReleaseIPs(ctx, ipsToRelease...)
 	if err != nil {
 		fmt.Printf("An error occurred while releasing some IPs: %s.  "+
 			"Problems are often caused by an out-of-date IPAM report.  "+

--- a/calicoctl/tests/fv/ipam_test.go
+++ b/calicoctl/tests/fv/ipam_test.go
@@ -196,7 +196,7 @@ func TestIPAM(t *testing.T) {
 			ips = append(ips, ipam.ReleaseOptions{Address: ip.IP.String()})
 		}
 		// Release the IPs
-		_, err = client.IPAM().ReleaseIPs(ctx, ips...)
+		_, _, err = client.IPAM().ReleaseIPs(ctx, ips...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 }

--- a/calicoctl/tests/fv/migrate_ipam_test.go
+++ b/calicoctl/tests/fv/migrate_ipam_test.go
@@ -229,6 +229,6 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 		ips = append(ips, ipam.ReleaseOptions{Address: ip.IP.String()})
 	}
 	// Release the IPs
-	_, err = client.IPAM().ReleaseIPs(ctx, ips...)
+	_, _, err = client.IPAM().ReleaseIPs(ctx, ips...)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -294,7 +294,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				for _, v6 := range v6Assignments.IPs {
 					v6IPs = append(v6IPs, ipam.ReleaseOptions{Address: v6.IP.String()})
 				}
-				_, err := calicoClient.IPAM().ReleaseIPs(ctx, v6IPs...)
+				_, _, err := calicoClient.IPAM().ReleaseIPs(ctx, v6IPs...)
 				if err != nil {
 					logrus.Errorf("Error releasing IPv6 addresses %+v on IPv4 address assignment failure: %s", v6IPs, err)
 				}
@@ -310,7 +310,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				for _, v4 := range v4Assignments.IPs {
 					v4IPs = append(v4IPs, ipam.ReleaseOptions{Address: v4.IP.String()})
 				}
-				_, err := calicoClient.IPAM().ReleaseIPs(ctx, v4IPs...)
+				_, _, err := calicoClient.IPAM().ReleaseIPs(ctx, v4IPs...)
 				if err != nil {
 					logrus.Errorf("Error releasing IPv4 addresses %+v on IPv6 address assignment failure: %s", v4IPs, err)
 				}
@@ -354,7 +354,7 @@ func acquireIPAMLockBestEffort(path string) unlockFn {
 	if path == "" {
 		path = ipamLockPath
 	}
-	err := os.MkdirAll(filepath.Dir(path), 0777)
+	err := os.MkdirAll(filepath.Dir(path), 0o777)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to make directory for IPAM lock")
 		// Fall through, still a slight chance the file is there for us to access.

--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -668,7 +668,7 @@ func releaseIPAddrs(ipAddrs []string, calico calicoclient.Interface, logger *log
 		if err != nil {
 			return err
 		}
-		unallocated, err := calico.IPAM().ReleaseIPs(context.Background(), libipam.ReleaseOptions{Address: cip.String()})
+		unallocated, _, err := calico.IPAM().ReleaseIPs(context.Background(), libipam.ReleaseOptions{Address: cip.String()})
 		if err != nil {
 			log.WithError(err).Error("Failed to release explicit IP")
 			return err
@@ -724,7 +724,6 @@ func ipAddrsResult(ipAddrs string, conf types.NetConf, args *skel.CmdArgs, logge
 // to get current.Result and then it unsets the IP field from CNI_ARGS ENV var,
 // so it doesn't pollute the subsequent requests.
 func callIPAMWithIP(ip net.IP, conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) (*cniv1.Result, error) {
-
 	// Save the original value of the CNI_ARGS ENV var for backup.
 	originalArgs := os.Getenv("CNI_ARGS")
 	logger.Debugf("Original CNI_ARGS=%s", originalArgs)

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -334,7 +334,17 @@ func startCompactor(ctx context.Context, interval time.Duration) {
 // getClients builds and returns Kubernetes and Calico clients.
 func getClients(kubeconfig string) (*kubernetes.Clientset, client.Interface, error) {
 	// Get Calico client
-	calicoClient, err := client.NewFromEnv()
+	config, err := apiconfig.LoadClientConfigFromEnvironment()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Increase the client QPS on the Calico client.
+	// - For one, this client is shared across a number of different controllers, so will need a higher request count.
+	// - Secondly, the IPAM GC controller can potentially generate a very large number of requests.
+	config.Spec.K8sClientQPS = 500
+
+	calicoClient, err := client.New(*config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build Calico client: %s", err)
 	}

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -359,6 +359,7 @@ func getClients(kubeconfig string) (*kubernetes.Clientset, client.Interface, err
 	// Increase the QPS of the Kubernetes client as well. This is also used heavily by the IPAM GC controller
 	// in some circumstances.
 	k8sconfig.QPS = 100
+	k8sconfig.Burst = 200
 
 	// Get Kubernetes clientset
 	k8sClientset, err := kubernetes.NewForConfig(k8sconfig)

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -356,6 +356,10 @@ func getClients(kubeconfig string) (*kubernetes.Clientset, client.Interface, err
 		return nil, nil, fmt.Errorf("failed to build kubernetes client config: %s", err)
 	}
 
+	// Increase the QPS of the Kubernetes client as well. This is also used heavily by the IPAM GC controller
+	// in some circumstances.
+	k8sconfig.QPS = 100
+
 	// Get Kubernetes clientset
 	k8sClientset, err := kubernetes.NewForConfig(k8sconfig)
 	if err != nil {

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -728,7 +728,7 @@ func (c *loadBalancerController) releaseIP(svcKey serviceKey, ip string) error {
 	releaseOptions := ipam.ReleaseOptions{
 		Address: ip,
 	}
-	_, err := c.calicoClient.IPAM().ReleaseIPs(context.Background(), releaseOptions)
+	_, _, err := c.calicoClient.IPAM().ReleaseIPs(context.Background(), releaseOptions)
 	if err != nil {
 		log.Errorf("error on removing assigned IP %s", ip)
 		return err

--- a/kube-controllers/pkg/controllers/node/fake_client.go
+++ b/kube-controllers/pkg/controllers/node/fake_client.go
@@ -262,14 +262,14 @@ func (f *fakeIPAMClient) AutoAssign(ctx context.Context, args ipam.AutoAssignArg
 
 // ReleaseIPs releases any of the given IP addresses that are currently assigned,
 // so that they are available to be used in another assignment.
-func (f *fakeIPAMClient) ReleaseIPs(ctx context.Context, opts ...ipam.ReleaseOptions) ([]cnet.IP, error) {
+func (f *fakeIPAMClient) ReleaseIPs(ctx context.Context, opts ...ipam.ReleaseOptions) ([]cnet.IP, []ipam.ReleaseOptions, error) {
 	f.Lock()
 	defer f.Unlock()
 
 	for _, opt := range opts {
 		f.handlesReleased[opt.Handle] = true
 	}
-	return nil, nil
+	return nil, opts, nil
 }
 
 // GetAssignmentAttributes returns the attributes stored with the given IP address

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1140,7 +1140,7 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 		return nil
 	}
 
-	// By release multple IPs at once, we can reduce the number of API calls the underlying IPAM code needs to make
+	// By releasing multiple IPs at once, we can reduce the number of API calls the underlying IPAM code needs to make
 	// in order to release the IPs. This is especially apparent when there are multple IP addresses from the same block
 	// that must be released, as they can all be released in a single API call to update the block.
 	log.WithField("num", len(opts)).Info("Garbage collecting leaked IP addresses")

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1112,8 +1112,10 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 	for id, a := range c.confirmedLeaks {
 		logc := log.WithFields(a.fields())
 
-		// Final check that the allocation is leaked.
-		if c.allocationIsValid(a, true) {
+		// Final check that the allocation is leaked. We prefer the cache when the hosting node has been
+		// deleted, as we're reasonably confident this is a leak. Otherwise, we go to the API server directly for extra confidence
+		// that the Pod is actually gone.
+		if c.allocationIsValid(a, a.knode == "") {
 			logc.Info("Leaked IP has been resurrected after querying latest state")
 			delete(c.confirmedLeaks, id)
 			a.markValid()

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1112,7 +1112,10 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 	// released, or were unallocated to begin with. In either case, we can mark them as released.
 	for _, opt := range releasedOpts {
 		// Find the allocation that matches these release options.
-		a := leaks[opt]
+		a, ok := leaks[opt]
+		if !ok {
+			logrus.WithField("opt", opt).Fatalf("BUG: unable to find allocation for release options: %+v", leaks)
+		}
 		logc := log.WithFields(a.fields())
 
 		// No longer a leak. Remove it here so we're not dependent on receiving

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -311,7 +311,6 @@ func (c *IPAMController) acceptScheduleRequests(stopCh <-chan struct{}) {
 	t := time.NewTicker(period)
 	log.Infof("Will run periodic IPAM sync every %s", period)
 
-	// Use time.Tick to add tightloop protection on the main loop.
 	for {
 		// Wait until something wakes us up, or we are stopped.
 		select {

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1121,7 +1121,7 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 		c.incrementReclamationMetric(a.block, a.node())
 		delete(c.confirmedLeaks, a.id())
 
-		logc.Debug("Successfully garbage collected leaked IP address")
+		logc.Info("Successfully garbage collected leaked IP address")
 		delete(leaks, opt)
 	}
 

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	gonet "net"
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
@@ -30,8 +31,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
-
-	gonet "net"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/config"
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -644,14 +644,15 @@ var _ = Describe("IPAM controller UTs", func() {
 			// Create 1k nodes.
 			for i := start; i < start+1000; i++ {
 				n := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)}}
-				cs.CoreV1().Nodes().Create(context.TODO(), n, metav1.CreateOptions{})
+				_, err := cs.CoreV1().Nodes().Create(context.TODO(), n, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
 
 				// Create a pod for the allocation so that it doesn't get GC'd.
 				pod := v1.Pod{}
 				pod.Name = fmt.Sprintf("test-pod-%d", i)
 				pod.Namespace = "test-namespace"
 				pod.Spec.NodeName = "kname"
-				_, err := cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+				_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				var gotPod *v1.Pod
 				Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
@@ -696,7 +697,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			// Delete all of the nodes.
 			for i := start; i < start+1000; i++ {
 				n := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)}}
-				cs.CoreV1().Nodes().Delete(context.TODO(), n.Name, metav1.DeleteOptions{})
+				Expect(cs.CoreV1().Nodes().Delete(context.TODO(), n.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 				c.OnKubernetesNodeDeleted(n)
 			}
 
@@ -705,7 +706,7 @@ var _ = Describe("IPAM controller UTs", func() {
 				pod := v1.Pod{}
 				pod.Name = fmt.Sprintf("test-pod-%d", i)
 				pod.Namespace = "test-namespace"
-				cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				Expect(cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 				var gotPod *v1.Pod
 				Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
 			}

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -19,6 +19,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/aws/smithy-go/ptr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -29,6 +30,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+
+	gonet "net"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/config"
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
@@ -125,6 +128,10 @@ var _ = Describe("IPAM controller UTs", func() {
 		pods = make(chan *v1.Pod, 1)
 		_, err := podInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
+				pod := obj.(*v1.Pod)
+				pods <- pod
+			},
+			DeleteFunc: func(obj interface{}) {
 				pod := obj.(*v1.Pod)
 				pods <- pod
 			},
@@ -622,6 +629,116 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() bool {
 			return fakeClient.affinityReleased("cnode")
 		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue())
+	})
+
+	It("should handle rapid and peristent node churn", func() {
+		// Start the controller.
+		c.Start(stopChan)
+
+		// Mark the syncer as InSync so that the GC will be triggered.
+		c.onStatusUpdate(bapi.InSync)
+
+		// Start a goroutine which continuously creates and deletes many nodes, assigning IPs to them.
+		// This is a stress test to ensure that the controller can handle rapid churn.
+		start := 0
+		churnNodes := func() {
+			// Create 1k nodes.
+			for i := start; i < start+1000; i++ {
+				n := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)}}
+				cs.CoreV1().Nodes().Create(context.TODO(), n, metav1.CreateOptions{})
+
+				// Create a pod for the allocation so that it doesn't get GC'd.
+				pod := v1.Pod{}
+				pod.Name = fmt.Sprintf("test-pod-%d", i)
+				pod.Namespace = "test-namespace"
+				pod.Spec.NodeName = "kname"
+				_, err := cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				var gotPod *v1.Pod
+				Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+
+				// Allocate IPs to each node.
+				ip := net.BigIntToIP(big.NewInt(int64(i)+1000), false)
+				cidr := ip.Network()
+				cidr.Mask = gonet.CIDRMask(30, 32)
+				key := model.BlockKey{CIDR: *cidr}
+				b := model.AllocationBlock{
+					CIDR:        *cidr,
+					Affinity:    ptr.String(fmt.Sprintf("host:%s", n.Name)),
+					Allocations: []*int{ptr.Int(0), ptr.Int(1), nil, nil},
+					Unallocated: []int{2, 3},
+					Attributes: []model.AllocationAttribute{
+						{
+							AttrPrimary: ptr.String(fmt.Sprintf("ipip-tunnel-addr-i-%d", i)),
+							AttrSecondary: map[string]string{
+								ipam.AttributeNode: n.Name,
+								ipam.AttributeType: ipam.AttributeTypeIPIP,
+							},
+						},
+						{
+							AttrPrimary: ptr.String(fmt.Sprintf("handle-%d", i)),
+							AttrSecondary: map[string]string{
+								ipam.AttributeNode:      n.Name,
+								ipam.AttributePod:       pod.Name,
+								ipam.AttributeNamespace: "test-namespace",
+							},
+						},
+					},
+				}
+				kvp := model.KVPair{Key: key, Value: &b}
+				// blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+				update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+				c.onUpdate(update)
+			}
+
+			// Wait a moment.
+			time.Sleep(1 * time.Second)
+
+			// Delete all of the nodes.
+			for i := start; i < start+1000; i++ {
+				n := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)}}
+				cs.CoreV1().Nodes().Delete(context.TODO(), n.Name, metav1.DeleteOptions{})
+				c.OnKubernetesNodeDeleted(n)
+			}
+
+			// Delete all the pods.
+			for i := start; i < start+1000; i++ {
+				pod := v1.Pod{}
+				pod.Name = fmt.Sprintf("test-pod-%d", i)
+				pod.Namespace = "test-namespace"
+				cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				var gotPod *v1.Pod
+				Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
+			}
+			start += 1000
+		}
+
+		churnNodes()
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+
+		// We should see a number of IPs released equal to 2 * 1k * number of churned nodes.
+		Eventually(func() int {
+			return len(fakeClient.handlesReleased)
+		}, 30*time.Second, 100*time.Millisecond).Should(Equal(2000), "Not all handles released")
+		// We should see a number of blocks released equal to 1k * number of churned nodes.
+		Eventually(func() int {
+			return len(fakeClient.affinitiesReleased)
+		}, 30*time.Second, 100*time.Millisecond).Should(Equal(1000), "Not all blocks released")
+
+		// Churn again a few times.
+		for range 5 {
+			churnNodes()
+			time.Sleep(5 * time.Second)
+		}
+		// We should see a number of blocks released equal to 1k * number of churned nodes.
+		Eventually(func() int {
+			return len(fakeClient.handlesReleased)
+		}, 30*time.Second, 100*time.Millisecond).Should(Equal(12000), "Not all handles released")
+		// We should see a number of blocks released equal to 1k * number of churned nodes.
+		Eventually(func() int {
+			return len(fakeClient.affinitiesReleased)
+		}, 30*time.Second, 100*time.Millisecond).Should(Equal(6000), "Not all blocks released")
 	})
 
 	It("should handle clusterinformation updates and maintain its clusterinformation datastoreReady cache", func() {

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -249,7 +249,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		Expect(len(affs.KVPairs)).To(Equal(2))
 
 		By("releasing the second IP address to create an empty affine block", func() {
-			unalloc, err := calicoClient.IPAM().ReleaseIPs(context.Background(), ipam.ReleaseOptions{Address: "192.168.0.65", Handle: handle2})
+			unalloc, _, err := calicoClient.IPAM().ReleaseIPs(context.Background(), ipam.ReleaseOptions{Address: "192.168.0.65", Handle: handle2})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(unalloc)).To(Equal(0))
 		})
@@ -726,7 +726,7 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 		Expect(len(affs.KVPairs)).To(Equal(2))
 
 		By("releasing the second IP address to create an empty affine block", func() {
-			unalloc, err := calicoClient.IPAM().ReleaseIPs(context.Background(), ipam.ReleaseOptions{Address: "192.168.0.65", Handle: handle2})
+			unalloc, _, err := calicoClient.IPAM().ReleaseIPs(context.Background(), ipam.ReleaseOptions{Address: "192.168.0.65", Handle: handle2})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(unalloc)).To(Equal(0))
 		})

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -38,6 +38,18 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
+var (
+	// Configure timeoutes for the tests. We expedite leak detection in order to speed up the tests.
+	leakGracePeriod = 1 * time.Second
+
+	// We don't want consistently blocks to take too long - but they need to wait at least a few
+	// grace periods to do their job.
+	consistentlyTimeout  = 3 * leakGracePeriod
+	consistentlyInterval = consistentlyTimeout / 10
+
+	retryInterval = 100 * time.Millisecond
+)
+
 var _ = Describe("IPAM garbage collection FV tests with short leak grace period", func() {
 	var (
 		etcd              *containers.Container
@@ -77,7 +89,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		Eventually(func() error {
 			_, err := k8sClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 			return err
-		}, 30*time.Second, 1*time.Second).Should(BeNil())
+		}, 30*time.Second, retryInterval).Should(BeNil())
 
 		// Apply the necessary CRDs. There can sometimes be a delay between starting
 		// the API server and when CRDs are apply-able, so retry here.
@@ -88,7 +100,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 			}
 			return nil
 		}
-		Eventually(apply, 10*time.Second).ShouldNot(HaveOccurred())
+		Eventually(apply, 10*time.Second, retryInterval).ShouldNot(HaveOccurred())
 
 		// Make a Calico client and backend client.
 		type accessor interface {
@@ -113,7 +125,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		By("shortening the leak grace period for the test", func() {
 			kcc := api.NewKubeControllersConfiguration()
 			kcc.Name = "default"
-			kcc.Spec.Controllers.Node = &api.NodeControllerConfig{LeakGracePeriod: &metav1.Duration{Duration: 5 * time.Second}}
+			kcc.Spec.Controllers.Node = &api.NodeControllerConfig{LeakGracePeriod: &metav1.Duration{Duration: leakGracePeriod}}
 			_, err = calicoClient.KubeControllersConfiguration().Create(context.Background(), kcc, options.SetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -144,7 +156,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 					metav1.CreateOptions{},
 				)
 				return err
-			}, time.Second*10, 500*time.Millisecond).ShouldNot(HaveOccurred())
+			}, time.Second*10, retryInterval).ShouldNot(HaveOccurred())
 		})
 
 		// Start the controller.
@@ -217,7 +229,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, 30*time.Second, 2*time.Second).Should(BeNil())
+		}, consistentlyTimeout, consistentlyInterval).Should(BeNil())
 	})
 
 	It("should clean up empty blocks after the grace period", func() {
@@ -257,7 +269,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		// Expect the block to be cleaned up by the GC, eventually.
 		Eventually(func() error {
 			return assertNumBlocks(bc, 1)
-		}, 15*time.Second, 2*time.Second).Should(BeNil())
+		}, 15*time.Second, retryInterval).Should(BeNil())
 	})
 
 	It("should NOT clean up allocations that are not Kubernetes pods", func() {
@@ -290,7 +302,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, 30*time.Second, 2*time.Second).Should(BeNil())
+		}, consistentlyTimeout, consistentlyInterval).Should(BeNil())
 	})
 
 	It("should clean up an IP with no corresponding pod", func() {
@@ -325,7 +337,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, time.Minute, 2*time.Second).Should(BeNil())
+		}, time.Minute, retryInterval).Should(BeNil())
 	})
 
 	It("should NOT garbage collect a valid IP address (status.PodIP)", func() {
@@ -376,7 +388,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(affs.KVPairs)).To(Equal(1))
 
-		// The valid IP should not be cleaned up. Wait 30 seconds (6 times the GC interval set for the test).
+		// The valid IP should not be cleaned up.
 		Consistently(func() error {
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleValidIP, 1); err != nil {
 				return err
@@ -385,7 +397,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, 30*time.Second, 2*time.Second).Should(BeNil())
+		}, consistentlyTimeout, consistentlyInterval).Should(BeNil())
 	})
 
 	It("should NOT garbage collect a valid IP address (status.PodIPs)", func() {
@@ -439,7 +451,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(affs.KVPairs)).To(Equal(1))
 
-		// The valid IP should not be cleaned up. Wait 30 seconds (6 times the GC interval set for the test).
+		// The valid IP should not be cleaned up.
 		Consistently(func() error {
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleValidIP, 1); err != nil {
 				return err
@@ -448,7 +460,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, 30*time.Second, 2*time.Second).Should(BeNil())
+		}, consistentlyTimeout, consistentlyInterval).Should(BeNil())
 	})
 
 	It("should NOT clean up an IP if the matching pod does not yet have an address in the API", func() {
@@ -505,7 +517,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, 30*time.Second, 2*time.Second).Should(BeNil())
+		}, 30*time.Second, retryInterval).Should(BeNil())
 	})
 
 	It("should GC IP allocations if they do not match the pod's IP", func() {
@@ -565,7 +577,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 				return err
 			}
 			return nil
-		}, time.Minute, 2*time.Second).Should(BeNil())
+		}, time.Minute, retryInterval).Should(BeNil())
 	})
 })
 
@@ -608,7 +620,7 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 		Eventually(func() error {
 			_, err := k8sClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 			return err
-		}, 30*time.Second, 1*time.Second).Should(BeNil())
+		}, 30*time.Second, retryInterval).Should(BeNil())
 
 		// Apply the necessary CRDs. There can sometimes be a delay between starting
 		// the API server and when CRDs are apply-able, so retry here.
@@ -619,7 +631,7 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 			}
 			return nil
 		}
-		Eventually(apply, 10*time.Second).ShouldNot(HaveOccurred())
+		Eventually(apply, 10*time.Second, retryInterval).ShouldNot(HaveOccurred())
 
 		// Make a Calico client and backend client.
 		type accessor interface {
@@ -676,7 +688,7 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 					metav1.CreateOptions{},
 				)
 				return err
-			}, time.Second*10, 500*time.Millisecond).ShouldNot(HaveOccurred())
+			}, time.Second*10, retryInterval).ShouldNot(HaveOccurred())
 		})
 
 		// Start the controller.
@@ -734,6 +746,6 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 		// Expect that the block is not removed immediately.
 		Consistently(func() error {
 			return assertNumBlocks(bc, 2)
-		}, 15*time.Second, 2*time.Second).Should(BeNil())
+		}, consistentlyTimeout, consistentlyInterval).Should(BeNil())
 	})
 })

--- a/kube-controllers/pkg/controllers/node/metrics_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/metrics_fv_test.go
@@ -719,7 +719,7 @@ func createPod(podName string, ip string, handle string, node string, k8sClient 
 func deletePodWithIP(pod string, ip string, k8sClient *kubernetes.Clientset, calicoClient client.Interface) {
 	err := k8sClient.CoreV1().Pods("default").Delete(context.Background(), pod, metav1.DeleteOptions{})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	_, err = calicoClient.IPAM().ReleaseIPs(context.Background(), ipam.ReleaseOptions{Address: ip})
+	_, _, err = calicoClient.IPAM().ReleaseIPs(context.Background(), ipam.ReleaseOptions{Address: ip})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 }
 

--- a/kube-controllers/pkg/controllers/node/metrics_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/metrics_fv_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -338,7 +338,7 @@ var _ = Describe("Calico node controller FV tests (KDD mode)", func() {
 		})
 
 		// This is a test for a specific bug which was fixed by https://github.com/projectcalico/libcalico-go/pull/1345
-		It("should handle improperly formatted handle IDs", func() {
+		FIt("should handle improperly formatted handle IDs", func() {
 			nodeA := "node-a"
 
 			// Create the nodes in the Kubernetes API.
@@ -376,9 +376,13 @@ var _ = Describe("Calico node controller FV tests (KDD mode)", func() {
 			_, err = bc.Update(context.Background(), blocks.KVPairs[0])
 			Expect(err).NotTo(HaveOccurred())
 
+			// Wait for the block update to be received.
+			time.Sleep(3 * time.Second)
+
 			// Deleting NodeA should clean up all IPAM data.
 			err = k8sClient.CoreV1().Nodes().Delete(context.Background(), nodeA, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
+
 			Eventually(func() error {
 				if err := assertIPsWithHandle(calicoClient.IPAM(), handleA, 0); err != nil {
 					return err
@@ -895,7 +899,10 @@ func assertNumBlocks(bc backend.Client, num int) error {
 		return fmt.Errorf("error querying blocks: %s", err)
 	}
 	if len(blocks.KVPairs) != num {
-		return fmt.Errorf("Expected %d blocks, found %d. Blocks: %#v", num, len(blocks.KVPairs), blocks)
+		for _, kvp := range blocks.KVPairs {
+			logrus.Infof("[TEST] found block: %+v", kvp.Value.(*model.AllocationBlock))
+		}
+		return fmt.Errorf("Expected %d blocks, found %d", num, len(blocks.KVPairs))
 	}
 	return nil
 }

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -338,7 +338,7 @@ var _ = Describe("Calico node controller FV tests (KDD mode)", func() {
 		})
 
 		// This is a test for a specific bug which was fixed by https://github.com/projectcalico/libcalico-go/pull/1345
-		FIt("should handle improperly formatted handle IDs", func() {
+		It("should handle improperly formatted handle IDs", func() {
 			nodeA := "node-a"
 
 			// Create the nodes in the Kubernetes API.

--- a/kube-controllers/pkg/controllers/utils/retry_controller.go
+++ b/kube-controllers/pkg/controllers/utils/retry_controller.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func NewRetryController(w func() time.Duration, r, s func()) *RetryController {
+	return &RetryController{
+		whenFn:    w,
+		retryFn:   r,
+		successFn: s,
+	}
+}
+
+// RetryController is a helper structure for managing a retry with a backoff mechanism. Note that the retry function
+// is called asynchronously, so should use a channel to communicate back with the main loop. This is intentional, to allow
+// for scheduled retries without sleeping on the main goroutine, otherwise blocking work.
+type RetryController struct {
+	sync.Mutex
+	retryPending bool
+
+	// whenFn is a function that returns a time to wait before the next retry.
+	whenFn func() time.Duration
+
+	// retryFn is the function to call after a retry timer pops.
+	retryFn func()
+
+	// successFn is the function to call on success.
+	successFn func()
+}
+
+func (c *RetryController) ScheduleRetry() {
+	// We keep at most one retry pending.
+	if c.pending() {
+		logrus.Debug("Retry is already pending")
+		return
+	}
+
+	// Schedule a retry.
+	c.mark()
+	go c.scheduledRetry(c.whenFn())
+}
+
+func (c *RetryController) Success() {
+}
+
+func (c *RetryController) scheduledRetry(wait time.Duration) {
+	// Wait the retry duration, then kick the channel.
+	logrus.WithField("wait", wait).Info("Scheduling retry")
+	<-time.After(wait)
+	logrus.Debug("Scheduled retry popped")
+	c.clear()
+	c.retryFn()
+}
+
+func (c *RetryController) pending() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.retryPending
+}
+
+func (c *RetryController) clear() {
+	c.Lock()
+	defer c.Unlock()
+	c.retryPending = false
+}
+
+func (c *RetryController) mark() {
+	c.Lock()
+	defer c.Unlock()
+	c.retryPending = true
+}

--- a/kube-controllers/pkg/controllers/utils/retry_controller_test.go
+++ b/kube-controllers/pkg/controllers/utils/retry_controller_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/utils"
+)
+
+func TestRetryController(t *testing.T) {
+	t.Run("It should schedule a retry", func(t *testing.T) {
+		ch := make(chan struct{}, 1)
+
+		c := utils.NewRetryController(
+			func() time.Duration { return 1 * time.Second },
+			func() { ch <- struct{}{} },
+			func() {},
+		)
+
+		// Should not get trigger to start.
+		expectNoRetry(t, ch, 100*time.Millisecond)
+
+		// Trigger a retry.
+		c.ScheduleRetry()
+
+		// We should get a kick in 1s, not less.
+		expectNoRetry(t, ch, 900*time.Millisecond)
+		expectRetry(t, ch, 200*time.Millisecond)
+	})
+
+	t.Run("It should allow multiple retry calls", func(t *testing.T) {
+		ch := make(chan struct{}, 1)
+
+		c := utils.NewRetryController(
+			func() time.Duration { return 1 * time.Second },
+			func() { ch <- struct{}{} },
+			func() {},
+		)
+
+		// Trigger a bunch of retries.
+		c.ScheduleRetry()
+		c.ScheduleRetry()
+		c.ScheduleRetry()
+		c.ScheduleRetry()
+		c.ScheduleRetry()
+
+		// We should only get one update.
+		expectRetry(t, ch, 2*time.Second)
+		expectNoRetry(t, ch, 1*time.Second)
+	})
+}
+
+func expectRetry(t *testing.T, ch chan struct{}, d time.Duration) {
+	select {
+	case <-ch:
+	case <-time.After(d):
+		t.Fatal("never received expected retry")
+	}
+}
+
+func expectNoRetry(t *testing.T, ch chan struct{}, d time.Duration) {
+	select {
+	case <-ch:
+		t.Fatal("unexpected retry detected")
+	case <-time.After(d):
+	}
+}

--- a/libcalico-go/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -316,9 +316,9 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 				By("Releasing the IP addresses and checking for no updates")
 				// Releasing IPs should leave the affine blocks assigned, so releasing the IPs
 				// should result in no updates.
-				_, err = c.IPAM().ReleaseIPs(ctx, ips1...)
+				_, _, err = c.IPAM().ReleaseIPs(ctx, ips1...)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = c.IPAM().ReleaseIPs(ctx, ips2...)
+				_, _, err = c.IPAM().ReleaseIPs(ctx, ips2...)
 				Expect(err).NotTo(HaveOccurred())
 				syncTester.ExpectCacheSize(expectedCacheSize)
 

--- a/libcalico-go/lib/clientv3/ippool_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ippool_e2e_test.go
@@ -1117,7 +1117,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests (etcd only)", testutils.Dat
 			Expect(err).To(HaveOccurred())
 
 			By("deleting the block and creating a pool with a different blockSize")
-			unreleased, err := c.IPAM().ReleaseIPs(ctx, assigned...)
+			unreleased, _, err := c.IPAM().ReleaseIPs(ctx, assigned...)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(unreleased).To(HaveLen(0))
 			_, err = c.IPPools().Create(ctx, &apiv3.IPPool{

--- a/libcalico-go/lib/clientv3/ippool_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ippool_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libcalico-go/lib/clientv3/node.go
+++ b/libcalico-go/lib/clientv3/node.go
@@ -155,7 +155,7 @@ func (r nodes) Delete(ctx context.Context, name string, opts options.DeleteOptio
 		ropts = append(ropts, ipam.ReleaseOptions{Address: ip.String()})
 	}
 
-	_, err = r.client.IPAM().ReleaseIPs(context.Background(), ropts...)
+	_, _, err = r.client.IPAM().ReleaseIPs(context.Background(), ropts...)
 	switch err.(type) {
 	case nil, errors.ErrorResourceDoesNotExist, errors.ErrorOperationNotSupported:
 	default:

--- a/libcalico-go/lib/clientv3/node.go
+++ b/libcalico-go/lib/clientv3/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libcalico-go/lib/ipam/interface.go
+++ b/libcalico-go/lib/ipam/interface.go
@@ -41,7 +41,7 @@ type Interface interface {
 
 	// ReleaseIPs releases any of the given IP addresses that are currently assigned,
 	// so that they are available to be used in another assignment.
-	ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]cnet.IP, error)
+	ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]cnet.IP, []ReleaseOptions, error)
 
 	// GetAssignmentAttributes returns the attributes stored with the given IP address
 	// upon assignment, as well as the handle used for assignment (if any).

--- a/libcalico-go/lib/ipam/interface.go
+++ b/libcalico-go/lib/ipam/interface.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -1130,7 +1130,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 	opts := []ReleaseOptions{}
 	for i := 0; i < len(ipsByBlock); i++ {
 		r := <-resultChan
-		log.Debugf("Received response #%d from release goroutine: %v", i, r)
+		log.Debugf("Received response #%d from release goroutine: %+v", i, r)
 		if r.Error != nil && err == nil {
 			err = r.Error
 		}

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -1112,11 +1112,13 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 		_, cidr, _ := net.ParseCIDR(blockCIDR)
 		go func(cidr net.IPNet, ips []ReleaseOptions, hm map[string]*model.KVPair) {
 			defer sem.Release(1)
-			r := retVal{Released: ips}
+			r := retVal{}
 			unalloc, err := c.releaseIPsFromBlock(ctx, hm, ips, cidr)
 			if err != nil {
 				log.Errorf("Error releasing IPs: %v", err)
 				r.Error = err
+			} else {
+				r.Released = ips
 			}
 			r.Unallocated = unalloc
 			resultChan <- r

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -992,11 +992,15 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 
 // ReleaseIPs releases any of the given IP addresses that are currently assigned,
 // so that they are available to be used in another assignment.
-func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]net.IP, error) {
+// ReleaseIPs returns:
+// - A list of IPs that were asked to be released, but were not allocated.
+// - A list of ReleaseOptions that did not encounter an error (either not allocated, or successfully released).
+// - An error, if one occurred.
+func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]net.IP, []ReleaseOptions, error) {
 	for i := 0; i < len(ips); i++ {
 		// Validate the input.
 		if ips[i].Address == "" {
-			return nil, fmt.Errorf("No IP address specified in options: %+v", ips[i])
+			return nil, nil, fmt.Errorf("No IP address specified in options: %+v", ips[i])
 		}
 
 		// Sanitize any handles.
@@ -1009,11 +1013,11 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 	// Get IP pools up front so we don't need to query for each IP address.
 	v4Pools, err := c.pools.GetEnabledPools(ctx, 4)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	v6Pools, err := c.pools.GetEnabledPools(ctx, 6)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Group IP addresses by block to minimize the number of writes
@@ -1024,7 +1028,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 
 		ip, err := opts.AsNetIP()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Find the IP pools for this address in the enabled pools if possible.
@@ -1034,19 +1038,19 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 			pool, err = c.blockReaderWriter.getPoolForIP(ctx, *ip, v4Pools)
 			if err != nil {
 				log.WithError(err).Warnf("Failed to get pool for IP")
-				return nil, err
+				return nil, nil, err
 			}
 		case 6:
 			pool, err = c.blockReaderWriter.getPoolForIP(ctx, *ip, v6Pools)
 			if err != nil {
 				log.WithError(err).Warnf("Failed to get pool for IP")
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
 		if pool == nil {
 			if cidr, err := c.blockReaderWriter.getBlockForIP(ctx, *ip); err != nil {
-				return nil, err
+				return nil, nil, err
 			} else {
 				if cidr == nil {
 					// The IP isn't in any block so it's already unallocated.
@@ -1083,7 +1087,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 		// List all handles, so we don't need to query them individually, and populate the map.
 		allHandles, err := c.blockReaderWriter.listHandles(ctx, "")
 		if err != nil {
-			return unallocated, err
+			return unallocated, nil, err
 		}
 		for _, h := range allHandles.KVPairs {
 			handleMap[sanitizeHandle(h.Key.(model.IPAMHandleKey).HandleID)] = h
@@ -1095,6 +1099,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 	type retVal struct {
 		Error       error
 		Unallocated []net.IP
+		Released    []ReleaseOptions
 	}
 	resultChan := make(chan retVal, len(ipsByBlock))
 	sem := semaphore.NewWeighted(int64(runtime.GOMAXPROCS(-1)))
@@ -1107,7 +1112,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 		_, cidr, _ := net.ParseCIDR(blockCIDR)
 		go func(cidr net.IPNet, ips []ReleaseOptions, hm map[string]*model.KVPair) {
 			defer sem.Release(1)
-			r := retVal{}
+			r := retVal{Released: ips}
 			unalloc, err := c.releaseIPsFromBlock(ctx, hm, ips, cidr)
 			if err != nil {
 				log.Errorf("Error releasing IPs: %v", err)
@@ -1120,6 +1125,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 
 	// Read the response from each goroutine.
 	err = nil
+	opts := []ReleaseOptions{}
 	for i := 0; i < len(ipsByBlock); i++ {
 		r := <-resultChan
 		log.Debugf("Received response #%d from release goroutine: %v", i, r)
@@ -1127,8 +1133,9 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 			err = r.Error
 		}
 		unallocated = append(unallocated, r.Unallocated...)
+		opts = append(opts, r.Released...)
 	}
-	return unallocated, err
+	return unallocated, opts, err
 }
 
 func (c ipamClient) releaseIPsFromBlock(ctx context.Context, handleMap map[string]*model.KVPair, ips []ReleaseOptions, blockCIDR net.IPNet) ([]net.IP, error) {
@@ -2048,7 +2055,7 @@ func (c ipamClient) ensureConsistentAffinity(ctx context.Context, b *model.Alloc
 			logCtx.WithError(err).WithField("node", affinityCfg.Host).Error("Failed to get node for host")
 			return err
 		}
-		logCtx.Info("Node doesn't exist, no need to release affinity")
+		logCtx.Debug("Node doesn't exist, no need to check its affinity")
 		return nil
 	}
 

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -3124,14 +3124,13 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				inIPs = inIPs[1:]
 			}
 
-			unallocatedIPs, rel, outErr := ic.ReleaseIPs(context.Background(), buildReleaseOptions(inIPs...)...)
+			unallocatedIPs, _, outErr := ic.ReleaseIPs(context.Background(), buildReleaseOptions(inIPs...)...)
 			if outErr != nil {
 				log.Println(outErr)
 			}
 
 			// Expect returned slice of unallocatedIPs to be equal to expected expUnallocatedIPs.
 			Expect(unallocatedIPs).To(Equal(expUnallocatedIPs))
-			Expect(len(rel)).To(Equal(len(inIPs)))
 
 			// Assert if an error was expected.
 			if expError != nil {

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -310,9 +310,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(v4IP)).To(Equal(1))
-				out, err := ic.ReleaseIPs(context.Background(), v4IP...)
+				out, rel, err := ic.ReleaseIPs(context.Background(), v4IP...)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(out)).To(Equal(0))
+				Expect(len(rel)).To(Equal(1))
 			})
 
 			Expect(runtime.Seconds()).Should(BeNumerically("<", 5))
@@ -376,9 +377,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 				// Release the IP address using the sequence number and handle. This simulates what kube-controllers will do, and
 				// should result in a conflict error being returned.
-				u, err := ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
+				u, rel, err := ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
 				Expect(err).To(HaveOccurred())
 				Expect(len(u)).To(Equal(0))
+				Expect(len(rel)).To(Equal(0))
 
 				// Requery the block in order to get information about the allocation necessary to safely release. This time,
 				// we won't race and will successfully release.
@@ -391,9 +393,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(seq).To(Equal(uint64(expectedSeqNum)))
 
 				// Release the IP using the correct sequence number.
-				u, err = ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
+				u, rel, err = ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(u)).To(Equal(0))
+				Expect(len(rel)).To(Equal(1))
 				expectedSeqNum += 2
 			}
 		})
@@ -457,9 +460,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// Release the IP address using the sequence number and handle. This simulates what kube-controllers will do, and
 			// should result in a conflict error being returned.
-			u, err := ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
+			u, rel, err := ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
 			Expect(err).To(HaveOccurred())
 			Expect(len(u)).To(Equal(0))
+			Expect(len(rel)).To(Equal(0))
 
 			// Requery the block in order to get information about the allocation necessary to safely release. This time,
 			// we won't race and will successfully release.
@@ -471,9 +475,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			seq = blocks.KVPairs[0].Value.(*model.AllocationBlock).GetSequenceNumberForOrdinal(ordinal)
 
 			// Release the IP using the correct sequence number.
-			u, err = ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
+			u, rel, err = ic.ReleaseIPs(context.TODO(), ReleaseOptions{Address: ip.IP.String(), SequenceNumber: &seq, Handle: handle})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(u)).To(Equal(0))
+			Expect(len(rel)).To(Equal(1))
 		})
 
 		It("should release a multitude of IPs in different blocks", func() {
@@ -526,9 +531,10 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			// Release them all. This should complete within a minute easily.
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
-			unalloc, err := ic.ReleaseIPs(ctx, buildReleaseOptions(ips...)...)
+			unalloc, rel, err := ic.ReleaseIPs(ctx, buildReleaseOptions(ips...)...)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(unalloc)).To(Equal(0))
+			Expect(len(rel)).To(Equal(len(ips)))
 		})
 	})
 
@@ -918,7 +924,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 		It("Should release with sentinel IP duplicated in the request args", func() {
 			// Releasing the same IP multiple times in a single request
 			// should be handled gracefully by the IPAM Block allocator
-			_, releaseErr := ic.ReleaseIPs(context.Background(),
+			_, _, releaseErr := ic.ReleaseIPs(context.Background(),
 				ReleaseOptions{Address: sentinelIP.String()},
 				ReleaseOptions{Address: sentinelIP.String()},
 			)
@@ -1690,8 +1696,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			// Release one of the IPs.
-			unallocated, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs[0:1]...)...)
+			unallocated, rel, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs[0:1]...)...)
 			Expect(len(unallocated)).To(Equal(0))
+			Expect(len(rel)).To(Equal(1))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should still have one affine block to this host.
@@ -1702,8 +1709,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			applyPool(pool1.String(), true, `foo != "bar"`)
 
 			// Release another one of the IPs.
-			unallocated, err = ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs[1:2]...)...)
+			unallocated, rel, err = ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs[1:2]...)...)
 			Expect(len(unallocated)).To(Equal(0))
+			Expect(len(rel)).To(Equal(1))
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block still have an affinity to this host.
@@ -1716,8 +1724,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(out.KVPairs)).To(Equal(1))
 
 			// Release the last IP.
-			unallocated, err = ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs[2:3]...)...)
+			unallocated, rel, err = ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs[2:3]...)...)
 			Expect(len(unallocated)).To(Equal(0))
+			Expect(len(rel)).To(Equal(1))
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block now has no affinity, and no IPs, so it should be deleted.
@@ -1919,8 +1928,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			// Release all IPs.
-			unallocated, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs...)...)
+			unallocated, rel, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs...)...)
 			Expect(len(unallocated)).To(Equal(0))
+			Expect(len(rel)).To(Equal(len(v4IPs)))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Change the selector for the IP pool so that it no longer matches node1.
@@ -2006,8 +2016,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			// Release all IPs.
-			unallocated, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs...)...)
+			unallocated, rel, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs...)...)
 			Expect(len(unallocated)).To(Equal(0))
+			Expect(len(rel)).To(Equal(len(v4IPs)))
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block should still have an affinity to this host.
@@ -2120,8 +2131,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			}
 
 			// Release all IPs.
-			unallocated, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs...)...)
+			unallocated, rel, err := ic.ReleaseIPs(context.Background(), buildReleaseOptions(v4IPs...)...)
 			Expect(len(unallocated)).To(Equal(0))
+			Expect(len(rel)).To(Equal(len(v4IPs)))
 			Expect(err).NotTo(HaveOccurred())
 
 			// The block should still have an affinity to this host.
@@ -3043,7 +3055,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 			// Release IPs using the given options.
 			for _, r := range ipsToRelease {
-				_, err := ic.ReleaseIPs(context.Background(), r.Options)
+				_, _, err := ic.ReleaseIPs(context.Background(), r.Options)
 				if r.Error {
 					Expect(err).To(HaveOccurred())
 				} else {
@@ -3112,13 +3124,14 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				inIPs = inIPs[1:]
 			}
 
-			unallocatedIPs, outErr := ic.ReleaseIPs(context.Background(), buildReleaseOptions(inIPs...)...)
+			unallocatedIPs, rel, outErr := ic.ReleaseIPs(context.Background(), buildReleaseOptions(inIPs...)...)
 			if outErr != nil {
 				log.Println(outErr)
 			}
 
 			// Expect returned slice of unallocatedIPs to be equal to expected expUnallocatedIPs.
 			Expect(unallocatedIPs).To(Equal(expUnallocatedIPs))
+			Expect(len(rel)).To(Equal(len(inIPs)))
 
 			// Assert if an error was expected.
 			if expError != nil {

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -422,7 +422,7 @@ func correctAllocationWithHandle(ctx context.Context, c client.Interface, addr, 
 	}
 
 	// Release the old allocation.
-	_, err := c.IPAM().ReleaseIPs(ctx, ipam.ReleaseOptions{Address: ipAddr.String()})
+	_, _, err := c.IPAM().ReleaseIPs(ctx, ipam.ReleaseOptions{Address: ipAddr.String()})
 	if err != nil {
 		// If we fail to release the old allocation, return an error.
 		log.WithField("IP", ipAddr.String()).WithError(err).Error("Error releasing address")

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -636,7 +636,7 @@ func removeHostTunnelAddr(ctx context.Context, c client.Interface, node *libapi.
 			} else if len(attr) == 0 && storedHandle == nil {
 				// Scenario #2: The allocation exists, but has no handle whatsoever.
 				// This is an ancient allocation and can be released.
-				if _, err := c.IPAM().ReleaseIPs(ctx, ipam.ReleaseOptions{Address: ipAddr.String()}); err != nil {
+				if _, _, err := c.IPAM().ReleaseIPs(ctx, ipam.ReleaseOptions{Address: ipAddr.String()}); err != nil {
 					logCtx.WithError(err).WithField("IP", ipAddr.String()).Error("Error releasing address from IPAM")
 					return err
 				}
@@ -644,7 +644,7 @@ func removeHostTunnelAddr(ctx context.Context, c client.Interface, node *libapi.
 				// Scenario #3: The allocation exists, has a handle, and it matches the one we expect.
 				// This means the handle object itself was wrongfully deleted. We can clean it up
 				// by releasing the IP directly with both address and handle specified.
-				if _, err := c.IPAM().ReleaseIPs(ctx, ipam.ReleaseOptions{Address: ipAddr.String(), Handle: handle}); err != nil {
+				if _, _, err := c.IPAM().ReleaseIPs(ctx, ipam.ReleaseOptions{Address: ipAddr.String(), Handle: handle}); err != nil {
 					logCtx.WithError(err).WithField("IP", ipAddr.String()).Error("Error releasing address from IPAM")
 					return err
 				}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This fixes a few performance issues:

- IPAM allocations were done serially. Instead, do them block-by-block to reduce the number of API calls required.
- Don't artificially rate limit node affinity release.
- Don't perform a GET to the API server on every IP release - this was dreadfully slow, and we can be reasonably confident in our cache.
- Increase the QPS for the Calico client.

Hopefully this is an easy win for larger clusters. The only potentially iffy change is the change to no longer force an API request for each Pod, instead checking with our cache fed by the informer. I think this should be relatively safe - we already have a leak grace period to handle timing issues - and it **substantially** improves the performance of the GC code in my testing.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve IPAM garbage collection performance by reducing the number of API calls required to release batches of IP addresses. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.