### PR TITLE
Improve IPSet dataplane callback API.

### DIFF
--- a/felix/bpf/ipsets/ipsets.go
+++ b/felix/bpf/ipsets/ipsets.go
@@ -254,7 +254,7 @@ func (m *bpfIPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
 	panic("Not implemented")
 }
 
-func (m *bpfIPSets) ApplyUpdates(_ func(ipSetName string) bool) set.Set[string] {
+func (m *bpfIPSets) ApplyUpdates(_ ipsets.UpdateListener) {
 	var numAdds, numDels uint
 	startTime := time.Now()
 
@@ -378,8 +378,6 @@ func (m *bpfIPSets) ApplyUpdates(_ func(ipSetName string) bool) set.Set[string] 
 	}
 
 	bpfIPSetsGauge.Set(float64(len(m.ipSets)))
-
-	return nil
 }
 
 // ApplyDeletions tries to delete any IP sets that are no longer needed.

--- a/felix/dataplane/ipsets/ipsets_mgr.go
+++ b/felix/dataplane/ipsets/ipsets_mgr.go
@@ -31,10 +31,12 @@ type IPSetsDataplane interface {
 	GetTypeOf(setID string) (ipsets.IPSetType, error)
 	GetDesiredMembers(setID string) (set.Set[string], error)
 	QueueResync()
-	ApplyUpdates(ipsetFilter func(ipSetName string) bool) (programmedIPs set.Set[string])
+	ApplyUpdates(listener UpdateListener)
 	ApplyDeletions() (reschedule bool)
 	SetFilter(neededIPSets set.Set[string])
 }
+
+type UpdateListener = ipsets.UpdateListener
 
 // Except for domain IP sets, IPSetsManager simply passes through IP set updates from the datastore
 // to the ipsets.IPSets dataplane layer.  For domain IP sets - which hereafter we'll just call

--- a/felix/dataplane/ipsets/mock_ipsets.go
+++ b/felix/dataplane/ipsets/mock_ipsets.go
@@ -92,9 +92,8 @@ func (s *MockIPSets) QueueResync() {
 	// Not implemented for UT.
 }
 
