### PR TITLE
Fix panic when Failsafe configs are set to empty list

### DIFF
--- a/felix/config/param_types.go
+++ b/felix/config/param_types.go
@@ -502,7 +502,7 @@ func (p *PortListParam) Parse(raw string) (interface{}, error) {
 	var result []ProtoPort
 	for _, portStr := range strings.Split(raw, ",") {
 		portStr = strings.Trim(portStr, " ")
-		if portStr == "" {
+		if portStr == "" || portStr == "[]" {
 			continue
 		}
 

--- a/felix/config/param_types_test.go
+++ b/felix/config/param_types_test.go
@@ -61,6 +61,27 @@ var _ = DescribeTable("CIDR list parameter parsing",
 	Entry("Mix of IP and CIDRs", "1.1.1.1/24, 2.2.2.2", []string{"1.1.1.0/24", "2.2.2.2/32"}, true),
 )
 
+var _ = DescribeTable("Port list parameter parsing",
+	func(raw string, expected []config.ProtoPort, expectSuccess bool) {
+		p := config.PortListParam{config.Metadata{
+			Name: "PortLists",
+		}}
+		actual, err := p.Parse(raw)
+		if expectSuccess {
+			Expect(err).To(BeNil())
+			Expect(actual).To(Equal(expected))
+		} else {
+			Expect(err).To(BeNil())
+		}
+	},
+	Entry("Empty", "", nil, true),
+	Entry("Empty", "[]", nil, true),
+	Entry("PortList", "tcp:22,udp:1.1.1.1:22,3033", []config.ProtoPort{
+		{Protocol: "tcp", Port: 22, Net: ""},
+		{Protocol: "udp", Port: 22, Net: "1.1.1.1/32"},
+		{Protocol: "tcp", Port: 3033, Net: ""}}, true),
+)
+
 var _ = DescribeTable("KeyValue list parameter parsing",
 	func(raw string, expected map[string]string) {
 		p := config.KeyValueListParam{config.Metadata{


### PR DESCRIPTION
## Description

FailSafeInBoundPorts and FailSafeOutBoundPorts can be set to an empty list ```"[]"```. This results in felix panicking. 
This PR fixes https://github.com/projectcalico/calico/issues/10338

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
