### PR TITLE
BPF midflow packet failover UT

### DIFF
--- a/felix/bpf/ut/midflow_test.go
+++ b/felix/bpf/ut/midflow_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	//tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/bpf/nat"
+)
+
+func TestMidflowFailoverNoConntrack(t *testing.T) {
+	RegisterTestingT(t)
+	resetBPFMaps()
+	var err error
+
+	// We are going to pretend to have a ConsistentHash-enabled NodePort
+	// on this machine.
+	hostIP := net.IPv4(1, 1, 1, 1)
+	hostPort := uint16(666)
+
+	defer func() {
+		// Disable debug while cleaning up the maps
+		logrus.SetLevel(logrus.WarnLevel)
+		cleanUpMaps()
+	}()
+
+	// Disable debug while filling up maps.
+	loglevel := logrus.GetLevel()
+	logrus.SetLevel(logrus.WarnLevel)
+	defer logrus.SetLevel(loglevel)
+
+	var svcKey nat.FrontendKeyInterface = nat.NewNATKey(hostIP, hostPort, 6)
+	var svcVal nat.FrontendValue = nat.NewNATValueWithFlags(123, 1, 0, 0, nat.NATFlgNatConsistentHash)
+	err = natMap.Update(svcKey.AsBytes(), svcVal.AsBytes())
+	Expect(err).NotTo(HaveOccurred())
+
+	// re-enable debug
+	logrus.SetLevel(loglevel)
+
+	_, _, _, _, packetBytes, err := testPacketV4(
+		nil,
+		&layers.IPv4{
+			Version:  4,
+			IHL:      5,
+			TTL:      64,
+			Flags:    layers.IPv4DontFragment,
+			SrcIP:    net.IPv4(1, 2, 3, 4),
+			DstIP:    net.IPv4(1, 1, 1, 1),
+			Protocol: layers.IPProtocolTCP,
+		},
+		&layers.TCP{
+			SrcPort:    54321,
+			DstPort:    7890,
+			SYN:        false,
+			DataOffset: 5,
+		},
+		nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer resetRTMap(rtMap)
+	defer func() { bpfIfaceName = "" }()
+
+	// With lru, we will able to create the entry and the packet must be allowed.
+	bpfIfaceName = "mf00"
+	//skbMark = tcdefs.MarkSeen
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		// Destination is a local workload - should pass
+		res, err := bpfrun(packetBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+	})
+}


### PR DESCRIPTION
## Description
Currently, when a midflow packet is seen for a connection which is not known, it is left fall through to the underlying network stack e.g. iptables. This PR adds a UT documenting this behaviour.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
