### PR TITLE
[release-v3.29] Auto pick #10117: Add support for custom DNS in the operator

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -45,6 +45,10 @@ spec:
       hostNetwork: true
       # This must be set when hostNetwork is true or else the cluster services won't resolve
       dnsPolicy: ClusterFirstWithHostNet
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       containers:
         - name: tigera-operator
           image: {{ template "tigera-operator.image" .Values.tigeraOperator}}

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -61,6 +61,8 @@ podAnnotations: {}
 # Custom labels for the tigera/operator pod.
 podLabels: {}
 
+# Custom DNS configuration for the tigera/operator pod.
+dnsConfig: {}
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator


### PR DESCRIPTION
Cherry pick of #10117 on release-v3.29.

#10117: Add support for custom DNS in the operator

# Original PR Body below

## Description
When deploying the operator with Windows and the `KUBERNETES_SERVICE_HOST` set (required by Windows) then the operator fails to resolve the DNS. This allows for passing in a custom DNS with will be appended to the pods DNS configuration allowing for communication to the API server for initial configuration.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The error you get is something like 

```
2025/03/27 22:51:30 [INFO] Go OS/Arch: linux/amd64
W0327 22:51:50.070616       1 reflector.go:535] pkg/mod/k8s.io/client-go@v0.28.9/tools/cache/reflector.go:229: failed to list *v1.ConfigMap: Get "https://capz-fl5y4z-9a54ece6.australiaeast.cloudapp.azure.com:6443/api/v1/namespaces/calico-system/configmaps?fieldSelector=metadata.name%3Dactive-operator&limit=500&resourceVersion=0": dial tcp: lookup capz-fl5y4z-
```

with the operator template values:

```
    installation:
      cni:
        type: Calico
      calicoNetwork:
        bgp: Disabled
        windowsDataplane: HNS
        mtu: 1350
        ipPools:
        - cidr: <cidr>
          encapsulation: VXLAN{{end}}
      serviceCIDRs: 
        - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
    kubernetesServiceEndpoint:
      host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
      port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
```

this allows to add something like this to the operator helm values file:

```
    # when kubernetesServiceEndpoint need to pass dns to look up the name properly
    dnsConfig: 
      nameservers:
        - 127.0.0.53
      options:
        - name: edns0
        - name: trust-ad
```

## Related issues/PRs
fixes #9536

Enables automated deployments in CAPZ:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5523

Partly Addresses: 
https://github.com/tigera/operator/issues/3113



<!-- If appropriate, include a link to the issue this fixes.


If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update Operator Helm values to support custom DNS settings
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.