### PR TITLE
Disable watchlist in API server

### DIFF
--- a/apiserver/cmd/apiserver/apiserver.go
+++ b/apiserver/cmd/apiserver/apiserver.go
@@ -36,11 +36,16 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	// The ConsistentListFromCache feature gate requires our resourceStore
-	// to support method RequestWatchProgress, which it does not.  Force-disable
-	// the gate.
 	err := feature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+		// The ConsistentListFromCache feature gate requires our resourceStore
+		// to support method RequestWatchProgress, which it does not.  Force-disable
+		// the gate.
 		string(features.ConsistentListFromCache): false,
+
+		// WatchList requires watch bookmarks, which our API server does not currently support.
+		// Note that the WatchBookmarks feature is required to be true - we should probably add
+		// support for this!
+		string(features.WatchList): false,
 	})
 	if err != nil {
 		logrus.Errorf("Error setting feature gates: %v.", err)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Kuberentes v1.32 added WatchList, allowing for the abilitty stream an initial List request with Watch sematnics instead of chunking the data. This relies on WatchBookmarks, which our API server does not (yet) support.

Kubernetes v1.33 disabled WatchList by default, as the brakes were put on as described here: https://github.com/kubernetes/kubernetes/pull/131359

How does this impact us? Well, in k8s v1.32 clusters, the kube-controller-manager namespace finalizing logic seems to get stuck because the controller is attempting to leverage WatchList semantics which our API server does not implement. This means Namespaces get stuck `Terminating` forever!

This is not a problem in 1.33 for the most part, since the WatchList feature gate was switched to `false` by default, but in theory could still be a problem for anyone who opts in to that feature.

This PR is a hotfix to disable WatchList in our API server, to get past the stuck `Namespace` deletion issue hinted at above. Longer term, we'll see where WatchList goes - upstream sentiment seems to be that justification is lacking, so it may never progress to GA.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Disable WatchList in Calico API server, fixing issue with stuck Namespace termination.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.