### PR TITLE
Fix calico-selector tool to use new API.  Add test.

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -814,6 +814,19 @@ blocks:
           commands:
             - ../.semaphore/run-and-monitor ci.log make ci
             - test-results publish ./report/*.xml --name "pod2daemon-ut-tests" || true
+  - name: "Tools (hack directory)"
+    run:
+      when: "true or change_in(['/*', '/hack/', '/api/', '/libcalico-go/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd hack
+      jobs:
+        - name: "Tools (hack directory)"
+          commands:
+            - ../.semaphore/run-and-monitor make-ci.log make ci
   - name: Typha
     run:
       when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/hack/test/certs/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -814,6 +814,19 @@ blocks:
           commands:
             - ../.semaphore/run-and-monitor ci.log make ci
             - test-results publish ./report/*.xml --name "pod2daemon-ut-tests" || true
+  - name: "Tools (hack directory)"
+    run:
+      when: "false or change_in(['/*', '/hack/', '/api/', '/libcalico-go/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd hack
+      jobs:
+        - name: "Tools (hack directory)"
+          commands:
+            - ../.semaphore/run-and-monitor make-ci.log make ci
   - name: Typha
     run:
       when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/hack/test/certs/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml.d/blocks/20-tools.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-tools.yml
@@ -1,0 +1,13 @@
+- name: "Tools (hack directory)"
+  run:
+    when: "${FORCE_RUN} or change_in(['/*', '/hack/', '/api/', '/libcalico-go/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  dependencies:
+    - Prerequisites
+  task:
+    prologue:
+      commands:
+        - cd hack
+    jobs:
+      - name: "Tools (hack directory)"
+        commands:
+          - ../.semaphore/run-and-monitor make-ci.log make ci

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -1,0 +1,61 @@
+include ../metadata.mk
+
+PACKAGE_NAME = github.com/projectcalico/calico/hack
+
+###############################################################################
+# Download and include ../lib.Makefile
+#   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
+#   that variable is evaluated when we declare DOCKER_RUN and siblings.
+###############################################################################
+include ../lib.Makefile
+
+###############################################################################
+
+BINDIR?=bin
+
+# Create a list of files upon which the generated file depends, skip the generated file itself
+APIS_SRCS := $(filter-out ./lib/apis/v3/zz_generated.deepcopy.go, $(wildcard ./lib/apis/v3/*.go))
+
+.PHONY: clean
+clean:
+	rm -rf $(BINDIR)
+	find . -name '*.coverprofile' -type f -delete
+
+###############################################################################
+# Building the binary
+###############################################################################
+
+
+###############################################################################
+# Static checks
+###############################################################################
+LINT_ARGS += --disable gosimple,unused,errcheck,ineffassign,staticcheck
+
+###############################################################################
+# Tests
+###############################################################################
+
+WHAT?=.
+GINKGO_FOCUS?=.*
+
+.PHONY:ut
+## Run the fast set of unit tests in a container.
+ut:
+	$(DOCKER_RUN) --privileged $(CALICO_BUILD) \
+		sh -c 'cd /go/src/$(PACKAGE_NAME) && go test ./...'
+
+fv:
+	$(DOCKER_RUN) $(CALICO_BUILD) \
+		sh -c 'cd /go/src/$(PACKAGE_NAME) && \
+		       go run ./cmd/calico-selector set-name "has(a)"&& \
+               go run ./cmd/calico-selector print-tree "a == \"b\" || has(d) || has(e) && has(g)"'
+
+st:
+	@echo "No STs available"
+
+###############################################################################
+# CI
+###############################################################################
+.PHONY: ci
+## Run what CI runs
+ci: clean static-checks test

--- a/hack/cmd/calico-selector/calico-selector_test.go
+++ b/hack/cmd/calico-selector/calico-selector_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/selector"
+)
+
+const selStr = `a == 'b' && c != 'd' && q in  {'1', '2'} && z not in {'6', '7'} && b startswith 'g' && b endswith 'h' && w contains 'u' && has(o) && !has(r) || global() || all()`
+const expectedTree = `OR
++-AND
+| +-(a == "b")
+| +-(c != "d")
+| +-(q in {1,2})
+| +-(z not in {6,7})
+| +-(b starts with "g")
+| +-(b ends with "h")
+| +-(w contains "u")
+| +-has(o)
+| +-NOT
+|   +-has(r)
++-global()
++-all()
+`
+
+func TestPrintTree(t *testing.T) {
+	var buf bytes.Buffer
+	sel, err := selector.Parse(selStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	printTree(&buf, "", sel.Root(), false)
+	if buf.String() != expectedTree {
+		t.Errorf("Unexpected output, got:\n%s\n\nExpected:\n%s", buf.String(), expectedTree)
+	}
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

`calico-selector` tool was broken by #10272 , which (for the first time in a long time!) changed the selector API.  Fix it up and add a tire-kick test.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
