### PR TITLE
OpenStack-level support for packet rate burst

### DIFF
--- a/libcalico-go/lib/apis/v3/generated.openapi.go
+++ b/libcalico-go/lib/apis/v3/generated.openapi.go
@@ -3166,14 +3166,7 @@ func schema_libcalico_go_lib_apis_v3_QoSControls(ref common.ReferenceCallback) c
 					},
 					"ingressPacketRate": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Ingress packet rate limit in packets per second.  Only applied if non-zero.  When non-zero, must be between 1 and 10^4 (10k).",
-							Type:        []string{"integer"},
-							Format:      "int64",
-						},
-					},
-					"egressPacketRate": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Egress packet rate limit in packets per second.  Only applied if non-zero.  When non-zero, must be between 1 and 10^4 (10k).",
+							Description: "Ingress packet rate limit in packets per second.  Only applied if non-zero.  When non-zero:\n\n- IngressPacketRate must be between 1 and 10^4 (10k).\n\n- IngressPacketBurst must be between 1 and 10^4 (10k).  If specified as 0, it is\n  defaulted to 5.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -3181,6 +3174,13 @@ func schema_libcalico_go_lib_apis_v3_QoSControls(ref common.ReferenceCallback) c
 					"ingressPacketBurst": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Ingress packet rate burst size in number of packets",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"egressPacketRate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Egress packet rate limit in packets per second.  Only applied if non-zero.  The same detail applies here as for egress packet rate, except using the corresponding Egress fields.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/libcalico-go/lib/apis/v3/workloadendpoint.go
