### PR TITLE
[release-v3.30] Auto pick #10490: Fix attaching ctlb for ipv6 and detaching programs in

### DIFF
--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -72,23 +72,27 @@ int bpf_update_link(struct bpf_link *link, struct bpf_object *obj, char *progNam
 	return err;
 }
 
-int bpf_ctlb_detach_legacy(int target_fd, int attach_type) {
-	int err;
-	__u32 attach_flags, prog_cnt, prog_id;
+int bpf_ctlb_get_prog_fd(int target_fd, int attach_type) {
+       int err;
+        __u32 attach_flags, prog_cnt, prog_id;
 
-	err = bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt);
-	if (err) {
-		goto out;
-	}
-	int prog_fd = bpf_prog_get_fd_by_id(prog_id);
-	if (prog_fd < 0) {
-		err = -prog_fd;
-		goto out;
-	}
-	err = bpf_prog_detach2(prog_fd, target_fd, attach_type);
+        err = bpf_prog_query(target_fd, attach_type, 0, &attach_flags, &prog_id, &prog_cnt);
+        if (err) {
+                goto out;
+        }
+        int prog_fd = bpf_prog_get_fd_by_id(prog_id);
+        if (prog_fd < 0) {
+                err = -prog_fd;
+                goto out;
+        }
 out:
         set_errno(err);
-        return err;
+        return prog_fd;
+}
+
+
+void bpf_ctlb_detach_legacy(int prog_fd, int target_fd, int attach_type) {
+        set_errno(bpf_prog_detach2(prog_fd, target_fd, attach_type));
 }
 
 struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio, uint handle)
@@ -338,7 +342,7 @@ out:
 	return link;
 }
 
