### PR TITLE
Update default trusted bundle file path from "tigera-ca-bundle.crt" to "ca.crt"

### DIFF
--- a/test-tools/mocknode/cmd/mocknode/main.go
+++ b/test-tools/mocknode/cmd/mocknode/main.go
@@ -110,7 +110,7 @@ func (s *syncerCallbacks) LogStats() {
 const (
 	typhaNamespace      = "calico-system"
 	typhaK8sServiceName = "calico-typha"
-	typhaCAFile         = "/etc/pki/tls/certs/tigera-ca-bundle.crt"
+	typhaCAFile         = "/etc/pki/tls/certs/ca.crt"
 	typhaCertFile       = "/node-certs/tls.crt"
 	typhaKeyFile        = "/node-certs/tls.key"
 	typhaCN             = "typha-server"

--- a/whisker-backend/pkg/config/api.go
+++ b/whisker-backend/pkg/config/api.go
@@ -34,7 +34,7 @@ type Config struct {
 	// TLS certificate and key for both server TLS and Goldmane client mTLS.
 	TLSCertPath string `default:"" envconfig:"TLS_CERT_PATH"`
 	TLSKeyPath  string `default:"" envconfig:"TLS_KEY_PATH"`
-	CACertPath  string `default:"/etc/pki/tls/certs/tigera-ca-bundle.crt" envconfig:"CA_CERT_PATH"`
+	CACertPath  string `default:"/etc/pki/tls/certs/ca.crt" envconfig:"CA_CERT_PATH"`
 }
 
 func NewConfig() (*Config, error) {


### PR DESCRIPTION
## Description

The config map key has been changed in via the operator. The old value is still available but we want to remove that value after a release or two.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
