### PR TITLE
Remove default tier prefix from Policy CRD without annotation

### DIFF
--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -646,59 +646,37 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 
 	if valueType == reflect.TypeOf(apiv3.NetworkPolicy{}) {
 		policy := iface.(*apiv3.NetworkPolicy)
-		annotations := policy.Annotations
-		if annotations != nil && annotations[metadataAnnotation] != "" {
-			policy.Name, policy.Annotations, err = parseMetadataAnnotation(annotations)
-			if err != nil {
-				return nil, err
-			}
+		policy.Name, policy.Annotations, err = determinePolicyName(policy.Name, policy.Spec.Tier, policy.Annotations)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	if valueType == reflect.TypeOf(apiv3.GlobalNetworkPolicy{}) {
 		policy := iface.(*apiv3.GlobalNetworkPolicy)
-		annotations := policy.Annotations
-		if annotations != nil && annotations[metadataAnnotation] != "" {
-			policy.Name, policy.Annotations, err = parseMetadataAnnotation(annotations)
-			if err != nil {
-				return nil, err
-			}
+		policy.Name, policy.Annotations, err = determinePolicyName(policy.Name, policy.Spec.Tier, policy.Annotations)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	if valueType == reflect.TypeOf(apiv3.StagedNetworkPolicy{}) {
 		policy := iface.(*apiv3.StagedNetworkPolicy)
-		annotations := policy.Annotations
-		if annotations != nil && annotations[metadataAnnotation] != "" {
-			policy.Name, policy.Annotations, err = parseMetadataAnnotation(annotations)
-			if err != nil {
-				return nil, err
-			}
+		policy.Name, policy.Annotations, err = determinePolicyName(policy.Name, policy.Spec.Tier, policy.Annotations)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	if valueType == reflect.TypeOf(apiv3.StagedGlobalNetworkPolicy{}) {
 		policy := iface.(*apiv3.StagedGlobalNetworkPolicy)
-		annotations := policy.Annotations
-		if annotations != nil && annotations[metadataAnnotation] != "" {
-			policy.Name, policy.Annotations, err = parseMetadataAnnotation(annotations)
-			if err != nil {
-				return nil, err
-			}
+		policy.Name, policy.Annotations, err = determinePolicyName(policy.Name, policy.Spec.Tier, policy.Annotations)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return iface, nil
-}
-
-func parseMetadataAnnotation(annotations map[string]string) (string, map[string]string, error) {
-	meta := &metav1.ObjectMeta{}
-	err := json.Unmarshal([]byte(annotations[metadataAnnotation]), meta)
-	if err != nil {
-		return "", nil, err
-	}
-	delete(annotations, metadataAnnotation)
-	return meta.Name, annotations, nil
 }
 
 // SerializeValue serializes a value in the model to a []byte to be stored in the datastore.  This
@@ -721,4 +699,25 @@ func SerializeValue(d *KVPair) ([]byte, error) {
 		return []byte(fmt.Sprint(d.Value)), nil
 	}
 	return json.Marshal(d.Value)
+}
+
+// determinePolicyName updates Policy name based on either the projectcalico.org/metadata annotation that was added in 3.30,
+// or defaults the name to be returned without the default prefix if no annotation was found. This was the default behaviour in =<3.28
+func determinePolicyName(name, tier string, annotations map[string]string) (string, map[string]string, error) {
+	if annotations != nil && annotations[metadataAnnotation] != "" {
+		meta := &metav1.ObjectMeta{}
+		err := json.Unmarshal([]byte(annotations[metadataAnnotation]), meta)
+		if err != nil {
+			return "", nil, err
+		}
+		delete(annotations, metadataAnnotation)
+		return meta.Name, annotations, nil
+	}
+
+	if tier == "default" || tier == "" {
+		// It's possible the policy does not contain tier, that means it's in the default Tier it's added later by the API server
+		return strings.TrimPrefix(name, "default."), annotations, nil
+	}
+
+	return name, annotations, nil
 }

--- a/libcalico-go/lib/clientv3/globalnetworkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/globalnetworkpolicy_e2e_test.go
@@ -16,6 +16,7 @@ package clientv3_test
 
 import (
 	"context"
+	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -403,6 +404,19 @@ var _ = testutils.E2eDatastoreDescribe("GlobalNetworkPolicy tests", testutils.Da
 		Entry("GlobalNetworkPolicy without default tier prefix", "netpol", "default.netpol"),
 		Entry("GlobalNetworkPolicy with default tier prefix", "default.netpol", "netpol"),
 	)
+
+	Describe("GlobalNetworkPolicy without name on the projectcalico.org annotation", func() {
+		It("Should return the name without default prefix", func() {
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				// We create the policies as a CRD to prevent the api server adding the correct annotation
+				err := exec.Command("kubectl", "create", "-f", "../../test/mock-policies.yaml").Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = c.NetworkPolicies().Get(ctx, "default", "prefix-test-policy", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
 
 	DescribeTable("GlobalNetworkPolicy name validation tests",
 		func(policyName string, tier string, expectError bool) {

--- a/libcalico-go/lib/clientv3/networkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/networkpolicy_e2e_test.go
@@ -16,6 +16,7 @@ package clientv3_test
 
 import (
 	"context"
+	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -426,6 +427,19 @@ var _ = testutils.E2eDatastoreDescribe("NetworkPolicy tests", testutils.Datastor
 		Entry("NetworkPolicy without default tier prefix", "netpol", "default.netpol"),
 		Entry("NetworkPolicy with default tier prefix", "default.netpol", "netpol"),
 	)
+
+	Describe("NetworkPolicy without name on the projectcalico.org annotation", func() {
+		It("Should return the name without default prefix", func() {
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				// We create the policies as a CRD to prevent the api server adding the correct annotation
+				err := exec.Command("kubectl", "create", "-f", "../../test/mock-policies.yaml").Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = c.NetworkPolicies().Get(ctx, "default", "prefix-test-policy", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
 
 	DescribeTable("NetworkPolicy name validation tests",
 		func(policyName string, tier string, expectError bool) {

--- a/libcalico-go/lib/clientv3/stagedglobalnetworkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/stagedglobalnetworkpolicy_e2e_test.go
@@ -16,6 +16,7 @@ package clientv3_test
 
 import (
 	"context"
+	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -397,6 +398,19 @@ var _ = testutils.E2eDatastoreDescribe("StagedGlobalNetworkPolicy tests", testut
 		Entry("StagedGlobalNetworkPolicy without default tier prefix", "netpol", "default.netpol"),
 		Entry("StagedGlobalNetworkPolicy with default tier prefix", "default.netpol", "netpol"),
 	)
+
+	Describe("StagedGlobalNetworkPolicy without name on the projectcalico.org annotation", func() {
+		It("Should return the name without default prefix", func() {
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				// We create the policies as a CRD to prevent the api server adding the correct annotation
+				err := exec.Command("kubectl", "create", "-f", "../../test/mock-policies.yaml").Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = c.StagedGlobalNetworkPolicies().Get(ctx, "prefix-test-policy", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
 
 	DescribeTable("StagedGlobalNetworkPolicy name validation tests",
 		func(policyName string, tier string, expectError bool) {

--- a/libcalico-go/lib/clientv3/stagednetworkpolicy_e2e_test.go
+++ b/libcalico-go/lib/clientv3/stagednetworkpolicy_e2e_test.go
@@ -16,6 +16,7 @@ package clientv3_test
 
 import (
 	"context"
+	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -429,6 +430,19 @@ var _ = testutils.E2eDatastoreDescribe("StagedNetworkPolicy tests", testutils.Da
 		Entry("StagedNetworkPolicy without default tier prefix", "netpol", "default.netpol"),
 		Entry("StagedNetworkPolicy with default tier prefix", "default.netpol", "netpol"),
 	)
+
+	Describe("StagedNetworkPolicy without name on the projectcalico.org annotation", func() {
+		It("Should return the name without default prefix", func() {
+			if config.Spec.DatastoreType == apiconfig.Kubernetes {
+				// We create the policies as a CRD to prevent the api server adding the correct annotation
+				err := exec.Command("kubectl", "create", "-f", "../../test/mock-policies.yaml").Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = c.StagedGlobalNetworkPolicies().Get(ctx, "prefix-test-policy", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
 
 	DescribeTable("StagedNetworkPolicy name validation tests",
 		func(policyName string, tier string, expectError bool) {

--- a/libcalico-go/test/mock-policies.yaml
+++ b/libcalico-go/test/mock-policies.yaml
@@ -1,0 +1,62 @@
+#These policies are used for testing if the correct policy name is returned when no name is part of the projectcalico.org/metadata annotation
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: default.prefix-test-policy
+  namespace: default
+  annotations:
+    test: test
+    projectcalico.org/metadata: '{}'
+spec:
+  tier: default
+  types:
+    - Ingress
+    - Egress
+
+---
+
+apiVersion: crd.projectcalico.org/v1
+kind: GlobalNetworkPolicy
+metadata:
+  name: default.prefix-test-policy
+  namespace: default
+  annotations:
+    test: test
+    projectcalico.org/metadata: '{}'
+spec:
+  tier: default
+  types:
+    - Ingress
+    - Egress
+
+---
+
+apiVersion: crd.projectcalico.org/v1
+kind: StagedNetworkPolicy
+metadata:
+  name: default.prefix-test-policy
+  namespace: default
+  annotations:
+    test: test
+    projectcalico.org/metadata: '{}'
+spec:
+  tier: default
+  types:
+    - Ingress
+    - Egress
+
+---
+
+apiVersion: crd.projectcalico.org/v1
+kind: StagedGlobalNetworkPolicy
+metadata:
+  name: default.prefix-test-policy
+  namespace: default
+  annotations:
+    test: test
+    projectcalico.org/metadata: '{}'
+spec:
+  tier: default
+  types:
+    - Ingress
+    - Egress


### PR DESCRIPTION
## Description
Update the way we return policy names, if there is no annotation on the underlying CRD we return the name of policy in the default Tier without the default. prefix

This fixes upgrade path from <=3.28 to >=3.30 as policies created in 3.28 and prior did not include the annotation on the CRD and were always returned without the default prefix by the API server.

Cherry pick of:
- #10399
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Policies created prior to v3.28.0 have their name retained across upgrade. Policies created in the default tier with version v3.29.[0-3] will have their names changed from `default.name` to `name`. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
