### PR TITLE
OpenStack: Log old and new port details in update_port_postcommit

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -775,6 +775,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                      original.get("status"), port.get("status"))
             return
 
+        LOG.debug("Old = %r", original)
+        LOG.debug("New = %r", port)
+
         # Re-read the port; we do this to guarantee correctly ordered handling
         # of multiple updates to the same port, when there are multiple Neutron
         # servers and so different updates could be processed on different


### PR DESCRIPTION
This is to investigate a problem where we see overlapping update and delete operations, in the Neutron server log, when a VM is deleted at the end of a test.  The overlapping delete causes the update processing to log an exception, which looks bad, like this:

    2025-07-20 20:38:10.424 53995 ERROR neutron.plugins.ml2.managers [None req-00ae8278-91fe-4973-be47-13476656af86 - - - - - -] Mechanism driver 'calico' failed in update_port_postcommit: neutron_lib.exceptions.PortNotFound: Port 54adae4b-84fc-4f7a-b57f-d4ca80b2c585 could not be found.

I thought I had addressed this with https://github.com/projectcalico/calico/pull/10678, but there has been a new occurrence of the error log after that change, at https://tigera.semaphoreci.com/workflows/a1fa0b88-b923-46bb-9e41-507685cd42d7?pipeline_id=4264bcb3-6a4e-45c6-b104-b6cfc07212a2. So add DEBUG logs to allow us to investigate further when this happens again.