### PR TITLE
fetch promotions for the correct Semphore pipeline

### DIFF
--- a/release/internal/ci/semaphore.go
+++ b/release/internal/ci/semaphore.go
@@ -147,7 +147,7 @@ func retrieveExpectedPromotions(repoRootDir string) ([]string, error) {
 	return list, nil
 }
 
-func getDistinctImagePromotions(promotions []promotion, orgURL, token string) (map[string]pipeline, error) {
+func gatherUniquePromotionPipelines(promotions []promotion, orgURL, token string) (map[string]pipeline, error) {
 	promotionsSet := make(map[string]pipeline)
 	for _, promotion := range promotions {
 		name := strings.ToLower(promotion.Name)
@@ -165,6 +165,7 @@ func getDistinctImagePromotions(promotions []promotion, orgURL, token string) (m
 				promotionsSet[name] = *newP
 			}
 		} else {
+			// Promotion does not exist in the set, check its status.
 			if promotion.Status != passed {
 				// If the promotion is not passed, skip checking for pipeline result and mark as failure.
 				logrus.WithField("promotion", name).Warnf("%q promotion did not pass, marking as failed", name)
@@ -173,7 +174,7 @@ func getDistinctImagePromotions(promotions []promotion, orgURL, token string) (m
 				}
 				continue
 			}
-			// If the promotion does not exist, add it to the set.
+			// Add the promotion pipeline to the set
 			pipelineResult, err := getPipelineResult(orgURL, promotion.PipelineID, token)
 			if err != nil {
 				return nil, fmt.Errorf("unable to get %q pipeline details: %w", promotion.Name, err)
@@ -221,7 +222,7 @@ func EvaluateImagePromotions(repoRootDir, orgURL, pipelineID, token string) (boo
 
 	// actualUniquePromotions is used to ensure that there are no duplicate promotions.
 	// It contains the names of the promotions in lowercase and their pipeline details.
-	actualUniquePromotions, err := getDistinctImagePromotions(promotions, orgURL, token)
+	actualUniquePromotions, err := gatherUniquePromotionPipelines(promotions, orgURL, token)
 	if err != nil {
 		return false, err
 	}

--- a/release/internal/ci/semaphore_test.go
+++ b/release/internal/ci/semaphore_test.go
@@ -314,7 +314,7 @@ func TestGetDistintImagePromotions(t *testing.T) {
 		}))
 		defer mockServer.Close()
 		promotions := []promotion{}
-		distinctPromotions, err := getDistinctImagePromotions(promotions, mockServer.URL, "test-token")
+		distinctPromotions, err := gatherUniquePromotionPipelines(promotions, mockServer.URL, "test-token")
 		if err != nil {
 			t.Fatal("failed to get distinct promotions:", err)
 		}
@@ -351,7 +351,7 @@ func TestGetDistintImagePromotions(t *testing.T) {
 				Name:       "Publish B images",
 			},
 		}
-		distinctPromotions, err := getDistinctImagePromotions(promotions, mockServer.URL, "test-token")
+		distinctPromotions, err := gatherUniquePromotionPipelines(promotions, mockServer.URL, "test-token")
 		if err != nil {
 			t.Fatal("failed to get distinct promotions:", err)
 		}
@@ -396,7 +396,7 @@ func TestGetDistintImagePromotions(t *testing.T) {
 				Name:       "Publish B images",
 			},
 		}
-		distinctPromotions, err := getDistinctImagePromotions(promotions, mockServer.URL, "test-token")
+		distinctPromotions, err := gatherUniquePromotionPipelines(promotions, mockServer.URL, "test-token")
 		if err != nil {
 			t.Fatal("failed to get distinct promotions:", err)
 		}
@@ -446,7 +446,7 @@ func TestGetDistintImagePromotions(t *testing.T) {
 				Name:       "Publish B images",
 			},
 		}
-		distinctPromotions, err := getDistinctImagePromotions(promotions, mockServer.URL, "test-token")
+		distinctPromotions, err := gatherUniquePromotionPipelines(promotions, mockServer.URL, "test-token")
 		if err != nil {
 			t.Fatal("failed to get distinct promotions:", err)
 		}
@@ -496,7 +496,7 @@ func TestGetDistintImagePromotions(t *testing.T) {
 				Name:       "Publish B images",
 			},
 		}
-		distinctPromotions, err := getDistinctImagePromotions(promotions, mockServer.URL, "test-token")
+		distinctPromotions, err := gatherUniquePromotionPipelines(promotions, mockServer.URL, "test-token")
 		if err != nil {
 			t.Fatal("failed to get distinct promotions:", err)
 		}


### PR DESCRIPTION
## Description

currently it tries to get the promotions for the hashrelease pipeline instead of the one that triggered the hashrelease pipeline

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
