### PR TITLE
Goldmane Stream refactor

### DIFF
--- a/goldmane/.gitignore
+++ b/goldmane/.gitignore
@@ -1,2 +1,5 @@
 coverage.profile
 *.log
+ca.crt
+tls.crt
+tls.key

--- a/goldmane/Makefile
+++ b/goldmane/Makefile
@@ -73,6 +73,16 @@ gen-mocks:
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'mockery'
 
 ###############################################################################
+# Run load generator against a real cluster using your KUBECONFIG env var.
+###############################################################################
+load:
+	kubectl get secret -n calico-system node-certs --template='{{index .data "tls.key"}}' | base64 -d > tls.key
+	kubectl get secret -n calico-system node-certs --template='{{index .data "tls.crt"}}' | base64 -d > tls.crt
+	kubectl get secret -n calico-system goldmane-key-pair --template='{{index .data "tls.crt"}}' | base64 -d > ca.crt
+	kubectl port-forward -n calico-system svc/goldmane 7443:7443 &
+	SERVER=goldmane:7443 CLIENT_CERT=tls.crt CLIENT_KEY=tls.key CA_FILE=ca.crt go run ./cmd/flowgen/main.go
+
+###############################################################################
 # Release
 ###############################################################################
 ## Deploys images to registry

--- a/goldmane/Makefile
+++ b/goldmane/Makefile
@@ -73,16 +73,6 @@ gen-mocks:
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'mockery'
 
 ###############################################################################
-# Run load generator against a real cluster using your KUBECONFIG env var.
-###############################################################################
-load:
-	kubectl get secret -n calico-system node-certs --template='{{index .data "tls.key"}}' | base64 -d > tls.key
-	kubectl get secret -n calico-system node-certs --template='{{index .data "tls.crt"}}' | base64 -d > tls.crt
-	kubectl get secret -n calico-system goldmane-key-pair --template='{{index .data "tls.crt"}}' | base64 -d > ca.crt
-	kubectl port-forward -n calico-system svc/goldmane 7443:7443 &
-	SERVER=goldmane:7443 CLIENT_CERT=tls.crt CLIENT_KEY=tls.key CA_FILE=ca.crt go run ./cmd/flowgen/main.go
-
-###############################################################################
 # Release
 ###############################################################################
 ## Deploys images to registry

--- a/goldmane/pkg/flowgen/generator.go
+++ b/goldmane/pkg/flowgen/generator.go
@@ -31,8 +31,11 @@ import (
 )
 
 const (
+	// flowsPerSecond is the number of flows to generate per second across all nodes.
+	flowsPerSecond = 2000
+
 	// number of flows to generate per 15s interval.
-	flowsPerInterval = 300
+	flowsPerInterval = flowsPerSecond * 15
 
 	// Configuration for flow generation. We need to balance this - too much generation
 	// can overwhelm a single client and backpressure will be applied. Scaling horizontally
@@ -40,7 +43,7 @@ const (
 	//
 	// In a production system, nodes won't attempt to send an entire hour's worth of flow data at once,
 	// but we want to do so here to burden Goldmane.
-	numNodes       = 30
+	numNodes       = 250
 	flowsPerWorker = flowsPerInterval / numNodes
 	numWorkers     = numNodes
 

--- a/goldmane/pkg/storage/bucket.go
+++ b/goldmane/pkg/storage/bucket.go
@@ -130,8 +130,8 @@ func (b *AggregationBucket) Reset(start, end int64) {
 
 // markReady marks this bucket as ready to be consumed by a stream.
 func (b *AggregationBucket) markReady() {
-	b.RLock()
-	defer b.RUnlock()
+	b.Lock()
+	defer b.Unlock()
 	b.ready = true
 }
 

--- a/goldmane/pkg/storage/bucket_ring.go
+++ b/goldmane/pkg/storage/bucket_ring.go
@@ -130,9 +130,10 @@ func NewBucketRing(n, interval int, now int64, opts ...BucketRingOption) *Bucket
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"headIndex":    ring.headIndex,
-		"curBucket":    ring.buckets[ring.headIndex],
-		"oldestBucket": ring.buckets[(ring.headIndex+1)%n],
+		"headIndex": ring.headIndex,
+		"start":     ring.BeginningOfHistory(),
+		"end":       ring.EndOfHistory(),
+		"now":       now,
 	}).Debug("Initialized bucket ring")
 	return ring
 }
