### PR TITLE
Update e2e hep to correctly check for hostEndpoints enabled

### DIFF
--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -14,6 +14,7 @@ package hostendpoints
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -45,10 +46,11 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 	func() {
 		f := utils.NewDefaultFramework("auto-hep")
 		var (
-			nodes           *v1.NodeList
-			nodeNames       []string
-			cli             ctrlclient.Client
-			autoHEPsEnabled bool
+			nodes       *v1.NodeList
+			nodeNames   []string
+			cli         ctrlclient.Client
+			originalKCC v3.KubeControllersConfiguration
+			testKCC     v3.KubeControllersConfiguration
 		)
 		const port9090 = 9090
 		const port9091 = 9091
@@ -89,17 +91,20 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 			Expect(utils.CleanDatastore(cli)).ShouldNot(HaveOccurred())
 
 			// Sanity check: make sure we have a default kubecontrollersconfiguration.
-			kcc := v3.KubeControllersConfiguration{}
-			err = cli.Get(context.Background(), types.NamespacedName{Name: "default"}, &kcc)
+			originalKCC = v3.KubeControllersConfiguration{}
+			err = cli.Get(context.Background(), types.NamespacedName{Name: "default"}, &originalKCC)
 			Expect(err).NotTo(HaveOccurred(), "Error getting kubecontrollersconfiguration")
 
-			// Store whether we are running auto host endpoints or not.
-			autoHEPsEnabled = GetAutoHEPsEnabled(cli)
+			// Make a copy of the original KCC so we can restore it later.
+			testKCC = *originalKCC.DeepCopy()
 
-			// Turn on auto host endpoints if not already enabled.
-			if !autoHEPsEnabled {
+			// Turn on default auto host endpoints if not already enabled.
+			if !GetAutoHEPsEnabled(originalKCC) {
 				logrus.Info("BeforeEach: auto host endpoints not previously enabled so enabling")
-				ToggleAutoHostEndpoints(cli, true)
+				// Enabled creation of auto host endpoints and creation of default host endpoints.
+				testKCC.Spec.Controllers.Node.HostEndpoint.AutoCreate = "Enabled"
+				testKCC.Spec.Controllers.Node.HostEndpoint.CreateDefaultHostEndpoint = v3.DefaultHostEndpointsEnabled
+				updateHostEndpointConfig(cli, testKCC)
 				WaitForAutoHEPs(cli, true)
 			}
 
@@ -118,9 +123,10 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 		})
 
 		AfterEach(func() {
-			if !autoHEPsEnabled {
+			// We've updated the kubecontrollersconfiguration, so we need to restore it to its original state.
+			if !reflect.DeepEqual(originalKCC.Spec.Controllers.Node.HostEndpoint, testKCC.Spec.Controllers.Node.HostEndpoint) {
 				logrus.Info("AfterEach: auto host endpoints not previously enabled so disabling")
-				ToggleAutoHostEndpoints(cli, false)
+				updateHostEndpointConfig(cli, originalKCC)
 				WaitForAutoHEPs(cli, false)
 			}
 		})
@@ -265,34 +271,30 @@ func getNodeHostname(node v1.Node) string {
 	return hostname
 }
 
-// ToggleAutoHostEndpoints turns auto host endpoints on or off.
-func ToggleAutoHostEndpoints(client ctrlclient.Client, enabled bool) {
-	toggle := "Enabled"
-	if !enabled {
-		toggle = "Disabled"
-	}
-
+// updateHostEndpointConfig updates the HostEndpointConfiguration to the desired stated
+func updateHostEndpointConfig(client ctrlclient.Client, desiredKCC v3.KubeControllersConfiguration) {
 	// Get the kubecontrollersconfiguration and patch it to toggle the
 	// auto-creation of host endpoints.
-	var kcc v3.KubeControllersConfiguration
-	err := client.Get(context.Background(), types.NamespacedName{Name: "default"}, &kcc)
+	var currentKCC v3.KubeControllersConfiguration
+	err := client.Get(context.Background(), types.NamespacedName{Name: "default"}, &currentKCC)
 	Expect(err).NotTo(HaveOccurred(), "Error getting kubecontrollersconfiguration")
 
 	// Patch the kubecontrollersconfiguration to toggle auto-creation of host endpoints.
-	kcc.Spec.Controllers.Node.HostEndpoint.AutoCreate = toggle
+	currentKCC.Spec.Controllers.Node.HostEndpoint = desiredKCC.Spec.Controllers.Node.HostEndpoint
 
-	err = client.Update(context.Background(), &kcc)
+	err = client.Update(context.Background(), &currentKCC)
 	Expect(err).NotTo(HaveOccurred(), "Error updating kubecontrollersconfiguration")
 
 	// Wait for the status to be updated to reflect the change, which indicates that
 	// the kube-controllers pod has been restarted and the new config has been applied.
 	Eventually(func() error {
-		err := client.Get(context.Background(), types.NamespacedName{Name: "default"}, &kcc)
+		err := client.Get(context.Background(), types.NamespacedName{Name: "default"}, &currentKCC)
 		if err != nil {
 			return err
 		}
-		enabled := kcc.Status.RunningConfig.Controllers.Node.HostEndpoint.AutoCreate
-		if enabled != toggle {
+
+		// Check if the current configuration matches the desired configuration.
+		if !reflect.DeepEqual(currentKCC.Status.RunningConfig.Controllers.Node.HostEndpoint, desiredKCC.Spec.Controllers.Node.HostEndpoint) {
 			return fmt.Errorf("failed to toggle auto-creation of host endpoints")
 		}
 		return nil
@@ -300,10 +302,7 @@ func ToggleAutoHostEndpoints(client ctrlclient.Client, enabled bool) {
 }
 
 // GetAutoHEPsEnabled returns true if AutoHEPs are enabled, false otherwise.
-func GetAutoHEPsEnabled(client ctrlclient.Client) bool {
-	var kcc v3.KubeControllersConfiguration
-	err := client.Get(context.Background(), types.NamespacedName{Name: "default"}, &kcc)
-	Expect(err).NotTo(HaveOccurred())
+func GetAutoHEPsEnabled(kcc v3.KubeControllersConfiguration) bool {
 	if kcc.Status.RunningConfig.Controllers.Node.HostEndpoint.AutoCreate != "Enabled" {
 		return false
 	}

--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -303,10 +303,10 @@ func updateHostEndpointConfig(client ctrlclient.Client, desiredKCC v3.KubeContro
 
 // GetAutoHEPsEnabled returns true if AutoHEPs are enabled, false otherwise.
 func GetAutoHEPsEnabled(kcc v3.KubeControllersConfiguration) bool {
-	if kcc.Status.RunningConfig.Controllers.Node.HostEndpoint.AutoCreate != "Enabled" {
+	if kcc.Spec.Controllers.Node.HostEndpoint.AutoCreate != "Enabled" {
 		return false
 	}
-	if kcc.Status.RunningConfig.Controllers.Node.HostEndpoint.CreateDefaultHostEndpoint != v3.DefaultHostEndpointsEnabled {
+	if kcc.Spec.Controllers.Node.HostEndpoint.CreateDefaultHostEndpoint != v3.DefaultHostEndpointsEnabled {
 		return false
 	}
 	return true

--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -271,7 +271,7 @@ func getNodeHostname(node v1.Node) string {
 	return hostname
 }
 
-// updateHostEndpointConfig updates the HostEndpointConfiguration to the desired stated
+// updateHostEndpointConfig updates the HostEndpointConfiguration to the desired state
 func updateHostEndpointConfig(client ctrlclient.Client, desiredKCC v3.KubeControllersConfiguration) {
 	// Get the kubecontrollersconfiguration and patch it to toggle the
 	// auto-creation of host endpoints.


### PR DESCRIPTION
## Description
Updates the HostEndpoint tests to check if both AutoCreate and CreateDefaultHostEndpoint are enabled before running tests and returns the kcc into the previous state after the test have finished.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
