### PR TITLE
OpenStack-level support for peakrate control

### DIFF
--- a/networking-calico/networking_calico/common/config.py
+++ b/networking-calico/networking_calico/common/config.py
@@ -48,12 +48,40 @@ SHARED_OPTS = [
                help="When in a multi-region OpenStack deployment, a unique "
                     "name for the region that this node (controller or "
                     "compute) belongs to."),
-    # Max connection options, in advance of max connection support being added
-    # properly to the Neutron API.
+
+    # Options for QoS parameters that are supported on the Calico
+    # WorkloadEndpoint resource but not (yet) represented on the Neutron API.
+    #
+    # The complete mapping between OpenStack-level config/API and the Calico
+    # WorkloadEndpoint.QoSControls is as follows.
+    #
+    # | QoSControls field     | Neutron API field     | Config field                     |
+    # |-----------------------+-----------------------+----------------------------------|
+    # | IngressBandwidth      | max_kbps * 1000       |                                  |
+    # | EgressBandwidth       | max_kbps * 1000       |                                  |
+    # | IngressBurst          |                       | ingress_burst_kbits * 1000       |
+    # | EgressBurst           |                       | egress_burst_kbits * 1000        |
+    # | IngressPeakrate       | max_burst_kbps * 1000 |                                  |
+    # | EgressPeakrate        | max_burst_kbps * 1000 |                                  |
+    # | IngressMinburst       |                       | ingress_minburst_bytes           |
+    # | EgressMinburst        |                       | egress_minburst_bytes            |
+    # | IngressPacketRate     | max_kpps * 1000       |                                  |
+    # | EgressPacketRate      | max_kpps * 1000       |                                  |
+    # | IngressMaxConnections |                       | max_ingress_connections_per_port |
+    # | EgressMaxConnections  |                       | max_egress_connections_per_port  |
+    #
     cfg.IntOpt('max_ingress_connections_per_port', default=0,
                help="If non-zero, a maximum number of ingress connections to impose on each port."),
     cfg.IntOpt('max_egress_connections_per_port', default=0,
                help="If non-zero, a maximum number of egress connections to impose on each port."),
+    cfg.IntOpt('ingress_burst_kbits', default=0,
+               help="If non-zero, configures the maximum allowed burst at peakrate, in the ingress direction."),
+    cfg.IntOpt('egress_burst_kbits', default=0,
+               help="If non-zero, configures the maximum allowed burst at peakrate, in the egress direction."),
+    cfg.IntOpt('ingress_minburst_bytes', default=0,
+               help="If non-zero, configures the minimum burst size for peakrate data, in the ingress direction."),
+    cfg.IntOpt('egress_minburst_bytes', default=0,
+               help="If non-zero, configures the minimum burst size for peakrate data, in the egress direction."),
 ]
 
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -339,15 +339,9 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                 LOG.debug("BW rule = %r", r)
                 direction = r.get('direction', 'egress')
                 if r['max_kbps'] != 0:
-                    if direction == "egress":
-                        qos['egressBandwidth'] = r['max_kbps'] * 1000
-                    else:
-                        qos['ingressBandwidth'] = r['max_kbps'] * 1000
+                    qos[direction+'Bandwidth'] = r['max_kbps'] * 1000
                 if r['max_burst_kbps'] != 0:
