### PR TITLE
Cherry-pick to v3.29: Fix CalicoNodeStatus update stuck in conflict

### DIFF
--- a/node/pkg/status/nodestatus.go
+++ b/node/pkg/status/nodestatus.go
@@ -288,8 +288,8 @@ func (r *NodeStatusReporter) processPendingUpdates() {
 				r.reporter[name] = reporter
 			} else {
 				// updated resource.
-				// Check if it has the same spec with the current status being handled by the reporter.
-				if r.reporter[name].HasSameSpec(data) {
+				// Check if it has the same or newer spec with the current status being handled by the reporter.
+				if r.reporter[name].HasSameOrNewerSpec(data) {
 					// we don't need to do anything. It is possible we get here
 					// because the resource has been updated by the reporter itself.
 					log.Debugf("Anticipated resource update: %s. Do nothing.", name)

--- a/node/pkg/status/nodestatus_test.go
+++ b/node/pkg/status/nodestatus_test.go
@@ -17,6 +17,7 @@ package status_test
 import (
 	"context"
 	"errors"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -30,6 +31,8 @@ import (
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/syncersv1/nodestatussyncer"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
@@ -51,6 +54,9 @@ var _ = Describe("Node status FV tests", func() {
 	Expect(err).NotTo(HaveOccurred())
 	cfg.Spec = apiconfig.CalicoAPIConfigSpec{
 		DatastoreType: apiconfig.Kubernetes,
+		KubeConfig: apiconfig.KubeConfig{
+			Kubeconfig: os.Getenv("KUBECONFIG"),
+		},
 	}
 
 	c, err := client.New(*cfg)
@@ -323,6 +329,42 @@ var _ = Describe("Node status FV tests", func() {
 			Expect(new.Status.BGP).To(Equal(emptyBGP))
 			Expect(new.Status.Routes).To(Equal(emptyRoutes))
 		})
+	})
+
+	Specify("Reporter should handle conflict in case of syncer missing update", func() {
+		// Create reporter without syncer, because we are going to simulate syncer missing update
+		mock := newMockBird(v4Status, v6Status, v4Peer, v6Peer, v4Route, v6Route)
+		r := status.NewNodeStatusReporter(nodeName, cfg, c, getPopulators(mock))
+		go r.Run()
+		defer r.Stop()
+
+		// Create a node status request with update period of 5 seconds, notify reporter
+		Expect(be.Clean()).NotTo(HaveOccurred())
+		createCalicoNodeStatus(c, nodeName, name, 5)
+		r.OnUpdates([]api.Update{
+			{KVPair: model.KVPair{Key: model.ResourceKey{Name: name}, Value: getCurrentStatus()}},
+		})
+		r.OnStatusUpdated(api.InSync)
+
+		// Wait for first immediate status update
+		var firstStatus *apiv3.CalicoNodeStatus
+		Eventually(func() metav1.Time {
+			firstStatus = getCurrentStatus()
+			return firstStatus.Status.LastUpdated
+		}, 2*time.Second, 500*time.Millisecond).Should(Not(BeZero()))
+
+		// Update object, but do not notify reporter (simulate syncer missing update)
+		newPeriod := uint32(1)
+		secondStatus := firstStatus.DeepCopy()
+		secondStatus.Spec.UpdatePeriodSeconds = &newPeriod
+		_, err = c.CalicoNodeStatus().Update(context.Background(), secondStatus, options.SetOptions{})
+		Expect(err).To(Not(HaveOccurred()))
+
+		// Update actual state and wait reporter to resolve conflict and update status
+		mock.setLastBootTime(BootTimeSecond)
+		Eventually(func() metav1.Time {
+			return getCurrentStatus().Status.LastUpdated
+		}, 10*time.Second, 500*time.Millisecond).Should(Not(Equal(firstStatus.Status.LastUpdated)))
 	})
 })
 


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/projectcalico/calico/pull/10555 to v3.29

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8715

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that CalicoNodeStatus updates could get blocked by datastore errors
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
