### PR TITLE
[release-v3.30] Auto pick #10660: fix ICMP replies when host has multiple IPs

### DIFF
--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1837,7 +1837,7 @@ func ipv6HopByHopExt() gopacket.SerializableLayer {
 	return hop
 }
 
-func testPacketUDPDefaultNPV6(destIP net.IP) (*layers.Ethernet, *layers.IPv6, gopacket.Layer, []byte, []byte, error) {
+func testPacketUDPDefaultNPV6WithPayload(destIP net.IP, payload []byte) (*layers.Ethernet, *layers.IPv6, gopacket.Layer, []byte, []byte, error) {
 	if destIP == nil {
 		return testPacketV6(nil, nil, nil, nil)
 	}
@@ -1854,8 +1854,12 @@ func testPacketUDPDefaultNPV6(destIP net.IP) (*layers.Ethernet, *layers.IPv6, go
 	tlv.OptionData = []byte{0x00, 0x00, 0x00, 0x00}
 	hop.Options = append(hop.Options, tlv)
 
-	e, ip6, l4, p, b, err := testPacketV6(nil, &ip, nil, nil, hop)
+	e, ip6, l4, p, b, err := testPacketV6(nil, &ip, nil, payload, hop)
 	return e, ip6, l4, p, b, err
+}
+
+func testPacketUDPDefaultNPV6(destIP net.IP) (*layers.Ethernet, *layers.IPv6, gopacket.Layer, []byte, []byte, error) {
+	return testPacketUDPDefaultNPV6WithPayload(destIP, nil)
 }
 
 func resetBPFMaps() {

--- a/felix/bpf/ut/icmp_too_big_test.go
+++ b/felix/bpf/ut/icmp_too_big_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/netstack/tcpip/header"
 	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	conntrack3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	"github.com/projectcalico/calico/felix/bpf/nat"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/ip"
 )
 
 func TestICMPTooBig(t *testing.T) {
@@ -126,4 +132,272 @@ func checkICMPTooBig(pktR gopacket.Packet, ipv4 *layers.IPv4, udp *layers.UDP, e
 	Expect(icmpData.Layer(layers.LayerTypeIPv4)).To(layersMatchFields(ipv4))
 	// the extra 8 bytes will contain the entire UDP header
 	Expect(icmpData.Layer(layers.LayerTypeUDP)).To(layersMatchFields(udp))
+}
+
+func TestICMPTooBigNATNodePort(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "PMTU"
+	defer func() { bpfIfaceName = "" }()
+
+	extHostIP := net.ParseIP("55.55.0.1")
+	_, ipv4, l4, payload, pktBytes, err := testPacketUDPDefaultNP(extHostIP)
+	Expect(err).NotTo(HaveOccurred())
+
+	origIPHeader := *ipv4
+	origIPHeader.IHL = 5 /* no options */
+	origIPHeader.Options = nil
+
+	udp := l4.(*layers.UDP)
+	natMap := nat.FrontendMap()
+	err = natMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	natBEMap := nat.BackendMap()
+	err = natBEMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	err = natMap.Update(
+		nat.NewNATKey(node1ip, uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+		nat.NewNATValue(0, 1, 0, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = natMap.Update(
+		nat.NewNATKey(extHostIP, uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+		nat.NewNATValue(0, 1, 0, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.IPv4(8, 8, 8, 8)
+	natPort := uint16(666)
+
+	err = natBEMap.Update(
+		nat.NewNATBackendKey(0, 0).AsBytes(),
+		nat.NewNATBackendValue(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	node2wCIDR := net.IPNet{
+		IP:   natIP,
+		Mask: net.IPv4Mask(255, 255, 255, 0),
+	}
+
+	ctMap := conntrack.Map()
+	err = ctMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+	resetCTMap(ctMap) // ensure it is clean
+
+	resetRTMap(rtMap)
+
+	hostIP = node1ip
+	skbMark = 0
+
+	// Setup routing
+	rtMap := routes.Map()
+	err = rtMap.EnsureExists()
+	defer resetRTMap(rtMap)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2wCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValueWithNextHop(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool,
+			ip.FromNetIP(node2ip).(ip.V4Addr)).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	extNodeCIDR := net.IPNet{
+		IP:   extHostIP,
+		Mask: net.IPv4Mask(255, 255, 255, 255),
+	}
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&extNodeCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	dumpRTMap(rtMap)
+
+	// Arriving at node 1, goodpacket, creates conntrack
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		Expect(ipv4L).NotTo(BeNil())
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(hostIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(node2ip.String()))
+
+		checkVxlanEncap(pktR, false, ipv4, udp, payload)
+
+		//		encapedPkt = res.dataOut
+
+		ct, err := conntrack.LoadMapMem(ctMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctKey := conntrack.NewKey(uint8(ipv4.Protocol),
+			ipv4.DstIP, uint16(udp.DstPort), ipv4.SrcIP, uint16(udp.SrcPort))
+
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr := ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+
+		ctKey = ctr.ReverseNATKey().(conntrack.Key)
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr = ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+
+		// Approved for both sides due to forwarding through the tunnel
+		Expect(ctr.Data().A2B.Approved).To(BeTrue())
+		Expect(ctr.Data().B2A.Approved).To(BeTrue())
+	})
+
+	dumpCTMap(ctMap)
+	ct, err := conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	v, ok := ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
+	Expect(ok).To(BeTrue())
+	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagNATNPFwd))
+
+	_, _, _, _, pkt2Bytes, err := testPacket(4, nil, &origIPHeader, udpDefault, make([]byte, 1600))
+	Expect(err).NotTo(HaveOccurred())
+
+	// Large packet arriving at node 1
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pkt2Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		Expect(ipv4L).NotTo(BeNil())
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(extHostIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(srcIP.String()))
+
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+
+		origPkt := gopacket.NewPacket(payloadL.Payload(), layers.LayerTypeIPv4, gopacket.Default)
+		Expect(origPkt).NotTo(BeNil())
+		fmt.Printf("origPkt = %+v\n", origPkt)
+
+		ipv4L = origPkt.Layer(layers.LayerTypeIPv4)
+		Expect(ipv4L).NotTo(BeNil())
+		ipv4R = ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(srcIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(extHostIP.String()))
+	})
+}
+
+func TestICMPv6TooBigNATNodePort(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "PMTU"
+	defer func() { bpfIfaceName = "" }()
+
+	extHostIP := net.ParseIP("dead::5555:0001")
+	_, ipv6, l4, _, pktBytes, err := testPacketUDPDefaultNPV6WithPayload(extHostIP, make([]byte, 1600))
+	Expect(err).NotTo(HaveOccurred())
+	udp := l4.(*layers.UDP)
+
+	err = natMapV6.Update(
+		nat.NewNATKeyV6(ipv6.DstIP, uint16(udp.DstPort), uint8(17)).AsBytes(),
+		nat.NewNATValueV6(0, 1, 0, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = natMapV6.Update(
+		nat.NewNATKeyV6(node1ipV6, uint16(udp.DstPort), uint8(17)).AsBytes(),
+		nat.NewNATValueV6(0, 1, 0, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.ParseIP("abcd::ffff:0808:0808")
+	natPort := uint16(666)
+
+	err = natBEMapV6.Update(
+		nat.NewNATBackendKeyV6(0, 0).AsBytes(),
+		nat.NewNATBackendValueV6(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMapV6(ctMapV6) // ensure it is clean
+
+	hostIP = node1ipV6
+
+	// Insert a reverse route for the source workload that is not in a calico
+	// poll, for example 3rd party CNI is used.
+	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
+	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()
+	err = rtMapV6.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+	extNodeCIDR := net.IPNet{
+		IP:   extHostIP,
+		Mask: net.CIDRMask(128, 128),
+	}
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&extNodeCIDR).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	node2wCIDR := net.IPNet{
+		IP:   natIP,
+		Mask: net.CIDRMask(128, 128),
+	}
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node2wCIDR).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6WithNextHop(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool,
+			ip.FromNetIP(node2ipV6).(ip.V6Addr)).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	dumpRTMapV6(rtMapV6)
+	dumpNATMapV6(natMapV6)
+
+	skbMark = 0
+	// Leaving workloada test for fc711b192f */
+	runBpfTest(t, "calico_from_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R := ipv6L.(*layers.IPv6)
+		Expect(ipv6R.SrcIP.String()).To(Equal(extHostIP.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(srcIPv6.String()))
+
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+
+		origPkt := gopacket.NewPacket(payloadL.Payload()[4:], layers.LayerTypeIPv6, gopacket.Default)
+		Expect(origPkt).NotTo(BeNil())
+		fmt.Printf("origPkt = %+v\n", origPkt)
+
+		ipv6L = origPkt.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R = ipv6L.(*layers.IPv6)
+		Expect(ipv6R.SrcIP.String()).To(Equal(srcIPv6.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(extHostIP.String()))
+	}, withIPv6())
 }


### PR DESCRIPTION
Cherry pick of projectcalico/calico/pull/10660 on release-v3.30.

#10660: fix ICMP replies when host has multiple IPs

# Original PR Body below

Previously, we would only reply with the IP of the interface used as k8s internel IP. That may not be correct if that IP is private and the node has an external IP assigned and the client reaches out via that public IP.

For PMTU we respond before we do any NAT and so if the dest IP of the original packet was a host IP, use that same ip as the source for the icmp seponse.

fixes https://github.com/projectcalico/calico/issues/10640
fixes https://github.com/projectcalico/calico/issues/4439

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixes ICMP response source IP when nodes have multiple IPs assigned
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.