### PR TITLE
CORE-11514: Added CI test to check images availability

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -112,6 +112,15 @@ promotions:
     auto_promote:
       when: "branch =~ 'master|release-.*'"
 blocks:
+  - name: Check images availability
+    run:
+      when: "true or change_in(['/charts/', '/manifests/'])"
+    dependencies: []
+    task:
+      jobs:
+        - name: Check images availability
+          commands:
+            - make check-images-availability
   - name: Prerequisites
     dependencies: []
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -112,6 +112,15 @@ promotions:
     auto_promote:
       when: "branch =~ 'master|release-.*'"
 blocks:
+  - name: Check images availability
+    run:
+      when: "false or change_in(['/charts/', '/manifests/'])"
+    dependencies: []
+    task:
+      jobs:
+        - name: Check images availability
+          commands:
+            - make check-images-availability
   - name: Prerequisites
     dependencies: []
     task:

--- a/.semaphore/semaphore.yml.d/blocks/10-check-images.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-check-images.yml
@@ -1,0 +1,9 @@
+- name: Check images availability
+  run:
+    when: "${FORCE_RUN} or change_in(['/charts/', '/manifests/'])"
+  dependencies: []
+  task:
+    jobs:
+      - name: Check images availability
+        commands:
+          - make check-images-availability

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ go-vet:
 check-dockerfiles:
 	./hack/check-dockerfiles.sh
 
+check-images-availability: bin/crane
+	cd ./hack && \
+		CALICO_VERSION=$(CALICO_VERSION) \
+		./check-images-availability.sh
+
 check-language:
 	./hack/check-language.sh
 

--- a/hack/check-images-availability.sh
+++ b/hack/check-images-availability.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+# Resolve script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Use provided CRANE or fallback to ../bin/crane (relative to hack/)
+CRANE="${CRANE:-../bin/crane}"
+CALICO_VERSION="${CALICO_VERSION:-}"
+
+if [ ! -x "$CRANE" ]; then
+  echo "Error: crane not found or not executable at: $CRANE" >&2
+  echo "Resolved path: $(realpath "$CRANE" 2>/dev/null || echo '<unresolvable>')" >&2
+  exit 1
+fi
+
+#########################################
+# Print versions if provided
+#########################################
+if [[ -n "$CALICO_VERSION" ]]; then
+  echo "CALICO_VERSION provided: $CALICO_VERSION"
+else
+  echo "CALICO_VERSION not provided; using tags from manifest as-is"
+fi
+
+#########################################
+# Step 1: Extract from manifests
+#########################################
+manifest_dir="${SCRIPT_DIR}/../manifests"
+
+manifest_images_raw=$(
+  grep -rhoE 'image:\s*["'\''"]?[a-z0-9./_-]+:[a-zA-Z0-9._-]+' "$manifest_dir" \
+  | sed -E 's/image:\s*["'\''"]?//' \
+  | grep -v -- '-fips'
+)
+
+# Step 1.1: Normalize and adjust image paths
+manifest_images=$(
+  while IFS= read -r image; do
+    base="${image%%:*}"
+    tag="${image##*:}"
+
+    if [[ "$base" == *.*/* ]]; then
+      # Fully qualified (has domain), e.g., quay.io/calico/node
+      if [[ "$base" == */calico/* && -n "$CALICO_VERSION" ]]; then
+        echo "${base}:${CALICO_VERSION}"
+      else
+        echo "${base}:${tag}"
+      fi
+    elif [[ "$base" == calico/* ]]; then
+      # Implicit quay.io for calico/*
+      if [[ -n "$CALICO_VERSION" ]]; then
+        echo "quay.io/${base}:${CALICO_VERSION}"
+      else
+        echo "quay.io/${base}:${tag}"
+      fi
+    elif [[ "$base" != */* ]]; then
+      # Single name like 'busybox'
+      echo "docker.io/${base}:${tag}"
+    else
+      # Everything else
+      echo "docker.io/${base}:${tag}"
+    fi
+  done <<< "$manifest_images_raw" | sort -u
+)
+
+count=$(echo "$manifest_images" | wc -l)
+echo -e "\033[1mTotal unique images (excluding -fips): ${count}\033[0m"
+
+#########################################
+# Step 2: Check availability with retries
+#########################################
+FAILED=0
+FAILED_IMAGES=()
+
+while IFS= read -r image; do
+  success=0
+  for attempt in 1 2 3; do
+    if "$CRANE" digest "$image" >/dev/null 2>&1; then
+      image_name="${image%%:*}"
+      image_tag="${image##*:}"
+      echo -e "✅ Available: ${image_name}:\033[1m${image_tag}\033[0m"
+      success=1
+      break
+    else
+      echo "Attempt $attempt failed for: $image"
+      if [ "$attempt" -eq 3 ]; then
+        echo "Used crane at: $(realpath "$CRANE" 2>/dev/null || echo '<unresolvable>')"
+      fi
+      sleep 3
+    fi
+  done
+
+  if [ "$success" -ne 1 ]; then
+    echo "❌ NOT FOUND after 3 attempts: $image"
+    FAILED=1
+    FAILED_IMAGES+=("$image")
+  fi
+done <<< "$manifest_images"
+
+#########################################
+# Step 3: Final result
+#########################################
+if [ "$FAILED" -eq 1 ]; then
+  echo ""
+  echo -e "\033[1m❗ Some images are missing or invalid:\033[0m"
+  for img in "${FAILED_IMAGES[@]}"; do
+    echo "   ❌ $img"
+  done
+  exit 1
+else
+  echo -e "\033[1m✅ All images from manifests are available!\033[0m"
+fi

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1249,6 +1249,25 @@ bin/yq:
 	tar -zxvf $(TMP)/yq4.tar.gz -C $(TMP)
 	mv $(TMP)/yq_linux_$(BUILDARCH) bin/yq
 
