### PR TITLE
Fine grained resource selection

### DIFF
--- a/libcalico-go/lib/backend/etcdv3/conversion.go
+++ b/libcalico-go/lib/backend/etcdv3/conversion.go
@@ -82,6 +82,11 @@ func convertWatchEvent(e *clientv3.Event, l model.ListInterface) (*api.WatchEven
 		return nil, nil
 	}
 
+	// "projectcalico.org/kind" label is expected for certain resources
+	// for selection
+	model.AddKindLabel(oldKV)
+	model.AddKindLabel(newKV)
+
 	return &api.WatchEvent{
 		Old:  oldKV,
 		New:  newKV,
@@ -89,9 +94,7 @@ func convertWatchEvent(e *clientv3.Event, l model.ListInterface) (*api.WatchEven
 	}, nil
 }
 
-var (
-	ErrMissingValue = fmt.Errorf("missing etcd KV")
-)
+var ErrMissingValue = fmt.Errorf("missing etcd KV")
 
 // etcdToKVPair converts an etcd KeyValue into model.KVPair.
 func etcdToKVPair(key model.Key, ekv *mvccpb.KeyValue) (*model.KVPair, error) {

--- a/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
@@ -285,6 +285,7 @@ var _ = Describe("Test Pod conversion", func() {
 			"labelB":                         "valueB",
 			"projectcalico.org/namespace":    "default",
 			"projectcalico.org/orchestrator": "k8s",
+			"projectcalico.org/kind":         libapiv3.KindWorkloadEndpoint,
 		}
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).ObjectMeta.Labels).To(Equal(expectedLabels))
 
@@ -960,6 +961,7 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).ObjectMeta.Labels).To(Equal(map[string]string{
 			"projectcalico.org/namespace":    "default",
 			"projectcalico.org/orchestrator": "k8s",
+			"projectcalico.org/kind":         libapiv3.KindWorkloadEndpoint,
 		}))
 
 		// Assert the interface name is fixed.  The calculation of this name should be consistent
@@ -1048,6 +1050,7 @@ var _ = Describe("Test Pod conversion", func() {
 			"labelB":                         "valueB",
 			"projectcalico.org/namespace":    "default",
 			"projectcalico.org/orchestrator": "k8s",
+			"projectcalico.org/kind":         libapiv3.KindWorkloadEndpoint,
 			apiv3.LabelServiceAccount:        "sa-test",
 		}
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).ObjectMeta.Labels).To(Equal(expectedLabels))
@@ -1122,6 +1125,7 @@ var _ = Describe("Test Pod conversion", func() {
 			"labelB":                         "valueB",
 			"projectcalico.org/namespace":    "default",
 			"projectcalico.org/orchestrator": "k8s",
+			"projectcalico.org/kind":         libapiv3.KindWorkloadEndpoint,
 		}
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).ObjectMeta.Labels).To(Equal(expectedLabels))
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).Spec.ServiceAccountName).To(Equal(longName))

--- a/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -278,6 +278,9 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		Value:    wep,
 		Revision: pod.ResourceVersion,
 	}
+
+	// When Calico reads WorkloadEndpoint, it must include the kind label.
+	model.AddKindLabel(&kvp)
 	return &kvp, nil
 }
 

--- a/libcalico-go/lib/backend/k8s/resources/customresource.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource.go
@@ -137,11 +137,18 @@ func (c *customK8sResourceClient) Create(ctx context.Context, kvp *model.KVPair)
 	// Update the revision information from the response.
 	kvp.Revision = resOut.GetObjectMeta().GetResourceVersion()
 
