### PR TITLE
Short names for staged policies (#10280)

### DIFF
--- a/apiserver/pkg/registry/projectcalico/rest/storage_calico.go
+++ b/apiserver/pkg/registry/projectcalico/rest/storage_calico.go
@@ -104,7 +104,7 @@ func (p RESTStorageProvider) NewV3Storage(
 		},
 		p.StorageType,
 		authorizer,
-		[]string{},
+		[]string{"sknp"},
 	)
 
 	stagedpolicyRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("stagednetworkpolicies"), nil)
@@ -126,7 +126,7 @@ func (p RESTStorageProvider) NewV3Storage(
 		},
 		p.StorageType,
 		authorizer,
-		[]string{},
+		[]string{"snp"},
 	)
 
 	networksetRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("networksets"), nil)
@@ -214,7 +214,7 @@ func (p RESTStorageProvider) NewV3Storage(
 		},
 		p.StorageType,
 		authorizer,
-		[]string{},
+		[]string{"sgnp"},
 	)
 
 	gNetworkSetRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("globalnetworksets"), nil)

--- a/apiserver/pkg/registry/projectcalico/stagedglobalnetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagedglobalnetworkpolicy/storage.go
@@ -39,6 +39,7 @@ type REST struct {
 	*genericregistry.Store
 	rbac.CalicoResourceLister
 	authorizer authorizer.TierAuthorizer
+	shortNames []string
 }
 
 // EmptyObject returns an empty instance
@@ -102,7 +103,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer)}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -165,4 +166,8 @@ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptio
 	}
 
 	return r.Store.Watch(ctx, options)
+}
+
+func (r *REST) ShortNames() []string {
+	return r.shortNames
 }

--- a/apiserver/pkg/registry/projectcalico/stagedkubernetesnetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagedkubernetesnetworkpolicy/storage.go
@@ -30,6 +30,7 @@ import (
 // rest implements a RESTStorage for API services against etcd
 type REST struct {
 	*genericregistry.Store
+	shortNames []string
 }
 
 // EmptyObject returns an empty instance
@@ -89,5 +90,9 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store}, nil
+	return &REST{store, opts.ShortNames}, nil
+}
+
+func (r *REST) ShortNames() []string {
+	return r.shortNames
 }

--- a/apiserver/pkg/registry/projectcalico/stagednetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagednetworkpolicy/storage.go
@@ -39,6 +39,7 @@ type REST struct {
 	*genericregistry.Store
 	rbac.CalicoResourceLister
 	authorizer authorizer.TierAuthorizer
+	shortNames []string
 }
 
 // EmptyObject returns an empty instance
@@ -98,7 +99,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer)}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -161,4 +162,8 @@ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptio
 	}
 
 	return r.Store.Watch(ctx, options)
+}
+
+func (r *REST) ShortNames() []string {
+	return r.shortNames
 }


### PR DESCRIPTION
Allow the use of short names for Staged Policies

StagedNetworkPolicy -> snp
StagedGlobalNetworkPolicy -> sgnp
StagedKubernetesNetworkPolicy -> sknp

Cherry pick of:
 - #10280  

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Introduces a shorthand for StagedNetworkPolicy -> snp, StagedGlobalNetworkPolicy -> sgnp and StagedKubernetesNetworkPolicy -> sknp
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
