### PR TITLE
Disable CSI driver by default in helm chart

### DIFF
--- a/charts/tigera-operator/templates/crs/custom-resources.yaml
+++ b/charts/tigera-operator/templates/crs/custom-resources.yaml
@@ -1,7 +1,6 @@
 {{ if .Values.installation.enabled }}
 {{ $installSpec := omit .Values.installation "enabled" }}
 {{ $_ := set $installSpec "imagePullSecrets" (include "tigera-operator.imagePullSecrets" . | fromYamlArray) }}
-{{ $_ := set $installSpec "kubeletVolumePluginPath" .Values.kubeletVolumePluginPath }}
 
 apiVersion: operator.tigera.io/v1
 kind: Installation

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -15,6 +15,9 @@ installation:
   # Example: --set installation.imagePullSecrets[0].name=my-existing-secret
   imagePullSecrets: []
 
+  # Disable CSI driver by default.
+  kubeletVolumePluginPath: "None"
+
 # apiServer configures the Calico API server, needed for interacting with
 # the projectcalico.org/v3 suite of APIs.
 apiServer:
@@ -85,8 +88,6 @@ tigeraOperator:
 calicoctl:
   image: quay.io/calico/ctl
   tag: master
-
-kubeletVolumePluginPath: /var/lib/kubelet
 
 # Optionally configure the host and port used to access the Kubernetes API server.
 kubernetesServiceEndpoint:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Disable CSI driver in helm chart by default, and remove top-level configuration option. Instead, rely on the Installation config option for
consistency.

## Related issues/PRs

Fixes https://github.com/projectcalico/calico/issues/8335

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Breaking change: kubeletVolumePath has been moved to the `installation` section of helm chart values.yaml
```

```release-note
CSI driver is now disabled by default in helm chart
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.