### PR TITLE
[release-v3.30] Auto pick #10377: Switch delete-local-data to delete-emptydir-data

### DIFF
--- a/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
@@ -508,7 +508,7 @@ func (n k8snode) Drain() error {
 	nodeName := string(n)
 	log.Infof("Start drain node %s", nodeName)
 	out, err := exec.Command("/usr/bin/kubectl", "drain",
-		"--ignore-daemonsets", "--delete-local-data", "--force", nodeName).CombinedOutput()
+		"--ignore-daemonsets", "--delete-emptydir-data", "--force", nodeName).CombinedOutput()
 	if err != nil {
 		log.Errorf("Drain node %s. \n ---Drain Node--- \n%s\n ------", nodeName, string(out))
 		return err
@@ -574,7 +574,6 @@ func updateConfigMapValue(k8sClientset *kubernetes.Clientset, namespace, name, k
 
 	log.Infof("Config map %s updated %s=%s.", name, key, value)
 	return nil
-
 }
 
 // wait for a node label to disappear.


### PR DESCRIPTION
Cherry pick of #10377 on release-v3.30.

#10377: Switch delete-local-data to delete-emptydir-data

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

`delete-local-data` was removed and replaced with `delete-emptydir-data`

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix flannel migration use of deprecated flag "delete-local-data"
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.