@@ -688,6 +689,7 @@ func (r *BucketRing) flushToStreams() {
 	// Collect the set of flows to emit to the stream manager. Each rollover, we emit
 	// a single bucket of flows to the stream manager.
 	bucket := r.streamingBucket()
+	logrus.WithFields(bucket.Fields()).Debug("Flushing bucket to stream manager")
 	r.streamBucket(bucket, r.streams)
 
 	if time.Since(start) > 1*time.Second {

--- a/goldmane/pkg/storage/bucket_ring.go
+++ b/goldmane/pkg/storage/bucket_ring.go
@@ -29,16 +29,11 @@ import (
 
 var StopBucketIteration = errors.New("stop bucket iteration")
 
-// StreamReceiver represents an object that can receive streams of flows.
-type StreamReceiver interface {
-	Receive(FlowBuilder, string)
-}
-
 type lookupFn func(key types.FlowKey) *DiachronicFlow
 
 type BucketRing struct {
 	// buckets is a ring buffer of aggregation buckets for efficient rollover.
-	buckets   []AggregationBucket
+	buckets   []*AggregationBucket
 	headIndex int
 	interval  int
 
@@ -58,7 +53,7 @@ type BucketRing struct {
 
 	// streams receives flows from the bucket ring on rollover in order to
 	// satisfy stream requests.
-	streams StreamReceiver
+	streams Receiver
 
 	// pushAfter is the number of buckets from the head to wait before including
 	// a bucket in an aggregated flow for emission. We only push
@@ -83,7 +78,7 @@ type BucketRing struct {
 
 func NewBucketRing(n, interval int, now int64, opts ...BucketRingOption) *BucketRing {
 	ring := &BucketRing{
-		buckets:     make([]AggregationBucket, n),
+		buckets:     make([]*AggregationBucket, n),
 		headIndex:   0,
 		interval:    interval,
 		diachronics: make(map[types.FlowKey]*DiachronicFlow),
@@ -111,12 +106,17 @@ func NewBucketRing(n, interval int, now int64, opts ...BucketRingOption) *Bucket
 	// flows that come from nodes with a clock that's slightly ahead of ours.
 	newestBucketStart := now + int64(interval)
 
-	// We need to seed the buckets with the correct state. To do this, we'll initialize the first bucket
+	// Initialize an empty bucket into each slot in the ring.
+	for i := range n {
+		ring.buckets[i] = NewAggregationBucket(time.Unix(0, 0), time.Unix(0, 0))
+	}
+
+	// Seed the buckets with the correct state. To do this, we'll initialize the first bucket
 	// to be the oldest bucket and then roll over the buckets until we have populated the entire ring. This
 	// is an easy way to ensure that the buckets are in the correct state.
 	oldestBucketStart := time.Unix(newestBucketStart-int64(interval*n), 0)
 	oldestBucketEnd := time.Unix(oldestBucketStart.Unix()+int64(interval), 0)
-	ring.buckets[0] = *NewAggregationBucket(oldestBucketStart, oldestBucketEnd)
+	ring.buckets[0] = NewAggregationBucket(oldestBucketStart, oldestBucketEnd)
 	for range n {
 		ring.Rollover(nil)
 	}
@@ -361,6 +361,9 @@ func (r *BucketRing) AddFlow(flow *types.Flow) {
 		return
 	}
 
+	// TODO: Adding the flow to the bucket can currently block if the bucket is being accessed
+	// by another thread. This should be relatively rare and short, but ideally we'd make adding a Flow
+	// to a bucket non-blocking.
 	fields := bucket.Fields()
 	fields["flowStart"] = flow.StartTime
 	fields["head"] = r.headIndex
@@ -433,7 +436,7 @@ func (r *BucketRing) findBucket(time int64) (int, *AggregationBucket) {
 	// most of the time we'll be looking for a recent bucket.
 	i := r.headIndex
 	for {
-		b := &r.buckets[i]
+		b := r.buckets[i]
 		if time >= b.StartTime && time < b.EndTime {
 			return i, b
 		}
@@ -538,7 +541,7 @@ func (r *BucketRing) maybeBuildFlowCollection(startIndex, endIndex int) *FlowCol
 
 	// Check if we're ready to emit. Wait until the oldest bucket in the window has not yet
 	// been pushed, as any newer buckets will not have been pushed either.
-	if r.buckets[startIndex].Pushed {
+	if r.buckets[startIndex].pushed {
 		logrus.WithFields(r.buckets[startIndex].Fields()).Debug("Bucket has already been published, waiting for next bucket")
 		return nil
 	}
@@ -556,7 +559,7 @@ func (r *BucketRing) maybeBuildFlowCollection(startIndex, endIndex int) *FlowCol
 
 		// Add a pointer to the bucket to the FlowCollection. This allows us to mark the bucket as pushed
 		// once emitted.
-		flows.buckets = append(flows.buckets, &r.buckets[i])
+		flows.buckets = append(flows.buckets, r.buckets[i])
 		return nil
 	})
 
@@ -695,22 +698,9 @@ func (r *BucketRing) flushToStreams() {
 	}
 }
 
-func (r *BucketRing) streamBucket(b *AggregationBucket, s StreamReceiver) {
-	// We need to construct a FlowBuilder for each DiachronicFlow in the bucket serially.
-	builders := []FlowBuilder{}
-	if b.Flows != nil {
-		b.Flows.Iter(func(d *DiachronicFlow) error {
-			builders = append(builders, NewDeferredFlowBuilder(d, b.StartTime, b.EndTime))
-			return nil
-		})
-	}
-
-	// We can send the builders to the stream manager asynchronously to unblock the main loop.
-	go func() {
-		for _, b := range builders {
-			s.Receive(b, "")
-		}
-	}()
+func (r *BucketRing) streamBucket(b *AggregationBucket, s Receiver) {
+	b.streamed = true
+	s.Receive(b, "")
 }
 
 // streamingBucket returns the bucket currently slated to be sent to the stream manager.
@@ -718,7 +708,7 @@ func (r *BucketRing) streamingBucket() *AggregationBucket {
 	// The head index is always one bucket into the future, and the bucket before
 	// is the currently filling one. So start two back from the head.
 	idx := r.indexSubtract(r.headIndex, 2)
-	return &r.buckets[idx]
+	return r.buckets[idx]
 }
 
 // BackfillEndTime returns the time that backfill should complete at. This ensures that backfill doesn't
@@ -760,7 +750,7 @@ func (r *BucketRing) iterBucketsTime(start, end int64, f func(b *AggregationBuck
 		return fmt.Errorf("failed to find bucket for time range %d:%d", start, end)
 	}
 	r.iterBuckets(startIdx, endIdx, func(i int) error {
-		return f(&r.buckets[i])
+		return f(r.buckets[i])
 	})
 	return nil
 }
@@ -772,6 +762,14 @@ func (r *BucketRing) NumFlows(start, end int64) int {
 		return nil
 	})
 	return count
+}
+
+func (r *BucketRing) Backfill(recv Receiver, id string, start int64) {
+	// Backfill the stream with any buckets that match its time range.
+	_ = r.iterBucketsTime(start, r.BackfillEndTime(), func(b *AggregationBucket) error {
+		recv.Receive(b, id)
+		return nil
+	})
 }
 
 // IterFlows iterates through all of the Flows in the given time range.

--- a/goldmane/pkg/storage/bucket_ring.go
+++ b/goldmane/pkg/storage/bucket_ring.go
@@ -701,7 +701,7 @@ func (r *BucketRing) flushToStreams() {
 }
 
 func (r *BucketRing) streamBucket(b *AggregationBucket, s Receiver) {
-	b.streamed = true
+	b.markReady()
 	s.Receive(b, "")
 }
 

--- a/goldmane/pkg/storage/bucket_test.go
+++ b/goldmane/pkg/storage/bucket_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/projectcalico/calico/goldmane/pkg/testutils"
+	"github.com/projectcalico/calico/goldmane/pkg/types"
+)
+
+var now = time.Now()
+
+func addFlows(b *AggregationBucket, cache *diachronicCache, n int) {
+	for range n {
+		f := testutils.NewRandomFlow(now.Unix())
+		tf := types.ProtoToFlow(f)
+		cache.add(tf)
+		b.AddFlow(tf)
+	}
+	b.markReady()
+}
+
+type diachronicCache struct {
+	sync.Mutex
+	d map[types.FlowKey]*DiachronicFlow
+}
+
+func (c *diachronicCache) add(f *types.Flow) {
+	c.Lock()
+	defer c.Unlock()
+	if _, ok := c.d[*f.Key]; !ok {
+		c.d[*f.Key] = NewDiachronicFlow(f.Key, 0)
+	}
+}
+
+func (c *diachronicCache) get(key types.FlowKey) *DiachronicFlow {
+	c.Lock()
+	defer c.Unlock()
+	return c.d[key]
+}
+
+// setup configures a test. Each call to setup() creates a unique environment for the test to execute within,
+// allowing for concurrent testing. Namely, each test gets:
+// - Its own context.
+// - Its own cache of diachronic flows.
+// - Its own bucket to operate on.
+// - Its own cancel function.
+func setup(t *testing.T) (context.Context, *diachronicCache, *AggregationBucket, func()) {
+	diachronics := &diachronicCache{d: make(map[types.FlowKey]*DiachronicFlow)}
+
+	var cancel context.CancelFunc
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	// Create a new Bucket for the test.
+	b := NewAggregationBucket(now, now.Add(15*time.Second))
+	b.lookupFlow = diachronics.get
+
+	return ctx, diachronics, b, func() { cancel() }
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	t.Run("multiple reads", func(t *testing.T) {
+		ctx, cache, b, cancel := setup(t)
+		defer cancel()
+
+		// Write some flows to the bucket.
+		addFlows(b, cache, 10)
+
+		// We should be able to start many readers at once.
+		num := 100
+		iterStarted := make(chan bool, num)
+		for range num {
+			go func(ctx context.Context) {
+				// Iterate the bucket, sending an indicator when we have started the first iteration.
+				// We'll then just wait for the context to expire and exit. If concurrent access does not function,
+				// we will block other readers.
+				b.Iter(func(b FlowBuilder) bool {
+					iterStarted <- true
+					<-ctx.Done()
+					return true // Indicates stop iteration.
+				})
+			}(ctx)
+		}
+
+		// Wait for indications that all goroutines successfully started iteration.
+		for range num {
+			select {
+			case <-ctx.Done():
+				t.Errorf("Test timed out")
+				return
+			case <-iterStarted:
+			}
+		}
+	})
+
+	t.Run("concurrent read/write", func(t *testing.T) {
+		ctx, cache, b, cancel := setup(t)
+		defer cancel()
+
+		// Write some initial flows to the bucket.
+		addFlows(b, cache, 100)
+
+		// Start a goroutine that adds flows continuously.
+		go func(ctx context.Context) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					addFlows(b, cache, 100)
+				}
+			}
+		}(ctx)
+
+		// We should be able to iterate the bucket without a problem.
+		for range 100 {
+			select {
+			case <-ctx.Done():
+				t.Errorf("Test timed out")
+				return
+			default:
+				b.Iter(func(FlowBuilder) bool {
+					return false
+				})
+			}
+		}
+
+		// We should be able to reset the bucket.
+		b.Reset(time.Now().Unix(), time.Now().Add(15*time.Second).Unix())
+	})
+}
+
+func TestReady(t *testing.T) {
+	// Bucket should not iterate if it is not marked ready.
+	_, cache, b, cancel := setup(t)
+	defer cancel()
+
+	addFlows(b, cache, 100)
+	b.ready = false
+	b.Iter(func(_ FlowBuilder) bool {
+		t.Errorf("Should not iterate!")
+		return true
+	})
+}

--- a/goldmane/pkg/storage/deferred_builder.go
+++ b/goldmane/pkg/storage/deferred_builder.go
@@ -19,6 +19,14 @@ import (
 	"github.com/projectcalico/calico/goldmane/proto"
 )
 
+type FlowProvider interface {
+	Iter(func(FlowBuilder) bool)
+}
+
+type Receiver interface {
+	Receive(FlowProvider, string)
+}
+
 // FlowBuilder provides an interface for building Flows. It allows us to conserve memory by
 // only rendering Flow objects when they match the filter.
 type FlowBuilder interface {

--- a/goldmane/pkg/storage/options.go
+++ b/goldmane/pkg/storage/options.go
@@ -35,7 +35,7 @@ func WithBucketsToAggregate(n int) BucketRingOption {
 	}
 }
 
-func WithStreamReceiver(sm StreamReceiver) BucketRingOption {
+func WithStreamReceiver(sm Receiver) BucketRingOption {
 	return func(r *BucketRing) {
 		logrus.WithField("streamReceiver", sm).Debug("Setting stream receiver")
 		r.streams = sm

--- a/goldmane/pkg/storage/utils.go
+++ b/goldmane/pkg/storage/utils.go
@@ -68,6 +68,6 @@ func (fc *FlowCollection) AddFlow(flow types.Flow) {
 // Note this must be called synchronously with the bucket ring.
 func (fc *FlowCollection) Complete() {
 	for _, b := range fc.buckets {
-		b.Pushed = true
+		b.pushed = true
 	}
 }

--- a/goldmane/pkg/stream/stream.go
+++ b/goldmane/pkg/stream/stream.go
@@ -73,7 +73,12 @@ func (s *stream) run() {
 		case <-s.ctx.Done():
 			logrus.WithField("id", s.ID).Debug("Stream context done")
 			return
-		case b := <-s.in:
+		case b, ok := <-s.in:
+			if !ok {
+				logrus.WithField("id", s.ID).Debug("Stream input channel closed")
+				return
+			}
+
 			b.Iter(func(f storage.FlowBuilder) bool {
 				if err := chanutil.WriteWithDeadline(s.ctx, s.out, f, 60*time.Second); err != nil {
 					// If we hit an error, indicate that we should stop iteration.

--- a/goldmane/pkg/stream/stream.go
+++ b/goldmane/pkg/stream/stream.go
@@ -27,6 +27,7 @@ type stream struct {
 
 	// Private fields.
 	id     string
+	in     chan storage.FlowProvider
 	out    chan storage.FlowBuilder
 	done   chan<- string
 	ctx    context.Context
@@ -62,16 +63,36 @@ func (s *stream) ID() string {
 	return s.id
 }
 
+func (s *stream) run() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			logrus.WithField("id", s.ID).Debug("Stream context done")
+			return
+		case b := <-s.in:
+			b.Iter(func(f storage.FlowBuilder) bool {
+				if err := chanutil.WriteWithDeadline(s.ctx, s.out, f, 60*time.Second); err != nil {
+					// If we hit an error, indicate that we should stop iteration.
+					s.rl.WithFields(logrus.Fields{"id": s.ID}).WithError(err).Debug("Error writing flow to stream output")
+					return true
+				}
+				// If we didn't hit an error, continue iteration.
+				return false
+			})
+		}
+	}
+}
+
 // receive tells the Stream about a newly learned Flow that matches the Stream's filter and
 // queues it for processing. Note that emission of the Flow to the Stream's output channel is asynchronous.
-func (s *stream) receive(b storage.FlowBuilder) {
+func (s *stream) receive(b storage.FlowProvider) {
 	// It's important that we don't block here, as this is called from the main loop.
 	logrus.WithFields(logrus.Fields{"id": s.ID}).Debug("Sending flow to stream")
 
 	// Send the flow to the output channel. If the channel is full, wait for a bit before giving up.
-	if err := chanutil.WriteWithDeadline(s.ctx, s.out, b, 1*time.Second); err != nil {
+	if err := chanutil.WriteWithDeadline(s.ctx, s.in, b, 1*time.Second); err != nil {
 		if !errors.Is(err, context.Canceled) {
-			s.rl.WithField("id", s.ID).WithError(err).Error("error writing flow to stream output")
+			s.rl.WithField("id", s.ID).WithError(err).Error("error writing flow provider to stream input")
 		}
 	}
 }

--- a/goldmane/pkg/stream/stream.go
+++ b/goldmane/pkg/stream/stream.go
@@ -64,6 +64,10 @@ func (s *stream) ID() string {
 }
 
 func (s *stream) run() {
+	// Close the output channel when the stream is done. This ensures we don't try to
+	// write to a closed channel.
+	defer close(s.out)
+
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/goldmane/pkg/stream/stream.go
+++ b/goldmane/pkg/stream/stream.go
@@ -92,11 +92,11 @@ func (s *stream) run() {
 	}
 }
 
-// receive tells the Stream about a newly learned Flow that matches the Stream's filter and
-// queues it for processing. Note that emission of the Flow to the Stream's output channel is asynchronous.
+// receive tells the Stream about a newly learned source of flows and queues it for processing.
+// Note that emission of the individual Flow objects to the Stream's output channel is asynchronous.
 func (s *stream) receive(b storage.FlowProvider) {
 	// It's important that we don't block here, as this is called from the main loop.
-	logrus.WithFields(logrus.Fields{"id": s.ID}).Debug("Sending flow to stream")
+	logrus.WithFields(logrus.Fields{"id": s.ID}).Debug("Sending FlowProvider to stream")
 
 	// Send the flow to the output channel. If the channel is full, wait for a bit before giving up.
 	if err := chanutil.WriteWithDeadline(s.ctx, s.in, b, 1*time.Second); err != nil {

--- a/goldmane/pkg/stream/stream_manager.go
+++ b/goldmane/pkg/stream/stream_manager.go
@@ -80,10 +80,10 @@ func (c *streamCache) remove(id string) {
 		return
 	}
 
-	// Close the stream's output channel. It is important that we do this here while holding the lock,
+	// Close the stream's input channel. It is important that we do this here while holding the lock,
 	// allowing an atomic closure and removal from the cache. This ensures that no other goroutine
-	// can access the stream after its output channel is closed.
-	close(s.out)
+	// can access the stream after its input channel is closed.
+	close(s.in)
 	delete(c.streams, id)
 }
 

--- a/goldmane/pkg/stream/stream_manager.go
+++ b/goldmane/pkg/stream/stream_manager.go
@@ -139,7 +139,7 @@ type streamManager struct {
 }
 
 func (m *streamManager) Run(ctx context.Context) {
-	go m.processIncomingFlows(ctx)
+	go m.processIncoming(ctx)
 
 	for {
 		select {
@@ -194,8 +194,8 @@ func (m *streamManager) Backfills() <-chan Stream {
 	return m.backfillRequests
 }
 
-// processIncomingFlows reads incoming updates and fans them to registered streams.
-func (m *streamManager) processIncomingFlows(ctx context.Context) {
+// processIncoming reads incoming updates and fans them to registered streams.
+func (m *streamManager) processIncoming(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/goldmane/pkg/stream/stream_manager.go
+++ b/goldmane/pkg/stream/stream_manager.go
@@ -39,14 +39,14 @@ type StreamManager interface {
 	Run(ctx context.Context)
 	Register(*proto.FlowStreamRequest, int) chan Stream
 	Backfills() <-chan Stream
-	Receive(storage.FlowBuilder, string)
+	Receive(storage.FlowProvider, string)
 }
 
 func NewStreamManager() *streamManager {
 	maxStreams := 100
 	return &streamManager{
 		streams:          streamCache{streams: make(map[string]*stream)},
-		flowCh:           make(chan storage.FlowBuilder, 5000),
+		in:               make(chan storage.FlowProvider, 500),
 		closedStreamsCh:  make(chan string, maxStreams),
 		streamRequests:   make(chan *streamRequest, 10),
 		backfillRequests: make(chan Stream, 10),
@@ -75,13 +75,16 @@ func (c *streamCache) remove(id string) {
 	c.Lock()
 	defer c.Unlock()
 	s, ok := c.streams[id]
-	if ok {
-		// Close the stream's output channel. It is important that we do this here while holding the lock,
-		// allowing an atomic closure and removal from the cache. This ensures that no other goroutine
-		// can access the stream after its output channel is closed.
-		close(s.out)
-		delete(c.streams, id)
+	if !ok {
+		logrus.WithField("id", id).Warn("Asked to close unknown stream")
+		return
 	}
+
+	// Close the stream's output channel. It is important that we do this here while holding the lock,
+	// allowing an atomic closure and removal from the cache. This ensures that no other goroutine
+	// can access the stream after its output channel is closed.
+	close(s.out)
+	delete(c.streams, id)
 }
 
 func (c *streamCache) get(id string) (*stream, bool) {
@@ -119,7 +122,7 @@ type streamManager struct {
 	// If this limit is reached, new streams will be rejected.
 	maxStreams int
 
-	// closedStreamsCh is a channel on which to receive UUof streams that have been closed.
+	// closedStreamsCh is a channel on which to receive the UUID of streams that have been closed.
 	closedStreamsCh chan string
 
 	// streamRequests is the channel to receive requests for new streams.
@@ -128,8 +131,8 @@ type streamManager struct {
 	// backfillRequests is a channel to send backfill requests on to the log aggregator.
 	backfillRequests chan Stream
 
-	// flowCh queues incoming flows to be processed by worker threads and emitted to streams.
-	flowCh chan storage.FlowBuilder
+	// in queues incoming data to be processed by worker threads and emitted to streams.
+	in chan storage.FlowProvider
 
 	// rl is used to rate limit log messages that may happen frequently.
 	rl *logutils.RateLimitedLogger
@@ -165,12 +168,11 @@ func (m *streamManager) Register(req *proto.FlowStreamRequest, size int) chan St
 	return sr.respCh
 }
 
-// Receive tells the stream manager about a new flow. The manager
-// informs all streams about the new flow, so they can decide to include it in their output.
+// Receive tells the stream manager about a new flow provider.
 //
-// Note: Receive may block if the flow channel is full. This is expected to be a rare event, but care
-// should be taken to avoid calling this function from the main loop.
-func (m *streamManager) Receive(b storage.FlowBuilder, id string) {
+// If an ID is provided, the manager sends the update to the stream with that ID.
+// If no ID is provided, the manager informs all streams about update, so they can decide to include it in their output.
+func (m *streamManager) Receive(b storage.FlowProvider, id string) {
 	if id != "" {
 		// An explicit ID was given. Send to the stream with that ID.
 		s, ok := m.streams.get(id)
@@ -181,7 +183,7 @@ func (m *streamManager) Receive(b storage.FlowBuilder, id string) {
 	}
 
 	// No ID was given - send to all streams.
-	if err := chanutil.WriteWithDeadline(context.TODO(), m.flowCh, b, 30*time.Second); err != nil {
+	if err := chanutil.WriteWithDeadline(context.TODO(), m.in, b, 30*time.Second); err != nil {
 		m.rl.WithError(err).Error("stream manager failed to handle flow(s), dropping")
 	}
 }
@@ -192,15 +194,14 @@ func (m *streamManager) Backfills() <-chan Stream {
 	return m.backfillRequests
 }
 
-// processIncomingFlows reads incoming flows from the stream manager and fans them to active streams.
-// Each stream is responsible for deciding whether to include the flow in its output.
+// processIncomingFlows reads incoming updates and fans them to registered streams.
 func (m *streamManager) processIncomingFlows(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
 			logrus.Debug("stream manager worker exiting")
 			return
-		case b := <-m.flowCh:
+		case b := <-m.in:
 			m.streams.iter(func(s *stream) {
 				s.receive(b)
 			})
@@ -218,6 +219,7 @@ func (m *streamManager) register(req *streamRequest) *stream {
 	stream := &stream{
 		Req:    req.req,
 		id:     uuid.NewString(),
+		in:     make(chan storage.FlowProvider, 500),
 		out:    make(chan storage.FlowBuilder, req.channelSize),
 		done:   m.closedStreamsCh,
 		ctx:    ctx,
@@ -227,6 +229,8 @@ func (m *streamManager) register(req *streamRequest) *stream {
 			logutils.OptInterval(15*time.Second),
 		),
 	}
+	go stream.run()
+
 	m.streams.add(stream)
 	numStreams.Set(float64(m.streams.size()))
 
@@ -236,13 +240,7 @@ func (m *streamManager) register(req *streamRequest) *stream {
 
 // unregister removes a stream from the stream manager.
 func (m *streamManager) unregister(id string) {
-	_, ok := m.streams.get(id)
-	if !ok {
-		logrus.WithField("id", id).Warn("Asked to close unknown stream")
-		return
-	}
 	logrus.WithField("id", id).Debug("Closing stream")
-
 	m.streams.remove(id)
 	numStreams.Set(float64(m.streams.size()))
 	logrus.WithField("id", id).Debug("Stream closed")

--- a/whisker-backend/test/fv/goldmaneintegration_test.go
+++ b/whisker-backend/test/fv/goldmaneintegration_test.go
@@ -112,7 +112,6 @@ func TestGoldmaneIntegration_FlowWatching(t *testing.T) {
 	req.Header.Set("Accept", "text/event-stream")
 
 	resp, err := http.DefaultClient.Do(req)
-
 	Expect(err).ShouldNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The main change in this PR is to adjust how data is send through streams. Previously, Goldmane would iterate each Flow and push it to the stream manager. This was exceptionally inefficient at scale, and resulted in long periods of time where the main loop was occupied feeding streams.

This PR adjusts that implementation such that Goldmane sends a pointer to the bucket to be streamed, allowing each stream to iterate the bucket at its own pace, on its own goroutine. This leaves moves congestion off of the main loop, allowing it to do more important things like ingest flows.

This does introduce a RWMutex into each bucket to prevent concurrent access. This does have some potential to block ingestion still, but is much less likely to happen because we only stream flows after some time has passed, so new flows should very rarely be indexed into a bucket that is actively being streamed. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve Goldmane flow streaming efficiency
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.