### PR TITLE
Auto resize the conntrack map from the userspace cleaner.

### DIFF
--- a/felix/bpf/conntrack/conntrack_test.go
+++ b/felix/bpf/conntrack/conntrack_test.go
@@ -45,7 +45,7 @@ var _ = Describe("BPF Conntrack LivenessCalculator", func() {
 		Expect(mockTime.KTimeNanos()).To(BeNumerically("==", cttestdata.Now))
 		ctMap = mock.NewMockMap(conntrack.MapParams)
 		lc = conntrack.NewLivenessScanner(timeouts.DefaultTimeouts(), false, conntrack.WithTimeShim(mockTime))
-		scanner = conntrack.NewScanner(ctMap, conntrack.KeyFromBytes, conntrack.ValueFromBytes, lc)
+		scanner = conntrack.NewScanner(ctMap, conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", lc)
 	})
 
 	// Convert test cases from the testdata package into Ginkgo table entries.

--- a/felix/bpf/conntrack/scanner.go
+++ b/felix/bpf/conntrack/scanner.go
@@ -15,6 +15,9 @@
 package conntrack
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -92,10 +95,15 @@ type EntryScannerSynced interface {
 // It provides a delete-save iteration over the conntrack table for multiple
 // evaluation functions, to keep their implementation simpler.
 type Scanner struct {
-	ctMap          maps.Map
-	keyFromBytes   func([]byte) KeyInterface
-	valueFromBytes func([]byte) ValueInterface
-	scanners       []EntryScanner
+	ctMap                        maps.Map
+	keyFromBytes                 func([]byte) KeyInterface
+	valueFromBytes               func([]byte) ValueInterface
+	scanners                     []EntryScanner
+	liveEntries                  int
+	higherCount                  int
+	maxEntries                   int
+	autoScale                    bool
+	configChangedRestartCallback func()
 
 	wg       sync.WaitGroup
 	stopCh   chan struct{}
@@ -105,14 +113,20 @@ type Scanner struct {
 // NewScanner returns a scanner for the given conntrack map and the set of
 // EntryScanner. They are executed in the provided order on each entry.
 func NewScanner(ctMap maps.Map, kfb func([]byte) KeyInterface, vfb func([]byte) ValueInterface,
+	configChangedRestartCallback func(),
+	autoScalingMode string,
 	scanners ...EntryScanner) *Scanner {
 
 	return &Scanner{
-		ctMap:          ctMap,
-		keyFromBytes:   kfb,
-		valueFromBytes: vfb,
-		scanners:       scanners,
-		stopCh:         make(chan struct{}),
+		ctMap:                        ctMap,
+		keyFromBytes:                 kfb,
+		valueFromBytes:               vfb,
+		scanners:                     scanners,
+		stopCh:                       make(chan struct{}),
+		liveEntries:                  ctMap.Size(),
+		maxEntries:                   ctMap.Size(),
+		autoScale:                    strings.ToLower(autoScalingMode) == "doubleiffull",
+		configChangedRestartCallback: configChangedRestartCallback,
 	}
 }
 
@@ -155,14 +169,56 @@ func (s *Scanner) Scan() {
 		return maps.IterNone
 	})
 
+	if err != nil {
+		log.WithError(err).Warn("Failed to iterate over conntrack map")
+		return
+	}
+
+	newLiveEntries := int(used - cleaned)
+	if s.liveEntries > newLiveEntries {
+		s.higherCount++
+	} else {
+		s.higherCount = 0
+	}
+	s.liveEntries = newLiveEntries
+
+	full := float64(newLiveEntries) / float64(s.maxEntries)
+	log.Debugf("full %f, total %d, totalDeleted %d", full, used, cleaned)
+
 	conntrackCounterSweeps.Inc()
 	conntrackGaugeUsed.Set(float64(used))
 	conntrackGaugeCleaned.Set(float64(cleaned))
 	conntrackGaugeSweepDuration.Set(float64(time.Since(start)))
-
-	if err != nil {
-		log.WithError(err).Warn("Failed to iterate over conntrack map")
+	// If the ct map keeps filling up and gets over 85% full or if it hits 90%
+	// no matter what, resize the map.
+	if s.higherCount >= 3 && full > 0.85 || full > 0.90 {
+		if err := s.writeNewSizeFile(); err != nil {
+			log.WithError(err).Warn("Failed to start resizing conntrack map when running out of space")
+		} else {
+			if s.configChangedRestartCallback != nil {
+				log.Warnf("The eBPF conntrack table is becoming full. To prevent connections from failing, "+
+					"resizing from %d to %d entries. Restarting Felix to apply the new size.", s.maxEntries, 2*s.maxEntries)
+				s.configChangedRestartCallback()
+			}
+		}
 	}
+}
+
+func (s *Scanner) writeNewSizeFile() error {
+	// Make sure directory exists.
+	if err := os.MkdirAll("/var/lib/calico", os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory /var/lib/calico: %s", err)
+	}
+
+	newSize := 2 * s.ctMap.Size()
+
+	// Write the new map size to disk so that restarts will pick it up.
+	filename := "/var/lib/calico/bpf_ct_map_size"
+	log.Debugf("Writing %d to "+filename, newSize)
+	if err := os.WriteFile(filename, []byte(fmt.Sprintf("%d", newSize)), 0o644); err != nil {
+		return fmt.Errorf("unable to write to %s: %w", filename, err)
+	}
+	return nil
 }
 
 func (s *Scanner) get(k KeyInterface) (ValueInterface, error) {

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -171,7 +171,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("creating a CT scanner", func() {
 			connScan = conntrack.NewScanner(ct,
-				conntrack.KeyFromBytes, conntrack.ValueFromBytes, conntrack.NewStaleNATScanner(s))
+				conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", conntrack.NewStaleNATScanner(s))
 		})
 
 		By("creating conntrack entries for test-service", makestep(func() {
@@ -1090,7 +1090,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("recreating a CT scanner for the actual syncer", func() {
 			connScan = conntrack.NewScanner(ct,
-				conntrack.KeyFromBytes, conntrack.ValueFromBytes, conntrack.NewStaleNATScanner(s))
+				conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", conntrack.NewStaleNATScanner(s))
 		})
 
 		By("checking that CT table emptied by connScan", makestep(func() {

--- a/felix/cmd/calico-bpf/commands/conntrack.go
+++ b/felix/cmd/calico-bpf/commands/conntrack.go
@@ -551,8 +551,6 @@ func (cmd *conntrackWriteCmd) Run(c *cobra.Command, _ []string) {
 		log.WithError(err).Error("Failed to access ConntrackMap")
 	}
 
-	log.SetLevel(log.InfoLevel)
-	log.Infof("Sridhar write command %v:%v", cmd.key, cmd.val)
 	if err := ctMap.Update(cmd.key, cmd.val); err != nil {
 		log.WithError(err).Error("Failed to update ConntrackMap")
 	}

--- a/felix/cmd/calico-bpf/commands/conntrack.go
+++ b/felix/cmd/calico-bpf/commands/conntrack.go
@@ -26,11 +26,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	//"golang.org/x/sys/unix"
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	v2 "github.com/projectcalico/calico/felix/bpf/conntrack/v2"
-	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
@@ -74,7 +73,7 @@ func newConntrackDumpCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 3, "version to dump from")
+	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 4, "version to dump from")
 	cmd.Command.Flags().BoolVar((&cmd.raw), "raw", false, "dump the raw conntrack table as is. For version < 3 it is always raw")
 	cmd.Command.Args = cmd.Args
 	cmd.Command.Run = cmd.Run
@@ -174,7 +173,7 @@ func (cmd *conntrackDumpCmd) prettyDump(k conntrack.KeyInterface, v conntrack.Va
 
 	switch v.Type() {
 	case conntrack.TypeNormal:
-		if v.Flags()&v3.FlagSrcDstBA != 0 {
+		if v.Flags()&v4.FlagSrcDstBA != 0 {
 			cmd.Printf("%s %s:%d -> %s:%d ", protoStr(k.Proto()), k.AddrB(), k.PortB(), k.AddrA(), k.PortA())
 		} else {
 			cmd.Printf("%s %s:%d -> %s:%d ", protoStr(k.Proto()), k.AddrA(), k.PortA(), k.AddrB(), k.PortB())
@@ -182,7 +181,7 @@ func (cmd *conntrackDumpCmd) prettyDump(k conntrack.KeyInterface, v conntrack.Va
 	case conntrack.TypeNATForward:
 		return
 	case conntrack.TypeNATReverse:
-		if v.Flags()&v3.FlagSrcDstBA != 0 {
+		if v.Flags()&v4.FlagSrcDstBA != 0 {
 			cmd.Printf("%s %s:%d -> %s:%d -> %s:%d ",
 				protoStr(k.Proto()), k.AddrB(), k.PortB(), d.OrigDst, d.OrigPort, k.AddrA(), k.PortA())
 		} else {
@@ -195,7 +194,7 @@ func (cmd *conntrackDumpCmd) prettyDump(k conntrack.KeyInterface, v conntrack.Va
 		}
 	}
 
-	if v.Flags()&v3.FlagHostPSNAT != 0 {
+	if v.Flags()&v4.FlagHostPSNAT != 0 {
 		cmd.Printf("source port changed from %d ", d.OrigSPort)
 	}
 
@@ -305,7 +304,7 @@ func newConntrackRemoveCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 3, "version to remove from")
+	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 4, "version to remove from")
 	cmd.Command.Args = cmd.Args
 	cmd.Command.Run = cmd.Run
 
@@ -399,7 +398,7 @@ func newConntrackCleanCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 3, "conntrack version to clean")
+	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 4, "conntrack version to clean")
 	cmd.Command.Args = cmd.Args
 	cmd.Command.Run = cmd.Run
 
@@ -447,7 +446,7 @@ func newConntrackCreateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 3, "conntrack version to create")
+	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 4, "conntrack version to create")
 	cmd.Command.Args = cmd.Args
 	cmd.Command.Run = cmd.Run
 
@@ -482,7 +481,7 @@ func newConntrackWriteCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 3, "conntrack map version")
+	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 4, "conntrack map version")
 	cmd.Command.Args = cmd.Args
 	cmd.Command.Run = cmd.Run
 
@@ -552,6 +551,8 @@ func (cmd *conntrackWriteCmd) Run(c *cobra.Command, _ []string) {
 		log.WithError(err).Error("Failed to access ConntrackMap")
 	}
 
+	log.SetLevel(log.InfoLevel)
+	log.Infof("Sridhar write command %v:%v", cmd.key, cmd.val)
 	if err := ctMap.Update(cmd.key, cmd.val); err != nil {
 		log.WithError(err).Error("Failed to update ConntrackMap")
 	}
@@ -581,7 +582,7 @@ func newConntrackStatsCmd() *cobra.Command {
 		protos: make(map[int]int),
 	}
 
-	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 3, "conntrack map version")
+	cmd.Command.Flags().IntVarP((&cmd.version), "ver", "v", 4, "conntrack map version")
 
 	cmd.Command.Args = cmd.Args
 	cmd.Command.Run = cmd.Run

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2808,7 +2808,10 @@ func startBPFDataplaneComponents(
 	if err != nil {
 		log.WithError(err).Fatal("Failed to create conntrack liveness scanner.")
 	}
-	conntrackScanner := bpfconntrack.NewScanner(bpfmaps.CtMap, ctKey, ctVal, livenessScanner)
+	conntrackScanner := bpfconntrack.NewScanner(bpfmaps.CtMap, ctKey, ctVal,
+		config.ConfigChangedRestartCallback,
+		config.BPFMapSizeConntrackScaling,
+		livenessScanner)
 
 	// Before we start, scan for all finished / timed out connections to
 	// free up the conntrack table asap as it may take time to sync up the


### PR DESCRIPTION
## Description

Userspace cleaner scans the conntrack map and takes account of the current live entries and deletes the stale entries. If it sees that the table is 85% or more full for 3 continuous iterations/if it sees the table is 90% full, the conntrack map size will be doubled. This logic is already in BPF cleaner, which is incompatible with the use of LRU. Hence we add this feature to the userspace cleaner too.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
