### PR TITLE
[release tool] fix operator image list

### DIFF
--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -309,6 +309,7 @@ func normalizeComponent(name string, c registry.Component) registry.Component {
 	if img == "" {
 		img = name
 	}
+	c.Image = img
 	if strings.HasPrefix(img, calicoImageNamespace) {
 		c.Image = strings.TrimPrefix(img, calicoImageNamespace)
 	}

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -41,6 +41,8 @@ const (
 	operatorComponentsFileName = "pinned_components.yml"
 )
 
+const calicoImageNamespace = "calico/"
+
 var excludedComponents = []string{
 	utils.Calico,
 	"calico/api",
@@ -200,6 +202,9 @@ func GenerateOperatorComponents(srcDir, outputDir string) (registry.OperatorComp
 	if err != nil {
 		return op, "", err
 	}
+	for name, component := range pinnedVersion.Components {
+		pinnedVersion.Components[name] = normalizeComponent(name, component)
+	}
 	operatorComponentsFilePath := filepath.Join(srcDir, operatorComponentsFileName)
 	operatorComponentsFile, err := os.Create(operatorComponentsFilePath)
 	if err != nil {
@@ -281,13 +286,7 @@ func RetrieveImageComponents(outputDir string) (map[string]registry.Component, e
 			delete(components, name)
 			continue
 		}
-		img := registry.ImageMap[name]
-		if img != "" {
-			component.Image = img
-		} else if component.Image == "" {
-			component.Image = name
-		}
-		components[name] = component
+		components[name] = normalizeComponent(name, component)
 	}
 	return components, nil
 }
@@ -299,4 +298,19 @@ func RetrieveVersions(outputDir string) (version.Versions, error) {
 	}
 
 	return version.NewHashreleaseVersions(version.New(pinnedVersion.Title), pinnedVersion.TigeraOperator.Version), nil
+}
+
+// normalizeComponent normalizes the component image name.
+// It checks if the image is in the registry.ImageMap and replaces it with the mapped value.
+// If the image is not found in the map, it sets it to the name of the component.
+// The image is also stripped of the calico namespace prefix if it exists.
+func normalizeComponent(name string, c registry.Component) registry.Component {
+	img := registry.ImageMap[c.Image]
+	if img == "" {
+		img = name
+	}
+	if strings.HasPrefix(img, calicoImageNamespace) {
+		c.Image = strings.TrimPrefix(img, calicoImageNamespace)
+	}
+	return c
 }

--- a/release/internal/pinnedversion/release.go
+++ b/release/internal/pinnedversion/release.go
@@ -64,10 +64,10 @@ func (p *CalicoReleaseVersions) ImageList() ([]string, error) {
 	}
 	componentNames := make([]string, 0, len(components))
 	for _, component := range components {
-		if component.Image == "tigera/operator" {
+		if component.Image == registry.TigeraOperatorImage {
 			continue
 		}
-		componentNames = append(componentNames, strings.TrimPrefix(component.Image, "calico/"))
+		componentNames = append(componentNames, strings.TrimPrefix(component.Image, calicoImageNamespace))
 	}
 	return componentNames, nil
 }

--- a/release/internal/registry/image.go
+++ b/release/internal/registry/image.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
+const TigeraOperatorImage = "tigera/operator"
+
 // ImageMap maps the image name to the repository.
 var ImageMap = map[string]string{
 	"typha":                     "calico/typha",

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -43,7 +43,7 @@ var (
 )
 
 const (
-	DefaultImage               = "tigera/operator"
+	DefaultImage               = registry.TigeraOperatorImage
 	DefaultOrg                 = utils.TigeraOrg
 	DefaultRepoName            = "operator"
 	DefaultRemote              = utils.DefaultRemote


### PR DESCRIPTION
## Description

This fixes an issue inadvertently introduced by #10524.

To allow generating operator using dev images while creating a hashrelease, the registry in operator gets updated and images passed have their names modified to remove the `calico/` namespace prefix.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
