### PR TITLE
Fix route table conflict test.

### DIFF
--- a/felix/fv/routes_test.go
+++ b/felix/fv/routes_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -169,30 +168,19 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 			for i := 0; i < 2; i++ {
 				w[0][i] = workload.Run(tc.Felixes[0], fmt.Sprintf("w%d", i), "default", "10.65.0.2", "8088", "tcp")
 				w[0][i].ConfigureInInfra(infra)
+
+				// Tie-breaker is the interface index, so the most recently started workload should win.
+				Eventually(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "10s").Should(ContainSubstring(w[0][i].InterfaceName))
 			}
 		})
 
-		waitForInitialRouteProgramming := func() (winner, loser int) {
-			// Winner is non-deterministic.
-			Eventually(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "10s").Should(Or(
-				ContainSubstring(w[0][0].InterfaceName),
-				ContainSubstring(w[0][1].InterfaceName),
-			))
-			out, err := tc.Felixes[0].ExecOutput("ip", "r", "get", "10.65.0.2")
-			Expect(err).NotTo(HaveOccurred())
-			if strings.Contains(out, w[0][0].InterfaceName) {
-				winner = 0
-				loser = 1
-			} else {
-				winner = 1
-				loser = 0
-			}
-			return
-		}
+		const (
+			loser  = 0
+			winner = 1
+		)
 
 		It("should resolve when winning endpoint is removed", func() {
 			// Winner is non-deterministic.
-			winner, loser := waitForInitialRouteProgramming()
 			w[0][winner].RemoveFromInfra(infra)
 			Eventually(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "10s").Should(
 				ContainSubstring(w[0][loser].InterfaceName),
@@ -201,7 +189,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 
 		It("should resolve when losing endpoint is removed", func() {
 			// Winner is non-deterministic.
-			winner, loser := waitForInitialRouteProgramming()
 			w[0][loser].RemoveFromInfra(infra)
 			Consistently(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "5s").Should(
 				ContainSubstring(w[0][winner].InterfaceName),
@@ -210,7 +197,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 
 		It("should resolve when winning interface goes down", func() {
 			// Winner is non-deterministic.
-			winner, loser := waitForInitialRouteProgramming()
 			w[0][winner].SetInterfaceUp(false)
 			Eventually(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "10s").Should(
 				ContainSubstring(w[0][loser].InterfaceName),
@@ -219,7 +205,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 
 		It("should resolve when losing interface goes down", func() {
 			// Winner is non-deterministic.
-			winner, loser := waitForInitialRouteProgramming()
 			w[0][loser].SetInterfaceUp(false)
 			Consistently(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "5s").Should(
 				ContainSubstring(w[0][winner].InterfaceName),

--- a/felix/fv/routes_test.go
+++ b/felix/fv/routes_test.go
@@ -180,7 +180,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 		)
 
 		It("should resolve when winning endpoint is removed", func() {
-			// Winner is non-deterministic.
 			w[0][winner].RemoveFromInfra(infra)
 			Eventually(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "10s").Should(
 				ContainSubstring(w[0][loser].InterfaceName),
@@ -188,7 +187,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 		})
 
 		It("should resolve when losing endpoint is removed", func() {
-			// Winner is non-deterministic.
 			w[0][loser].RemoveFromInfra(infra)
 			Consistently(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "5s").Should(
 				ContainSubstring(w[0][winner].InterfaceName),
@@ -196,7 +194,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 		})
 
 		It("should resolve when winning interface goes down", func() {
-			// Winner is non-deterministic.
 			w[0][winner].SetInterfaceUp(false)
 			Eventually(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "10s").Should(
 				ContainSubstring(w[0][loser].InterfaceName),
@@ -204,7 +201,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ routing table tests", []api
 		})
 
 		It("should resolve when losing interface goes down", func() {
-			// Winner is non-deterministic.
 			w[0][loser].SetInterfaceUp(false)
 			Consistently(tc.Felixes[0].ExecOutputFn("ip", "r", "get", "10.65.0.2"), "5s").Should(
 				ContainSubstring(w[0][winner].InterfaceName),


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Waiting for felix to be ready exposed a race in the tests. Since felix was ready when we created the workloads, felix would respond to the first workload more quickly, resulting in the winner changing mid-test.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