-                    if direction == "egress":
-                        qos['egressBurst'] = r['max_burst_kbps'] * 1000
-                    else:
-                        qos['ingressBurst'] = r['max_burst_kbps'] * 1000
+                    qos[direction+'Peakrate'] = r['max_burst_kbps'] * 1000
 
             rules = context.session.query(
                 qos_models.QosPacketRateLimitRule
@@ -358,15 +352,20 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                 LOG.debug("PR rule = %r", r)
                 direction = r.get('direction', 'egress')
                 if r['max_kpps'] != 0:
-                    if direction == "egress":
-                        qos['egressPacketRate'] = r['max_kpps'] * 1000
-                    else:
-                        qos['ingressPacketRate'] = r['max_kpps'] * 1000
+                    qos[direction+'PacketRate'] = r['max_kpps'] * 1000
 
         if cfg.CONF.calico.max_ingress_connections_per_port != 0:
             qos['ingressMaxConnections'] = cfg.CONF.calico.max_ingress_connections_per_port
         if cfg.CONF.calico.max_egress_connections_per_port != 0:
             qos['egressMaxConnections'] = cfg.CONF.calico.max_egress_connections_per_port
+        if cfg.CONF.calico.ingress_burst_kbits != 0:
+            qos['ingressBurst'] = cfg.CONF.calico.ingress_burst_kbits * 1000
+        if cfg.CONF.calico.egress_burst_kbits != 0:
+            qos['egressBurst'] = cfg.CONF.calico.egress_burst_kbits * 1000
+        if cfg.CONF.calico.ingress_minburst_bytes != 0:
+            qos['ingressMinburst'] = cfg.CONF.calico.ingress_minburst_bytes
+        if cfg.CONF.calico.egress_minburst_bytes != 0:
+            qos['egressMinburst'] = cfg.CONF.calico.egress_minburst_bytes
 
         port_extra.qos = qos
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -355,6 +355,10 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_compat.cfg.CONF.calico.openstack_region = self.region
         lib.m_compat.cfg.CONF.calico.max_ingress_connections_per_port = 0
         lib.m_compat.cfg.CONF.calico.max_egress_connections_per_port = 0
+        lib.m_compat.cfg.CONF.calico.ingress_burst_kbits = 0
+        lib.m_compat.cfg.CONF.calico.egress_burst_kbits = 0
+        lib.m_compat.cfg.CONF.calico.ingress_minburst_bytes = 0
+        lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 0
         calico_config._reset_globals()
         datamodel_v2._reset_globals()
 
@@ -941,6 +945,10 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # Add configuration for max connections.
         lib.m_compat.cfg.CONF.calico.max_ingress_connections_per_port = 10
         lib.m_compat.cfg.CONF.calico.max_egress_connections_per_port = 20
+        lib.m_compat.cfg.CONF.calico.ingress_burst_kbits = 31
+        lib.m_compat.cfg.CONF.calico.egress_burst_kbits = 41
+        lib.m_compat.cfg.CONF.calico.ingress_minburst_bytes = 1651
+        lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 1761
         self.driver.update_port_postcommit(context)
 
         # Expected changes
@@ -948,6 +956,10 @@ class TestPluginEtcdBase(_TestEtcdBase):
             'egressBandwidth': 10000000,
             'ingressMaxConnections': 10,
             'egressMaxConnections': 20,
+            'ingressBurst': 31000,
+            'egressBurst': 41000,
+            'ingressMinburst': 1651,
+            'egressMinburst': 1761,
         }
         expected_writes = {
             ep_hello_key_v3: ep_hello_value_v3,
@@ -965,12 +977,16 @@ class TestPluginEtcdBase(_TestEtcdBase):
         ep_hello_value_v3['spec']['qosControls'] = {
             'ingressBandwidth': 1000,
             'egressBandwidth': 3000,
-            'ingressBurst': 2000,
-            'egressBurst': 4000,
+            'ingressPeakrate': 2000,
+            'egressPeakrate': 4000,
             'ingressPacketRate': 5000,
             'egressPacketRate': 6000,
             'ingressMaxConnections': 10,
             'egressMaxConnections': 20,
+            'ingressBurst': 31000,
+            'egressBurst': 41000,
+            'ingressMinburst': 1651,
+            'egressMinburst': 1761,
         }
         expected_writes = {
             ep_hello_key_v3: ep_hello_value_v3,
@@ -982,6 +998,10 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # Reset for future tests.
         lib.m_compat.cfg.CONF.calico.max_ingress_connections_per_port = 0
         lib.m_compat.cfg.CONF.calico.max_egress_connections_per_port = 0
+        lib.m_compat.cfg.CONF.calico.ingress_burst_kbits = 0
+        lib.m_compat.cfg.CONF.calico.egress_burst_kbits = 0
+        lib.m_compat.cfg.CONF.calico.ingress_minburst_bytes = 0
+        lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 0
 
         # Set a QoS policy on the network instead of directly on the port.
         #


### PR DESCRIPTION
Add the Calico-specific config parameters.

Change our current bandwidth rule coding so that:

- it configures burst size using the new Calico-specific parameters instead of max_burst_kbps

- it uses max_burst_kbps to configure the peakrate

- it configures the minburst size using new Calico-specific parameters.

## Release Note

```release-note
TBD
```