### PR TITLE
[release-v3.30] (pick #10433) Disable watchlist in API server

### DIFF
--- a/apiserver/cmd/apiserver/apiserver.go
+++ b/apiserver/cmd/apiserver/apiserver.go
@@ -35,11 +35,16 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	// The ConsistentListFromCache feature gate requires our resourceStore
-	// to support method RequestWatchProgress, which it does not.  Force-disable
-	// the gate.
 	err := feature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+		// The ConsistentListFromCache feature gate requires our resourceStore
+		// to support method RequestWatchProgress, which it does not.  Force-disable
+		// the gate.
 		string(features.ConsistentListFromCache): false,
+
+		// WatchList requires watch bookmarks, which our API server does not currently support.
+		// Note that the WatchBookmarks feature is required to be true - we should probably add
+		// support for this!
+		string(features.WatchList): false,
 	})
 	if err != nil {
 		logrus.Errorf("Error setting feature gates: %v.", err)


### PR DESCRIPTION
## Description

Pick #10433

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Disable WatchList in Calico API server, fixing issue with stuck Namespace termination.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
