### PR TITLE
Fix logging of error when falling back to calicoctl client in e2e

### DIFF
--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -37,10 +37,11 @@ func New(cfg *rest.Config) (client.Client, error) {
 	if err := c.Get(context.TODO(), client.ObjectKey{Name: "default"}, &operatorv1.APIServer{}); err == nil {
 		logrus.Infof("Using API server client for projectcalico.org/v3 API")
 		return c, nil
+	} else {
+		logrus.Infof("Falling back to calicoctl exec client for projectcalico.org/v3 API: %v", err)
 	}
 
 	// No API server available, fall back to calicoctl exec client.
-	logrus.Infof("Falling back to calicoctl exec client for projectcalico.org/v3 API: %v", err)
 	return NewCalicoctlExecClient(c)
 }
 

--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -33,8 +33,8 @@ func New(cfg *rest.Config) (client.Client, error) {
 		return nil, err
 	}
 
-	// Check to see if the APIServer is available.
-	if err := c.Get(context.TODO(), client.ObjectKey{Name: "default"}, &operatorv1.APIServer{}); err == nil {
+	// Check to see if an APIServer is available.
+	if err := c.List(context.TODO(), &operatorv1.APIServerList{}); err == nil {
 		logrus.Infof("Using API server client for projectcalico.org/v3 API")
 		return c, nil
 	} else {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.