+	// Add "projectcalico.org/kind" label to certain resources
+	// to assist with selection
+	model.AddKindLabel(kvp)
 	return kvp, nil
 }
 
 // Update updates an existing Custom K8s Resource instance in the k8s API from the supplied KVPair.
 func (c *customK8sResourceClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	// "projectcalico.org/kind" label should not be updated into the datastore
+	// It only exists for calico
+	defer model.AddKindLabel(kvp)
+	model.RemoveKindLabel(kvp)
 	logContext := log.WithFields(log.Fields{
 		"Key":      kvp.Key,
 		"Value":    kvp.Value,
@@ -334,7 +341,14 @@ func (c *customK8sResourceClient) Get(ctx context.Context, key model.Key, revisi
 		return nil, K8sErrorToCalico(err, key)
 	}
 
-	return c.convertResourceToKVPair(resOut)
+	kvp, err := c.convertResourceToKVPair(resOut)
+	if err != nil {
+		return nil, err
+	}
+	// Add "projectcalico.org/kind" label to certain resources
+	// to assist with selection
+	model.AddKindLabel(kvp)
+	return kvp, nil
 }
 
 // List lists configured Custom K8s Resource instances in the k8s API matching the
@@ -411,6 +425,9 @@ func (c *customK8sResourceClient) List(ctx context.Context, list model.ListInter
 		if err != nil {
 			return nil, err
 		}
+		// Add "projectcalico.org/kind" label to certain resources
+		// to assist with selection
+		model.AddKindLabel(kvp)
 		return []*model.KVPair{kvp}, nil
 	}
 	return pagedList(ctx, logContext, revision, list, convertFunc, listFunc)
@@ -440,7 +457,14 @@ func (c *customK8sResourceClient) Watch(ctx context.Context, list model.ListInte
 		return nil, K8sErrorToCalico(err, list)
 	}
 	toKVPair := func(r Resource) (*model.KVPair, error) {
-		return c.convertResourceToKVPair(r)
+		kvp, err := c.convertResourceToKVPair(r)
+		if err != nil {
+			return nil, err
+		}
+		// Add "projectcalico.org/kind" label to certain resources
+		// to assist with selection
+		model.AddKindLabel(kvp)
+		return kvp, nil
 	}
 
 	return newK8sWatcherConverter(ctx, rlo.Kind+" (custom)", toKVPair, k8sWatch), nil

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -367,8 +367,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Name:      wepName,
 					Namespace: "testNamespace",
 					Labels: map[string]string{
-						apiv3.LabelNamespace:    "testNamespace",
-						apiv3.LabelOrchestrator: "k8s",
+						apiv3.LabelNamespace:     "testNamespace",
+						apiv3.LabelOrchestrator:  "k8s",
+						"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 					},
 				},
 				Spec: libapiv3.WorkloadEndpointSpec{
@@ -415,8 +416,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 								Name:      "test--node-k8s-simplePod-eth0",
 								Namespace: "testNamespace",
 								Labels: map[string]string{
-									apiv3.LabelNamespace:    "testNamespace",
-									apiv3.LabelOrchestrator: "k8s",
+									apiv3.LabelNamespace:     "testNamespace",
+									apiv3.LabelOrchestrator:  "k8s",
+									"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 								},
 							},
 							Spec: libapiv3.WorkloadEndpointSpec{
@@ -483,8 +485,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 								Name:      "test--node-k8s-simplePod-eth0",
 								Namespace: "testNamespace",
 								Labels: map[string]string{
-									apiv3.LabelNamespace:    "testNamespace",
-									apiv3.LabelOrchestrator: "k8s",
+									apiv3.LabelNamespace:     "testNamespace",
+									apiv3.LabelOrchestrator:  "k8s",
+									"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 								},
 							},
 							Spec: libapiv3.WorkloadEndpointSpec{
@@ -576,8 +579,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 								Name:      "test--node-k8s-simplePod-eth0",
 								Namespace: "testNamespace",
 								Labels: map[string]string{
-									apiv3.LabelNamespace:    "testNamespace",
-									apiv3.LabelOrchestrator: "k8s",
+									apiv3.LabelNamespace:     "testNamespace",
+									apiv3.LabelOrchestrator:  "k8s",
+									"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 								},
 							},
 							Spec: libapiv3.WorkloadEndpointSpec{
@@ -599,8 +603,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 								Name:      "test--node-k8s-simplePod2-eth0",
 								Namespace: "testNamespace",
 								Labels: map[string]string{
-									apiv3.LabelNamespace:    "testNamespace",
-									apiv3.LabelOrchestrator: "k8s",
+									apiv3.LabelNamespace:     "testNamespace",
+									apiv3.LabelOrchestrator:  "k8s",
+									"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 								},
 							},
 							Spec: libapiv3.WorkloadEndpointSpec{
@@ -643,8 +648,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 						Name:      "test--node-k8s-simplePod-eth0",
 						Namespace: "testNamespace",
 						Labels: map[string]string{
-							apiv3.LabelNamespace:    "testNamespace",
-							apiv3.LabelOrchestrator: "k8s",
+							apiv3.LabelNamespace:     "testNamespace",
+							apiv3.LabelOrchestrator:  "k8s",
+							"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 						},
 					},
 					Spec: libapiv3.WorkloadEndpointSpec{
@@ -708,8 +714,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 							Name:      "test--node-k8s-termPod-eth0",
 							Namespace: "testNamespace",
 							Labels: map[string]string{
-								apiv3.LabelNamespace:    "testNamespace",
-								apiv3.LabelOrchestrator: "k8s",
+								apiv3.LabelNamespace:     "testNamespace",
+								apiv3.LabelOrchestrator:  "k8s",
+								"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 							},
 						},
 						Spec: libapiv3.WorkloadEndpointSpec{
@@ -731,8 +738,9 @@ var _ = Describe("WorkloadEndpointClient", func() {
 							Name:      "test--node-k8s-termPod2-eth0",
 							Namespace: "testNamespace",
 							Labels: map[string]string{
-								apiv3.LabelNamespace:    "testNamespace",
-								apiv3.LabelOrchestrator: "k8s",
+								apiv3.LabelNamespace:     "testNamespace",
+								apiv3.LabelOrchestrator:  "k8s",
+								"projectcalico.org/kind": libapiv3.KindWorkloadEndpoint,
 							},
 						},
 						Spec: libapiv3.WorkloadEndpointSpec{

--- a/libcalico-go/lib/backend/model/kind_label.go
+++ b/libcalico-go/lib/backend/model/kind_label.go
@@ -1,0 +1,95 @@
+package model
+
+import (
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const KindLabel = "projectcalico.org/kind"
+
+// AddKindLabel adds "projectcalico.org/kind" to GlobalNetworkSet, NetworkSet, HostEndpoint
+// and WorkloadEndpoint resources.
+func AddKindLabel(kvp *KVPair) {
+	if kvp == nil {
+		return
+	}
+
+	var meta metav1.ObjectMetaAccessor
+	var kind string
+
+	switch resource := kvp.Value.(type) {
+	case apiv3.GlobalNetworkSet, *apiv3.GlobalNetworkSet:
+		meta = valuesToPtr[apiv3.GlobalNetworkSet](resource)
+		kind = apiv3.KindGlobalNetworkSet
+	case apiv3.NetworkSet, *apiv3.NetworkSet:
+		meta = valuesToPtr[apiv3.NetworkSet](resource)
+		kind = apiv3.KindNetworkSet
+	case apiv3.HostEndpoint, *apiv3.HostEndpoint:
+		meta = valuesToPtr[apiv3.HostEndpoint](resource)
+		kind = apiv3.KindHostEndpoint
+	case libapiv3.WorkloadEndpoint, *libapiv3.WorkloadEndpoint:
+		meta = valuesToPtr[libapiv3.WorkloadEndpoint](resource)
+		kind = libapiv3.KindWorkloadEndpoint
+	default:
+		return
+	}
+
+	appendLabel := func(labels map[string]string, kind string) map[string]string {
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[KindLabel] = kind
+		return labels
+	}
+
+	labels := appendLabel(
+		meta.GetObjectMeta().GetLabels(),
+		kind,
+	)
+	meta.GetObjectMeta().SetLabels(labels)
+	kvp.Value = meta
+}
+
+// RemoveKindLabel removes "projectcalico.org/kind" from GlobalNetworkSet, NetworkSet, HostEndpoint
+// and WorkloadEndpoint resources.
+// This function is useful to remove kind label before storing a resource in the datastore.
+func RemoveKindLabel(kvp *KVPair) {
+	if kvp == nil {
+		return
+	}
+
+	var meta metav1.ObjectMetaAccessor
+
+	switch resource := kvp.Value.(type) {
+	case apiv3.GlobalNetworkSet, *apiv3.GlobalNetworkSet:
+		meta = valuesToPtr[apiv3.GlobalNetworkSet](resource)
+	case apiv3.NetworkSet, *apiv3.NetworkSet:
+		meta = valuesToPtr[apiv3.NetworkSet](resource)
+	case apiv3.HostEndpoint, *apiv3.HostEndpoint:
+		meta = valuesToPtr[apiv3.HostEndpoint](resource)
+	case libapiv3.WorkloadEndpoint, *libapiv3.WorkloadEndpoint:
+		meta = valuesToPtr[libapiv3.WorkloadEndpoint](resource)
+	default:
+		return
+	}
+
+	meta.GetObjectMeta().GetLabels()
+	labels := meta.GetObjectMeta().GetLabels()
+	delete(labels, KindLabel)
+	meta.GetObjectMeta().SetLabels(labels)
+	kvp.Value = meta
+}
+
+// valuesToPtr will always return a pointer to the value provided.
+// This is necessary to satisfy tests where non-pointers are provided to a model.KVPair.Value
+func valuesToPtr[T any](value interface{}) *T {
+	switch t := value.(type) {
+	case T:
+		return &t
+	case *T:
+		return t
+	default:
+		return nil
+	}
+}

--- a/libcalico-go/lib/backend/model/kind_label_test.go
+++ b/libcalico-go/lib/backend/model/kind_label_test.go
@@ -1,0 +1,469 @@
+package model_test
+
+import (
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	. "github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+)
+
+var _ = DescribeTable(
+	"add kind label to intended resources",
+	func(kvp *KVPair, kind string) {
+		oldLabels := getLabels(kvp)
+		AddKindLabel(kvp)
+		newLabels := getLabels(kvp)
+
+		Expect(newLabels).To(HaveKey(KindLabel))
+		Expect(newLabels[KindLabel]).To(Equal(kind))
+
+		delete(newLabels, KindLabel)
+		if len(newLabels) == 0 {
+			newLabels = nil
+		}
+
+		Expect(oldLabels).To(Equal(newLabels))
+	},
+	Entry(
+		"GlobalNetworkSet should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "GlobalNetworkSet",
+				Name: "gns",
+			},
+			Value: apiv3.GlobalNetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gns",
+				},
+				Spec: apiv3.GlobalNetworkSetSpec{},
+			},
+		},
+		apiv3.KindGlobalNetworkSet,
+	),
+	Entry(
+		"GlobalNetworkSet even as a pointer should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "GlobalNetworkSet",
+				Name: "gns",
+			},
+			Value: &apiv3.GlobalNetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gns",
+				},
+				Spec: apiv3.GlobalNetworkSetSpec{},
+			},
+		},
+		apiv3.KindGlobalNetworkSet,
+	),
+	Entry(
+		"NetworkSet should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "NetworkSet",
+				Name: "ns",
+			},
+			Value: apiv3.NetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+					Labels: map[string]string{
+						"x": "y",
+					},
+				},
+				Spec: apiv3.NetworkSetSpec{},
+			},
+		},
+		apiv3.KindNetworkSet,
+	),
+	Entry(
+		"NetworkSet even as a pointer should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "NetworkSet",
+				Name: "ns",
+			},
+			Value: &apiv3.NetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+					Labels: map[string]string{
+						"x": "y",
+					},
+				},
+				Spec: apiv3.NetworkSetSpec{},
+			},
+		},
+		apiv3.KindNetworkSet,
+	),
+	Entry(
+		"HostEndpoints should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "HostEndpoint",
+				Name: "ns",
+			},
+			Value: apiv3.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hep",
+					Labels: map[string]string{
+						"x": "y",
+						"a": "b",
+					},
+				},
+				Spec: apiv3.HostEndpointSpec{},
+			},
+		},
+		apiv3.KindHostEndpoint,
+	),
+	Entry(
+		"HostEndpoint even as a pointer should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "HostEndpoint",
+				Name: "ns",
+			},
+			Value: &apiv3.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hep",
+					Labels: map[string]string{
+						"x": "y",
+						"a": "b",
+					},
+				},
+				Spec: apiv3.HostEndpointSpec{},
+			},
+		},
+		apiv3.KindHostEndpoint,
+	),
+
+	Entry(
+		"WorkloadEndpoints should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "WorkloadEndpoint",
+				Name: "wep",
+			},
+			Value: libapiv3.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wep",
+					Labels: map[string]string{
+						"x": "y",
+						"a": "b",
+					},
+				},
+				Spec: libapiv3.WorkloadEndpointSpec{},
+			},
+		},
+		libapiv3.KindWorkloadEndpoint,
+	),
+	Entry(
+		"WorkloadEndpoints even as a pointer should have the label",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "WorkloadEndpoint",
+				Name: "wep",
+			},
+			Value: &libapiv3.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wep",
+					Labels: map[string]string{
+						"x": "y",
+						"a": "b",
+					},
+				},
+				Spec: libapiv3.WorkloadEndpointSpec{},
+			},
+		},
+		libapiv3.KindWorkloadEndpoint,
+	),
+)
+
+var _ = DescribeTable(
+	"delete kind label from intended resources",
+	func(kvp *KVPair) {
+		// resource := kvp.Value.(metav1.ObjectMetaAccessor)
+		oldLabels := getLabels(kvp)
+		RemoveKindLabel(kvp)
+		newLabels := getLabels(kvp)
+
+		delete(oldLabels, model.KindLabel)
+		// if len(oldLabels) == 0 {
+		// 	oldLabels = nil
+		// }
+		Expect(newLabels).To(Equal(oldLabels))
+	},
+	Entry(
+		"GlobalNetworkSet should have label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "GlobalNetworkSet",
+				Name: "gns",
+			},
+			Value: apiv3.GlobalNetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gns",
+					Labels: map[string]string{
+						model.KindLabel: apiv3.KindGlobalNetworkSet,
+					},
+				},
+				Spec: apiv3.GlobalNetworkSetSpec{},
+			},
+		},
+	),
+	Entry(
+		"GlobalNetworkSet even as a pointer should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "GlobalNetworkSet",
+				Name: "gns",
+			},
+			Value: &apiv3.GlobalNetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gns",
+					Labels: map[string]string{
+						model.KindLabel: apiv3.KindGlobalNetworkSet,
+					},
+				},
+				Spec: apiv3.GlobalNetworkSetSpec{},
+			},
+		},
+	),
+	Entry(
+		"NetworkSet should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "NetworkSet",
+				Name: "ns",
+			},
+			Value: apiv3.NetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+					Labels: map[string]string{
+						"x":             "y",
+						model.KindLabel: apiv3.KindNetworkSet,
+					},
+				},
+				Spec: apiv3.NetworkSetSpec{},
+			},
+		},
+	),
+	Entry(
+		"NetworkSet even as a pointer should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "NetworkSet",
+				Name: "ns",
+			},
+			Value: &apiv3.NetworkSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+					Labels: map[string]string{
+						"x":             "y",
+						model.KindLabel: apiv3.KindNetworkSet,
+					},
+				},
+				Spec: apiv3.NetworkSetSpec{},
+			},
+		},
+	),
+	Entry(
+		"HostEndpoints should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "HostEndpoint",
+				Name: "ns",
+			},
+			Value: apiv3.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hep",
+					Labels: map[string]string{
+						"x":             "y",
+						"a":             "b",
+						model.KindLabel: apiv3.KindHostEndpoint,
+					},
+				},
+				Spec: apiv3.HostEndpointSpec{},
+			},
+		},
+	),
+	Entry(
+		"HostEndpoint even as a pointer should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "HostEndpoint",
+				Name: "ns",
+			},
+			Value: &apiv3.HostEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hep",
+					Labels: map[string]string{
+						"x":             "y",
+						"a":             "b",
+						model.KindLabel: apiv3.KindHostEndpoint,
+					},
+				},
+				Spec: apiv3.HostEndpointSpec{},
+			},
+		},
+	),
+
+	Entry(
+		"WorkloadEndpoints should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "WorkloadEndpoint",
+				Name: "wep",
+			},
+			Value: libapiv3.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wep",
+					Labels: map[string]string{
+						"x":             "y",
+						"a":             "b",
+						model.KindLabel: libapiv3.KindWorkloadEndpoint,
+					},
+				},
+				Spec: libapiv3.WorkloadEndpointSpec{},
+			},
+		},
+	),
+	Entry(
+		"WorkloadEndpoints even as a pointer should have the label deleted",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "WorkloadEndpoint",
+				Name: "wep",
+			},
+			Value: &libapiv3.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wep",
+					Labels: map[string]string{
+						"x":             "y",
+						"a":             "b",
+						model.KindLabel: libapiv3.KindWorkloadEndpoint,
+					},
+				},
+				Spec: libapiv3.WorkloadEndpointSpec{},
+			},
+		},
+	),
+	Entry(
+		"An intended resource (WorkloadEndpoint in this case) without the label should not behave abnormally",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "WorkloadEndpoint",
+				Name: "wep",
+			},
+			Value: &libapiv3.WorkloadEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wep",
+					Labels: map[string]string{
+						"x": "y",
+						"a": "b",
+					},
+				},
+				Spec: libapiv3.WorkloadEndpointSpec{},
+			},
+		},
+	),
+)
+
+var _ = DescribeTable(
+	"attempting to add kind label to unintended resources (IPPool in this case)",
+	func(kvp *KVPair) {
+		// resource := kvp.Value.(metav1.ObjectMetaAccessor)
+		oldLabels := getLabels(kvp)
+		AddKindLabel(kvp)
+		newLabels := getLabels(kvp)
+
+		Expect(newLabels).To(Equal(oldLabels))
+	},
+	Entry(
+		"IPPool should not have the label added",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "IPPool",
+				Name: "ippool-1",
+			},
+			Value: &apiv3.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ippool-1",
+					Labels: map[string]string{
+						"x": "y",
+					},
+				},
+				Spec: apiv3.IPPoolSpec{
+					CIDR: "1.2.3.0/24",
+				},
+			},
+		},
+	),
+)
+
+var _ = DescribeTable(
+	"attempting to delete kind label from unintended resources (IPPool in this case)",
+	func(kvp *KVPair) {
+		// resource := kvp.Value.(metav1.ObjectMetaAccessor)
+		oldLabels := getLabels(kvp)
+		AddKindLabel(kvp)
+		newLabels := getLabels(kvp)
+
+		Expect(newLabels).To(Equal(oldLabels))
+	},
+	Entry(
+		"IPPool does not have the label, so deletion must not misbehave",
+		&KVPair{
+			Key: ResourceKey{
+				Kind: "IPPool",
+				Name: "ippool-1",
+			},
+			Value: &apiv3.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ippool-1",
+					Labels: map[string]string{
+						"x": "y",
+					},
+				},
+				Spec: apiv3.IPPoolSpec{
+					CIDR: "1.2.3.0/24",
+				},
+			},
+		},
+	),
+)
+
+func getLabels(kvp *KVPair) map[string]string {
+	var meta metav1.ObjectMetaAccessor
+
+	switch resource := kvp.Value.(type) {
+	case apiv3.GlobalNetworkSet, *apiv3.GlobalNetworkSet:
+		meta = valueToPtr[apiv3.GlobalNetworkSet](resource)
+	case *apiv3.NetworkSet, apiv3.NetworkSet:
+		meta = valueToPtr[apiv3.NetworkSet](resource)
+	case *apiv3.HostEndpoint, apiv3.HostEndpoint:
+		meta = valueToPtr[apiv3.HostEndpoint](resource)
+	case *libapiv3.WorkloadEndpoint, libapiv3.WorkloadEndpoint:
+		meta = valueToPtr[libapiv3.WorkloadEndpoint](resource)
+
+	case *apiv3.IPPool:
+		meta = resource
+	}
+	return maps.Clone(meta.GetObjectMeta().GetLabels())
+}
+
+func valueToPtr[T interface{}](value interface{}) *T {
+	switch r := value.(type) {
+	case *T:
+		return r
+	case T:
+		return &r
+	default:
+		return nil
+	}
+}

