### PR TITLE
OpenStack: ignore 'revision_number' when detecting status-only port updates

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -1154,7 +1154,7 @@ def port_status_change(port, original):
     port = port.copy()
     original = original.copy()
 
-    for ignore_field in ['status', 'updated_at']:
+    for ignore_field in ['status', 'updated_at', 'revision_number']:
         port.pop(ignore_field, None)
         original.pop(ignore_field, None)
 


### PR DESCRIPTION
This completes https://github.com/projectcalico/calico/pull/10678 - I somehow missed that there is also a `revision_number` field right after `updated_at`.  We need to ignore that one too, when determining if a change is one that we need to sync through to the Calico WorkloadEndpoint data.

Example:

    2025-07-21 18:55:42.493 54502 DEBUG networking_calico.plugins.ml2.drivers.calico.mech_calico [None req-f28820ac-f658-47f8-9a86-eaf1fe3193ce - - - - - -] Old = {'id': '489fcddb-a4a0-4561-a7e3-62133080879b', 'name': '', 'network_id': '387c5116-caff-4c25-8e16-5aefa4c239f9', 'tenant_id': '942802ec37054ed3af7d878491bf389a', 'mac_address': 'fa:16:3e:3d:6d:20', 'admin_state_up': True, 'status': 'ACTIVE', 'device_id': 'e7f40137-c57a-456f-b005-f67c9ed7d5c2', 'device_owner': 'compute:wt-vtsx3-ms-fullfv-mr-ub-carajammy-compute1-region-one', 'standard_attr_id': 1175, 'fixed_ips': [{'subnet_id': '17d74f8e-d592-45d2-a9e3-0fa7bf877909', 'ip_address': '10.28.3.175'}, {'subnet_id': '5ba1db54-6213-4c0c-8d14-f4123a6b3ed1', 'ip_address': 'fd5f:5d21:845:1c2e:2::1fa'}], 'allowed_address_pairs': [], 'extra_dhcp_opts': [], 'security_groups': ['83c196d1-7b5b-45a1-ada6-d44aeeba5f93'], 'description': '', 'binding:vnic_type': 'normal', 'binding:profile': {}, 'binding:host_id': 'wt-vtsx3-ms-fullfv-mr-ub-carajammy-compute1-region-one', 'binding:vif_type': 'tap', 'binding:vif_details': {'connectivity': 'legacy', 'port_filter': True, 'mac_address': '00:61:fe:ed:ca:fe', 'bound_drivers': {'0': 'calico'}}, 'qos_policy_id': None, 'qos_network_policy_id': None, 'resource_request': None, 'tags': [], 'created_at': '2025-07-21T18:54:11Z', 'updated_at': '2025-07-21T18:54:48Z', 'revision_number': 4, 'project_id': '942802ec37054ed3af7d878491bf389a'} update_port_postcommit /usr/lib/python3/dist-packages/networking_calico/plugins/ml2/drivers/calico/mech_calico.py:778
    2025-07-21 18:55:42.493 54502 DEBUG networking_calico.plugins.ml2.drivers.calico.mech_calico [None req-f28820ac-f658-47f8-9a86-eaf1fe3193ce - - - - - -] New = {'id': '489fcddb-a4a0-4561-a7e3-62133080879b', 'name': '', 'network_id': '387c5116-caff-4c25-8e16-5aefa4c239f9', 'tenant_id': '942802ec37054ed3af7d878491bf389a', 'mac_address': 'fa:16:3e:3d:6d:20', 'admin_state_up': True, 'status': 'DOWN',   'device_id': 'e7f40137-c57a-456f-b005-f67c9ed7d5c2', 'device_owner': 'compute:wt-vtsx3-ms-fullfv-mr-ub-carajammy-compute1-region-one', 'standard_attr_id': 1175, 'fixed_ips': [{'subnet_id': '17d74f8e-d592-45d2-a9e3-0fa7bf877909', 'ip_address': '10.28.3.175'}, {'subnet_id': '5ba1db54-6213-4c0c-8d14-f4123a6b3ed1', 'ip_address': 'fd5f:5d21:845:1c2e:2::1fa'}], 'allowed_address_pairs': [], 'extra_dhcp_opts': [], 'security_groups': ['83c196d1-7b5b-45a1-ada6-d44aeeba5f93'], 'description': '', 'binding:vnic_type': 'normal', 'binding:profile': {}, 'binding:host_id': 'wt-vtsx3-ms-fullfv-mr-ub-carajammy-compute1-region-one', 'binding:vif_type': 'tap', 'binding:vif_details': {'connectivity': 'legacy', 'port_filter': True, 'mac_address': '00:61:fe:ed:ca:fe', 'bound_drivers': {'0': 'calico'}}, 'qos_policy_id': None, 'qos_network_policy_id': None, 'resource_request': None, 'tags': [], 'created_at': '2025-07-21T18:54:11Z', 'updated_at': '2025-07-21T18:55:42Z', 'revision_number': 5, 'project_id': '942802ec37054ed3af7d878491bf389a'} update_port_postcommit /usr/lib/python3/dist-packages/networking_calico/plugins/ml2/drivers/calico/mech_calico.py:779