### PR TITLE
[release-tool] fix normalizing pinned images components

### DIFF
--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -301,13 +301,13 @@ func RetrieveVersions(outputDir string) (version.Versions, error) {
 }
 
 // normalizeComponent normalizes the component image name.
-// It checks if the image is in the registry.ImageMap and replaces it with the mapped value.
-// If the image is not found in the map, it sets it to the name of the component.
-// The image is also stripped of the calico namespace prefix if it exists.
-func normalizeComponent(name string, c registry.Component) registry.Component {
-	img := registry.ImageMap[c.Image]
+// It checks if the component name is in the registry.ImageMap and replaces it with the mapped value.
+// If the image name is not found in the map, it sets it to the component name.
+// The image name is also stripped of the calico namespace prefix.
+func normalizeComponent(componentName string, c registry.Component) registry.Component {
+	img := registry.ImageMap[componentName]
 	if img == "" {
-		img = name
+		img = componentName
 	}
 	c.Image = img
 	if strings.HasPrefix(img, calicoImageNamespace) {

--- a/release/internal/pinnedversion/pinnedversion_test.go
+++ b/release/internal/pinnedversion/pinnedversion_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pinnedversion
+
+import (
+	"testing"
+
+	"github.com/projectcalico/calico/release/internal/registry"
+)
+
+func TestNormalizeComponent(t *testing.T) {
+	for _, tt := range []struct {
+		componentName string
+		component     registry.Component
+		expected      registry.Component
+	}{
+		// components in registry.ImageMap
+		{
+			componentName: "typha",
+			component: registry.Component{
+				Version: "v1.0.0",
+			},
+			expected: registry.Component{
+				Version: "v1.0.0",
+				Image:   "typha",
+			},
+		},
+		{
+			componentName: "calicoctl",
+			component: registry.Component{
+				Version: "v1.0.0",
+			},
+			expected: registry.Component{
+				Version: "v1.0.0",
+				Image:   "ctl",
+			},
+		},
+		{
+			componentName: "flannel",
+			component: registry.Component{
+				Version:  "v0.14.0",
+				Registry: "quay.io",
+			},
+			expected: registry.Component{
+				Version:  "v0.14.0",
+				Image:    "coreos/flannel",
+				Registry: "quay.io",
+			},
+		},
+		{
+			componentName: "flexvol",
+			component: registry.Component{
+				Version: "v1.0.0",
+			},
+			expected: registry.Component{
+				Version: "v1.0.0",
+				Image:   "pod2daemon-flexvol",
+			},
+		},
+		{
+			componentName: "key-cert-provisioner",
+			component: registry.Component{
+				Version: "v1.0.0",
+			},
+			expected: registry.Component{
+				Version: "v1.0.0",
+				Image:   "key-cert-provisioner",
+			},
+		},
+		{
+			componentName: "csi-node-driver-registrar",
+			component: registry.Component{
+				Version: "v1.0.0",
+			},
+			expected: registry.Component{
+				Version: "v1.0.0",
+				Image:   "node-driver-registrar",
+			},
+		},
+		// components not in registry.ImageMap
+		{
+			componentName: "calico/cni",
+			component: registry.Component{
+				Version: "v1.0.0",
+				Image:   "cni",
+			},
+			expected: registry.Component{
+				Version: "v1.0.0",
+				Image:   "cni",
+			},
+		},
+	} {
+		t.Run(tt.componentName, func(t *testing.T) {
+			got := normalizeComponent(tt.componentName, tt.component)
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This fixes the normalization of images for a component to check in the registry image map using the component name.

Also added tests

## Related issues/PRs

- error introduced in #10583 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
