### PR TITLE
[Release v3.30] Match all supported protocols in app policy matcher

### DIFF
--- a/app-policy/checker/match_test.go
+++ b/app-policy/checker/match_test.go
@@ -520,6 +520,210 @@ func TestMatchL4Protocol(t *testing.T) {
 	Expect(match("testns", rule, reqCache)).To(BeFalse())
 	req.GetAttributes().GetDestination().Address = nil
 	rule.NotProtocol = nil
+
+	// With Protocol == 1 rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 1,
+		},
+	}
+	Expect(matchL4Protocol(rule, 1)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 100)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != 1 rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 1,
+		},
+	}
+	Expect(matchL4Protocol(rule, 1)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 100)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == ICMP rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "ICMP",
+		},
+	}
+	Expect(matchL4Protocol(rule, 1)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 99)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != ICMP rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "ICMP",
+		},
+	}
+	Expect(matchL4Protocol(rule, 1)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 99)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == 132 (SCTP) rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 132,
+		},
+	}
+	Expect(matchL4Protocol(rule, 132)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 110)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != 132 (SCTP) rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 132,
+		},
+	}
+	Expect(matchL4Protocol(rule, 132)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 110)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == SCTP rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "SCTP",
+		},
+	}
+	Expect(matchL4Protocol(rule, 132)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 120)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != SCTP rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "SCTP",
+		},
+	}
+	Expect(matchL4Protocol(rule, 132)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 120)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == 58 (ICMPv6) rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 58,
+		},
+	}
+	Expect(matchL4Protocol(rule, 58)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 60)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != 58 (ICMPv6) rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 58,
+		},
+	}
+	Expect(matchL4Protocol(rule, 58)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 60)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == ICMPv6 rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "ICMPv6",
+		},
+	}
+	Expect(matchL4Protocol(rule, 58)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 40)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != ICMPv6 rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "ICMPv6",
+		},
+	}
+	Expect(matchL4Protocol(rule, 58)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 40)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == 136 (UDPLite) rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 136,
+		},
+	}
+	Expect(matchL4Protocol(rule, 136)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 60)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != 136 (UDPLite) rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 136,
+		},
+	}
+	Expect(matchL4Protocol(rule, 136)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 60)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With Protocol == ICMPv6 rule.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "UDPLite",
+		},
+	}
+	Expect(matchL4Protocol(rule, 136)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 80)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With Protocol != ICMPv6 rule.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "UDPLite",
+		},
+	}
+	Expect(matchL4Protocol(rule, 136)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 80)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With an random protocol.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 99,
+		},
+	}
+	Expect(matchL4Protocol(rule, 99)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 80)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With an randome protocol NOT selected.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Number{
+			Number: 99,
+		},
+	}
+	Expect(matchL4Protocol(rule, 99)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 80)).To(BeTrue())
+	rule.NotProtocol = nil
+
+	// With a randome protocol name.
+	rule.Protocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "protoX",
+		},
+	}
+	Expect(matchL4Protocol(rule, 99)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 0)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 300)).To(BeFalse())
+	Expect(matchL4Protocol(rule, -30)).To(BeFalse())
+	rule.Protocol = nil
+
+	// With a randome protocol name NOT selecte.
+	rule.NotProtocol = &proto.Protocol{
+		NumberOrName: &proto.Protocol_Name{
+			Name: "protoX",
+		},
+	}
+	Expect(matchL4Protocol(rule, 99)).To(BeTrue())
+	Expect(matchL4Protocol(rule, 0)).To(BeFalse())
+	Expect(matchL4Protocol(rule, 300)).To(BeFalse())
+	Expect(matchL4Protocol(rule, -30)).To(BeFalse())
+	rule.NotProtocol = nil
 }
 
 func TestMatchNet(t *testing.T) {


### PR DESCRIPTION
## Description

Accept all supported protocol cases in app policy matcher based on API definition here: https://github.com/projectcalico/calico/blob/master/api/pkg/apis/projectcalico/v3/policy_common.go#L45-L46

Pick of https://github.com/projectcalico/calico/pull/10546

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Match all supported protocols in app policy .
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
