### PR TITLE
fix querying semaphore API

### DIFF
--- a/release/internal/ci/semaphore.go
+++ b/release/internal/ci/semaphore.go
@@ -35,8 +35,20 @@ type pipelineDetails struct {
 	Pipeline pipeline `json:"pipeline"`
 }
 
+func buildRequestURL(orgURL string, path ...string) (string, error) {
+	if orgURL == "" {
+		return "", errors.New("organization URL is empty")
+	}
+	path = append([]string{"api", "v1alpha"}, path...)
+	u, err := url.JoinPath(orgURL, path...)
+	if err != nil {
+		return "", fmt.Errorf("failed to construct API URL: %s", err.Error())
+	}
+	return u, nil
+}
+
 func fetchImagePromotions(orgURL, pipelineID, token string) ([]promotion, error) {
-	promotionsURL, err := url.JoinPath(orgURL, "promotions")
+	promotionsURL, err := buildRequestURL(orgURL, "promotions")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get promotions URL: %s", err.Error())
 	}
@@ -79,7 +91,7 @@ func fetchImagePromotions(orgURL, pipelineID, token string) ([]promotion, error)
 }
 
 func getPipelineResult(orgURL, pipelineID, token string) (*pipeline, error) {
-	pipelineURL, err := url.JoinPath(orgURL, "pipelines", pipelineID)
+	pipelineURL, err := buildRequestURL(orgURL, "pipelines", pipelineID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pipeline URL: %s", err.Error())
 	}
@@ -109,7 +121,7 @@ func getPipelineResult(orgURL, pipelineID, token string) (*pipeline, error) {
 }
 
 func fetchParentPipelineID(orgURL, pipelineID, token string) (string, error) {
-	pipelineURL, err := url.JoinPath(orgURL, "pipelines", pipelineID)
+	pipelineURL, err := buildRequestURL(orgURL, "pipelines", pipelineID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get pipeline URL: %s", err.Error())
 	}


### PR DESCRIPTION

## Description

currently constructs a `ORG_URL/PATH` but should be `ORG_URL/api/v1alpha/PATH`


## Related issues/PRs

error introduced when #10587 removed `apiURL` function

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
