### PR TITLE
Avoid IPAM handle leak when context expires during assignment.

### DIFF
--- a/node/tests/k8st/deploy_resources_on_kind_cluster.sh
+++ b/node/tests/k8st/deploy_resources_on_kind_cluster.sh
@@ -84,9 +84,14 @@ wait_pod_ready -l k8s-app=kube-dns -n kube-system
 wait_pod_ready calicoctl -n kube-system
 
 echo "Wait for tigera status to be ready"
-${kubectl} wait --for=condition=Available tigerastatus/calico
-${kubectl} wait --for=condition=Available tigerastatus/apiserver
-
+if ! ${kubectl} wait --for=condition=Available tigerastatus/calico; then
+  ${kubectl} get -o yaml tigerastatus/calico
+  exit 1
+fi
+if ! ${kubectl} wait --for=condition=Available tigerastatus/apiserver; then
+  ${kubectl} get -o yaml tigerastatus/apiserver
+  exit 1
+fi
 echo "Calico is running."
 echo
 

--- a/node/tests/k8st/deploy_resources_on_kind_cluster.sh
+++ b/node/tests/k8st/deploy_resources_on_kind_cluster.sh
@@ -85,7 +85,13 @@ wait_pod_ready calicoctl -n kube-system
 
 echo "Wait for tigera status to be ready"
 if ! ${kubectl} wait --for=condition=Available tigerastatus/calico; then
+  echo "TigeraStatus for Calico is down, collecting diags..."
   ${kubectl} get -o yaml tigerastatus/calico
+  echo "Logs for tigera-operator:"
+  ${kubectl} logs -n tigera-operator -l k8s-app=tigera-operator
+  echo "Status of pods:"
+  ${kubectl} get po -A -o wide
+  ${kubectl} describe po -n calico-system
   exit 1
 fi
 if ! ${kubectl} wait --for=condition=Available tigerastatus/apiserver; then


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Don't include time to acquire IPAM lock in the timeout. Under heavy load, IPAM allocation calls could get stacked up. As the lock acquisition time approaches 90s, it gets into an equilibrium where each IPAM call succeeds in creating a handle but times out while doing the actual assignment.  This leaks handles at a rapid rate.

  Speeding up IPAM requires a significant rework so this is a pragmatic fix for now.

- Belt and braces: use extended context timeouts for cleanup operations. If the context expires during IPAM allocation and hence we need to clean up a handle, use a fresh context so that the cleanup doesn't immediately time out.

- Clean up some unhandled errors and remove a duplicate conditional.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-11632
CI-1807

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that IPAM allocation could leak handles when many workloads are scheduled to the same node at the same time, causing timeouts by "thundering herd".
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
