### PR TITLE
Consider LoadBalancerClass when assigning service IP

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -51,6 +51,7 @@ const (
 	annotationIPv4Pools      = "projectcalico.org/ipv4pools"
 	annotationIPv6Pools      = "projectcalico.org/ipv6pools"
 	annotationLoadBalancerIP = "projectcalico.org/loadBalancerIPs"
+	calicoLoadBalancerClass  = "calico"
 	timer                    = 5 * time.Minute
 )
 
@@ -786,13 +787,22 @@ func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool 
 	}
 
 	if assignIPs == api.AllServices {
+		if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != calicoLoadBalancerClass {
+			return false
+		}
 		return true
 	}
 
-	if svc.Annotations[annotationIPv4Pools] != "" ||
-		svc.Annotations[annotationIPv6Pools] != "" ||
-		svc.Annotations[annotationLoadBalancerIP] != "" {
-		return true
+	if assignIPs == api.RequestedServicesOnly {
+		if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass == calicoLoadBalancerClass {
+			return true
+		}
+
+		if svc.Annotations[annotationIPv4Pools] != "" ||
+			svc.Annotations[annotationIPv6Pools] != "" ||
+			svc.Annotations[annotationLoadBalancerIP] != "" {
+			return true
+		}
 	}
 	return false
 }

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -801,6 +801,11 @@ func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool 
 		if svc.Annotations[annotationIPv4Pools] != "" ||
 			svc.Annotations[annotationIPv6Pools] != "" ||
 			svc.Annotations[annotationLoadBalancerIP] != "" {
+
+			if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != calicoLoadBalancerClass {
+				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer annotation set with spec.LoadBalancerClass != calico is not supported")
+				return false
+			}
 			return true
 		}
 	}

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -159,6 +159,13 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
 		Expect(managed).To(BeFalse())
 
+		svc.Annotations = map[string]string{
+			annotationIPv4Pools: "poolv4",
+		}
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeFalse())
+		svc.Annotations = map[string]string{}
+
 		loadBalancerClass = "calico"
 		svc.Spec.LoadBalancerClass = &loadBalancerClass
 		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -151,6 +151,24 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)
 		Expect(managed).To(BeTrue())
 
+		loadBalancerClass := "not-calico"
+		svc.Spec.LoadBalancerClass = &loadBalancerClass
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)
+		Expect(managed).To(BeFalse())
+
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeFalse())
+
+		loadBalancerClass = "calico"
+		svc.Spec.LoadBalancerClass = &loadBalancerClass
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)
+		Expect(managed).To(BeTrue())
+
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeTrue())
+
+		svc.Spec.LoadBalancerClass = nil
+
 		svc.Annotations = map[string]string{
 			annotationIPv4Pools: "poolv4",
 		}


### PR DESCRIPTION
## Description
Updates the condition when LoadBalancerController should assign IP to service. 

Newly the LoadBalancerController will assign IP to service with LoadBalancerClass == calico if assignIPs is set to RequestedServicesOnly and will skip assignment of IPs when LoadBalancerClass is != calico and assignIPs is set to either AllServices or RequestedServicesOnly

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
#10544

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico LoadBalancerController will consider service.spec.LoadBalancerClass in determining if IP should be assigned. When in RequestedServicesOnly mode service will be assigned IP if LoadBalancerClass is set to calico. When running is AllServices and RequestedServicesOnly mode and the LoadBalancerClass is set to other value than calico, service will not be assigned an IP
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