+++ b/libcalico-go/lib/apis/v3/workloadendpoint.go
@@ -154,13 +154,21 @@ type QoSControls struct {
 	EgressMinburst int64 `json:"egressMinburst,omitempty"`
 
 	// Ingress packet rate limit in packets per second.  Only applied if non-zero.  When
-	// non-zero, must be between 1 and 10^4 (10k).
+	// non-zero:
+	//
+	// - IngressPacketRate must be between 1 and 10^4 (10k).
+	//
+	// - IngressPacketBurst must be between 1 and 10^4 (10k).  If specified as 0, it is
+	//   defaulted to 5.
+	//
 	IngressPacketRate int64 `json:"ingressPacketRate,omitempty"`
-	// Egress packet rate limit in packets per second.  Only applied if non-zero.  When
-	// non-zero, must be between 1 and 10^4 (10k).
-	EgressPacketRate int64 `json:"egressPacketRate,omitempty"`
 	// Ingress packet rate burst size in number of packets
 	IngressPacketBurst int64 `json:"ingressPacketBurst,omitempty"`
+
+	// Egress packet rate limit in packets per second.  Only applied if non-zero.  The same
+	// detail applies here as for egress packet rate, except using the corresponding Egress
+	// fields.
+	EgressPacketRate int64 `json:"egressPacketRate,omitempty"`
 	// Egress packet rate burst size in number of packets
 	EgressPacketBurst int64 `json:"egressPacketBurst,omitempty"`
 

--- a/networking-calico/networking_calico/common/config.py
+++ b/networking-calico/networking_calico/common/config.py
@@ -12,12 +12,13 @@
 
 import re
 
-from networking_calico.compat import cfg
 from networking_calico import datamodel_v2
 from networking_calico import datamodel_v3
+from networking_calico.compat import cfg
 
 
 DEFAULT_BW_BURST = 4294967296
+DEFAULT_PR_BURST = 5
 
 SHARED_OPTS = [
     # etcd connection information.
@@ -69,9 +70,14 @@ SHARED_OPTS = [
     # | EgressMinburst        |                       | egress_minburst_bytes            |
     # | IngressPacketRate     | max_kpps * 1000       |                                  |
     # | EgressPacketRate      | max_kpps * 1000       |                                  |
+    # | IngressPacketBurst    |                       | ingress_burst_packets            |
+    # | EgressPacketBurst     |                       | egress_burst_packets             |
+    # |  (not implemented)    | max_burst_kpps        |                                  |
     # | IngressMaxConnections |                       | max_ingress_connections_per_port |
     # | EgressMaxConnections  |                       | max_egress_connections_per_port  |
     #
+    # Note, max_burst_kpps is not currently implemented, because we have not
+    # yet found a reasonable way to do that.
     cfg.IntOpt('max_ingress_connections_per_port', default=0,
                help="If non-zero, a maximum number of ingress connections to impose on each port."),
     cfg.IntOpt('max_egress_connections_per_port', default=0,
@@ -84,6 +90,10 @@ SHARED_OPTS = [
                help="If non-zero, configures the minimum burst size for peakrate data, in the ingress direction."),
     cfg.IntOpt('egress_minburst_bytes', default=0,
                help="If non-zero, configures the minimum burst size for peakrate data, in the egress direction."),
+    cfg.IntOpt('ingress_burst_packets', default=DEFAULT_PR_BURST,
+               help="If non-zero, configures the maximum allowed packet rule burst, in the ingress direction."),
+    cfg.IntOpt('egress_burst_packets', default=DEFAULT_PR_BURST,
+               help="If non-zero, configures the maximum allowed packet rule burst, in the egress direction."),
 ]
 
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -336,6 +336,7 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         MINMAX_BW_MINBURST = (1000, 10**8)
 
         MINMAX_PACKET_RATE = (1, 10**4)
+        MINMAX_PR_BURST = (1, 10**4)
 
         MINMAX_CONNECTIONS = (1, 4294967295)
 
@@ -394,6 +395,18 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                 qos['egressBurst'] = calico_config.DEFAULT_BW_BURST
             if cfg.CONF.calico.egress_minburst_bytes != 0 and 'egressPeakrate' in qos:
                 qos['egressMinburst'] = cap(cfg.CONF.calico.egress_minburst_bytes, MINMAX_BW_MINBURST)
+
+        if 'ingressPacketRate' in qos:
+            if cfg.CONF.calico.ingress_burst_packets != 0:
+                qos['ingressPacketBurst'] = cap(cfg.CONF.calico.ingress_burst_packets, MINMAX_PR_BURST)
+            else:
+                qos['ingressPacketBurst'] = calico_config.DEFAULT_PR_BURST
+
+        if 'egressPacketRate' in qos:
+            if cfg.CONF.calico.egress_burst_packets != 0:
+                qos['egressPacketBurst'] = cap(cfg.CONF.calico.egress_burst_packets, MINMAX_PR_BURST)
+            else:
+                qos['egressPacketBurst'] = calico_config.DEFAULT_PR_BURST
 
         port_extra.qos = qos
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -359,6 +359,8 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_compat.cfg.CONF.calico.egress_burst_bits = 0
         lib.m_compat.cfg.CONF.calico.ingress_minburst_bytes = 0
         lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 0
+        lib.m_compat.cfg.CONF.calico.ingress_burst_packets = 0
+        lib.m_compat.cfg.CONF.calico.egress_burst_packets = 0
         calico_config._reset_globals()
         datamodel_v2._reset_globals()
 
@@ -951,6 +953,8 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_compat.cfg.CONF.calico.egress_burst_bits = 41000
         lib.m_compat.cfg.CONF.calico.ingress_minburst_bytes = 1651
         lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 1761
+        lib.m_compat.cfg.CONF.calico.ingress_burst_packets = 81
+        lib.m_compat.cfg.CONF.calico.egress_burst_packets = 91
         self.driver.update_port_postcommit(context)
 
         # Expected changes
@@ -986,6 +990,8 @@ class TestPluginEtcdBase(_TestEtcdBase):
             'egressPacketRate': 6000,
             'ingressMaxConnections': 10,
             'egressMaxConnections': 20,
+            'ingressPacketBurst': 81,
+            'egressPacketBurst': 91,
         }
         expected_writes = {
             ep_hello_key_v3: ep_hello_value_v3,
@@ -1001,6 +1007,8 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_compat.cfg.CONF.calico.egress_burst_bits = 0
         lib.m_compat.cfg.CONF.calico.ingress_minburst_bytes = 0
         lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 0
+        lib.m_compat.cfg.CONF.calico.ingress_burst_packets = 0
+        lib.m_compat.cfg.CONF.calico.egress_burst_packets = 0
 
         # Set a QoS policy on the network instead of directly on the port.
         #


### PR DESCRIPTION
Add Calico-specific config parameters to control number of packets that can burst when using a packet rate rule.

## Release Note

```release-note
Calico for OpenStack's QoS support has been enhanced to cover packet rate burst size configuration.  There are new driver settings (cluster-wide, set in `neutron.conf`) for configuring max and min packet burst sizes in each direction.
```