### PR TITLE
[BPF] batch map userspace ops

### DIFF
--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -162,7 +162,7 @@ const (
 func KeyFromBytes(k []byte) KeyInterface {
 	var ctKey Key
 	if len(k) != len(ctKey) {
-		log.Panic("Key has unexpected length")
+		log.Panicf("Key has unexpected length %d != %d", len(k), len(ctKey))
 	}
 	copy(ctKey[:], k[:])
 	return ctKey

--- a/felix/bpf/conntrack/scanner_test.go
+++ b/felix/bpf/conntrack/scanner_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conntrack
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/conntrack/v4"
+	"github.com/projectcalico/calico/felix/bpf/maps"
+)
+
+func BenchmarkScanner(b *testing.B) {
+	scannerBenchmark(b, 4000000 /*v4.MaxEntries*/, 0)
+}
+
+func scannerBenchmark(b *testing.B, entries, batchSize int) {
+	RegisterTestingT(b)
+
+	logrus.SetLevel(logrus.InfoLevel)
+
+	SetMapSize(entries)
+	m := Map()
+	err := m.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		os.Remove(m.Path())
+		m.Close()
+	}()
+
+	ipA := net.IPv4(1, 2, 3, 4)
+	ipB := net.IPv4(5, 6, 7, 8)
+	ipC := net.IPv4(1, 0, 1, 0)
+
+	now := bpf.KTimeNanos()
+
+	batchK := make([][]byte, 1000)
+	batchV := make([][]byte, 1000)
+
+	c := 0
+
+	for i := 0; i < entries; i += 2 {
+		k1 := v4.NewKey(6, ipA, uint16(i/(1<<16)), ipB, uint16(i%(1<<16)))
+		k2 := v4.NewKey(6, ipC, uint16(i/(1<<16)), ipB, uint16(i%(1<<16)))
+
+		v1 := NewValueNATReverse(time.Duration(now), 0,
+			Leg{SynSeen: true, AckSeen: true}, Leg{SynSeen: true, AckSeen: true},
+			nil, nil, 0)
+		v2 := NewValueNATForward(time.Duration(now), 0, k1)
+
+		batchK[c] = k1[:]
+		batchK[c+1] = k2[:]
+		batchV[c] = v1[:]
+		batchV[c+1] = v2[:]
+
+		c += 2
+
+		if c == 1000 {
+			n, err := m.(*maps.PinnedMap).BatchUpdate(batchK, batchV, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(c))
+			c = 0
+		}
+	}
+
+	if c > 0 {
+		n, err := m.(*maps.PinnedMap).BatchUpdate(batchK[0:c], batchV[0:c], 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(c))
+	}
+
+	ctKey := KeyFromBytes
+	ctVal := ValueFromBytes
+
+	conntrackScanner := NewScanner(m, ctKey, ctVal, nil, "none")
+
+	for b.Loop() {
+		conntrackScanner.Scan()
+	}
+}
+
+type testScanner struct {
+	count int
+	m     map[KeyInterface]ValueInterface
+}
+
+func (ts *testScanner) Check(k KeyInterface, v ValueInterface, _ EntryGet) ScanVerdict {
+	ts.m[k] = v
+	ts.count++
+	return ScanVerdictOK
+}
+
+func TestScannerBatchIteration(t *testing.T) {
+	RegisterTestingT(t)
+
+	logrus.SetLevel(logrus.InfoLevel)
+
+	entries := 50000
+
+	SetMapSize(entries)
+	m := Map()
+	err := m.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		os.Remove(m.Path())
+		m.Close()
+	}()
+
+	ipA := net.IPv4(1, 2, 3, 4)
+	ipB := net.IPv4(5, 6, 7, 8)
+	ipC := net.IPv4(1, 0, 1, 0)
+
+	now := bpf.KTimeNanos()
+
+	batchK := make([][]byte, 1000)
+	batchV := make([][]byte, 1000)
+
+	c := 0
+
+	mx := make(map[KeyInterface]ValueInterface)
+
+	for i := 0; i < entries; i += 2 {
+		k1 := v4.NewKey(6, ipA, uint16(i/(1<<16)), ipB, uint16(i%(1<<16)))
+		k2 := v4.NewKey(6, ipC, uint16(i/(1<<16)), ipB, uint16(i%(1<<16)))
+
+		v1 := NewValueNATReverse(time.Duration(now), 0,
+			Leg{SynSeen: true, AckSeen: true}, Leg{SynSeen: true, AckSeen: true},
+			nil, nil, 0)
+		v2 := NewValueNATForward(time.Duration(now), 0, k1)
+
+		mx[k1] = v1
+		mx[k2] = v2
+
+		batchK[c] = k1[:]
+		batchK[c+1] = k2[:]
+		batchV[c] = v1[:]
+		batchV[c+1] = v2[:]
+
+		c += 2
+
+		if c == 1000 {
+			n, err := m.(*maps.PinnedMap).BatchUpdate(batchK, batchV, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(c))
+			c = 0
+		}
+	}
+
+	Expect(len(mx)).To(Equal(entries))
+
+	if c > 0 {
+		n, err := m.(*maps.PinnedMap).BatchUpdate(batchK[0:c], batchV[0:c], 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(c))
+	}
+
+	ctKey := KeyFromBytes
+	ctVal := ValueFromBytes
+
+	ts := testScanner{
+		m: make(map[KeyInterface]ValueInterface),
+	}
+
+	conntrackScanner := NewScanner(m, ctKey, ctVal, nil, "none", &ts)
+	conntrackScanner.Scan()
+
+	Expect(len(ts.m)).To(BeNumerically(">", entries*95/100))
+	for k, v := range ts.m {
+		x, ok := mx[k]
+		if !ok {
+			t.Fatalf("Missing key %v", k)
+		}
+		Expect(x).To(Equal(v))
+	}
+}

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -649,3 +649,20 @@ func ObjGet(path string) (int, error) {
 
 	return int(fd), err
 }
