### PR TITLE
[BPF] fix regression for multihomed nodes

### DIFF
--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -124,6 +124,7 @@ skip_redir_ifindex:
 		}
 
 		if (state->ct_result.ifindex_fwd == CT_INVALID_IFINDEX) {
+			CALI_DEBUG("ifindex_fwd is CT_INVALID_IFINDEX, doing FIB lookup");
 			*fib_params(ctx) = (struct bpf_fib_lookup) {
 #ifdef IPVER6
 				.family = 10, /* AF_INET6 */
@@ -268,7 +269,7 @@ try_fib_external:
 			rc = bpf_redirect_neigh(state->ct_result.ifindex_fwd, NULL, 0, 0);
 			if (rc == TC_ACT_REDIRECT) {
 				counter_inc(ctx, CALI_REDIRECT_NEIGH);
-				CALI_DEBUG("Redirect to dev %d without fib lookup", state->ct_result.ifindex_fwd);
+				CALI_DEBUG("Redirect to host dev %d without fib lookup", state->ct_result.ifindex_fwd);
 				goto no_fib_redirect;
 			}
 			CALI_DEBUG("Fall through to full FIB lookup rc %d", rc);

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -9,35 +9,39 @@
 #include "skb.h"
 #include "routes.h"
 
-static CALI_BPF_INLINE bool wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
+#define RPF_RES_FAIL	0
+#define RPF_RES_STRICT	1
+#define RPF_RES_LOOSE	2
+
+static CALI_BPF_INLINE int wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
         CALI_DEBUG("Workload RPF check src=" IP_FMT " skb iface=%d.",
                         debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
         if (!r) {
                 CALI_INFO("Workload RPF fail: missing route.");
-                return false;
+                return RPF_RES_FAIL;
         }
 #ifdef IPVER6
 	if (ctx->state->ip_proto == IPPROTO_ICMPV6) {
-		return true;
+		return RPF_RES_STRICT;
 	}
 #endif
         if (!cali_rt_flags_local_workload(r->flags)) {
                 CALI_INFO("Workload RPF fail: not a local workload.");
-                return false;
+                return RPF_RES_FAIL;
         }
         if (r->if_index != ctx->skb->ifindex) {
                 CALI_INFO("Workload RPF fail skb iface (%d) != route iface (%d)",
                                 ctx->skb->ifindex, r->if_index);
-                return false;
+                return RPF_RES_FAIL;
         }
 
-        return true;
+        return RPF_RES_STRICT;
 }
 
-static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
+static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 {
-	bool ret = false;
+	int ret = RPF_RES_FAIL;
 	bool strict;
 #ifdef IPVER6
 	bool linkLocal = false;
@@ -86,7 +90,9 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 		case BPF_FIB_LKUP_RET_SUCCESS:
 		case BPF_FIB_LKUP_RET_NO_NEIGH:
 			if (strict) {
-				ret = ctx->skb->ingress_ifindex == fib_params.ifindex;
+				if (ctx->skb->ingress_ifindex == fib_params.ifindex) {
+					ret = RPF_RES_STRICT;
+				}
 #ifdef IPVER6
 #ifdef VERIFIER_IS_COOL
 				CALI_DEBUG("Host RPF check skb strict if %d", fib_params.ifindex);
@@ -96,7 +102,11 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			} else {
-				ret = fib_params.ifindex != CT_INVALID_IFINDEX;
+				if (ctx->skb->ingress_ifindex == fib_params.ifindex) {
+					ret = RPF_RES_STRICT;
+				} else if (fib_params.ifindex != CT_INVALID_IFINDEX) {
+					ret = RPF_RES_LOOSE;
+				}
 #ifdef IPVER6
 #ifdef VERIFIER_IS_COOL
 				CALI_DEBUG("Host RPF check skb loose if %d", fib_params.ifindex);
@@ -110,7 +120,7 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 #ifdef IPVER6
 		case BPF_FIB_LKUP_RET_NOT_FWDED:
 			if (linkLocal) {
-				ret = true;
+				ret = RPF_RES_STRICT;
 			}
 			break;
 #endif

--- a/felix/fv/bpf_multi_home_test.go
+++ b/felix/fv/bpf_multi_home_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
+)
+
+var (
+	_ = describeBPFMultiHomedTests()
+)
+
+func describeBPFMultiHomedTests() bool {
+	if !BPFMode() {
+		return true
+	}
+	desc := fmt.Sprintf("_BPF_ _BPF-SAFE_ BPF multi-homed tests")
+	return infrastructure.DatastoreDescribe(desc, []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+		var (
+			infra        infrastructure.DatastoreInfra
+			tc           infrastructure.TopologyContainers
+			calicoClient client.Interface
+			Felix        *infrastructure.Felix
+			w            *workload.Workload
+		)
+
+		BeforeEach(func() {
+			infra = getInfra()
+			opts := infrastructure.DefaultTopologyOptions()
+			opts.IPIPMode = api.IPIPModeNever
+			opts.SimulateBIRDRoutes = true
+			opts.FelixLogSeverity = "Debug"
+			opts.ExtraEnvVars["FELIX_BPFLogLevel"] = "Debug"
+			tc, calicoClient = infrastructure.StartNNodeTopology(2, opts, infra)
+			Felix = tc.Felixes[0]
+
+			w = workload.New(Felix, "workload", "default", "10.65.0.2", "8055", "tcp")
+			err := w.Start()
+			Expect(err).NotTo(HaveOccurred())
+			w.ConfigureInInfra(infra)
+
+			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+				IP:       cnet.MustParseIP(w.IP),
+				HandleID: &w.Name,
+				Attrs: map[string]string{
+					ipam.AttributeNode: Felix.Hostname,
+				},
+				Hostname: Felix.Hostname,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			ensureBPFProgramsAttached(tc.Felixes[0])
+		})
+
+		AfterEach(func() {
+			tc.Stop()
+			infra.Stop()
+		})
+
+		JustAfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Felix.Exec("conntrack", "-L", "-f", "ipv6")
+				Felix.Exec("ip6tables-save", "-c")
+				Felix.Exec("ip", "link")
+				Felix.Exec("ip", "addr")
+				Felix.Exec("ip", "rule")
+				Felix.Exec("ip", "route", "show", "table", "all")
+				Felix.Exec("calico-bpf", "routes", "dump")
+			}
+		})
+
+		It("should allow asymmetric routing", func() {
+			By("setting up node's fake external iface")
+			// We name the iface eth20 since such ifaces are
+			// treated by felix as external to the node
+			//
+			// Using a test-workload creates the namespaces and the
+			// interfaces to emulate the host NICs
+			eth20 := &workload.Workload{
+				Name:          "eth20",
+				C:             Felix.Container,
+				IP:            "192.168.20.1",
+				Ports:         "57005", // 0xdead
+				Protocol:      "tcp",
+				InterfaceName: "eth20",
+				MTU:           1500, // Need to match host MTU or felix will restart.
+			}
+			err := eth20.Start()
+			Expect(err).NotTo(HaveOccurred())
+
+			eth30 := &workload.Workload{
+				Name:          "eth30",
+				C:             Felix.Container,
+				IP:            "192.168.30.1",
+				Ports:         "57005", // 0xdead
+				Protocol:      "tcp",
+				InterfaceName: "eth30",
+				MTU:           1500, // Need to match host MTU or felix will restart.
+			}
+			err = eth30.Start()
+			Expect(err).NotTo(HaveOccurred())
+
+			// assign address to eth20 and add route to the .20 network
+			// tc.Felixes[1].Exec("ip", "route", "add", eth20Route, "dev", "eth20")
+			// This multi-NIC scenario works only if the kernel's RPF check
+			// is not strict so we need to override it for the test and must
+			// be set properly when product is deployed. We reply on
+			// iptables to do require check for us.
+			Felix.Exec("sysctl", "-w", "net.ipv4.conf.eth0.rp_filter=2")
+
+			Eventually(func() error {
+				return Felix.ExecMayFail("sysctl", "-w", "net.ipv4.conf.eth20.rp_filter=2")
+			}, "5s", "300ms").Should(Succeed())
+
+			Felix.Exec("ip", "addr", "add", "192.168.20.20/24", "dev", "lo")
+			Felix.Exec("ip", "addr", "add", "192.168.30.30/24", "dev", "eth30")
+			Felix.Exec("bash", "-c", "echo 200 container_route >> /etc/iproute2/rt_tables")
+			Felix.Exec("ip", "route", "add", "10.65.1.0/24", "dev", "eth20",
+				"table", "container_route")
+			Felix.Exec("ip", "rule", "add", "from", w.IP, "table", "container_route")
+			Felix.Exec("ip", "route", "flush", "cache")
+			Felix.Exec("ip", "neigh", "add", "10.65.1.3", "lladdr", "ee:ee:ee:ee:ee:ee", "dev", "eth20")
+
+			Felix.Exec("ip", "route", "add", "192.168.30.1/32", "dev", "eth30")
+
+			_, err = eth20.RunCmd("ip", "route", "add", "blackhole", "10.65.1.0/32")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = eth30.RunCmd("ip", "addr", "add", "192.168.30.1/24", "dev", "eth0")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = eth30.RunCmd("ip", "route", "add", "10.65.0.0/24", "via", "192.168.30.30", "dev", "eth0")
+			Expect(err).NotTo(HaveOccurred())
+			Felix.Exec("sysctl", "-w", "net.ipv4.conf.eth30.rp_filter=2")
+
+			_, err = w.RunCmd("bash", "-c", "echo 200 bh_route >> /etc/iproute2/rt_tables")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = w.RunCmd("ip", "rule", "add", "from", "10.65.1.3", "table", "bh_route", "priority", "1")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = w.RunCmd("ip", "rule", "del", "from", "all", "lookup", "local", "priority", "0")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = w.RunCmd("ip", "rule", "add", "from", "all", "lookup", "local", "priority", "2")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = w.RunCmd("ip", "route", "add", "blackhole", w.IP+"/32")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+				IP:       cnet.MustParseIP("10.65.1.3"),
+				HandleID: &w.Name,
+				Attrs: map[string]string{
+					ipam.AttributeNode: tc.Felixes[1].Hostname,
+				},
+				Hostname: tc.Felixes[1].Hostname,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			dump20 := Felix.AttachTCPDump("eth20")
+			dump20.SetLogEnabled(true)
+			dump20.AddMatcher("eth20-egress", regexp.MustCompile("10.65.0.2.30444 > 10.65.1.3.30444: UDP"))
+			dump20.Start("-v", "udp", "and", "dst", "host", "10.65.1.3")
+			defer dump20.Stop()
+
+			dump30 := Felix.AttachTCPDump("eth30")
+			dump30.SetLogEnabled(true)
+			dump30.AddMatcher("eth30-ingress", regexp.MustCompile("10.65.1.3.30444 > 10.65.0.2.30444: UDP"))
+			dump30.Start("-v", "udp", "and", "dst", "host", "10.65.0.2")
+			defer dump30.Stop()
+
+			By("Sending packet from the workload via eth20")
+			_, err = w.RunCmd("pktgen", w.IP, "10.65.1.3", "udp", "--ip-id", "1",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Sending reply via eth30")
+			_, err = eth30.RunCmd("pktgen", "10.65.1.3", w.IP, "udp", "--ip-id", "2",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Sending packet from the workload via eth20")
+			_, err = w.RunCmd("pktgen", w.IP, "10.65.1.3", "udp", "--ip-id", "3",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Sending reply via eth30")
+			_, err = eth30.RunCmd("pktgen", "10.65.1.3", w.IP, "udp", "--ip-id", "4",
+				"--port-src", "30444", "--port-dst", "30444")
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(dump20.MatchCountFn("eth20-egress"), "5s", "330ms").Should(BeNumerically("==", 2))
+			Eventually(dump30.MatchCountFn("eth30-ingress"), "5s", "330ms").Should(BeNumerically("==", 2))
+		})
+	})
+}


### PR DESCRIPTION
## Description

    When there is asymetric routing on a host with multiple NICs, we have
    packets returning from a different device then outbound packets are sent
    to. We should not use the ingress device indef for egress forwarding.
    
    This requires loose rpf check. We were previously switching remembered
    ifindex whenever we see packets arriving from a different NIC. This
    change will only remember the index if the returning packets satisfy
    strict RPF - that is when the return path reflects routing.


fixes https://github.com/projectcalico/calico/issues/10469

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix forwarding for asymetric routing https://github.com/projectcalico/calico/issues/10469
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
