### PR TITLE
eBPF: Hybrid conntrack cleaner

### DIFF
--- a/felix/bpf-gpl/conntrack_cleanup.c
+++ b/felix/bpf-gpl/conntrack_cleanup.c
@@ -27,9 +27,9 @@ struct ct_iter_ctx {
 	__u64 num_cleaned;
 };
 
-static CALI_BPF_INLINE bool if_ct_key_equal(struct calico_ct_key *key1, struct calico_ct_key *key2) {
+static CALI_BPF_INLINE bool ct_key_equal(struct calico_ct_key *key1, struct calico_ct_key *key2) {
 	if (!key1 || !key2) {
-		return false;
+		return key1 == key2;
 	}
 	if ((key1->protocol == key2->protocol) &&
 			(key1->port_a == key2->port_a) &&
@@ -67,7 +67,7 @@ static long process_ccq_entry(void *map, struct calico_ct_key *key, struct cali_
 		// Check if the fwd key still points to the same reverse key.
 		if (nat_fwd_value) {
 			struct calico_ct_key *nat_rev_key = &nat_fwd_value->nat_rev_key;
-			if (!if_ct_key_equal(nat_rev_key, rev_key)) {
+			if (!ct_key_equal(nat_rev_key, rev_key)) {
 		       		goto delete;
 			}
 		}

--- a/felix/bpf-gpl/conntrack_cleanup.c
+++ b/felix/bpf-gpl/conntrack_cleanup.c
@@ -24,229 +24,66 @@ struct ct_iter_ctx {
 	__u64 now;
 	__u64 end_time;
 
-	__u64 num_kvs_seen_normal;
-	__u64 num_kvs_seen_nat_fwd;
-	__u64 num_kvs_seen_nat_rev;
-	__u64 num_kvs_deleted_normal;
-	__u64 num_kvs_deleted_nat_fwd;
-	__u64 num_kvs_deleted_nat_rev;
+	__u64 num_cleaned;
 };
-
-// sub_age calculates now-then assuming that the difference is less than
-// 1<<63.  Values larger than that are assumed to have wrapped (then>now) and
-// 0 is returned in that case.
-static __u64 sub_age(__u64 now, __u64 then)
-{
-	__u64 age = now - then;
-	if (age > (1ull<<63)) {
-		// Wrapped, assume that means then > now.
-		return 0;
-	}
-	return age;
-}
-
-#define CT_VALUE_FINS_SEEN_DSR(value) (value->a_to_b.fin_seen || value->b_to_a.fin_seen)
-#define CT_VALUE_FINS_SEEN_NON_DSR(value) (value->a_to_b.fin_seen && value->b_to_a.fin_seen)
-#define CT_VALUE_ESTABLISHED(value) (value->a_to_b.syn_seen && value->a_to_b.ack_seen && value->b_to_a.syn_seen && value->b_to_a.ack_seen)
-#define CT_VALUE_DSR(value) (value->flags & CALI_CT_FLAG_DSR_FWD)
-
-// max_age returns the maximum age for the given conntrack "tracking" entry.
-static __u64 calculate_max_age(const struct calico_ct_key *key, const struct calico_ct_value *value)
-{
-	__u64 max_age;
-	switch (key->protocol) {
-	case IPPROTO_TCP:
-		if (value->a_to_b.rst_seen || value->b_to_a.rst_seen) {
-			max_age = __globals.tcp_reset_seen;
-		} else if (
-		    (CT_VALUE_DSR(value) && CT_VALUE_FINS_SEEN_DSR(value)) ||
-		    CT_VALUE_FINS_SEEN_NON_DSR(value)
-		) {
-			max_age = __globals.tcp_fins_seen;
-		} else if (CT_VALUE_ESTABLISHED(value) || CT_VALUE_DSR(value)) {
-			if (value->rst_seen) {
-				/* We have seen RST in the past, but we have seen traffic
-				 * since then so we want to be cautious and not tear down
-				 * the conntrack too soon in case the RST was spurious,
-				 * but we are also not sure if the connection is still
-				 * established.
-				 */
-				max_age = __globals.tcp_fins_seen;
-			} else {
-				max_age = __globals.tcp_established;
-			}
-		} else {
-			max_age = __globals.tcp_syn_sent;
-		}
-		break;
-	case IPPROTO_UDP:
-		max_age = __globals.udp_timeout;
-		break;
-	case IPPROTO_ICMP_46:
-		max_age = __globals.icmp_timeout;
-		break;
-	default:
-		max_age = __globals.generic_timeout;
-		break;
-	}
-	CALI_DEBUG("max_age %d", max_age / 1000000000);
-	return max_age;
-}
-
-static bool entry_expired(const struct calico_ct_key *key, const struct calico_ct_value *value, struct ct_iter_ctx *ctx)
-{
-	__u64 age = sub_age(ctx->now, value->last_seen);
-	__u64 max_age = calculate_max_age(key, value);
-	return age > max_age;
-}
-
-// process_ct_entry callback function for the conntrack map iteration.  Checks
-// the entry for expiry.  Expired normal entries are deleted inline.  Expired
-// NAT entries are queued for deletion in the cali_ccq map.
-static long process_ct_entry(void *map, const void *key, void *value, void *ctx)
-{
-	const struct calico_ct_key *ct_key = key;
-	struct calico_ct_value *ct_value = value;
-	struct calico_ct_value *rev_value;
-	struct ct_iter_ctx *ictx = ctx;
-
-	__u64 age = sub_age(ictx->now, ct_value->last_seen);
-	__u64 age_s = age/1000000000ull;
-
-	CALI_DEBUG("Checking: proto=%d " IP_FMT ":%d", ct_key->protocol, debug_ip(ct_key->addr_a), ct_key->port_a);
-	CALI_DEBUG("  <-> " IP_FMT ":%d age=%ds", debug_ip(ct_key->addr_b), ct_key->port_b, age_s);
-
-	__u64 max_age, max_age_s;
-
-	switch (ct_value->type) {
-	case CALI_CT_TYPE_NORMAL:
-		// Non-NAT entry, we only need to look at this entry to determine if it
-		// has expired.
-		ictx->num_kvs_seen_normal++;
-		max_age = calculate_max_age(ct_key, ct_value);
-		max_age_s = max_age/1000000000ull;
-		if (age > max_age) {
-			CALI_DEBUG("  EXPIRED: normal entry (max_age=%d).", max_age_s);
-			if (cali_ct_delete_elem(ct_key) == 0) {
-				ictx->num_kvs_deleted_normal++;
-			}
-		}
-		break;
-	case CALI_CT_TYPE_NAT_FWD:
-		// One half of a NAT entry.  The "forward" NAT entry is just a pointer
-		// to the "reverse" one, where we do the book-keeping.  In particular,
-		// the last-seen timestamp on the "reverse" entry is updated when we see
-		// traffic in either direction.
-		ictx->num_kvs_seen_nat_fwd++;
-		rev_value = cali_ct_lookup_elem(&ct_value->nat_rev_key);
-		if (!rev_value) {
-			// No reverse value found, see if this is a new entry.
-			__u64 age = sub_age(ictx->now, ct_value->last_seen);
-			if (age < __globals.creation_grace) {
-				// New entry, assume we're racing with creation.
-				CALI_DEBUG("  INVALID: Forward NAT entry with no reverse entry, ignoring due to creation grace period.");
-				break;
-			}
-
-			// Entry is not fresh so it looks invalid.  Clean it up.
-			CALI_DEBUG("  INVALID: Forward NAT entry with no reverse entry, cleaning up.");
-			if (cali_ct_delete_elem(ct_key) == 0) {
-				ictx->num_kvs_deleted_nat_fwd++;
-			}
-			break;
-		}
-
-		// Got a reverse entry, which has the overall "last_seen" for the
-		// connection.  Check if this entry has expired.
-		age = sub_age(ictx->now, rev_value->last_seen);
-		age_s = age/1000000000ull;
-
-		CALI_DEBUG("  Reverse NAT: proto=%d " IP_FMT ":%d", ct_key->protocol, debug_ip(ct_value->nat_rev_key.addr_a), ct_value->nat_rev_key.port_a);
-		CALI_DEBUG("    <->" IP_FMT ":%d age=%ds", debug_ip(ct_value->nat_rev_key.addr_b), ct_value->nat_rev_key.port_b, age_s);
-
-		max_age = calculate_max_age(&ct_value->nat_rev_key, rev_value);
-		max_age_s = max_age/1000000000ull;
-		if (age > max_age) {
-			// Expired, mark the entries for cleanup.  We can't just delete
-			// them now because it's not safe to delete _other_ entries from
-			// the map while iterating.
-			CALI_DEBUG("  EXPIRED: forward/reverse NAT entries (max_age=%d), queuing for deletion.", max_age_s);
-			if (cali_ccq_update_elem(&ct_value->nat_rev_key, ct_key, BPF_ANY)) {
-				CALI_DEBUG("  Failed to queue entry, queue full?");
-			}
-		}
-
-		break;
-	case CALI_CT_TYPE_NAT_REV:
-		// One half of a NAT entry.  The "reverse" entry is updated when we see
-		// traffic in either direction.
-		ictx->num_kvs_seen_nat_rev++;
-		if (entry_expired(ct_key, ct_value, ictx)) {
-			// Reverse entry has expired, but the reverse entry doesn't have a
-			// link to the forward entry so we write a dummy key and use
-			// BPF_NOEXIST to avoid overwriting a real key.
-			struct calico_ct_key dummy_key = {};
-			long rc = cali_ccq_update_elem(ct_key, &dummy_key, BPF_NOEXIST);
-			if (rc) {
-				CALI_DEBUG("  EXPIRED: Reverse NAT entry, already in queue or queue full (rc=%d).", rc);
-			} else {
-				CALI_DEBUG("  EXPIRED: Reverse NAT entry, queued for deletion. (Forward NAT entry not yet seen.)");
-			}
-		}
-		break;
-	}
-
-	return 0;
-}
 
 // process_ccq_entry processes an entry in the "cleanup queue" map.  The map
 // is keyed on the reverse NAT entry's key, with the value storing the forward
 // entry's key (or a zero value if the forward entry is missing).
-static long process_ccq_entry(void *map, const void *key, void *value, void *ctx)
+static long process_ccq_entry(void *map, struct calico_ct_key *key, struct cali_ccq_value *value, void *ctx)
 {
-	// Map stores mapping from reverse key to forward key (if known).
-	const struct calico_ct_key *rev_key = key;
-	const struct calico_ct_key *fwd_key = value;
+	bool isNatForward = false;
+	struct calico_ct_key *lookup_key = key;
 	struct ct_iter_ctx *ictx = ctx;
 
-	// It might be a few ms since we queued this entry, recheck it to make sure
-	// it is still expired.
-	const struct calico_ct_value *rev_value = cali_ct_lookup_elem(rev_key);
-	if (rev_value) {
-		__u64 age = sub_age(ictx->now, rev_value->last_seen);
-		__u64 age_s = age/1000000000ull;
-#ifdef IPVER6
-		CALI_DEBUG("Re-checking: proto=%d [%pI6]:%d", rev_key->protocol, &rev_key->addr_a, rev_key->port_a);
-		CALI_DEBUG("  <->[%pI6]:%d age=%ds", &rev_key->addr_b, rev_key->port_b, age_s);
-#else
-		CALI_DEBUG("Re-checking: proto=%d %pI4:%d", rev_key->protocol, &rev_key->addr_a, rev_key->port_a);
-		CALI_DEBUG("  <->%pI4:%d age=%ds", &rev_key->addr_b, rev_key->port_b, age_s);
-#endif
-		__u64 max_age = calculate_max_age(rev_key, rev_value);
-		__u64 max_age_s = max_age/1000000000ull;
-		if (age < max_age) {
-			// Race with a packet, CT entry now live again.
-			CALI_DEBUG("  RESURRECTED: entry no longer expired (max_age=%d).", max_age_s);
-			goto out;
+	// If NAT fwd entry, do a lookup of the rev_key.
+	if (value->rev_key.protocol != 0) {
+		isNatForward = true;
+		lookup_key = &value->rev_key;
+	}
+
+	const struct calico_ct_value *actual_ct_value = cali_ct_lookup_elem(lookup_key);
+	if (actual_ct_value) {
+		if (isNatForward) {
+			// If the reverse key has expired, go to delete.
+			if (actual_ct_value->last_seen == value->rev_last_seen) {
+			       goto delete;
+			}
+			return 0;
+		} else {
+			// This is normal or NAT reverse entry.
+			if (actual_ct_value->last_seen == value->last_seen) {
+				goto delete;
+			}
+			return 0;
 		}
-		CALI_DEBUG("  EXPIRED: cleaning up forward/reverse entries (max_age=%d).", max_age_s);
-	} else {
-		CALI_DEBUG("  MISSING: lookup failed.");
+	} else if (isNatForward) {
+		// Its a NAT forward entry but the reverse entry is not present in the CT table.
+		// Set the lookup_key to the forward entry and do a lookup of the fwd entry.
+		// If the timestamp's match, delete it.
+		lookup_key = key;
+		actual_ct_value = cali_ct_lookup_elem(lookup_key);
+		// Reverse key is present, but it is already deleted from the CT table.
+		if (actual_ct_value && actual_ct_value->last_seen == value->last_seen) {
+			goto delete;
+		}
+		return 0;
 	}
-
-	// Still expired, delete both entries.  The forward key might be a dummy
-	// all-zeros key but we know that key won't exist so we just let
-	// cali_ct_delete_elem handle that.
-	if (cali_ct_delete_elem(fwd_key) == 0) {
-		ictx->num_kvs_deleted_nat_fwd++;
+delete:
+	// If the entry is Normal or Reverse, lookup_key points to the entry.
+	// Delete the entry and if successful, increment the counter.
+	// If the entry is forward, we have 2 cases,
+	// Rev_entry present - lookup_key points to the reverse entry and key points to the
+	// forward entry. Delete both the entries togethere.
+	// Rev_entry not present - lookup_key points to the forward entry.
+	// Delete it.
+	if(!cali_ct_delete_elem(lookup_key)) {
+		ictx->num_cleaned++;
+		if (isNatForward && !cali_ct_delete_elem(key)) {
+			ictx->num_cleaned++;
+		}
+		cali_ccq_delete_elem(key);
 	}
-	if (cali_ct_delete_elem(rev_key) == 0) {
-		ictx->num_kvs_deleted_nat_rev++;
-	}
-
-out:
-	// Always remove the entry in our scratch map.
-	cali_ccq_delete_elem(key);
 	return 0;
 }
 
@@ -264,21 +101,10 @@ __attribute__((section("tc"))) int conntrack_cleanup(struct __sk_buff *skb)
 		// time.
 		ictx.now = bpf_ktime_get_ns();
 	}
-
-	CALI_DEBUG("Scanning conntrack map for expired non-NAT entries...");
-	bpf_for_each_map_elem(&CT_MAP_V, process_ct_entry, &ictx, 0);
-	CALI_DEBUG("First pass complete, expired %d KVs so far of %d total.",
-		ictx.num_kvs_deleted_normal + ictx.num_kvs_deleted_nat_fwd + ictx.num_kvs_deleted_nat_rev,
-		ictx.num_kvs_seen_normal + ictx.num_kvs_seen_nat_fwd + ictx.num_kvs_seen_nat_rev);
-	CALI_DEBUG("Processing NAT entries...");
+	CALI_DEBUG("Scanning conntrack cleanup map for entries to be cleaned up...");
 	bpf_for_each_map_elem(&CCQ_MAP_V, process_ccq_entry, &ictx, 0);
-	CALI_DEBUG("Conntrack cleanup complete: expired %d KVs of %d total.",
-		ictx.num_kvs_deleted_normal + ictx.num_kvs_deleted_nat_fwd + ictx.num_kvs_deleted_nat_rev,
-		ictx.num_kvs_seen_normal + ictx.num_kvs_seen_nat_fwd + ictx.num_kvs_seen_nat_rev);
-
 	// Give detailed stats back to userspace.
 	ictx.end_time = bpf_ktime_get_ns();
 	bpf_skb_store_bytes(skb, 0, &ictx, sizeof(ictx), 0);
-
 	return 0;
 }

--- a/felix/bpf-gpl/conntrack_cleanup.h
+++ b/felix/bpf-gpl/conntrack_cleanup.h
@@ -13,13 +13,19 @@
 
 #ifdef IPVER6
 #define CCQ_MAP cali_v6_ccq
-#define CCQ_MAP_V cali_v6_ccq1
+#define CCQ_MAP_V cali_v6_ccq2
 #define CT_MAP_V cali_v6_ct4
 #else
 #define CCQ_MAP cali_v4_ccq
-#define CCQ_MAP_V cali_v4_ccq1
+#define CCQ_MAP_V cali_v4_ccq2
 #define CT_MAP_V cali_v4_ct4
 #endif
+
+struct cali_ccq_value {
+	struct calico_ct_key rev_key;
+	__u64 last_seen;
+	__u64 rev_last_seen;
+};
 
 // The cali_ccq map is our "cleanup queue".  NAT records in the conntrack map
 // require two entries in the map, a forward entry and a reverse entry. When
@@ -27,10 +33,10 @@
 // as little time between as possible in order to avoid racing with the
 // dataplane.  To do that, we copy the keys to this map temporarily and then
 // iterate over this map, deleting the pair together.
-CALI_MAP_NAMED(CCQ_MAP, cali_ccq, 1,
+CALI_MAP_NAMED(CCQ_MAP, cali_ccq, 2,
 		BPF_MAP_TYPE_HASH,
 		struct calico_ct_key, // key = NAT rev key
-		struct calico_ct_key, // value = NAT fwd key
+		struct cali_ccq_value, // value = NAT fwd key
 		100000,
 		BPF_F_NO_PREALLOC
 );

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -46,6 +46,7 @@ type IPMaps struct {
 	CtMap        maps.Map
 	SrMsgMap     maps.Map
 	CtNatsMap    maps.Map
+	CtCleanupMap maps.Map
 }
 
 type CommonMaps struct {
@@ -117,6 +118,7 @@ func getIPMaps(ipFamily int) *IPMaps {
 		AffinityMap:  getmap(nat.AffinityMap, nat.AffinityMapV6),
 		RouteMap:     getmap(routes.Map, routes.MapV6),
 		CtMap:        getmap(conntrack.Map, conntrack.MapV6),
+		CtCleanupMap: getmap(conntrack.CleanupMap, conntrack.CleanupMapV6),
 		SrMsgMap:     getmap(nat.SendRecvMsgMap, nat.SendRecvMsgMapV6),
 		CtNatsMap:    getmap(nat.AllNATsMsgMap, nat.AllNATsMsgMapV6),
 	}
@@ -135,7 +137,6 @@ func CreateBPFMaps(ipV6Enabled bool) (*Maps, error) {
 	for i, bpfMap := range mps {
 		err := bpfMap.EnsureExists()
 		if err != nil {
-
 			for j := 0; j < i; j++ {
 				m := mps[j]
 				os.Remove(m.(pinnedMap).Path())
@@ -185,6 +186,7 @@ func (i *IPMaps) slice() []maps.Map {
 		i.AffinityMap,
 		i.RouteMap,
 		i.CtMap,
+		i.CtCleanupMap,
 		i.SrMsgMap,
 		i.CtNatsMap,
 	}

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -118,7 +118,7 @@ func getIPMaps(ipFamily int) *IPMaps {
 		AffinityMap:  getmap(nat.AffinityMap, nat.AffinityMapV6),
 		RouteMap:     getmap(routes.Map, routes.MapV6),
 		CtMap:        getmap(conntrack.Map, conntrack.MapV6),
-		CtCleanupMap: getmap(conntrack.CleanupMap, conntrack.CleanupMapV6),
+		CtCleanupMap: getmapWithExistsCheck(conntrack.CleanupMap, conntrack.CleanupMapV6),
 		SrMsgMap:     getmap(nat.SendRecvMsgMap, nat.SendRecvMsgMapV6),
 		CtNatsMap:    getmap(nat.AllNATsMsgMap, nat.AllNATsMsgMapV6),
 	}

--- a/felix/bpf/conntrack/bpf_scanner.go
+++ b/felix/bpf/conntrack/bpf_scanner.go
@@ -17,20 +17,15 @@ package conntrack
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
 	"path"
-	"strings"
-	"sync"
 	"unsafe"
 
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
-	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
 type BPFLogLevel string
@@ -40,88 +35,45 @@ const (
 	BPFLogLevelNone  BPFLogLevel = "no_log"
 )
 
-var (
-	registerOnce sync.Once
-
-	gaugeVecConntrackEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "felix_bpf_conntrack_entries_seen",
-		Help: "Number of entries seen in the conntrack table at the last GC sweep, grouped by type.",
-	}, []string{"type"})
-	counterVecConntrackEntriesDeleted = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "felix_bpf_conntrack_entries_deleted",
-		Help: "Cumulative number of entries deleted from the conntrack table, grouped by type.",
-	}, []string{"type"})
-	summaryCleanerExecTime = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "felix_bpf_conntrack_cleaner_seconds",
-		Help: "Time taken to run the conntrack cleaner BPF program.",
-	})
-)
-
-func registerConntrackMetrics() {
-	registerOnce.Do(func() {
-		prometheus.MustRegister(
-			gaugeVecConntrackEntries,
-			counterVecConntrackEntriesDeleted,
-			summaryCleanerExecTime,
-		)
-	})
-}
-
-// BPFProgLivenessScanner is a scanner that uses a BPF program to scan the
+// BPFProgCleaner uses a BPF program to scan the
 // conntrack table for expired entries.  The BPF program does the entry
 // deletion, taking care to delete forward and reverse NAT entries together,
 // thus minimising the window where only one entry is present.
 //
 // Note: the tests for this object are largely in the bpf/ut package, since
 // we require a privileged environment to test the BPF program.
-type BPFProgLivenessScanner struct {
-	ipVersion                    int
-	timeouts                     timeouts.Timeouts
-	logLevel                     BPFLogLevel
-	autoScale                    bool
-	configChangedRestartCallback func()
-	maxEntries                   int
-	liveEntries                  int
-	higherCount                  int
+type BPFProgCleaner struct {
+	ipVersion int
+	timeouts  timeouts.Timeouts
+	logLevel  BPFLogLevel
 
 	bpfExpiryProgram *libbpf.Obj
 }
 
-func NewBPFProgLivenessScanner(
+func NewBPFProgCleaner(
 	ipVersion int,
 	timeouts timeouts.Timeouts,
 	bpfLogLevel BPFLogLevel,
-	configChangedRestartCallback func(),
-	autoScalingMode string,
-) (*BPFProgLivenessScanner, error) {
+) (*BPFProgCleaner, error) {
 	if ipVersion != 4 && ipVersion != 6 {
 		return nil, fmt.Errorf("invalid IP version: %d", ipVersion)
 	}
 	if bpfLogLevel != BPFLogLevelDebug && bpfLogLevel != BPFLogLevelNone {
 		return nil, fmt.Errorf("invalid BPF log level: %s", bpfLogLevel)
 	}
-	ctMapParams := MapParams
-	if ipVersion == 6 {
-		ctMapParams = MapParamsV6
+	s := &BPFProgCleaner{
+		ipVersion: ipVersion,
+		timeouts:  timeouts,
+		logLevel:  bpfLogLevel,
 	}
-	s := &BPFProgLivenessScanner{
-		ipVersion:                    ipVersion,
-		timeouts:                     timeouts,
-		logLevel:                     bpfLogLevel,
-		autoScale:                    strings.ToLower(autoScalingMode) == "doubleiffull",
-		configChangedRestartCallback: configChangedRestartCallback,
-		maxEntries:                   maps.Size(ctMapParams.VersionedName()),
-	}
-	s.liveEntries = s.maxEntries
 	_, err := s.ensureBPFExpiryProgram()
 	if err != nil {
 		return nil, err
 	}
-	registerConntrackMetrics()
 	return s, nil
 }
 
-func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
+func (s *BPFProgCleaner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 	if s.bpfExpiryProgram != nil {
 		return s.bpfExpiryProgram, nil
 	}
@@ -130,10 +82,6 @@ func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 	// needs a newer than co-re.
 	binaryToLoad := path.Join(bpfdefs.ObjectDir,
 		fmt.Sprintf("conntrack_cleanup_%s_co-re_v%d.o", s.logLevel, s.ipVersion))
-	ctMapParams := MapParams
-	if s.ipVersion == 6 {
-		ctMapParams = MapParamsV6
-	}
 
 	ctCleanupData := &libbpf.CTCleanupGlobalData{
 		CreationGracePeriod: s.timeouts.CreationGracePeriod,
@@ -145,31 +93,12 @@ func (s *BPFProgLivenessScanner) ensureBPFExpiryProgram() (*libbpf.Obj, error) {
 		GenericTimeout:      s.timeouts.GenericTimeout,
 		ICMPTimeout:         s.timeouts.ICMPTimeout}
 
-	obj, err := bpf.LoadObject(binaryToLoad, ctCleanupData, ctMapParams.VersionedName())
+	obj, err := bpf.LoadObject(binaryToLoad, ctCleanupData)
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s: %w", binaryToLoad, err)
 	}
 	s.bpfExpiryProgram = obj
 	return s.bpfExpiryProgram, nil
-}
-
-func (s *BPFProgLivenessScanner) IterationStart() {
-	err := s.RunBPFExpiryProgram()
-	if err != nil {
-		log.WithError(err).Error("Failed to run conntrack cleanup BPF program.  Conntrack entries may leak.")
-	}
-}
-
-func (s *BPFProgLivenessScanner) Check(
-	keyInterface KeyInterface,
-	valueInterface ValueInterface,
-	get EntryGet,
-) ScanVerdict {
-	return ScanVerdictOK
-}
-
-func (s *BPFProgLivenessScanner) IterationEnd() {
-
 }
 
 // CleanupContext is the result of running the BPF cleanup program.
@@ -180,13 +109,7 @@ type CleanupContext struct {
 	StartTime uint64
 	EndTime   uint64
 
-	NumKVsSeenNormal     uint64
-	NumKVsSeenNATForward uint64
-	NumKVsSeenNATReverse uint64
-
-	NumKVsDeletedNormal     uint64
-	NumKVsDeletedNATForward uint64
-	NumKVsDeletedNATReverse uint64
+	NumKVsCleaned uint64
 }
 
 type RunOpt func(result *CleanupContext)
@@ -197,7 +120,7 @@ func WithStartTime(t uint64) RunOpt {
 	}
 }
 
-func (s *BPFProgLivenessScanner) RunBPFExpiryProgram(opts ...RunOpt) error {
+func (s *BPFProgCleaner) Run(opts ...RunOpt) error {
 	program, err := s.ensureBPFExpiryProgram()
 	if err != nil {
 		return fmt.Errorf("failed to load BPF program: %w", err)
@@ -232,74 +155,11 @@ func (s *BPFProgLivenessScanner) RunBPFExpiryProgram(opts ...RunOpt) error {
 		"timeTaken": result.Duration,
 		"stats":     cr,
 	}).Debug("Conntrack cleanup result.")
-
-	// Record stats...
-	summaryCleanerExecTime.Observe(result.Duration.Seconds())
-
-	total := cr.NumKVsSeenNormal + cr.NumKVsSeenNATForward + cr.NumKVsSeenNATReverse
-
-	gaugeVecConntrackEntries.WithLabelValues("total").Set(float64(total))
-	gaugeVecConntrackEntries.WithLabelValues("normal").Set(float64(cr.NumKVsSeenNormal))
-	gaugeVecConntrackEntries.WithLabelValues("nat_forward").Set(float64(cr.NumKVsSeenNATForward))
-	gaugeVecConntrackEntries.WithLabelValues("nat_reverse").Set(float64(cr.NumKVsSeenNATReverse))
-
-	totalDeleted := cr.NumKVsDeletedNormal + cr.NumKVsDeletedNATForward + cr.NumKVsDeletedNATReverse
-
-	counterVecConntrackEntriesDeleted.WithLabelValues("total").Add(float64(totalDeleted))
-	counterVecConntrackEntriesDeleted.WithLabelValues("normal").Add(float64(cr.NumKVsDeletedNormal))
-	counterVecConntrackEntriesDeleted.WithLabelValues("nat_forward").Add(float64(cr.NumKVsDeletedNATForward))
-	counterVecConntrackEntriesDeleted.WithLabelValues("nat_reverse").Add(float64(cr.NumKVsDeletedNATReverse))
-
-	if !s.autoScale {
-		return nil
-	}
-
-	newLiveEntries := int(total - totalDeleted)
-	if s.liveEntries > newLiveEntries {
-		s.higherCount++
-	} else {
-		s.higherCount = 0
-	}
-	s.liveEntries = newLiveEntries
-
-	full := float64(newLiveEntries) / float64(s.maxEntries)
-	log.Debugf("full %f, total %d, totalDeleted %d", full, total, totalDeleted)
-	// If the ct map keeps filling up and gets over 90% full or if it hits 95%
-	// no matter what, resize the map.
-	if s.higherCount >= 3 && full > 0.90 || full > 0.95 {
-		if err := s.writeNewSizeFile(); err != nil {
-			log.WithError(err).Warn("Failed to start resizing conntrack map when running out of space")
-		} else {
-			log.Warnf("The eBPF conntrack table is becoming full. To prevent connections from failing, "+
-				"resizing from %d to %d entries. Restarting Felix to apply the new size.", s.maxEntries, 2*s.maxEntries)
-			s.configChangedRestartCallback()
-		}
-	}
-
 	return nil
 }
 
-func (s *BPFProgLivenessScanner) writeNewSizeFile() error {
-	// Make sure directory exists.
-	if err := os.MkdirAll("/var/lib/calico", os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create directory /var/lib/calico: %s", err)
-	}
-
-	newSize := 2 * s.maxEntries
-
-	// Write the new map size to disk so that restarts will pick it up.
-	filename := "/var/lib/calico/bpf_ct_map_size"
-	log.Debugf("Writing %d to "+filename, newSize)
-	if err := os.WriteFile(filename, []byte(fmt.Sprintf("%d", newSize)), 0o644); err != nil {
-		return fmt.Errorf("unable to write to %s: %w", filename, err)
-	}
-	return nil
-}
-
-func (s *BPFProgLivenessScanner) Close() error {
+func (s *BPFProgCleaner) Close() error {
 	err := s.bpfExpiryProgram.Close()
 	s.bpfExpiryProgram = nil
 	return err
 }
-
-var _ EntryScannerSynced = (*BPFProgLivenessScanner)(nil)

--- a/felix/bpf/conntrack/cleanupv1/map.go
+++ b/felix/bpf/conntrack/cleanupv1/map.go
@@ -87,3 +87,26 @@ type ValueInterface interface {
 	Timestamp() uint64
 	RevTimestamp() uint64
 }
+
+type MapMem map[v4.Key]Value
+
+// LoadMapMem loads ConntrackMap into memory
+func LoadMapMem(m maps.Map) (MapMem, error) {
+	ret := make(MapMem)
+
+	err := m.Iter(func(k, v []byte) maps.IteratorAction {
+		ks := len(v4.Key{})
+		vs := len(Value{})
+
+		var key v4.Key
+		copy(key[:ks], k[:ks])
+
+		var val Value
+		copy(val[:vs], v[:vs])
+
+		ret[key] = val
+		return maps.IterNone
+	})
+
+	return ret, err
+}

--- a/felix/bpf/conntrack/cleanupv1/map.go
+++ b/felix/bpf/conntrack/cleanupv1/map.go
@@ -56,6 +56,23 @@ func (e *Value) SetRevTS(ts uint64) {
 	binary.LittleEndian.PutUint64(e[KeySize+8:], ts)
 }
 
+func (e Value) ReverseNATKey() v4.KeyInterface {
+	var ret v4.Key
+
+	l := len(v4.Key{})
+	copy(ret[:l], e[0:KeySize])
+
+	return ret
+}
+
+func (e Value) Timestamp() uint64 {
+	return binary.LittleEndian.Uint64(e[KeySize : KeySize+8])
+}
+
+func (e Value) RevTimestamp() uint64 {
+	return binary.LittleEndian.Uint64(e[KeySize+8:])
+}
+
 func NewValue(key []byte, ts, rev_ts uint64) Value {
 	v := Value{}
 	v.SetKey(key)
@@ -66,4 +83,7 @@ func NewValue(key []byte, ts, rev_ts uint64) Value {
 
 type ValueInterface interface {
 	AsBytes() []byte
+	ReverseNATKey() v4.KeyInterface
+	Timestamp() uint64
+	RevTimestamp() uint64
 }

--- a/felix/bpf/conntrack/cleanupv1/map.go
+++ b/felix/bpf/conntrack/cleanupv1/map.go
@@ -56,7 +56,7 @@ func (e *Value) SetRevTS(ts uint64) {
 	binary.LittleEndian.PutUint64(e[KeySize+8:], ts)
 }
 
-func (e Value) ReverseNATKey() v4.KeyInterface {
+func (e Value) OtherNATKey() v4.KeyInterface {
 	var ret v4.Key
 
 	l := len(v4.Key{})
@@ -83,7 +83,7 @@ func NewValue(key []byte, ts, rev_ts uint64) Value {
 
 type ValueInterface interface {
 	AsBytes() []byte
-	ReverseNATKey() v4.KeyInterface
+	OtherNATKey() v4.KeyInterface
 	Timestamp() uint64
 	RevTimestamp() uint64
 }

--- a/felix/bpf/conntrack/cleanupv1/map6.go
+++ b/felix/bpf/conntrack/cleanupv1/map6.go
@@ -81,3 +81,26 @@ func NewValueV6(key []byte, ts, rev_ts uint64) ValueV6 {
 	v.SetRevTS(rev_ts)
 	return v
 }
+
+type MapMemV6 map[v4.KeyV6]ValueV6
+
+// LoadMapMem loads ConntrackMap into memory
+func LoadMapMemV6(m maps.Map) (MapMemV6, error) {
+	ret := make(MapMemV6)
+
+	err := m.Iter(func(k, v []byte) maps.IteratorAction {
+		ks := len(v4.KeyV6{})
+		vs := len(ValueV6{})
+
+		var key v4.KeyV6
+		copy(key[:ks], k[:ks])
+
+		var val ValueV6
+		copy(val[:vs], v[:vs])
+
+		ret[key] = val
+		return maps.IterNone
+	})
+
+	return ret, err
+}

--- a/felix/bpf/conntrack/cleanupv1/map6.go
+++ b/felix/bpf/conntrack/cleanupv1/map6.go
@@ -12,22 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v3
+package cleanupv1
 
 import (
+	"encoding/binary"
+
 	"golang.org/x/sys/unix"
 
-	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
 // Both our key and value are actually keys from the conntrack map.
 
-const KeyV6Size = v3.KeyV6Size
-const ValueV6Size = KeyV6Size
+const KeyV6Size = v4.KeyV6Size
+const ValueV6Size = KeyV6Size + 8 + 8
 
-type KeyV6 = v3.KeyV6
-type ValueV6 = v3.KeyV6
+type ValueV6 [ValueV6Size]byte
 
 var MapParamsV6 = maps.MapParameters{
 	Type:         "hash",
@@ -36,6 +37,30 @@ var MapParamsV6 = maps.MapParameters{
 	MaxEntries:   MaxEntries,
 	Name:         "cali_v6_ccq",
 	Flags:        unix.BPF_F_NO_PREALLOC,
-	Version:      1,
-	UpdatedByBPF: true,
+	Version:      2,
+	UpdatedByBPF: false,
+}
+
+func (e ValueV6) AsBytes() []byte {
+	return e[:]
+}
+
+func (e *ValueV6) SetKey(key []byte) {
+	copy(e[0:KeyV6Size], key)
+}
+
+func (e *ValueV6) SetTS(ts uint64) {
+	binary.LittleEndian.PutUint64(e[KeyV6Size:KeyV6Size+8], ts)
+}
+
+func (e *ValueV6) SetRevTS(ts uint64) {
+	binary.LittleEndian.PutUint64(e[KeyV6Size+8:], ts)
+}
+
+func NewValueV6(key []byte, ts, rev_ts uint64) ValueV6 {
+	v := ValueV6{}
+	v.SetKey(key)
+	v.SetTS(ts)
+	v.SetRevTS(rev_ts)
+	return v
 }

--- a/felix/bpf/conntrack/cleanupv1/map6.go
+++ b/felix/bpf/conntrack/cleanupv1/map6.go
@@ -57,6 +57,23 @@ func (e *ValueV6) SetRevTS(ts uint64) {
 	binary.LittleEndian.PutUint64(e[KeyV6Size+8:], ts)
 }
 
+func (e ValueV6) ReverseNATKey() v4.KeyInterface {
+	var ret v4.KeyV6
+
+	l := len(v4.KeyV6{})
+	copy(ret[:l], e[0:KeyV6Size])
+
+	return ret
+}
+
+func (e ValueV6) Timestamp() uint64 {
+	return binary.LittleEndian.Uint64(e[KeySize : KeySize+8])
+}
+
+func (e ValueV6) RevTimestamp() uint64 {
+	return binary.LittleEndian.Uint64(e[KeySize+8:])
+}
+
 func NewValueV6(key []byte, ts, rev_ts uint64) ValueV6 {
 	v := ValueV6{}
 	v.SetKey(key)

--- a/felix/bpf/conntrack/cleanupv1/map6.go
+++ b/felix/bpf/conntrack/cleanupv1/map6.go
@@ -57,7 +57,7 @@ func (e *ValueV6) SetRevTS(ts uint64) {
 	binary.LittleEndian.PutUint64(e[KeyV6Size+8:], ts)
 }
 
-func (e ValueV6) ReverseNATKey() v4.KeyInterface {
+func (e ValueV6) OtherNATKey() v4.KeyInterface {
 	var ret v4.KeyV6
 
 	l := len(v4.KeyV6{})

--- a/felix/bpf/conntrack/inforeader.go
+++ b/felix/bpf/conntrack/inforeader.go
@@ -75,7 +75,7 @@ func NewInfoReader(timeouts timeouts.Timeouts, dsr bool, time timeshim.Interface
 }
 
 // Check checks a conntrack entry and translates to collector.ConntrackInfo.
-func (r *InfoReader) Check(key KeyInterface, val ValueInterface, get EntryGet) ScanVerdict {
+func (r *InfoReader) Check(key KeyInterface, val ValueInterface, get EntryGet) (ScanVerdict, int64) {
 
 	switch val.Type() {
 	case TypeNATReverse:
@@ -90,7 +90,7 @@ func (r *InfoReader) Check(key KeyInterface, val ValueInterface, get EntryGet) S
 	}
 
 	// We never delete
-	return ScanVerdictOK
+	return ScanVerdictOK, 0
 }
 
 func makeTuple(ipSrc, ipDst net.IP, portSrc, portDst uint16, proto uint8) tuple.Tuple {

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -150,11 +150,11 @@ func MapV6() maps.Map {
 	return b
 }
 
-func CleanupMap() maps.Map {
+func CleanupMap() maps.MapWithExistsCheck {
 	return maps.NewPinnedMap(MapParamsCleanup)
 }
 
-func CleanupMapV6() maps.Map {
+func CleanupMapV6() maps.MapWithExistsCheck {
 	return maps.NewPinnedMap(MapParamsCleanupV6)
 }
 

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -133,6 +133,8 @@ type Leg = curVer.Leg
 
 var MapParams = curVer.MapParams
 var MapParamsV6 = curVer.MapParamsV6
+var MapParamsCleanup = curVerCleanup.MapParams
+var MapParamsCleanupV6 = curVerCleanup.MapParamsV6
 
 func Map() maps.Map {
 	b := maps.NewPinnedMap(MapParams)
@@ -146,6 +148,14 @@ func MapV6() maps.Map {
 	b := maps.NewPinnedMap(MapParamsV6)
 	b.GetMapParams = GetMapParams
 	return b
+}
+
+func CleanupMap() maps.Map {
+	return maps.NewPinnedMap(MapParamsCleanup)
+}
+
+func CleanupMapV6() maps.Map {
+	return maps.NewPinnedMap(MapParamsCleanupV6)
 }
 
 func MapV2() maps.Map {

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -187,6 +187,15 @@ func ValueFromBytes(v []byte) ValueInterface {
 	return ctVal
 }
 
+func CleanupValueFromBytes(v []byte) curVerCleanup.ValueInterface {
+	var ctCleanupVal curVerCleanup.Value
+	if len(v) != len(ctCleanupVal) {
+		log.Panic("Value has unexpected length")
+	}
+	copy(ctCleanupVal[:], v[:])
+	return ctCleanupVal
+}
+
 type MapMem = curVer.MapMem
 
 // LoadMapMem loads ConntrackMap into memory
@@ -244,6 +253,15 @@ func ValueV6FromBytes(v []byte) ValueInterface {
 	}
 	copy(ctVal[:], v[:])
 	return ctVal
+}
+
+func CleanupValueV6FromBytes(v []byte) curVerCleanup.ValueInterface {
+	var ctCleanupVal curVerCleanup.ValueV6
+	if len(v) != len(ctCleanupVal) {
+		log.Panic("Value has unexpected length")
+	}
+	copy(ctCleanupVal[:], v[:])
+	return ctCleanupVal
 }
 
 type MapMemV6 = curVer.MapMemV6

--- a/felix/bpf/conntrack/scanner.go
+++ b/felix/bpf/conntrack/scanner.go
@@ -76,6 +76,8 @@ const (
 	ScanVerdictDelete
 )
 
+const cleanupBatchSize int = 1000
+
 // EntryGet is a function prototype provided to EntryScanner in case it needs to
 // evaluate other entries to make a verdict
 type EntryGet func(KeyInterface) (ValueInterface, error)
@@ -256,7 +258,7 @@ func (s *Scanner) Scan() {
 				s.updateCleanupMap(ctKey, dummy, uint64(ts), uint64(ts))
 			}
 		}
-		if numExpired > 0 && numExpired%1000 == 0 {
+		if numExpired > 0 && numExpired%cleanupBatchSize == 0 {
 			cleaned += s.runBPFCleaner()
 		}
 		return maps.IterNone
@@ -280,7 +282,7 @@ func (s *Scanner) Scan() {
 				s.updateCleanupMap(k, revKey, ts, revTS)
 			}
 			delete(s.revNATKeyToFwdNATInfo, k)
-			if keysProcessed%1000 == 0 {
+			if keysProcessed%cleanupBatchSize == 0 {
 				// Run the bpf cleaner
 				cleaned += s.runBPFCleaner()
 			}

--- a/felix/bpf/conntrack/scanner.go
+++ b/felix/bpf/conntrack/scanner.go
@@ -162,7 +162,11 @@ func (s *Scanner) handleNATEntries(key KeyInterface, val ValueInterface, rev_ts 
 		// timestamp returned from the scanner will match the
 		// same as that of entry's ts. Just go ahead with deletion.
 		if ts == rev_ts {
-			return s.updateCleanupMap(key, revKey, uint64(ts), rev_ts)
+			if s.ipVersion == 6 {
+				return s.updateCleanupMap(key, dummyKeyV6, uint64(ts), rev_ts)
+			} else {
+				return s.updateCleanupMap(key, dummyKey, uint64(ts), rev_ts)
+			}
 		}
 		_, ok := s.keyTracker[revKey]
 		if !ok {

--- a/felix/bpf/conntrack/scanner.go
+++ b/felix/bpf/conntrack/scanner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/felix/bpf/conntrack/cleanupv1"
 	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/jitter"
@@ -77,7 +78,7 @@ type EntryGet func(KeyInterface) (ValueInterface, error)
 
 // EntryScanner is a function prototype to be called on every entry by the scanner
 type EntryScanner interface {
-	Check(KeyInterface, ValueInterface, EntryGet) ScanVerdict
+	Check(KeyInterface, ValueInterface, EntryGet) (ScanVerdict, int64)
 }
 
 // EntryScannerSynced is a scanner synchronized with the iteration start/end.
@@ -96,6 +97,7 @@ type EntryScannerSynced interface {
 // evaluation functions, to keep their implementation simpler.
 type Scanner struct {
 	ctMap                        maps.Map
+	ctCleanupMap                 maps.Map
 	keyFromBytes                 func([]byte) KeyInterface
 	valueFromBytes               func([]byte) ValueInterface
 	scanners                     []EntryScanner
@@ -104,6 +106,8 @@ type Scanner struct {
 	maxEntries                   int
 	autoScale                    bool
 	configChangedRestartCallback func()
+	bpfCleaner                   Cleaner
+	ipVersion                    int
 
 	wg       sync.WaitGroup
 	stopCh   chan struct{}
@@ -114,11 +118,14 @@ type Scanner struct {
 // EntryScanner. They are executed in the provided order on each entry.
 func NewScanner(ctMap maps.Map, kfb func([]byte) KeyInterface, vfb func([]byte) ValueInterface,
 	configChangedRestartCallback func(),
-	autoScalingMode string,
+	autoScalingMode string, ctCleanupMap maps.Map,
+	ipVersion int,
+	bpfCleaner Cleaner,
 	scanners ...EntryScanner) *Scanner {
 
 	return &Scanner{
 		ctMap:                        ctMap,
+		ctCleanupMap:                 ctCleanupMap,
 		keyFromBytes:                 kfb,
 		valueFromBytes:               vfb,
 		scanners:                     scanners,
@@ -127,6 +134,8 @@ func NewScanner(ctMap maps.Map, kfb func([]byte) KeyInterface, vfb func([]byte) 
 		maxEntries:                   ctMap.Size(),
 		autoScale:                    strings.ToLower(autoScalingMode) == "doubleiffull",
 		configChangedRestartCallback: configChangedRestartCallback,
+		bpfCleaner:                   bpfCleaner,
+		ipVersion:                    ipVersion,
 	}
 }
 
@@ -142,6 +151,8 @@ func (s *Scanner) Scan() {
 	used := 0
 	cleaned := 0
 
+	var val cleanupv1.ValueInterface
+
 	log.Debug("Starting conntrack scanner iteration")
 	err := s.ctMap.Iter(func(k, v []byte) maps.IteratorAction {
 		ctKey := s.keyFromBytes(k)
@@ -156,14 +167,31 @@ func (s *Scanner) Scan() {
 				"entry": ctVal,
 			}).Debug("Examining conntrack entry")
 		}
+		val = cleanupv1.Value{}
+		if s.ipVersion == 6 {
+			val = cleanupv1.ValueV6{}
+		}
 
 		for _, scanner := range s.scanners {
-			if verdict := scanner.Check(ctKey, ctVal, s.get); verdict == ScanVerdictDelete {
+			if verdict, ts := scanner.Check(ctKey, ctVal, s.get); verdict == ScanVerdictDelete {
 				if debug {
 					log.Debug("Deleting conntrack entry.")
 				}
 				cleaned++
-				return maps.IterDelete
+
+				revKey := []byte{}
+				if ctVal.Type() == TypeNATForward {
+					revKey = ctVal.ReverseNATKey().AsBytes()
+				}
+
+				val = cleanupv1.NewValue(revKey, uint64(ctVal.LastSeen()), uint64(ts))
+				if s.ipVersion == 6 {
+					val = cleanupv1.NewValueV6(revKey, uint64(ctVal.LastSeen()), uint64(ts))
+				}
+				err := s.ctCleanupMap.Update(ctKey.AsBytes(), val.AsBytes())
+				if err != nil {
+					log.Debugf("error updating cleanup map. Entry may not cleaned up %v", err)
+				}
 			}
 		}
 		return maps.IterNone
@@ -172,6 +200,14 @@ func (s *Scanner) Scan() {
 	if err != nil {
 		log.WithError(err).Warn("Failed to iterate over conntrack map")
 		return
+	}
+
+	// Run the BPF cleanup program.
+	if s.bpfCleaner != nil {
+		err := s.bpfCleaner.Run()
+		if err != nil {
+			log.WithError(err).Warn("Failed to run bpf conntrack cleaner.")
+		}
 	}
 
 	conntrackCounterSweeps.Inc()
@@ -287,6 +323,10 @@ func (s *Scanner) Stop() {
 	})
 }
 
+func (s *Scanner) Close() {
+	s.bpfCleaner.Close()
+}
+
 // AddUnlocked adds an additional EntryScanner to a non-running Scanner
 func (s *Scanner) AddUnlocked(scanner EntryScanner) {
 	s.scanners = append(s.scanners, scanner)
@@ -296,4 +336,9 @@ func (s *Scanner) AddUnlocked(scanner EntryScanner) {
 // the first scanner to be called.
 func (s *Scanner) AddFirstUnlocked(scanner EntryScanner) {
 	s.scanners = append([]EntryScanner{scanner}, s.scanners...)
+}
+
+type Cleaner interface {
+	Run(opts ...RunOpt) error
+	Close() error
 }

--- a/felix/bpf/conntrack/scanner.go
+++ b/felix/bpf/conntrack/scanner.go
@@ -141,6 +141,7 @@ func NewScanner(ctMap maps.Map, kfb func([]byte) KeyInterface, vfb func([]byte) 
 		bpfCleaner:                   bpfCleaner,
 		keyTracker:                   make(map[KeyInterface]cleanupv1.ValueInterface),
 	}
+
 	switch ipVersion {
 	case 4:
 		s.ctCleanupMap = cachingmap.New[KeyInterface, cleanupv1.ValueInterface](ctCleanupMap.GetName(),
@@ -324,6 +325,7 @@ func (s *Scanner) runBPFCleaner() int {
 		if err != nil {
 			log.WithError(err).Warn("Failed to run bpf conntrack cleaner.")
 		}
+		s.ctCleanupMap.Desired().DeleteAll()
 		return int(cr.NumKVsCleaned)
 	}
 	return 0
@@ -442,7 +444,7 @@ func (h ipv4Helper) newCleanupValue(revKeyBytes []byte, ts, rev_ts uint64) clean
 }
 
 func (h ipv4Helper) dummyKey() KeyInterface {
-	return dummyKey // Assumes existing global/package variable for the IPv4 dummy key
+	return dummyKey
 }
 
 type ipv6Helper struct{}
@@ -452,5 +454,5 @@ func (h ipv6Helper) newCleanupValue(revKeyBytes []byte, ts, rev_ts uint64) clean
 }
 
 func (h ipv6Helper) dummyKey() KeyInterface {
-	return dummyKeyV6 // Assumes existing global/package variable for the IPv6 dummy key
+	return dummyKeyV6
 }

--- a/felix/bpf/mock/cleaner.go
+++ b/felix/bpf/mock/cleaner.go
@@ -33,7 +33,7 @@ func NewMockBPFCleaner(ctMap, ctCleanupMap *Map) *mockBPFCleaner {
 
 func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) (*conntrack.CleanupContext, error) {
 	err := m.ctCleanupMap.Iter(func(k, v []byte) maps.IteratorAction {
-		revKey := conntrack.CleanupValueFromBytes(v).ReverseNATKey()
+		revKey := conntrack.CleanupValueFromBytes(v).OtherNATKey()
 		if revKey.Proto() != 0 {
 			if err := m.ctMap.Delete(revKey.AsBytes()); err != nil {
 				return maps.IterNone

--- a/felix/bpf/mock/cleaner.go
+++ b/felix/bpf/mock/cleaner.go
@@ -23,12 +23,12 @@ import (
 )
 
 type mockBPFCleaner struct {
-        ctMap        *Map
-        ctCleanupMap *Map
+	ctMap        *Map
+	ctCleanupMap *Map
 }
 
 func NewMockBPFCleaner(ctMap, ctCleanupMap *Map) *mockBPFCleaner {
-        return &mockBPFCleaner{ctMap: ctMap, ctCleanupMap: ctCleanupMap}
+	return &mockBPFCleaner{ctMap: ctMap, ctCleanupMap: ctCleanupMap}
 }
 
 func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) error {
@@ -36,11 +36,11 @@ func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) error {
 		if err := m.ctMap.Delete(k); err != nil {
 			return maps.IterNone
 		}
-                return maps.IterDelete
-        })
-        return err
+		return maps.IterDelete
+	})
+	return err
 }
 
 func (m *mockBPFCleaner) Close() error {
-        return nil
+	return nil
 }

--- a/felix/bpf/mock/cleaner.go
+++ b/felix/bpf/mock/cleaner.go
@@ -1,0 +1,46 @@
+//go:build !windows
+// +build !windows
+
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/maps"
+)
+
+type mockBPFCleaner struct {
+        ctMap        *Map
+        ctCleanupMap *Map
+}
+
+func NewMockBPFCleaner(ctMap, ctCleanupMap *Map) *mockBPFCleaner {
+        return &mockBPFCleaner{ctMap: ctMap, ctCleanupMap: ctCleanupMap}
+}
+
+func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) error {
+	err := m.ctCleanupMap.Iter(func(k, v []byte) maps.IteratorAction {
+		if err := m.ctMap.Delete(k); err != nil {
+			return maps.IterNone
+		}
+                return maps.IterDelete
+        })
+        return err
+}
+
+func (m *mockBPFCleaner) Close() error {
+        return nil
+}

--- a/felix/bpf/mock/cleaner.go
+++ b/felix/bpf/mock/cleaner.go
@@ -31,14 +31,14 @@ func NewMockBPFCleaner(ctMap, ctCleanupMap *Map) *mockBPFCleaner {
 	return &mockBPFCleaner{ctMap: ctMap, ctCleanupMap: ctCleanupMap}
 }
 
-func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) error {
+func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) (*conntrack.CleanupContext, error) {
 	err := m.ctCleanupMap.Iter(func(k, v []byte) maps.IteratorAction {
 		if err := m.ctMap.Delete(k); err != nil {
 			return maps.IterNone
 		}
 		return maps.IterDelete
 	})
-	return err
+	return &conntrack.CleanupContext{}, err
 }
 
 func (m *mockBPFCleaner) Close() error {

--- a/felix/bpf/mock/cleaner.go
+++ b/felix/bpf/mock/cleaner.go
@@ -33,6 +33,12 @@ func NewMockBPFCleaner(ctMap, ctCleanupMap *Map) *mockBPFCleaner {
 
 func (m *mockBPFCleaner) Run(opts ...conntrack.RunOpt) (*conntrack.CleanupContext, error) {
 	err := m.ctCleanupMap.Iter(func(k, v []byte) maps.IteratorAction {
+		revKey := conntrack.CleanupValueFromBytes(v).ReverseNATKey()
+		if revKey.Proto() != 0 {
+			if err := m.ctMap.Delete(revKey.AsBytes()); err != nil {
+				return maps.IterNone
+			}
+		}
 		if err := m.ctMap.Delete(k); err != nil {
 			return maps.IterNone
 		}

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -45,11 +45,11 @@ func init() {
 
 var _ = Describe("BPF Syncer", func() {
 	var (
-		svcs *mockNATMap
-		eps  *mockNATBackendMap
-		aff  *mockAffinityMap
-		ct   *mock.Map
-		ctCleanup   *mock.Map
+		svcs      *mockNATMap
+		eps       *mockNATBackendMap
+		aff       *mockAffinityMap
+		ct        *mock.Map
+		ctCleanup *mock.Map
 
 		s        *proxy.Syncer
 		connScan *conntrack.Scanner

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -49,6 +49,7 @@ var _ = Describe("BPF Syncer", func() {
 		eps  *mockNATBackendMap
 		aff  *mockAffinityMap
 		ct   *mock.Map
+		ctCleanup   *mock.Map
 
 		s        *proxy.Syncer
 		connScan *conntrack.Scanner
@@ -70,6 +71,7 @@ var _ = Describe("BPF Syncer", func() {
 		eps = newMockNATBackendMap()
 		aff = newMockAffinityMap()
 		ct = mock.NewMockMap(conntrack.MapParams)
+		ctCleanup = mock.NewMockMap(conntrack.MapParamsCleanup)
 
 		rt = proxy.NewRTCache()
 
@@ -171,7 +173,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("creating a CT scanner", func() {
 			connScan = conntrack.NewScanner(ct,
-				conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", conntrack.NewStaleNATScanner(s))
+				conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", ctCleanup, 4, mock.NewMockBPFCleaner(ct, ctCleanup), conntrack.NewStaleNATScanner(s))
 		})
 
 		By("creating conntrack entries for test-service", makestep(func() {
@@ -1090,7 +1092,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("recreating a CT scanner for the actual syncer", func() {
 			connScan = conntrack.NewScanner(ct,
-				conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", conntrack.NewStaleNATScanner(s))
+				conntrack.KeyFromBytes, conntrack.ValueFromBytes, nil, "Disabled", ctCleanup, 4, mock.NewMockBPFCleaner(ct, ctCleanup), conntrack.NewStaleNATScanner(s))
 		})
 
 		By("checking that CT table emptied by connScan", makestep(func() {

--- a/felix/bpf/ut/bpf_ct_cleanup_test.go
+++ b/felix/bpf/ut/bpf_ct_cleanup_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/conntrack/cttestdata"
 	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
 	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/timeshim/mocktime"
 )
 
-func TestBPFProgLivenessScanner(t *testing.T) {
+func TestBPFProgCleaner(t *testing.T) {
 	for _, tc := range cttestdata.CTCleanupTests {
 		t.Run(tc.Description, func(t *testing.T) {
 			runCTCleanupTest(t, tc)
@@ -43,28 +44,29 @@ func runCTCleanupTest(t *testing.T, tc cttestdata.CTCleanupTest) {
 	}
 
 	// Run the scanner, mocking out the current time to match the conntrack state.
-	err := scanner.RunBPFExpiryProgram(conntrack.WithStartTime(uint64(cttestdata.Now)))
-	Expect(err).NotTo(HaveOccurred(), "Failed to run BPFProgLivenessScanner")
-
+	scanner.Scan()
 	// Check that the expected entries were deleted.
 	deletedEntries := calculateDeletedEntries(tc, ctMap)
 	Expect(deletedEntries).To(ConsistOf(tc.ExpectedDeletions),
 		"Scan() did not delete the expected entries")
 }
 
-func setUpConntrackScanTest(t *testing.T) *conntrack.BPFProgLivenessScanner {
+func setUpConntrackScanTest(t *testing.T) *conntrack.Scanner {
 	RegisterTestingT(t)
-	scanner, err := conntrack.NewBPFProgLivenessScanner(
-		4, timeouts.DefaultTimeouts(), conntrack.BPFLogLevelDebug,
-		nil, "Disabled")
-	Expect(err).NotTo(HaveOccurred(), "Failed to create BPFProgLivenessScanner")
+	lc := conntrack.NewLivenessScanner(timeouts.DefaultTimeouts(), true, conntrack.WithTimeShim(mocktime.New()))
+	cleaner, err := conntrack.NewBPFProgCleaner(4, timeouts.DefaultTimeouts(), conntrack.BPFLogLevelDebug)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create BPFCleaner")
+	scanner := conntrack.NewScanner(ctMap, conntrack.KeyFromBytes,
+		conntrack.ValueFromBytes,
+		nil, "Disabled", ctCleanupMap, 4,
+		cleaner, lc)
 	t.Cleanup(func() {
-		err := scanner.Close()
-		Expect(err).NotTo(HaveOccurred(), "Failed to close BPFProgLivenessScanner")
+		scanner.Close()
 	})
 
 	clearCTMap := func() {
 		resetMap(ctMap)
+		resetMap(ctCleanupMap)
 	}
 	clearCTMap()          // Make sure we start with an empty map.
 	t.Cleanup(clearCTMap) // Make sure we leave a clean map.

--- a/felix/bpf/ut/bpf_ct_cleanup_test.go
+++ b/felix/bpf/ut/bpf_ct_cleanup_test.go
@@ -62,7 +62,7 @@ func setUpConntrackScanTest(t *testing.T) *conntrack.Scanner {
 	Expect(err).NotTo(HaveOccurred(), "Failed to create BPFCleaner")
 	scanner := conntrack.NewScanner(ctMap, conntrack.KeyFromBytes,
 		conntrack.ValueFromBytes,
-		nil, "Disabled", ctCleanupMap, 4,
+		nil, "Disabled", ctCleanupMap.(maps.MapWithExistsCheck), 4,
 		cleaner, lc)
 	t.Cleanup(func() {
 		scanner.Close()

--- a/felix/bpf/ut/bpf_ct_cleanup_test.go
+++ b/felix/bpf/ut/bpf_ct_cleanup_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/conntrack/cleanupv1"
 	"github.com/projectcalico/calico/felix/bpf/conntrack/cttestdata"
 	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
 	"github.com/projectcalico/calico/felix/bpf/maps"
@@ -49,6 +50,9 @@ func runCTCleanupTest(t *testing.T, tc cttestdata.CTCleanupTest) {
 	deletedEntries := calculateDeletedEntries(tc, ctMap)
 	Expect(deletedEntries).To(ConsistOf(tc.ExpectedDeletions),
 		"Scan() did not delete the expected entries")
+	cleanUpMapMem, err := cleanupv1.LoadMapMem(ctCleanupMap)
+	Expect(err).NotTo(HaveOccurred(), "Failed to load ct cleanup map")
+	Expect(len(cleanUpMapMem)).To(Equal(0))
 }
 
 func setUpConntrackScanTest(t *testing.T) *conntrack.Scanner {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -582,12 +582,12 @@ func bpftool(args ...string) ([]byte, error) {
 var (
 	mapInitOnce sync.Once
 
-	natMap, natBEMap, ctMap, rtMap, ipsMap, testStateMap, affinityMap, arpMap, fsafeMap, ipfragsMap maps.Map
-	natMapV6, natBEMapV6, ctMapV6, rtMapV6, ipsMapV6, affinityMapV6, arpMapV6, fsafeMapV6           maps.Map
-	stateMap, countersMap, ifstateMap, progMap, progMapXDP, policyJumpMap, policyJumpMapXDP         maps.Map
-	perfMap                                                                                         maps.Map
-	profilingMap, ipfragsMapTmp                                                                     maps.Map
-	allMaps                                                                                         []maps.Map
+	natMap, natBEMap, ctMap, ctCleanupMap, rtMap, ipsMap, testStateMap, affinityMap, arpMap, fsafeMap, ipfragsMap maps.Map
+	natMapV6, natBEMapV6, ctMapV6, ctCleanupMapV6, rtMapV6, ipsMapV6, affinityMapV6, arpMapV6, fsafeMapV6         maps.Map
+	stateMap, countersMap, ifstateMap, progMap, progMapXDP, policyJumpMap, policyJumpMapXDP                       maps.Map
+	perfMap                                                                                                       maps.Map
+	profilingMap, ipfragsMapTmp                                                                                   maps.Map
+	allMaps                                                                                                       []maps.Map
 )
 
 func initMapsOnce() {
@@ -598,6 +598,8 @@ func initMapsOnce() {
 		natBEMapV6 = nat.BackendMapV6()
 		ctMap = conntrack.Map()
 		ctMapV6 = conntrack.MapV6()
+		ctCleanupMap = conntrack.CleanupMap()
+		ctCleanupMapV6 = conntrack.CleanupMapV6()
 		rtMap = routes.Map()
 		rtMapV6 = routes.MapV6()
 		ipsMap = ipsets.Map()
@@ -620,7 +622,7 @@ func initMapsOnce() {
 
 		perfMap = perf.Map("perf_evnt", 512)
 
-		allMaps = []maps.Map{natMap, natBEMap, natMapV6, natBEMapV6, ctMap, ctMapV6, rtMap, rtMapV6, ipsMap, ipsMapV6,
+		allMaps = []maps.Map{natMap, natBEMap, natMapV6, natBEMapV6, ctMap, ctMapV6, ctCleanupMap, ctCleanupMapV6, rtMap, rtMapV6, ipsMap, ipsMapV6,
 			stateMap, testStateMap, affinityMap, affinityMapV6, arpMap, arpMapV6, fsafeMap, fsafeMapV6,
 			countersMap, ipfragsMap, ipfragsMapTmp, ifstateMap, profilingMap,
 			policyJumpMap, policyJumpMapXDP}

--- a/felix/cachingmap/caching_map.go
+++ b/felix/cachingmap/caching_map.go
@@ -80,13 +80,13 @@ func (c *CachingMap[K, V]) LoadCacheFromDataplane() error {
 type ReadOnlyMap[K comparable, V any] interface {
 	Get(k K) (v V, exists bool)
 	Iter(func(k K, v V))
+	DeleteAll()
 }
 
 type ReadWriteMap[K comparable, V any] interface {
 	ReadOnlyMap[K, V]
 	Set(k K, v V)
 	Delete(k K)
-	DeleteAll()
 }
 
 func (c *CachingMap[K, V]) Desired() ReadWriteMap[K, V] {

--- a/felix/cachingmap/caching_map.go
+++ b/felix/cachingmap/caching_map.go
@@ -80,13 +80,13 @@ func (c *CachingMap[K, V]) LoadCacheFromDataplane() error {
 type ReadOnlyMap[K comparable, V any] interface {
 	Get(k K) (v V, exists bool)
 	Iter(func(k K, v V))
-	DeleteAll()
 }
 
 type ReadWriteMap[K comparable, V any] interface {
 	ReadOnlyMap[K, V]
 	Set(k K, v V)
 	Delete(k K)
+	DeleteAll()
 }
 
 func (c *CachingMap[K, V]) Desired() ReadWriteMap[K, V] {
@@ -94,7 +94,10 @@ func (c *CachingMap[K, V]) Desired() ReadWriteMap[K, V] {
 	return c.deltaTracker.Desired()
 }
 
-func (c *CachingMap[K, V]) Dataplane() ReadOnlyMap[K, V] {
+// Updating the dataplane means it is updated out-of-band
+// and its the caller's responsibility to keep Desired and
+// Dataplane in sync.
+func (c *CachingMap[K, V]) Dataplane() ReadWriteMap[K, V] {
 	// Pass through to the delta tracker.
 	return c.deltaTracker.Dataplane()
 }

--- a/felix/fv/bpf_map_resize_test.go
+++ b/felix/fv/bpf_map_resize_test.go
@@ -245,7 +245,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf conntrack table d
 
 		line := ""
 		// Program 10k tcp ct entries into map. This is done in batches of 2k.
-		for i := 1; i <= 10000; i++ {
+		for i := 1; i <= 20000; i++ {
 			sport := uint16(i)
 			dport := uint16(i & 0xffff)
 			key := formatBytesWithPrefix(conntrack.NewKey(6 /* UDP */, srcIP, sport, dstIP, dport).AsBytes())

--- a/felix/fv/bpf_map_resize_test.go
+++ b/felix/fv/bpf_map_resize_test.go
@@ -185,7 +185,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf conntrack table d
 		opts := infrastructure.DefaultTopologyOptions()
 		opts.ExtraEnvVars["FELIX_BPFMapSizeConntrack"] = "10000"
 		opts.ExtraEnvVars["FELIX_debugDisableLogDropping"] = "true"
-		opts.ExtraEnvVars["FELIX_BPFConntrackTimeouts"] = "TCPFinsSeen=5s"
 		opts.FelixLogSeverity = "Debug"
 		tc, _ = infrastructure.StartNNodeTopology(1, opts, infra)
 
@@ -241,6 +240,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf conntrack table d
 		srcIP := net.IPv4(123, 123, 123, 123)
 		dstIP := net.IPv4(121, 121, 121, 121)
 
+		val := formatBytesWithPrefix(conntrack.NewValueNormal(now, 0, leg, leg).AsBytes())
 		c := tc.Felixes[0].WatchStdoutFor(regexp.MustCompile(".*Overriding bpfMapSizeConntrack \\(10000\\) with map size growth \\(20000\\)"))
 
 		line := ""
@@ -249,12 +249,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf conntrack table d
 			sport := uint16(i)
 			dport := uint16(i & 0xffff)
 			key := formatBytesWithPrefix(conntrack.NewKey(6 /* UDP */, srcIP, sport, dstIP, dport).AsBytes())
-			if i%10 == 0 {
-				leg.FinSeen = true
-			}
-
-			val := formatBytesWithPrefix(conntrack.NewValueNormal(now, 0, leg, leg).AsBytes())
-
 			args := []string{"map", "update", "pinned", conntrack.Map().Path()}
 			args = append(args, "key")
 			args = append(args, key...)
@@ -276,7 +270,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf conntrack table d
 			}
 		}
 
-		time.Sleep(40 * time.Second)
 		defer os.Remove("/tmp/data_in")
 		Eventually(func() bool {
 			select {


### PR DESCRIPTION
## Description

This PR implements the BPF conntrack cleaner. Earlier we had a separate BPF conntrack cleaner, which scans the entire conntrack map, runs the conntrack expiry logic. This was disabled when we moved to LRU conntrack map, as scanning the entire map from the kernel will disturb the LRU logic. 

This resulted in just the userspace cleaner and we are back to having races when cleaning up entries. This PR tries to solve this race as mentioned below
1. The liveness and stale NAT scanner scans the conntrack map and if the entry needs to be deleted, it returns `ScanVerdictDelete` along with the `last_seen` timestamp. If the conntrack entry is `NATForward`, the scanner returns the `last_seen` timestamp of the reverse entry.
2. This information is updated in the conntrack cleanup map. The conntrack cleanup map, has the following structure key = `conntrack_key` and value = `<conntrack_reverse_key>:<last_seen_ts><rev_last_seen_ts>`. 
3. After all the entries are scanned, the userspace cleaner runs the bpfCleaner.

### bpfCleaner

The `bpfCleaner` does the following
1. For each element in the cleanup map, we do a lookup of the key into the conntrack map. This lookup_key points to the reverse key stored in the cleanup map's value if there is a valid reverse key. 
2. The conntrack value's `last_seen` is compared with `last_seen` in the cleanupmap value or it is compared with the reverse_last_seen if the entry is of type `NATForward`.
3. If the timestamps match, the conntrack entry is deleted from the conntrack map as well as the cleanup map. In the case of NATForward entry, both the forward and reverse entries are deleted from the conntrack map.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF: conntrack cleanup now uses a hybrid approach with a scan being done from user space (to avoid disturbing LRU state) and then deletions being done from BPF program. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