+# This setup is used to download and install the 'crane' binary into the local bin/ directory.
+# The binary will be placed at: ./bin/crane
+# Normalize architecture for go-containerregistry filenames
+CRANE_BUILDARCH := $(shell uname -m | sed 's/amd64/x86_64/;s/x86_64/x86_64/;s/aarch64/arm64/')
+ifeq ($(CRANE_BUILDARCH),)
+  $(error Unsupported or unknown architecture: $(shell uname -m))
+endif
+CRANE_VERSION := v0.20.6
+CRANE_FILENAME := go-containerregistry_Linux_$(CRANE_BUILDARCH).tar.gz
+CRANE_URL := https://github.com/google/go-containerregistry/releases/download/$(CRANE_VERSION)/$(CRANE_FILENAME)
+
+# Install crane binary into bin/
+bin/crane:
+	mkdir -p bin
+	$(eval TMP := $(shell mktemp -d))
+	curl -sSfL --retry 5 -o $(TMP)/crane.tar.gz $(CRANE_URL)
+	tar -xzf $(TMP)/crane.tar.gz -C $(TMP) crane
+	mv $(TMP)/crane bin/crane
+
 ###############################################################################
 # Common functions for launching a local Kubernetes control plane.
 ###############################################################################


### PR DESCRIPTION
## Description

🎯 **Motivation**

In [this commit](https://github.com/projectcalico/calico/commit/e26e8c8236ae16323bf1d8200dfac017d2fd8128#diff-839f3e1a8baf4617a31a2fa2d55feeef106d5c60ae4ba96c5bcfa13410a89d71R16), we mistakenly changed the flannel image registry to quay.io, but flannel does not publish images there. This was not caught by CI and led to manifest errors that broke some e2e runs.

This test aims to catch such issues early by validating image availability using [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane) before merge.

✅ **What This Test Does**
 - Parses all Kubernetes manifests in the /manifests directory.
 - Extracts all referenced container images.
 - Normalizes them with correct registry defaults (e.g., quay.io/calico/*, docker.io/library/*).
 - Uses crane digest to check if the image is available and valid.
 - Fails the pipeline if any image is not found.

⚙️ **Trigger Conditions**
 - Runs only when changes occur in the `/charts` or `/manifests` directories.
 - Runs in the `prerequisites` stage of the `Semaphore` pipeline, in parallel with the **Preflight check**.
 - Does not check upcoming release-version images like `v3.x.y` – those are already covered in our [release template test](https://github.com/projectcalico/calico/blob/master/release/internal/pinnedversion/templates/calico-versions.yaml.gotmpl).

📌 **Notes**
This test is focused on manifest correctness and aims to catch invalid or mistyped image names/tags.

📎 **Related Ticket**
 - [CORE-11514](https://tigera.atlassian.net/browse/CORE-11514) – Create a CI test that checks that all images in our manifests actually exist.
 - Slack thread: https://tigera.slack.com/archives/CC08CBB43/p1749229140375309

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
