### PR TITLE
Fix the insertion of ~ into Debian package versions

### DIFF
--- a/release/packaging/utils/create-update-packages.sh
+++ b/release/packaging/utils/create-update-packages.sh
@@ -183,7 +183,7 @@ function do_net_cal {
     pushd "${rootdir}/networking-calico"
     PKG_NAME=networking-calico \
 	    NAME=networking-calico \
-	    DEB_EPOCH=2: \
+	    DEB_EPOCH=3: \
 	    "${rootdir}/release/packaging/utils/make-packages.sh" deb rpm
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'networking-calico_*-*' -exec mv '{}' "$outputDir" \;
@@ -214,7 +214,7 @@ function do_felix {
 	    NAME=Felix \
 	    RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \
 	    DPKG_EXCL="-I'bin/calico-felix-*' -I.git -I.gitignore -I'*.d' -I'*.ll' -I.go-pkg-cache -I.git -Ivendor -Ireport" \
-	    DEB_EPOCH=2: \
+	    DEB_EPOCH=3: \
 	    "${rootdir}/release/packaging/utils/make-packages.sh" rpm deb
 
     # Packages are produced in rootDir/ - move them to the output dir.

--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -57,7 +57,7 @@ function git_version_to_deb {
     # but git_auto_version changes them to 'v3.31.0rc.post267'
     # For the Debian package version, translate that to v3.31.0~rc.post267,
     # because it's logically _before_ v3.31.0.
-    echo "${1/rc*/~&}"
+    echo $1 | sed 's/rc/~rc/'
 }
 
 function git_version_to_rpm {


### PR DESCRIPTION
There are two lingering problems from [this change](https://github.com/projectcalico/calico/pull/8685/files#diff-8df104c987921f79e6436b0896850c8db0de53b8bdebfd46cf1b882a6a3b42e5R60) in `git_version_to_deb`

Firstly, the `&` appears not to work as a substitution indicator in Bash:

It was doing this:

    nell@glaurung:~/go/src/github.com/projectcalico/calico$ echo $version
    3.31.0rc0.post409
    nell@glaurung:~/go/src/github.com/projectcalico/calico$ git_version_to_deb $version
    3.31.0~&

After this commit, it does this, as intended:

    nell@glaurung:~/go/src/github.com/projectcalico/calico$ git_version_to_deb $version
    3.31.0~rc0.post409

Secondly, we need to bump the epoch; otherwise a new version _with_ a tilde will always be considered to be older than previous versions without a tilde.