### PR TITLE
Replace the existing tc filter program

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -167,7 +167,7 @@ func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 }
 
 // AttachClassifier return the program id and pref and handle of the qdisc
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handle int) (int, int, int, error) {
 	cSecName := C.CString(secName)
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cSecName))
@@ -177,7 +177,7 @@ func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int) (
 		return -1, -1, -1, err
 	}
 
-	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio))
+	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio), C.int(handle))
 	if err != nil {
 		return -1, -1, -1, fmt.Errorf("error attaching tc program %w", err)
 	}

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,12 +50,16 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
-struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio)
+struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)
 {
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
 			.attach_point = ingress ? BPF_TC_INGRESS : BPF_TC_EGRESS,
 			);
 	DECLARE_LIBBPF_OPTS(bpf_tc_opts, attach, .priority=prio,);
+	if (prio) {
+		attach.handle = handle;
+		attach.flags = BPF_TC_F_REPLACE;
+	}
 
 	attach.prog_fd = bpf_program__fd(bpf_object__find_program_by_name(obj, secName));
 	if (attach.prog_fd < 0) {

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -73,7 +73,7 @@ func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 	panic("LIBBPF syscall stub")
 }
 
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handle int) (int, int, int, error) {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -120,12 +120,12 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 
 	/* XXX we should remember the tag of the program and skip the rest if the tag is
 	* still the same */
-	progsToClean, err := ap.listAttachedPrograms(true)
+	progsAttached, err := ap.listAttachedPrograms(true)
 	if err != nil {
 		return nil, err
 	}
 
-	prio := findFilterPriority(progsToClean)
+	prio, handle := findFilterPriority(progsAttached)
 	obj, err := ap.loadObject(binaryToLoad)
 	if err != nil {
 		logCxt.Warn("Failed to load program")
@@ -133,17 +133,12 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 	}
 	defer obj.Close()
 
-	res.progId, res.prio, res.handle, err = obj.AttachClassifier("cali_tc_preamble", ap.Iface, ap.Hook == hook.Ingress, prio)
+	res.progId, res.prio, res.handle, err = obj.AttachClassifier("cali_tc_preamble", ap.Iface, ap.Hook == hook.Ingress, prio, handle)
 	if err != nil {
 		logCxt.Warnf("Failed to attach to TC section cali_tc_preamble")
 		return nil, err
 	}
 	logCxt.Info("Program attached to TC.")
-
-	if err := ap.detachPrograms(progsToClean); err != nil {
-		return nil, err
-	}
-
 	return res, nil
 }
 
@@ -373,19 +368,26 @@ func RemoveQdisc(ifaceName string) error {
 	return libbpf.RemoveQDisc(ifaceName)
 }
 
-func findFilterPriority(progsToClean []attachedProg) int {
+func findFilterPriority(progsToClean []attachedProg) (int, int) {
 	prio := 0
+	handle := 0
 	for _, p := range progsToClean {
 		pref, err := strconv.Atoi(p.pref)
 		if err != nil {
 			continue
 		}
 
+		handle64, err := strconv.ParseInt(p.handle[2:], 16, 64)
+		if err != nil {
+			continue
+		}
+
 		if pref > prio {
 			prio = pref
+			handle = int(handle64)
 		}
 	}
-	return prio
+	return prio, handle
 }
 
 func (ap *AttachPoint) Config() string {

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -239,7 +239,7 @@ func (ap *AttachPoint) listAttachedPrograms(includeLegacy bool) ([]attachedProg,
 	}
 	// Lines look like this; the section name always includes calico.
 	// filter protocol all pref 49152 bpf chain 0 handle 0x1 to_hep_no_log.o:[calico_to_host_ep] direct-action not_in_hw id 821 tag ee402594f8f85ac3 jited
-	var progsToClean []attachedProg
+	var progsAttached []attachedProg
 	for _, line := range strings.Split(string(out), "\n") {
 		if !strings.Contains(line, "cali_tc_preambl") && (!includeLegacy || !strings.Contains(line, "calico")) {
 			continue
@@ -251,10 +251,10 @@ func (ap *AttachPoint) listAttachedPrograms(includeLegacy bool) ([]attachedProg,
 				handle: sm[2],
 			}
 			log.WithField("prog", p).Debug("Found old calico program")
-			progsToClean = append(progsToClean, p)
+			progsAttached = append(progsAttached, p)
 		}
 	}
-	return progsToClean, nil
+	return progsAttached, nil
 }
 
 // ProgramName returns the name of the program associated with this AttachPoint

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -818,8 +818,8 @@ func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
 
 }
 
