### PR TITLE
feat: Add IPAM block cleanup for removed nodes

### DIFF
--- a/calicoctl/calicoctl/commands/ipam.go
+++ b/calicoctl/calicoctl/commands/ipam.go
@@ -32,6 +32,7 @@ func IPAM(args []string) error {
   <BINARY_NAME> ipam <command> [<args>...]
 
     check            Check the integrity of the IPAM datastructures.
+    clean            Clean up orphaned or unused IPAM resources.
     release          Release a Calico assigned IP address.
     show             Show details of a Calico configuration,
                      assigned IP address, or of overall IP usage.
@@ -70,6 +71,8 @@ Description:
 	switch command {
 	case "check":
 		return ipam.Check(args, buildinfo.Version)
+	case "clean":
+		return ipam.Clean(args, buildinfo.Version)
 	case "release":
 		return ipam.Release(args, buildinfo.Version)
 	case "show":

--- a/calicoctl/calicoctl/commands/ipam/clean.go
+++ b/calicoctl/calicoctl/commands/ipam/clean.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	docopt "github.com/docopt/docopt-go"
+
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/clientmgr"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+// Clean IPAM resources that are orphaned or no longer needed.
+func Clean(args []string, version string) error {
+	doc := constants.DatastoreIntro + `Usage:
+  <BINARY_NAME> ipam clean orphaned-blocks [--force] [--config=<CONFIG>] [--allow-version-mismatch]
+
+Options:
+  -h --help                    Show this screen.
+  -f --force                   Delete blocks even if they have active IP allocations.
+  -c --config=<CONFIG>         Path to the file containing connection configuration in
+                               YAML or JSON format.
+     --allow-version-mismatch  Allow client and cluster versions mismatch.
+
+Description:
+  The clean command is used to clean up IPAM resources that are orphaned or no 
+  longer needed.
+
+  The orphaned-blocks subcommand cleans up IPAM blocks that have affinity to nodes 
+  that are no longer present in the cluster.
+`
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	parsedArgs, err := docopt.ParseArgs(doc, args, "")
+	if err != nil {
+		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	err = common.CheckVersionMismatch(parsedArgs["--config"], parsedArgs["--allow-version-mismatch"])
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Load config.
+	cf := parsedArgs["--config"].(string)
+	cfg, err := clientmgr.LoadClientConfig(cf)
+	if err != nil {
+		return err
+	}
+
+	// Create a new backend client.
+	client, err := clientmgr.NewClientFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Get the IPAM client
+	ipamClient := client.IPAM()
+
+	// Execute the appropriate subcommand.
+	if parsedArgs["orphaned-blocks"].(bool) {
+		// Get all nodes from the cluster.
+		nodeList, err := client.Nodes().List(ctx, options.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Extract node names.
+		var nodes []string
+		for _, node := range nodeList.Items {
+			nodes = append(nodes, node.Name)
+		}
+
+		// Call the IPAM client to clean up orphaned blocks.
+		force := parsedArgs["--force"].(bool)
+		count, err := ipamClient.CleanupBlocksForRemovedNodes(ctx, nodes, force)
+		if err != nil {
+			return err
+		}
+
+		// Print a message indicating how many blocks were cleaned up.
+		if count == 0 {
+			fmt.Println("No orphaned IPAM blocks found.")
+		} else {
+			fmt.Printf("Successfully cleaned up %d orphaned IPAM block(s).\n", count)
+		}
+
+		return nil
+	}
+
+	// If we get here, the command is not recognized.
+	fmt.Println(doc)
+	return nil
+}

--- a/kube-controllers/pkg/controllers/node/fake_ipam_cleaner.go
+++ b/kube-controllers/pkg/controllers/node/fake_ipam_cleaner.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+)
+
+// CleanupBlocksForRemovedNodes is a no-op implementation for the fake IPAM client
+func (c *fakeIPAMClient) CleanupBlocksForRemovedNodes(ctx context.Context, activeNodes []string, force bool) (int, error) {
+	// This is a simple implementation for testing purposes
+	// Just return 0 (no blocks cleaned up) and nil (no error)
+	return 0, nil
+}

--- a/libcalico-go/lib/ipam/cleanup.go
+++ b/libcalico-go/lib/ipam/cleanup.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+)
+
+// CleanupBlocksForRemovedNodes cleans up IPAM blocks that have affinity to nodes
+// that are no longer in the cluster.
+// activeNodes: List of active node names in the cluster
+// force: If true, will delete blocks even if they have active IP allocations
+// Returns: Number of blocks cleaned up and any error encountered
+func (c ipamClient) CleanupBlocksForRemovedNodes(ctx context.Context, activeNodes []string, force bool) (int, error) {
+	logCtx := log.WithFields(log.Fields{
+		"activeNodes": len(activeNodes),
+		"force":       force,
+	})
+	logCtx.Info("Cleaning up IPAM blocks for removed nodes")
+
+	// Get all blocks
+	blocks, err := c.blockReaderWriter.listBlocks(ctx, "")
+	if err != nil {
+		return 0, err
+	}
+
+	// Create a map of active nodes for efficient lookup
+	activeNodeMap := map[string]bool{}
+	for _, node := range activeNodes {
+		activeNodeMap[node] = true
+	}
+
+	// Find blocks with affinity to non-existent nodes
+	var cleanupBlocks []*model.KVPair
+	for _, b := range blocks.KVPairs {
+		// Create a local copy of the block so we can safely take its address
+		block := b
+		if affinity := block.Value.(*model.AllocationBlock).Affinity; affinity != nil {
+			// Parse affinity to get node name
+			parts := strings.Split(*affinity, ":")
+			if len(parts) != 2 {
+				// Skip blocks with malformed affinity
+				logCtx.WithField("affinity", *affinity).Debug("Skipping block with malformed affinity")
+				continue
+			}
+
+			affinityType, nodeName := parts[0], parts[1]
+
+			// Skip if not host affinity or if node still exists
+			if affinityType != "host" || activeNodeMap[nodeName] {
+				continue
+			}
+
+			// If force is false, only clean up empty blocks
+			blockObj := allocationBlock{block.Value.(*model.AllocationBlock)}
+			if !force && !blockObj.empty() {
+				logCtx.WithFields(log.Fields{
+					"block":        block.Key.(model.BlockKey).CIDR.String(),
+					"node":         nodeName,
+					"allocatedIPs": blockObj.inUseIPs(),
+				}).Info("Skipping non-empty block because force is false")
+				continue
+			}
+
+			// Add the block to our cleanup list
+			cleanupBlocks = append(cleanupBlocks, block)
+		}
+	}
+
+	// If no blocks to clean up, return early
+	if len(cleanupBlocks) == 0 {
+		logCtx.Info("No orphaned blocks found")
+		return 0, nil
+	}
+
+	logCtx.WithField("blocksToClean", len(cleanupBlocks)).Info("Found orphaned blocks to clean")
+
+	// Delete the blocks in parallel with limited concurrency
+	workers := runtime.GOMAXPROCS(0)
+	if workers > 10 {
+		workers = 10 // Limit max concurrent workers
+	}
+
+	sem := semaphore.NewWeighted(int64(workers))
+	var cleanedCount int32 = 0
+	var errorMutex sync.Mutex
+	var lastError error
+
+	for _, block := range cleanupBlocks {
+		// Check for context cancellation
+		if ctx.Err() != nil {
+			return int(cleanedCount), ctx.Err()
+		}
+
+		if err := sem.Acquire(ctx, 1); err != nil {
+			// Context canceled or deadline exceeded
+			return int(cleanedCount), err
+		}
+
+		go func(b *model.KVPair) {
+			defer sem.Release(1)
+
+			blockCIDR := b.Key.(model.BlockKey).CIDR
+			affinity := b.Value.(*model.AllocationBlock).Affinity
+			blockLogCtx := logCtx.WithFields(log.Fields{
+				"blockCIDR": blockCIDR.String(),
+				"affinity":  *affinity,
+			})
+			blockLogCtx.Info("Cleaning up orphaned block")
+
+			// Try to delete the block directly
+			err := c.blockReaderWriter.deleteBlock(ctx, b)
+			if err != nil {
+				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+					// Block already deleted, that's fine
+					blockLogCtx.Info("Block already deleted, skipping")
+				} else {
+					blockLogCtx.WithError(err).Error("Failed to delete block")
+					// Save the last error
+					errorMutex.Lock()
+					lastError = err
+					errorMutex.Unlock()
+					return
+				}
+			}
+
+			atomic.AddInt32(&cleanedCount, 1)
+			blockLogCtx.Info("Successfully deleted orphaned block")
+		}(block)
+	}
+
+	// Wait for all workers to finish
+	if err := sem.Acquire(ctx, int64(workers)); err != nil {
+		return int(cleanedCount), err
+	}
+
+	// If we had errors during processing, return the last one
+	if lastError != nil {
+		return int(cleanedCount), lastError
+	}
+
+	logCtx.WithField("cleanedCount", cleanedCount).Info("Successfully cleaned up orphaned blocks")
+	return int(cleanedCount), nil
+}

--- a/libcalico-go/lib/ipam/interface.go
+++ b/libcalico-go/lib/ipam/interface.go
@@ -100,6 +100,13 @@ type Interface interface {
 	// GetUtilization returns IP utilization info for the specified pools, or for all pools.
 	GetUtilization(ctx context.Context, args GetUtilizationArgs) ([]*PoolUtilization, error)
 
+	// CleanupBlocksForRemovedNodes cleans up IPAM blocks that have affinity to nodes
+	// that are no longer in the cluster.
+	// activeNodes: List of active node names in the cluster
+	// force: If true, will delete blocks even if they have active IP allocations
+	// Returns: Number of blocks cleaned up and any error encountered
+	CleanupBlocksForRemovedNodes(ctx context.Context, activeNodes []string, force bool) (int, error)
+
 	// EnsureBlock returns single IPv4/IPv6 IPAM block for a host as specified by the provided BlockArgs.
 	// If there is no block allocated already for this host, allocate one and return its CIDR.
 	// Otherwise, return the CIDR of the IPAM block allocated for this host.


### PR DESCRIPTION
This adds a new CleanupBlocksForRemovedNodes method to the IPAM interface and implements a new CLI command 'calicoctl ipam clean orphaned-blocks' to help administrators clean up IPAM blocks for nodes that no longer exist.

The implementation includes:
- New interface method in libcalico-go/lib/ipam/interface.go
- Implementation in libcalico-go/lib/ipam/cleanup.go
- CLI command in calicoctl/calicoctl/commands/ipam/clean.go
- Test support in kube-controllers/pkg/controllers/node/fake_ipam_cleaner.go

This resolves the issue of slow IPAM block release when nodes are removed from the cluster, providing a built-in alternative to external cleanup scripts.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
