### PR TITLE
Upstream IP sets dataplane API changes.

### DIFF
--- a/felix/bpf/ipsets/map.go
+++ b/felix/bpf/ipsets/map.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // Copyright (c) 2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/felix/dataplane/ipsets/ipsets_mgr.go
+++ b/felix/dataplane/ipsets/ipsets_mgr.go
@@ -31,7 +31,7 @@ type IPSetsDataplane interface {
 	GetTypeOf(setID string) (ipsets.IPSetType, error)
 	GetDesiredMembers(setID string) (set.Set[string], error)
 	QueueResync()
-	ApplyUpdates()
+	ApplyUpdates(ipsetFilter func(ipSetName string) bool) (programmedIPs set.Set[string])
 	ApplyDeletions() (reschedule bool)
 	SetFilter(neededIPSets set.Set[string])
 }

--- a/felix/dataplane/ipsets/mock_ipsets.go
+++ b/felix/dataplane/ipsets/mock_ipsets.go
@@ -92,8 +92,9 @@ func (s *MockIPSets) QueueResync() {
 	// Not implemented for UT.
 }
 
-func (s *MockIPSets) ApplyUpdates() {
+func (s *MockIPSets) ApplyUpdates(ipsetFilter func(ipSetName string) bool) set.Set[string] {
 	// Not implemented for UT.
+	return nil
 }
 
 func (s *MockIPSets) ApplyDeletions() bool {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2483,7 +2483,7 @@ func (d *InternalDataplane) apply() {
 	for _, ipSets := range d.ipSets {
 		ipSetsWG.Add(1)
 		go func(ipSets dpsets.IPSetsDataplane) {
-			ipSets.ApplyUpdates()
+			ipSets.ApplyUpdates(nil)
 			d.reportHealth()
 			ipSetsWG.Done()
 		}(ipSets)

--- a/felix/dataplane/windows/ipsets/ipsets.go
+++ b/felix/dataplane/windows/ipsets/ipsets.go
@@ -186,7 +186,8 @@ func (m *IPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
 	panic("Not implemented")
 }
 
-func (m *IPSets) ApplyUpdates() {
+func (m *IPSets) ApplyUpdates(ipsetFilter func(ipSetName string) bool) (programmedIPs set.Set[string]) {
+	return nil
 }
 
 func (m *IPSets) ApplyDeletions() bool {

--- a/felix/ipsets/cmd_shim.go
+++ b/felix/ipsets/cmd_shim.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017,2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/ipsets/ipset_defs.go
+++ b/felix/ipsets/ipset_defs.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/proto"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
 )
 
@@ -192,11 +193,12 @@ func (f IPFamily) Version() int {
 
 // IPSetMetadata contains the metadata for a particular IP set, such as its name, type and size.
 type IPSetMetadata struct {
-	SetID    string
-	Type     IPSetType
-	MaxSize  int
-	RangeMin int
-	RangeMax int
+	SetID      string
+	Type       IPSetType
+	UpdateType proto.IPSetUpdate_IPSetType
+	MaxSize    int
+	RangeMin   int
+	RangeMax   int
 }
 
 // IPVersionConfig wraps up the metadata for a particular IP version.  It can be used by

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -248,7 +248,7 @@ var _ = Describe("IP sets dataplane", func() {
 
 	reschedRequested := false
 	apply := func() {
-		ipsets.ApplyUpdates()
+		ipsets.ApplyUpdates(nil)
 		reschedRequested = ipsets.ApplyDeletions()
 	}
 
@@ -281,7 +281,7 @@ var _ = Describe("IP sets dataplane", func() {
 		// Apply updates.
 		ipsets.ApplyDeletions() // No-op
 		dataplane.ExpectMembers(map[string][]string{})
-		ipsets.ApplyUpdates()
+		ipsets.ApplyUpdates(nil)
 		dataplane.ExpectMembers(map[string][]string{
 			v4MainIPSetName: {"10.0.0.2", "10.0.0.3"},
 		})
@@ -802,7 +802,7 @@ var _ = Describe("IP sets dataplane", func() {
 			})
 			It("should panic eventually", func() {
 				ipsets.AddMembers(ipSetID, []string{"10.0.0.5"})
-				Expect(func() { ipsets.ApplyUpdates() }).To(Panic())
+				Expect(func() { ipsets.ApplyUpdates(nil) }).To(Panic())
 				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", time.Second))
 			})
 		})
@@ -812,7 +812,7 @@ var _ = Describe("IP sets dataplane", func() {
 			})
 			It("should panic eventually", func() {
 				ipsets.QueueResync()
-				Expect(func() { ipsets.ApplyUpdates() }).To(Panic())
+				Expect(func() { ipsets.ApplyUpdates(nil) }).To(Panic())
 				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", time.Second))
 			})
 		})
@@ -823,7 +823,7 @@ var _ = Describe("IP sets dataplane", func() {
 			})
 			It("should panic eventually", func() {
 				ipsets.QueueResync()
-				Expect(func() { ipsets.ApplyUpdates() }).To(Panic())
+				Expect(func() { ipsets.ApplyUpdates(nil) }).To(Panic())
 				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", time.Second))
 			})
 		})

--- a/felix/nftables/ipsets.go
+++ b/felix/nftables/ipsets.go
@@ -325,7 +325,7 @@ func (s *IPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
 
 // ApplyUpdates applies the updates to the dataplane.  Returns a set of programmed IPs in the IPSets included by the
 // ipsetFilter.
-func (s *IPSets) ApplyUpdates() {
+func (s *IPSets) ApplyUpdates(filter func(setName string) bool) (programmedIPs set.Set[string]) {
 	success := false
 	retryDelay := 1 * time.Millisecond
 	backOff := func() {
@@ -333,6 +333,7 @@ func (s *IPSets) ApplyUpdates() {
 		retryDelay *= 2
 	}
 
+	programmedIPs = set.New[string]()
 	for attempt := 0; attempt < 10; attempt++ {
 		if attempt > 0 {
 			s.logCxt.Info("Retrying after an nftables set update failure...")
@@ -351,7 +352,7 @@ func (s *IPSets) ApplyUpdates() {
 			s.resyncRequired = false
 		}
 
-		if err := s.tryUpdates(); err != nil {
+		if err := s.tryUpdates(filter, programmedIPs); err != nil {
 			// Update failures may mean that our iptables updates fail.  We need to do an immediate resync.
 			s.logCxt.WithError(err).Warning("Failed to update IP sets. Marking dataplane for resync.")
 			s.resyncRequired = true
@@ -365,6 +366,7 @@ func (s *IPSets) ApplyUpdates() {
 	if !success {
 		s.logCxt.Panic("Failed to update IP sets after multiple retries.")
 	}
+	return
 }
 
 // tryResync attempts to bring our state into sync with the dataplane.  It scans the contents of the
@@ -580,7 +582,7 @@ func (s *IPSets) NFTablesSet(name string) *knftables.Set {
 }
 
 // tryUpdates attempts to apply any pending updates to the dataplane.
-func (s *IPSets) tryUpdates() error {
+func (s *IPSets) tryUpdates(ipsetFilter func(ipSetName string) bool, programmedIPs set.Set[string]) error {
 	var dirtyIPSets []string
 
 	s.ipSetsWithDirtyMembers.Iter(func(setName string) error {
@@ -637,6 +639,10 @@ func (s *IPSets) tryUpdates() error {
 		members.Desired().Iter(func(member SetMember) {
 			if members.Dataplane().Contains(member) {
 				return
+			}
+			if ipsetFilter != nil && ipsetFilter(setName) {
+				// We want to include the IPs from this set.
+				programmedIPs.Add(member.String())
 			}
 			tx.Add(&knftables.Element{
 				Set: setName,

--- a/felix/nftables/ipsets_test.go
+++ b/felix/nftables/ipsets_test.go
@@ -38,7 +38,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 	})
 
 	It("should Apply() on an empty state)", func() {
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 	})
 
 	It("should handle a failed ListElements call", func() {
@@ -49,7 +49,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 		s.AddOrReplaceIPSet(m1, []string{"10.0.0.1"})
 		s.AddOrReplaceIPSet(m2, []string{"10.0.0.2"})
 		s.AddOrReplaceIPSet(m3, []string{"10.0.0.3"})
-		s.ApplyUpdates()
+		s.ApplyUpdates(nil)
 
 		// Modifiy each set out-of-band.
 		tx := f.NewTransaction()
@@ -73,7 +73,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 		// Trigger a resync, which should fix the out-of-band modifications.
 		f.Reset()
 		s.QueueResync()
-		s.ApplyUpdates()
+		s.ApplyUpdates(nil)
 
 		// Expect all errors to have been executed.
 		Expect(f.ListElementsErrors).To(HaveLen(0))
@@ -90,7 +90,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 		It(fmt.Sprintf("should program IP sets of type %s", t), func() {
 			meta := ipsets.IPSetMetadata{SetID: "test", Type: t}
 			s.AddOrReplaceIPSet(meta, []string{})
-			Expect(s.ApplyUpdates).NotTo(Panic())
+			Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 			sets, err := f.List(context.Background(), "sets")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(sets).To(HaveLen(1))
@@ -101,7 +101,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 		// Create an IP set in the dataplane via the IPSets object.
 		meta := ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashIP}
 		s.AddOrReplaceIPSet(meta, []string{"10.0.0.1", "10.0.0.2"})
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 
 		// Create an IP set in the dataplane directly.
 		tx := f.NewTransaction()
@@ -123,7 +123,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 
 		// Trigger a resync.
 		s.QueueResync()
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 		Expect(s.ApplyDeletions()).To(BeFalse())
 
 		// We expect:
@@ -159,7 +159,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 
 		// Trigger a resync.
 		s.QueueResync()
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 	})
 
 	It("should handle unexpected sets with types that are not supported", func() {
@@ -174,7 +174,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 
 		// Trigger a resync. We should delete the unexpected set.
 		s.QueueResync()
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 		Expect(s.ApplyDeletions()).To(BeFalse())
 
 		// We expect the set to be deleted.
@@ -203,7 +203,7 @@ var _ = Describe("IPSets with empty data plane", func() {
 
 		// Apply.
 		s.QueueResync()
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 
 		// Expect the set to exist.
 		sets, err := f.List(context.Background(), "sets")
@@ -227,7 +227,7 @@ var _ = DescribeTable("IPSets programming v4",
 		ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil)
 		s := NewIPSets(ipv, f, logutils.NewSummarizer("test loop"))
 		s.AddOrReplaceIPSet(meta, members)
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 
 		// Read it back.
 		sets, err := f.List(context.Background(), "sets")
@@ -240,7 +240,7 @@ var _ = DescribeTable("IPSets programming v4",
 
 		// Trigger a resync to make sure we can handle it.
 		s.QueueResync()
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 
 		// Read it back again.
 		m, err = f.ListElements(context.Background(), "set", "cali40"+meta.SetID)
@@ -281,7 +281,7 @@ var _ = DescribeTable("IPSets programming v6",
 		ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil)
 		s := NewIPSets(ipv, f, logutils.NewSummarizer("test loop"))
 		s.AddOrReplaceIPSet(meta, members)
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 
 		// Read it back.
 		sets, err := f.List(context.Background(), "sets")
@@ -294,7 +294,7 @@ var _ = DescribeTable("IPSets programming v6",
 
 		// Trigger a resync to make sure we can handle it.
 		s.QueueResync()
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 
 		// Read it back again.
 		m, err = f.ListElements(context.Background(), "set", "cali60"+meta.SetID)
@@ -355,7 +355,7 @@ var _ = DescribeTable("NFTablesSet",
 		ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil)
 		s := NewIPSets(ipv, f, logutils.NewSummarizer("test loop"))
 		s.AddOrReplaceIPSet(meta, []string{})
-		Expect(s.ApplyUpdates).NotTo(Panic())
+		Expect(func() { s.ApplyUpdates(nil) }).NotTo(Panic())
 		Expect(s.NFTablesSet(fmt.Sprintf("cali40%s", meta.SetID))).To(Equal(exp))
 	},
 


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Enterprise needs an extra callback to tell it when particular IPs have been updated.  Upstream that, just to reduce OS<->Enterprise code diffs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
