### PR TITLE
Replace IPSetMember struct with an interface

### DIFF
--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -42,7 +42,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/utils"
 	"github.com/projectcalico/calico/felix/environment"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/proto"
 )
 
@@ -501,7 +501,7 @@ type cgroupProgEntry struct {
 }
 
 type ProtoPort struct {
-	Proto labelindex.IPSetPortProtocol
+	Proto ipsetmember.Protocol
 	Port  uint16
 }
 
@@ -576,7 +576,7 @@ func (b *BPFLib) DumpFailsafeMap() ([]ProtoPort, error) {
 		if err != nil {
 			return nil, err
 		}
-		pp = append(pp, ProtoPort{labelindex.IPSetPortProtocol(proto), port})
+		pp = append(pp, ProtoPort{ipsetmember.Protocol(proto), port})
 	}
 
 	return pp, nil

--- a/felix/bpf/bpf_test.go
+++ b/felix/bpf/bpf_test.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/environment"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/logutils"
 )
 
@@ -595,11 +595,11 @@ func TestFailsafeMapContent(t *testing.T) {
 	}
 
 	t.Log("Updating a failsafe map should succeed")
-	err = bpfDP.UpdateFailsafeMap(uint8(labelindex.ProtocolTCP), port1)
+	err = bpfDP.UpdateFailsafeMap(uint8(ipsetmember.ProtocolTCP), port1)
 	if err != nil {
 		t.Fatalf("cannot update map: %v", err)
 	}
-	err = bpfDP.UpdateFailsafeMap(uint8(labelindex.ProtocolUDP), port2)
+	err = bpfDP.UpdateFailsafeMap(uint8(ipsetmember.ProtocolUDP), port2)
 	if err != nil {
 		t.Fatalf("cannot update map: %v", err)
 	}
@@ -611,23 +611,23 @@ func TestFailsafeMapContent(t *testing.T) {
 	}
 
 	t.Log("Looking up items from a failsafe map should succeed")
-	exists, err = bpfDP.LookupFailsafeMap(uint8(labelindex.ProtocolTCP), port1)
+	exists, err = bpfDP.LookupFailsafeMap(uint8(ipsetmember.ProtocolTCP), port1)
 	if err != nil || !exists {
 		t.Fatalf("cannot lookup map: %v exists=%v", err, exists)
 	}
 
-	exists, err = bpfDP.LookupFailsafeMap(uint8(labelindex.ProtocolUDP), port2)
+	exists, err = bpfDP.LookupFailsafeMap(uint8(ipsetmember.ProtocolUDP), port2)
 	if err != nil || !exists {
 		t.Fatalf("cannot lookup map: %v exists=%v", err, exists)
 	}
 
 	t.Log("Removing an existent item from a failsafe map should succeed")
-	err = bpfDP.RemoveItemFailsafeMap(uint8(labelindex.ProtocolTCP), port1)
+	err = bpfDP.RemoveItemFailsafeMap(uint8(ipsetmember.ProtocolTCP), port1)
 	if err != nil {
 		t.Fatalf("cannot remove item from map: %v", err)
 	}
 	t.Log("Removing an already removed item from a failsafe map should fail")
-	err = bpfDP.RemoveItemFailsafeMap(uint8(labelindex.ProtocolTCP), port1)
+	err = bpfDP.RemoveItemFailsafeMap(uint8(ipsetmember.ProtocolTCP), port1)
 	if err == nil {
 		t.Fatalf("removing already removed item should have failed")
 	}
@@ -639,7 +639,7 @@ func TestFailsafeMapContent(t *testing.T) {
 	}
 
 	t.Log("Looking up from a removed failsafe map should fail")
-	exists, err = bpfDP.LookupFailsafeMap(uint8(labelindex.ProtocolTCP), port1)
+	exists, err = bpfDP.LookupFailsafeMap(uint8(ipsetmember.ProtocolTCP), port1)
 	if err == nil || exists {
 		t.Fatalf("map should have been deleted")
 	}

