### PR TITLE
Update CI builds and felix depends [v3.30]

### DIFF
--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -3,7 +3,7 @@ name: Publish openstack packages
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 
 execution_time_limit:
   minutes: 60

--- a/felix/debian/control
+++ b/felix/debian/control
@@ -29,6 +29,7 @@ Depends:
  ipset,
  libpcap0.8,
  net-tools,
+ nftables,
  ${misc:Depends},
  ${shlibs:Depends}
 Description: Project Calico virtual networking for cloud data centers.

--- a/felix/debian/control
+++ b/felix/debian/control
@@ -29,7 +29,6 @@ Depends:
  ipset,
  libpcap0.8,
  net-tools,
- nftables,
  ${misc:Depends},
  ${shlibs:Depends}
 Description: Project Calico virtual networking for cloud data centers.


### PR DESCRIPTION
(Cherry-pick of #10621)

- ~Add `nftables` to felix dependencies~
- Use ubuntu 24.04 images for openstack builds

## Description

~Two~  One openstack packaging fixes:

1. Switch to using Ubuntu 24.04 Noble for Openstack packaging. We need this because the version of `patchelf` in previous Ubuntu releases corrupts binaries enough that running `strip` on them makes them unusable. Moving to Noble for builds allows us to separate out debug symbols into separate packages for customers who want that without requiring that extra space on every install.
2. ~Add `nftables` to the calico-felix dependencies.~ Cherry-pick @nelljerram's change from #10625 since we will now gracefully handle missing `nft` commands.


## Release Note

```release-note
Calico packages for Ubuntu Noble are built with separate debug symbols for Calico v3.30 and later. To install, add the `main/debug` component in your `project-calico-ubuntu-master-noble.sources` file alongside the `main` component and then run `apt update` and install the `calico-felix-dbgsym` package.
```

