### PR TITLE
Start adding Calico specific e2es to repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ image:
 # Run local e2e smoke test against the checked-out code
 # using a local kind cluster.
 ###############################################################################
-E2E_FOCUS ?= "sig-network.*Conformance"
+E2E_FOCUS ?= "sig-network.*Conformance|sig-calico.*Conformance"
 ADMINPOLICY_SUPPORTED_FEATURES ?= "AdminNetworkPolicy,BaselineAdminNetworkPolicy"
 ADMINPOLICY_UNSUPPORTED_FEATURES ?= ""
 e2e-test:

--- a/api/pkg/apis/projectcalico/v3/register.go
+++ b/api/pkg/apis/projectcalico/v3/register.go
@@ -24,8 +24,10 @@ import (
 const GroupName = "projectcalico.org"
 
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v3"}
-var SchemeGroupVersionInternal = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+var (
+	SchemeGroupVersion         = schema.GroupVersion{Group: GroupName, Version: "v3"}
+	SchemeGroupVersionInternal = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+)
 
 var (
 	SchemeBuilder      runtime.SchemeBuilder

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,7 +3,8 @@ include ../metadata.mk
 PACKAGE_NAME=github.com/projectcalico/calico/e2e
 include ../lib.Makefile
 
-build: bin/k8s/e2e.test bin/adminpolicy/e2e.test
+SRC_FILES=$(shell find . -name '*.go')
+build: bin/k8s/e2e.test bin/adminpolicy/e2e.test $(SRC_FILES)
 bin/k8s/e2e.test: $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o $@

--- a/e2e/cmd/k8s/e2e_test.go
+++ b/e2e/cmd/k8s/e2e_test.go
@@ -19,12 +19,13 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	caliconfig "github.com/projectcalico/calico/e2e/pkg/config"
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
+
+	caliconfig "github.com/projectcalico/calico/e2e/pkg/config"
 
 	// Import tests.
 	_ "k8s.io/kubernetes/test/e2e/network"

--- a/e2e/cmd/k8s/e2e_test.go
+++ b/e2e/cmd/k8s/e2e_test.go
@@ -25,8 +25,9 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/config"
 
 	// Import tests.
-	_ "github.com/projectcalico/calico/e2e/pkg/policy"
 	_ "k8s.io/kubernetes/test/e2e/network"
+
+	_ "github.com/projectcalico/calico/e2e/pkg/policy"
 )
 
 func init() {

--- a/e2e/cmd/k8s/e2e_test.go
+++ b/e2e/cmd/k8s/e2e_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
+	caliconfig "github.com/projectcalico/calico/e2e/pkg/utils/e2ecfg"
+	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -31,16 +33,21 @@ import (
 )
 
 func init() {
+	// Set up logging. We need to set the output for various logging systems used by the tests
+	// and libraries imported by the tests.
 	klog.SetOutput(ginkgo.GinkgoWriter)
+	logrus.SetOutput(ginkgo.GinkgoWriter)
 
 	// Register flags.
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
+	caliconfig.RegisterFlags(flag.CommandLine)
 
 	// Parse all the flags
 	flag.Parse()
 	framework.AfterReadingAllFlags(&framework.TestContext)
+	caliconfig.AfterReadingAllFlags()
 }
 
 func TestE2E(t *testing.T) {

--- a/e2e/cmd/k8s/e2e_test.go
+++ b/e2e/cmd/k8s/e2e_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	caliconfig "github.com/projectcalico/calico/e2e/pkg/utils/e2ecfg"
+	caliconfig "github.com/projectcalico/calico/e2e/pkg/config"
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e"
@@ -29,7 +29,7 @@ import (
 	// Import tests.
 	_ "k8s.io/kubernetes/test/e2e/network"
 
-	_ "github.com/projectcalico/calico/e2e/pkg/policy"
+	_ "github.com/projectcalico/calico/e2e/pkg/tests/policy"
 )
 
 func init() {

--- a/e2e/cmd/k8s/e2e_test.go
+++ b/e2e/cmd/k8s/e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/config"
 
 	// Import tests.
+	_ "github.com/projectcalico/calico/e2e/pkg/policy"
 	_ "k8s.io/kubernetes/test/e2e/network"
 )
 

--- a/e2e/pkg/config/config.go
+++ b/e2e/pkg/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2ecfg
+package config
 
 import (
 	"flag"

--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package describe
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// CalicoDescribe is a SIGDescribe for the Calico e2e tests.
+var CalicoDescribe = framework.SIGDescribe("calico")
+
+type Team string
+
+const (
+	Core Team = "CORE"
+)
+
+// TODO: We shouldn't need a Team label - we can maintain a mapping of feature / category -> team.
+func WithTeam(team Team) any {
+	return framework.WithLabel(fmt.Sprintf("Team:%s", team))
+}
+
+// TODO: These categories are largely inherited from organically grown feature categories.
+//
+//	Is this really the right breakdown?
+type Category string
+
+const (
+	// Policy is used for tests that verify policy enforcement behavior in the dataplane.
+	Policy Category = "Policy"
+)
+
+func WithCategory(cat Category) any {
+	return framework.WithLabel(fmt.Sprintf("Category:%s", cat))
+}
+
+// features is the set of high level features that are tested by the e2e tests.
+// All tests must be marked with one of these features.
+//
+// If you are unsure which feature to use, please ask!
+var features = map[string]bool{
+	"NetworkPolicy": true,
+}
+
+// WithFeature marks tests as verifying a specific feature.
+func WithFeature(feature string) any {
+	if !features[feature] {
+		framework.Failf("%s is not a supported feature", feature)
+	}
+	return framework.WithLabel(fmt.Sprintf("Feature:%s", feature))
+}
+
+// WithWindows marks tests that can run on clusters with Windows nodes.
+func WithWindows() any {
+	return framework.WithLabel("RunsOnWindows")
+}
+
+// WithAzure marks tests that must run on Azure.
+func WithAzure() any {
+	return framework.WithLabel("RunsOnAzure")
+}
+
+// WithAzure marks tests that must run on AWS.
+func WithAWS() any {
+	return framework.WithLabel("RunsOnAWS")
+}
+
+// WithExternalNode marks tests that require an external node outside of the base cluster,
+// and additional configuration passed to the e2e code in order to run commands on that node.
+func WithExternalNode() any {
+	return framework.WithLabel("ExternalNode")
+}
+
+// RequiresAzureIPAM marks tests that require a cluster with Azure IPAM.
+func RequiresAzureIPAM() any {
+	return framework.WithLabel("AzureIPAM")
+}
+
+// RequiresRKE2 marks tests that require an RKE2 environment.
+func RequiresRKE2() any {
+	return framework.WithLabel("RunsOnRKE2")
+}
+
+// RequiresRKE marks tests that require RHEL nodes.
+func RequiresRHEL() any {
+	return framework.WithLabel("RunsOnRHEL")
+}
+
+// WithSmokeTest marks tests that are considered smoke tests.
+// A Smoke test must pass in under a minute, and is expected to pass on all platforms regardless of configuration.
+func WithSmokeTest() any {
+	return framework.WithLabel("SmokeTest")
+}
+
+// Dataplane defines a dataplane requirement.
+type Dataplane string
+
+const (
+	BPF Dataplane = "BPF"
+	LB  Dataplane = "LB"
+)
+
+func WithDataplane(d Dataplane) any {
+	return framework.WithLabel(fmt.Sprintf("Dataplane:%s", d))
+}
+
+// WithObserve marks tests that may be obsolete or insuitable for e2e testing.
+// These are tests that either are duplicated by another e2e test, are suitably covered via UTs / FVs, or
+// just generally don't apply to the current state of the codebase.
+func WithObserve() any {
+	return framework.WithLabel("Observe")
+}
+
+// Import of framework functions to keep imports in test files simpler.
+var (
+	WithSerial     = framework.WithSerial
+	WithDisruptive = framework.WithDisruptive
+)

--- a/e2e/pkg/policy/policy.go
+++ b/e2e/pkg/policy/policy.go
@@ -1,0 +1,372 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calico
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/calico/e2e/pkg/describe"
+	"github.com/projectcalico/calico/e2e/pkg/utils"
+	"github.com/projectcalico/calico/e2e/pkg/utils/client"
+	"github.com/projectcalico/calico/e2e/pkg/utils/conncheck"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = describe.CalicoDescribe(
+	describe.WithTeam(describe.Core),
+	describe.WithFeature("NetworkPolicy"),
+	describe.WithCategory(describe.Policy),
+	"Calico NetworkPolicy",
+	func() {
+		// Define variables common across all tests.
+		var err error
+		var cli ctrlclient.Client
+		var checker conncheck.ConnectionTester
+		var server1 *conncheck.Server
+		var client1 *conncheck.Client
+
+		// Create a new framework for the tests.
+		f := utils.NewDefaultFramework("networkpolicy")
+
+		BeforeEach(func() {
+			// Create a connection tester for the test.
+			checker = conncheck.NewConnectionTester(f)
+
+			cli, err = client.New(f.ClientConfig())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Ensure a clean starting environment before each test.
+			Expect(utils.CleanDatastore(cli)).ShouldNot(HaveOccurred())
+		})
+
+		// Before each test, perform the following steps:
+		// - Create a server pod and corresponding service in the main namespace for the test.
+		// - Create a client pod and assert that it can connect to the service.
+		BeforeEach(func() {
+			By(fmt.Sprintf("Creating server pod in namespace %s", f.Namespace))
+			server1 = conncheck.NewServer("server", f.Namespace, conncheck.WithServerLabels(map[string]string{"role": "server"}))
+			client1 = conncheck.NewClient("client", f.Namespace)
+			checker.AddServer(server1)
+			checker.AddClient(client1)
+			checker.Deploy()
+		})
+
+		AfterEach(func() {
+			checker.Stop()
+		})
+
+		// This is a baseline test to ensure that the test framework is working as expected.
+		framework.ConformanceIt("should provide a default allow", func() {
+			checker.ExpectSuccess(client1, server1.ClusterIPs()...)
+			checker.Execute()
+		})
+
+		// This test performs the following steps.
+		// - Creates a second namespace, "namespace B"
+		// - Creating a server pod in namespace B.
+		// - Creating a client in namespace B and asserting it can access the server pod in namespace B.
+		// - Creating a default-deny policy applied to both namespaces using a GlobalNetworkPolicy.
+		// - Isolating both namespaces with ingress and egress policies
+		// - Asserting only same namespace connectivity exists.
+		framework.ConformanceIt("should correctly isolate namespaces [RunsOnWindows]", func() {
+			nsA := f.Namespace
+
+			By("Creating a second namespace B")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			nsB, err := f.CreateNamespace(ctx, f.BaseName+"-b", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a second server pod and wait for it to start.
+			server2 := conncheck.NewServer("server-b", nsB)
+			client2 := conncheck.NewClient("client-b", nsB)
+			checker.AddServer(server2)
+			checker.AddClient(client2)
+			checker.Deploy()
+
+			// Create a client and assert it can talk to the second server pod.
+			By("Verifying that the client in namespace B can talk to the server in the same namespace")
+			checker.ExpectSuccess(client2, server2.ClusterIP())
+			checker.Execute()
+
+			// Create a GNP that selects the two namespaces by name, enacting a default deny for
+			// all traffic to / from pods within the test's namespaces, but leaving all other namespaces and
+			// any host endpoints untouched.
+			testNamespacesOnly := fmt.Sprintf(
+				"kubernetes.io/metadata.name == '%s' || kubernetes.io/metadata.name == '%s'",
+				nsA.Name,
+				nsB.Name,
+			)
+
+			By("Creating a default-deny policy selecting both namespaces")
+			var defaultDenyPriority float64 = 5000
+			defaultDenyGNP := v3.NewGlobalNetworkPolicy()
+			defaultDenyGNP.Name = "default-deny-all"
+			defaultDenyGNP.Spec.Order = &defaultDenyPriority
+			defaultDenyGNP.Spec.NamespaceSelector = testNamespacesOnly
+			err = cli.Create(ctx, defaultDenyGNP)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := cli.Delete(ctx, defaultDenyGNP)
+				if err != nil {
+					framework.Failf("failed to delete resource: %s", err)
+				}
+			}()
+
+			// Create a GlobalNetworkPolicy that allows any pods access to DNS. This is needed so
+			// that pods can lookup service IPs by service name in subsequent steps.
+			// We only apply this to the test namespaces, as other namespaces shouldn't be impacted by
+			// the policies created by this test.
+			By("Creating global network policy which allows pods to access kube-dns")
+			var dnsPriority float64 = 400
+			allowEgressToDNS := v3.NewGlobalNetworkPolicy()
+			allowEgressToDNS.Name = "allow-egress-to-kube-dns"
+			allowEgressToDNS.Spec.Order = &dnsPriority
+			allowEgressToDNS.Spec.NamespaceSelector = testNamespacesOnly
+			allowEgressToDNS.Spec.Egress = []v3.Rule{
+				{
+					// Allow to kube-system DNS.
+					Action: "Allow",
+					Destination: v3.EntityRule{
+						NamespaceSelector: "kubernetes.io/metadata.name == 'kube-system'",
+						Selector:          "k8s-app == 'kube-dns'",
+					},
+				},
+				{
+					// Allow to openshift DNS.
+					Action: "Allow",
+					Destination: v3.EntityRule{
+						NamespaceSelector: "kubernetes.io/metadata.name == 'openshift-dns'",
+					},
+				},
+			}
+			err = cli.Create(ctx, allowEgressToDNS)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := cli.Delete(ctx, allowEgressToDNS)
+				if err != nil {
+					framework.Failf("failed to delete resource: %s", err)
+				}
+			}()
+
+			By("Checking the default deny is functioning")
+			checker.ResetExpectations()
+			checker.ExpectFailure(client1, server1.ClusterIP(), server2.ClusterIP())
+			checker.ExpectFailure(client2, server1.ClusterIP(), server2.ClusterIP())
+			checker.Execute()
+
+			// Create a policy which prevents ingress and egress traffic to / from pods in
+			// namespace A, unless the traffic is from / to another pod in namespace A.
+			By("Creating namespace isolation policy in the first namespace")
+			policyName := "namespace-isolation-a"
+			namespaceASelector := fmt.Sprintf("e2e-framework == '%s'", f.BaseName)
+			isolateNamespaceA := newNamespaceIsolationPolicy(policyName, nsA.Name, namespaceASelector, namespaceASelector)
+			err = cli.Create(ctx, isolateNamespaceA)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := cli.Delete(ctx, isolateNamespaceA)
+				if err != nil {
+					framework.Failf("failed to delete resource: %s", err)
+				}
+			}()
+
+			// Create a policy which prevents ingress and egress traffic to / from pods in
+			// namespace B, unless the traffic is from / to another pod in namespace B.
+			By("Creating namespace isolation policy in the second namespace")
+			policyNameB := "namespace-isolation-b"
+			namespaceBSelector := fmt.Sprintf("kubernetes.io/metadata.name == '%s'", nsB.Name)
+			isolateNamespaceB := newNamespaceIsolationPolicy(policyNameB, nsB.Name, namespaceBSelector, namespaceBSelector)
+			err = cli.Create(ctx, isolateNamespaceB)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := cli.Delete(ctx, isolateNamespaceB)
+				if err != nil {
+					framework.Failf("failed to delete resource: %s", err)
+				}
+			}()
+
+			By("Checking clients can only communicate within their own Namespace")
+			checker.ResetExpectations()
+			checker.ExpectSuccess(client1, server1.ClusterIP())
+			checker.ExpectFailure(client1, server2.ClusterIP())
+			checker.ExpectSuccess(client2, server2.ClusterIP())
+			checker.ExpectFailure(client2, server1.ClusterIP())
+			checker.Execute()
+		})
+
+		framework.ConformanceIt("should support service account selectors", func() {
+			ns := f.Namespace
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			By(fmt.Sprintf("Applying a default-deny policy to namespace %s", ns.Name))
+			defaultDeny := newDefaultDenyPolicy(ns.Name)
+			cli.Create(ctx, defaultDeny)
+			defer func() {
+				err := cli.Delete(ctx, defaultDeny)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			// Verify the default deny.
+			checker.ExpectFailure(client1, server1.ClusterIP())
+			checker.Execute()
+
+			By("Allowing traffic through a service account selector")
+			sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			sa.ObjectMeta.Labels = map[string]string{"ns-name": ns.Name}
+			_, err = f.ClientSet.CoreV1().ServiceAccounts(ns.Name).Update(ctx, sa, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			np := &v3.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-through-service-account",
+					Namespace: ns.Name,
+				},
+				Spec: v3.NetworkPolicySpec{
+					ServiceAccountSelector: fmt.Sprintf("ns-name == '%s'", ns.Name),
+					Order:                  ptr.Float64(100),
+					Ingress: []v3.Rule{
+						{
+							Action: v3.Allow,
+							Source: v3.EntityRule{
+								ServiceAccounts: &v3.ServiceAccountMatch{
+									Selector: fmt.Sprintf("ns-name == '%s'", ns.Name),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err = cli.Create(ctx, np)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := cli.Delete(ctx, np)
+				if err != nil {
+					framework.Failf("failed to delete resource: %s", err)
+				}
+			}()
+
+			// Verify the policy allows traffic.
+			checker.ResetExpectations()
+			checker.ExpectSuccess(client1, server1.ClusterIP())
+			checker.Execute()
+		})
+
+		framework.ConformanceIt("should support namespace selectors", func() {
+			ns := f.Namespace
+			ctx := context.Background()
+
+			By(fmt.Sprintf("Applying a default-deny policy to namespace %s", ns.Name))
+			defaultDeny := newDefaultDenyPolicy(ns.Name)
+			cli.Create(ctx, defaultDeny)
+			defer func() {
+				err := cli.Delete(ctx, defaultDeny)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+			logrus.Info("Applied default-deny policy.")
+
+			// Verify the default deny.
+			checker.ExpectFailure(client1, server1.ClusterIP())
+			checker.Execute()
+
+			By("Allowing traffic through a namespace selector")
+
+			np := &v3.GlobalNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "allow-through-namespace-selector",
+				},
+				Spec: v3.GlobalNetworkPolicySpec{
+					NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", ns.Name),
+					Order:             ptr.Float64(100),
+					Ingress: []v3.Rule{
+						{
+							Action: "Allow",
+							Source: v3.EntityRule{
+								NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", ns.Name),
+							},
+						},
+					},
+				},
+			}
+
+			err := cli.Create(ctx, np)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := cli.Delete(ctx, np)
+				if err != nil {
+					framework.Failf("failed to delete resource: %s", err)
+				}
+			}()
+
+			// Verify the policy allows traffic.
+			checker.ResetExpectations()
+			checker.ExpectSuccess(client1, server1.ClusterIP())
+			checker.Execute()
+		})
+	})
+
+// Creates a new NetworkPolicy that isolates a namespace by allowing ingress and egress traffic only from / to pods in the same namespace.
+func newNamespaceIsolationPolicy(name, namespace, ingressSelector, egressSelector string) *v3.NetworkPolicy {
+	return &v3.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order: ptr.Float64(1000),
+			Ingress: []v3.Rule{
+				{
+					Action: v3.Allow,
+					Source: v3.EntityRule{
+						NamespaceSelector: ingressSelector,
+					},
+				},
+			},
+			Egress: []v3.Rule{
+				{
+					Action: v3.Allow,
+					Destination: v3.EntityRule{
+						NamespaceSelector: egressSelector,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newDefaultDenyPolicy(namespace string) *v3.NetworkPolicy {
+	return &v3.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-deny",
+			Namespace: namespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    ptr.Float64(5000),
+			Selector: "all()",
+		},
+	}
+}

--- a/e2e/pkg/policy/policy.go
+++ b/e2e/pkg/policy/policy.go
@@ -22,16 +22,16 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	"github.com/projectcalico/calico/e2e/pkg/describe"
-	"github.com/projectcalico/calico/e2e/pkg/utils"
-	"github.com/projectcalico/calico/e2e/pkg/utils/client"
-	"github.com/projectcalico/calico/e2e/pkg/utils/conncheck"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/projectcalico/calico/e2e/pkg/describe"
+	"github.com/projectcalico/calico/e2e/pkg/utils"
+	"github.com/projectcalico/calico/e2e/pkg/utils/client"
+	"github.com/projectcalico/calico/e2e/pkg/utils/conncheck"
 )
 
 var _ = describe.CalicoDescribe(

--- a/e2e/pkg/policy/policy.go
+++ b/e2e/pkg/policy/policy.go
@@ -65,7 +65,7 @@ var _ = describe.CalicoDescribe(
 		// - Create a server pod and corresponding service in the main namespace for the test.
 		// - Create a client pod and assert that it can connect to the service.
 		BeforeEach(func() {
-			By(fmt.Sprintf("Creating server pod in namespace %s", f.Namespace))
+			By(fmt.Sprintf("Creating server pod in namespace %s", f.Namespace.Name))
 			server1 = conncheck.NewServer("server", f.Namespace, conncheck.WithServerLabels(map[string]string{"role": "server"}))
 			client1 = conncheck.NewClient("client", f.Namespace)
 			checker.AddServer(server1)

--- a/e2e/pkg/tests/policy/policy.go
+++ b/e2e/pkg/tests/policy/policy.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package calico
+package policy
 
 import (
 	"context"

--- a/e2e/pkg/utils/clean.go
+++ b/e2e/pkg/utils/clean.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CleanDatastore removes any resources that a previous test may have created.
+// It's intended to be called in the BeforeEach of a test in order to ensure a
+// clean starting environment.
+func CleanDatastore(cli client.Client) error {
+	return errorRetry("CleanDatastore", func() error {
+		logrus.Info("Cleaning any left-over datastore resources")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		// Clean up HEPs first; if we delete GNPs first then we can end up with default deny and block
+		// traffic (if failsafe ports aren't configured correctly for this env).
+		heps := &v3.HostEndpointList{}
+		err := cli.List(ctx, heps)
+		if err != nil {
+			return fmt.Errorf("failed to list host endpoints: %w", err)
+		}
+		logrus.Info("Cleaning left-over HEPs")
+		for _, hep := range heps.Items {
+			// Keep auto or non-cluster host endpoints.
+			isAutoHostEndpoint := hep.Labels["projectcalico.org/created-by"] == "calico-kube-controllers"
+			isNonClusterHostEndpoint := hep.Labels["hostendpoint.projectcalico.org/type"] == "nonclusterhost"
+			if isAutoHostEndpoint || isNonClusterHostEndpoint {
+				logrus.WithField("name", hep.Name).Info("Skipping deletion of auto or non-cluster host endpoint")
+			} else {
+				err = cli.Delete(ctx, &hep)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Clean up Calico network policies.
+		nps := &v3.NetworkPolicyList{}
+		err = cli.List(ctx, nps)
+		if err != nil {
+			return err
+		}
+
+		// Filter-out any policies in the allow-tigera tier. These are included
+		// with Calico Enterprise and not provisioned by the tests.
+		logrus.Info("Cleaning any left-over network policies")
+		for _, np := range nps.Items {
+			if np.Spec.Tier != "allow-tigera" && np.Namespace != "addon-policies" {
+				if err = cli.Delete(ctx, &np); err != nil {
+					return fmt.Errorf("failed to delete network policy %s: %w", np.Name, err)
+				}
+			}
+		}
+
+		// Clean up GNPs.
+		gnps := &v3.GlobalNetworkPolicyList{}
+		err = cli.List(ctx, gnps)
+		if err != nil {
+			return err
+		}
+		// Filter-out any policies in the allow-tigera tier. These are included
+		// with Calico Enterprise and not provisioned by the tests.
+		logrus.Info("Cleaning left-over GNPs")
+		for _, gnp := range gnps.Items {
+			if gnp.Spec.Tier != "allow-tigera" {
+				err = cli.Delete(ctx, &gnp)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+// errorRetry is a local helper for retrying a function on error.
+func errorRetry(desc string, f func() error) error {
+	var err error
+	for i := 0; i < 5; i++ {
+		if err = f(); err != nil {
+			logrus.WithError(err).Infof("Retrying function (%s) after error", desc)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("function %s failed after 5 retries: %v", desc, err)
+}

--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// New returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
+func New(cfg *rest.Config) (client.Client, error) {
+	// Create a new Scheme and add the projectcalico.org/v3 API group to it.
+	scheme := runtime.NewScheme()
+	if err := v3.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{Scheme: scheme})
+}

--- a/e2e/pkg/utils/conncheck/client.go
+++ b/e2e/pkg/utils/conncheck/client.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func NewClient(id string, ns *v1.Namespace, opts ...ClientOption) *Client {
+	if ns == nil {
+		msg := fmt.Sprintf("Namespace is required for client %s", id)
+		framework.Fail(msg, 1)
+	}
+	if id == "" {
+		msg := fmt.Sprintf("ID is required for client in namespace %s", ns.Name)
+		framework.Fail(msg, 1)
+	}
+
+	c := &Client{
+		name:      id,
+		namespace: ns,
+	}
+	for _, opt := range opts {
+		_ = opt(c)
+	}
+	return c
+}
+
+type Client struct {
+	name       string
+	namespace  *v1.Namespace
+	labels     map[string]string
+	pod        *v1.Pod
+	customizer func(pod *v1.Pod)
+}
+
+func (c *Client) ID() string {
+	return fmt.Sprintf("%s/%s", c.namespace.Name, c.name)
+}
+
+func (c *Client) Name() string {
+	return c.name
+}
+
+func (c *Client) Pod() *v1.Pod {
+	if c.pod == nil {
+		msg := fmt.Sprintf("No pod is running for client %s/%s", c.namespace.Name, c.name)
+		framework.Fail(msg, 1)
+	}
+	return c.pod
+}
+
+type ClientOption func(*Client) error
+
+func WithClientLabels(labels map[string]string) ClientOption {
+	return func(c *Client) error {
+		c.labels = labels
+		return nil
+	}
+}
+
+func WithClientCustomizer(customizer func(pod *v1.Pod)) ClientOption {
+	return func(c *Client) error {
+		c.customizer = customizer
+		return nil
+	}
+}

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
-
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -31,11 +32,9 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 
-	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/calico/e2e/pkg/utils/images"
 	"github.com/projectcalico/calico/e2e/pkg/utils/remotecluster"
 	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -17,6 +17,7 @@ package conncheck
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"strings"
 	"time"
@@ -482,7 +483,6 @@ func createClientPod(f *framework.Framework, namespace *v1.Namespace, baseName s
 	podName := GenerateRandomName(baseName)
 
 	if windows.ClusterIsWindows() {
-		windows.MaybeUpdateNamespaceForOpenShift(f, namespace.Name)
 		image = images.WindowsClientImage()
 		command = []string{"powershell.exe"}
 		args = []string{"Start-Sleep", "600"}
@@ -495,10 +495,10 @@ func createClientPod(f *framework.Framework, namespace *v1.Namespace, baseName s
 		nodeselector["kubernetes.io/os"] = "linux"
 	}
 
-	mergedLabels := map[string]string{"pod-name": baseName}
-	for k, v := range labels {
-		mergedLabels[k] = v
-	}
+	// Merge the base labels with the pod name label.
+	mergedLabels := make(map[string]string)
+	maps.Copy(mergedLabels, labels)
+	mergedLabels["pod-name"] = baseName
 
 	// Create the pod.
 	zero := int64(0)

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -1,0 +1,664 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/calico/e2e/pkg/utils/images"
+	"github.com/projectcalico/calico/e2e/pkg/utils/remotecluster"
+	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
+
+type connectionTester struct {
+	f            *framework.Framework
+	servers      map[string]*Server
+	clients      map[string]*Client
+	expectations map[string]*Expectation
+	deployed     bool
+}
+
+type ConnectionTester interface {
+	AddClient(client *Client)
+	AddServer(server *Server)
+	Deploy()
+	ExpectSuccess(client *Client, targets ...Target)
+	ExpectFailure(client *Client, targets ...Target)
+	Execute()
+	ResetExpectations()
+	Stop()
+}
+
+var _ ConnectionTester = &connectionTester{}
+
+func NewConnectionTester(f *framework.Framework) ConnectionTester {
+	return &connectionTester{
+		f:            f,
+		clients:      make(map[string]*Client),
+		servers:      make(map[string]*Server),
+		expectations: make(map[string]*Expectation),
+	}
+}
+
+func (c *connectionTester) ResetExpectations() {
+	if err := c.expectationsTested(); err != nil {
+		framework.Fail(fmt.Sprintf("ResetExpectations() called before all expectations were tested: %v", err), 1)
+	}
+	c.expectations = make(map[string]*Expectation)
+}
+
+func (c *connectionTester) Deploy() {
+	framework.ExpectNoErrorWithOffset(1, c.deploy())
+}
+
+func (c *connectionTester) deploy() error {
+	// For each client and server, deploy a long lived pod.
+	for _, client := range c.clients {
+		if client.pod != nil {
+			// Pod was already deployed. Skip it, and only deploy new pods.
+			continue
+		}
+		By(fmt.Sprintf("Deploying client pod %s/%s", client.namespace.Name, client.name))
+		pod, err := createClientPod(c.f, client.namespace, client.name, client.labels, client.customizer)
+		if err != nil {
+			return err
+		}
+		client.pod = pod
+	}
+	for _, server := range c.servers {
+		if server.pod != nil {
+			// Pod was already deployed. Skip it, and only deploy new pods.
+			continue
+		}
+		By(fmt.Sprintf("Deploying server pod %s/%s", server.namespace.Name, server.name))
+		pod, svc := CreateServerPodAndServiceX(
+			c.f,
+			server.namespace,
+			server.name,
+			server.ports,
+			server.labels,
+			server.podCustomizer,
+			server.svcCustomizer,
+		)
+		server.pod = pod
+		server.service = svc
+	}
+
+	// Wait for all pods to be running.
+	By("Waiting for all pods in the connection checker to be running")
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	for _, client := range c.clients {
+		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, 1*time.Minute)
+		if err != nil {
+			return err
+		}
+		// Update the client pod object with the actual pod spec. i.e Spec.NodeName etc.
+		p, err := c.f.ClientSet.CoreV1().Pods(client.namespace.Name).Get(ctx, client.pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		client.pod = p
+	}
+	for _, server := range c.servers {
+		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, server.pod.Name, server.pod.Namespace, 1*time.Minute)
+		if err != nil {
+			return err
+		}
+
+		// Update the server pod object with the actual pod IP.
+		p, err := c.f.ClientSet.CoreV1().Pods(server.namespace.Name).Get(ctx, server.pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		server.pod = p
+	}
+	c.deployed = true
+	return nil
+}
+
+func (c *connectionTester) Stop() {
+	framework.ExpectNoErrorWithOffset(1, c.stop())
+}
+
+func (c *connectionTester) stop() error {
+	By("Tearing down the connection tester")
+
+	// Delete all of the pods.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	for _, client := range c.clients {
+		By(fmt.Sprintf("Deleting client pod %s", client.pod.Name))
+		err := c.f.ClientSet.CoreV1().Pods(client.namespace.Name).Delete(ctx, client.pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, server := range c.servers {
+		By(fmt.Sprintf("Deleting server pod %s and service %s", server.pod.Name, server.service.Name))
+		err := c.f.ClientSet.CoreV1().Pods(server.namespace.Name).Delete(ctx, server.pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		err = c.f.ClientSet.CoreV1().Services(server.namespace.Name).Delete(ctx, server.service.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Wait for pods to be deleted.
+	for _, client := range c.clients {
+		By(fmt.Sprintf("Waiting for client pod %s to be deleted", client.pod.Name))
+		if err := e2epod.WaitForPodNotFoundInNamespace(ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, 1*time.Minute); err != nil {
+			return err
+		}
+	}
+	for _, server := range c.servers {
+		By(fmt.Sprintf("Waiting for server pod %s to be deleted", server.pod.Name))
+		if err := e2epod.WaitForPodNotFoundInNamespace(ctx, c.f.ClientSet, server.pod.Name, server.pod.Namespace, 1*time.Minute); err != nil {
+			return err
+		}
+	}
+
+	return c.expectationsTested()
+}
+
+func (c *connectionTester) expectationsTested() error {
+	for _, exp := range c.expectations {
+		if !exp.executed {
+			return fmt.Errorf("Expected connection %s was not executed. Did you call Execute()?", exp.Description)
+		}
+	}
+	return nil
+}
+
+func (c *connectionTester) AddClient(client *Client) {
+	if client.namespace == nil {
+		framework.Failf("Client %s has no namespace", client.name)
+	}
+	if _, ok := c.clients[client.ID()]; ok {
+		framework.Failf("Client with ID %s already exists", client.ID())
+	}
+	c.clients[client.ID()] = client
+}
+
+func (c *connectionTester) AddServer(server *Server) {
+	if server.namespace == nil {
+		framework.Failf("Server %s has no namespace", server.name)
+	}
+	if _, ok := c.servers[server.ID()]; ok {
+		framework.Failf("Server with ID %s already exists", server.ID())
+	}
+	c.servers[server.ID()] = server
+}
+
+type Expectation struct {
+	Client         *v1.Pod
+	Target         Target
+	Description    string
+	ExpectedResult ResultStatus
+
+	// Track whether or not we have executed this expectation.
+	// This is helpful for spotting test bugs where we forget to execute.
+	executed bool
+}
+
+func (e *Expectation) String() string {
+	// An Expectation is defined by:
+	// - Client name and namespace.
+	// - The target name (and if applicable, namespace).
+	// - The type of connection, e.g., ClusterIP/ICMP.
+	return fmt.Sprintf("Client=%s/%s; Server=%s; Type=%s",
+		e.Client.Namespace,
+		e.Client.Name,
+		e.Target.String(),
+		e.Target.AccessType(),
+	)
+}
+
+func (c *connectionTester) ExpectSuccess(client *Client, targets ...Target) {
+	for _, target := range targets {
+		c.expectSuccess(client, target)
+	}
+}
+
+func (c *connectionTester) expectSuccess(client *Client, target Target) {
+	if c.clients[client.ID()] == nil {
+		framework.Fail(fmt.Sprintf("Test bug: client %s not registered with connection tester. AddClient()?", client.ID()), 2)
+	}
+	if c.clients[client.ID()].pod == nil {
+		framework.Fail(fmt.Sprintf("Client %s has no running pod. Did you Deploy()?", client.ID()), 2)
+	}
+
+	// Prevent duplication expectations. This is a common mistake when writing tests.
+	e := &Expectation{
+		Client:         c.clients[client.ID()].pod,
+		Target:         target,
+		Description:    fmt.Sprintf("%s -> %s", client.name, target.String()),
+		ExpectedResult: Success,
+	}
+	if c.expectations[e.String()] != nil {
+		// Protect against tests accidentally calling ExpectX with the same values
+		// multiple times, which is indicative of a test bug.
+		framework.Fail(fmt.Sprintf("Test bug: duplicate expectation: %s", e.String()), 2)
+	}
+	c.expectations[e.String()] = e
+}
+
+func (c *connectionTester) ExpectFailure(client *Client, targets ...Target) {
+	for _, target := range targets {
+		c.expectFailure(client, target)
+	}
+}
+
+func (c *connectionTester) expectFailure(client *Client, target Target) {
+	if c.clients[client.ID()] == nil {
+		framework.Fail(fmt.Sprintf("Test bug: client %s not registered with connection tester. AddClient()?", client.ID()), 2)
+	}
+	if c.clients[client.ID()].pod == nil {
+		framework.Fail(fmt.Sprintf("Client %s has no running pod. Did you Deploy()?", client.ID()), 2)
+	}
+
+	// Prevent duplication expectations. This is a common mistake when writing tests.
+	e := &Expectation{
+		Client:         c.clients[client.ID()].pod,
+		Target:         target,
+		Description:    fmt.Sprintf("%s -> %s", client.name, target.String()),
+		ExpectedResult: Failure,
+	}
+	if c.expectations[e.String()] != nil {
+		framework.Fail(fmt.Sprintf("Test bug: duplicate expectation: %s", e.String()), 2)
+	}
+	c.expectations[e.String()] = e
+}
+
+// TestConnections tests one or more connections in parallel. It will fail the test if any of the connections fail.
+func (c *connectionTester) Execute() {
+	if !c.deployed {
+		framework.Fail("Execute() called before Deploy()", 1)
+	}
+	By(fmt.Sprintf("Testing %d connections in parallel", len(c.expectations)))
+	resultChan := make(chan connectionResult, len(c.expectations))
+
+	// Launch all of the connections in parallel. We'll wait for them all to finish at the end and report on success / failure.
+	for _, expectation := range c.expectations {
+		go c.runConnection(expectation, resultChan)
+	}
+
+	// Wait for all of the connections to finish.
+	var results []connectionResult
+	var failed bool
+	for range c.expectations {
+		result := <-resultChan
+		results = append(results, result)
+		if result.Failed() {
+			failed = true
+			logDiagsForConnection(c.f, result)
+		}
+	}
+
+	// If we had any errors, log out the per-test diags and then fail the test.
+	if failed {
+		logDiagsForNamespace(c.f, c.f.Namespace)
+		msg := buildFailureMessage(results)
+		framework.Fail(msg, 1)
+	}
+}
+
+func (c *connectionTester) runConnection(exp *Expectation, results chan<- connectionResult) {
+	// Exec into the client pod and try to connect to the server.
+	cmd := c.command(exp.Target)
+
+	var out string
+	var err error
+	// Ensure the kubectl command executes in the remote cluster if required. Remote framework objects do not control
+	// how kubeconfigs are resolved by the kubectl command, so we must use this wrapper. See NewDefaultFrameworkForRemoteCluster.
+	remotecluster.RemoteFrameworkAwareExec(c.f, func() {
+		if windows.RunningWindowsTest() {
+			out, err = ExecInPod(exp.Client, "powershell.exe", "-Command", cmd)
+		} else {
+			out, err = ExecInPod(exp.Client, "sh", "-c", cmd)
+		}
+	})
+	logrus.WithFields(logrus.Fields{
+		"output": out,
+		"cmd":    cmd,
+		"err":    err,
+	}).Info("Output from connection attempt.")
+	result := Success
+	if err != nil {
+		result = Failure
+	}
+
+	exp.executed = true
+	results <- connectionResult{
+		clientPod: exp.Client,
+		target:    exp.Target,
+		expected:  exp.ExpectedResult,
+		actual:    result,
+		err:       err,
+	}
+}
+
+func (c *connectionTester) command(t Target) string {
+	var cmd string
+
+	if windows.RunningWindowsTest() {
+		// Windows.
+		switch t.GetProtocol() {
+		case TCP:
+			cmd = fmt.Sprintf("$sb={Invoke-WebRequest %s -UseBasicParsing -TimeoutSec 3 -DisableKeepAlive}; "+
+				"For ($i=0; $i -lt 5; $i++) { sleep 5; "+
+				"try {& $sb} catch { echo failed loop $i ; continue }; exit 0 ; }; exit 1", t.Destination())
+		case ICMP:
+			cmd = fmt.Sprintf("Test-Connection -Count 5 -ComputerName %s", t.Destination())
+		default:
+			framework.Failf("Unsupported protocol %s", t.GetProtocol())
+		}
+	} else {
+		// Linux.
+		switch t.GetProtocol() {
+		case TCP:
+			cmd = fmt.Sprintf("wget -qO- -T 5 %s", t.Destination())
+		case ICMP:
+			cmd = fmt.Sprintf("ping -c 5 %s", t.Destination())
+		case HTTP:
+			cmdArgs := []string{"curl", "--connect-timeout", "5", "--verbose", "--fail"}
+			req := t.HTTPParams()
+			cmdArgs = append(cmdArgs, "--request", req.Method)
+			for _, header := range req.Headers {
+				cmdArgs = append(cmdArgs, "--header", fmt.Sprintf("'%s'", header))
+			}
+			cmdArgs = append(cmdArgs, fmt.Sprintf("'http://%s%s'", t.Destination(), req.Path))
+			cmd = strings.Join(cmdArgs, " ")
+		default:
+			framework.Failf("Unsupported protocol %s", t.GetProtocol())
+		}
+	}
+	return cmd
+}
+
+type ResultStatus string
+
+const (
+	Success ResultStatus = "SUCCESS"
+	Failure ResultStatus = "FAILURE"
+)
+
+func NewConnectionResult(exp, act ResultStatus, c v1.Pod, t Target, err error) connectionResult {
+	return connectionResult{
+		expected:  exp,
+		actual:    act,
+		clientPod: &c,
+		target:    t,
+		err:       err,
+	}
+}
+
+type connectionResult struct {
+	clientPod *v1.Pod
+	target    Target
+	expected  ResultStatus
+	actual    ResultStatus
+	err       error
+}
+
+func (r *connectionResult) Failed() bool {
+	return r.expected != r.actual
+}
+
+func buildFailureMessage(results []connectionResult) string {
+	// Builed an error message.
+	msg := "One or more connection tests failed:\n"
+
+	// Add expected results.
+	for _, res := range results {
+		exp := res.expected
+		actual := res.actual
+		status := "   OK"
+		if exp != actual {
+			status = "ERROR"
+		}
+		msg += fmt.Sprintf(
+			"\n%s: %s/%s -> %s (%s, %s, %s); Expected=%s, Actual=%s",
+			status,
+			res.clientPod.Namespace, res.clientPod.Name,
+			res.target.String(),
+			res.target.Destination(),
+			res.target.GetProtocol(),
+			res.target.AccessType(),
+			exp,
+			actual,
+		)
+	}
+	msg += "\n"
+	return msg
+}
+
+// createClientPod creates a long lived pod that sleeps, and can be used to execute connection tests as a client.
+func createClientPod(f *framework.Framework, namespace *v1.Namespace, baseName string, labels map[string]string, customizer func(pod *v1.Pod)) (*v1.Pod, error) {
+	var image string
+	var args []string
+	var command []string
+	nodeselector := map[string]string{}
+	pullPolicy := v1.PullAlways
+
+	// Randomize pod names to avoid clashes with previous tests.
+	podName := GenerateRandomName(baseName)
+
+	if windows.RunningWindowsTest() {
+		windows.MaybeUpdateNamespaceForOpenShift(f, namespace.Name)
+		image = images.WindowsClientImage()
+		command = []string{"powershell.exe"}
+		args = []string{"Start-Sleep", "600"}
+		nodeselector["kubernetes.io/os"] = "windows"
+		pullPolicy = v1.PullIfNotPresent
+	} else {
+		image = images.Alpine
+		command = []string{"/bin/sleep"}
+		args = []string{"3600"}
+		nodeselector["kubernetes.io/os"] = "linux"
+	}
+
+	mergedLabels := map[string]string{"pod-name": baseName}
+	for k, v := range labels {
+		mergedLabels[k] = v
+	}
+
+	// Create the pod.
+	zero := int64(0)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   podName,
+			Labels: mergedLabels,
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy:                 v1.RestartPolicyNever,
+			NodeSelector:                  nodeselector,
+			TerminationGracePeriodSeconds: &zero,
+			Containers: []v1.Container{
+				{
+					Name:            "client-container",
+					Image:           image,
+					Command:         command,
+					Args:            args,
+					ImagePullPolicy: pullPolicy,
+				},
+			},
+			Tolerations: []v1.Toleration{
+				corev1.Toleration{
+					Key:      "kubernetes.io/arch",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "arm64",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	if customizer != nil {
+		customizer(pod)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return f.ClientSet.CoreV1().Pods(namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+}
+
+func logDiagsForConnection(f *framework.Framework, res connectionResult) {
+	By(fmt.Sprintf("Collecting diagnostics for connection %s -> %s", res.clientPod.Name, res.target.Destination()))
+
+	logrus.WithError(res.err).WithFields(logrus.Fields{
+		"from":   fmt.Sprintf("%s/%s", res.clientPod.Namespace, res.clientPod.Name),
+		"to":     res.target.Destination(),
+		"ns":     res.clientPod.Namespace,
+		"expect": res.expected,
+	}).Error("Error running connection test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, res.clientPod.Namespace, res.clientPod.Name, fmt.Sprintf("%s-container", res.clientPod.Name))
+	if err != nil {
+		logrus.WithError(err).Error("Error getting container logs")
+	}
+	logrus.Infof("[DIAGS] Pod %s/%s logs:\n%s", res.clientPod.Namespace, res.clientPod.Name, logs)
+	prevLogs, err := e2epod.GetPreviousPodLogs(ctx, f.ClientSet, res.clientPod.Namespace, res.clientPod.Name, fmt.Sprintf("%s-container", res.clientPod.Name))
+	if err != nil {
+		logrus.WithError(err).Error("Error getting prev container logs")
+	}
+	logrus.Infof("[DIAGS] Pod %s/%s logs (previous):\n%s", res.clientPod.Namespace, res.clientPod.Name, prevLogs)
+
+	// Get Pod Describe output.
+	podDesc, err := kubectl.RunKubectl(res.clientPod.Namespace, "describe", "pod", res.clientPod.Name)
+	if err != nil {
+		logrus.WithError(err).Error("Error getting pod description")
+	}
+	logrus.Infof("[DIAGS] Pod %s/%s describe:\n%s", res.clientPod.Namespace, res.clientPod.Name, podDesc)
+
+	// // Collect/log Calico diags.
+	// err = calico.LogCalicoDiagsForPodNode(f, res.clientPod.Namespace, res.clientPod.Name)
+	// if err != nil {
+	// 	logrus.WithError(err).Error("Error getting Calico diags")
+	// }
+}
+
+func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
+	// Collect current NetworkPolicies applied in the test namespace.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	policies, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logrus.WithError(err).Infof("error getting current NetworkPolicies for %s namespace", f.Namespace.Name)
+	}
+	logrus.Infof("[DIAGS] NetworkPolicies:\n\t%v", policies.Items)
+
+	if f.Namespace.Name != ns.Name {
+		// If the pod namespace is different from the test namespace, collect the NetworkPolicies for the pod namespace as well.
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		policies, err := f.ClientSet.NetworkingV1().NetworkPolicies(ns.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			logrus.WithError(err).Infof("error getting current NetworkPolicies for %s namespace", ns.Name)
+		}
+		logrus.Infof("[DIAGS] NetworkPolicies (pod NS):\n\t%v", policies.Items)
+	}
+
+	// Collect Calico network policies and heps.
+	nps := &v3.NetworkPolicyList{}
+	gnps := &v3.GlobalNetworkPolicyList{}
+	heps := &v3.HostEndpointList{}
+	logrus.Infof("Current test namespace is %s, but will get policies for all", f.Namespace.Name)
+
+	// TODO:
+	// client, err := calico.NewClient(f)
+	// if err != nil {
+	// 	logrus.WithError(err).Info("error getting calico client")
+	// } else {
+	// 	err = client.List("networkpolicies", "", nps)
+	// 	if err != nil {
+	// 		logrus.WithError(err).Info("error getting current Calico NetworkPolicies")
+	// 	}
+	// 	err = client.List("globalnetworkpolicies", "", gnps)
+	// 	if err != nil {
+	// 		logrus.WithError(err).Info("error getting current Calico GlobalNetworkPolicies")
+	// 	}
+	// 	err = client.List("hostendpoints", "", heps)
+	// 	if err != nil {
+	// 		logrus.WithError(err).Info("error getting current Calico HEPs")
+	// 	}
+	// }
+	logrus.Infof("[DIAGS] Calico NetworkPolicies:\n\t%v", nps.Items)
+	logrus.Infof("[DIAGS] Calico GlobalNetworkPolicies:\n\t%v", gnps.Items)
+	logrus.Infof("[DIAGS] Calico HostEndpoints:\n\t%v", heps.Items)
+
+	// Collect the list of pods running in the test namespace.
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	podsInNS, err := e2epod.GetPodsInNamespace(ctx, f.ClientSet, ns.Name, map[string]string{})
+	if err != nil {
+		logrus.WithError(err).Infof("error getting pods for %s namespace", f.Namespace.Name)
+	}
+	logrus.Infof("[DIAGS] Pods in namespace %s:", ns.Name)
+	for _, p := range podsInNS {
+		logrus.Infof("Namespace: %s, Pod: %s, Status: %s", ns.Name, p.Name, p.Status.String())
+	}
+
+	// Dump debug information for the test namespace.
+	e2eoutput.DumpDebugInfo(context.Background(), f.ClientSet, f.Namespace.Name)
+}
+
+func GenerateRandomName(base string) string {
+	if len(base) > maxGeneratedNameLength {
+		base = base[:maxGeneratedNameLength]
+	}
+	return fmt.Sprintf("%s-%s", base, randomString(randomLength))
+}
+
+func randomString(length int) string {
+	// Generate a random string of the specified length.
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// ExecInPod executes a kubectl command in a pod. Returns the response as a string, or an error upon failure.
+func ExecInPod(pod *v1.Pod, sh, opt, cmd string) (string, error) {
+	return kubectl.RunKubectl(pod.Namespace, "exec", pod.Name, "--", sh, opt, cmd)
+}

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -358,7 +358,7 @@ func (c *connectionTester) runConnection(exp *Expectation, results chan<- connec
 		"output": out,
 		"cmd":    cmd,
 		"err":    err,
-	}).Info("Output from connection attempt.")
+	}).Debug("Output from connection attempt.")
 	result := Success
 	if err != nil {
 		result = Failure

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/images"
+	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace, podName string, ports []int, labels map[string]string, podCustomizer func(pod *v1.Pod), serviceCustomizer func(svc *v1.Service)) (*v1.Pod, *v1.Service) {
+	// Because we have a variable amount of ports, we'll first loop through and generate our Containers for our pod,
+	// and ServicePorts.for our Service.
+	var image string
+	containers := []v1.Container{}
+	servicePorts := []v1.ServicePort{}
+	nodeselector := map[string]string{}
+	imagePull := v1.PullAlways
+
+	if windows.RunningWindowsTest() {
+		windows.MaybeUpdateNamespaceForOpenShift(f, namespace.Name)
+		image = images.Porter
+		nodeselector["kubernetes.io/os"] = "windows"
+		imagePull = v1.PullIfNotPresent
+	} else {
+		image = images.TestWebserver
+		nodeselector["kubernetes.io/os"] = "linux"
+	}
+	for _, port := range ports {
+		args := []string{}
+		if !windows.RunningWindowsTest() {
+			args = []string{fmt.Sprintf("--port=%d", port)}
+		}
+
+		// Build the containers for the server pod.
+		containers = append(containers, v1.Container{
+			Name:            fmt.Sprintf("%s-container-%d", podName, port),
+			Image:           image,
+			ImagePullPolicy: imagePull,
+			Args:            args,
+			Env: []v1.EnvVar{
+				{
+					Name:  fmt.Sprintf("SERVE_PORT_%d", port),
+					Value: "foo",
+				},
+			},
+			Ports: []v1.ContainerPort{
+				{
+					ContainerPort: int32(port),
+					Name:          fmt.Sprintf("serve-%d", port),
+				},
+			},
+			ReadinessProbe: &v1.Probe{
+				ProbeHandler: v1.ProbeHandler{
+					HTTPGet: &v1.HTTPGetAction{
+						Path: "/",
+						Port: intstr.IntOrString{
+							IntVal: int32(port),
+						},
+						Scheme: v1.URISchemeHTTP,
+					},
+				},
+			},
+		})
+
+		// Build the Service Ports for the service.
+		servicePorts = append(servicePorts, v1.ServicePort{
+			Name:       fmt.Sprintf("%s-%d", podName, port),
+			Port:       int32(port),
+			TargetPort: intstr.FromInt(port),
+		})
+	}
+
+	// TODO: Can we remove this now?
+	// Windows 1903 vxlan has an issue on connections between windows node to windows pod.
+	// Turn readiness off if that is the case.
+	if windows.RunningWindowsTest() && windows.DisableReadiness() {
+		logrus.Info("Do not enable readiness check for windows vxlan")
+		for i := range containers {
+			containers[i].ReadinessProbe = nil
+		}
+	}
+
+	newLabels := make(map[string]string)
+	for k, v := range labels {
+		newLabels[k] = v
+	}
+	newLabels["pod-name"] = podName
+
+	By(fmt.Sprintf("Creating a server pod %s in namespace %s", podName, namespace.Name))
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   podName,
+			Labels: newLabels,
+		},
+		Spec: v1.PodSpec{
+			Containers:    containers,
+			RestartPolicy: v1.RestartPolicyNever,
+			NodeSelector:  nodeselector,
+			Tolerations: []v1.Toleration{
+				corev1.Toleration{
+					Key:      "kubernetes.io/arch",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "arm64",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	// Allow customization of the pod spec before creation.
+	if podCustomizer != nil {
+		podCustomizer(pod)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pod, err := f.ClientSet.CoreV1().Pods(namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	logrus.Infof("Created pod %v", pod.ObjectMeta.Name)
+
+	svcName := fmt.Sprintf("svc-%s", podName)
+	By(fmt.Sprintf("Creating a service %s for pod %s in namespace %s", svcName, podName, namespace.Name))
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: svcName,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: servicePorts,
+			Selector: map[string]string{
+				"pod-name": podName,
+			},
+		},
+	}
+
+	if serviceCustomizer != nil {
+		serviceCustomizer(svc)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	svc, err = f.ClientSet.CoreV1().Services(namespace.Name).Create(ctx, svc, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	if !pod.Spec.HostNetwork {
+		// Create an ipv6 service for the pod as well. We do this unconditionally, even on IPv4 only clusters
+		// since it shouldn't cause any issues.
+		ipFamilies := []v1.IPFamily{v1.IPv6Protocol}
+		svcName := v6ServiceName(svcName)
+		policy := v1.IPFamilyPolicyRequireDualStack
+
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: svcName,
+			},
+			Spec: v1.ServiceSpec{
+				Ports: servicePorts,
+				Selector: map[string]string{
+					"pod-name": podName,
+				},
+				IPFamilies:     ipFamilies,
+				IPFamilyPolicy: &policy,
+			},
+		}
+		if serviceCustomizer != nil {
+			serviceCustomizer(svc)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		By(fmt.Sprintf("Creating a service %s for pod %s in namespace %s", svcName, podName, namespace.Name))
+		svc, err = f.ClientSet.CoreV1().Services(namespace.Name).Create(ctx, svc, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return pod, svc
+}
+
+// Return a ipv6 service name based on a ipv4 service name.
+func v6ServiceName(name string) string {
+	return name + "-ipv6"
+}

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -21,15 +21,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/projectcalico/calico/e2e/pkg/utils/images"
-	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/images"
+	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
 )
 
 func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace, podName string, ports []int, labels map[string]string, podCustomizer func(pod *v1.Pod), serviceCustomizer func(svc *v1.Service)) (*v1.Pod, *v1.Service) {

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -99,7 +99,7 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 	// Windows 1903 vxlan has an issue on connections between windows node to windows pod.
 	// Turn readiness off if that is the case.
 	if windows.RunningWindowsTest() && windows.DisableReadiness() {
-		logrus.Info("Do not enable readiness check for windows vxlan")
+		logrus.Debug("Do not enable readiness check for windows vxlan")
 		for i := range containers {
 			containers[i].ReadinessProbe = nil
 		}

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -42,7 +42,7 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 	nodeselector := map[string]string{}
 	imagePull := v1.PullAlways
 
-	if windows.RunningWindowsTest() {
+	if windows.ClusterIsWindows() {
 		windows.MaybeUpdateNamespaceForOpenShift(f, namespace.Name)
 		image = images.Porter
 		nodeselector["kubernetes.io/os"] = "windows"
@@ -53,7 +53,7 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 	}
 	for _, port := range ports {
 		args := []string{}
-		if !windows.RunningWindowsTest() {
+		if !windows.ClusterIsWindows() {
 			args = []string{fmt.Sprintf("--port=%d", port)}
 		}
 

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -17,6 +17,7 @@ package conncheck
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -89,20 +90,8 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 		})
 	}
 
-	// TODO: Can we remove this now?
-	// Windows 1903 vxlan has an issue on connections between windows node to windows pod.
-	// Turn readiness off if that is the case.
-	if windows.RunningWindowsTest() && windows.DisableReadiness() {
-		logrus.Debug("Do not enable readiness check for windows vxlan")
-		for i := range containers {
-			containers[i].ReadinessProbe = nil
-		}
-	}
-
 	newLabels := make(map[string]string)
-	for k, v := range labels {
-		newLabels[k] = v
-	}
+	maps.Copy(newLabels, labels)
 	newLabels["pod-name"] = podName
 
 	By(fmt.Sprintf("Creating a server pod %s in namespace %s", podName, namespace.Name))

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -62,12 +62,6 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 			Image:           image,
 			ImagePullPolicy: imagePull,
 			Args:            args,
-			Env: []v1.EnvVar{
-				{
-					Name:  fmt.Sprintf("SERVE_PORT_%d", port),
-					Value: "foo",
-				},
-			},
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: int32(port),

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -43,7 +43,6 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 	imagePull := v1.PullAlways
 
 	if windows.ClusterIsWindows() {
-		windows.MaybeUpdateNamespaceForOpenShift(f, namespace.Name)
 		image = images.Porter
 		nodeselector["kubernetes.io/os"] = "windows"
 		imagePull = v1.PullIfNotPresent

--- a/e2e/pkg/utils/conncheck/server.go
+++ b/e2e/pkg/utils/conncheck/server.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func NewServer(name string, ns *v1.Namespace, opts ...ServerOption) *Server {
+	if ns == nil {
+		msg := fmt.Sprintf("Namespace is required for server %s", name)
+		framework.Fail(msg, 1)
+	}
+	if name == "" {
+		msg := fmt.Sprintf("Name is required for server in namespace %s", ns.Name)
+		framework.Fail(msg, 1)
+	}
+	s := &Server{
+		name:      name,
+		namespace: ns,
+		ports:     []int{80},
+	}
+	for _, opt := range opts {
+		_ = opt(s)
+	}
+	return s
+}
+
+type Server struct {
+	name          string
+	namespace     *v1.Namespace
+	ports         []int
+	labels        map[string]string
+	pod           *v1.Pod
+	service       *v1.Service
+	podCustomizer func(*v1.Pod)
+	svcCustomizer func(*v1.Service)
+}
+
+func (s *Server) ID() string {
+	return fmt.Sprintf("%s/%s", s.namespace.Name, s.name)
+}
+
+func (s *Server) Name() string {
+	return s.name
+}
+
+func (s *Server) Pod() *v1.Pod {
+	if s.pod == nil {
+		msg := fmt.Sprintf("No pod is running for server %s/%s", s.namespace.Name, s.name)
+		framework.Fail(msg, 1)
+	}
+	return s.pod
+}
+
+func (s *Server) Service() *v1.Service {
+	if s.service == nil {
+		msg := fmt.Sprintf("No service is running for server %s/%s", s.namespace.Name, s.name)
+		framework.Fail(msg, 1)
+	}
+	return s.service
+}
+
+// ClusterIPs returns a list of targets that can be used to connect to the service's ClusterIPs, if
+// there are multiple (e.g., for dual-stack services).
+func (s *Server) ClusterIPs() []Target {
+	var targets []Target
+	for _, ip := range s.Service().Spec.ClusterIPs {
+		targets = append(targets, &target{
+			server:      s,
+			targetType:  TypeClusterIP,
+			destination: ip,
+			protocol:    TCP,
+		})
+	}
+	return targets
+}
+
+// ClusterIP returns a target that can be used to connect to the service's Spec.ClusterIP.
+// Most callers should use ClusterIPs() instead in order to test both IPv4 and IPv6 (when enabled).
+func (s *Server) ClusterIP() Target {
+	return &target{
+		server:      s,
+		targetType:  TypeClusterIP,
+		destination: s.Service().Spec.ClusterIP,
+		protocol:    TCP,
+	}
+}
+
+// NodePortPort returns port number of a NodePort service associated with the server.
+func (s *Server) NodePortPort() int {
+	svc := s.Service()
+	if svc.Spec.Type != v1.ServiceTypeNodePort {
+		msg := fmt.Sprintf("Service running for server %s/%s is not NodePort type", s.namespace.Name, s.name)
+		framework.Fail(msg, 1)
+	}
+
+	return int(svc.Spec.Ports[0].NodePort)
+}
+
+// NodePort returns a target that can be used to connect to the service's NodePort.
+// Callers should pass in the IP of a cluster node.
+func (s *Server) NodePort(nodeIP string) Target {
+	return &target{
+		server:      s,
+		targetType:  TypeNodePort,
+		destination: nodeIP,
+		port:        s.NodePortPort(),
+		protocol:    TCP,
+	}
+}
+
+// ICMP returns a target that can be used to connect to the pod's IP directly using ICMP.
+func (s *Server) ICMP() Target {
+	return &target{
+		server:      s,
+		targetType:  TypePodIP,
+		destination: s.Pod().Status.PodIP,
+		protocol:    ICMP,
+	}
+}
+
+// ServiceDomain returns a target that can be used to connect to the service via DNS lookup.
+func (s *Server) ServiceDomain(opts ...TargetOption) Target {
+	t := &target{
+		server:      s,
+		targetType:  TypeService,
+		destination: fmt.Sprintf("%s.%s", s.Service().Name, s.Service().Namespace),
+		protocol:    TCP,
+	}
+	for _, opt := range opts {
+		if err := opt(t); err != nil {
+			framework.ExpectNoError(err)
+		}
+	}
+	return t
+}
+
+type ServerOption func(*Server) error
+
+func WithServerLabels(labels map[string]string) ServerOption {
+	return func(c *Server) error {
+		c.labels = labels
+		return nil
+	}
+}
+
+func WithHostNetworking() ServerOption {
+	return func(c *Server) error {
+		if c.podCustomizer != nil {
+			return fmt.Errorf("Customizer already set")
+		}
+		c.podCustomizer = func(pod *v1.Pod) {
+			pod.Spec.HostNetwork = true
+		}
+		return nil
+	}
+}
+
+func WithServerPodCustomizer(customizer func(*v1.Pod)) ServerOption {
+	return func(c *Server) error {
+		if c.podCustomizer != nil {
+			return fmt.Errorf("Pod customizer already set")
+		}
+		c.podCustomizer = customizer
+		return nil
+	}
+}
+
+func WithServerSvcCustomizer(customizer func(*v1.Service)) ServerOption {
+	return func(c *Server) error {
+		if c.svcCustomizer != nil {
+			return fmt.Errorf("Service customizer already set")
+		}
+		c.svcCustomizer = customizer
+		return nil
+	}
+}
+
+func WithPorts(ports ...int) ServerOption {
+	return func(c *Server) error {
+		c.ports = ports
+		return nil
+	}
+}

--- a/e2e/pkg/utils/conncheck/target.go
+++ b/e2e/pkg/utils/conncheck/target.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type Protocol string
+
+const (
+	ICMP Protocol = "ICMP"
+	TCP  Protocol = "TCP"
+	HTTP Protocol = "HTTP"
+)
+
+// AccessType represents how the target is accessed. A Kubenretes pod can be accessed in a variety of ways, such as
+// via a Service (ClusterIP, ServiceDNS), directly via its IP (PodIP). Some targets are not backed by a pod, such as
+// a domain name.
+type AccessType string
+
+const (
+	// TypeClusterIP represents a target that is accessed via the service's cluster IP.
+	TypeClusterIP AccessType = "ClusterIP"
+
+	// TypePodIP represents a target that is accessed via the pod's real IP address.
+	TypePodIP AccessType = "PodIP"
+
+	// TypeService represents a target that is accessed via the service's in-cluster DNS name.
+	TypeService AccessType = "ServiceDNS"
+
+	// TypeDomain represents a target that is accessed via a domain name. Typically used for external services.
+	TypeDomain AccessType = "Domain"
+
+	// TypeNodePort represents a target that is accessed via the service's NodePort.
+	TypeNodePort AccessType = "NodePort"
+)
+
+type Target interface {
+	// String returns a human-readable name for the target.
+	String() string
+
+	// Destination returns the destination of the target, combining the IP/hostname and port (if set).
+	Destination() string
+
+	// AccessType returns the way in which the target is accessed. e.g., ClusterIP, PodIP, ServiceDNS, Domain.
+	AccessType() string
+
+	// GetProtocol returns the protocol of the target.
+	GetProtocol() Protocol
+
+	// Port sets the port of the target to the given value.
+	Port(int) Target
+
+	// HTTPParams returns the HTTP Request set on the target.
+	HTTPParams() *HTTPParams
+}
+
+var _ Target = &target{}
+
+type target struct {
+	server      *Server
+	destination string
+	port        int
+	protocol    Protocol
+	targetType  AccessType
+	http        *HTTPParams
+}
+
+func (t *target) Destination() string {
+	if t.port != 0 {
+		return fmt.Sprintf("%s:%d", t.destination, t.port)
+	}
+	return t.destination
+}
+
+func (t *target) GetProtocol() Protocol {
+	return t.protocol
+}
+
+// String returns a human-readable name for the target.
+func (t *target) String() string {
+	if t.server != nil {
+		chunks := []string{
+			fmt.Sprintf("%s/%s", t.server.Pod().Namespace, t.server.Pod().Name),
+		}
+		if t.port != 0 {
+			chunks = append(chunks, fmt.Sprintf("%d", t.port))
+		}
+		if t.http != nil {
+			sha := sha1.New()
+			sha.Write([]byte(fmt.Sprintf("%s:%s %v", t.http.Method, t.http.Path, t.http.Headers)))
+			chunks = append(chunks, base64.URLEncoding.EncodeToString(sha.Sum(nil))[:7])
+		}
+		return strings.Join(chunks, ":")
+	}
+	return t.Destination()
+}
+
+func (t *target) AccessType() string {
+	return string(t.targetType)
+}
+
+func (t *target) Port(i int) Target {
+	t.port = i
+	return t
+}
+
+func (t *target) HTTPParams() *HTTPParams {
+	return t.http
+}
+
+func NewDomainTarget(dst string) Target {
+	return &target{
+		destination: dst,
+		targetType:  TypeDomain,
+		protocol:    TCP,
+	}
+}
+
+func NewPodPingTarget(pod *v1.Pod) Target {
+	return &target{
+		destination: pod.Status.PodIP,
+		targetType:  TypePodIP,
+		protocol:    ICMP,
+	}
+}
+
+func NewTarget(dst string, targetType AccessType, proto Protocol) Target {
+	return &target{
+		destination: dst,
+		targetType:  targetType,
+		protocol:    proto,
+	}
+}
+
+type TargetOption func(*target) error
+
+type HTTPParams struct {
+	Method  string
+	Path    string
+	Headers []string
+}
+
+func WithHTTP(method, path string, headers []string) TargetOption {
+	return func(t *target) error {
+		t.protocol = HTTP
+		t.http = &HTTPParams{
+			Method:  method,
+			Path:    path,
+			Headers: headers,
+		}
+		return nil
+	}
+}

--- a/e2e/pkg/utils/e2ecfg/config.go
+++ b/e2e/pkg/utils/e2ecfg/config.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2ecfg
+
+import "os"
+
+type configType struct {
+	envVarName   string
+	helpText     string
+	defaultValue string
+	actualValue  string
+	envValue     string
+	cmdLineValue string
+}
+
+const (
+	remoteKubeConfig = "REMOTE_KUBECONFIG"
+)
+
+var config = map[string]*configType{
+	remoteKubeConfig: {
+		envVarName:   remoteKubeConfig,
+		helpText:     "The fully qualified path to the admin kubeconfig file of the remote cluster.",
+		defaultValue: "",
+	},
+}
+
+func RemoteClusterKubeconfig() string {
+	return config[remoteKubeConfig].actualValue
+}
+
+func init() {
+	// Load defaults and env variables
+	for _, c := range config {
+		if ev, exists := os.LookupEnv(c.envVarName); exists {
+			if ev == "" {
+				c.envValue = "<empty-string>"
+			} else {
+				c.envValue = ev
+			}
+		} else if c.defaultValue != "" {
+			_ = os.Setenv(c.envVarName, os.ExpandEnv(c.defaultValue))
+		}
+	}
+	for _, c := range config {
+		if ev, exists := os.LookupEnv(c.envVarName); exists && ev != "" {
+			c.actualValue = os.ExpandEnv(ev)
+		} else {
+			c.actualValue = os.ExpandEnv(c.defaultValue)
+		}
+	}
+}

--- a/e2e/pkg/utils/e2ecfg/config.go
+++ b/e2e/pkg/utils/e2ecfg/config.go
@@ -105,10 +105,10 @@ func AfterReadingAllFlags() {
 	}
 
 	// And log out the values of all config options.
-	logrus.Infof("Running tests with the following user-specified configuration:")
+	logrus.Infof("Running tests with the following configuration:")
 	for _, c := range allConfigOptions {
 		if c.actualValue != "" {
-			logrus.Infof("  %s => %s", c.envVarName, c.actualValue)
+			logrus.Infof("%s => %s", c.envVarName, c.actualValue)
 		}
 	}
 }

--- a/e2e/pkg/utils/framework.go
+++ b/e2e/pkg/utils/framework.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+	admission "k8s.io/pod-security-admission/api"
+)
+
+// The default pod security admission level for a test namespace is restricted in most managed public cloud.
+// The PodSecurity admission controller sets annotation "pod-security.kubernetes.io/enforce: restricted" on
+// a test namespace. This will block e2e to create any pod without a restricted security context.
+// We need to set admission level to priviledged for any test namespace to work around this issue.
+func NewDefaultFramework(name string) *framework.Framework {
+	f := framework.NewDefaultFramework(name)
+	f.NamespacePodSecurityEnforceLevel = admission.LevelPrivileged
+	return f
+}

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package images
+
+import (
+	"os"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	Alpine        = "docker.io/alpine:3"
+	Porter        = "calico/porter"
+	TestWebserver = "k8s.gcr.io/test-webserver:1.0"
+)
+
+// Get client image and powershell command based on windows OS version
+func WindowsClientImage() string {
+	opsys := os.Getenv("WINDOWS_OS")
+	if opsys == "" {
+		framework.Failf("WINDOWS_OS env not specified. Please set env properly")
+		return ""
+	}
+	if opsys == "1809" || opsys == "1909" || opsys == "1903" || opsys == "2004" || opsys == "20H2" {
+		return "mcr.microsoft.com/windows/servercore:" + opsys
+	} else if opsys == "2022" {
+		// For 2022, servercore uses "ltsc2022" and does not have the image tag
+		// "2022" (unlike previous Windows versions).
+		return "mcr.microsoft.com/windows/servercore:ltsc2022"
+	} else {
+		framework.Failf("Windows OS version currently not supported: %s", opsys)
+	}
+	return ""
+}

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -23,7 +23,7 @@ import (
 const (
 	Alpine        = "docker.io/alpine:3"
 	Porter        = "calico/porter"
-	TestWebserver = "k8s.gcr.io/test-webserver:1.0"
+	TestWebserver = "gcr.io/kubernetes-e2e-test-images/test-webserver:1.0"
 )
 
 // Get client image and powershell command based on windows OS version

--- a/e2e/pkg/utils/platforms.go
+++ b/e2e/pkg/utils/platforms.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	v1 "github.com/tigera/operator/api/v1"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/client"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func IsOpenShift(f *framework.Framework) bool {
+	// Create a client to the API server.
+	cli, err := client.New(f.ClientConfig())
+	Expect(err).NotTo(HaveOccurred())
+
+	// Query Installation object to check if we are running on OpenShift.
+	installs := &v1.InstallationList{}
+	err = cli.List(context.TODO(), installs)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, inst := range installs.Items {
+		if inst.Spec.KubernetesProvider == v1.ProviderOpenShift {
+			return true
+		}
+	}
+	return false
+}

--- a/e2e/pkg/utils/platforms.go
+++ b/e2e/pkg/utils/platforms.go
@@ -19,9 +19,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	v1 "github.com/tigera/operator/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/projectcalico/calico/e2e/pkg/utils/client"
-	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 func IsOpenShift(f *framework.Framework) bool {

--- a/e2e/pkg/utils/remotecluster/exec.go
+++ b/e2e/pkg/utils/remotecluster/exec.go
@@ -18,10 +18,9 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/calico/e2e/pkg/config"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
-
-	"github.com/projectcalico/calico/e2e/pkg/utils/e2ecfg"
 )
 
 const RemoteClusterNamespacePrefix = "rmt-"
@@ -38,7 +37,7 @@ func IsRemoteClusterFramework(f *framework.Framework) bool {
 // RemoteFrameworkAwareExec should be embedded into existing utilities so that developers do not need to think about
 // which functions do not use f.ClientSet when writing tests for remote clusters.
 func RemoteFrameworkAwareExec(f *framework.Framework, fn func()) {
-	if IsRemoteClusterFramework(f) && e2ecfg.RemoteClusterKubeconfig() != "" {
+	if IsRemoteClusterFramework(f) && config.RemoteClusterKubeconfig() != "" {
 		// Capture the original kubeconfig path and host, defer their reset.
 		originalKubeconfig := framework.TestContext.KubeConfig
 		originalHost := framework.TestContext.Host
@@ -48,7 +47,7 @@ func RemoteFrameworkAwareExec(f *framework.Framework, fn func()) {
 		}()
 
 		// Resolve the new kubeconfig path.
-		newKubeconfigPath := e2ecfg.RemoteClusterKubeconfig()
+		newKubeconfigPath := config.RemoteClusterKubeconfig()
 
 		// Resolve the new host.
 		newKubeconfig, err := clientcmd.LoadFromFile(newKubeconfigPath)

--- a/e2e/pkg/utils/remotecluster/exec.go
+++ b/e2e/pkg/utils/remotecluster/exec.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotecluster
+
+import (
+	"strings"
+
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/calico/e2e/pkg/utils/e2ecfg"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const RemoteClusterNamespacePrefix = "rmt-"
+
+func IsRemoteClusterFramework(f *framework.Framework) bool {
+	return f != nil && f.Namespace != nil && strings.HasPrefix(f.Namespace.Name, RemoteClusterNamespacePrefix)
+}
+
+// RemoteFrameworkAwareExec is used to execute commands in a context that forces the executed function to utilize the
+// remote kubeconfig. While the framework.Framework returned by NewDefaultFrameworkForRemoteCluster automatically
+// ensures that actions are executed against the remote cluster in most cases, some cases cannot be handled purely by
+// the modified framework.Framework object. These cases typically occur when commands are executed against a cluster
+// without the use of the f.ClientSet, like when running kubectl commands or building a k8s calico client. Usages of
+// RemoteFrameworkAwareExec should be embedded into existing utilities so that developers do not need to think about
+// which functions do not use f.ClientSet when writing tests for remote clusters.
+func RemoteFrameworkAwareExec(f *framework.Framework, fn func()) {
+	if IsRemoteClusterFramework(f) && e2ecfg.RemoteClusterKubeconfig() != "" {
+		// Capture the original kubeconfig path and host, defer their reset.
+		originalKubeconfig := framework.TestContext.KubeConfig
+		originalHost := framework.TestContext.Host
+		defer func() {
+			framework.TestContext.KubeConfig = originalKubeconfig
+			framework.TestContext.Host = originalHost
+		}()
+
+		// Resolve the new kubeconfig path.
+		newKubeconfigPath := e2ecfg.RemoteClusterKubeconfig()
+
+		// Resolve the new host.
+		newKubeconfig, err := clientcmd.LoadFromFile(newKubeconfigPath)
+		Expect(err).NotTo(HaveOccurred())
+		var newKubeconfigContext string
+		if strings.Contains(newKubeconfig.CurrentContext, "@") {
+			// Some generated kubeconfigs will include a username in the context string.
+			newKubeconfigContext = strings.Split(newKubeconfig.CurrentContext, "@")[1]
+		} else {
+			newKubeconfigContext = newKubeconfig.CurrentContext
+		}
+		cluster := newKubeconfig.Clusters[newKubeconfigContext]
+		Expect(cluster).NotTo(BeNil())
+		newHost := cluster.Server
+
+		// Set the new kubeconfig path and host.
+		framework.TestContext.KubeConfig = newKubeconfigPath
+		framework.TestContext.Host = newHost
+	}
+
+	// Execute the passed function.
+	fn()
+}

--- a/e2e/pkg/utils/remotecluster/exec.go
+++ b/e2e/pkg/utils/remotecluster/exec.go
@@ -18,9 +18,10 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
-	"github.com/projectcalico/calico/e2e/pkg/utils/e2ecfg"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/e2ecfg"
 )
 
 const RemoteClusterNamespacePrefix = "rmt-"

--- a/e2e/pkg/utils/remotecluster/exec.go
+++ b/e2e/pkg/utils/remotecluster/exec.go
@@ -18,9 +18,10 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
-	"github.com/projectcalico/calico/e2e/pkg/config"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/config"
 )
 
 const RemoteClusterNamespacePrefix = "rmt-"

--- a/e2e/pkg/utils/windows/windows.go
+++ b/e2e/pkg/utils/windows/windows.go
@@ -38,8 +38,12 @@ import (
 // Map to store serviceName and respective endpointIP
 var ServiceEndpointIP = map[string]string{}
 
-// Check if we are running windows specific test cases.
-func RunningWindowsTest() bool {
+// ClusterIsWindows returns true if the cluster supports running Windows tests and false otherwise.
+//
+// TODO: Right now, we assume that the presence of "RunsOnWindows" in the focus strings means
+// that the tests are running on a Windows cluster. This isn't necessarily true. We could be more
+// precise by either checking the cluster itself, or adding a CLi flag to control this behavior.
+func ClusterIsWindows() bool {
 	cfg, _ := ginkgo.GinkgoConfiguration()
 	for _, s := range cfg.FocusStrings {
 		if strings.Contains(s, "RunsOnWindows") {
@@ -55,7 +59,7 @@ func RunningWindowsTest() bool {
 // TODO(lmm): Once we have moved away from using Windows Machine Config
 // Bootstrapper to provision OCP Windows nodes, we should delete this.
 func MaybeUpdateNamespaceForOpenShift(f *framework.Framework, nsName string) {
-	if utils.IsOpenShift(f) && RunningWindowsTest() {
+	if utils.IsOpenShift(f) && ClusterIsWindows() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		ns, err := f.ClientSet.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})

--- a/e2e/pkg/utils/windows/windows.go
+++ b/e2e/pkg/utils/windows/windows.go
@@ -22,7 +22,6 @@ package windows
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -79,11 +78,6 @@ func MaybeUpdateNamespaceForOpenShift(f *framework.Framework, nsName string) {
 			logrus.Infof("Labels on namespace %q updated", ns.Name)
 		}
 	}
-}
-
-// Temporarily disable readiness check for windows cluster if flag is set.
-func DisableReadiness() bool {
-	return os.Getenv("WINDOWS_DISABLE_READINESS") == "true"
 }
 
 // This is a hack for windows to use EndpointIP instead of service's

--- a/e2e/pkg/utils/windows/windows.go
+++ b/e2e/pkg/utils/windows/windows.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2018 Tigera, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package makes public methods out of some of the utility methods for testing windows cluster found at test/e2e/network_policy.go
+// Eventually these utilities should replace those and be used for any calico tests
+
+package windows
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/calico/e2e/pkg/utils"
+
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// Map to store serviceName and respective endpointIP
+var ServiceEndpointIP = map[string]string{}
+
+// Check if we are running windows specific test cases.
+func RunningWindowsTest() bool {
+	cfg, _ := ginkgo.GinkgoConfiguration()
+	for _, s := range cfg.FocusStrings {
+		if strings.Contains(s, "RunsOnWindows") {
+			return true
+		}
+	}
+	return false
+}
+
+// For Windows on OpenShift, pods scheduled for non-default namespaces must
+// disable SCC. See: https://bugzilla.redhat.com/show_bug.cgi?id=1768858
+//
+// TODO(lmm): Once we have moved away from using Windows Machine Config
+// Bootstrapper to provision OCP Windows nodes, we should delete this.
+func MaybeUpdateNamespaceForOpenShift(f *framework.Framework, nsName string) {
+	if utils.IsOpenShift(f) && RunningWindowsTest() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		ns, err := f.ClientSet.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+		if err != nil {
+			err = fmt.Errorf("could not get namespace for Windows test on OpenShift: %w", err)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		logrus.Info("Running Windows test on OpenShift, checking if namespace label 'openshift.io/run-level: 1'...")
+		// Check if we need to update the ns or not
+		if v, ok := ns.Labels["openshift.io/run-level"]; !ok || v != "1" {
+			ns.Labels["openshift.io/run-level"] = "1"
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_, err := f.ClientSet.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+			if err != nil {
+				err = fmt.Errorf("could not update namespace for Windows test on OpenShift: %w", err)
+			}
+			Expect(err).NotTo(HaveOccurred())
+			logrus.Infof("Labels on namespace %q updated", ns.Name)
+		}
+	}
+}
+
+// Temporarily disable readiness check for windows cluster if flag is set.
+func DisableReadiness() bool {
+	return os.Getenv("WINDOWS_DISABLE_READINESS") == "true"
+}
+
+// This is a hack for windows to use EndpointIP instead of service's
+// ClusterIP, Since we have known issue with service's ClusterIP
+func GetTarget(f *framework.Framework, service *v1.Service, targetPort int) (string, string) {
+	var targetIP string
+	// check if serviceEndpointIP is already present in map,else
+	// raise a request to get it
+	key := fmt.Sprintf("%s-%s", service.Namespace, service.Name)
+	if ip, exist := ServiceEndpointIP[key]; exist {
+		targetIP = ip
+	} else {
+		targetIP = getServiceEndpointIP(f, service.Namespace, service.Name)
+		ServiceEndpointIP[key] = targetIP
+	}
+	serviceTarget := fmt.Sprintf("http://%s:%d", service.Spec.ClusterIP, targetPort)
+	podTarget := fmt.Sprintf("http://%s:%d", targetIP, targetPort)
+	fmt.Printf("podTarget :%s and serviceTarget :%s \n", podTarget, serviceTarget)
+	return podTarget, serviceTarget
+}
+
+// Since we have a known issue related to service ClusterIP on windows,hence using EndpointIP
+// to connect
+func getServiceEndpointIP(f *framework.Framework, svcNSName string, svcName string) string {
+	var err error
+	err = framework.WaitForServiceEndpointsNum(context.Background(), f.ClientSet, svcNSName, svcName, 1, time.Second, 60*time.Second)
+	if err != nil {
+		framework.Failf("Unable to get endpoint for service %s: %v", svcName, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	endpoint, err := f.ClientSet.CoreV1().Endpoints(svcNSName).Get(ctx, svcName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(endpoint.Subsets).To(HaveLen(1), fmt.Sprintf("Failed to find endpoint subset for service %s", svcName))
+	Expect(endpoint.Subsets[0].Addresses).To(HaveLen(1), fmt.Sprintf("Failed to find endpoint address for service %s", svcName))
+	endpointIP := endpoint.Subsets[0].Addresses[0].IP
+	logrus.Infof("ServiceName: %s endpointIP: %s.", svcName, endpointIP)
+	return endpointIP
+}
+
+// function to cleanup ServiceName and EndpointIP map
+func CleanupServiceEndpointMap() {
+	for i := range ServiceEndpointIP {
+		delete(ServiceEndpointIP, i)
+	}
+}

--- a/e2e/pkg/utils/windows/windows.go
+++ b/e2e/pkg/utils/windows/windows.go
@@ -28,13 +28,12 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/projectcalico/calico/e2e/pkg/utils"
-
 	"github.com/sirupsen/logrus"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils"
 )
 
 // Map to store serviceName and respective endpointIP

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tchap/go-patricia/v2 v2.3.2
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
+	github.com/tigera/operator/api v0.0.0-20250729225329-a4e446dfb054
 	github.com/vishvananda/netlink v1.3.1-0.20250303224720-0e7078ed04c8
 	go.etcd.io/etcd/api/v3 v3.5.21
 	go.etcd.io/etcd/client/pkg/v3 v3.5.21
@@ -116,7 +117,7 @@ require (
 	k8s.io/kube-aggregator v0.32.6
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f
 	k8s.io/kubernetes v1.32.6
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	modernc.org/memory v1.10.0
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/kind v0.27.0
@@ -366,11 +367,13 @@ require (
 	k8s.io/kubectl v0.32.6 // indirect
 	k8s.io/kubelet v0.32.6 // indirect
 	k8s.io/mount-utils v0.32.6 // indirect
-	k8s.io/pod-security-admission v0.32.6 // indirect
+	k8s.io/pod-security-admission v0.32.6
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
-	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 )
+
+require github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 // indirect
 
 replace (
 	github.com/projectcalico/api => ./api

--- a/go.mod
+++ b/go.mod
@@ -373,11 +373,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 )
 
-require (
-	github.com/go-logr/zapr v1.3.0 // indirect
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-)
+require github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 // indirect
 
 replace (
 	github.com/projectcalico/api => ./api

--- a/go.mod
+++ b/go.mod
@@ -373,7 +373,11 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 )
 
-require github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 // indirect
+require (
+	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
+)
 
 replace (
 	github.com/projectcalico/api => ./api

--- a/go.sum
+++ b/go.sum
@@ -643,6 +643,8 @@ github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba h1:aaF2byUCZ
 github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba/go.mod h1:q8EdCgBdMQzgiX/uk4GXLWLk+gIHd1a7mWUAamJKDb4=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:Jt2Pic9dxgJisekm8q2WV9FaWxUJhhRfwHSP640drww=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1 h1:DP+PUNVOc+Bkft8a4QunLzaZ0RspWuD3tBbcPHr2PeE=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1/go.mod h1:6x4x0t9BP35g4XcjkHE9EB3RxhyfxpdpmZKd/Qyk8+M=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -724,6 +726,8 @@ github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae h1:vgGSvdW5Lqg+I1
 github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae/go.mod h1:quDq6Se6jlGwiIKia/itDZxqC5rj6/8OdFyMMAwTxCs=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
+github.com/tigera/operator/api v0.0.0-20250729225329-a4e446dfb054 h1:wWh3xiy/Ws88YjEXELit9ll0EJwFf40nkl4yXfshbUI=
+github.com/tigera/operator/api v0.0.0-20250729225329-a4e446dfb054/go.mod h1:VHTGNLahatombm93XGzp3ikt3dCaZVqWEEt6o38ZLZA=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
@@ -1053,8 +1057,8 @@ k8s.io/pod-security-admission v0.32.6 h1:LQQ9y3ZWAMi5dzK/0vBCYaFtzCJqPxhe+wVJAub
 k8s.io/pod-security-admission v0.32.6/go.mod h1:IBllTyNB/i9J46zCcXc1C1rvoCa2PifIvaNxNt5RrXQ=
 k8s.io/sample-apiserver v0.32.6 h1:q3+eiqYLyenLdrFKE+u/xNH+4SkO5/YrxMJwIZbShNo=
 k8s.io/sample-apiserver v0.32.6/go.mod h1:6742mJ4w+XhJ7tR/3P1RBxZkdaPTHfYO06kxxDYfBD8=
-k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
-k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=
 modernc.org/mathutil v1.7.1/go.mod h1:4p5IwJITfppl0G4sUEDtCr4DthTaT47/N3aT6MhfgJg=
 modernc.org/memory v1.10.0 h1:fzumd51yQ1DxcOxSO+S6X7+QTuVU+n8/Aj7swYjFfC4=
@@ -1063,8 +1067,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
-sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
-sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
+sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
+sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.27.0 h1:PQ3f0iAWNIj66LYkZ1ivhEg/+Zb6UPMbO+qVei/INZA=
 sigs.k8s.io/kind v0.27.0/go.mod h1:RZVFmy6qcwlSWwp6xeIUv7kXCPF3i8MXsEXxW/J+gJY=
 sigs.k8s.io/knftables v0.0.18 h1:6Duvmu0s/HwGifKrtl6G3AyAPYlWiZqTgS8bkVMiyaE=
@@ -1075,7 +1079,7 @@ sigs.k8s.io/kustomize/kyaml v0.18.1 h1:WvBo56Wzw3fjS+7vBjN6TeivvpbW9GmRaWZ9CIVmt
 sigs.k8s.io/kustomize/kyaml v0.18.1/go.mod h1:C3L2BFVU1jgcddNBE1TxuVLgS46TjObMwW5FT9FcjYo=
 sigs.k8s.io/network-policy-api v0.1.5 h1:xyS7VAaM9EfyB428oFk7WjWaCK6B129i+ILUF4C8l6E=
 sigs.k8s.io/network-policy-api v0.1.5/go.mod h1:D7Nkr43VLNd7iYryemnj8qf0N/WjBzTZDxYA+g4u1/Y=
-sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aNqRlpuvjmwA=
-sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
+sigs.k8s.io/structured-merge-diff/v4 v4.5.0 h1:nbCitCK2hfnhyiKo6uf2HxUPTCodY6Qaf85SbDIaMBk=
+sigs.k8s.io/structured-merge-diff/v4 v4.5.0/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,6 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esuG4MuU0Pjs5y6iknohY=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
-github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
-github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
@@ -942,8 +940,6 @@ golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uI
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
-gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
-gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/api v0.215.0 h1:jdYF4qnyczlEz2ReWIsosNLDuzXyvFHJtI5gcr0J7t0=
 google.golang.org/api v0.215.0/go.mod h1:fta3CVtuJYOEdugLNWm6WodzOS8KdFckABwN4I40hzY=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esuG4MuU0Pjs5y6iknohY=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
+github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
+github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
@@ -940,6 +942,8 @@ golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uI
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/api v0.215.0 h1:jdYF4qnyczlEz2ReWIsosNLDuzXyvFHJtI5gcr0J7t0=
 google.golang.org/api v0.215.0/go.mod h1:fta3CVtuJYOEdugLNWm6WodzOS8KdFckABwN4I40hzY=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We've had a suite of e2e tests maintained separately for some time now.

This PR is the first of several to start moving those here, which should allow us to more easily manage them and also run them pre-commit as part of CI like we do for upstream e2es.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.