### PR TITLE
Add publishing OpenStack RPMs to Google Artifact Registry

### DIFF
--- a/release/packaging/utils/create-update-packages.sh
+++ b/release/packaging/utils/create-update-packages.sh
@@ -74,6 +74,11 @@ function require_version {
         PATCH=${BASH_REMATCH[3]}
         PY2SUFFIX=${BASH_REMATCH[4]}
         : ${REPO_NAME:=calico-${MAJOR}.${MINOR}${PY2SUFFIX}}
+        # Set the GCLOUD_REPO_NAME; Google Artifact Registry doesn't allow for
+        # most characters, including periods, to be in registry names, meaning
+        # we can't use e.g. `calico-3.30`. For now, specify it manually. In
+        # future, after more testing, possibly we can just strip the period out
+        # of whatever REPO_NAME is set to.
         : ${GCLOUD_REPO_NAME:=calico-${MAJOR}${MINOR}}
     else
         echo "ERROR: Unhandled VERSION \"${VERSION}\""
@@ -185,13 +190,13 @@ function do_bld_images {
 }
 
 function do_net_cal {
-    # Build networking-calico packages.
+    # Build networking-calico packages, with RPM packages built first to be consistent
+    # with felix (which has a hard requirement on building rpm first at the moment)
     pushd "${rootdir}/networking-calico"
     PKG_NAME=networking-calico \
             NAME=networking-calico \
             DEB_EPOCH=3: \
-            # Build DEB packages first, followed by RPM packages, to maintain consistency with other build steps.
-            "${rootdir}/release/packaging/utils/make-packages.sh" deb rpm
+            "${rootdir}/release/packaging/utils/make-packages.sh" rpm deb
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'networking-calico_*-*' -exec mv '{}' "$outputDir" \;
     # Revert the changes made to networking-calico as part of the package build.
@@ -217,6 +222,9 @@ function do_felix {
     # Override dpkg's default file exclusions, otherwise our binaries won't get included (and some
     # generated files will).
     # Build rpm first and then deb because we need to patchelf bin/calico-felix for Debian.
+    #
+    # TODO: move the `patchelf` command that the debian packages require into the debian
+    # packaging scripts instead, so that they're not affecting things outside of themselves.
     PKG_NAME=felix \
             NAME=Felix \
             RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \

--- a/release/packaging/utils/create-update-packages.sh
+++ b/release/packaging/utils/create-update-packages.sh
@@ -190,7 +190,8 @@ function do_net_cal {
     PKG_NAME=networking-calico \
             NAME=networking-calico \
             DEB_EPOCH=3: \
-            "${rootdir}/release/packaging/utils/make-packages.sh" rpm deb
+            # Build DEB packages first, followed by RPM packages, to maintain consistency with other build steps.
+            "${rootdir}/release/packaging/utils/make-packages.sh" deb rpm
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'networking-calico_*-*' -exec mv '{}' "$outputDir" \;
     # Revert the changes made to networking-calico as part of the package build.

--- a/release/packaging/utils/create-update-packages.sh
+++ b/release/packaging/utils/create-update-packages.sh
@@ -42,7 +42,7 @@ function check_bin {
 }
 
 function error_exit {
-    echo "[error] $*"
+    echo >&2 "[error] $*"
     exit 1
 }
 
@@ -58,28 +58,32 @@ function require_version {
     # of the master branch of the relevant Calico components.  For
     # "vX.Y.Z" we build and publish packages from that tag in each
     # relevant Calico component.
-    test -n "$VERSION"
+    test -n "$VERSION" || error_exit 'VERSION must be specified; try `master` or `v3.30.2` for example'
     echo VERSION is "$VERSION"
 
     # Determine REPO_NAME.
     if [ $VERSION = master ]; then
-	: ${REPO_NAME:=master}
+        : ${REPO_NAME:=master}
     elif [[ $VERSION =~ ^release-v ]]; then
-	: ${REPO_NAME:=testing}
+        : ${REPO_NAME:=testing}
     elif [[ $VERSION =~ ^pr-[0-9]+$ ]]; then
-	: ${REPO_NAME:=${VERSION}}
+        : ${REPO_NAME:=${VERSION}}
     elif [[ $VERSION =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-python2)?$ ]]; then
-	MAJOR=${BASH_REMATCH[1]}
-	MINOR=${BASH_REMATCH[2]}
-	PATCH=${BASH_REMATCH[3]}
-	PY2SUFFIX=${BASH_REMATCH[4]}
-	: ${REPO_NAME:=calico-${MAJOR}.${MINOR}${PY2SUFFIX}}
+        MAJOR=${BASH_REMATCH[1]}
+        MINOR=${BASH_REMATCH[2]}
+        PATCH=${BASH_REMATCH[3]}
+        PY2SUFFIX=${BASH_REMATCH[4]}
+        : ${REPO_NAME:=calico-${MAJOR}.${MINOR}${PY2SUFFIX}}
+        : ${GCLOUD_REPO_NAME:=calico-${MAJOR}${MINOR}}
     else
-	echo "ERROR: Unhandled VERSION \"${VERSION}\""
-	exit 1
+        echo "ERROR: Unhandled VERSION \"${VERSION}\""
+        exit 1
     fi
+    : ${GCLOUD_REPO_NAME:=${REPO_NAME}}
     export REPO_NAME
+    export GCLOUD_REPO_NAME
     echo "REPO_NAME is $REPO_NAME"
+    echo "GCLOUD_REPO_NAME is ${GCLOUD_REPO_NAME}"
 }
 
 function require_repo_name {
@@ -142,7 +146,7 @@ function precheck_pub_debs {
     require_repo_name
     curl -fsSL -I "https://launchpad.net/~project-calico/+archive/ubuntu/${REPO_NAME}" > /dev/null
     if [[ $? != 0 ]]; then
-    	cat <<EOF
+            cat <<EOF
 
 ERROR: PPA for ${REPO_NAME} does not exist.  Create it, then rerun this job.
 
@@ -155,7 +159,7 @@ ERROR: PPA for ${REPO_NAME} does not exist.  Create it, then rerun this job.
   series.)
 
 EOF
-	    exit 1
+            exit 1
     fi
 
     # We'll need a secret key to upload new source packages.
@@ -184,9 +188,9 @@ function do_net_cal {
     # Build networking-calico packages.
     pushd "${rootdir}/networking-calico"
     PKG_NAME=networking-calico \
-	    NAME=networking-calico \
-	    DEB_EPOCH=3: \
-	    "${rootdir}/release/packaging/utils/make-packages.sh" deb rpm
+            NAME=networking-calico \
+            DEB_EPOCH=3: \
+            "${rootdir}/release/packaging/utils/make-packages.sh" rpm deb
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'networking-calico_*-*' -exec mv '{}' "$outputDir" \;
     # Revert the changes made to networking-calico as part of the package build.
@@ -213,11 +217,11 @@ function do_felix {
     # generated files will).
     # Build rpm first and then deb because we need to patchelf bin/calico-felix for Debian.
     PKG_NAME=felix \
-	    NAME=Felix \
-	    RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \
-	    DPKG_EXCL="-I'bin/calico-felix-*' -I.git -I.gitignore -I'*.d' -I'*.ll' -I.go-pkg-cache -I.git -Ivendor -Ireport" \
-	    DEB_EPOCH=3: \
-	    "${rootdir}/release/packaging/utils/make-packages.sh" rpm deb
+            NAME=Felix \
+            RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \
+            DPKG_EXCL="-I'bin/calico-felix-*' -I.git -I.gitignore -I'*.d' -I'*.ll' -I.go-pkg-cache -I.git -Ivendor -Ireport" \
+            DEB_EPOCH=3: \
+            "${rootdir}/release/packaging/utils/make-packages.sh" rpm deb
 
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'felix_*-*' -exec mv '{}' "$outputDir" \;
@@ -227,13 +231,13 @@ function do_felix {
 function do_etcd3gw {
     pushd "${rootdir}/release/packaging/etcd3gw"
     if ${PACKAGE_ETCD3GW:-false}; then
-	# When PACKAGE_ETCD3GW is explicitly specified, build RPM Python 2 packages for etcd3gw.
-	PKG_NAME=python-etcd3gw "${rootdir}/release/packaging/utils/make-packages.sh" rpm
+        # When PACKAGE_ETCD3GW is explicitly specified, build RPM Python 2 packages for etcd3gw.
+        PKG_NAME=python-etcd3gw "${rootdir}/release/packaging/utils/make-packages.sh" rpm
     else
         # Otherwise, no-op.  We don't have Python 3 RPM packaging for etcd3gw, so it makes sense to
-	# retreat to the same solution as for Debian/Ubuntu: don't build etcd3gw packages, and
-	# instead document that 'pip install' should be used to install etcd3gw.
-	:
+        # retreat to the same solution as for Debian/Ubuntu: don't build etcd3gw packages, and
+        # instead document that 'pip install' should be used to install etcd3gw.
+        :
     fi
     popd
 }

--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -134,6 +134,8 @@ function test_validate_version {
 # be set by the caller.
 ssh_host="gcloud --quiet compute ssh ${GCLOUD_ARGS} ${HOST}"
 scp_host="gcloud --quiet compute scp ${GCLOUD_ARGS}"
+
+upload_artifact="gcloud --quiet --no-user-output-enabled artifacts yum upload ${GCLOUD_REPO_NAME} --location=us-west1 --project=tigera-wp-tcp-redirect"
 rpmdir=/usr/share/nginx/html/rpm
 
 function ensure_repo_exists {
@@ -146,13 +148,36 @@ function copy_rpms_to_host {
     rootdir=$(git_repo_root)
     shopt -s nullglob
     for arch in src noarch x86_64; do
-	set -- $(find ${rootdir}/release/packaging/output/dist/rpms-el7 -name "*.$arch.rpm")
-	if test $# -gt 0; then
-	    $ssh_host -- mkdir -p $rpmdir/$reponame/$arch/
-	    $scp_host "$@" ${HOST}:$rpmdir/$reponame/$arch/
-	fi
+        set -- $(find ${rootdir}/release/packaging/output/dist/rpms-el7 -name "*.$arch.rpm")
+        if test $# -gt 0; then
+            $ssh_host -- mkdir -p $rpmdir/$reponame/$arch/
+            $scp_host "$@" ${HOST}:$rpmdir/$reponame/$arch/
+        fi
     done
 }
+
+function copy_rpms_to_artifact_registry {
+    reponame=$1
+    rootdir=$(git_repo_root)
+    upload_errors=""
+    shopt -s nullglob
+    echo "Uploading RPMs to Google Artifact Registry"
+    for rpmfile in $(find ${rootdir}/release/packaging/output/dist/rpms-el7 -name "*.rpm" | sort); do
+        filename=$(basename ${rpmfile})
+        echo "  Uploading ${filename}"
+        ${upload_artifact} --source="${rpmfile}" || upload_errors="${upload_errors} ${filename}"
+    done
+
+    if [[ ${upload_errors} != "" ]]; then
+        echo >&2 "Uploading RPMs complete, but the following files failed to upload to artifact registry:"
+        for file in $upload_errors; do
+            echo >&2 "  ${file}"
+        done
+        exit 1
+    fi
+    echo "Uploading RPMs complete"
+}
+
 
 # Clean and update repository metadata.  This includes ensuring that
 # all RPMs are signed with the Project Calico Maintainers secret key,

--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -135,7 +135,7 @@ function test_validate_version {
 ssh_host="gcloud --quiet compute ssh ${GCLOUD_ARGS} ${HOST}"
 scp_host="gcloud --quiet compute scp ${GCLOUD_ARGS}"
 
-upload_artifact="gcloud --quiet --no-user-output-enabled artifacts yum upload ${GCLOUD_REPO_NAME} --location=us-west1 --project=tigera-wp-tcp-redirect"
+upload_artifact="gcloud --quiet --no-user-output-enabled artifacts yum upload ${GCLOUD_REPO_NAME} --location=us-west1 --project=${GCLOUD_PROJECT:-tigera-wp-tcp-redirect}"
 rpmdir=/usr/share/nginx/html/rpm
 
 function ensure_repo_exists {

--- a/release/packaging/utils/publish-rpms.sh
+++ b/release/packaging/utils/publish-rpms.sh
@@ -20,3 +20,8 @@ copy_rpms_to_host "${REPO_NAME}"
 
 # Update repository metadata.
 update_repo_metadata "${REPO_NAME}"
+
+# Upload RPMs to Google Artifact Registry
+# Make sure this is last, as it wants to `exit 1` if
+# uploads failed. It's a hack, but it works.
+copy_rpms_to_artifact_registry "${REPO_NAME}"


### PR DESCRIPTION
Currently we publish RedHat RPMs for Openstack to a Google Cloud VM, but for our use cases publishing to Google Cloud's Artifact Registry is probably sufficient. This would allow us to remove the VM entirely, reducing our maintenance overhead to host these RPMs.

In future:

1. Redirect binaries.projectcalico.org to Artifact Registry
2. Remove the VM once we know things are stable

Unfortunately since PackageCloud was acquired, there are no good "host my packages for me" services that I can find, so GAR is the most feasible option for now.