### PR TITLE
[cherry pick] [v3.29] [release tool] fixes for image scanning service (#10365) [DE-3382]

### DIFF
--- a/release/internal/imagescanner/scanner.go
+++ b/release/internal/imagescanner/scanner.go
@@ -89,6 +89,9 @@ func (i *Scanner) Scan(productCode string, images []string, stream string, relea
 	query.Add("scanner_select", i.config.Scanner)
 	query.Add("project_name", productCode)
 	query.Add("project_version", stream)
+	if !release {
+		query.Add("upload", "daily")
+	}
 	req.URL.RawQuery = query.Encode()
 	logrus.WithFields(logrus.Fields{
 		"images":      images,

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -41,10 +41,11 @@ const (
 	operatorComponentsFileName = "pinned_components.yml"
 )
 
-var noImageComponents = []string{
+var excludedComponents = []string{
 	utils.Calico,
 	"calico/api",
 	"networking-calico",
+	"flannel",
 }
 
 type PinnedVersions interface {
@@ -273,7 +274,7 @@ func RetrieveImageComponents(outputDir string) (map[string]registry.Component, e
 	components[initImage.Image] = operator.InitImage()
 	for name, component := range components {
 		// Remove components that do not produce images.
-		if utils.Contains(noImageComponents, name) {
+		if utils.Contains(excludedComponents, name) {
 			delete(components, name)
 			continue
 		}


### PR DESCRIPTION
- ~update images in metadata file~
- exclude flannel from images sent in hashreleases
- add new query parameter (upload=daily) for hashreleases

## Description

- ~update images in metadata file~
- exclude flannel from images sent in hashreleases
- add new query parameter (upload=daily) for hashreleases

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
