### PR TITLE
Reduce log level for spammy log

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr.go
+++ b/felix/dataplane/linux/endpoint_mgr.go
@@ -901,7 +901,8 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
 		m.localBGPPeerIP = m.newLocalBGPPeerIP
 		log.WithFields(log.Fields{
 			"oldIP": m.localBGPPeerIP,
-			"newIP": m.newLocalBGPPeerIP}).Debug("local BGP peer IP updated.")
+			"newIP": m.newLocalBGPPeerIP,
+		}).Debug("local BGP peer IP updated.")
 		// Reconfigure the interfaces of all active workload endpoints.
 		for ifaceName := range m.activeWlIfaceNameToID {
 			m.wlIfaceNamesToReconfigure.Add(ifaceName)
@@ -1518,7 +1519,11 @@ func (m *endpointManager) configureInterface(name string) error {
 			if err2 != nil {
 				log.WithError(err2).Error("Error checking if interface exists")
 			}
-			log.WithError(err).WithField("ifaceName", name).Warnf("Could not set accept_ra")
+			if m.ipVersion == 6 {
+				log.WithError(err).WithField("ifaceName", name).Warn("Could not set accept_ra")
+			} else {
+				log.WithError(err).WithField("ifaceName", name).Debug("Could not set accept_ra")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/6318


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Reduce log level for spammy IPv6 RA log when IPv6 is disabled.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.