### PR TITLE
Remove gotestsum installation step for every release UT run

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -23,15 +23,10 @@ bin/release: $(shell find . -name "*.go")
 
 POSTRELEASE_TEST_PACKAGE		:= $(PACKAGE_NAME)/pkg/postrelease
 UNIT_TEST_PACKAGES	:= $(shell go list ./... | grep -v $(POSTRELEASE_TEST_PACKAGE))
-ut: bin/gotestsum
+ut:
 	@mkdir -p report
 	@$(DOCKER_GO_BUILD) gotestsum --junitfile report/unit-tests.xml \
 		-- -coverprofile=report/coverage.out $(UNIT_TEST_PACKAGES)
-
-GOTESTSUM_VERSION := v1.12.1
-bin/gotestsum:
-	@mkdir -p bin
-	@$(DOCKER_GO_BUILD) go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
 ###############################################################################
 # CI/CD


### PR DESCRIPTION
## Description

The gotestsum utility is already included in the calico/go-build image [1]. Therefore, it does not need to be reinstalled during each execution of the release utility unit tests.

[1] https://github.com/projectcalico/go-build/blob/aef1b9c7c5ba41341510e6113fffc33d26eff78d/images/calico-go-build/Dockerfile#L174

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
