### PR TITLE
[BPF] on ingress to node use pre-dnat IP for icmp response

### DIFF
--- a/felix/bpf-gpl/icmp6.h
+++ b/felix/bpf-gpl/icmp6.h
@@ -77,7 +77,7 @@ static CALI_BPF_INLINE int icmp_v6_reply(struct cali_tc_ctx *ctx,
 	ctx->ipheader_len = IP_SIZE;
 
 	if  (CALI_F_FROM_HEP && !ip_equal(ctx->state->pre_nat_ip_dst, ctx->state->post_nat_ip_dst)) {
-		CALI_DEBUG("ICMP v4 reply: from orig pre DNAT IP");
+		CALI_DEBUG("ICMP v6 reply: from orig pre DNAT IP");
 		ipv6_addr_t_to_ipv6hdr_ip(&ip_hdr(ctx)->saddr, &orig_dst);
 	} else {
 		struct cali_rt *r = cali_rt_lookup(&orig_dst);

--- a/felix/bpf-gpl/icmp6.h
+++ b/felix/bpf-gpl/icmp6.h
@@ -76,15 +76,19 @@ static CALI_BPF_INLINE int icmp_v6_reply(struct cali_tc_ctx *ctx,
 
 	ctx->ipheader_len = IP_SIZE;
 
-	/* use the host IP of the program that handles the packet */
-	struct cali_rt *r = cali_rt_lookup(&orig_dst);
-	if (r && cali_rt_flags_local_host(r->flags)) {
-		CALI_DEBUG("ICMP v6 reply: from orig dst host IP " IP_FMT, &orig_dst);
+	if  (CALI_F_FROM_HEP && !ip_equal(ctx->state->pre_nat_ip_dst, ctx->state->post_nat_ip_dst)) {
+		CALI_DEBUG("ICMP v4 reply: from orig pre DNAT IP");
 		ipv6_addr_t_to_ipv6hdr_ip(&ip_hdr(ctx)->saddr, &orig_dst);
 	} else {
-		/* use the host IP of the program that handles the packet */
-		CALI_DEBUG("ICMP v6 reply: from IP of the intf " IP_FMT, &INTF_IP);
-		ipv6_addr_t_to_ipv6hdr_ip(&ip_hdr(ctx)->saddr, (ipv6_addr_t *)&INTF_IP);
+		struct cali_rt *r = cali_rt_lookup(&orig_dst);
+		if (r && cali_rt_flags_local_host(r->flags)) {
+			CALI_DEBUG("ICMP v6 reply: from orig dst host IP " IP_FMT, &orig_dst);
+			ipv6_addr_t_to_ipv6hdr_ip(&ip_hdr(ctx)->saddr, &orig_dst);
+		} else {
+			/* use the host IP of the program that handles the packet */
+			CALI_DEBUG("ICMP v6 reply: from IP of the intf " IP_FMT, &INTF_IP);
+			ipv6_addr_t_to_ipv6hdr_ip(&ip_hdr(ctx)->saddr, (ipv6_addr_t *)&INTF_IP);
+		}
 	}
 	ipv6_addr_t_to_ipv6hdr_ip(&ip_hdr(ctx)->daddr, &orig_src);
 

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1827,7 +1827,7 @@ func testPacketUDPDefault() (*layers.Ethernet, *layers.IPv4, gopacket.Layer, []b
 	return e, ip4.(*layers.IPv4), l4, p, b, err
 }
 
-func testPacketUDPDefaultNP(destIP net.IP) (*layers.Ethernet, *layers.IPv4, gopacket.Layer, []byte, []byte, error) {
+func testPacketUDPDefaultNPWithPayload(destIP net.IP, payload []byte) (*layers.Ethernet, *layers.IPv4, gopacket.Layer, []byte, []byte, error) {
 	if destIP == nil {
 		return testPacketUDPDefault()
 	}
@@ -1841,7 +1841,7 @@ func testPacketUDPDefaultNP(destIP net.IP) (*layers.Ethernet, *layers.IPv4, gopa
 	}}
 	ip.IHL += 2
 
-	e, ip4, l4, p, b, err := testPacket(4, nil, &ip, nil, nil)
+	e, ip4, l4, p, b, err := testPacket(4, nil, &ip, nil, payload)
 	return e, ip4.(*layers.IPv4), l4, p, b, err
 }
 
@@ -1856,6 +1856,10 @@ func ipv6HopByHopExt() gopacket.SerializableLayer {
 	hop.Options = append(hop.Options, tlv)
 
 	return hop
+}
+
+func testPacketUDPDefaultNP(destIP net.IP) (*layers.Ethernet, *layers.IPv4, gopacket.Layer, []byte, []byte, error) {
+	return testPacketUDPDefaultNPWithPayload(destIP, nil)
 }
 
 func testPacketUDPDefaultNPV6WithPayload(destIP net.IP, payload []byte) (*layers.Ethernet, *layers.IPv6, gopacket.Layer, []byte, []byte, error) {

--- a/felix/bpf/ut/icmp_ttl_exceeded_test.go
+++ b/felix/bpf/ut/icmp_ttl_exceeded_test.go
@@ -44,7 +44,7 @@ func TestICMPttlExceeded(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPttlExceeded(pktR, ipv4)
+		checkICMPttlExceeded(pktR, ipv4.SrcIP, intfIP)
 	})
 
 }
@@ -84,7 +84,7 @@ func TestICMPttlExceededFromHEP(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPttlExceeded(pktR, ipv4)
+		checkICMPttlExceeded(pktR, ipv4.SrcIP, ipv4.DstIP)
 	})
 	expectMark(tcdefs.MarkSeenBypassForward)
 
@@ -107,19 +107,19 @@ func TestICMPttlExceededFromHEP(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPttlExceeded(pktR, ipv4)
+		checkICMPttlExceeded(pktR, ipv4.SrcIP, intfIP)
 	})
 	expectMark(tcdefs.MarkSeenBypassForward)
 }
 
