### PR TITLE
[release-v3.29] Auto pick #10466: Pin ctlb programs

### DIFF
--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,6 +22,7 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
+	CtlbPinDir  = "ctlb"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,7 +22,7 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
-	CtlbPinDir  = "ctlb"
+	CtlbPinDir   = "ctlb"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -191,7 +191,7 @@ func DetachCTLBProgramsLegacy(cgroup string) error {
 }
 
 // AttachClassifier return the program id and pref and handle of the qdisc
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handle int) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int, handle uint32) (int, int, int, error) {
 	cSecName := C.CString(secName)
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cSecName))
@@ -201,7 +201,7 @@ func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handl
 		return -1, -1, -1, err
 	}
 
-	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio), C.int(handle))
+	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio), C.uint(handle))
 	if err != nil {
 		return -1, -1, -1, fmt.Errorf("error attaching tc program %w", err)
 	}

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -302,6 +302,32 @@ func (l *Link) Close() error {
 	return fmt.Errorf("link nil")
 }
 
+func (l *Link) Pin(path string) error {
+	if l.link != nil {
+		cPath := C.CString(path)
+		defer C.free(unsafe.Pointer(cPath))
+		errno := C.bpf_link__pin(l.link, cPath)
+		if errno != 0 {
+			return fmt.Errorf("faild to pin link to %s: %w", path, syscall.Errno(errno))
+		}
+		return nil
+	}
+	return fmt.Errorf("link nil")
+}
+
+func (o *Obj) UpdateLink(path, progName string) error {
+	cPath := C.CString(path)
+	cProgName := C.CString(progName)
+	defer C.free(unsafe.Pointer(cPath))
+	defer C.free(unsafe.Pointer(cProgName))
+
+	_, err := C.bpf_update_link(o.obj, cProgName, cPath)
+	if err != nil {
+		return fmt.Errorf("error updating link %w", err)
+	}
+	return nil
+}
+
 func CreateQDisc(ifName string) error {
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cIfName))

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -72,14 +72,9 @@ int bpf_update_link(struct bpf_link *link, struct bpf_object *obj, char *progNam
 	return err;
 }
 
-int bpf_ctlb_detach_legacy(int target_fd, int prog_type) {
+int bpf_ctlb_detach_legacy(int target_fd, int attach_type) {
 	int err;
-	int attach_type = bpf_attach_type(prog_type);
 	__u32 attach_flags, prog_cnt, prog_id;
-	if (attach_type == -1) {
-		err = EINVAL;
-		goto out;
-	}
 
 	err = bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt);
 	if (err) {

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,6 +50,24 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
+int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
+{
+	struct bpf_link *link = bpf_link__open(path);
+	int err = libbpf_get_error(link);
+	if (err) {
+		return err;
+	}
+	struct bpf_program *prog = bpf_object__find_program_by_name(obj, progName);
+        if (prog == NULL) {
+                errno = ENOENT;
+                return -1;
+        }
+
+	err = bpf_link__update_program(link, prog);
+	set_errno(err);
+	return err;
+}
+
 struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)
 {
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -92,8 +92,8 @@ int bpf_ctlb_detach_legacy(int target_fd, int prog_type) {
 		goto out;
 	}
 
-	if (bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt)) {
-		err = ENOENT;
+	err = bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt);
+	if (err) {
 		goto out;
 	}
 	int prog_fd = bpf_prog_get_fd_by_id(prog_id);

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -91,7 +91,7 @@ out:
         return err;
 }
 
-struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)
+struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, uint handle)
 {
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
 			.attach_point = ingress ? BPF_TC_INGRESS : BPF_TC_EGRESS,

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,11 +50,26 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
+int bpf_detach_link(char *path)
+{
+	struct bpf_link *link = bpf_link__open(path);
+	int err = libbpf_get_error(link);
+	if (err) {
+		set_errno(err);
+		return err;
+	}
+
+	err = bpf_link__detach(link);
+	set_errno(err);
+	return err;
+}
+
 int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
 {
 	struct bpf_link *link = bpf_link__open(path);
 	int err = libbpf_get_error(link);
 	if (err) {
+		set_errno(err);
 		return err;
 	}
 	struct bpf_program *prog = bpf_object__find_program_by_name(obj, progName);
@@ -66,6 +81,30 @@ int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
 	err = bpf_link__update_program(link, prog);
 	set_errno(err);
 	return err;
+}
+
+int bpf_ctlb_detach_legacy(int target_fd, int prog_type) {
+	int err;
+	int attach_type = bpf_attach_type(prog_type);
+	__u32 attach_flags, prog_cnt, prog_id;
+	if (attach_type == -1) {
+		err = EINVAL;
+		goto out;
+	}
+
+	if (bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt)) {
+		err = ENOENT;
+		goto out;
+	}
+	int prog_fd = bpf_prog_get_fd_by_id(prog_id);
+	if (prog_fd < 0) {
+		err = -prog_fd;
+		goto out;
+	}
+	err = bpf_prog_detach2(prog_fd, target_fd, attach_type);
+out:
+        set_errno(err);
+        return err;
 }
 
 struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, int handle)

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,35 +50,24 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
-int bpf_detach_link(char *path)
-{
+struct bpf_link *bpf_link_open(char *path) {
 	struct bpf_link *link = bpf_link__open(path);
 	int err = libbpf_get_error(link);
 	if (err) {
 		set_errno(err);
-		return err;
+		return NULL;
 	}
-
-	err = bpf_link__detach(link);
-	set_errno(err);
-	return err;
+	return link;
 }
 
-int bpf_update_link(struct bpf_object *obj, char *progName, char *path)
+int bpf_update_link(struct bpf_link *link, struct bpf_object *obj, char *progName)
 {
-	struct bpf_link *link = bpf_link__open(path);
-	int err = libbpf_get_error(link);
-	if (err) {
-		set_errno(err);
-		return err;
-	}
 	struct bpf_program *prog = bpf_object__find_program_by_name(obj, progName);
         if (prog == NULL) {
                 errno = ENOENT;
                 return -1;
         }
-
-	err = bpf_link__update_program(link, prog);
+	int err = bpf_link__update_program(link, prog);
 	set_errno(err);
 	return err;
 }

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -94,6 +94,14 @@ func (o *Obj) AttachCGroup(_, _ string) (*Link, error) {
 	panic("LIBBPF syscall stub")
 }
 
+func (o *Obj) AttachCGroupLegacy(_, _ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (o *Obj) UpdateLink(_, _ string) error {
+	panic("LIBBPF syscall stub")
+}
+
 func (o *Obj) PinPrograms(_ string) error {
 	panic("LIBBPF syscall stub")
 }
@@ -115,6 +123,18 @@ func CreateQDisc(ifName string) error {
 }
 
 func RemoveQDisc(ifName string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func DetachLink(_ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (l *Link) Pin(_ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func DetachCTLBProgramsLegacy(_ string) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -74,7 +74,7 @@ func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 	panic("LIBBPF syscall stub")
 }
 
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio, handle int) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int, handle uint32) (int, int, int, error) {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -134,6 +134,22 @@ func (l *Link) Pin(_ string) error {
 	panic("LIBBPF syscall stub")
 }
 
+func (l *Link) Update(obj *Obj, progName string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func (l *Link) Close() error {
+	panic("LIBBPF syscall stub")
+}
+
+func OpenLink(path string) (*Link, error) {
+	panic("LIBBPF syscall stub")
+}
+
+func (l *Link) Detach() error {
+	panic("LIBBPF syscall stub")
+}
+
 func DetachCTLBProgramsLegacy(_ string) error {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -90,7 +90,13 @@ func detachCtlbPrograms(pinDir, cgroupv2 string) error {
 		if strings.HasPrefix(info.Name(), "cali_") || strings.HasPrefix(info.Name(), "calico_") {
 			numLinksDetached++
 			log.WithField("path", path).Debug("Detaching pinned link")
-			err = libbpf.DetachLink(path)
+			link, err := libbpf.OpenLink(path)
+			if err != nil {
+				log.WithField("path", path).Error("Error opening link")
+				return err
+			}
+			defer link.Close()
+			err = link.Detach()
 			if err != nil {
 				log.WithField("path", path).Error("Error detaching link")
 				return err
@@ -160,9 +166,14 @@ func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bo
 
 func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Duration, excludeUDP bool, obj *libbpf.Obj, legacy bool) error {
 	progName := "calico_" + name + "_v" + ipver
-	progPinDir := path.Join(bpfMount, progName)
-	if _, err := os.Stat(progPinDir); err == nil {
-		if err := obj.UpdateLink(progPinDir, progName); err != nil {
+	progPinPath := path.Join(bpfMount, progName)
+	if _, err := os.Stat(progPinPath); err == nil {
+		link, err := libbpf.OpenLink(progPinPath)
+		if err != nil {
+			return fmt.Errorf("error opening link %s : %w", progPinPath, err)
+		}
+		defer link.Close()
+		if err := link.Update(obj, progName); err != nil {
 			return fmt.Errorf("error updating program %s : %w", progName, err)
 		}
 		return nil
@@ -188,7 +199,7 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 	}
 	if link != nil {
 		defer link.Close()
-		err := link.Pin(progPinDir)
+		err := link.Pin(progPinPath)
 		if err != nil {
 			return fmt.Errorf("failed to pin program %s:%w", progName, err)
 		}

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf"
@@ -66,7 +65,7 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 
 	bpfMount, err := utils.MaybeMountBPFfs()
 	if err != nil {
-		return errors.Wrap(err, "Failed to mount bpffs")
+		return fmt.Errorf("failed to mount bpffs: %w", err)
 	}
 
 	pinDir := path.Join(bpfMount, bpfdefs.CtlbPinDir)
@@ -117,7 +116,7 @@ func detachCtlbPrograms(pinDir, cgroupv2 string) error {
 func detachLegacyCtlb(cgroupv2 string) error {
 	cgroupPath, err := ensureCgroupPath(cgroupv2)
 	if err != nil {
-		return errors.Wrap(err, "failed to set-up cgroupv2")
+		return fmt.Errorf("failed to set-up cgroupv2: %w", err)
 	}
 	return libbpf.DetachCTLBProgramsLegacy(cgroupPath)
 }
@@ -196,8 +195,7 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 			return fmt.Errorf("failed to attach program %s: %w", progName, err)
 		}
 		link = nil
-	}
-	if link != nil {
+	} else if link != nil {
 		defer link.Close()
 		err := link.Pin(progPinPath)
 		if err != nil {
@@ -239,7 +237,7 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 
 	cgroupPath, err := ensureCgroupPath(cgroupv2)
 	if err != nil {
-		return errors.Wrap(err, "failed to set-up cgroupv2")
+		return fmt.Errorf("failed to set-up cgroupv2: %w", err)
 	}
 
 	ctlbProgsMap := newProgramsMap()
@@ -368,7 +366,7 @@ func ensureCgroupPath(cgroupv2 string) (string, error) {
 		err = os.MkdirAll(cgroupPath, 0766)
 		if err != nil {
 			log.WithError(err).Error("Failed to make cgroup")
-			return "", errors.Wrap(err, "failed to create cgroup")
+			return "", fmt.Errorf("failed to create cgroup: %w", err)
 		}
 	}
 	return cgroupPath, nil

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -34,13 +34,6 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/utils"
 )
 
-type cgroupProgs struct {
-	ID          int    `json:"id"`
-	AttachType  string `json:"attach_type"`
-	AttachFlags string `json:"attach_flags"`
-	Name        string `json:"name"`
-}
-
 const (
 	ProgIndexCTLBConnectV6 = iota
 	ProgIndexCTLBSendV6
@@ -77,21 +70,25 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 	}
 
 	pinDir := path.Join(bpfMount, bpfdefs.CtlbPinDir)
+	defer bpf.CleanUpCalicoPins(pinDir)
+	ctlbProgsMap := newProgramsMap()
+	defer os.Remove(ctlbProgsMap.Path())
+
 	if err := detachCtlbPrograms(pinDir, cgroupv2); err != nil {
 		return err
 	}
 	bpf.CleanUpCalicoPins(pinDir)
-	ctlbProgsMap := newProgramsMap()
-	os.Remove(ctlbProgsMap.Path())
 	return nil
 }
 
 func detachCtlbPrograms(pinDir, cgroupv2 string) error {
+	numLinksDetached := 0
 	err := filepath.Walk(pinDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if strings.HasPrefix(info.Name(), "cali_") || strings.HasPrefix(info.Name(), "calico_") {
+			numLinksDetached++
 			log.WithField("path", path).Debug("Detaching pinned link")
 			err = libbpf.DetachLink(path)
 			if err != nil {
@@ -102,22 +99,21 @@ func detachCtlbPrograms(pinDir, cgroupv2 string) error {
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
-		log.Errorf("error detaching link %w", err)
+		log.WithError(err).Error("error detaching link")
 		return err
 	}
-	if err == nil {
-		return nil
+	if numLinksDetached == 0 {
+		return detachLegacyCtlb(cgroupv2)
 	}
-	return DetachLegacyCtlb(pinDir)
+	return nil
 }
 
-func DetachLegacyCtlb(cgroupv2 string) error {
-	cg, err := os.Open(cgroupv2)
+func detachLegacyCtlb(cgroupv2 string) error {
+	cgroupPath, err := ensureCgroupPath(cgroupv2)
 	if err != nil {
-		return fmt.Errorf("error opening cgroup root %s : %w", cgroupv2, err)
+		return errors.Wrap(err, "failed to set-up cgroupv2")
 	}
-	defer cg.Close()
-	return libbpf.DetachCTLBProgramsLegacy(int(cg.Fd()))
+	return libbpf.DetachCTLBProgramsLegacy(cgroupPath)
 }
 
 func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bool) (*libbpf.Obj, error) {
@@ -162,7 +158,7 @@ func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bo
 	return obj, nil
 }
 
-func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Duration, excludeUDP bool, obj *libbpf.Obj) error {
+func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Duration, excludeUDP bool, obj *libbpf.Obj, legacy bool) error {
 	progName := "calico_" + name + "_v" + ipver
 	progPinDir := path.Join(bpfMount, progName)
 	if _, err := os.Stat(progPinDir); err == nil {
@@ -172,9 +168,23 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 		return nil
 	}
 
+	// Used only for UT to test legacy way to attach.
+	if legacy {
+		err := obj.AttachCGroupLegacy(cgroupPath, progName)
+		if err != nil {
+			return fmt.Errorf("failed to attach program %s: %w", progName, err)
+		}
+		return nil
+	}
+
+	// Tries non-legacy and fallsback to legacy if non-legacy fails.
 	link, err := obj.AttachCGroup(cgroupPath, progName)
 	if err != nil {
-		return fmt.Errorf("failed to attach program %s: %w", progName, err)
+		err = obj.AttachCGroupLegacy(cgroupPath, progName)
+		if err != nil {
+			return fmt.Errorf("failed to attach program %s: %w", progName, err)
+		}
+		link = nil
 	}
 	if link != nil {
 		defer link.Close()
@@ -184,7 +194,6 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 		}
 	}
 	log.WithFields(log.Fields{"program": progName, "cgroup": cgroupPath}).Info("Loaded cgroup program")
-
 	return nil
 }
 
@@ -204,7 +213,7 @@ func updateCTLBJumpMap(jumpMap maps.Map, obj *libbpf.Obj) error {
 	return nil
 }
 
-func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
+func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP, legacy bool) error {
 	bpfMount, err := utils.MaybeMountBPFfs()
 	if err != nil {
 		log.WithError(err).Error("Failed to mount bpffs, unable to do connect-time load balancing")
@@ -238,32 +247,32 @@ func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 stri
 			return err
 		}
 		defer v46Obj.Close()
-		err = attachProgram("connect", "4", pinDir, cgroupPath, udpNotSeen, excludeUDP, v4Obj)
+		err = attachProgram("connect", "4", pinDir, cgroupPath, udpNotSeen, excludeUDP, v4Obj, legacy)
 		if err != nil {
 			return err
 		}
-		err = attachProgram("connect", "46", pinDir, cgroupPath, udpNotSeen, excludeUDP, v46Obj)
+		err = attachProgram("connect", "46", pinDir, cgroupPath, udpNotSeen, excludeUDP, v46Obj, legacy)
 		if err != nil {
 			return err
 		}
 
 		if !excludeUDP {
-			err = attachProgram("sendmsg", "4", pinDir, cgroupPath, udpNotSeen, false, v4Obj)
+			err = attachProgram("sendmsg", "4", pinDir, cgroupPath, udpNotSeen, false, v4Obj, legacy)
 			if err != nil {
 				return err
 			}
 
-			err = attachProgram("recvmsg", "4", pinDir, cgroupPath, udpNotSeen, false, v4Obj)
+			err = attachProgram("recvmsg", "4", pinDir, cgroupPath, udpNotSeen, false, v4Obj, legacy)
 			if err != nil {
 				return err
 			}
 
-			err = attachProgram("sendmsg", "46", pinDir, cgroupPath, udpNotSeen, false, v46Obj)
+			err = attachProgram("sendmsg", "46", pinDir, cgroupPath, udpNotSeen, false, v46Obj, legacy)
 			if err != nil {
 				return err
 			}
 
-			err = attachProgram("recvmsg", "46", pinDir, cgroupPath, udpNotSeen, false, v46Obj)
+			err = attachProgram("recvmsg", "46", pinDir, cgroupPath, udpNotSeen, false, v46Obj, legacy)
 			if err != nil {
 				return err
 			}
@@ -291,18 +300,18 @@ func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 stri
 				return err
 			}
 		} else {
-			err = attachProgram("connect", "6", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v6Obj)
+			err = attachProgram("connect", "6", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v6Obj, legacy)
 			if err != nil {
 				return err
 			}
 
 			if !excludeUDP {
-				err = attachProgram("sendmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj)
+				err = attachProgram("sendmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj, legacy)
 				if err != nil {
 					return err
 				}
 
-				err = attachProgram("recvmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj)
+				err = attachProgram("recvmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj, legacy)
 				if err != nil {
 					return err
 				}
@@ -310,6 +319,14 @@ func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 stri
 		}
 	}
 	return nil
+}
+
+func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
+	return installCTLB(ipv4Enabled, ipv6Enabled, cgroupv2, logLevel, udpNotSeen, excludeUDP, false)
+}
+
+func InstallConnectTimeLoadBalancerLegacy(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
+	return installCTLB(ipv4Enabled, ipv6Enabled, cgroupv2, logLevel, udpNotSeen, excludeUDP, true)
 }
 
 func ProgFileName(logLevel string, ipver string) string {

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -17,7 +17,6 @@ package tc
 import (
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"os/exec"
 	"path"
@@ -393,7 +392,7 @@ func findFilterPriority(progsToClean []attachedProg) (int, uint32) {
 		}
 
 		handle64, err := strconv.ParseUint(p.handle[2:], 16, 32)
-		if err != nil || (handle64 < 0 || handle64 > math.MaxUint32) {
+		if err != nil {
 			continue
 		}
 

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -17,6 +17,7 @@ package tc
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os/exec"
 	"path"
@@ -382,23 +383,23 @@ func RemoveQdisc(ifaceName string) error {
 	return libbpf.RemoveQDisc(ifaceName)
 }
 
-func findFilterPriority(progsToClean []attachedProg) (int, int) {
+func findFilterPriority(progsToClean []attachedProg) (int, uint32) {
 	prio := 0
-	handle := 0
+	handle := uint32(0)
 	for _, p := range progsToClean {
 		pref, err := strconv.Atoi(p.pref)
 		if err != nil {
 			continue
 		}
 
-		handle64, err := strconv.ParseInt(p.handle[2:], 16, 32)
-		if err != nil {
+		handle64, err := strconv.ParseUint(p.handle[2:], 16, 32)
+		if err != nil || (handle64 < 0 || handle64 > math.MaxUint32) {
 			continue
 		}
 
 		if pref > prio {
 			prio = pref
-			handle = int(handle64)
+			handle = uint32(handle64)
 		}
 	}
 	return prio, handle

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -391,7 +391,7 @@ func findFilterPriority(progsToClean []attachedProg) (int, int) {
 			continue
 		}
 
-		handle64, err := strconv.ParseInt(p.handle[2:], 16, 64)
+		handle64, err := strconv.ParseInt(p.handle[2:], 16, 32)
 		if err != nil {
 			continue
 		}

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -20,11 +20,13 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -36,6 +38,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/tc"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	linux "github.com/projectcalico/calico/felix/dataplane/linux"
@@ -841,6 +844,48 @@ func TestRepeatedAttach(t *testing.T) {
 	Expect(valid).To(BeTrue())
 	Expect(newPrio).To(Equal(prio))
 	Expect(newHandle).To(Equal(handle))
+}
+
+func TestCTLBAttach(t *testing.T) {
+	RegisterTestingT(t)
+
+	err := nat.InstallConnectTimeLoadBalancer(true, false, "", "debug", 60*time.Second, false)
+	Expect(err).NotTo(HaveOccurred())
+
+	checkPinPath := func(pinPath string, mustExist bool) {
+		_, err := os.Stat(pinPath)
+		if mustExist {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	}
+
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", true)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", true)
+
+	cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err := cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
+
+	err = nat.RemoveConnectTimeLoadBalancer("")
+	Expect(err).NotTo(HaveOccurred())
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
+
+	cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err = cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
 }
 
 func TestLogFilters(t *testing.T) {

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -846,9 +846,43 @@ func TestRepeatedAttach(t *testing.T) {
 	Expect(newHandle).To(Equal(handle))
 }
 
+func TestCTLBAttachLegacy(t *testing.T) {
+	RegisterTestingT(t)
+	err := nat.InstallConnectTimeLoadBalancerLegacy(true, false, "", "debug", 60*time.Second, false)
+	Expect(err).NotTo(HaveOccurred())
+
+	checkPinPath := func(pinPath string, mustExist bool) {
+		_, err := os.Stat(pinPath)
+		if mustExist {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	}
+
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
+	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
+
+	cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err := cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
+
+	err = nat.RemoveConnectTimeLoadBalancer("")
+	Expect(err).NotTo(HaveOccurred())
+
+	cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+	out, err = cmd.Output()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
+}
+
 func TestCTLBAttach(t *testing.T) {
 	RegisterTestingT(t)
-
 	err := nat.InstallConnectTimeLoadBalancer(true, false, "", "debug", 60*time.Second, false)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10466 on release-v3.29.

#10466: Pin ctlb programs

# Original PR Body below

Cherry pick of projectcalico/calico/pull/10425 on release-v3.30.

#10425: Pin ctlb programs

# Original PR Body below

## Description

Below are the changes in this PR
1. Pin the links returned by attaching programs to CGROUPS to the BPF FS. This results in CTLB working during felix restarts.
2. If there is a program attached and link already pinned, just update the link.
3. In the case of legacy kernels, we already had support for attaching CTLB and we were using bpftool to detach programs. This PR has the changes to detach the CTLB programs using APIs.
4. Add UTs to attach and detach CTLB programs for both legacy and non legacy way.

## Related issues/PRs

refs https://github.com/projectcalico/calico/issues/9620

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF - Fixed attaching and detaching CTLB programs
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.