### PR TITLE
always allow the kube-controller-manager user to access resources

### DIFF
--- a/apiserver/cmd/apiserver/server/userAuthorization.go
+++ b/apiserver/cmd/apiserver/server/userAuthorization.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+const kubeControllerManagerUser = "system:kube-controller-manager"
+
+func NewAllowUser(alwaysAllowUsers []string) authorizer.Authorizer {
+
+	return authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+		if a.GetUser() == nil {
+			return authorizer.DecisionNoOpinion, "no user info", nil
+		}
+		user := a.GetUser().GetName()
+		for _, u := range alwaysAllowUsers {
+			if u == user {
+				return authorizer.DecisionAllow, "user is allowed", nil
+			}
+		}
+		return authorizer.DecisionNoOpinion, "", nil
+	})
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fix #9527 
In Kubernetes cluster, the `system:kube-controller-manager` user has, by default, list and watch permissions on all resources. However, when the Calico API server uses the get verb to check permissions, this will fail. While it is possible to resolve this by adding the appropriate RBAC rules by #9879, I believe it would be more appropriate to handle this specifically within Calico's internal authorization process.
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
always allow the kube-controller-manager user to access resources in calico-apiserver
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
