### PR TITLE
CORE-11514: Add CI test to check Calico images availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ ci-preflight-checks:
 	$(MAKE) check-go-mod
 	$(MAKE) verify-go-mods
 	$(MAKE) check-dockerfiles
+	$(MAKE) check-images-availability
 	$(MAKE) check-language
 	$(MAKE) generate
 	$(MAKE) fix-all
@@ -70,6 +71,10 @@ go-vet:
 
 check-dockerfiles:
 	./hack/check-dockerfiles.sh
+
+check-images-availability: bin/yq
+	OPERATOR_VERSION=$(OPERATOR_VERSION) \
+	hack/check-images-availability.sh
 
 check-language:
 	./hack/check-language.sh

--- a/hack/check-images-availability.sh
+++ b/hack/check-images-availability.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# Use provided YQ or fall back to ../bin/yq
+YQ="${YQ:-../bin/yq}"
+
+# Resolve script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Get default operator version from values.yaml if not set
+defaultOperatorVersion=$("$YQ" .tigeraOperator.version < "${SCRIPT_DIR}/../charts/tigera-operator/values.yaml")
+OPERATOR_VERSION="${OPERATOR_VERSION:-$defaultOperatorVersion}"
+
+echo "Checking images for OPERATOR_VERSION=${OPERATOR_VERSION}"
+IMAGE_SOURCE="quay.io/tigera/operator:${OPERATOR_VERSION}"
+
+#########################################
+# Step 1: Fetch image list from operator
+#########################################
+echo "Fetching image list from ${IMAGE_SOURCE}..."
+
+# Intentionally skip FIPS variants — they may not be published and are not officially supported
+operator_images=$(
+  docker run --rm "${IMAGE_SOURCE}" --print-images=list 2>/dev/null \
+  | grep -E '^[a-z0-9.-]+\.[a-z0-9.-]+/[a-z0-9._/-]+:[a-zA-Z0-9._-]+' \
+  | grep -v -- '-fips' \
+  | sort -u
+)
+
+#########################################
+# Step 2: Extract images from manifests
+#########################################
+echo "Scanning manifests directory for image references..."
+manifest_dir="${SCRIPT_DIR}/../manifests"
+
+# Intentionally skip FIPS variants — they may not be published and are not officially supported
+manifest_images=$(
+  grep -rhoP 'image:\s*["'\'']?\K([a-z0-9.-]+\.[a-z0-9.-]+/[^\s"'\'']+)' "$manifest_dir" \
+  | grep -E '^[a-z0-9.-]+\.[a-z0-9.-]+/[a-z0-9._/-]+:[a-zA-Z0-9._-]+' \
+  | grep -v -- '-fips' \
+  | sort -u
+)
+
+#########################################
+# Step 3: Combine and deduplicate
+#########################################
+all_images=$(echo -e "${operator_images}\n${manifest_images}" | sort -u)
+count=$(echo "$all_images" | wc -l)
+
+echo "Total unique images to check (excluding -fips): ${count}"
+
+#########################################
+# Step 4: Check availability using crane
+#########################################
+FAILED=0
+
+while IFS= read -r image; do
+  if crane digest "$image" >/dev/null 2>&1; then
+    echo "✅ Available: $image"
+  else
+    echo "❌ NOT FOUND: $image"
+    FAILED=1
+  fi
+done <<< "$all_images"
+
+#########################################
+# Step 5: Final result
+#########################################
+if [ "$FAILED" -eq 1 ]; then
+  echo "❗ Some images are missing or invalid."
+  exit 1
+else
+  echo "All images are available!"
+fi


### PR DESCRIPTION
## Description

**TBD**

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
