### PR TITLE
update registries in operator when using dev/custom registries

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -110,6 +110,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					}
 				}
 
+				productRegistriesFromFlag := c.StringSlice(registryFlag.Name)
+
 				// Build the operator
 				operatorOpts := []operator.Option{
 					operator.WithOperatorDirectory(operatorDir),
@@ -121,6 +123,12 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithVersion(data.OperatorVersion()),
 					operator.WithCalicoDirectory(cfg.RepoRootDir),
 					operator.WithTempDirectory(cfg.TmpDir),
+				}
+				if reg := c.String(operatorRegistryFlag.Name); reg != "" {
+					operatorOpts = append(operatorOpts, operator.WithRegistry(reg))
+				}
+				if len(productRegistriesFromFlag) > 0 {
+					operatorOpts = append(operatorOpts, operator.WithProductRegistry(productRegistriesFromFlag[0]))
 				}
 				if !c.Bool(skipOperatorFlag.Name) {
 					o := operator.NewManager(operatorOpts...)
@@ -147,10 +155,9 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
 				}
-				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
-					opts = append(opts, calico.WithImageRegistries(reg))
+				if len(productRegistriesFromFlag) > 0 {
+					opts = append(opts, calico.WithImageRegistries(productRegistriesFromFlag))
 				}
