### PR TITLE
[release-v3.30] Auto pick #10355: calicoctl: fix panic when using wrong

### DIFF
--- a/libcalico-go/lib/names/workloadendpoint.go
+++ b/libcalico-go/lib/names/workloadendpoint.go
@@ -260,6 +260,9 @@ func ParseWorkloadEndpointName(wepName string) (WorkloadEndpointIdentifiers, err
 			orchFlds = otherFields
 		}
 		if pl > 2 {
+			if len(parts[2:]) > len(orchFlds) {
+				return WorkloadEndpointIdentifiers{}, fmt.Errorf("Error parsing %s, verify that WorkloadEndpoint name is correct", wepName)
+			}
 			weidR := reflect.ValueOf(&weid)
 			weidStruct := weidR.Elem()
 			for i, part := range parts[2:] {

--- a/libcalico-go/lib/names/workloadendpoint_test.go
+++ b/libcalico-go/lib/names/workloadendpoint_test.go
@@ -240,4 +240,18 @@ var _ = DescribeTable("WorkloadEndpoint name parsing",
 		Workload:     "workload",
 		Endpoint:     "eth0",
 	}),
+	Entry("Workload name used instead of WorkloadEndpoint name", "coredns-668d6bf9bc-bxhr6", false, names.WorkloadEndpointIdentifiers{
+		Node:         "coredns",
+		Orchestrator: "668d6bf9bc",
+		Endpoint:     "",
+		Workload:     "bxhr6",
+		Pod:          "",
+	}),
+	Entry("Workload name with lots of dashes used instead of WorkloadEndpoint name", "calico-kube-controllers-7946b84856-2fwwq", true, names.WorkloadEndpointIdentifiers{
+		Node:         "",
+		Orchestrator: "",
+		Workload:     "",
+		Endpoint:     "",
+		Pod:          "",
+	}),
 )


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10355 on release-v3.30.

#10355: calicoctl: fix panic when using wrong

# Original PR Body below

## Description

Fix a panic when using wrong WorkloadEndpoint name with a specific format (using a Workload name instead of the WorkloadEndpoint, where any field contains some dashes resulting in a name with 4 or more dashes in it).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

fixes https://github.com/projectcalico/calico/issues/9855

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed a panic in calicoctl when using a wrong WorkloadEndpoint name with a specific format.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.