### PR TITLE
Use felix for ipip routes in ebpf tests

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -380,9 +380,16 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				// Enable adding simulated routes.
 				options.SimulateBIRDRoutes = true
 			case "ipip":
-				// IPIP is not supported in IPv6. We need to mimic routes in FVs.
-				options.IPIPMode = api.IPIPModeAlways
-				options.SimulateBIRDRoutes = true
+				if testOpts.ipv6 {
+					// IPIP is not supported in IPv6. We need to mimic routes in FVs.
+					options.IPIPMode = api.IPIPModeAlways
+					options.SimulateBIRDRoutes = true
+				} else {
+					// Let Felix program IPIP routes. Do not mimic routes.
+					options.IPIPMode = api.IPIPModeAlways
+					options.SimulateBIRDRoutes = false
+					options.ExtraEnvVars["FELIX_ProgramClusterRoutes"] = "Enabled"
+				}
 			case "vxlan":
 				options.VXLANMode = api.VXLANModeAlways
 				options.VXLANStrategy = infrastructure.NewDefaultTunnelStrategy(options.IPPoolCIDR, options.IPv6PoolCIDR)


### PR DESCRIPTION
## Description

Use Felix ability to write IPIP tunnel routes instead of simulating those routes in FVs whenever possible. This PR changes ebpf FVs to use Felix programming IPIP routes for IPv4 pools.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
