### PR TITLE
Attempt to fix notrack policies in nftables dataplane

### DIFF
--- a/.github/ISSUE_TEMPLATE/generate-purpose-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generate-purpose-issue-template.md
@@ -38,7 +38,7 @@ assignees: ''
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 * Calico version
-* Calico dataplane (iptables, windows etc.)
-* Orchestrator version (e.g. kubernetes, mesos, rkt):
+* Calico dataplane (bpf, nftables, iptables, windows etc.)
+* Orchestrator version (e.g. kubernetes, openshift, etc.):
 * Operating System and version:
 * Link to your project (optional):

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -180,7 +180,6 @@ func collectDiags(opts *diagOpts) error {
 }
 
 func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts) {
-
 	// If --focus-nodes is specified, put those node names at the start of the node list.
 	nodeList := strings.Split(opts.FocusNodes, ",")
 
@@ -253,7 +252,6 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 }
 
 func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient kubernetes.Interface, nodeList []string, ns string, selector *v1.LabelSelector) {
-
 	labelMap, err := v1.LabelSelectorAsMap(selector)
 	if err != nil {
 		fmt.Printf("ERROR forming pod selector: %v\n", err)
@@ -477,7 +475,7 @@ type tls struct {
 func collectTLSSecrets(kubeClient kubernetes.Interface, dir string) {
 	fmt.Println("Collecting (censored) TLS secrets")
 	ctx := context.Background()
-	err := os.MkdirAll(dir, 0777)
+	err := os.MkdirAll(dir, 0o777)
 	if err != nil {
 		fmt.Printf("failed to create TLS directory: %v\n", err)
 		return
@@ -517,7 +515,7 @@ func collectTLSSecrets(kubeClient kubernetes.Interface, dir string) {
 				censorSecret(secret)
 				yamlData, err := yaml.Marshal(secret)
 				if err == nil {
-					err = os.WriteFile(fmt.Sprintf("%s/%s_%s.yaml", dir, ns, t.name), yamlData, 0644)
+					err = os.WriteFile(fmt.Sprintf("%s/%s_%s.yaml", dir, ns, t.name), yamlData, 0o644)
 					if err != nil {
 						fmt.Printf("failed to write YAML to file: %v\n", err)
 					}

--- a/calicoctl/calicoctl/commands/node/diags.go
+++ b/calicoctl/calicoctl/commands/node/diags.go
@@ -86,6 +86,7 @@ func runDiags(logDir string) error {
 		{"Dumping routes (IPv6)", "ip -6 route", "ipv6_route"},
 		{"Dumping interface info (IPv4)", "ip -4 addr", "ipv4_addr"},
 		{"Dumping interface info (IPv6)", "ip -6 addr", "ipv6_addr"},
+		{"Dumping nftables", "nft -n -a list ruleset", "nft_ruleset"},
 		{"Dumping iptables (IPv4)", "iptables-save -c", "ipv4_tables"},
 		{"Dumping iptables (IPv6)", "ip6tables-save -c", "ipv6_tables"},
 		{"Dumping ipsets", "ipset list", "ipsets"},


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Noticed that uni-directional do-not-track policies applied to host endpoints were not passing one of our end-to-end tests. Namely, the failing scenario involves:

- Creating a host endpoint
- Creating a do-not-track GlobalNetworkPolicy that selects it an allows ingress+egress to/from port 9090
- Creating a do-not-track GlobalNetworkPolicy that allows ingress to port 9091, but not egress from.

The expected result is that port 9090 is accessible, but port 9091 is not (because conntrack does not allow the return packets). However, in testing it appears that the return packets are being allowed by this rule:

```
ct status dnat counter jump mangle-cali-to-host-endpoint 
```

This rule is meant to be equivalent to the iptables variant:

```
-A cali-POSTROUTING -m comment --comment "cali:nquN8Jw8Tz72pcBW" -m conntrack --ctstate DNAT -j cali-to-host-endpoint
```

However, it seems that the match is not identical. I suspect this behavioral difference is because the iptables `-m conntrack --ctstate DNAT` is a virtual match that compares the original destination address to the packet's source address, whereas `ct status dnat` is directly checking conntrack status bits (but am not yet confident in this assesment).

This would mean that in iptables mode, the DNAT check would execute HEP policies on return packets, resulting in a drop, whereas in nftables mode these return packets skip policy execution and are allowed.

So, it seems we need a different implementation of this in nftables. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.