-
 				r := calico.NewManager(opts...)
 				if err := r.Build(); err != nil {
 					return err

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -237,10 +237,14 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithHashrelease(*hashrel, *serverCfg),
 					calico.WithPublishImages(c.Bool(publishHashreleaseImageFlag.Name)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
-					calico.WithImageScanning(!c.Bool(skipImageScanFlag.Name), *imageScanningAPIConfig(c)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
-					opts = append(opts, calico.WithImageRegistries(reg))
+					opts = append(opts,
+						calico.WithImageRegistries(reg),
+						calico.WithImageScanning(false, imagescanner.Config{}), // Disable image scanning if using custom registries.
+					)
+				} else {
+					opts = append(opts, calico.WithImageScanning(!c.Bool(skipImageScanFlag.Name), *imageScanningAPIConfig(c)))
 				}
 				// Note: We only need to check that the correct images exist if we haven't built them ourselves.
 				// So, skip this check if we're configured to build and publish images from the local codebase.

--- a/release/internal/pinnedversion/templates/calico-versions.yaml.gotmpl
+++ b/release/internal/pinnedversion/templates/calico-versions.yaml.gotmpl
@@ -20,7 +20,6 @@
       version:  {{.ProductVersion}}
     calico/apiserver:
       version: {{.ProductVersion}}
-      image: calico/apiserver
     calico/kube-controllers:
       version: {{.ProductVersion}}
     calico/api:

--- a/release/internal/registry/registry.go
+++ b/release/internal/registry/registry.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+var DefaultCalicoRegistries = []string{
+	"docker.io/calico",
+	"quay.io/calico",
+	"gcr.io/projectcalico-org",
+	"eu.gcr.io/projectcalico-org",
+	"asia.gcr.io/projectcalico-org",
+	"us.gcr.io/projectcalico-org",
+}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -40,15 +40,8 @@ import (
 
 // Global configuration for releases.
 var (
-	// Default DefaultRegistries to which all release images are pushed.
-	DefaultRegistries = []string{
-		"docker.io/calico",
-		"quay.io/calico",
-		"gcr.io/projectcalico-org",
-		"eu.gcr.io/projectcalico-org",
-		"asia.gcr.io/projectcalico-org",
-		"us.gcr.io/projectcalico-org",
-	}
+	// Default defaultRegistries to which all release images are pushed.
+	defaultRegistries = registry.DefaultCalicoRegistries
 
 	// Directories that publish images.
 	imageReleaseDirs = []string{
@@ -120,7 +113,7 @@ func NewManager(opts ...Option) *CalicoManager {
 		publishImages:    true,
 		publishTag:       true,
 		publishGithub:    true,
-		imageRegistries:  DefaultRegistries,
+		imageRegistries:  defaultRegistries,
 		operatorRegistry: operator.DefaultRegistry,
 		operatorImage:    operator.DefaultImage,
 	}
@@ -625,7 +618,7 @@ func (r *CalicoManager) releasePrereqs() error {
 
 	// If we are releasing to projectcalico/calico, make sure we are releasing to the default registries.
 	if r.githubOrg == utils.ProjectCalicoOrg && r.repo == utils.CalicoRepoName {
-		if !reflect.DeepEqual(r.imageRegistries, DefaultRegistries) {
+		if !reflect.DeepEqual(r.imageRegistries, defaultRegistries) {
 			return fmt.Errorf("image registries cannot be different from default registries for a release")
 		}
 	}
@@ -913,7 +906,7 @@ func (r *CalicoManager) generateManifests() error {
 	env = append(env, fmt.Sprintf("OPERATOR_VERSION=%s", r.operatorVersion))
 	env = append(env, fmt.Sprintf("OPERATOR_REGISTRY=%s", r.operatorRegistry))
 	env = append(env, fmt.Sprintf("OPERATOR_IMAGE=%s", r.operatorImage))
-	if !slices.Equal(r.imageRegistries, DefaultRegistries) {
+	if !slices.Equal(r.imageRegistries, defaultRegistries) {
 		env = append(env, fmt.Sprintf("REGISTRY=%s", r.imageRegistries[0]))
 	}
 	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "gen-manifests", env...); err != nil {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -17,6 +17,7 @@ package calico
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -633,6 +634,17 @@ type imageExistsResult struct {
 	err    error
 }
 
+func (r *CalicoManager) componentImages() map[string]string {
+	components := map[string]string{}
+	for name, component := range r.imageComponents {
+		if component.Registry == "" {
+			component.Registry = r.imageRegistries[0]
+		}
+		components[name] = component.String()
+	}
+	return components
+}
+
 // checkHashreleaseImagesPublished checks that the images required for the hashrelease exist in the specified registries.
 func (r *CalicoManager) checkHashreleaseImagesPublished() ([]registry.Component, error) {
 	logrus.Info("Checking images required for hashrelease have already been published")
@@ -644,16 +656,16 @@ func (r *CalicoManager) checkHashreleaseImagesPublished() ([]registry.Component,
 
 	resultsCh := make(chan imageExistsResult, numOfComponents)
 
-	for name, component := range r.imageComponents {
-		go func(name string, component registry.Component, ch chan imageExistsResult) {
-			exists, err := registry.CheckImage(component.String())
+	for name, image := range r.componentImages() {
+		go func(name string, image string, ch chan imageExistsResult) {
+			exists, err := registry.CheckImage(image)
 			resultsCh <- imageExistsResult{
 				name:   name,
-				image:  component.String(),
+				image:  image,
 				exists: exists,
 				err:    err,
 			}
-		}(name, component, resultsCh)
+		}(name, image, resultsCh)
 	}
 
 	var resultsErr error
@@ -697,12 +709,8 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 
 	if r.imageScanning {
 		logrus.Info("Sending images to ISS")
-		imageList := []string{}
-		for _, component := range r.imageComponents {
-			imageList = append(imageList, component.String())
-		}
 		imageScanner := imagescanner.New(r.imageScanningConfig)
-		err := imageScanner.Scan(r.productCode, imageList, r.hashrelease.Stream, false, r.tmpDir)
+		err := imageScanner.Scan(r.productCode, slices.Collect(maps.Values(r.componentImages())), r.hashrelease.Stream, false, r.tmpDir)
 		if err != nil {
 			// Error is logged and ignored as this is not considered a fatal error
 			logrus.WithError(err).Error("Failed to scan images")

--- a/release/pkg/manager/operator/options.go
+++ b/release/pkg/manager/operator/options.go
@@ -127,3 +127,17 @@ func WithVersion(version string) Option {
 		return nil
 	}
 }
+
+func WithRegistry(registry string) Option {
+	return func(o *OperatorManager) error {
+		o.registry = registry
+		return nil
+	}
+}
+
+func WithProductRegistry(registry string) Option {
+	return func(o *OperatorManager) error {
+		o.productRegistry = registry
+		return nil
+	}
+}

--- a/release/pkg/manager/operator/template/images.go.gotmpl
+++ b/release/pkg/manager/operator/template/images.go.gotmpl
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-{{.Year}} Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package components
+
+// Default registries for Calico and Tigera.
+const (
+	CalicoRegistry = "{{.ProductRegistry}}/"
+	TigeraRegistry = "gcr.io/unique-caldron-775/cnx/"
+	// For production InitRegistry should match TigeraRegistry.
+	// For the master branch and other testing scenarios we switch TigeraRegistry to
+	// point to a testing repo but the init image will be pushed to quay, so having
+	// these separate allows pulling the proper test images for the Tigera components
+	// and Init image when testing.
+	InitRegistry = "{{.Registry}}/"
+)

--- a/release/pkg/postrelease/images_test.go
+++ b/release/pkg/postrelease/images_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/projectcalico/calico/release/internal/registry"
-	"github.com/projectcalico/calico/release/pkg/manager/calico"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
 
@@ -26,7 +25,7 @@ func TestImagesPublished(t *testing.T) {
 		checkVersion(t, releaseVersion)
 		checkImages(t, images)
 
-		for _, reg := range calico.DefaultRegistries {
+		for _, reg := range registry.DefaultCalicoRegistries {
 			for _, image := range strings.Split(images, " ") {
 				if strings.Contains(image, operator.DefaultImage) {
 					// Operator images are checked separately


### PR DESCRIPTION
## Description

This adds support for building operator with user-defined registry specified when using custom registries.

This rounds up the changes started with #9754 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
