### PR TITLE
[release-v3.30] Auto pick #10508: Fix race in Goldmane writing to stream

### DIFF
--- a/goldmane/pkg/stream/stream_manager.go
+++ b/goldmane/pkg/stream/stream_manager.go
@@ -84,11 +84,18 @@ func (c *streamCache) remove(id string) {
 	}
 }
 
-func (c *streamCache) get(id string) (*stream, bool) {
+// sendToStream directs the given flow provider to the stream with the given ID if it exists.
+// It does this atomically, to ensure the input channel isn't closed.
+// Note that writing to a stream can theoretically block, but this is expected to be exceedingly rare.
+func (c *streamCache) sendToStream(id string, p storage.FlowProvider) {
 	c.Lock()
 	defer c.Unlock()
 	s, ok := c.streams[id]
-	return s, ok
+	if !ok {
+		logrus.WithField("id", id).Warn("Send to unknown stream")
+		return
+	}
+	s.receive(p)
 }
 
 func (c *streamCache) size() int {
@@ -173,10 +180,7 @@ func (m *streamManager) Register(req *proto.FlowStreamRequest, size int) chan St
 func (m *streamManager) Receive(b storage.FlowBuilder, id string) {
 	if id != "" {
 		// An explicit ID was given. Send to the stream with that ID.
-		s, ok := m.streams.get(id)
-		if ok {
-			s.receive(b)
-		}
+		m.streams.sendToStream(id, b)
 		return
 	}
 


### PR DESCRIPTION
Cherry pick of #10508 on release-v3.30.

#10508: Fix race in Goldmane writing to stream

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We weren't holding the lock while writing to the stream input channel,
which meant that another goroutine could close the channel between
getting the stream and writing to the input channel.

```
panic: send on closed channel06:10
goroutine 266 [running]:06:10
github.com/projectcalico/calico/lib/std/chanutil.WriteWithDeadline[...]({0x36436b0?, 0xc0003d0af0}, 0xc0004625b0, {0x361e400, 0xc004ce40c0}, 0x3b9aca00)06:10
	/go/src/github.com/projectcalico/calico/lib/std/chanutil/chan.go:122 +0x15206:10
github.com/projectcalico/calico/goldmane/pkg/stream.(*stream).receive(0xc0003d0be0, {0x361e400, 0xc004ce40c0})06:10
 06:10
github.com/projectcalico/calico/goldmane/pkg/stream.(*streamManager).Receive(0xc00218ce80, {0x361e400, 0xc004ce40c0}, {0xc00336bfb0, 0x24})06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/stream/stream_manager.go:180 +0x10706:10
github.com/projectcalico/calico/goldmane/pkg/storage.(*BucketRing).Backfill.func1(0xc004ce40c0)06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/storage/bucket_ring.go:772 +0x6e06:10
github.com/projectcalico/calico/goldmane/pkg/storage.(*BucketRing).iterBucketsTime.func1(0xee)06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/storage/bucket_ring.go:755 +0x7d06:10
github.com/projectcalico/calico/goldmane/pkg/storage.(*BucketRing).iterBuckets(0xc00446b8f0, 0xeb, 0xf0, 0xc000063a78)06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/storage/bucket_ring.go:728 +0x6306:10
github.com/projectcalico/calico/goldmane/pkg/storage.(*BucketRing).iterBucketsTime(0xc00446b8f0, 0x3e2, 0x3e7, 0xc000063b18)06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/storage/bucket_ring.go:754 +0x23d06:10
github.com/projectcalico/calico/goldmane/pkg/storage.(*BucketRing).Backfill(0xc00446b8f0, {0x74f87dfc2db0, 0xc00218ce80}, {0xc00336bfb0, 0x24}, 0x3e2)06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/storage/bucket_ring.go:771 +0x1be06:10
github.com/projectcalico/calico/goldmane/pkg/goldmane.(*Goldmane).backfill(0xc0005a7680, {0x3646780, 0xc0003d0be0})06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/goldmane/goldmane.go:406 +0x37c06:10
github.com/projectcalico/calico/goldmane/pkg/goldmane.(*Goldmane).Run(0xc0005a7680, 0x3e8)06:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/goldmane/goldmane.go:290 +0xb9f06:10
created by github.com/projectcalico/calico/goldmane/pkg/goldmane_test.TestStreams.func5 in goroutine 265
```

https://tigera.semaphoreci.com/jobs/65b71e78-872a-4727-8739-850311ebebac#L1217

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix Goldmane race condition when terminating streams
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.