### PR TITLE
Use more efficient ListPager API.

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/k8sservice_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/k8sservice_test.go
@@ -23,14 +23,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils/k8sfake"
 )
 
 var _ = Describe("Service tests with fake clientSet", func() {
-	var clientSet *FakeClientSetWithListRevAndFiltering
+	var clientSet *k8sfake.FakeClientSetWithListRevAndFiltering
 	var client *serviceClient
 
 	BeforeEach(func() {
-		clientSet = NewFakeClientSetWithListRevAndFiltering()
+		clientSet = k8sfake.NewFakeClientSetWithListRevAndFiltering()
 		client = NewServiceClient(clientSet).(*serviceClient)
 
 		service, err := clientSet.CoreV1().Services("some-ns").Create(context.TODO(), &k8sapi.Service{

--- a/libcalico-go/lib/backend/k8s/resources/list_pager.go
+++ b/libcalico-go/lib/backend/k8s/resources/list_pager.go
@@ -16,6 +16,7 @@ package resources
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -39,28 +40,47 @@ func pagedList(
 	*model.KVPairList,
 	error,
 ) {
-	lp := pager.New(listFunc)
+	// Wrap our incoming listFunc with one that stashes the revision and number
+	// of items we've seen so far.  This allows us to use the more efficient
+	// EachListItem() method, while also capturing the list metadata that we
+	// need.
+	listResourceVersion := ""
+	var numItemsLoaded atomic.Int64 // listFunc is called from background goroutine.
+	shimmedListFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		obj, err := listFunc(ctx, opts)
+		m, err := meta.ListAccessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if m.GetResourceVersion() != "" {
+			listResourceVersion = m.GetResourceVersion()
+		}
+		numItemsLoaded.Add(int64(meta.LenList(obj)))
+		return obj, err
+	}
+	lp := pager.New(shimmedListFunc)
+
 	opts := metav1.ListOptions{ResourceVersion: revision}
 	if revision != "" {
 		opts.ResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
 	}
-	result, isPaged, err := lp.List(ctx, opts)
-	if err != nil {
-		return nil, K8sErrorToCalico(err, list)
-	}
-	logCtx := log.WithField("pagedList", isPaged)
-	logCtx.Debug("List() call completed, convert results")
 
-	// For each item in the response, convert it to a KVPair and add it to the list.
-	kvps := []*model.KVPair{}
-	err = meta.EachListItem(result, func(obj runtime.Object) error {
+	var kvps []*model.KVPair
+	err := lp.EachListItem(ctx, opts, func(obj runtime.Object) error {
 		res := obj.(Resource)
 		result, err := toKVPs(res)
 		if err != nil {
-			logCtx.WithError(err).WithField("Item", res).Warning("unable to process resource, skipping")
+			log.WithError(err).WithField("Item", res).Warning("Unable to process resource, skipping")
 			return nil
 		}
 		if result != nil {
+			if kvps == nil {
+				// Try to guess a suitable result slice capacity.  In practice,
+				// this will be the size of the first page (but that's usually
+				// the only page.)
+				ratio := len(result)
+				kvps = make([]*model.KVPair, 0, int(numItemsLoaded.Load())*ratio)
+			}
 			kvps = append(kvps, result...)
 		}
 		return nil
@@ -69,13 +89,12 @@ func pagedList(
 		return nil, K8sErrorToCalico(err, list)
 	}
 
-	// Extract list revision information.
-	m, err := meta.ListAccessor(result)
-	if err != nil {
-		return nil, err
+	if listResourceVersion == "" {
+		log.WithField("list", list).Panic("Failed to extract resource version from list.")
 	}
+
 	return &model.KVPairList{
 		KVPairs:  kvps,
-		Revision: m.GetResourceVersion(),
+		Revision: listResourceVersion,
 	}, nil
 }

--- a/libcalico-go/lib/backend/k8s/resources/node_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/node_test.go
@@ -26,6 +26,7 @@ import (
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils/k8sfake"
 )
 
 var _ = Describe("Test Node conversion", func() {
@@ -612,11 +613,11 @@ var _ = Describe("Test Node conversion", func() {
 })
 
 var _ = Describe("Node tests with fake clientSet", func() {
-	var clientSet *FakeClientSetWithListRevAndFiltering
+	var clientSet *k8sfake.FakeClientSetWithListRevAndFiltering
 	var client *nodeClient
 
 	BeforeEach(func() {
-		clientSet = NewFakeClientSetWithListRevAndFiltering()
+		clientSet = k8sfake.NewFakeClientSetWithListRevAndFiltering()
 		client = NewNodeClient(clientSet, false).(*nodeClient)
 
 		node, err := clientSet.CoreV1().Nodes().Create(context.TODO(), &k8sapi.Node{

--- a/libcalico-go/lib/backend/k8s/resources/profile_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/profile_test.go
@@ -24,14 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils/k8sfake"
 )
 
 var _ = Describe("Profile tests with fake clientSet", func() {
-	var clientSet *FakeClientSetWithListRevAndFiltering
+	var clientSet *k8sfake.FakeClientSetWithListRevAndFiltering
 	var client *profileClient
 
 	BeforeEach(func() {
-		clientSet = NewFakeClientSetWithListRevAndFiltering()
+		clientSet = k8sfake.NewFakeClientSetWithListRevAndFiltering()
 
 		// Use unique revision for each of the base types so we can verify that
 		// they flow through correctly.

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils/k8sfake"
 )
 
 var _ = Describe("WorkloadEndpointClient", func() {
@@ -752,7 +753,7 @@ var _ = Describe("WorkloadEndpointClient", func() {
 })
 
 func testListWorkloadEndpoints(pods []runtime.Object, listOptions model.ResourceListOptions, expectedWEPs []*libapiv3.WorkloadEndpoint) {
-	k8sClient := fake.NewSimpleClientset(pods...)
+	k8sClient := k8sfake.NewFakeClientSetWithListRevAndFiltering(pods...)
 	wepClient := resources.NewWorkloadEndpointClient(k8sClient).(*resources.WorkloadEndpointClient)
 
 	kvps, err := wepClient.List(context.Background(), listOptions, "")

--- a/libcalico-go/lib/testutils/k8sfake/fake_clientset.go
+++ b/libcalico-go/lib/testutils/k8sfake/fake_clientset.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package resources
+package k8sfake
 
 import (
 	"reflect"
@@ -35,9 +35,9 @@ type FakeClientSetWithListRevAndFiltering struct {
 	CurrentListRevisionByType  map[string]string
 }
 
-func NewFakeClientSetWithListRevAndFiltering() *FakeClientSetWithListRevAndFiltering {
+func NewFakeClientSetWithListRevAndFiltering(objs ...runtime.Object) *FakeClientSetWithListRevAndFiltering {
 	clientset := &FakeClientSetWithListRevAndFiltering{
-		Clientset:                  fake.NewSimpleClientset(),
+		Clientset:                  fake.NewSimpleClientset(objs...),
 		DefaultCurrentListRevision: "123",
 		CurrentListRevisionByType:  map[string]string{},
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Use ListPager.EachListItem instead of ListPager.List.  Allows for incremental conversion page-by-page instead of loading up all pages into an upstream-format List object and then converting en-masse.

Noticed the more efficient API when doing a code read for a different issue.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico now uses less RAM when resyncing with the API server.  Objects are converted to Calico format in pages instead of buffering all upstream Kubernetes objects pre-conversion.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
