### PR TITLE
Cherry-pick to v3.30: Fix CalicoNodeStatus update stuck in conflict

### DIFF
--- a/node/pkg/status/nodestatus.go
+++ b/node/pkg/status/nodestatus.go
@@ -288,8 +288,8 @@ func (r *NodeStatusReporter) processPendingUpdates() {
 				r.reporter[name] = reporter
 			} else {
 				// updated resource.
-				// Check if it has the same spec with the current status being handled by the reporter.
-				if r.reporter[name].HasSameSpec(data) {
+				// Check if it has the same or newer spec with the current status being handled by the reporter.
+				if r.reporter[name].HasSameOrNewerSpec(data) {
 					// we don't need to do anything. It is possible we get here
 					// because the resource has been updated by the reporter itself.
 					log.Debugf("Anticipated resource update: %s. Do nothing.", name)


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/projectcalico/calico/pull/10555 to v3.30

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8715

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that CalicoNodeStatus updates could get blocked by datastore errors
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
