### PR TITLE
[cherry-pick #10788] Make `var-require` targets less noisy

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -939,13 +939,13 @@ var-require: $(addprefix var-set-,$(subst -, ,$(REQUIRED_VARS)))
 # there isn't a non empty variable for each given value. For instance, to require FOO and BAR both must be set you would
 # call var-require-all-FOO-BAR.
 var-require-all-%:
-	$(MAKE) var-require REQUIRED_VARS=$* FAIL_NOT_SET=true
+	@$(MAKE) --quiet --no-print-directory var-require REQUIRED_VARS=$* FAIL_NOT_SET=true
 
 # var-require-one-of-% checks if the there are non empty variables set for the hyphen separated values in %, and fails
 # there isn't a non empty variable for at least one of the given values. For instance, to require either FOO or BAR both
 # must be set you would call var-require-all-FOO-BAR.
 var-require-one-of-%:
-	$(MAKE) var-require REQUIRED_VARS=$*
+	@$(MAKE) --quiet --no-print-directory var-require REQUIRED_VARS=$*
 
 # sem-cut-release triggers the cut-release pipeline (or test-cut-release if CONFIRM is not specified) in semaphore to
 # cut the release. The pipeline is triggered for the current commit, and the branch it's triggered on is calculated


### PR DESCRIPTION
(This PR is a cherry-pick of #10788.)

Adds two flags to the `make` invocation when calling `var-require` make targets:

1. `--no-print-directory` - skips the "entering directory/exiting directory" messages
2. `--quiet` - skips the 'is up to date' messages

Also add an `@` before the `$(MAKE)` call so that the parent make does not print out the `make` command.

All of the information removed is irrelevant if `var-require` succeeds; otherwise, we still print out the error saying what the problem was anyway.

Example output:

Before:
```
❱ VERSION=v1.2.3 DRYRUN=sure make release-publish-windows-archive-gcs
make var-require REQUIRED_VARS=CONFIRM-DRYRUN
make[1]: Entering directory '/path/to/calico-master/node'
make[1]: 'var-require' is up to date.
make[1]: Leaving directory '/path/to/calico-master/node'
make var-require REQUIRED_VARS=VERSION FAIL_NOT_SET=true
make[1]: Entering directory '/path/to/calico-master/node'
make[1]: 'var-require' is up to date.
make[1]: Leaving directory '/path/to/calico-master/node'
cp dist/bin/calico-node.exe windows-packaging/CalicoWindows/calico-node.exe
<...>
```

After:
```
❱ VERSION=v1.2.3 DRYRUN=sure make release-publish-windows-archive-gcs
cp -r ../confd/windows-packaging/config-bgp.ps1 windows-packaging/CalicoWindows/confd/config-bgp.ps1
<...>
```

And it still provides relevant error output:

```
❱ make cut-release
lib.Makefile:1056: *** one of CONFIRM DRYRUN is not set or empty, but at least one is required.  Stop.
make: *** [lib.Makefile:1068: var-require-one-of-CONFIRM-DRYRUN] Error 2
```