### PR TITLE
Fix flakiness of win cni-plugin CI (#10588)

### DIFF
--- a/process/testing/winfv-cni-plugin/aso/Makefile
+++ b/process/testing/winfv-cni-plugin/aso/Makefile
@@ -40,7 +40,8 @@ create-vmss: $(VMSS_MARKER)
 $(VMSS_MARKER): $(BINDIR)/kubectl $(BINDIR)/gomplate
 	@echo "Creating azure resources include vmss-linux and vmss-windows ..."
 	./vmss.sh create
-	./vmss.sh show
+	./vmss.sh info
+	./vmss.sh confirm-ssh
 	touch $@
 
 .PHONY: delete-vmss

--- a/process/testing/winfv-cni-plugin/aso/vmss.sh
+++ b/process/testing/winfv-cni-plugin/aso/vmss.sh
@@ -53,6 +53,7 @@ function delete_azure_crds() {
 
 function show_connections() {
   # Wait for vmss deployments
+  echo; echo "show_connections started..."
   echo "Wait for vmss-linux to be ready ..."
   ${KUBECTL} wait --for=condition=Ready --timeout=8m -n winfv virtualmachinescalesets vmss-linux
   LINUX_INSTANCE_ID=$(az vmss list-instances --name vmss-linux --resource-group $AZURE_RESOURCE_GROUP --query "[0].instanceId" | sed 's/"//g')
@@ -112,6 +113,56 @@ EOF
 chmod +x ./scp-from-windows.sh
 
   pause-for-debug
+  echo "show_connections done."; echo
+}
+
+function retry-ssh() {
+  local SSH_CMD=$1
+  local RETRY_INTERVAL=30         # Seconds between retries
+  local MAX_DURATION=300
+
+  # Tracking time
+  START_TIME=$(date +%s)
+
+  while true; do
+    echo "Attempting $SSH_CMD..."
+    if $SSH_CMD; then
+        echo "SSH command succeeded."
+        return 0
+    else
+        echo "SSH command failed. Running show_connections and retrying in $RETRY_INTERVAL seconds..."
+        show_connections  # Replace with your actual command or function
+    fi
+
+    sleep $RETRY_INTERVAL
+
+    CURRENT_TIME=$(date +%s)
+    ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
+
+    if [ $ELAPSED_TIME -ge $MAX_DURATION ]; then
+        echo "Timeout reached after $((MAX_DURATION / 60)) minutes. Giving up."
+        exit 1
+    fi
+  done
+}
+
+# Azure may assign a different public IP to a VM even after it is marked as ready.
+# This function attempts to SSH into the VM multiple times to ensure it is accessible.
+function confirm-nodes-ssh() {
+  echo;echo "confirm nodes can be accessed by ssh..."
+  show_connections
+  retry-ssh "${MASTER_CONNECT_COMMAND} echo"
+  retry-ssh "${WINDOWS_CONNECT_COMMAND} -Command 'echo'"
+
+  # Azure may assign another public IP to the VM.
+  # So even the first batch of SSHes works, the ip could be updated later.
+  # Sleep and retry.
+  echo "sleep 30 seconds..."
+  sleep 30
+  show_connections
+  retry-ssh "${MASTER_CONNECT_COMMAND} echo"
+  retry-ssh "${WINDOWS_CONNECT_COMMAND} -Command 'echo'"
+  echo "VMs can be accessed by ssh.";echo
 }
 
 function parse_options() {
@@ -149,8 +200,11 @@ case $1 in
   info)
     show_connections
     ;;
+  confirm-ssh)
+    confirm-nodes-ssh
+    ;;
   *)
-    echo "vmss.sh [create|info]"
+    echo "vmss.sh [create|info|confirm-ssh]"
     ;;
 esac
 


### PR DESCRIPTION
* Fix flakiness of win cni-plugin CI

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
