### PR TITLE
[release-v3.30] Auto pick #10425: Pin ctlb programs

### DIFF
--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,6 +22,7 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
+	CtlbPinDir  = "ctlb"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,7 +22,7 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
-	CtlbPinDir  = "ctlb"
+	CtlbPinDir   = "ctlb"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -191,7 +191,7 @@ func DetachCTLBProgramsLegacy(cgroup string) error {
 }
 
 // AttachClassifier return the program id and pref and handle of the qdisc
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handle int) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int, handle uint32) (int, int, int, error) {
 	cSecName := C.CString(secName)
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cSecName))
@@ -201,7 +201,7 @@ func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handl
 		return -1, -1, -1, err
 	}
 
-	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio), C.int(handle))
+	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio), C.uint(handle))
 	if err != nil {
 		return -1, -1, -1, fmt.Errorf("error attaching tc program %w", err)
 	}

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -15,6 +15,7 @@
 package libbpf
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -31,6 +32,16 @@ import (
 // #cgo arm64 LDFLAGS: -L${SRCDIR}/../../bpf-gpl/libbpf/src/arm64 -lbpf -lelf -lz
 // #include "libbpf_api.h"
 import "C"
+
+const (
+	PROG_TYPE_CGROUP_INET4_CONNECT = iota
+	PROG_TYPE_CGROUP_INET4_SENDMSG
+	PROG_TYPE_CGROUP_INET4_RECVMSG
+	PROG_TYPE_CGROUP_INET6_CONNECT
+	PROG_TYPE_CGROUP_INET6_SENDMSG
+	PROG_TYPE_CGROUP_INET6_RECVMSG
+	PROG_TYPE_MAX
+)
 
 type Obj struct {
 	obj *C.struct_bpf_object
@@ -163,6 +174,17 @@ func QueryClassifier(ifindex, handle, pref int, ingress bool) (int, error) {
 func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 	_, err := C.bpf_tc_program_detach(C.int(ifindex), C.int(handle), C.int(pref), C.bool(ingress))
 
+	return err
+}
+
+func DetachCTLBProgramsLegacy(targetFd int) error {
+	var err error
+	for i := PROG_TYPE_CGROUP_INET4_CONNECT; i < PROG_TYPE_MAX; i++ {
+		_, perr := C.bpf_ctlb_detach_legacy(C.int(targetFd), C.int(i))
+		if perr != nil {
+			errors.Join(err, perr)
+		}
+	}
 	return err
 }
 
@@ -313,6 +335,13 @@ func (l *Link) Pin(path string) error {
 		return nil
 	}
 	return fmt.Errorf("link nil")
+}
+
+func DetachLink(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	_, err := C.bpf_detach_link(cPath)
+	return err
 }
 
 func (o *Obj) UpdateLink(path, progName string) error {

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -302,6 +302,32 @@ func (l *Link) Close() error {
 	return fmt.Errorf("link nil")
 }
 
+func (l *Link) Pin(path string) error {
+	if l.link != nil {
+		cPath := C.CString(path)
+		defer C.free(unsafe.Pointer(cPath))
+		errno := C.bpf_link__pin(l.link, cPath)
+		if errno != 0 {
+			return fmt.Errorf("faild to pin link to %s: %w", path, syscall.Errno(errno))
+		}
+		return nil
+	}
+	return fmt.Errorf("link nil")
+}
+
+func (o *Obj) UpdateLink(path, progName string) error {
+	cPath := C.CString(path)
+	cProgName := C.CString(progName)
+	defer C.free(unsafe.Pointer(cPath))
+	defer C.free(unsafe.Pointer(cProgName))
+
+	_, err := C.bpf_update_link(o.obj, cProgName, cPath)
+	if err != nil {
+		return fmt.Errorf("error updating link %w", err)
+	}
+	return nil
+}
+
 func CreateQDisc(ifName string) error {
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cIfName))

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -72,14 +72,9 @@ int bpf_update_link(struct bpf_link *link, struct bpf_object *obj, char *progNam
 	return err;
 }
 
-int bpf_ctlb_detach_legacy(int target_fd, int prog_type) {
+int bpf_ctlb_detach_legacy(int target_fd, int attach_type) {
 	int err;
-	int attach_type = bpf_attach_type(prog_type);
 	__u32 attach_flags, prog_cnt, prog_id;
-	if (attach_type == -1) {
-		err = EINVAL;
-		goto out;
-	}
 
 	err = bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt);
 	if (err) {

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,6 +50,24 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
+int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
+{
+	struct bpf_link *link = bpf_link__open(path);
+	int err = libbpf_get_error(link);
+	if (err) {
+		return err;
+	}
+	struct bpf_program *prog = bpf_object__find_program_by_name(obj, progName);
+        if (prog == NULL) {
+                errno = ENOENT;
+                return -1;
+        }
+
+	err = bpf_link__update_program(link, prog);
+	set_errno(err);
+	return err;
+}
+
 struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)
 {
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -92,8 +92,8 @@ int bpf_ctlb_detach_legacy(int target_fd, int prog_type) {
 		goto out;
 	}
 
-	if (bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt)) {
-		err = ENOENT;
+	err = bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt);
+	if (err) {
 		goto out;
 	}
 	int prog_fd = bpf_prog_get_fd_by_id(prog_id);

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -91,7 +91,7 @@ out:
         return err;
 }
 
-struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)
+struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, uint handle)
 {
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
 			.attach_point = ingress ? BPF_TC_INGRESS : BPF_TC_EGRESS,

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,11 +50,26 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
+int bpf_detach_link(char *path)
+{
+	struct bpf_link *link = bpf_link__open(path);
+	int err = libbpf_get_error(link);
+	if (err) {
+		set_errno(err);
+		return err;
+	}
+
+	err = bpf_link__detach(link);
+	set_errno(err);
+	return err;
+}
+
 int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
 {
 	struct bpf_link *link = bpf_link__open(path);
 	int err = libbpf_get_error(link);
 	if (err) {
+		set_errno(err);
 		return err;
 	}
 	struct bpf_program *prog = bpf_object__find_program_by_name(obj, progName);
@@ -66,6 +81,30 @@ int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
 	err = bpf_link__update_program(link, prog);
 	set_errno(err);
 	return err;
+}
+
+int bpf_ctlb_detach_legacy(int target_fd, int prog_type) {
+	int err;
+	int attach_type = bpf_attach_type(prog_type);
+	__u32 attach_flags, prog_cnt, prog_id;
+	if (attach_type == -1) {
+		err = EINVAL;
+		goto out;
+	}
+
+	if (bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt)) {
+		err = ENOENT;
+		goto out;
+	}
+	int prog_fd = bpf_prog_get_fd_by_id(prog_id);
+	if (prog_fd < 0) {
+		err = -prog_fd;
+		goto out;
+	}
+	err = bpf_prog_detach2(prog_fd, target_fd, attach_type);
+out:
+        set_errno(err);
+        return err;
 }
 
 struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,35 +50,24 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
