### PR TITLE
Enable pre-merge packaging via a manual promotion

### DIFF
--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -35,20 +35,22 @@ global_job_config:
       - install-package --no-install-recommends devscripts moreutils patchelf
 
 blocks:
+  # This promotion is only _automatic_ for the master branch.  For other
+  # branches, and PRs, it is available but not automatic.  This means a
+  # developer can trigger the building and publishing of release branch and
+  # pre-merge packages by clicking the "Publish openstack packages" button in
+  # the Semaphore UI.  When building from the master branch, packages are
+  # published to the "master" PPA.  When building from any other branch,
+  # packages are published to the "testing" PPA.  When building from a PR,
+  # packages are published to the "pr-${SEMAPHORE_GIT_PR_NUMBER}" PPA, and that
+  # PPA must have been created manually first.  PRs requiring packaging must
+  # use a branch on github.com/projectcalico/calico, instead of on a fork repo,
+  # because packaging requires secrets that we do not (and should not!) expose
+  # to fork PRs.
   - name: "Publish openstack packages"
-    skip:
-      # Only run on branches, not PRs.
-      #
-      # This promotion is only _automatic_ for the master branch.  For other
-      # branches, it is an available promotion, but not automatic.  This makes
-      # it easy for a developer to trigger the building and publishing of
-      # release branch packages, simply by clicking the "Publish openstack
-      # packages" button in the Semaphore UI.  When building from the master
-      # branch, packages are published to the "master" PPA.  When building from
-      # any other branch, packages are published to the "testing" PPA.
-      when: "branch !~ '.+'"
     task:
       jobs:
         - name: "packages"
           commands:
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C release/packaging release-publish VERSION=$SEMAPHORE_GIT_BRANCH; fi
+            - if [ -n "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C release/packaging release-publish VERSION=pr-$SEMAPHORE_GIT_PR_NUMBER; fi

--- a/release/packaging/utils/create-update-packages.sh
+++ b/release/packaging/utils/create-update-packages.sh
@@ -66,6 +66,8 @@ function require_version {
 	: ${REPO_NAME:=master}
     elif [[ $VERSION =~ ^release-v ]]; then
 	: ${REPO_NAME:=testing}
+    elif [[ $VERSION =~ ^pr-[0-9]+$ ]]; then
+	: ${REPO_NAME:=${VERSION}}
     elif [[ $VERSION =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-python2)?$ ]]; then
 	MAJOR=${BASH_REMATCH[1]}
 	MINOR=${BASH_REMATCH[2]}


### PR DESCRIPTION
Sometimes we want to test a change in our Calico/OpenStack ST (`calico-test`) before merging it. But the Calico/OpenStack ST is driven by packaged code, so this means we need to package the pre-merge code.  The changes in this PR enable that, as follows:

1. Push the relevant code to a branch of github.com/projectcalico/calico.  It must be that repo, not a fork, because the process needs secrets that we don't share with forks.

2. Create a PR from that branch.

3. Create a PPA at https://launchpad.net/~project-calico named `pr-<N>`, where `<N>` is the number of the PR.  (If that PPA doesn't already exist.)

4. Click the "Publish openstack packages" promotion.

That should result in packages with the pre-merge code being uploaded to the `pr-<N>` PPA.  When those have been built and published, you can push a branch to github.com/tigera/calico-test with, for example:

    modified   build_and_run_fv.sh
    @@ -23,7 +23,7 @@ CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
     : ${BUILD_NUMBER:=0}
     : ${WORKSPACE:="$(pwd)"}
     : ${PKG_SRC_STEM:='master'}
    -: ${INSTALL_SOURCE:=""}
    +: ${INSTALL_SOURCE:="ppa:project-calico/pr-10610"}
     # PKG_SRC_STEM is only used if INSTALL_SOURCE is not set.
     : ${TEST_BRANCH:=${CURRENT_BRANCH}}
     : ${TEST_REQ:='smoke'}

and that will kick off an ST run using that PPA.