-int bpf_program_attach_cgroup_legacy(struct bpf_object *obj, int cgroup_fd, char *name)
+void bpf_program_attach_cgroup_legacy(struct bpf_object *obj, int cgroup_fd, char *name)
 {
 	int err = 0, prog_fd;
 	struct bpf_program *prog;
@@ -360,7 +364,6 @@ int bpf_program_attach_cgroup_legacy(struct bpf_object *obj, int cgroup_fd, char
 
 out:
 	set_errno(err);
-	return err;
 }
 
 void bpf_ctlb_set_globals(struct bpf_map *map, uint udp_not_seen_timeo, bool exclude_udp)

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -149,7 +149,7 @@ func (l *Link) Detach() error {
 	panic("LIBBPF syscall stub")
 }
 
-func DetachCTLBProgramsLegacy(_ string) error {
+func DetachCTLBProgramsLegacy(_ bool, _ string) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -71,7 +71,17 @@ func RemoveConnectTimeLoadBalancer(ipv4Enabled bool, cgroupv2 string) error {
 	pinDir := path.Join(bpfMount, bpfdefs.CtlbPinDir)
 	defer bpf.CleanUpCalicoPins(pinDir)
 	ctlbProgsMap := newProgramsMap()
-	defer os.Remove(ctlbProgsMap.Path())
+	if err := ctlbProgsMap.EnsureExists(); err != nil {
+		return fmt.Errorf("failed to create ctlb jump map: %w", err)
+	}
+	for _, index := range ctlbProgToIndex {
+		err := ctlbProgsMap.Delete(jump.Key(index))
+		if err != nil && !os.IsNotExist(err) {
+			log.Errorf("failed to delete the ctlb jump map entry: %s", err)
+		}
+	}
+	ctlbProgsMap.Close()
+	os.Remove(ctlbProgsMap.Path())
 
 	if err := detachCtlbPrograms(ipv4Enabled, pinDir, cgroupv2); err != nil {
 		return err

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -57,7 +57,7 @@ func newProgramsMap() maps.Map {
 	return maps.NewPinnedMap(ProgramsMapParameters)
 }
 
-func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
+func RemoveConnectTimeLoadBalancer(ipv4Enabled bool, cgroupv2 string) error {
 	if os.Getenv("FELIX_DebugSkipCTLBCleanup") == "true" {
 		log.Info("FV special case: skipping CTLB cleanup")
 		return nil
@@ -73,14 +73,14 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 	ctlbProgsMap := newProgramsMap()
 	defer os.Remove(ctlbProgsMap.Path())
 
-	if err := detachCtlbPrograms(pinDir, cgroupv2); err != nil {
+	if err := detachCtlbPrograms(ipv4Enabled, pinDir, cgroupv2); err != nil {
 		return err
 	}
 	bpf.CleanUpCalicoPins(pinDir)
 	return nil
 }
 
-func detachCtlbPrograms(pinDir, cgroupv2 string) error {
+func detachCtlbPrograms(ipv4Enabled bool, pinDir, cgroupv2 string) error {
 	numLinksDetached := 0
 	err := filepath.Walk(pinDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -108,17 +108,17 @@ func detachCtlbPrograms(pinDir, cgroupv2 string) error {
 		return err
 	}
 	if numLinksDetached == 0 {
-		return detachLegacyCtlb(cgroupv2)
+		return detachLegacyCtlb(ipv4Enabled, cgroupv2)
 	}
 	return nil
 }
 
-func detachLegacyCtlb(cgroupv2 string) error {
+func detachLegacyCtlb(ipv4Enabled bool, cgroupv2 string) error {
 	cgroupPath, err := ensureCgroupPath(cgroupv2)
 	if err != nil {
 		return fmt.Errorf("failed to set-up cgroupv2: %w", err)
 	}
-	return libbpf.DetachCTLBProgramsLegacy(cgroupPath)
+	return libbpf.DetachCTLBProgramsLegacy(ipv4Enabled, cgroupPath)
 }
 
 func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bool) (*libbpf.Obj, error) {
@@ -276,18 +276,18 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 				return err
 			}
 		} else {
-			err = attachProgram("connect", "6", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v6Obj, legacy)
+			err = attachProgram("connect", "6", pinDir, cgroupPath, udpNotSeen, excludeUDP, v6Obj, legacy)
 			if err != nil {
 				return err
 			}
 
 			if !excludeUDP {
-				err = attachProgram("sendmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj, legacy)
+				err = attachProgram("sendmsg", "6", pinDir, cgroupPath, udpNotSeen, false, v6Obj, legacy)
 				if err != nil {
 					return err
 				}
 
-				err = attachProgram("recvmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj, legacy)
+				err = attachProgram("recvmsg", "6", pinDir, cgroupPath, udpNotSeen, false, v6Obj, legacy)
 				if err != nil {
 					return err
 				}

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -949,10 +949,6 @@ func TestCTLBAttachLegacy(t *testing.T) {
 			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v6"))
 			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v6"))
 		}
-		cmd = exec.Command("bpftool", "map", "show")
-		out, err = cmd.Output()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(out)).ShouldNot(ContainSubstring("cali_ctlb_progs"))
 		cmd = exec.Command("bpftool", "prog", "show")
 		out, err = cmd.Output()
 		Expect(err).NotTo(HaveOccurred())
@@ -962,6 +958,7 @@ func TestCTLBAttachLegacy(t *testing.T) {
 	}
 	testCtlbAttachLegacy(true, false)
 	testCtlbAttachLegacy(false, true)
+	testCtlbAttachLegacy(true, true)
 }
 
 func TestCTLBAttach(t *testing.T) {
@@ -1036,11 +1033,6 @@ func TestCTLBAttach(t *testing.T) {
 			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v6"))
 			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v6"))
 		}
-
-		cmd = exec.Command("bpftool", "map", "show")
-		out, err = cmd.Output()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(out)).ShouldNot(ContainSubstring("cali_ctlb_progs"))
 		cmd = exec.Command("bpftool", "prog", "show")
 		out, err = cmd.Output()
 		Expect(err).NotTo(HaveOccurred())
@@ -1050,6 +1042,7 @@ func TestCTLBAttach(t *testing.T) {
 	}
 	testCtlbAttach(true, false)
 	testCtlbAttach(false, true)
+	testCtlbAttach(true, true)
 }
 
 func TestLogFilters(t *testing.T) {

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -892,78 +892,164 @@ func TestRepeatedAttach(t *testing.T) {
 
 func TestCTLBAttachLegacy(t *testing.T) {
 	RegisterTestingT(t)
-	err := nat.InstallConnectTimeLoadBalancerLegacy(true, false, "", "debug", 60*time.Second, false)
-	Expect(err).NotTo(HaveOccurred())
 
-	checkPinPath := func(pinPath string, mustExist bool) {
-		_, err := os.Stat(pinPath)
-		if mustExist {
-			Expect(err).NotTo(HaveOccurred())
-		} else {
-			Expect(err).To(HaveOccurred())
+	testCtlbAttachLegacy := func(v4, v6 bool) {
+		err := nat.InstallConnectTimeLoadBalancerLegacy(v4, v6, "", "debug", 60*time.Second, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		checkPinPath := func(pinPath string, mustExist bool) {
+			_, err := os.Stat(pinPath)
+			if mustExist {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
 		}
+
+		checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v6", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v6", false)
+		checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v6", false)
+
+		cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+		out, err := cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		if v4 {
+			Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
+			Expect(string(out)).Should(ContainSubstring("calico_sendmsg_v4"))
+			Expect(string(out)).Should(ContainSubstring("calico_recvmsg_v4"))
+			Expect(string(out)).Should(ContainSubstring("calico_connect_v46"))
+			Expect(string(out)).Should(ContainSubstring("calico_sendmsg_v46"))
+			Expect(string(out)).Should(ContainSubstring("calico_recvmsg_v46"))
+		} else if v6 {
+			Expect(string(out)).Should(ContainSubstring("calico_connect_v6"))
+			Expect(string(out)).Should(ContainSubstring("calico_sendmsg_v6"))
+			Expect(string(out)).Should(ContainSubstring("calico_recvmsg_v6"))
+		}
+		err = nat.RemoveConnectTimeLoadBalancer(v4, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+		out, err = cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		if v4 {
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v4"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v4"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v46"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v46"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v46"))
+		} else if v6 {
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v6"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v6"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v6"))
+		}
+		cmd = exec.Command("bpftool", "map", "show")
+		out, err = cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(out)).ShouldNot(ContainSubstring("cali_ctlb_progs"))
+		cmd = exec.Command("bpftool", "prog", "show")
+		out, err = cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(out)).ShouldNot(ContainSubstring("calico_connect"))
+		Expect(string(out)).ShouldNot(ContainSubstring("calico_send"))
+		Expect(string(out)).ShouldNot(ContainSubstring("calico_recv"))
 	}
-
-	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
-
-	cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
-	out, err := cmd.Output()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
-
-	err = nat.RemoveConnectTimeLoadBalancer("")
-	Expect(err).NotTo(HaveOccurred())
-
-	cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
-	out, err = cmd.Output()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
+	testCtlbAttachLegacy(true, false)
+	testCtlbAttachLegacy(false, true)
 }
 
 func TestCTLBAttach(t *testing.T) {
 	RegisterTestingT(t)
-	err := nat.InstallConnectTimeLoadBalancer(true, false, "", "debug", 60*time.Second, false)
-	Expect(err).NotTo(HaveOccurred())
+	testCtlbAttach := func(v4, v6 bool) {
+		err := nat.InstallConnectTimeLoadBalancer(v4, v6, "", "debug", 60*time.Second, false)
+		Expect(err).NotTo(HaveOccurred())
 
-	checkPinPath := func(pinPath string, mustExist bool) {
-		_, err := os.Stat(pinPath)
-		if mustExist {
-			Expect(err).NotTo(HaveOccurred())
-		} else {
-			Expect(err).To(HaveOccurred())
+		checkPinPath := func(pinPath string, mustExist bool) {
+			_, err := os.Stat(pinPath)
+			if mustExist {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
 		}
+		if v4 {
+			checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", true)
+		} else if v6 {
+			checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v6", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v6", true)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v6", true)
+		}
+
+		cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+		out, err := cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		if v4 {
+			Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
+			Expect(string(out)).Should(ContainSubstring("calico_sendmsg_v4"))
+			Expect(string(out)).Should(ContainSubstring("calico_recvmsg_v4"))
+			Expect(string(out)).Should(ContainSubstring("calico_connect_v46"))
+			Expect(string(out)).Should(ContainSubstring("calico_sendmsg_v46"))
+			Expect(string(out)).Should(ContainSubstring("calico_recvmsg_v46"))
+		} else if v6 {
+			Expect(string(out)).Should(ContainSubstring("calico_connect_v6"))
+			Expect(string(out)).Should(ContainSubstring("calico_sendmsg_v6"))
+			Expect(string(out)).Should(ContainSubstring("calico_recvmsg_v6"))
+		}
+		err = nat.RemoveConnectTimeLoadBalancer(v4, "")
+		Expect(err).NotTo(HaveOccurred())
+		if v4 {
+			checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
+		} else if v6 {
+			checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v6", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v6", false)
+			checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v6", false)
+		}
+
+		cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
+		out, err = cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		if v4 {
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v4"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v4"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v46"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v46"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v46"))
+		} else if v6 {
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v6"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_sendmsg_v6"))
+			Expect(string(out)).ShouldNot(ContainSubstring("calico_recvmsg_v6"))
+		}
+
+		cmd = exec.Command("bpftool", "map", "show")
+		out, err = cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(out)).ShouldNot(ContainSubstring("cali_ctlb_progs"))
+		cmd = exec.Command("bpftool", "prog", "show")
+		out, err = cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(out)).ShouldNot(ContainSubstring("calico_connect"))
+		Expect(string(out)).ShouldNot(ContainSubstring("calico_send"))
+		Expect(string(out)).ShouldNot(ContainSubstring("calico_recv"))
 	}
-
-	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", true)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", true)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", true)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", true)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", true)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", true)
-
-	cmd := exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
-	out, err := cmd.Output()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(string(out)).Should(ContainSubstring("calico_connect_v4"))
-
-	err = nat.RemoveConnectTimeLoadBalancer("")
-	Expect(err).NotTo(HaveOccurred())
-	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v4", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_connect_v46", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v4", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_sendmsg_v46", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v4", false)
-	checkPinPath("/sys/fs/bpf/ctlb/calico_recvmsg_v46", false)
-
-	cmd = exec.Command("bpftool", "cgroup", "show", "/run/calico/cgroup")
-	out, err = cmd.Output()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(string(out)).ShouldNot(ContainSubstring("calico_connect_v4"))
+	testCtlbAttach(true, false)
+	testCtlbAttach(false, true)
 }
 
 func TestLogFilters(t *testing.T) {

--- a/felix/cmd/calico-bpf/commands/connect_time.go
+++ b/felix/cmd/calico-bpf/commands/connect_time.go
@@ -30,7 +30,7 @@ var ctCleanupCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "removes connect-time BPF programs",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := nat.RemoveConnectTimeLoadBalancer(""); err != nil {
+		if err := nat.RemoveConnectTimeLoadBalancer(true, ""); err != nil {
 			log.WithError(err).Error("Failed to clean up connect-time load balancer.")
 		}
 	},

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -784,7 +784,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.RegisterManager(newPolicyManager(rawTableV4, mangleTableV4, filterTableV4, ruleRenderer, 4, config.RulesConfig.NFTables))
 
 		// Clean up any leftover BPF state.
-		err := bpfnat.RemoveConnectTimeLoadBalancer("")
+		err := bpfnat.RemoveConnectTimeLoadBalancer(true, "")
 		if err != nil {
 			log.WithError(err).Info("Failed to remove BPF connect-time load balancer, ignoring.")
 		}
@@ -958,7 +958,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			log.Infof("Connect time load balancer enabled: %s", config.BPFConnTimeLB)
 		} else {
 			// Deactivate the connect-time load balancer.
-			err = nat.RemoveConnectTimeLoadBalancer(config.BPFCgroupV2)
+			err = nat.RemoveConnectTimeLoadBalancer(true, config.BPFCgroupV2)
 			if err != nil {
 				log.WithError(err).Warn("Failed to detach connect-time load balancer. Ignoring.")
 			}


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10490 on release-v3.30.

#10490: Fix attaching ctlb for ipv6 and detaching programs in

# Original PR Body below

## Description

This PR fixes
1. Attach cgroup for ipv6
2. While detaching cgroup-legacy, the cgroup root has to be opened, closed every time for each CGROUP attach type.
3. Close FD when opening link from a pin.
4. UTs for attach/detach for v4 and v6. UTs validate there are no ctlb programs lingering around after removing ctlb.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.