### PR TITLE
Allow changing extenal client image in Felix FVs

### DIFF
--- a/felix/fv/infrastructure/ext_client.go
+++ b/felix/fv/infrastructure/ext_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/utils"
@@ -25,6 +26,7 @@ import (
 
 type ExtClientOpts struct {
 	IPv6Enabled bool
+	Image       string
 }
 
 func RunExtClient(namePrefix string) *containers.Container {
@@ -34,6 +36,12 @@ func RunExtClient(namePrefix string) *containers.Container {
 func RunExtClientWithOpts(namePrefix string, opts ExtClientOpts) *containers.Container {
 	wd, err := os.Getwd()
 	Expect(err).NotTo(HaveOccurred(), "failed to get working directory")
+
+	image := utils.Config.BusyboxImage
+	if opts.Image != "" {
+		image = opts.Image
+	}
+	logrus.Infof("Running external client container with options %#v", opts)
 	c := containers.Run(
 		namePrefix,
 		containers.RunOpts{
@@ -41,7 +49,7 @@ func RunExtClientWithOpts(namePrefix string, opts ExtClientOpts) *containers.Con
 		},
 		"--privileged",                    // So that we can add routes inside the container.
 		"-v", wd+"/../bin:/usr/local/bin", // Map in the test-connectivity binary etc.
-		utils.Config.BusyboxImage,
+		image,
 		"/bin/sh", "-c", "sleep 1000")
 
 	if opts.IPv6Enabled {


### PR DESCRIPTION
## Description

By default, Felix FVs use `busybox` image for external client container. However, in some cases, it's desirable to use another one. As an example, in this [PR](https://github.com/projectcalico/calico/pull/10718), I need to add iptables rules to external client container to drop packets based on DSCP value. However, `busybox` image does not contain iptables by default. Instead, it's possible to use `calico node` image for the external client since it already include iptables binary.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