-func (s *MockIPSets) ApplyUpdates(ipsetFilter func(ipSetName string) bool) set.Set[string] {
+func (s *MockIPSets) ApplyUpdates(_ ipsets.UpdateListener) {
 	// Not implemented for UT.
-	return nil
 }
 
 func (s *MockIPSets) ApplyDeletions() bool {

--- a/felix/dataplane/windows/ipsets/ipsets.go
+++ b/felix/dataplane/windows/ipsets/ipsets.go
@@ -19,6 +19,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
@@ -186,8 +187,7 @@ func (m *IPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
 	panic("Not implemented")
 }
 
-func (m *IPSets) ApplyUpdates(ipsetFilter func(ipSetName string) bool) (programmedIPs set.Set[string]) {
-	return nil
+func (m *IPSets) ApplyUpdates(_ ipsets.UpdateListener) {
 }
 
 func (m *IPSets) ApplyDeletions() bool {

--- a/felix/nftables/ipsets.go
+++ b/felix/nftables/ipsets.go
@@ -368,7 +368,6 @@ func (s *IPSets) ApplyUpdates(listener ipsets.UpdateListener) {
 	if !success {
 		s.logCxt.Panic("Failed to update IP sets after multiple retries.")
 	}
-	return
 }
 
 // tryResync attempts to bring our state into sync with the dataplane.  It scans the contents of the
@@ -622,8 +621,8 @@ func (s *IPSets) tryUpdates(listener ipsets.UpdateListener) error {
 	for _, setName := range dirtyIPSets {
 		// If the set is already programmed, we can skip it.
 		if _, ok := s.setNameToProgrammedMetadata.Dataplane().Get(setName); !ok {
-			if set := s.NFTablesSet(setName); set != nil {
-				tx.Add(set)
+			if nfSet := s.NFTablesSet(setName); nfSet != nil {
+				tx.Add(nfSet)
 			}
 		}
 
@@ -813,6 +812,7 @@ func CanonicaliseMember(t ipsets.IPSetType, member string) SetMember {
 		if ipAddr == nil {
 			// This should be prevented by validation in libcalico-go.
 			log.WithField("ip", member).Panic("Failed to parse IP")
+			panic("Failed to parse IP part of IP,port member")
 		}
 		return simpleMember(ipAddr.String())
 	case ipsets.IPSetTypeHashIPPort:
@@ -825,6 +825,7 @@ func CanonicaliseMember(t ipsets.IPSetType, member string) SetMember {
 		if ipAddr == nil {
 			// This should be prevented by validation.
 			log.WithField("member", member).Panic("Failed to parse IP part of IP,port member")
+			panic("Failed to parse IP part of IP,port member")
 		}
 		parts = strings.Split(parts[1], ":")
 		if len(parts) != 2 {

--- a/felix/nftables/ipsets.go
+++ b/felix/nftables/ipsets.go
@@ -323,9 +323,12 @@ func (s *IPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
 	return strs, nil
 }
 
-// ApplyUpdates applies the updates to the dataplane.  Returns a set of programmed IPs in the IPSets included by the
-// ipsetFilter.
-func (s *IPSets) ApplyUpdates(filter func(setName string) bool) (programmedIPs set.Set[string]) {
+// ApplyUpdates applies the updates to the dataplane.  If listener is non-nil,
+// it will receive callbacks when members are programmed.  The callbacks occur
+// before we have final confirmation that the members are in the dataplane, so
+// the caller may wish to defer acting on the information until ApplyUpdates
+// returns.
+func (s *IPSets) ApplyUpdates(listener ipsets.UpdateListener) {
 	success := false
 	retryDelay := 1 * time.Millisecond
 	backOff := func() {
@@ -333,7 +336,6 @@ func (s *IPSets) ApplyUpdates(filter func(setName string) bool) (programmedIPs s
 		retryDelay *= 2
 	}
 
-	programmedIPs = set.New[string]()
 	for attempt := 0; attempt < 10; attempt++ {
 		if attempt > 0 {
 			s.logCxt.Info("Retrying after an nftables set update failure...")
@@ -352,7 +354,7 @@ func (s *IPSets) ApplyUpdates(filter func(setName string) bool) (programmedIPs s
 			s.resyncRequired = false
 		}
 
-		if err := s.tryUpdates(filter, programmedIPs); err != nil {
+		if err := s.tryUpdates(listener); err != nil {
 			// Update failures may mean that our iptables updates fail.  We need to do an immediate resync.
 			s.logCxt.WithError(err).Warning("Failed to update IP sets. Marking dataplane for resync.")
 			s.resyncRequired = true
@@ -582,7 +584,7 @@ func (s *IPSets) NFTablesSet(name string) *knftables.Set {
 }
 
 // tryUpdates attempts to apply any pending updates to the dataplane.
-func (s *IPSets) tryUpdates(ipsetFilter func(ipSetName string) bool, programmedIPs set.Set[string]) error {
+func (s *IPSets) tryUpdates(listener ipsets.UpdateListener) error {
 	var dirtyIPSets []string
 
 	s.ipSetsWithDirtyMembers.Iter(func(setName string) error {
@@ -636,13 +638,13 @@ func (s *IPSets) tryUpdates(ipsetFilter func(ipSetName string) bool, programmedI
 		})
 
 		// Add desired members to the set.
+		listenerCares := listener != nil && listener.CaresAboutIPSet(setName)
 		members.Desired().Iter(func(member SetMember) {
 			if members.Dataplane().Contains(member) {
 				return
 			}
-			if ipsetFilter != nil && ipsetFilter(setName) {
-				// We want to include the IPs from this set.
-				programmedIPs.Add(member.String())
+			if listenerCares {
+				listener.OnMemberProgrammed(member.String())
 			}
 			tx.Add(&knftables.Element{
 				Set: setName,


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Introduce UpdateListener interface; remove automatic return of a set. Let the update filter decide how it wants to track updates.

Think this is a lot cleaner overall.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Follow up on #10397 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
