### PR TITLE
[BPF] scale trampoline stride in policy programs

### DIFF
--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -695,6 +695,9 @@ func (b *Block) addInsnWithOffsetFixup(insn Insn, targetLabel string) {
 }
 
 func (b *Block) maybeWriteTrampoline(nextInsn Insn) {
+	if !b.trampolinesEnabled {
+		return
+	}
 	if len(b.insns)-b.lastTrampolineAddr < trampolineInterval {
 		return
 	}

--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -381,6 +381,7 @@ type Block struct {
 	lastTrampolineAddr int
 	deferredErr        error
 	NumJumps           int
+	trampolineStride   int
 }
 
 func NewBlock(policyDebugEnabled bool) *Block {
@@ -392,6 +393,7 @@ func NewBlock(policyDebugEnabled bool) *Block {
 		policyDebugEnabled: policyDebugEnabled,
 		fixUps:             map[string][]fixUp{},
 		trampolinesEnabled: true,
+		trampolineStride:   TrampolineStrideDefault,
 	}
 }
 
@@ -686,7 +688,7 @@ type OffsetFixer func(origInsn Insn) Insn
 // (1-2 for a rule, one to jump to accept/deny/end-of-tier) this seems like
 // it should be enough.
 const trampolineHeadroom = 100
-const trampolineInterval = math.MaxInt16 - trampolineHeadroom
+const TrampolineStrideDefault = math.MaxInt16 - trampolineHeadroom
 
 func (b *Block) addInsnWithOffsetFixup(insn Insn, targetLabel string) {
 	b.maybeWriteTrampoline(insn)
@@ -698,7 +700,8 @@ func (b *Block) maybeWriteTrampoline(nextInsn Insn) {
 	if !b.trampolinesEnabled {
 		return
 	}
-	if len(b.insns)-b.lastTrampolineAddr < trampolineInterval {
+
+	if len(b.insns)-b.lastTrampolineAddr < b.trampolineStride {
 		return
 	}
 	if nextInsn.OpCode() == LoadImm64Pt2 {
@@ -906,4 +909,10 @@ func (b *Block) ReserveInstructionCapacity(n int) {
 
 func (b *Block) SetTrampolinesEnabled(en bool) {
 	b.trampolinesEnabled = en
+}
+
+func (b *Block) SetTrampolineStride(s int) {
+	if s > 0 && s < (1<<14) {
+		b.trampolineStride = s
+	}
 }

--- a/felix/bpf/asm/asm_test.go
+++ b/felix/bpf/asm/asm_test.go
@@ -196,7 +196,7 @@ func TestSingleTrampoline(t *testing.T) {
 	// a trampoline.
 	b.JumpEq64(R1, R2, "longB")
 	b.JumpEq64(R1, R2, "longA")
-	for i := 0; i < trampolineInterval; i++ {
+	for i := 0; i < TrampolineStrideDefault; i++ {
 		b.NoOp()
 	}
 
@@ -214,7 +214,7 @@ func TestSingleTrampoline(t *testing.T) {
 	// Calculate where the trampoline should be.  We sort the jumps within
 	// the trampoline for determinacy so longA will be before longB.
 	const (
-		trampolineStartAddr = trampolineInterval + iota
+		trampolineStartAddr = TrampolineStrideDefault + iota
 		longATrampolineAddr
 		longBTrampolineAddr
 		trampolineEndAddr
@@ -227,7 +227,7 @@ func TestSingleTrampoline(t *testing.T) {
 	Expect(insns[jumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longATrampolineAddr-jumpToAAddr-1, 0)))
 
 	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
-	for i := 2; i < trampolineInterval-1; i++ {
+	for i := 2; i < TrampolineStrideDefault-1; i++ {
 		Expect(insns[i]).To(Equal(noOp))
 	}
 
@@ -259,7 +259,7 @@ func TestTrampolineLoadImm64(t *testing.T) {
 	// a trampoline.
 	b.JumpEq64(R1, R2, "longB")
 	b.JumpEq64(R1, R2, "longA")
-	for i := 0; i < trampolineInterval-3; i++ {
+	for i := 0; i < TrampolineStrideDefault-3; i++ {
 		b.NoOp()
 	}
 	b.LoadImm64(R3, 1234)
@@ -281,7 +281,7 @@ func TestTrampolineLoadImm64(t *testing.T) {
 	// Calculate where the trampoline should be.  We sort the jumps within
 	// the trampoline for determinacy so longA will be before longB.
 	const (
-		trampolineStartAddr = trampolineInterval + 1 + iota
+		trampolineStartAddr = TrampolineStrideDefault + 1 + iota
 		longBTrampolineAddr
 		trampolineEndAddr
 	)
@@ -293,7 +293,7 @@ func TestTrampolineLoadImm64(t *testing.T) {
 	Expect(insns[jumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, trampolineStartAddr-jumpToAAddr-1, 0)))
 
 	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
-	for i := 2; i < trampolineInterval-1; i++ {
+	for i := 2; i < TrampolineStrideDefault-1; i++ {
 		Expect(insns[i]).To(Equal(noOp))
 	}
 
@@ -319,7 +319,7 @@ func TestShortJumpAndTrampoline(t *testing.T) {
 	b.JumpEq64(R1, R2, "shortA")
 	b.JumpEq64(R1, R2, "longA")
 	b.LabelNextInsn("shortA")
-	for i := 0; i < trampolineInterval; i++ {
+	for i := 0; i < TrampolineStrideDefault; i++ {
 		b.NoOp()
 	}
 
@@ -335,7 +335,7 @@ func TestShortJumpAndTrampoline(t *testing.T) {
 	// Calculate where the trampoline should be.  We sort the jumps within
 	// the trampoline for determinacy so longA will be before longB.
 	const (
-		trampolineStartAddr = trampolineInterval + iota
+		trampolineStartAddr = TrampolineStrideDefault + iota
 		longATrampolineAddr
 		trampolineEndAddr
 	)
@@ -348,7 +348,7 @@ func TestShortJumpAndTrampoline(t *testing.T) {
 	Expect(insns[jumpToLong]).To(Equal(MakeInsn(JumpEq64, R1, R2, longATrampolineAddr-jumpToLong-1, 0)))
 
 	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
-	for i := 2; i < trampolineInterval-1; i++ {
+	for i := 2; i < TrampolineStrideDefault-1; i++ {
 		Expect(insns[i]).To(Equal(noOp))
 	}
 
@@ -376,7 +376,7 @@ func TestDoubleTrampoline(t *testing.T) {
 	// a trampoline.
 	b.JumpEq64(R1, R2, "longB")
 	b.JumpEq64(R1, R2, "longA")
-	for i := 0; i < trampolineInterval; i++ {
+	for i := 0; i < TrampolineStrideDefault; i++ {
 		b.NoOp()
 	}
 
@@ -385,7 +385,7 @@ func TestDoubleTrampoline(t *testing.T) {
 	b.JumpEq64(R1, R2, "longA")
 	b.JumpEq64(R1, R3, "longC")
 
-	for i := 0; i < trampolineInterval; i++ {
+	for i := 0; i < TrampolineStrideDefault; i++ {
 		b.NoOp()
 	}
 
@@ -405,7 +405,7 @@ func TestDoubleTrampoline(t *testing.T) {
 	// Calculate where the trampolines should be.  We sort the jumps within
 	// the trampoline for determinacy so longA will be before longB.
 	const (
-		trampoline0StartAddr = trampolineInterval + iota
+		trampoline0StartAddr = TrampolineStrideDefault + iota
 		longATrampoline0Addr
 		longBTrampoline0Addr
 		trampoline0EndAddr
@@ -415,7 +415,7 @@ func TestDoubleTrampoline(t *testing.T) {
 		jumpToAAddr
 	)
 	const (
-		trampoline1StartAddr = trampolineInterval*2 + iota
+		trampoline1StartAddr = TrampolineStrideDefault*2 + iota
 		longATrampoline1Addr
 		longBTrampoline1Addr
 		longCTrampoline1Addr
@@ -433,7 +433,7 @@ func TestDoubleTrampoline(t *testing.T) {
 	Expect(insns[jumpToBAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longBTrampoline0Addr-jumpToBAddr-1, 0)))
 	Expect(insns[jumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longATrampoline0Addr-jumpToAAddr-1, 0)))
 	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
-	for i := 2; i < trampolineInterval-1; i++ {
+	for i := 2; i < TrampolineStrideDefault-1; i++ {
 		Expect(insns[i]).To(Equal(noOp))
 	}
 

--- a/felix/bpf/bpf_syscall.go
+++ b/felix/bpf/bpf_syscall.go
@@ -108,8 +108,16 @@ func tryLoadBPFProgramFromInsns(insns asm.Insns, name, license string, logSize u
 		goLog := strings.TrimSpace(C.GoString((*C.char)(logBuf)))
 		log.WithError(errno).Debug("BPF_PROG_LOAD failed")
 		if len(goLog) > 0 {
-			for _, l := range strings.Split(goLog, "\n") {
+			lines := strings.Split(goLog, "\n")
+			for _, l := range lines {
 				log.Error("BPF_PROG_LOAD failed, BPF Verifier output:    ", l)
+			}
+			if errno == 524 /* Linux ENOTSUPP */ && len(lines) == 1 {
+				// likely a JIT error, verifier passed
+				// XXX we could test if it says Processed x instructions, but
+				// the message may change
+				log.Error("Likely a JIT error, bpf_harden may be set.")
+				return 0, unix.ERANGE
 			}
 		} else if logSize > 0 {
 			log.Error("BPF_PROG_LOAD failed, verifier log was empty.")

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -62,6 +62,7 @@ type Builder struct {
 	numRulesInProgram  int
 	xdp                bool
 	flowLogsEnabled    bool
+	trampolineStride   int
 }
 
 type ipSetIDProvider interface {
@@ -229,6 +230,7 @@ const (
 func (p *Builder) Instructions(rules Rules) ([]Insns, error) {
 	p.xdp = rules.ForXDP
 	p.b = NewBlock(p.policyDebugEnabled)
+	p.b.SetTrampolineStride(p.trampolineStride)
 	p.blocks = append(p.blocks, p.b)
 	p.writeProgramHeader()
 
@@ -1274,6 +1276,12 @@ func WithIPv6() Option {
 func WithFlowLogs() Option {
 	return func(p *Builder) {
 		p.flowLogsEnabled = true
+	}
+}
+
+func WithTrampolineStride(s int) Option {
+	return func(p *Builder) {
+		p.trampolineStride = s
 	}
 }
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -366,8 +367,9 @@ type bpfEndpointManager struct {
 	// Service routes
 	hostNetworkedNATMode hostNetworkedNATMode
 
-	bpfPolicyDebugEnabled bool
-	bpfRedirectToPeer     string
+	bpfPolicyDebugEnabled  bool
+	bpfRedirectToPeer      string
+	policyTrampolineStride atomic.Int32
 
 	routeTableV4     *routetable.ClassView
 	routeTableV6     *routetable.ClassView
@@ -508,6 +510,8 @@ func NewBPFEndpointManager(
 		features:         dataplanefeatures,
 		profiling:        config.BPFProfiling,
 	}
+
+	m.policyTrampolineStride.Store(int32(asm.TrampolineStrideDefault))
 
 	specialInterfaces := []string{"egress.calico"}
 	if config.RulesConfig.IPIPEnabled {
@@ -3905,16 +3909,42 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 		stride = jump.XDPMaxEntryPoints
 	}
 	opts = append(opts, polprog.WithPolicyMapIndexAndStride(polJumpMapIdx, stride))
-	progFDs, insns, err := m.loadPolicyProgramFn(
-		progName,
-		ipFamily,
-		rules,
-		staticProgsMap,
-		polProgsMap,
-		opts...,
+
+	tstrideOrig := int(m.policyTrampolineStride.Load())
+	tstride := tstrideOrig
+
+	var (
+		progFDs []fileDescriptor
+		insns   []asm.Insns
 	)
-	if err != nil {
-		return nil, err
+
+	for {
+		var err error
+
+		options := append(opts, polprog.WithTrampolineStride(tstride))
+		progFDs, insns, err = m.loadPolicyProgramFn(
+			progName,
+			ipFamily,
+			rules,
+			staticProgsMap,
+			polProgsMap,
+			options...,
+		)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) && tstride >= 1000 {
+				tstride -= 1000
+				continue
+			} else {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+
+	if tstride < tstrideOrig {
+		m.policyTrampolineStride.Store(int32(tstride))
+		log.Warnf("Reducing policy program trampoline stride to %d", tstride)
 	}
 
 	defer func() {


### PR DESCRIPTION
## Description

    When jit_harden is enabled, some long jump may get over the allowed
    distance of +/-15bit when rewritten by the kernel. When this happens, we
    may retry and recompile the policy programs with the trampolines that
    make the jumps shorter. If that still fails we may retry with even more
    dense trampolines.
    
    We remember the newly found stride for the given node so that we do not
    need to keep figuring out for other policy programs. It is likely that
    many policies would face the same issue.
    
    Note that the hardedning already increases the amount of executed
    instructions and adding some extra trampolines have probably much
    smaller effect than in a non-hardened program.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
