### PR TITLE
fix ISS result in slack annoucements

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -261,12 +261,16 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				if !c.Bool(skipImageScanFlag.Name) {
-					hashrel.ImageScanResultURL, err = imagescanner.RetrieveResultURL(cfg.TmpDir)
+					url, err := imagescanner.RetrieveResultURL(cfg.TmpDir)
 					// Only log error as a warning if the image scan result URL could not be retrieved
 					// as it is not an error that should stop the hashrelease process.
 					if err != nil {
 						logrus.WithError(err).Warn("Failed to retrieve image scan result URL")
 					}
+					if url == "" {
+						logrus.Warn("Image scan result URL is empty")
+					}
+					hashrel.ImageScanResultURL = url
 				}
 
 				// Send a slack message to notify that the hashrelease has been published.

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -266,8 +266,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					// as it is not an error that should stop the hashrelease process.
 					if err != nil {
 						logrus.WithError(err).Warn("Failed to retrieve image scan result URL")
-					}
-					if url == "" {
+					} else if url == "" {
 						logrus.Warn("Image scan result URL is empty")
 					}
 					hashrel.ImageScanResultURL = url

--- a/release/internal/imagescanner/scanner.go
+++ b/release/internal/imagescanner/scanner.go
@@ -169,8 +169,8 @@ func RetrieveResultURL(outputDir string) (string, error) {
 		logrus.WithError(err).Error("Failed to unmarshal image scan result")
 		return "", err
 	}
-	if link, ok := result["results_link"].(string); ok {
-		return link, nil
+	if link, ok := result["results_link"]; ok {
+		return link.(string), nil
 	}
 	return "", fmt.Errorf("no results link found in image scan result")
 }

--- a/release/internal/imagescanner/scanner.go
+++ b/release/internal/imagescanner/scanner.go
@@ -169,8 +169,8 @@ func RetrieveResultURL(outputDir string) (string, error) {
 		logrus.WithError(err).Error("Failed to unmarshal image scan result")
 		return "", err
 	}
-	if link, ok := result["results_link"]; ok {
-		return link.(string), nil
+	if link, ok := result["results_link"].(string); ok {
+		return link, nil
 	}
 	return "", fmt.Errorf("no results link found in image scan result")
 }

--- a/release/internal/slack/message.go
+++ b/release/internal/slack/message.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"


### PR DESCRIPTION
## Description

Slack annoucements for hashreleases are not including the ISS result link. This is either because the result link from the API is blank or it is not being set correctly in the hashrelease.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