--- a/felix/bpf/cmd/felix-xdp.go
+++ b/felix/bpf/cmd/felix-xdp.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/pkg/buildinfo"
 )
 
@@ -43,10 +43,10 @@ func populate() {
 	cmdVethPairArgs := []string{"-c", "ip link add eth42 type veth peer name eth43 || true"}
 	_, _ = exec.Command("/bin/sh", cmdVethPairArgs...).CombinedOutput()
 	_, _ = bpfLib.NewFailsafeMap()
-	_ = bpfLib.UpdateFailsafeMap(uint8(labelindex.ProtocolTCP), 53)
-	_ = bpfLib.UpdateFailsafeMap(uint8(labelindex.ProtocolTCP), 80)
-	_ = bpfLib.UpdateFailsafeMap(uint8(labelindex.ProtocolTCP), 22)
-	_ = bpfLib.UpdateFailsafeMap(uint8(labelindex.ProtocolUDP), 53)
+	_ = bpfLib.UpdateFailsafeMap(uint8(ipsetmember.ProtocolTCP), 53)
+	_ = bpfLib.UpdateFailsafeMap(uint8(ipsetmember.ProtocolTCP), 80)
+	_ = bpfLib.UpdateFailsafeMap(uint8(ipsetmember.ProtocolTCP), 22)
+	_ = bpfLib.UpdateFailsafeMap(uint8(ipsetmember.ProtocolUDP), 53)
 
 	_ = bpfLib.RemoveXDP("eth42", bpf.XDPGeneric)
 	_, _ = bpfLib.NewCIDRMap("eth42", bpf.IPFamilyV4)
@@ -64,11 +64,11 @@ func dump() {
 	for _, entry := range pp {
 		proto := "<unknown>"
 		switch entry.Proto {
-		case labelindex.ProtocolTCP:
+		case ipsetmember.ProtocolTCP:
 			proto = "TCP"
-		case labelindex.ProtocolUDP:
+		case ipsetmember.ProtocolUDP:
 			proto = "UDP"
-		case labelindex.ProtocolSCTP:
+		case ipsetmember.ProtocolSCTP:
 			proto = "SCTP"
 		}
 		fmt.Printf("  %s: %d\n", proto, entry.Port)

--- a/felix/bpf/mock_bpf_lib.go
+++ b/felix/bpf/mock_bpf_lib.go
@@ -26,7 +26,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 )
 
 var id = 0
@@ -345,7 +345,7 @@ func (b *MockBPFLib) LookupCIDRMap(ifName string, family IPFamily, ip net.IP, ma
 
 func (b *MockBPFLib) LookupFailsafeMap(proto uint8, port uint16) (bool, error) {
 	pp := ProtoPort{
-		Proto: labelindex.IPSetPortProtocol(proto),
+		Proto: ipsetmember.Protocol(proto),
 		Port:  port,
 	}
 
@@ -413,7 +413,7 @@ func (b *MockBPFLib) RemoveItemFailsafeMap(proto uint8, port uint16) error {
 	}
 
 	pp := ProtoPort{
-		Proto: labelindex.IPSetPortProtocol(proto),
+		Proto: ipsetmember.Protocol(proto),
 		Port:  port,
 	}
 
@@ -463,7 +463,7 @@ func (b *MockBPFLib) UpdateFailsafeMap(proto uint8, port uint16) error {
 	}
 
 	pp := ProtoPort{
-		Proto: labelindex.IPSetPortProtocol(proto),
+		Proto: ipsetmember.Protocol(proto),
 		Port:  port,
 	}
 

--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -22,6 +22,7 @@ import (
 	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/dispatcher"
 	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/serviceindex"
 	"github.com/projectcalico/calico/felix/types"
@@ -41,8 +42,8 @@ func init() {
 
 type ipSetUpdateCallbacks interface {
 	OnIPSetAdded(setID string, ipSetType proto.IPSetUpdate_IPSetType)
-	OnIPSetMemberAdded(setID string, ip labelindex.IPSetMember)
-	OnIPSetMemberRemoved(setID string, ip labelindex.IPSetMember)
+	OnIPSetMemberAdded(setID string, ip ipsetmember.IPSetMember)
+	OnIPSetMemberRemoved(setID string, ip ipsetmember.IPSetMember)
 	OnIPSetRemoved(setID string)
 }
 
@@ -255,7 +256,7 @@ func NewCalculationGraph(
 	serviceIndex := serviceindex.NewServiceIndex()
 	serviceIndex.RegisterWith(allUpdDispatcher)
 	// Send the Service IP set member index's outputs to the dataplane.
-	serviceIndex.OnMemberAdded = func(ipSetID string, member labelindex.IPSetMember) {
+	serviceIndex.OnMemberAdded = func(ipSetID string, member ipsetmember.IPSetMember) {
 		if log.GetLevel() >= log.DebugLevel {
 			log.WithFields(log.Fields{
 				"ipSetID": ipSetID,
@@ -264,7 +265,7 @@ func NewCalculationGraph(
 		}
 		callbacks.OnIPSetMemberAdded(ipSetID, member)
 	}
-	serviceIndex.OnMemberRemoved = func(ipSetID string, member labelindex.IPSetMember) {
+	serviceIndex.OnMemberRemoved = func(ipSetID string, member ipsetmember.IPSetMember) {
 		if log.GetLevel() >= log.DebugLevel {
 			log.WithFields(log.Fields{
 				"ipSetID": ipSetID,
@@ -327,7 +328,7 @@ func NewCalculationGraph(
 	}
 
 	// Send the IP set member index's outputs to the dataplane.
-	ipsetMemberIndex.OnMemberAdded = func(ipSetID string, member labelindex.IPSetMember) {
+	ipsetMemberIndex.OnMemberAdded = func(ipSetID string, member ipsetmember.IPSetMember) {
 		if log.GetLevel() >= log.DebugLevel {
 			log.WithFields(log.Fields{
 				"ipSetID": ipSetID,
@@ -336,7 +337,7 @@ func NewCalculationGraph(
 		}
 		callbacks.OnIPSetMemberAdded(ipSetID, member)
 	}
-	ipsetMemberIndex.OnMemberRemoved = func(ipSetID string, member labelindex.IPSetMember) {
+	ipsetMemberIndex.OnMemberRemoved = func(ipSetID string, member ipsetmember.IPSetMember) {
 		if log.GetLevel() >= log.DebugLevel {
 			log.WithFields(log.Fields{
 				"ipSetID": ipSetID,

--- a/felix/calc/state_test.go
+++ b/felix/calc/state_test.go
@@ -17,7 +17,6 @@ package calc_test
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	googleproto "google.golang.org/protobuf/proto"
@@ -171,8 +170,8 @@ func (s State) withIPSet(name string, members []string) (newState State) {
 		delete(newState.ExpectedIPSets, name)
 	} else {
 		memSet := set.New[string]()
-		for _, ip := range members {
-			memSet.Add(strings.ToLower(ip))
+		for _, member := range members {
+			memSet.Add(member)
 		}
 		newState.ExpectedIPSets[name] = memSet
 	}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -71,7 +71,7 @@ import (
 	"github.com/projectcalico/calico/felix/iptables"
 	"github.com/projectcalico/calico/felix/iptables/cmdshim"
 	"github.com/projectcalico/calico/felix/jitter"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/linkaddrs"
 	"github.com/projectcalico/calico/felix/logutils"
 	"github.com/projectcalico/calico/felix/netlinkshim"
@@ -2114,16 +2114,16 @@ func (d *InternalDataplane) setUpIptablesNormal() {
 	}
 }
 
-func stringToProtocol(protocol string) (labelindex.IPSetPortProtocol, error) {
+func stringToProtocol(protocol string) (ipsetmember.Protocol, error) {
 	switch protocol {
 	case "tcp":
-		return labelindex.ProtocolTCP, nil
+		return ipsetmember.ProtocolTCP, nil
 	case "udp":
-		return labelindex.ProtocolUDP, nil
+		return ipsetmember.ProtocolUDP, nil
 	case "sctp":
-		return labelindex.ProtocolSCTP, nil
+		return ipsetmember.ProtocolSCTP, nil
 	}
-	return labelindex.ProtocolNone, fmt.Errorf("unknown protocol %q", protocol)
+	return ipsetmember.ProtocolNone, fmt.Errorf("unknown protocol %q", protocol)
 }
 
 func (d *InternalDataplane) setXDPFailsafePorts() error {

--- a/felix/ipsets/ipset_defs.go
+++ b/felix/ipsets/ipset_defs.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/ip"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/proto"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
 )
@@ -90,7 +90,7 @@ var AllIPSetTypes = []IPSetType{
 type V4IPPort struct {
 	IP       ip.V4Addr
 	Port     uint16
-	Protocol labelindex.IPSetPortProtocol
+	Protocol ipsetmember.Protocol
 }
 
 func (p V4IPPort) String() string {
@@ -100,7 +100,7 @@ func (p V4IPPort) String() string {
 type V6IPPort struct {
 	IP       ip.V6Addr
 	Port     uint16
-	Protocol labelindex.IPSetPortProtocol
+	Protocol ipsetmember.Protocol
 }
 
 func (p V6IPPort) String() string {

--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/deltatracker"
 	"github.com/projectcalico/calico/felix/ip"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/logutils"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
@@ -1220,14 +1220,14 @@ func CanonicaliseMember(t IPSetType, member string) IPSetMember {
 		}
 		// parts[1] should contain "(tcp|udp|sctp):<port number>"
 		parts = strings.Split(parts[1], ":")
-		var proto labelindex.IPSetPortProtocol
+		var proto ipsetmember.Protocol
 		switch strings.ToLower(parts[0]) {
 		case "udp":
-			proto = labelindex.ProtocolUDP
+			proto = ipsetmember.ProtocolUDP
 		case "tcp":
-			proto = labelindex.ProtocolTCP
+			proto = ipsetmember.ProtocolTCP
 		case "sctp":
-			proto = labelindex.ProtocolSCTP
+			proto = ipsetmember.ProtocolSCTP
 		default:
 			log.WithField("member", member).Panic("Unknown protocol")
 		}

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/ip"
 	. "github.com/projectcalico/calico/felix/ipsets"
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/felix/logutils"
 	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
@@ -76,7 +76,7 @@ var _ = Describe("IPSetTypeHashIPPort", func() {
 		Expect(CanonicaliseMember(IPSetTypeHashIPPort, "10.0.0.1,TCP:1234")).
 			To(Equal(V4IPPort{
 				IP:       ip.FromString("10.0.0.1").(ip.V4Addr),
-				Protocol: labelindex.ProtocolTCP,
+				Protocol: ipsetmember.ProtocolTCP,
 				Port:     1234,
 			}))
 	})
@@ -84,7 +84,7 @@ var _ = Describe("IPSetTypeHashIPPort", func() {
 		Expect(CanonicaliseMember(IPSetTypeHashIPPort, "10.0.0.1,SCTP:1234")).
 			To(Equal(V4IPPort{
 				IP:       ip.FromString("10.0.0.1").(ip.V4Addr),
-				Protocol: labelindex.ProtocolSCTP,
+				Protocol: ipsetmember.ProtocolSCTP,
 				Port:     1234,
 			}))
 	})
@@ -92,7 +92,7 @@ var _ = Describe("IPSetTypeHashIPPort", func() {
 		Expect(CanonicaliseMember(IPSetTypeHashIPPort, "feed:0::beef,uDp:3456")).
 			To(Equal(V6IPPort{
 				IP:       ip.FromString("feed::beef").(ip.V6Addr),
-				Protocol: labelindex.ProtocolUDP,
+				Protocol: ipsetmember.ProtocolUDP,
 				Port:     3456,
 			}))
 	})
@@ -180,14 +180,14 @@ var _ = Describe("IPPort types", func() {
 	It("V4 should stringify correctly", func() {
 		Expect(V4IPPort{
 			IP:       ip.FromString("10.0.0.0").(ip.V4Addr),
-			Protocol: labelindex.ProtocolTCP,
+			Protocol: ipsetmember.ProtocolTCP,
 			Port:     1234,
 		}.String()).To(Equal("10.0.0.0,tcp:1234"))
 	})
 	It("V6 should stringify correctly", func() {
 		Expect(V6IPPort{
 			IP:       ip.FromString("feed:beef::").(ip.V6Addr),
-			Protocol: labelindex.ProtocolUDP,
+			Protocol: ipsetmember.ProtocolUDP,
 			Port:     1234,
 		}.String()).To(Equal("feed:beef::,udp:1234"))
 	})

--- a/felix/labelindex/ipsetmember/ip_set_member.go
+++ b/felix/labelindex/ipsetmember/ip_set_member.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipsetmember
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/ip"
+)
+
+type IPSetMember interface {
+	ToProtobufFormat() string
+	fmt.Stringer
+}
+
+func MakeIPPortProto(addr ip.Addr, port uint16, proto Protocol) IPSetMember {
+	if port == 0 && proto == ProtocolNone {
+		return MakeCIDROrIPOnly(addr.AsCIDR())
+	}
+
+	// By using the address type as a type parameter, we can embed the IP
+	// directly in the struct and use a lot less storage.
+	switch addr := addr.(type) {
+	case ip.V4Addr:
+		return ipPortProtoIPSetMember[ip.V4Addr]{
+			addr:  addr,
+			port:  port,
+			proto: proto,
+		}
+	case ip.V6Addr:
+		return ipPortProtoIPSetMember[ip.V6Addr]{
+			addr:  addr,
+			port:  port,
+			proto: proto,
+		}
+	default:
+		logrus.WithField("addr", addr).Panic("Unknown IP type.")
+		panic("Unknown IP type.")
+	}
+}
+
+type ipPortProtoIPSetMember[IPType ip.Addr] struct {
+	addr  IPType
+	port  uint16
+	proto Protocol
+}
+
+func (m ipPortProtoIPSetMember[IPType]) ToProtobufFormat() string {
+	switch m.Protocol() {
+	case ProtocolTCP:
+		return fmt.Sprintf("%s,tcp:%d", m.CIDR().Addr(), m.PortNumber())
+	case ProtocolUDP:
+		return fmt.Sprintf("%s,udp:%d", m.CIDR().Addr(), m.PortNumber())
+	case ProtocolSCTP:
+		return fmt.Sprintf("%s,sctp:%d", m.CIDR().Addr(), m.PortNumber())
+	default:
+		logrus.WithField("member", m).Panic("protocol can't be ProtocolNone in a ipPortProtoIPSetMember")
+		panic("protocol can't be ProtocolNone in a ipPortProtoIPSetMember")
+	}
+}
+
+func (m ipPortProtoIPSetMember[IPType]) String() string {
+	return fmt.Sprintf("%T(%v,%v,%v)", m, m.addr, m.port, m.proto)
+}
+
+func (m ipPortProtoIPSetMember[IPType]) CIDR() ip.CIDR {
+	return m.addr.AsCIDR()
+}
+
+func (m ipPortProtoIPSetMember[IPType]) Protocol() Protocol {
+	return m.proto
+}
+
+func (m ipPortProtoIPSetMember[IPType]) PortNumber() uint16 {
+	return m.port
+}
+
+func MakeCIDROrIPOnly(cidr ip.CIDR) CIDROrIPOnlyIPSetMember {
+	if cidr.IsSingleAddress() {
+		return MakeSingleIP(cidr.Addr())
+	}
+	switch cidr := cidr.(type) {
+	case ip.V4CIDR:
+		return cidrIPSetMember[ip.V4CIDR]{
+			cidr: cidr,
+		}
+	case ip.V6CIDR:
+		return cidrIPSetMember[ip.V6CIDR]{
+			cidr: cidr,
+		}
+	default:
+		logrus.WithField("cidr", cidr).Panic("Unknown CIDR type.")
+		panic("Unknown CIDR type.")
+	}
+}
+
+type CIDROrIPOnlyIPSetMember interface {
+	IPSetMember
+	CIDR() ip.CIDR
+
+	CIDROrIPOnlyIPSetMember() // No-op marker method
+}
+
+type cidrIPSetMember[CIDRType ip.CIDR] struct {
+	cidr CIDRType
+}
+
+func (m cidrIPSetMember[CIDRType]) CIDROrIPOnlyIPSetMember() {}
+
+func (m cidrIPSetMember[CIDRType]) ToProtobufFormat() string {
+	return m.CIDR().String()
+}
+
+func (m cidrIPSetMember[CIDRType]) String() string {
+	return fmt.Sprintf("%T(%s)", m, m.ToProtobufFormat())
+}
+
+func (m cidrIPSetMember[CIDRType]) CIDR() ip.CIDR {
+	return m.cidr
+}
+
+func MakeSingleIP(addr ip.Addr) CIDROrIPOnlyIPSetMember {
+	switch addr := addr.(type) {
+	case ip.V4Addr:
+		return ipAddrIPSetMember[ip.V4Addr]{
+			addr: addr,
+		}
+	case ip.V6Addr:
+		return ipAddrIPSetMember[ip.V6Addr]{
+			addr: addr,
+		}
+	default:
+		logrus.WithField("cidr", addr).Panic("Unknown CIDR type.")
+		panic("Unknown CIDR type.")
+	}
+}
+
+type ipAddrIPSetMember[AddrType ip.Addr] struct {
+	addr AddrType
+}
+
+func (m ipAddrIPSetMember[AddrType]) CIDROrIPOnlyIPSetMember() {}
+
+func (m ipAddrIPSetMember[AddrType]) ToProtobufFormat() string {
+	return m.CIDR().String()
+}
+
+func (m ipAddrIPSetMember[AddrType]) String() string {
+	return fmt.Sprintf("%T(%s)", m, m.ToProtobufFormat())
+}
+
+func (m ipAddrIPSetMember[AddrType]) CIDR() ip.CIDR {
+	return m.addr.AsCIDR()
+}

--- a/felix/labelindex/ipsetmember/ipset_port_protocol.go
+++ b/felix/labelindex/ipsetmember/ipset_port_protocol.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved
+
+package ipsetmember
+
+import (
+	"strings"
+
+	"github.com/projectcalico/api/pkg/lib/numorstring"
+	"github.com/sirupsen/logrus"
+)
+
+type Protocol uint8
+
+func (p Protocol) MatchesModelProtocol(protocol numorstring.Protocol) bool {
+	if protocol.Type == numorstring.NumOrStringNum {
+		if protocol.NumVal == 0 {
+			// Special case: named ports default to TCP if protocol isn't specified.
+			return p == ProtocolTCP
+		}
+		return protocol.NumVal == uint8(p)
+	}
+	switch p {
+	case ProtocolTCP:
+		return strings.ToLower(protocol.StrVal) == "tcp"
+	case ProtocolUDP:
+		return strings.ToLower(protocol.StrVal) == "udp"
+	case ProtocolSCTP:
+		return strings.ToLower(protocol.StrVal) == "sctp"
+	}
+	logrus.WithField("protocol", p).Panic("Unknown protocol")
+	return false
+}
+
+func (p Protocol) String() string {
+	switch p {
+	case ProtocolTCP:
+		return "tcp"
+	case ProtocolUDP:
+		return "udp"
+	case ProtocolSCTP:
+		return "sctp"
+	case ProtocolNone:
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	ProtocolNone Protocol = 0
+	ProtocolTCP  Protocol = 6
+	ProtocolUDP  Protocol = 17
+	ProtocolSCTP Protocol = 132
+)

--- a/felix/labelindex/named_port_bench_test.go
+++ b/felix/labelindex/named_port_bench_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	. "github.com/projectcalico/calico/felix/labelindex"
+	. "github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	"github.com/projectcalico/calico/lib/std/uniquelabels"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"

--- a/felix/serviceindex/serviceindex_test.go
+++ b/felix/serviceindex/serviceindex_test.go
@@ -21,7 +21,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/projectcalico/calico/felix/labelindex"
+	"github.com/projectcalico/calico/felix/labelindex/ipsetmember"
 	. "github.com/projectcalico/calico/felix/serviceindex"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
@@ -33,7 +33,7 @@ var _ = Describe("ServiceIndex", func() {
 
 	BeforeEach(func() {
 		idx = NewServiceIndex()
-		recorder = &testRecorder{ipsets: make(map[string]map[labelindex.IPSetMember]bool)}
+		recorder = &testRecorder{ipsets: make(map[string]map[ipsetmember.IPSetMember]bool)}
 		idx.OnMemberAdded = recorder.OnMemberAdded
 		idx.OnMemberRemoved = recorder.OnMemberRemoved
 	})
@@ -68,7 +68,7 @@ var _ = Describe("ServiceIndex", func() {
 		})
 
 		// Not yet active, so ipset membership should be empty.
-		Expect(recorder.ipsets).To(Equal(map[string]map[labelindex.IPSetMember]bool{}))
+		Expect(recorder.ipsets).To(Equal(map[string]map[ipsetmember.IPSetMember]bool{}))
 
 		// Make it active.
 		idx.UpdateIPSet("identifier", "default/svc1")
@@ -206,7 +206,7 @@ var _ = Describe("ServiceIndex", func() {
 		})
 
 		// Not yet active, so ipset membership should be empty.
-		Expect(recorder.ipsets).To(Equal(map[string]map[labelindex.IPSetMember]bool{}))
+		Expect(recorder.ipsets).To(Equal(map[string]map[ipsetmember.IPSetMember]bool{}))
 
 		// Make it active. We should have 6 IP set members - one for each address / port combination.
 		idx.UpdateIPSet("identifier", "default/svc1")
@@ -403,19 +403,19 @@ var _ = Describe("ServiceIndex", func() {
 })
 
 type testRecorder struct {
-	ipsets map[string]map[labelindex.IPSetMember]bool
+	ipsets map[string]map[ipsetmember.IPSetMember]bool
 }
 
-func (t *testRecorder) OnMemberAdded(ipSetID string, member labelindex.IPSetMember) {
+func (t *testRecorder) OnMemberAdded(ipSetID string, member ipsetmember.IPSetMember) {
 	s := t.ipsets[ipSetID]
 	if s == nil {
-		s = make(map[labelindex.IPSetMember]bool)
+		s = make(map[ipsetmember.IPSetMember]bool)
 		t.ipsets[ipSetID] = s
 	}
 	s[member] = true
 }
 
-func (t *testRecorder) OnMemberRemoved(ipSetID string, member labelindex.IPSetMember) {
+func (t *testRecorder) OnMemberRemoved(ipSetID string, member ipsetmember.IPSetMember) {
 	s := t.ipsets[ipSetID]
 	delete(s, member)
 	if len(s) == 0 {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The `IPSetMember` struct:

- Was very large, with high occupancy (we store hundreds of thousands of them in larger clusters).
- Contained lots of fields that were only used in a minority of cases.
- Was error prone: which fields were allowed to be "zero" and in which combinations?

This commit replaces the struct with an interface along with several small implementation structs covering each use case.  This reduces memory usage a lot and it makes it explicit which combinations of fields are required.

The new interface moves to its own package to reduce import cycle fun.

Move the protobuf encoding to the implementation structs; this is cleaner than a type switch in the event sequencer.

For the very common cases (simple IP-only or CIDR-only members), go the extra mile and make variants of the structs that store:

- A single IPv4 CIDR
- A single IPv6 CIDR
- A single IPv4 addr
- A single IPv6 addr

This means that, instead of a large struct embedding an `ip.CIDR` interface, which in turn points at a CIDR struct, we just have an interface that points at a CIDR (or an even smaller IP) struct.

Also: remove the expectation that IP set members should be lower case in the FV tests. This was interfering with various IP set types in enterprise.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-11410
## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now uses a more efficient internal representation when storing IP set membership.  This reduces RAM usage at high scale and improve performance.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