--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -505,7 +505,8 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 				Key: model.NetworkSetKey{Name: "anetworkset"},
 				Value: &model.NetworkSet{
 					Labels: uniquelabels.Make(map[string]string{
-						"a": "b",
+						"a":             "b",
+						model.KindLabel: apiv3.KindGlobalNetworkSet,
 					}),
 					Nets: []net.IPNet{
 						*expGNet,
@@ -540,6 +541,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 					Labels: uniquelabels.Make(map[string]string{
 						"a":                           "b",
 						"projectcalico.org/namespace": "namespace-1",
+						model.KindLabel:               apiv3.KindNetworkSet,
 					}),
 					Nets: []net.IPNet{
 						*expNet,
@@ -594,7 +596,8 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 					ExpectedIPv4Addrs: []net.IP{net.MustParseIP("1.2.3.4")},
 					ExpectedIPv6Addrs: []net.IP{net.MustParseIP("aa:bb::cc:dd")},
 					Labels: uniquelabels.Make(map[string]string{
-						"label1": "value1",
+						"label1":        "value1",
+						model.KindLabel: apiv3.KindHostEndpoint,
 					}),
 					ProfileIDs: []string{"profile1", "profile2"},
 					Ports: []model.EndpointPort{


### PR DESCRIPTION
I noticed that this issue hasn't been active for a month, so I'm giving it a try.

## Description

This draft addresses an enhancement suggestion for fine-grained selection of resources such as `GlobalNetworkSet`.

### Solution

I forced calico to set the label `projectcalico.org/kind` when a resource is created using the `clientv3` package. It seems to offer a consistent mechanism for resource selection.

### Tests

- Existing tests have been modified to verify the label after creation of a resource.
- Some tests in `calico/libcalico-go/lib/backend/syncersv1` have also been fixed by including the new label to prevent breakage.
---

@caseydavenport @sebhoss Let me know if this approach aligns with your intent, I can rework this draft.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

fixes #9857

## Todos

- [x] Tests - Passed tests for `calico/libcalico-go`
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
