### PR TITLE
CORE-11535: Fix svlogd rotated log files permissions

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -76,6 +76,7 @@ RUN rpm -i ${IPSET_SOURCERPM_URL} && \
 # get it from the debian repos as the official website doesn't support https
 RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz | tar xz -C /root && \
     cd /root/admin/runit-${RUNIT_VER} && \
+    sed -i '208s/0744/0644/' src/svlogd.c && sed -i '285s/0744/0644/' src/svlogd.c && sed -i '375s/0744/0644/' src/svlogd.c && \
     package/compile
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS ubi


### PR DESCRIPTION
## Description

📝 **Summary**
This PR addresses an issue where svlogd creates rotated log files with `0744` permissions, making them executable. Executable permissions on log files are unnecessary and potentially confusing or risky. The fix modifies `svlogd.c` to use `0644` instead, ensuring log files are readable but not executable.

🐞 **Initial Problem**
In the Calico node container, rotated log files under `/var/log/calico/*** were being created with permissions `-rwxr--r-- (0744)`. These permissions are overly permissive for logs, which should not be executable.

**Jira**
https://tigera.atlassian.net/browse/CI-1790

✅ **Testing**
 - Rebuilt `svlogd` with patched permissions using sed during the image build step.
 - Deployed and tested in a `local Kind` cluster.
 - Verified that rotated log files are now created with `0644` permissions.
 - Confirmed that `svlogd` continues to handle log rotation and writing correctly.

📦 Components Affected
 - `calico/node` image (Docker build step)
 - Logging subsystem (svlogd behavior)

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
