### PR TITLE
[release-v3.30] Auto pick #10512: Close race condition in Goldmane startup

### DIFF
--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -191,8 +191,8 @@ func Run(ctx context.Context, cfg Config) {
 	collector.RegisterWith(grpcServer)
 	go collector.Run()
 
-	// Start Goldmane.
-	go gm.Run(storage.GetStartTime(int(cfg.AggregationWindow.Seconds())))
+	// Start Goldmane, waiting for it to be ready to receive requests before continuing.
+	<-gm.Run(storage.GetStartTime(int(cfg.AggregationWindow.Seconds())))
 
 	// Start a flow server, serving from Goldmane.
 	flowServer := server.NewFlowsServer(gm)

--- a/goldmane/pkg/goldmane/goldmane.go
+++ b/goldmane/pkg/goldmane/goldmane.go
@@ -244,7 +244,15 @@ func NewGoldmane(opts ...Option) *Goldmane {
 	return a
 }
 
-func (a *Goldmane) Run(startTime int64) {
+// Run starts Goldmane - it returns a channel that can be used by the caller to wait
+// for Goldmane to be ready to process requests. The channel will be closed when Goldmane is ready.
+func (a *Goldmane) Run(startTime int64) <-chan struct{} {
+	ready := make(chan struct{})
+	go a.run(startTime, ready)
+	return ready
+}
+
+func (a *Goldmane) run(startTime int64, ready chan<- struct{}) {
 	// Initialize the buckets.
 	opts := []storage.BucketRingOption{
 		storage.WithBucketsToAggregate(a.bucketsToAggregate),
@@ -277,6 +285,9 @@ func (a *Goldmane) Run(startTime int64) {
 
 	// Schedule the first rollover one aggregation period from now.
 	rolloverCh := a.rolloverFunc(a.bucketDuration)
+
+	// Indicate that we're ready to process requests.
+	close(ready)
 
 	for {
 		select {

--- a/goldmane/pkg/goldmane/goldmane_test.go
+++ b/goldmane/pkg/goldmane/goldmane_test.go
@@ -84,8 +84,8 @@ func TestList(t *testing.T) {
 	}
 	defer setupTest(t, opts...)()
 
-	// Start the goldmane.
-	go gm.Run(now)
+	// Start goldmane.
+	<-gm.Run(now)
 
 	// Ingest a flow log.
 	fl := &proto.Flow{
@@ -284,7 +284,7 @@ func TestLabelMerge(t *testing.T) {
 		goldmane.WithNowFunc(c.Now),
 	}
 	defer setupTest(t, opts...)()
-	go gm.Run(c.Now().Unix())
+	<-gm.Run(c.Now().Unix())
 
 	// Create 10 flows, each with one common label and one unique label.
 	// All other fields are the same.
@@ -336,7 +336,7 @@ func TestRotation(t *testing.T) {
 		goldmane.WithNowFunc(c.Now),
 	}
 	defer setupTest(t, opts...)()
-	go gm.Run(now)
+	<-gm.Run(now)
 
 	// Create a Flow. This test relies on an understanding of the underlying bucket ring:
 	// - The index contains two extra buckets, one currently filling, and one in the future.
@@ -422,7 +422,7 @@ func TestManyFlows(t *testing.T) {
 		goldmane.WithNowFunc(c.Now),
 	}
 	defer setupTest(t, opts...)()
-	go gm.Run(now)
+	<-gm.Run(now)
 
 	// Create 20k flows and send them as fast as we can. See how Goldmane handles it.
 	fl := &proto.Flow{
@@ -472,7 +472,7 @@ func TestPagination(t *testing.T) {
 		goldmane.WithNowFunc(c.Now),
 	}
 	defer setupTest(t, opts...)()
-	go gm.Run(now)
+	<-gm.Run(now)
 
 	// Create 30 different flows.
 	for i := range 30 {
@@ -662,7 +662,7 @@ func TestTimeRanges(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			defer setupTest(t, opts...)()
-			go gm.Run(now)
+			<-gm.Run(now)
 
 			// Create flows.
 			prepareFlows()
@@ -753,7 +753,7 @@ func TestSink(t *testing.T) {
 
 		// Start Goldmane, and rollover to trigger an emission.
 		// We shouldn't see any buckets pushed to the sink, as we haven't sent any flows.
-		go gm.Run(now)
+		<-gm.Run(now)
 
 		// Set the sink. Setting the Sink is asynchronous and triggers a check for flow emission - as such,
 		// we need to wait for this to complete before we can start sending flows.
@@ -889,7 +889,7 @@ func TestSink(t *testing.T) {
 
 		// Start Goldmane, and rollover to trigger an emission.
 		// We shouldn't see any buckets pushed to the sink, as we haven't sent any flows.
-		go gm.Run(now)
+		<-gm.Run(now)
 
 		// Set the sink. Setting the Sink is asynchronous and triggers a check for flow emission - as such,
 		// we need to wait for this to complete before we can start sending flows.
@@ -956,7 +956,7 @@ func TestSink(t *testing.T) {
 
 		// Start Goldmane, and rollover to trigger an emission.
 		// We shouldn't see any buckets pushed to the sink, as we haven't sent any flows.
-		go gm.Run(now)
+		<-gm.Run(now)
 
 		// Load up Goldmane with Flow data across a widge range of buckets, spanning
 		// multiple emission windows.
@@ -1039,7 +1039,7 @@ func TestBucketDrift(t *testing.T) {
 	//
 	// From there, we can expect Goldmane to notice that it has missed time somehow and accelerate the scheduling of the next rollover
 	// in order to compensate.
-	go gm.Run(c.Now().Unix())
+	<-gm.Run(c.Now().Unix())
 
 	// We want to simulate a rollover that happens 3 seconds late for the scheduled rollover.
 	rt := int64(initialNow + aggregationWindowSecs + 3)
@@ -1094,8 +1094,8 @@ func TestStreams(t *testing.T) {
 		}
 		defer setupTest(t, opts...)()
 
-		// Start the goldmane.
-		go gm.Run(c.Now().Unix())
+		// Start goldmane.
+		<-gm.Run(c.Now().Unix())
 
 		// Insert some random historical flow data from the past over the
 		// time range of now-10 to now-5.
@@ -1202,8 +1202,8 @@ func TestStreams(t *testing.T) {
 		}
 		defer setupTest(t, opts...)()
 
-		// Start the goldmane.
-		go gm.Run(c.Now().Unix())
+		// Start goldmane.
+		<-gm.Run(c.Now().Unix())
 
 		// Create a flow that will span multiple time buckets.
 		newestStart := c.Now().Unix() - 2
@@ -1281,7 +1281,7 @@ func TestStreams(t *testing.T) {
 		defer setupTest(t, opts...)()
 
 		// Start Goldmane.
-		go gm.Run(c.Now().Unix())
+		<-gm.Run(c.Now().Unix())
 
 		// Create a flow that will span multiple time buckets, with the
 		// newest start time falling at Now().
@@ -1380,7 +1380,7 @@ func TestSortOrder(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create a bunch of random flows.
 			for range 100 {
@@ -1649,7 +1649,7 @@ func TestFilter(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create 10 flows, with a mix of fields to filter on.
 			for i := range 10 {
@@ -1788,7 +1788,7 @@ func TestFilterHints(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create 10 flows, with a mix of fields to filter on.
 			for i := range 10 {
@@ -1860,7 +1860,7 @@ func TestFilterHints(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create 10 flows, with a mix of fields to filter on.
 			for i := range 10 {
@@ -1967,7 +1967,7 @@ func TestStatistics(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create some flows.
 			flows := createFlows(numFlows, mutateUniquePolicyName)
@@ -2099,7 +2099,7 @@ func TestStatistics(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create some flows.
 			_ = createFlows(numFlows, mutateUniquePolicyName)
@@ -2152,7 +2152,7 @@ func TestStatistics(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create some flows, mutating the first policy hit in each to be an EndOfTier hit.
 			mutateEndOftier := func(fl *proto.Flow, i int) {
@@ -2220,7 +2220,7 @@ func TestStatistics(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create some flows, mutating the first policy hit in each to be an EndOfTier hit.
 			mutateEndOftier := func(fl *proto.Flow, i int) {
@@ -2278,7 +2278,7 @@ func TestStatistics(t *testing.T) {
 				goldmane.WithNowFunc(c.Now),
 			}
 			defer setupTest(t, opts...)()
-			go gm.Run(c.Now().Unix())
+			<-gm.Run(c.Now().Unix())
 
 			// Create some flows.
 			_ = createFlows(numFlows, mutateUniquePolicyName)


### PR DESCRIPTION
Cherry pick of #10512 on release-v3.30.

#10512: Close race condition in Goldmane startup

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Since Goldmane was launched in a separate goroutine, it was possible for the gRPC server to start receiving requests before Goldmane was initialized
and ready to handle them. This PR closes that gap.

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2d6b3f9]05:10
goroutine 316 [running]:05:10
github.com/projectcalico/calico/goldmane/pkg/storage.(*BucketRing).BeginningOfHistory(...)05:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/storage/bucket_ring.go:39805:10
github.com/projectcalico/calico/goldmane/pkg/goldmane.(*Goldmane).normalizeTimeRange(0xc00090d4d0, 0x0, 0x0)05:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/goldmane/goldmane.go:419 +0x13905:10
github.com/projectcalico/calico/goldmane/pkg/goldmane.(*Goldmane).Statistics(0xc00090d4d0, 0xc0003ba500)05:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/goldmane/goldmane.go:382 +0x9505:10
github.com/projectcalico/calico/goldmane/pkg/server.(*Statistics).List(0xc0000ca398, 0xc0003ba500, {0x389c070, 0xc000d1ed60})05:10
	/go/src/github.com/projectcalico/calico/goldmane/pkg/server/statistics_service.go:46 +0xc505:10
github.com/projectcalico/calico/goldmane/proto._Statistics_List_Handler({0x314b7c0, 0xc0000ca398}, {0x3898ff8, 0xc000700e00})05:10
	/go/src/github.com/projectcalico/calico/goldmane/proto/api_grpc.pb.go:430 +0x14505:10
google.golang.org/grpc.(*Server).processStreamingRPC(0xc001412400, {0x38920c0, 0xc002bd6fc0}, 0xc002336720, 0xc003c3d530, 0x4d4b940, 0x0)05:10
	/go/pkg/mod/google.golang.org/grpc@v1.72.0/server.go:1695 +0x1f9805:10
google.golang.org/grpc.(*Server).handleStream(0xc001412400, {0x3892830, 0xc000836ea0}, 0xc002336720)
```
https://tigera.semaphoreci.com/jobs/54369b07-33b5-4604-ac49-3abcaaa330fe#L1128

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix race condition in Goldmane startup
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.