### PR TITLE
[BPF] Set missing tunnel key on vxlan if BYPASS is set

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -82,7 +82,10 @@ int calico_tc_main(struct __sk_buff *skb)
 
 	/* Optimisation: if another BPF program has already pre-approved the packet,
 	 * skip all processing. */
-	if (CALI_F_FROM_HOST && skb->mark == CALI_SKB_MARK_BYPASS) {
+	if (CALI_F_FROM_HOST && skb->mark == CALI_SKB_MARK_BYPASS &&
+			/* If we are on vxlan and we do not have the key set, we cannot short-cirquit */
+			!(CALI_F_VXLAN &&
+			 !skb_mark_equals(skb, CALI_SKB_MARK_TUNNEL_KEY_SET, CALI_SKB_MARK_TUNNEL_KEY_SET))) {
 		if  (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_DEBUG) {
 			/* This generates a bit more richer output for logging */
 			DECLARE_TC_CTX(_ctx,
@@ -200,6 +203,20 @@ int calico_tc_main(struct __sk_buff *skb)
 		CALI_DEBUG("Drop malformed or unsupported packet");
 		ctx->fwd.res = TC_ACT_SHOT;
 		goto finalize;
+	}
+
+	if (CALI_F_VXLAN && CALI_F_TO_HEP
+			&& skb_mark_equals(ctx->skb, CALI_SKB_MARK_BYPASS, CALI_SKB_MARK_BYPASS)) {
+		/* In case we are on VXLAN device, CALI_SKB_MARK_BYPASS is set we only got
+		 * here because CALI_SKB_MARK_TUNNEL_KEY_SET wasn't set. This happens when
+		 * redirecting on a WEP was disabled, e.g. not to bypass the qdisc. We do
+		 * not have the key set, but CALI_SKB_MARK_BYPASS tells us that we do not
+		 * need to do more than that. Juset forward the packet. We already parsed
+		 * IP header so we have enough to forward via vxlan. So just got to allow
+		 * and forward it. forward_or_drop() will set the key.
+		 */
+		tc_state_fill_from_iphdr(ctx);
+		goto allow;
 	}
 
 #ifndef IPVER6


### PR DESCRIPTION
Workload endpoints set the vxlan tunnel key just before they redirect the packet to the vxlan device. If for any reason redirection is disabled, but the packet is routed via vxlan, it may be that BYPASS is set on an established connection. The vxlan device must not short-cirquit everything, it still needs to fill in the tunnel key as it does for host traffic.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
