### PR TITLE
API server - Policy WatchManager  (#10346)

### DIFF
--- a/apiserver/cmd/apiserver/server/run_server.go
+++ b/apiserver/cmd/apiserver/server/run_server.go
@@ -87,8 +87,10 @@ func RunServer(opts *CalicoServerOptions, server *apiserver.ProjectCalicoServer)
 
 		// Start the Calico resource handler and shared informers and wait for sync before starting other components.
 		server.CalicoResourceLister.Start()
+		server.WatchManager.Start()
 		server.SharedInformerFactory.Start(ctx.Done())
 		server.CalicoResourceLister.WaitForCacheSync(ctx.Done())
+		server.WatchManager.WaitForCacheSync(ctx.Done())
 		server.SharedInformerFactory.WaitForCacheSync(ctx.Done())
 
 		if opts.PrintSwagger {

--- a/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
@@ -17,6 +17,7 @@ package globalpolicy
 import (
 	"context"
 
+	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -38,8 +39,9 @@ import (
 type REST struct {
 	*genericregistry.Store
 	rbac.CalicoResourceLister
-	authorizer authorizer.TierAuthorizer
-	shortNames []string
+	authorizer   authorizer.TierAuthorizer
+	watchManager *util.WatchManager
+	shortNames   []string
 }
 
 // EmptyObject returns an empty instance
@@ -53,7 +55,7 @@ func NewList() runtime.Object {
 }
 
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister, watchManager *util.WatchManager) (*REST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
@@ -103,7 +105,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), watchManager, opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -165,7 +167,20 @@ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptio
 		return nil, err
 	}
 
-	return r.Store.Watch(ctx, options)
+	w, err := r.Store.Watch(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	record := util.WatchRecord{
+		ID:    uuid.New().String(),
+		Kind:  calico.KindGlobalNetworkPolicy,
+		Watch: w,
+		Ctx:   ctx,
+	}
+	r.watchManager.AddWatch(record)
+
+	return w, nil
 }
 
 func (r *REST) ShortNames() []string {

--- a/apiserver/pkg/registry/projectcalico/networkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/networkpolicy/storage.go
@@ -17,6 +17,7 @@ package networkpolicy
 import (
 	"context"
 
+	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -38,8 +39,9 @@ import (
 type REST struct {
 	*genericregistry.Store
 	rbac.CalicoResourceLister
-	authorizer authorizer.TierAuthorizer
-	shortNames []string
+	authorizer   authorizer.TierAuthorizer
+	watchManager *util.WatchManager
+	shortNames   []string
 }
 
 // EmptyObject returns an empty instance
@@ -56,7 +58,7 @@ func NewList() runtime.Object {
 }
 
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister, watchManager *util.WatchManager) (*REST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
@@ -102,7 +104,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), watchManager, opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -164,7 +166,20 @@ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptio
 		return nil, err
 	}
 
-	return r.Store.Watch(ctx, options)
+	w, err := r.Store.Watch(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	record := util.WatchRecord{
+		ID:    uuid.New().String(),
+		Kind:  calico.KindNetworkPolicy,
+		Watch: w,
+		Ctx:   ctx,
+	}
+	r.watchManager.AddWatch(record)
+
+	return w, nil
 }
 
 func (r *REST) ShortNames() []string {

--- a/apiserver/pkg/registry/projectcalico/rest/storage_calico.go
+++ b/apiserver/pkg/registry/projectcalico/rest/storage_calico.go
@@ -46,6 +46,7 @@ import (
 	calicostagedk8spolicy "github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/stagedkubernetesnetworkpolicy"
 	calicostagedpolicy "github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/stagednetworkpolicy"
 	calicotier "github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/tier"
+	"github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/util"
 	calicostorage "github.com/projectcalico/calico/apiserver/pkg/storage/calico"
 	"github.com/projectcalico/calico/apiserver/pkg/storage/etcd"
 )
@@ -62,6 +63,7 @@ func (p RESTStorageProvider) NewV3Storage(
 	restOptionsGetter generic.RESTOptionsGetter,
 	authorizer authorizer.Authorizer,
 	calicoLister rbac.CalicoResourceLister,
+	watchManager *util.WatchManager,
 ) (map[string]rest.Storage, error) {
 	policyRESTOptions, err := restOptionsGetter.GetRESTOptions(calico.Resource("networkpolicies"), nil)
 	if err != nil {
@@ -527,11 +529,11 @@ func (p RESTStorageProvider) NewV3Storage(
 
 	storage := map[string]rest.Storage{}
 	storage["tiers"] = rESTInPeace(calicotier.NewREST(scheme, *tierOpts))
-	storage["networkpolicies"] = rESTInPeace(calicopolicy.NewREST(scheme, *policyOpts, calicoLister))
-	storage["stagednetworkpolicies"] = rESTInPeace(calicostagedpolicy.NewREST(scheme, *stagedpolicyOpts, calicoLister))
+	storage["networkpolicies"] = rESTInPeace(calicopolicy.NewREST(scheme, *policyOpts, calicoLister, watchManager))
+	storage["stagednetworkpolicies"] = rESTInPeace(calicostagedpolicy.NewREST(scheme, *stagedpolicyOpts, calicoLister, watchManager))
 	storage["stagedkubernetesnetworkpolicies"] = rESTInPeace(calicostagedk8spolicy.NewREST(scheme, *stagedk8spolicyOpts))
-	storage["globalnetworkpolicies"] = rESTInPeace(calicogpolicy.NewREST(scheme, *gpolicyOpts, calicoLister))
-	storage["stagedglobalnetworkpolicies"] = rESTInPeace(calicostagedgpolicy.NewREST(scheme, *stagedgpolicyOpts, calicoLister))
+	storage["globalnetworkpolicies"] = rESTInPeace(calicogpolicy.NewREST(scheme, *gpolicyOpts, calicoLister, watchManager))
+	storage["stagedglobalnetworkpolicies"] = rESTInPeace(calicostagedgpolicy.NewREST(scheme, *stagedgpolicyOpts, calicoLister, watchManager))
 	storage["globalnetworksets"] = rESTInPeace(calicognetworkset.NewREST(scheme, *gNetworkSetOpts))
 	storage["networksets"] = rESTInPeace(caliconetworkset.NewREST(scheme, *networksetOpts))
 	storage["hostendpoints"] = rESTInPeace(calicohostendpoint.NewREST(scheme, *hostEndpointOpts))

--- a/apiserver/pkg/registry/projectcalico/stagedglobalnetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagedglobalnetworkpolicy/storage.go
@@ -17,6 +17,7 @@ package stagedglobalpolicy
 import (
 	"context"
 
+	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -38,8 +39,9 @@ import (
 type REST struct {
 	*genericregistry.Store
 	rbac.CalicoResourceLister
-	authorizer authorizer.TierAuthorizer
-	shortNames []string
+	authorizer   authorizer.TierAuthorizer
+	watchManager *util.WatchManager
+	shortNames   []string
 }
 
 // EmptyObject returns an empty instance
@@ -53,7 +55,7 @@ func NewList() runtime.Object {
 }
 
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister, watchManager *util.WatchManager) (*REST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
@@ -103,7 +105,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), watchManager, opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -165,7 +167,20 @@ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptio
 		return nil, err
 	}
 
-	return r.Store.Watch(ctx, options)
+	w, err := r.Store.Watch(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	record := util.WatchRecord{
+		ID:    uuid.New().String(),
+		Kind:  calico.KindStagedGlobalNetworkPolicy,
+		Watch: w,
+		Ctx:   ctx,
+	}
+	r.watchManager.AddWatch(record)
+
+	return w, nil
 }
 
 func (r *REST) ShortNames() []string {

--- a/apiserver/pkg/registry/projectcalico/stagednetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagednetworkpolicy/storage.go
@@ -17,6 +17,7 @@ package stagednetworkpolicy
 import (
 	"context"
 
+	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -38,8 +39,9 @@ import (
 type REST struct {
 	*genericregistry.Store
 	rbac.CalicoResourceLister
-	authorizer authorizer.TierAuthorizer
-	shortNames []string
+	authorizer   authorizer.TierAuthorizer
+	watchManager *util.WatchManager
+	shortNames   []string
 }
 
 // EmptyObject returns an empty instance
@@ -53,7 +55,7 @@ func NewList() runtime.Object {
 }
 
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister) (*REST, error) {
+func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister rbac.CalicoResourceLister, watchManager *util.WatchManager) (*REST, error) {
 	strategy := NewStrategy(scheme)
 
 	prefix := "/" + opts.ResourcePrefix()
@@ -99,7 +101,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options, calicoResourceLister r
 		DestroyFunc: dFunc,
 	}
 
-	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), opts.ShortNames}, nil
+	return &REST{store, calicoResourceLister, authorizer.NewTierAuthorizer(opts.Authorizer), watchManager, opts.ShortNames}, nil
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -161,7 +163,20 @@ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptio
 		return nil, err
 	}
 
-	return r.Store.Watch(ctx, options)
+	w, err := r.Store.Watch(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	record := util.WatchRecord{
+		ID:    uuid.New().String(),
+		Kind:  calico.KindStagedNetworkPolicy,
+		Watch: w,
+		Ctx:   ctx,
+	}
+	r.watchManager.AddWatch(record)
+
+	return w, nil
 }
 
 func (r *REST) ShortNames() []string {

--- a/apiserver/pkg/registry/projectcalico/util/watch_manager.go
+++ b/apiserver/pkg/registry/projectcalico/util/watch_manager.go
@@ -1,0 +1,106 @@
+package util
+
+import (
+	"context"
+	"sync"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/watchersyncer"
+)
+
+type WatchRecord struct {
+	ID    string
+	Kind  string
+	Watch watch.Interface
+	Ctx   context.Context
+}
+
+// WatchManager is used for managing watches for policies. Due to the policy tiers implementation and RBAC we are not able to update the watch on the go.
+// This causes that established watch might miss out on events if a new Tier has been created after the watch has been established and the user has access to that Tier.
+// WatchManager ensures that in an even of new Tier being added all watches are canceled and the consumer will reestablish watch receiving events from the newly added tier
+// This is true for all policies - NetworkPolicy, GlobalNetworkPolicy, StagedNetworkPolicy, StagedGlobalNetworkPolicy
+type WatchManager struct {
+	client       api.Client
+	syncer       api.Syncer
+	sync         chan struct{}
+	watchRecords sync.Map
+}
+
+func NewWatchManager(cc api.Client) *WatchManager {
+	return &WatchManager{
+		client:       cc,
+		sync:         make(chan struct{}),
+		watchRecords: sync.Map{},
+	}
+}
+
+func (m *WatchManager) Start() {
+	m.syncer = watchersyncer.New(
+		m.client,
+		[]watchersyncer.ResourceType{
+			{ListInterface: model.ResourceListOptions{Kind: v3.KindTier}},
+		},
+		m,
+	)
+	m.syncer.Start()
+}
+
+func (m *WatchManager) WaitForCacheSync(stopCh <-chan struct{}) {
+	select {
+	case <-m.sync:
+	case <-stopCh:
+	}
+}
+
+func (m *WatchManager) OnStatusUpdated(status api.SyncStatus) {
+	if status == api.InSync {
+		close(m.sync)
+	}
+}
+
+func (m *WatchManager) OnUpdates(updates []api.Update) {
+	for _, u := range updates {
+		// We do not need to cancel watches for delete as the original watch is still valid with other records
+		if u.Key.(model.ResourceKey).Kind == v3.KindTier && u.KVPair.Value != nil {
+			// New Tier added, we need to stop all watches in case there is a user that can watch policies in the new Tier
+			// When the watch is re-established it will contain policies in the newly created Tier
+			logrus.WithField("Tier", u.Key.(model.ResourceKey).Name).Debug("New Tier added, removing all WatchRecords")
+			m.watchRecords.Range(func(k, v interface{}) bool {
+				id, ok := k.(string)
+				if !ok {
+					logrus.WithField("id", k).Warn("ID is not a string")
+					return true
+				}
+				record, ok := v.(WatchRecord)
+				if !ok {
+					logrus.WithField("id", id).Errorf("Value is not a WatchRecord")
+					return true
+				}
+				logrus.WithFields(logrus.Fields{"id": record.ID, "Kind": record.Kind}).Debug("Closing watch")
+				record.Watch.Stop()
+				return true
+			})
+			m.watchRecords = sync.Map{}
+		}
+	}
+}
+
+// AddWatch adds a watch to our map and triggers monitoring for watch closure by the consumer or API server
+func (m *WatchManager) AddWatch(record WatchRecord) {
+	logrus.WithFields(logrus.Fields{"id": record.ID, "Kind": record.Kind}).Debug("Adding WatchRecord")
+	m.watchRecords.Store(record.ID, record)
+	go m.monitorWatch(record)
+}
+
+// monitorWatch waits to see if the context is done signaling that the watch has been ended. We can remove the watch from our map
+func (m *WatchManager) monitorWatch(record WatchRecord) {
+	<-record.Ctx.Done()
+	// Watch has been closed, we should remove it from our map
+	logrus.WithFields(logrus.Fields{"id": record.ID, "Kind": record.Kind}).Debug("Watch has been stopped, removing WatchRecord")
+	m.watchRecords.Delete(record.ID)
+}


### PR DESCRIPTION
## Description
This change introduces a WatchManager that keeps track of all active Watch channels and stops the watch when new tier is added.

This fixes an issue when new Tier is added the Watch is not receiving events about policies in the new Tier. This is because when a Watch() is created and no selectors were specified by the consumer, we default the selector to contain all Tiers that the consumer has authorization for. When new Tier as added, it's possible that the user has access to those policies as well, and not receiving them.

WatchManager keeps track of all active Watch events for policies, when new Tier is added the WatchManager cancels all Watch that it has in map. This forces the consumer to reestablish the Watch, this new Watch will include the newly added Tier.

Cherry-pick of: #10346 
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Introduces a WatchManager for policies that will close the policy watch when a new tier is added to ensure the consumer is always subscribed to the latest events
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