-int bpf_detach_link(char *path)
-{
+struct bpf_link *bpf_link_open(char *path) {
 	struct bpf_link *link = bpf_link__open(path);
 	int err = libbpf_get_error(link);
 	if (err) {
 		set_errno(err);
-		return err;
+		return NULL;
 	}
-
-	err = bpf_link__detach(link);
-	set_errno(err);
-	return err;
+	return link;
 }
 
-int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
+int bpf_update_link(struct bpf_link *link, struct bpf_object *obj, char *progName)
 {
-	struct bpf_link *link = bpf_link__open(path);
-	int err = libbpf_get_error(link);
-	if (err) {
-		set_errno(err);
-		return err;
-	}
 	struct bpf_program *prog = bpf_object__find_program_by_name(obj, progName);
         if (prog == NULL) {
                 errno = ENOENT;
                 return -1;
         }
-
-	err = bpf_link__update_program(link, prog);
+	int err = bpf_link__update_program(link, prog);
 	set_errno(err);
 	return err;
 }

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -73,7 +73,7 @@ func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 	panic("LIBBPF syscall stub")
 }
 
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handle int) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int, handle uint32) (int, int, int, error) {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -133,6 +133,22 @@ func (l *Link) Pin(_ string) error {
 	panic("LIBBPF syscall stub")
 }
 
+func (l *Link) Update(obj *Obj, progName string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (l *Link) Close() error {
+	panic("LIBBPF syscall stub")
+}
+
+func OpenLink(path string) (*Link, error) {
+	panic("LIBBPF syscall stub")
+}
+
+func (l *Link) Detach() error {
+	panic("LIBBPF syscall stub")
+}
+
 func DetachCTLBProgramsLegacy(_ string) error {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -93,6 +93,14 @@ func (o *Obj) AttachCGroup(_, _ string) (*Link, error) {
 	panic("LIBBPF syscall stub")
 }
 
+func (o *Obj) AttachCGroupLegacy(_, _ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (o *Obj) UpdateLink(_, _ string) error {
+	panic("LIBBPF syscall stub")
+}
+
 func (o *Obj) PinPrograms(_ string) error {
 	panic("LIBBPF syscall stub")
 }
@@ -114,6 +122,18 @@ func CreateQDisc(ifName string) error {
 }
 
 func RemoveQDisc(ifName string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func DetachLink(_ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (l *Link) Pin(_ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func DetachCTLBProgramsLegacy(_ string) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -75,10 +76,48 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 		return errors.Wrap(err, "Failed to mount bpffs")
 	}
 
-	bpf.CleanUpCalicoPins(path.Join(bpfMount, bpfdefs.CtlbPinDir))
+	pinDir := path.Join(bpfMount, bpfdefs.CtlbPinDir)
+	if err := detachCtlbPrograms(pinDir, cgroupv2); err != nil {
+		return err
+	}
+	bpf.CleanUpCalicoPins(pinDir)
 	ctlbProgsMap := newProgramsMap()
 	os.Remove(ctlbProgsMap.Path())
 	return nil
+}
+
+func detachCtlbPrograms(pinDir, cgroupv2 string) error {
+	err := filepath.Walk(pinDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(info.Name(), "cali_") || strings.HasPrefix(info.Name(), "calico_") {
+			log.WithField("path", path).Debug("Detaching pinned link")
+			err = libbpf.DetachLink(path)
+			if err != nil {
+				log.WithField("path", path).Error("Error detaching link")
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		log.Errorf("error detaching link %w", err)
+		return err
+	}
+	if err == nil {
+		return nil
+	}
+	return DetachLegacyCtlb(pinDir)
+}
+
+func DetachLegacyCtlb(cgroupv2 string) error {
+	cg, err := os.Open(cgroupv2)
+	if err != nil {
+		return fmt.Errorf("error opening cgroup root %s : %w", cgroupv2, err)
+	}
+	defer cg.Close()
+	return libbpf.DetachCTLBProgramsLegacy(int(cg.Fd()))
 }
 
 func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bool) (*libbpf.Obj, error) {
@@ -105,7 +144,11 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 		return fmt.Errorf("failed to attach program %s: %w", progName, err)
 	}
 	if link != nil {
-		link.Pin(progPinDir)
+		defer link.Close()
+		err := link.Pin(progPinDir)
+		if err != nil {
+			return fmt.Errorf("failed to pin program %s:%w", progName, err)
+		}
 	}
 	log.WithFields(log.Fields{"program": progName, "cgroup": cgroupPath}).Info("Loaded cgroup program")
 
@@ -267,6 +310,5 @@ func ensureCgroupPath(cgroupv2 string) (string, error) {
 			return "", errors.Wrap(err, "failed to create cgroup")
 		}
 	}
-	log.Infof("Sridhar Cgroup path %s", cgroupPath)
 	return cgroupPath, nil
 }

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -15,12 +15,9 @@
 package nat
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -73,47 +70,14 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 		return nil
 	}
 
-	cgroupPath, err := ensureCgroupPath(cgroupv2)
+	bpfMount, err := utils.MaybeMountBPFfs()
 	if err != nil {
-		return errors.Wrap(err, "failed to set-up cgroupv2")
+		return errors.Wrap(err, "Failed to mount bpffs")
 	}
 
-	cmd := exec.Command("bpftool", "-j", "-p", "cgroup", "show", cgroupPath)
-	log.WithField("args", cmd.Args).Info("Running bpftool to look up programs attached to cgroup")
-	out, err := cmd.Output()
-	if err != nil || strings.TrimSpace(string(out)) == "" {
-		log.WithError(err).WithField("output", string(out)).Info(
-			"Failed to list BPF programs.  Assuming not supported/nothing to clean up.")
-		return err
-	}
-
-	var progs []cgroupProgs
-
-	err = json.Unmarshal(out, &progs)
-	if err != nil {
-		log.WithError(err).WithField("output", string(out)).Error("BPF program list not json.")
-		return err
-	}
-
-	for _, p := range progs {
-		if !strings.HasPrefix(p.Name, "cali_") {
-			continue
-		}
-
-		cmd = exec.Command("bpftool", "cgroup", "detach", cgroupPath, p.AttachType, "id", strconv.Itoa(p.ID))
-		log.WithField("args", cmd.Args).Info("Running bpftool to detach program")
-		out, err = cmd.CombinedOutput()
-		if err != nil {
-			log.WithError(err).WithField("output", string(out)).Error(
-				"Failed to detach connect-time load balancing program.")
-			return err
-		}
-	}
-
-	bpf.CleanUpCalicoPins("/sys/fs/bpf/calico_connect4")
+	bpf.CleanUpCalicoPins(path.Join(bpfMount, bpfdefs.CtlbPinDir))
 	ctlbProgsMap := newProgramsMap()
 	os.Remove(ctlbProgsMap.Path())
-
 	return nil
 }
 
@@ -127,18 +91,22 @@ func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bo
 }
 
 func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Duration, excludeUDP bool, obj *libbpf.Obj) error {
-
-	progPinDir := path.Join(bpfMount, "calico_connect4")
-	_ = os.RemoveAll(progPinDir)
-
 	progName := "calico_" + name + "_v" + ipver
-
-	// N.B. no need to remember the link since we are never going to detach
-	// these programs unless Felix restarts.
-	if _, err := obj.AttachCGroup(cgroupPath, progName); err != nil {
-		return fmt.Errorf("failed to attach program %s: %w", progName, err)
+	progPinDir := path.Join(bpfMount, progName)
+	if _, err := os.Stat(progPinDir); err == nil {
+		if err := obj.UpdateLink(progPinDir, progName); err != nil {
+			return fmt.Errorf("error updating program %s : %w", progName, err)
+		}
+		return nil
 	}
 
+	link, err := obj.AttachCGroup(cgroupPath, progName)
+	if err != nil {
+		return fmt.Errorf("failed to attach program %s: %w", progName, err)
+	}
+	if link != nil {
+		link.Pin(progPinDir)
+	}
 	log.WithFields(log.Fields{"program": progName, "cgroup": cgroupPath}).Info("Loaded cgroup program")
 
 	return nil
@@ -161,10 +129,15 @@ func updateCTLBJumpMap(jumpMap maps.Map, obj *libbpf.Obj) error {
 }
 
 func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
-
 	bpfMount, err := utils.MaybeMountBPFfs()
 	if err != nil {
 		log.WithError(err).Error("Failed to mount bpffs, unable to do connect-time load balancing")
+		return err
+	}
+
+	pinDir := path.Join(bpfMount, bpfdefs.CtlbPinDir)
+	if err = os.MkdirAll(pinDir, 0700); err != nil {
+		log.WithError(err).Error("Failed to create pin dir, unable to do connect-time load balancing")
 		return err
 	}
 
@@ -189,32 +162,32 @@ func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 stri
 			return err
 		}
 		defer v46Obj.Close()
-		err = attachProgram("connect", "4", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v4Obj)
+		err = attachProgram("connect", "4", pinDir, cgroupPath, udpNotSeen, excludeUDP, v4Obj)
 		if err != nil {
 			return err
 		}
-		err = attachProgram("connect", "46", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v46Obj)
+		err = attachProgram("connect", "46", pinDir, cgroupPath, udpNotSeen, excludeUDP, v46Obj)
 		if err != nil {
 			return err
 		}
 
 		if !excludeUDP {
-			err = attachProgram("sendmsg", "4", bpfMount, cgroupPath, udpNotSeen, false, v4Obj)
+			err = attachProgram("sendmsg", "4", pinDir, cgroupPath, udpNotSeen, false, v4Obj)
 			if err != nil {
 				return err
 			}
 
-			err = attachProgram("recvmsg", "4", bpfMount, cgroupPath, udpNotSeen, false, v4Obj)
+			err = attachProgram("recvmsg", "4", pinDir, cgroupPath, udpNotSeen, false, v4Obj)
 			if err != nil {
 				return err
 			}
 
-			err = attachProgram("sendmsg", "46", bpfMount, cgroupPath, udpNotSeen, false, v46Obj)
+			err = attachProgram("sendmsg", "46", pinDir, cgroupPath, udpNotSeen, false, v46Obj)
 			if err != nil {
 				return err
 			}
 
-			err = attachProgram("recvmsg", "46", bpfMount, cgroupPath, udpNotSeen, false, v46Obj)
+			err = attachProgram("recvmsg", "46", pinDir, cgroupPath, udpNotSeen, false, v46Obj)
 			if err != nil {
 				return err
 			}
@@ -294,5 +267,6 @@ func ensureCgroupPath(cgroupv2 string) (string, error) {
 			return "", errors.Wrap(err, "failed to create cgroup")
 		}
 	}
+	log.Infof("Sridhar Cgroup path %s", cgroupPath)
 	return cgroupPath, nil
 }

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -376,7 +376,7 @@ func findFilterPriority(progsToClean []attachedProg) (int, int) {
 			continue
 		}
 
