### PR TITLE
chore:  #HELM Allow to specify goldman and whisker crd spec

### DIFF
--- a/charts/tigera-operator/templates/crs/custom-resources.yaml
+++ b/charts/tigera-operator/templates/crs/custom-resources.yaml
@@ -24,20 +24,25 @@ spec:
 {{ end }}
 
 {{ if .Values.goldmane.enabled }}
+{{ $goldmaneSpec := omit .Values.goldmane "enabled" }}
 ---
 
 apiVersion: operator.tigera.io/v1
 kind: Goldmane
 metadata:
   name: default
-
+spec:
+{{ $goldmaneSpec | toYaml | indent 2 }}
 {{ end }}
 
 {{ if .Values.whisker.enabled }}
+{{ $whiskerSpec := omit .Values.whisker "enabled" }}
 ---
 
 apiVersion: operator.tigera.io/v1
 kind: Whisker
 metadata:
   name: default
+spec:
+{{ $whiskerSpec | toYaml | indent 2 }}
 {{ end }}


### PR DESCRIPTION
## Description

With recent release new Goldmane and Whisker services are added. I would like to have an option to specify those CRDs  spec from tigera operator values instead of creating separate resources. 
Looks like CRD is ready to tune this its. You can check this by running for example 'kubectl explain whisker.spec.whiskerDeployment.spec.template.spec.containers.resources' to check whenever it is possible to set resources for it.


## Related issues/PRs

No issue created/

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add Goldmane + Whisker CRD specs to helm values.yaml
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
