### PR TITLE
[v3.29] do not mark already published hashreleases as failed (#10794)

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -95,10 +95,11 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if published, err := tasks.HashreleasePublished(hashreleaseServerConfig(c), data.Hash(), c.Bool(ciFlag.Name)); err != nil {
 					return fmt.Errorf("failed to check if hashrelease has been published: %v", err)
 				} else if published {
-					// On CI, we want it to fail if the hashrelease has already been published.
+					// On CI, if the hashrelease has already been published, we exit successfully (return nil).
 					// However, on local builds, we just log a warning and continue.
 					if c.Bool(ciFlag.Name) {
-						return fmt.Errorf("hashrelease %s has already been published", data.Hash())
+						logrus.Infof("hashrelease %s has already been published", data.Hash())
+						return nil
 					} else {
 						logrus.Warnf("hashrelease %s has already been published", data.Hash())
 					}
@@ -193,7 +194,14 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if published, err := tasks.HashreleasePublished(serverCfg, hashrel.Hash, c.Bool(ciFlag.Name)); err != nil {
 					return fmt.Errorf("failed to check if hashrelease has been published: %v", err)
 				} else if published {
-					return fmt.Errorf("%s hashrelease (%s) has already been published", hashrel.Name, hashrel.Hash)
+					// On CI, we exit successfully (return nil) if the hashrelease has already been published.
+					// This is not an error scenario; we just log a warning and continue locally.
+					if c.Bool(ciFlag.Name) {
+						logrus.Infof("hashrelease %s has already been published", hashrel.Hash)
+						return nil
+					} else {
+						logrus.Warnf("hashrelease %s has already been published", hashrel.Hash)
+					}
 				}
 
 				// Push the operator hashrelease first before validaion


### PR DESCRIPTION
* do not mark already published hashreleases as failed

* Apply suggestions from code review



---------

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
