### PR TITLE
[BPF] repurpose unused mark for CALI_SKB_MARK_TUNNEL_KEY_SET

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -204,10 +204,10 @@ enum calico_skb_mark {
 	 * know that and we have resolved NAT etc.
 	 */
 	CALI_SKB_MARK_RELATED_RESOLVED        = 0x21000000,
-	/* CALI_SKB_MARK_TO_NAT_IFACE_OUT signals to routing that this packet should to
-	 * to the bpfnatout interface.
+	/* CALI_SKB_MARK_TUNNEL_KEY_SET indicates to tunnel device, that the key
+	 * is already set. If not, it needs to set it itself.
 	 */
-	CALI_SKB_MARK_TO_NAT_IFACE_OUT        = 0x41000000,
+	CALI_SKB_MARK_TUNNEL_KEY_SET        = 0x41000000,
 	/* CALI_SKB_MARK_FROM_NAT_IFACE_OUT signals to the next hop that the packet passed
 	 * through bpfnatout so that it can set its conntrack correctly.
 	 */

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -165,6 +165,7 @@ skip_redir_ifindex:
 
 			int err = bpf_skb_set_tunnel_key(ctx->skb, &key, size, flags);
 			CALI_DEBUG("bpf_skb_set_tunnel_key %d nh " IP_FMT, err, &dest_rt->next_hop);
+			ctx->fwd.mark |= CALI_SKB_MARK_TUNNEL_KEY_SET;
 
 			rc = bpf_redirect(state->ct_result.ifindex_fwd, 0);
 			if (rc == TC_ACT_REDIRECT) {
@@ -174,7 +175,8 @@ skip_redir_ifindex:
 			}
 		}
 	} else if (CALI_F_VXLAN && CALI_F_TO_HEP) {
-		if (!(ctx->skb->mark & CALI_SKB_MARK_SEEN) || (ctx->fwd.mark & CALI_SKB_MARK_FROM_NAT_IFACE_OUT)) {
+		if (!(ctx->skb->mark & CALI_SKB_MARK_SEEN) ||
+			!skb_mark_equals(ctx->skb, CALI_SKB_MARK_TUNNEL_KEY_SET, CALI_SKB_MARK_TUNNEL_KEY_SET)) {
 			/* packet to vxlan from the host, needs to set tunnel key. Either
 			 * it wasn't seen or it was routed via the bpfnat device because
 			 * its destination was a service and CTLB is disabled
@@ -207,6 +209,7 @@ skip_redir_ifindex:
 
 			int err = bpf_skb_set_tunnel_key(ctx->skb, &key, size, flags);
 			CALI_DEBUG("bpf_skb_set_tunnel_key %d nh " IP_FMT, err, &dest_rt->next_hop);
+			ctx->fwd.mark |= CALI_SKB_MARK_TUNNEL_KEY_SET;
 		}
 	}
 

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -317,8 +317,6 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 			 ct_result_rc(ctx->state->ct_result.rc) == CALI_CT_ESTABLISHED_BYPASS) &&
 			ctx->state->ct_result.flags & CALI_CT_FLAG_VIA_NAT_IF) {
 		CALI_DEBUG("should route via bpfnatout");
-		ctx->fwd.mark |= CALI_SKB_MARK_TO_NAT_IFACE_OUT;
-		/* bpfnatout need to process the packet */
 		ct_result_set_rc(ctx->state->ct_result.rc, CALI_CT_ESTABLISHED);
 	}
 

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -40,7 +40,7 @@ const (
 	MarkLinuxConntrackEstablished     = 0x08000000
 	MarkLinuxConntrackEstablishedMask = 0x08000000
 
-	MarkSeenToNatIfaceOut   = 0x41000000
+	MarkSeenTunnelKeySet    = 0x41000000
 	MarkSeenFromNatIfaceOut = 0x81000000
 
 	MarksMask uint32 = 0x1ff00000


### PR DESCRIPTION
CALI_SKB_MARK_TO_NAT_IFACE_OUT is not used and we need a bit to tell tunnel (vxlan) that the tunnel has been already set. We could set the tunnel always at the vxlan device, however, for workloads, we have alredy done some lookups that we would need to duplicate at the tunnel device. At the same time, packets from host do no thave it set yet and we need to distinguish those. Especially when they are looped via the bpfin.cali device where the seen flag is already set.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
