### PR TITLE
[release-v3.29] Auto pick #10503: Fix mounting cgroupv2 into calico-node

### DIFF
--- a/node/cmd/mountns/main.go
+++ b/node/cmd/mountns/main.go
@@ -49,11 +49,11 @@ import (
 __attribute__((constructor)) void set_namespaces(void) {
 	// open /initproc/ns/cgroup, which is equivalent to /proc/1/ns/cgroup on host.
 	// Then run setns syscall to change the cgroup namespace to this value.
-	setns(open("/initproc/ns/cgroup", O_RDONLY, 0), CLONE_NEWCGROUP);
+	setns(open("/nodeproc/1/ns/cgroup", O_RDONLY, 0), CLONE_NEWCGROUP);
 
-	// open /initproc/ns/mnt, which is equivalent to /proc/1/ns/mnt on host.
+	// open /nodeproc/1/ns/mnt, which is equivalent to /proc/1/ns/mnt on host.
 	// Then run setns syscall to change the mount namespace to this value.
-	setns(open("/initproc/ns/mnt", O_RDONLY, 0), CLONE_NEWNS);
+	setns(open("/nodeproc/1/ns/mnt", O_RDONLY, 0), CLONE_NEWNS);
 } */
 import "C"
 

--- a/node/cmd/mountns/main.go
+++ b/node/cmd/mountns/main.go
@@ -27,8 +27,8 @@ import (
 // we need to mount root cgroup at /run/calico/cgroup (where felix expects it), not the one
 // allocated by k8s to calico-node. This binary takes the following steps to solve it:
 // - Enter the namespace root before mounting cgroup2 fs. (Usually, /proc/1/ns points to
-//   the root of all namespaces, however, we mount /proc/1 on host at /initproc on calico-node pod,
-//   so /initproc/ns is the root of namespaces.)
+//   the root of all namespaces, however, we mount /proc on host at /nodeproc on calico-node pod,
+//   so /nodeproc/1/ns is the root of namespaces.)
 // - Mount root cgroups fs at /run/calico/cgroup.
 
 // The following C code is executed as a cgo constructor which runs before the main function.
@@ -47,7 +47,7 @@ import (
 #include <fcntl.h>
 
 __attribute__((constructor)) void set_namespaces(void) {
-	// open /initproc/ns/cgroup, which is equivalent to /proc/1/ns/cgroup on host.
+	// open /nodeproc/1/ns/cgroup, which is equivalent to /proc/1/ns/cgroup on host.
 	// Then run setns syscall to change the cgroup namespace to this value.
 	setns(open("/nodeproc/1/ns/cgroup", O_RDONLY, 0), CLONE_NEWCGROUP);
 


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10503 on release-v3.29.

#10503: Fix mounting cgroupv2 into calico-node

# Original PR Body below

## Description

calico-node mounts the host's cgroupv2 to install CTLB. This is done by entering the cgroup namespace of the host which is at ```/proc/1/ns/cgroup``` and ```/proc/1/ns/mnt```. 

In the operator, we mount ```/proc``` into ```/nodeproc```  at https://github.com/tigera/operator/blob/master/pkg/render/node.go#L1055. In the mountns utility we were still using the wrong path to enter into the host ns which resulted in cgroupv2 not mounted.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF - Fixed mounting cgroupv2 for connect time load balancing.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.