### PR TITLE
Fix confd ut on local bgp peer

### DIFF
--- a/confd/Makefile
+++ b/confd/Makefile
@@ -56,7 +56,6 @@ test-kdd: bin/confd-$(ARCH) bin/kubectl bin/bird bin/bird6 bin/calico-node bin/c
 		-v $(CURDIR)/bin:/calico/bin/ \
 		-v $(CURDIR)/etc/calico:/etc/calico/ \
 		-v $(CURDIR)/../:/go/src/github.com/projectcalico/calico:rw \
-		-v /var/run/calico/endpoint-status \
 		-e GOPATH=/go \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e FELIX_TYPHAADDR=127.0.0.1:5473 \
@@ -90,7 +89,6 @@ test-etcd: bin/confd-$(ARCH) bin/etcdctl bin/bird bin/bird6 bin/calico-node bin/
 		-v $(CURDIR)/bin:/calico/bin/ \
 		-v $(CURDIR)/etc/calico:/etc/calico/ \
 		-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
-		-v /var/run/calico/endpoint-status \
 		-e GOPATH=/go \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e UPDATE_EXPECTED_DATA=$(UPDATE_EXPECTED_DATA) \

--- a/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird.cfg
@@ -77,10 +77,12 @@ function 'bgp_import-only-filter_importFilterV4'() {
 
 
 
+
+
+
+
 # ------------- Global local bgp peers -------------
-
-
-
+ 
 # For peer /bgp/v1/global/peer_v4/192.168.162.134
 protocol bgp Local_Workload_192_168_162_134 from bgp_template {
   ttl security off;
@@ -110,11 +112,12 @@ protocol bgp Local_Workload_192_168_162_134 from bgp_template {
 
 
 
+
+
+
+
 # ------------- Node-specific local BGP peers -------------
-
-
-
-
+ 
 # For peer /bgp/v1/host/kube-master/peer_v4/192.168.162.136
 protocol bgp Local_Workload_192_168_162_136 from bgp_template {
   ttl security off;

--- a/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local_bgp_peer/bird6.cfg
@@ -77,10 +77,12 @@ function 'bgp_import-only-filter_importFilterV6'() {
 
 
 
+
+
+
+
 # ------------- Global local bgp peers -------------
-
-
-
+ 
 # For peer /bgp/v1/global/peer_v6/fd00:10:244:0:586d:4461:e980:a284
 protocol bgp Local_Workload_fd00_10_244_0_586d_4461_e980_a284 from bgp_template {
   ttl security off;
@@ -107,11 +109,13 @@ protocol bgp Local_Workload_fd00_10_244_0_586d_4461_e980_a284 from bgp_template 
 
 
 
+
+
+
+
+
 # ------------- Node-specific local BGP peers -------------
-
-
-
-
+ 
 # For peer /bgp/v1/host/kube-master/peer_v6/fd00:10:244:0:586d:4461:e980:a286
 protocol bgp Local_Workload_fd00_10_244_0_586d_4461_e980_a286 from bgp_template {
   ttl security off;


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Confd UT starts the confd daemon before creating the endpoint status files. This causes confd to fail to read and process the status files. This PR changes the sequence so that the unit test creates the endpoint status files before starting the confd daemon."


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
