### PR TITLE
Add initial Guardian FV

### DIFF
--- a/guardian/Makefile
+++ b/guardian/Makefile
@@ -70,7 +70,12 @@ $(GUARDIAN_CONTAINER_CREATED): docker-image/guardian/Dockerfile $(BINDIR)/guardi
 .PHONY: ut
 ## Run only Unit Tests.
 ut:
-	$(DOCKER_GO_BUILD) go test ./... -cover -count 1
+	$(DOCKER_GO_BUILD) go test ./pkg/... -cover -count 1
+
+.PHONY: ut
+## Run only Unit Tests.
+fv:
+	$(DOCKER_GO_BUILD) go test ./tests/fv/... -cover -count 1
 
 ##########################################################################################
 # CI/CD
@@ -81,7 +86,7 @@ ut:
 # Run CI cycle - build, test, etc.
 #############################################
 ## Run all CI steps for build and test, likely other targets.
-ci: static-checks ut
+ci: static-checks ut fv
 
 clean:
 	rm -rf $(BINDIR)

--- a/guardian/tests/fv/fv_test.go
+++ b/guardian/tests/fv/fv_test.go
@@ -1,0 +1,222 @@
+package fv_test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net"
+	"net/http"
+	url2 "net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
+
+	calicotls "github.com/projectcalico/calico/crypto/pkg/tls"
+	"github.com/projectcalico/calico/guardian/pkg/config"
+	"github.com/projectcalico/calico/guardian/pkg/daemon"
+	"github.com/projectcalico/calico/guardian/pkg/server"
+	"github.com/projectcalico/calico/lib/std/cryptoutils"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+)
+
+func TestRequestsFromGuardianToUpstream(t *testing.T) {
+	logutils.ConfigureFormatter("guardian")
+	logutils.RedirectLogrusToTestingT(t)
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.DebugLevel)
+
+	RegisterTestingT(t)
+
+	tmpDir := os.TempDir()
+
+	mgmtCertFile, err := os.Create(tmpDir + "/" + "management-cluster.crt")
+	Expect(err).ShouldNot(HaveOccurred())
+	defer mgmtCertFile.Close()
+
+	mgmtKeyFile, err := os.Create(tmpDir + "/" + "management-cluster.key")
+	Expect(err).ShouldNot(HaveOccurred())
+	defer mgmtKeyFile.Close()
+
+	ca, err := cryptoutils.NewCA("test")
+	Expect(err).ShouldNot(HaveOccurred())
+
+	serverCert, err := ca.CreateServerCert("test-server-cert", []string{"localhost"})
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(serverCert.WriteCertificates(mgmtCertFile)).ShouldNot(HaveOccurred())
+	Expect(serverCert.WritePrivateKey(mgmtKeyFile)).ShouldNot(HaveOccurred())
+
+	// Generate managed cluster certificates to send requests to the management cluster.
+	createKeyCertPair(tmpDir, "managed-cluster.crt", "managed-cluster.key")
+
+	type obj struct {
+		Name string `json:"name"`
+	}
+
+	fooServerCert, fooServerKey := createKeyCertPair(tmpDir, "foo-server.crt", "foo-server.key")
+	go func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/foobar", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(obj{Name: "test-server-cert"})
+		})
+		srv := http.Server{
+			Addr:    "localhost:8999",
+			Handler: mux,
+		}
+		if err := srv.ListenAndServeTLS(fooServerCert, fooServerKey); err != nil {
+			panic(err)
+		}
+	}()
+
+	cfg := config.Config{
+		LogLevel:                "DEBUG",
+		CertPath:                tmpDir,
+		TunnelDialRetryAttempts: -1,
+		TunnelDialRetryInterval: 5 * time.Second,
+		TunnelDialTimeout:       5 * time.Second,
+		VoltronURL:              "localhost:8443",
+		KeepAliveEnable:         true,
+		KeepAliveInterval:       1000000,
+	}
+
+	tlsCfg := getTLSConfig(mgmtCertFile.Name(), mgmtKeyFile.Name())
+
+	upstreamSrv := newUpstreamServer(":8443", tlsCfg)
+	defer upstreamSrv.listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	daemonDoneSig := make(chan struct{})
+	go func() {
+		defer close(daemonDoneSig)
+
+		url, err := url2.Parse("https://localhost:8999")
+		Expect(err).ShouldNot(HaveOccurred())
+		daemon.Run(ctx, cfg, []server.Target{
+			{Path: "/", Dest: url, AllowInsecureTLS: true},
+		})
+	}()
+
+	mux := upstreamSrv.Accept()
+
+	http2Transport, err := http2.ConfigureTransports(http.DefaultTransport.(*http.Transport))
+	Expect(err).ShouldNot(HaveOccurred())
+
+	http2Conn := openHttp2TLSConn(http2Transport, mux)
+
+	req, err := http.NewRequest(http.MethodGet, "https://localhost:8999/foobar", nil)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	resp, err := http2Conn.RoundTrip(req)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+	defer resp.Body.Close()
+
+	var rspObj obj
+	Expect(json.NewDecoder(resp.Body).Decode(&rspObj)).ShouldNot(HaveOccurred())
+	Expect(rspObj).Should(Equal(obj{Name: "test-server-cert"}))
+
+	// Close the mux and allow guardian to try to reconnect, as we want to test that we can still use the tunnel after
+	// reconnecting.
+	t.Log("testing that we can use the tunnel after reconnecting")
+	mux.Close()
+	upstreamSrv.Close()
+	time.Sleep(10 * time.Second)
+
+	upstreamSrv = newUpstreamServer(":8443", tlsCfg)
+	mux = upstreamSrv.Accept()
+
+	http2Conn = openHttp2TLSConn(http2Transport, mux)
+
+	req, err = http.NewRequest(http.MethodGet, "https://localhost:8999/foobar", nil)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	resp, err = http2Conn.RoundTrip(req)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+	defer resp.Body.Close()
+
+	rspObj = obj{}
+	Expect(json.NewDecoder(resp.Body).Decode(&rspObj)).ShouldNot(HaveOccurred())
+	Expect(rspObj).Should(Equal(obj{Name: "test-server-cert"}))
+
+	cancel()
+	<-daemonDoneSig
+}
+
+func openHttp2TLSConn(http2Transport *http2.Transport, mux *yamux.Session) *http2.ClientConn {
+	conn, err := mux.Open()
+	Expect(err).ShouldNot(HaveOccurred())
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
+	})
+
+	Expect(tlsConn.Handshake()).ShouldNot(HaveOccurred())
+
+	http2Conn, err := http2Transport.NewClientConn(tlsConn)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return http2Conn
+}
+
+type upstreamServer struct {
+	listener net.Listener
+}
+
+func newUpstreamServer(addr string, tlsCfg *tls.Config) *upstreamServer {
+	serverListener := newTLSListener(addr, tlsCfg)
+
+	return &upstreamServer{
+		listener: serverListener,
+	}
+}
+
+func (ups *upstreamServer) Accept() *yamux.Session {
+	conn, err := ups.listener.Accept()
+	Expect(err).ShouldNot(HaveOccurred())
+
+	cfg := yamux.DefaultConfig()
+	cfg.AcceptBacklog = 1000
+	cfg.EnableKeepAlive = true
+	cfg.KeepAliveInterval = 10000
+
+	mux, err := yamux.Server(conn, cfg)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return mux
+}
+
+func (ups *upstreamServer) Close() {
+	_ = ups.listener.Close()
+}
+
+func newTLSListener(addr string, tlsCfg *tls.Config) net.Listener {
+	listener, err := net.Listen("tcp", addr)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return tls.NewListener(listener, tlsCfg)
+}
+
+func getTLSConfig(certPath, keyPath string) *tls.Config {
+	pemCert, err := os.ReadFile(certPath)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	pemKey, err := os.ReadFile(keyPath)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	cert, err := tls.X509KeyPair(pemCert, pemKey)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	tlsConfig, err := calicotls.NewTLSConfig()
+	Expect(err).ShouldNot(HaveOccurred())
+	tlsConfig.Certificates = []tls.Certificate{cert}
+	return tlsConfig
+}

