### PR TITLE
Add GH action for stale enhancements and bugs

### DIFF
--- a/.github/workflows/inactive_issues.yml
+++ b/.github/workflows/inactive_issues.yml
@@ -10,6 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # This step marks support issues and PRs as stale.
       - uses: actions/stale@v9
         with:
           # Issues configuration. We mark issues as stale after 30 days, and close them another two weeks after that if there
@@ -22,7 +23,7 @@ jobs:
 
           # Once an issue is triaged as either an enhancement or a bug, we have accepted it as real and
           # it can be exempted from automatic closure.
-          exempt-issue-labels: "kind/enhancement,kind/bug"
+          exempt-issue-labels: "kind/enhancement,kind/bug,triage/eternal"
 
           # PR configuration. For PRs, we mark them as stale after a couple of months but we never automatically close them.
           # This just makes it easier to search for stale PRs.
@@ -30,5 +31,26 @@ jobs:
           days-before-pr-stale: 60
           days-before-pr-close: -1
           stale-pr-message: "This PR is stale because it has been open for 60 days with no activity."
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step marks kind/enhancement and kind/bug as stale, after a longer period of time.
+      - uses: actions/stale@v9
+        with:
+          # Mark enhancement and bug issues stale after 6 months, then close them after another month of inactivity.
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it is kind/enhancement or kind/bug and has been open for 180 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+
+          # This action applies only to enhancement and bug type issues, which we want to mark stale but at a much
+          # slower rate than untagged and support issues.
+          any-of-issue-labels: "kind/enhancement,kind/bug"
+          exempt-issue-labels: "triage/eternal"
+
+          # This action doesn't do anything for PRs.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
 
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add GH action to close inactive enhancements and bugs.

This is a separate action from the one added here: https://github.com/projectcalico/calico/pull/10361

This allows us to control the rate at which enhancements and bugs are marked stale - these should remain valid for much longer.

This PR sets the stale timeout to 180 days, and an additional 30 day grace period. 

Applying the `triage/eternal` label will exclude issues from being marked stale. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.