+
+// MapUpdateBatch expects all key, values in a single slice, bytes of a one
+// key/value appended back to back to the previous value.
+func MapUpdateBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
+	cK := C.CBytes(k)
+	defer C.free(cK)
+	cV := C.CBytes(v)
+	defer C.free(cV)
+
+	_, err := C.bpf_map_batch_update(C.int(fd), cK, cV, (*C.__u32)(unsafe.Pointer(&count)), C.__u64(flags))
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -454,6 +454,14 @@ void bpf_map_set_max_entries(struct bpf_map *map, uint max_entries) {
 	set_errno(bpf_map__set_max_entries(map, max_entries));
 }
 
+void bpf_map_batch_update(int fd, const void *keys, const void *values, __u32 *count, __u64 flags)
+{
+	DECLARE_LIBBPF_OPTS(bpf_map_batch_opts, opts,
+		.flags = flags);
+
+	set_errno(bpf_map_update_batch(fd, keys, values, count, &opts));
+}
+
 int num_possible_cpu()
 {
     return libbpf_num_possible_cpus();

--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -415,6 +415,28 @@ func (b *PinnedMap) UpdateWithFlags(k, v []byte, flags int) error {
 	return UpdateMapEntryWithFlags(b.fd, k, v, flags)
 }
 
+func (b *PinnedMap) BatchUpdate(ks, vs [][]byte, flags uint64) (int, error) {
+	count := len(ks)
+
+	if count != len(vs) {
+		return 0, fmt.Errorf("number of keys is not equal the number of values")
+	}
+
+	if count == 0 {
+		return 0, nil
+	}
+
+	k := make([]byte, 0, count*len(ks[0]))
+	v := make([]byte, 0, count*len(vs[0]))
+
+	for i := 0; i < count; i++ {
+		k = append(k, ks[i]...)
+		v = append(v, vs[i]...)
+	}
+
+	return libbpf.MapUpdateBatch(int(b.fd), k, v, count, flags)
+}
+
 func (b *PinnedMap) Get(k []byte) ([]byte, error) {
 	valueSize := b.ValueSize
 	if b.perCPU {

--- a/felix/bpf/maps/syscall_common.go
+++ b/felix/bpf/maps/syscall_common.go
@@ -42,14 +42,20 @@ type Iterator struct {
 	// then the pointers we write to the bpf_attr union could end up being stale (since
 	// the union is opaque to the garbage collector).
 
-	// keyBeforeNextBatch is either nil at start of day or points to a buffer containing
-	// the key to pass to bpf_map_load_multi.
-	keyBeforeNextBatch unsafe.Pointer
+	// This is a u32 in kernel value and we only need to pass a pointer to where
+	// the kernel can store the next token to pass to bpf_map_lookup_batch as
+	// batch_out and then receive it back as batch_in.
+	token uint32
 
 	// keys points to a buffer containing up to IteratorNumKeys keys
-	keys unsafe.Pointer
+	keysBuff    unsafe.Pointer
+	keysBufSize int
 	// values points to a buffer containing up to IteratorNumKeys values
-	values unsafe.Pointer
+	valuesBuff    unsafe.Pointer
+	valuesBufSize int
+
+	keys   []byte
+	values []byte
 
 	// valueStride is the step through the values buffer.  I.e. the size of the value
 	// rounded up for alignment.


### PR DESCRIPTION
It is much faster to read many values/keys in a single syscall than to use a syscall to first get next key and then to get the value.

Also adds batch userspace update

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
