### PR TITLE
[release-v3.30] Auto pick #10526: Fix ReadEgressQdisc in qos.go

### DIFF
--- a/felix/dataplane/linux/qos/qos.go
+++ b/felix/dataplane/linux/qos/qos.go
@@ -183,30 +183,14 @@ func ReadEgressQdisc(intf string) (*TokenBucketState, error) {
 		return nil, fmt.Errorf("Failed to list qdiscs on link %s: %w", ifbDeviceName, err)
 	}
 
-	tbs := &TokenBucketState{}
 	for _, qdisc := range qdiscs {
 		tbf, isTbf := qdisc.(*netlink.Tbf)
-		// TBF info may be split in multiple netlink messages, loop through them to populate TokenBucketState
 		if isTbf {
-			if tbf.Rate > 0 {
-				tbs.Rate = tbf.Rate
-			}
-			if tbf.Buffer > 0 {
-				tbs.Buffer = tbf.Buffer
-			}
-			if tbf.Limit > 0 {
-				tbs.Limit = tbf.Limit
-			}
-			if tbf.Peakrate > 0 {
-				tbs.Peakrate = tbf.Peakrate
-			}
-			if tbf.Minburst > 0 {
-				tbs.Minburst = tbf.Minburst
-			}
+			return &TokenBucketState{Rate: tbf.Rate, Buffer: tbf.Buffer, Limit: tbf.Limit, Peakrate: tbf.Peakrate, Minburst: tbf.Minburst}, nil
 		}
 	}
 
-	return tbs, nil
+	return nil, nil
 }
 
 const maxIfbDeviceLength = 15


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10526 on release-v3.30.

#10526: Fix ReadEgressQdisc in qos.go

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.