### PR TITLE
[v3.29] BPF: Fix that stale-NAT cleanup didn't wait for kube-proxy sync

### DIFF
--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -254,7 +254,7 @@ func (kp *KubeProxy) ConntrackFrontendHasBackend(ip net.IP, port uint16, backend
 	// Thanks to holding the lock since ConntrackScanStart, this condition holds for the
 	// whole iteration. So if we started without syncer, we will also finish without it.
 	// And if we had a syncer, we will have the same until the end.
-	if kp.syncer != nil {
+	if kp.syncer != nil && kp.syncer.HasSynced() {
 		return kp.syncer.ConntrackFrontendHasBackend(ip, port, backendIP, backendPort, proto)
 	}
 

--- a/felix/bpf/proxy/kube-proxy_internal_test.go
+++ b/felix/bpf/proxy/kube-proxy_internal_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net"
+	"testing"
+)
+
+// The main suite of tests in kube-proxy_test.go use a real syncer, making it
+// hard to check for the start of day race between the CheckXXX methods and the
+// initial sync.  These tests hack in a mock syncer so we can test the low
+// level logic
+
+func TestConntrackFrontendHasBackendChecksHasSynced(t *testing.T) {
+	m := &mockSyncer{}
+	kp := KubeProxy{
+		syncer: m,
+	}
+
+	if !kp.ConntrackFrontendHasBackend(nil, 0, nil, 0, 0) {
+		t.Errorf("ConntrackFrontendHasBackend should return true when syncer has not synced")
+	}
+	m.synced = true
+	if kp.ConntrackFrontendHasBackend(nil, 0, nil, 0, 0) {
+		t.Errorf("ConntrackFrontendHasBackend should return false when syncer has synced")
+	}
+}
+
+type mockSyncer struct {
+	DPSyncer
+	synced bool
+}
+
+func (s *mockSyncer) HasSynced() bool {
+	return s.synced
+}
+
+func (s *mockSyncer) ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP,
+	backendPort uint16, proto uint8) bool {
+	return false
+}
+
+func (s *mockSyncer) ConntrackDestIsService(ip net.IP, port uint16, proto uint8) bool {
+	return true
+}

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -73,6 +73,7 @@ type DPSyncer interface {
 	ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP, backendPort uint16, proto uint8) bool
 	Stop()
 	SetTriggerFn(func())
+	HasSynced() bool
 }
 
 type proxy struct {

--- a/felix/bpf/proxy/proxy_test.go
+++ b/felix/bpf/proxy/proxy_test.go
@@ -645,6 +645,7 @@ func (s *mockSyncer) Apply(state proxy.DPSyncerState) error {
 
 type syncerConntrackAPIDummy struct{}
 
+func (*syncerConntrackAPIDummy) HasSynced() bool     { return true }
 func (*syncerConntrackAPIDummy) ConntrackScanStart() {}
 func (*syncerConntrackAPIDummy) ConntrackScanEnd()   {}
 func (*syncerConntrackAPIDummy) ConntrackFrontendHasBackend(ip net.IP, port uint16, backendIP net.IP,

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -1218,6 +1218,10 @@ func (s *Syncer) cleanupSticky() error {
 	return nil
 }
 
+func (s *Syncer) HasSynced() bool {
+	return s.synced
+}
+
 // ConntrackFrontendHasBackend returns true if the given front-backend pair exists
 func (s *Syncer) ConntrackFrontendHasBackend(ip net.IP, port uint16,
 	backendIP net.IP, backendPort uint16, proto uint8) (ret bool) {


### PR DESCRIPTION
## Cherry-pick history (this PR at top)
- Pick projectcalico/calico#10721 onto **release-v3.29**.
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Conntrack cleanup could fire before kube-proxy had loaded the services, resulting in _every_ NAT entry looking stale.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Should fix #10670

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF: Fix race between loading kubernetes services and conntrack cleanup.  If conntrack cleanup ran before services were loaded, all service entries would look stale and get cleaned up.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.