### PR TITLE
Report port status down, not error, when retrying interface configuration

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr.go
+++ b/felix/dataplane/linux/endpoint_mgr.go
@@ -619,7 +619,7 @@ func (m *endpointManager) calculateWorkloadEndpointStatus(id types.WorkloadEndpo
 	var status string
 	if known {
 		if failed {
-			status = "error"
+			status = "down"
 		} else if operUp && adminUp {
 			status = "up"
 		} else {

--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -1856,9 +1856,9 @@ func endpointManagerTests(ipVersion uint8, flowlogs bool) func() {
 						})
 						applyUpdates(epMgr)
 					})
-					It("should report the interface in error", func() {
+					It("should report the interface as down", func() {
 						Expect(statusReportRec.currentState).To(Equal(map[interface{}]string{
-							types.ProtoToWorkloadEndpointID(&wlEPID1): "error",
+							types.ProtoToWorkloadEndpointID(&wlEPID1): "down",
 						}))
 					})
 				})


### PR DESCRIPTION
Context: I recently addressed the persistent failure of `test_rebuild_vm` in https://github.com/projectcalico/calico/pull/10608, however we are still seeing occasional failures, albeit at a reduced rate.

In the Calico/OpenStack ST for rebuilding a VM, the Calico Neutron driver now sees this sequence of port status transitions for the VM:

    [ VM first created ]
    2025-07-07 18:21:31.706 ... DOWN
    2025-07-07 18:21:33.791 ... ACTIVE

    [ VM rebuild requested ]
    2025-07-07 18:22:43.817 ... DOWN
    2025-07-07 18:22:44.909 ... ERROR
    2025-07-07 18:22:45.962 ... DOWN
    2025-07-07 18:22:47.043 ... ACTIVE
    2025-07-07 18:22:48.078 ... DOWN
    2025-07-07 18:22:49.174 ... ACTIVE

    [ VM deleted ]
    2025-07-07 18:22:50.180 ... DOWN

The transition from DOWN to ERROR causes Neutron to send a network-vif-plugged event to Nova with `status: failed`:

    2025-07-07 18:22:46.086 71717 DEBUG neutron.notifiers.nova [-] Sending events: [{'server_uuid': 'daf468bc-d947-4765-b5e1-5b7dc5b9c9e1', 'name': 'network-vif-plugged', 'status': 'failed', 'tag': '09bea628-41d2-4b52-af70-6ded767376fa'}] send_events /usr/lib/python3/dist-packages/neutron/notifiers/nova.py:279

Which Nova interprets as a permanent failure of the rebuild process, leaving the VM in ERROR state:

    2025-07-07 18:22:46.235 56947 ERROR nova.virt.libvirt.driver [req-1d7cc081-9378-4585-ab5d-a3aa57fb49a2 b14e9af8128649fb8d8884c5e7f1ff36 b2f1937698d648f389a30011c6015539 - default default] [instance: daf468bc-d947-4765-b5e1-5b7dc5b9c9e1] Neutron Reported failure on event network-vif-plugged-09bea628-41d2-4b52-af70-6ded767376fa for instance daf468bc-d947-4765-b5e1-5b7dc5b9c9e1: NotImplementedError

We can avoid this if Felix reports DOWN instead of ERROR, and code reading indicates that the only Felix-originated cause of an ERROR endpoint status is

		failed = m.wlIfaceNamesToReconfigure.Contains(workload.Name)

which means when something about the interface configuration needs retrying.  Given that Felix _will_ retry, this is not a final error state, so it seems reasonable to report DOWN instead of ERROR.

Looking at the Calico/OpenStack STs in
https://github.com/tigera/calico-test/blob/bobcat/calicotest/openstack/test_status_reporting.py, we don't have any tests that _expect_ to see ERROR endpoint status (since the time of Calico 3.2). Overall, therefore, I don't think there's any downside of reporting DOWN here instead of ERROR, and I believe that this change will finally fix the `test_rebuild_vm` scenario.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix: In Calico for OpenStack the operation to rebuild a VM could sometimes fail to complete successfully, with the VM getting stuck in ERROR state.  (Completion of #10608)
```