-// This test verifies that we use the same tc priority but toggle between
-// handles when repeatedly attaching the preamble program.
+// This test verifies if the tc program gets replaced
+// and thus returns the same handle and priority.
 func TestRepeatedAttach(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -851,11 +851,7 @@ func TestRepeatedAttach(t *testing.T) {
 		tcRes, ok = res.(tc.AttachResult)
 		Expect(ok).To(BeTrue())
 		Expect(tcRes.Prio()).To(Equal(prio))
-		if i%2 == 0 {
-			Expect(tcRes.Handle()).To(Equal(handle + 1))
-		} else {
-			Expect(tcRes.Handle()).To(Equal(handle))
-		}
+		Expect(tcRes.Handle()).To(Equal(handle))
 	}
 }
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -108,11 +108,8 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				EndpointToHostAction: "RETURN",
 			},
 			BPFExtToServiceConnmark: 0,
-			FeatureGates: map[string]string{
-				"BPFConnectTimeLoadBalancingWorkaround": "enabled",
-			},
-			BPFPolicyDebugEnabled: true,
-			BPFIpv6Enabled:        ipv6Enabled,
+			BPFPolicyDebugEnabled:   true,
+			BPFIpv6Enabled:          ipv6Enabled,
 		},
 		bpfmaps,
 		regexp.MustCompile("^workloadep[0123]"),
@@ -557,10 +554,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 					EndpointToHostAction: "RETURN",
 				},
 				BPFExtToServiceConnmark: 0,
-				FeatureGates: map[string]string{
-					"BPFConnectTimeLoadBalancingWorkaround": "enabled",
-				},
-				BPFPolicyDebugEnabled: true,
+				BPFPolicyDebugEnabled:   true,
 			},
 			bpfmaps,
 			regexp.MustCompile("^workloadep[123]"),
@@ -686,10 +680,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 					EndpointToHostAction: "RETURN",
 				},
 				BPFExtToServiceConnmark: 0,
-				FeatureGates: map[string]string{
-					"BPFConnectTimeLoadBalancingWorkaround": "enabled",
-				},
-				BPFPolicyDebugEnabled: true,
+				BPFPolicyDebugEnabled:   true,
 			},
 			bpfmaps,
 			regexp.MustCompile("^workloadep[123]"),
@@ -746,10 +737,7 @@ func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
 				EndpointToHostAction: "RETURN",
 			},
 			BPFExtToServiceConnmark: 0,
-			FeatureGates: map[string]string{
-				"BPFConnectTimeLoadBalancingWorkaround": "enabled",
-			},
-			BPFPolicyDebugEnabled: true,
+			BPFPolicyDebugEnabled:   true,
 		},
 		bpfmaps,
 		regexp.MustCompile("^workloadep[123]"),
@@ -872,10 +860,7 @@ func TestRepeatedAttach(t *testing.T) {
 				EndpointToHostAction: "RETURN",
 			},
 			BPFExtToServiceConnmark: 0,
-			FeatureGates: map[string]string{
-				"BPFConnectTimeLoadBalancingWorkaround": "enabled",
-			},
-			BPFPolicyDebugEnabled: true,
+			BPFPolicyDebugEnabled:   true,
 		},
 		bpfmaps,
 		regexp.MustCompile("^workloadep[123]"),
@@ -921,11 +906,8 @@ func TestLogFilters(t *testing.T) {
 			EndpointToHostAction: "RETURN",
 		},
 		BPFExtToServiceConnmark: 0,
-		FeatureGates: map[string]string{
-			"BPFConnectTimeLoadBalancingWorkaround": "enabled",
-		},
-		BPFPolicyDebugEnabled: true,
-		BPFLogFilters:         map[string]string{"hostep1": "tcp"},
+		BPFPolicyDebugEnabled:   true,
+		BPFLogFilters:           map[string]string{"hostep1": "tcp"},
 	}
 
 	bpfEpMgr, err := newBPFTestEpMgr(


### PR DESCRIPTION
## Description

This PR replaces the existing Tc program instead of attaching a new program in the same priority. 
1. If there are no programs attached to interface, hook, attach a new program.
2. If there is a program already attached to interface, hook, replace the existing program at the same priority, handle. 

This fixes https://github.com/projectcalico/calico/issues/10376
## Related issues/PRs

https://github.com/projectcalico/calico/issues/10376

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Fixed attaching bpf programs by atomically replacing the old program rather than attaching new and detaching old.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
