### PR TITLE
[release-v3.30] Auto pick #10330: Add workaround for limited /boot partition space

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -934,6 +934,15 @@ blocks:
           # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
           # or replace the existing version.  Happily we do know that, so let's do it upfront here.
           - sudo apt-get remove -y python3-wrapt || true
+          # Install all the packages that would trigger an initramfs update using a workaround
+          # for limited /boot partition space in the ubuntu2004 image
+          - sudo apt update
+          - sudo rsync -av /boot/ /boot2/
+          - sudo mount --bind /boot2 /boot
+          - sudo apt install -y cryptsetup lsscsi open-iscsi thin-provisioning-tools
+          - sudo umount /boot
+          - sudo rsync -av /boot2/ /boot/ --exclude "*.new" --exclude "*.dpkg-bak" --delete --inplace
+          - sudo rm -rf /boot2/
           - git checkout -b devstack-test
           - export LIBVIRT_TYPE=qemu
           - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -934,6 +934,15 @@ blocks:
           # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
           # or replace the existing version.  Happily we do know that, so let's do it upfront here.
           - sudo apt-get remove -y python3-wrapt || true
+          # Install all the packages that would trigger an initramfs update using a workaround
+          # for limited /boot partition space in the ubuntu2004 image
+          - sudo apt update
+          - sudo rsync -av /boot/ /boot2/
+          - sudo mount --bind /boot2 /boot
+          - sudo apt install -y cryptsetup lsscsi open-iscsi thin-provisioning-tools
+          - sudo umount /boot
+          - sudo rsync -av /boot2/ /boot/ --exclude "*.new" --exclude "*.dpkg-bak" --delete --inplace
+          - sudo rm -rf /boot2/
           - git checkout -b devstack-test
           - export LIBVIRT_TYPE=qemu
           - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -22,6 +22,15 @@
           # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
           # or replace the existing version.  Happily we do know that, so let's do it upfront here.
           - sudo apt-get remove -y python3-wrapt || true
+          # Install all the packages that would trigger an initramfs update using a workaround
+          # for limited /boot partition space in the ubuntu2004 image
+          - sudo apt update
+          - sudo rsync -av /boot/ /boot2/
+          - sudo mount --bind /boot2 /boot
+          - sudo apt install -y cryptsetup lsscsi open-iscsi thin-provisioning-tools
+          - sudo umount /boot
+          - sudo rsync -av /boot2/ /boot/ --exclude "*.new" --exclude "*.dpkg-bak" --delete --inplace
+          - sudo rm -rf /boot2/
           - git checkout -b devstack-test
           - export LIBVIRT_TYPE=qemu
           - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10330 on release-v3.30.

#10330: Add workaround for limited /boot partition space

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.