--- a/guardian/tests/fv/util_test.go
+++ b/guardian/tests/fv/util_test.go
@@ -1,0 +1,32 @@
+package fv_test
+
+import (
+	"crypto/x509"
+	"os"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/lib/std/cryptoutils"
+)
+
+func createKeyCertPair(dir, certFileName, keyFileName string) (string, string) {
+	certPEM, keyPEM, err := cryptoutils.GenerateSelfSignedCert(
+		cryptoutils.WithDNSNames("localhost"),
+		cryptoutils.WithExtKeyUsages(x509.ExtKeyUsageAny))
+	Expect(err).ShouldNot(HaveOccurred())
+
+	certFile, err := os.Create(dir + "/" + certFileName)
+	Expect(err).ShouldNot(HaveOccurred())
+	defer certFile.Close()
+
+	keyFile, err := os.Create(dir + "/" + keyFileName)
+	Expect(err).ShouldNot(HaveOccurred())
+	defer keyFile.Close()
+
+	_, err = certFile.Write(certPEM)
+	Expect(err).ShouldNot(HaveOccurred())
+	_, err = keyFile.Write(keyPEM)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return certFile.Name(), keyFile.Name()
+}

--- a/lib/std/cryptoutils/ca.go
+++ b/lib/std/cryptoutils/ca.go
@@ -1,0 +1,275 @@
+package cryptoutils
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	mathrand "math/rand"
+	"net"
+	"time"
+)
+
+type CA interface {
+	AddToCertPool(pool *x509.CertPool) error
+	CreateServerCert(name string, hosts []string) (*TLSCertificate, error)
+	SignCertificate(template *x509.Certificate, requestKey crypto.PublicKey) (*x509.Certificate, error)
+	WriteCertificates(w io.Writer) error
+}
+
+type certificateAuthority struct {
+	cfg *TLSCertificate
+}
+
+type TLSCertificate struct {
+	certs []*x509.Certificate
+	key   crypto.PrivateKey
+}
+
+func NewCA(name string) (CA, error) {
+	rootCAPublicKey, rootCAPrivateKey, publicKeyHash, err := newKeyPairWithHash()
+	if err != nil {
+		return nil, err
+	}
+
+	subject := pkix.Name{CommonName: name}
+
+	// AuthorityKeyId and SubjectKeyId should match for a self-signed CA
+	authorityKeyId := publicKeyHash
+	subjectKeyId := publicKeyHash
+
+	caLifetime := 10 * 365 * 24 * time.Hour
+
+	rootCATemplate := &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore: time.Now().Add(-1 * time.Second),
+		NotAfter:  time.Now().Add(caLifetime),
+
+		// Specify a random serial number to avoid the same issuer+serial
+		// number referring to different certs in a chain of trust if the
+		// signing certificate is ever rotated.
+		SerialNumber: big.NewInt(randomSerialNumber()),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+
+		AuthorityKeyId: authorityKeyId,
+		SubjectKeyId:   subjectKeyId,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, rootCATemplate, rootCATemplate, rootCAPublicKey, rootCAPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) != 1 {
+		return nil, errors.New("expected a single certificate")
+	}
+
+	rootCACert := certs[0]
+
+	return &certificateAuthority{
+		cfg: &TLSCertificate{
+			certs: []*x509.Certificate{rootCACert},
+			key:   rootCAPrivateKey,
+		},
+	}, nil
+}
+
+func (ca *certificateAuthority) CreateServerCert(name string, hosts []string) (*TLSCertificate, error) {
+	serverPublicKey, serverPrivateKey, publicKeyHash, err := newKeyPairWithHash()
+	if err != nil {
+		return nil, err
+	}
+
+	authorityKeyId := ca.cfg.certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+
+	subject := pkix.Name{CommonName: name}
+	caLifetime := 10 * 365 * 24 * time.Hour
+	serverTemplate := &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore:    time.Now().Add(-1 * time.Second),
+		NotAfter:     time.Now().Add(caLifetime),
+		SerialNumber: big.NewInt(1),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+
+		AuthorityKeyId: authorityKeyId,
+		SubjectKeyId:   subjectKeyId,
+	}
+
+	serverTemplate.IPAddresses, serverTemplate.DNSNames = ipAddressesDNSNames(hosts)
+
+	serverCrt, err := ca.SignCertificate(serverTemplate, serverPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TLSCertificate{
+		certs: append([]*x509.Certificate{serverCrt}, ca.cfg.certs...),
+		key:   serverPrivateKey,
+	}, nil
+}
+
+func (ca *certificateAuthority) SignCertificate(template *x509.Certificate, requestKey crypto.PublicKey) (*x509.Certificate, error) {
+	// Increment and persist serial
+	serial := randomSerialNumber()
+
+	template.SerialNumber = big.NewInt(serial)
+	return signCertificate(template, requestKey, ca.cfg.certs[0], ca.cfg.key)
+}
+
+func (ca *certificateAuthority) AddToCertPool(pool *x509.CertPool) error {
+	for _, cert := range ca.cfg.certs {
+		pool.AddCert(cert)
+	}
+
+	return nil
+}
+
+func (ca *certificateAuthority) WriteCertificates(w io.Writer) error {
+	byts, err := encodeCertificates(ca.cfg.certs...)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(byts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cert *TLSCertificate) WriteCertificates(w io.Writer) error {
+	byts, err := encodeCertificates(cert.certs...)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(byts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func encodeCertificates(certs ...*x509.Certificate) ([]byte, error) {
+	b := bytes.Buffer{}
+	for _, cert := range certs {
+		if err := pem.Encode(&b, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return []byte{}, err
+		}
+	}
+	return b.Bytes(), nil
+}
+
+func (cert *TLSCertificate) WritePrivateKey(w io.Writer) error {
+	byts, err := encodeKey(cert.key)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(byts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func encodeKey(key crypto.PrivateKey) ([]byte, error) {
+	b := bytes.Buffer{}
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		keyBytes, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			return []byte{}, err
+		}
+		if err := pem.Encode(&b, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}); err != nil {
+			return b.Bytes(), err
+		}
+	case *rsa.PrivateKey:
+		if err := pem.Encode(&b, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+			return []byte{}, err
+		}
+	default:
+		return []byte{}, errors.New("unrecognized key type")
+
+	}
+	return b.Bytes(), nil
+}
+
+func signCertificate(template *x509.Certificate, requestKey crypto.PublicKey, issuer *x509.Certificate, issuerKey crypto.PrivateKey) (*x509.Certificate, error) {
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, issuer, requestKey, issuerKey)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) != 1 {
+		return nil, errors.New("expected a single certificate")
+	}
+	return certs[0], nil
+}
+
+func ipAddressesDNSNames(hosts []string) ([]net.IP, []string) {
+	var ips []net.IP
+	var dns []string
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			dns = append(dns, host)
+		}
+	}
+
+	// Include IP addresses as DNS subjectAltNames in the cert as well, for the sake of Python, Windows (< 10), and unnamed other libraries
+	// Ensure these technically invalid DNS subjectAltNames occur after the valid ones, to avoid triggering cert errors in Firefox
+	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1148766
+	for _, ip := range ips {
+		dns = append(dns, ip.String())
+	}
+
+	return ips, dns
+}
+
+// randomSerialNumber returns a random int64 serial number based on
+// time.Now. It is defined separately from the generator interface so
+// that the caller doesn't have to worry about an input template or
+// error - these are unnecessary when creating a random serial.
+func randomSerialNumber() int64 {
+	r := mathrand.New(mathrand.NewSource(time.Now().UTC().UnixNano()))
+	return r.Int63()
+}
+
+func newKeyPairWithHash() (crypto.PublicKey, crypto.PrivateKey, []byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	publicKey := &privateKey.PublicKey
+	var publicKeyHash []byte
+	hash := sha1.New()
+	hash.Write(publicKey.N.Bytes())
+	publicKeyHash = hash.Sum(nil)
+
+	return publicKey, privateKey, publicKeyHash, err
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This tests basic functionality where guardian connects and sends requests to the upstream.

This is just an initial test to commit something, more tests need to be added.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
