### PR TITLE
Add optional calicoctl API client

### DIFF
--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -54,6 +54,10 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 		const port9091 = 9091
 
 		denyEgressPolicy := &v3.GlobalNetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "GlobalNetworkPolicy",
+				APIVersion: v3.SchemeGroupVersion.String(),
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "autohep-e2e-egress-deny",
 			},
@@ -172,6 +176,10 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 					// Declare a policy that blocks ingress to the server
 					// pod on port 9090. But don't apply the policy yet.
 					denyIngressPolicy = &v3.GlobalNetworkPolicy{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "GlobalNetworkPolicy",
+							APIVersion: v3.SchemeGroupVersion.String(),
+						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "autohep-e2e-ingress",
 						},

--- a/e2e/pkg/tests/policy/policy.go
+++ b/e2e/pkg/tests/policy/policy.go
@@ -241,6 +241,10 @@ var _ = describe.CalicoDescribe(
 			Expect(err).NotTo(HaveOccurred())
 
 			np := &v3.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "NetworkPolicy",
+					APIVersion: v3.SchemeGroupVersion.String(),
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "allow-through-service-account",
 					Namespace: ns.Name,
@@ -365,6 +369,10 @@ var _ = describe.CalicoDescribe(
 // Creates a new NetworkPolicy that isolates a namespace by allowing ingress and egress traffic only from / to pods in the same namespace.
 func newNamespaceIsolationPolicy(name, namespace, ingressSelector, egressSelector string) *v3.NetworkPolicy {
 	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NetworkPolicy",
+			APIVersion: v3.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -393,6 +401,10 @@ func newNamespaceIsolationPolicy(name, namespace, ingressSelector, egressSelecto
 
 func newDefaultDenyPolicy(namespace string) *v3.NetworkPolicy {
 	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NetworkPolicy",
+			APIVersion: v3.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default-deny",
 			Namespace: namespace,

--- a/e2e/pkg/tests/policy/service_policy.go
+++ b/e2e/pkg/tests/policy/service_policy.go
@@ -75,6 +75,10 @@ var _ = describe.CalicoDescribe(
 
 				// Policy to allow client egress using ServiceMatch for the server's service
 				allowClientByServicePolicy = &v3.NetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "NetworkPolicy",
+						APIVersion: v3.SchemeGroupVersion.String(),
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "allow-client-egress",
 						Namespace: f.Namespace.Name,
@@ -98,6 +102,10 @@ var _ = describe.CalicoDescribe(
 
 				// Policy to allow client egress using the server's pod-name
 				allowClientByNamePolicy = &v3.NetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "NetworkPolicy",
+						APIVersion: v3.SchemeGroupVersion.String(),
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "allow-client-egress",
 						Namespace: f.Namespace.Name,
@@ -118,6 +126,10 @@ var _ = describe.CalicoDescribe(
 
 				// Policy to allow server ingress using ServiceMatch for the client's service
 				allowServerByServicePolicy = &v3.NetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "NetworkPolicy",
+						APIVersion: v3.SchemeGroupVersion.String(),
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "allow-server-ingress",
 						Namespace: f.Namespace.Name,
@@ -141,6 +153,10 @@ var _ = describe.CalicoDescribe(
 
 				// Policy to allow server ingress using the client's pod-name
 				allowServerByNamePolicy = &v3.NetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "NetworkPolicy",
+						APIVersion: v3.SchemeGroupVersion.String(),
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "allow-server-ingress",
 						Namespace: f.Namespace.Name,

--- a/e2e/pkg/utils/client/calicoctl.go
+++ b/e2e/pkg/utils/client/calicoctl.go
@@ -1,0 +1,190 @@
+package client
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/kubernetes/test/e2e/framework/kubectl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ client.Client = &calicoctlExecClient{}
+
+// calicoctlExecClient client that meets the controller-runtime client.Client interface but implements it using exec commands into a calicoctl pod.
+// This allows us to run tests that interact with Calico's projectcalico.org/v3 API without needing to run Calico's API server directly.
+type calicoctlExecClient struct {
+	// The pod to exec into.
+	namespace string
+	name      string
+
+	// The scheme is used to encode and decode objects correctly.
+	scheme *runtime.Scheme
+}
+
+// Create saves the object obj in the Kubernetes cluster. obj must be a
+// struct pointer so that obj can be updated with the content returned by the Server.
+func (c *calicoctlExecClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	// Create the stdin input for the calicoctl command.
+	serializer := json.NewSerializer(json.DefaultMetaFactory, c.scheme, c.scheme, false)
+
+	w := &strings.Builder{}
+	serializer.Encode(obj, w)
+
+	// Create a calicoctl command to create the object.
+	cmd := []string{"exec", "-i", c.name, "--", "calicoctl", "create", "-f", "-"}
+
+	// Execute the command in the specified pod.
+	_, err := kubectl.RunKubectlInput(c.namespace, w.String(), cmd...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete deletes the given obj from Kubernetes cluster.
+func (c *calicoctlExecClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	kind, err := c.kindFromObject(obj)
+	if err != nil {
+		return err
+	}
+
+	// Create a calicoctl command to delete the object.
+	cmd := []string{"exec", c.name, "--", "calicoctl", "delete", kind, obj.GetName()}
+	if obj.GetNamespace() != "" {
+		cmd = append(cmd, "--namespace="+obj.GetNamespace())
+	}
+
+	// Execute the command in the specified pod.
+	out, err := kubectl.RunKubectl(c.namespace, cmd...)
+	logrus.WithFields(logrus.Fields{"output": out}).Info("calicoctl delete output")
+	return err
+}
+
+// Update updates the given obj in the Kubernetes cluster. obj must be a
+// struct pointer so that obj can be updated with the content returned by the Server.
+func (c *calicoctlExecClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	// Create the stdin input for the calicoctl command.
+	serializer := json.NewSerializer(json.DefaultMetaFactory, c.scheme, c.scheme, false)
+
+	w := &strings.Builder{}
+	if err := serializer.Encode(obj, w); err != nil {
+		return err
+	}
+
+	// Create a calicoctl command to update the object.
+	cmd := []string{"exec", "-i", c.name, "--", "calicoctl", "apply", "-f", "-"}
+
+	// Execute the command in the specified pod.
+	_, err := kubectl.RunKubectlInput(c.namespace, w.String(), cmd...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get retrieves an obj for the given object key from the Kubernetes Cluster.
+// obj must be a struct pointer so that obj can be updated with the response
+// returned by the Server.
+func (c *calicoctlExecClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	kind, err := c.kindFromObject(obj)
+	if err != nil {
+		return err
+	}
+
+	// Create a calicoctl command to get the object.
+	cmd := []string{"exec", c.name, "--", "calicoctl", "get", kind, key.Name}
+	if key.Namespace != "" {
+		cmd = append(cmd, "--namespace="+key.Namespace)
+	}
+	cmd = append(cmd, "-o", "yaml")
+
+	// Execute the command in the specified pod.
+	out, err := kubectl.RunKubectl(c.namespace, cmd...)
+	logrus.WithFields(logrus.Fields{"output": out}).Debug("calicoctl get output")
+	if err != nil {
+		return err
+	}
+
+	f := serializer.NewCodecFactory(c.scheme)
+	if err := runtime.DecodeInto(f.UniversalDecoder(), []byte(out), obj); err != nil {
+		logrus.WithError(err).Error("failed to decode calicoctl get output")
+		return err
+	}
+	return nil
+}
+
+// List retrieves list of objects for a given namespace and list options. On a
+// successful call, Items field in the list will be populated with the
+// result returned from the server.
+func (c *calicoctlExecClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	kind, err := c.kindFromObject(list)
+	if err != nil {
+		return err
+	}
+	out, err := kubectl.RunKubectl(c.namespace, "exec", c.name, "--", "calicoctl", "get", kind, "-o", "yaml")
+	logrus.WithFields(logrus.Fields{"output": out}).Debug("calicoctl list output")
+	if err != nil {
+		return err
+	}
+
+	f := serializer.NewCodecFactory(c.scheme)
+	if err := runtime.DecodeInto(f.UniversalDecoder(), []byte(out), list); err != nil {
+		logrus.WithError(err).Error("failed to decode calicoctl list output")
+		return err
+	}
+	return nil
+}
+
+func (c *calicoctlExecClient) kindFromObject(obj runtime.Object) (string, error) {
+	// Get the kind of the object from the scheme.
+	kinds, _, err := c.scheme.ObjectKinds(obj)
+	if err != nil {
+		return "", err
+	}
+	if len(kinds) == 0 {
+		return "", nil // No kind found, return empty string.
+	}
+
+	// If the kind is a list, return the kind without "List" suffix.
+	return strings.TrimSuffix(kinds[0].Kind, "List"), nil
+}
+
+// The following methods are not implemented in this client,
+
+func (c *calicoctlExecClient) Scheme() *runtime.Scheme {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) RESTMapper() meta.RESTMapper {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) SubResource(subResource string) client.SubResourceClient {
+	panic("not implemented")
+}
+
+func (c *calicoctlExecClient) Status() client.SubResourceWriter {
+	panic("not implemented")
+}

--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -15,7 +15,10 @@
 package client
 
 import (
+	"context"
+
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -24,13 +27,58 @@ import (
 
 // New returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
 func New(cfg *rest.Config) (client.Client, error) {
+	// Use the API client if the Calico v3 API is available, otherwise fall abck to the calicoctl exec client.
+	c, err := NewAPIClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check to see if the APIServer is available.
+	if err := c.Get(context.TODO(), client.ObjectKey{Name: "default"}, &operatorv1.APIServer{}); err == nil {
+		logrus.Infof("Using API server client for projectcalico.org/v3 API")
+		return c, nil
+	}
+
+	// No API server available, fall back to calicoctl exec client.
+	logrus.Infof("Falling back to calicoctl exec client for projectcalico.org/v3 API: %v", err)
+	return NewCalicoctlExecClient()
+}
+
+// NewAPIClient returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
+func NewAPIClient(cfg *rest.Config) (client.Client, error) {
+	scheme, err := newScheme()
+	if err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{Scheme: scheme})
+}
+
+// NewCalicoctlExecClient returns a new controller-runtime client that uses exec commands into a calicoctl pod to interact with the projectcalico.org/v3 API.
+// This is useful for testing purposes when the Calico API server is not running, however it requires that the cluster has a
+// calicoctl pod running in the kube-system namespace.
+//
+// Additionally, this client does not support all operations that a normal controller-runtime client would support. For example, it cannot
+// interact with API groups other than projectcalico.org/v3.
+func NewCalicoctlExecClient() (client.Client, error) {
+	scheme, err := newScheme()
+	if err != nil {
+		return nil, err
+	}
+	return &calicoctlExecClient{
+		scheme:    scheme,
+		name:      "calicoctl",
+		namespace: "kube-system",
+	}, nil
+}
+
+func newScheme() (*runtime.Scheme, error) {
 	// Create a new Scheme and add the projectcalico.org/v3 API group to it.
 	scheme := runtime.NewScheme()
 	if err := v3.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	if er := operatorv1.AddToScheme(scheme); er != nil {
-		return nil, er
+	if err := operatorv1.AddToScheme(scheme); err != nil {
+		return nil, err
 	}
-	return client.New(cfg, client.Options{Scheme: scheme})
+	return scheme, nil
 }

--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -27,7 +27,7 @@ import (
 
 // New returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
 func New(cfg *rest.Config) (client.Client, error) {
-	// Use the API client if the Calico v3 API is available, otherwise fall abck to the calicoctl exec client.
+	// Use the API client if the Calico v3 API is available, otherwise fall back to the calicoctl exec client.
 	c, err := NewAPIClient(cfg)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func New(cfg *rest.Config) (client.Client, error) {
 
 	// No API server available, fall back to calicoctl exec client.
 	logrus.Infof("Falling back to calicoctl exec client for projectcalico.org/v3 API: %v", err)
-	return NewCalicoctlExecClient()
+	return NewCalicoctlExecClient(c)
 }
 
 // NewAPIClient returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
@@ -59,13 +59,10 @@ func NewAPIClient(cfg *rest.Config) (client.Client, error) {
 //
 // Additionally, this client does not support all operations that a normal controller-runtime client would support. For example, it cannot
 // interact with API groups other than projectcalico.org/v3.
-func NewCalicoctlExecClient() (client.Client, error) {
-	scheme, err := newScheme()
-	if err != nil {
-		return nil, err
-	}
+func NewCalicoctlExecClient(base client.Client) (client.Client, error) {
 	return &calicoctlExecClient{
-		scheme:    scheme,
+		base:      base,
+		scheme:    base.Scheme(),
 		name:      "calicoctl",
 		namespace: "kube-system",
 	}, nil


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

For some environments - e.g., in etcd mode - we do not run the Calico API server, which means we are unable to make API queries to the v3 API group using the default controller-runtime client.

This PR introduces a controller-runtime client.Client implementation that is backed by a `calicoctl` Pod running on the cluster. It uses `kubectl exec` to execute CRUD, allowing for relatively speedy execution.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.