-func checkICMPttlExceeded(pktR gopacket.Packet, ipv4 *layers.IPv4) {
+func checkICMPttlExceeded(pktR gopacket.Packet, src, dst net.IP) {
 	ipv4L := pktR.Layer(layers.LayerTypeIPv4)
 	Expect(ipv4L).NotTo(BeNil())
 	ipv4R := ipv4L.(*layers.IPv4)
 
 	Expect(ipv4R.Protocol).To(Equal(layers.IPProtocolICMPv4))
-	Expect(ipv4R.SrcIP.String()).To(Equal(intfIP.String()))
-	Expect(ipv4R.DstIP).To(Equal(ipv4.SrcIP))
+	Expect(ipv4R.SrcIP.String()).To(Equal(dst.String()))
+	Expect(ipv4R.DstIP).To(Equal(src))
 
 	icmpL := pktR.Layer(layers.LayerTypeICMPv4)
 	Expect(ipv4L).NotTo(BeNil())

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -1639,7 +1639,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
 
-		checkICMPTooBig(pktR, ipv4, udp, natTunnelMTU)
+		checkICMPTooBig(pktR, ipv4, udp, ipv4.DstIP, natTunnelMTU)
 	})
 
 	expectMark(tcdefs.MarkSeenBypassForward)


### PR DESCRIPTION
Nodes may have just private IPs abut may implement ExternalIPs for services. In that case, responding with private IP would not work. Let's use the ExternalIP as our node is that one that impements the VIP and thus can act like a node with that IP.

fixes https://github.com/projectcalico/calico/issues/10640
fixes https://github.com/projectcalico/calico/issues/10669

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: on ingress to node use pre-dnat IP for icmp response. Either it is an external IP or routable from the previous hop. The node can pose as having the VIP.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
