### PR TITLE
Fix confd on Windows by skipping watching endpoint status files (#10691)

### DIFF
--- a/process/testing/winfv-cni-plugin/aso/vmss.sh
+++ b/process/testing/winfv-cni-plugin/aso/vmss.sh
@@ -87,11 +87,11 @@ EOF
 
   echo
   echo "Generating helper files"
-  echo ${MASTER_CONNECT_COMMAND} > ./ssh-node-linux.sh
+  echo '${MASTER_CONNECT_COMMAND} "$@"' > ./ssh-node-linux.sh
   chmod +x ./ssh-node-linux.sh
 
   cat << EOF > ssh-node-windows.sh
-#usage: . /ssh-node-windows.sh "Restart-Computer -force"
+#usage: ./ssh-node-windows.sh "Restart-Computer -force"
 ${WINDOWS_CONNECT_COMMAND} \$1
 EOF
   chmod +x ./ssh-node-windows.sh
@@ -117,7 +117,7 @@ chmod +x ./scp-from-windows.sh
 }
 
 function retry-ssh() {
-  local SSH_CMD=$1
+  local SSH_CMD="$@"
   local RETRY_INTERVAL=30         # Seconds between retries
   local MAX_DURATION=300
 
@@ -151,8 +151,8 @@ function retry-ssh() {
 function confirm-nodes-ssh() {
   echo;echo "confirm nodes can be accessed by ssh..."
   show_connections
-  retry-ssh "${MASTER_CONNECT_COMMAND} echo"
-  retry-ssh "${WINDOWS_CONNECT_COMMAND} -Command 'echo'"
+  retry-ssh ./ssh-node-linux.sh echo
+  retry-ssh ./ssh-node-windows.sh "-Help"
 
   # Azure may assign another public IP to the VM.
   # So even the first batch of SSHes works, the ip could be updated later.
@@ -160,8 +160,8 @@ function confirm-nodes-ssh() {
   echo "sleep 30 seconds..."
   sleep 30
   show_connections
-  retry-ssh "${MASTER_CONNECT_COMMAND} echo"
-  retry-ssh "${WINDOWS_CONNECT_COMMAND} -Command 'echo'"
+  retry-ssh ./ssh-node-linux.sh echo
+  retry-ssh ./ssh-node-windows.sh "-Help"
   echo "VMs can be accessed by ssh.";echo
 }
 


### PR DESCRIPTION
* Fix confd on Windows by skipping watching endpoint status files

(cherry picked from commit cf69604e76692dc26e916fdd6ccacf5d0ae76616)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix confd on Windows by skipping watching endpoint status files.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
