### PR TITLE
default policy name to not contain default tier prefix

### DIFF
--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -653,6 +653,7 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 				return nil, err
 			}
 		}
+		policy.Name = determinePolicyName(policy.Name, policy.Spec.Tier)
 	}
 
 	if valueType == reflect.TypeOf(apiv3.GlobalNetworkPolicy{}) {
@@ -664,6 +665,7 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 				return nil, err
 			}
 		}
+		policy.Name = determinePolicyName(policy.Name, policy.Spec.Tier)
 	}
 
 	if valueType == reflect.TypeOf(apiv3.StagedNetworkPolicy{}) {
@@ -675,6 +677,7 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 				return nil, err
 			}
 		}
+		policy.Name = determinePolicyName(policy.Name, policy.Spec.Tier)
 	}
 
 	if valueType == reflect.TypeOf(apiv3.StagedGlobalNetworkPolicy{}) {
@@ -686,6 +689,7 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 				return nil, err
 			}
 		}
+		policy.Name = determinePolicyName(policy.Name, policy.Spec.Tier)
 	}
 
 	return iface, nil
@@ -721,4 +725,13 @@ func SerializeValue(d *KVPair) ([]byte, error) {
 		return []byte(fmt.Sprint(d.Value)), nil
 	}
 	return json.Marshal(d.Value)
+}
+
+func determinePolicyName(name, tier string) string {
+	if tier == "default" || tier == "" {
+		// It's possible the policy does not contain tier, that means it's in the default Tier it's added later by the API server
+		return strings.TrimPrefix(name, "default.")
+	}
+
+	return name
 }


### PR DESCRIPTION
## Description
Update the way we return policy names, if there is no annotation on the underlying CRD we return the name of policy in the default Tier without the default. prefix

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