-		handle64, err := strconv.ParseInt(p.handle[2:], 16, 64)
+		handle64, err := strconv.ParseInt(p.handle[2:], 16, 32)
 		if err != nil {
 			continue
 		}

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -17,6 +17,7 @@ package tc
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os/exec"
 	"path"
@@ -367,23 +368,23 @@ func RemoveQdisc(ifaceName string) error {
 	return libbpf.RemoveQDisc(ifaceName)
 }
 
-func findFilterPriority(progsToClean []attachedProg) (int, int) {
+func findFilterPriority(progsToClean []attachedProg) (int, uint32) {
 	prio := 0
-	handle := 0
+	handle := uint32(0)
 	for _, p := range progsToClean {
 		pref, err := strconv.Atoi(p.pref)
 		if err != nil {
 			continue
 		}
 
-		handle64, err := strconv.ParseInt(p.handle[2:], 16, 32)
-		if err != nil {
+		handle64, err := strconv.ParseUint(p.handle[2:], 16, 32)
+		if err != nil || (handle64 < 0 || handle64 > math.MaxUint32) {
 			continue
 		}
 
 		if pref > prio {
 			prio = pref
-			handle = int(handle64)
+			handle = uint32(handle64)
 		}
 	}
 	return prio, handle

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -17,7 +17,6 @@ package tc
 import (
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"os/exec"
 	"path"
@@ -378,7 +377,7 @@ func findFilterPriority(progsToClean []attachedProg) (int, uint32) {
 		}
 
 		handle64, err := strconv.ParseUint(p.handle[2:], 16, 32)
-		if err != nil || (handle64 < 0 || handle64 > math.MaxUint32) {
+		if err != nil {
 			continue
 		}
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -890,9 +890,43 @@ func TestRepeatedAttach(t *testing.T) {
 	Expect(newHandle).To(Equal(handle))
 }
 
+func TestCTLBAttachLegacy(t *testing.T) {
+	RegisterTestingT(t)
+	err := nat.InstallConnectTimeLoadBalancerLegacy(true, false, "", "debug", 60*time.Second, false)
+	Expect(err).NotTo(HaveOccurred())
+
+	checkPinPath := func(pinPath string, mustExist bool) {
+		_, err := os.Stat(pinPath)
+		if mustExist {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	}
+
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
+
+	cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err := cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
+
+	err = nat.RemoveConnectTimeLoadBalancer("")
+	Expect(err).NotTo(HaveOccurred())
+
+	cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err = cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
+}
+
 func TestCTLBAttach(t *testing.T) {
 	RegisterTestingT(t)
-
 	err := nat.InstallConnectTimeLoadBalancer(true, false, "", "debug", 60*time.Second, false)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -20,11 +20,13 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -36,6 +38,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/tc"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	"github.com/projectcalico/calico/felix/calc"
@@ -885,6 +888,48 @@ func TestRepeatedAttach(t *testing.T) {
 	Expect(valid).To(BeTrue())
 	Expect(newPrio).To(Equal(prio))
 	Expect(newHandle).To(Equal(handle))
+}
+
+func TestCTLBAttach(t *testing.T) {
+	RegisterTestingT(t)
+
+	err := nat.InstallConnectTimeLoadBalancer(true, false, "", "debug", 60*time.Second, false)
+	Expect(err).NotTo(HaveOccurred())
+
+	checkPinPath := func(pinPath string, mustExist bool) {
+		_, err := os.Stat(pinPath)
+		if mustExist {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	}
+
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", true)
+
+	cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err := cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
+
+	err = nat.RemoveConnectTimeLoadBalancer("")
+	Expect(err).NotTo(HaveOccurred())
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
+
+	cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err = cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
 }
 
 func TestLogFilters(t *testing.T) {


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10425 on release-v3.30.

#10425: Pin ctlb programs

# Original PR Body below

## Description

Below are the changes in this PR
1. Pin the links returned by attaching programs to CGROUPS to the BPF FS. This results in CTLB working during felix restarts.
2. If there is a program attached and link already pinned, just update the link.
3. In the case of legacy kernels, we already had support for attaching CTLB and we were using bpftool to detach programs. This PR has the changes to detach the CTLB programs using APIs.
4. Add UTs to attach and detach CTLB programs for both legacy and non legacy way.

## Related issues/PRs

refs https://github.com/projectcalico/calico/issues/9620

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF - Fixed attaching and detaching CTLB programs
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.