### PR TITLE
[cherry-pick #10632] Fixup parent-release-branch script [v3.30]

### DIFF
--- a/hack/find-parent-release-branch.sh
+++ b/hack/find-parent-release-branch.sh
@@ -10,29 +10,15 @@ best=""
 
 current_branch=$(git branch --show-current)
 
-# Some of our team members use "tigera" in their github usernames, which this script
-# doesn't account for when `git_repo_slug` starts with `tigera`; for example, for
-# `tigera/somerepository`. This results in us fetching multiple lines of results
-# as multiple lines match, which results in invalid input to grep.
+# Find the appropriate remote, handling common forms of git URL:
 #
-#                                ┌────────this───────┐
-# Expected match: git@github.com:tigera/somerepository.git
+#  -  proto://github.com/foo/bar.git
+#  -  git@github.com:foo/bar.git
 #
-#                                         ┌─────also this─────┐
-# Unexpected match: git@github.com:userbootigera/somerepository.git
+#  And avoiding matching prefixes of the desired slug:
 #
-# We can't just grab the first or last line because we don't know what order the
-# remotes will be in, nor what actual format the remote URL will be in, so we
-# just include matches with one of [:/] in front of it. This covers both of the
-# delimiters used in these two common Git URL forms:
-#
-#                     ↓
-#   proto://github.com/foo/bar.git
-#       git@github.com:foo/bar.git
-#
-# Filtering to specifically these characters prevents us from misinterpreting valid
-# non-alphanumeric characters (e.g. test_tigera/somerepo.git).
-
+#   Match:  git@github.com:tigera/somerepository.git
+#   But not: git@github.com:userbootigera/somerepository.git
 echo "[debug] Trying to detect base branch by looking for most similar branch" >&2
 
 remote=$(git remote -v | grep "[:/]${git_repo_slug}.*fetch" | cut -f1 )

--- a/hack/find-parent-release-branch.sh
+++ b/hack/find-parent-release-branch.sh
@@ -8,8 +8,45 @@ best=""
 : "${release_prefix:=release-v}"
 : "${git_repo_slug:=projectcalico/calico}"
 
-remote=$(git remote -v | grep "${git_repo_slug}.*fetch" | cut -f1 )
-echo "Git remote: ${git_repo_slug} -> ${remote}" >&2
+current_branch=$(git branch --show-current)
+
+# Some of our team members use "tigera" in their github usernames, which breaks
+# this script for specifically those members when `git_repo_slug` starts with `tigera`;
+# for example, for `tigera/somerepository`. This results in us fetching multiple
+# lines of results as multiple lines match, which breaks the script.
+#
+#                                ┌────────this───────┐
+# Expected match: git@github.com:tigera/somerepository.git
+#
+#                                         ┌─────also this─────┐
+# Unexpected match: git@github.com:userbootigera/somerepository.git
+#
+# We can't just grab the first or last line because we don't know what order the
+# remotes will be in, nor what actual format the remote URL will be in, so we
+# just exclude matches with any alpha character in front of it.
+
+echo "[debug] Trying to detect base branch by looking for most similar branch" >&2
+
+remote=$(git remote -v | grep "[^a-zA-Z0-9]${git_repo_slug}.*fetch" | cut -f1 )
+
+if [[ -z "${remote}" ]]; then
+  echo "[error] Could not detect a git remote for ${git_repo_slug}; stop" >&2
+  exit 1
+fi
+
+# If we're running in a CI environment...
+if [[ -v CI ]]; then
+  # Do we have a fetch that references multiple branches?
+  if git config get remote.origin.fetch | fgrep -q "*"; then
+    echo "[debug] We seem to be configured to fetch all branches" >&2
+  else
+    echo "[debug] We don't seem to be configured to fetch all branches; fixing and re-fetching..." >&2
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch --all --quiet
+  fi # git config
+fi # -v CI
+
+echo "[debug] Git remote: ${git_repo_slug} -> ${remote}" >&2
 
 for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/${remote} | \
              grep --perl "${remote}/master$|${remote}/${release_prefix}[3-9]\.[2-9].*" ); do
@@ -22,4 +59,5 @@ for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/${remote}
   fi
 done
 
+echo "[debug] Found best result ${best} with a difference of ${count}" >&2
 echo $best

--- a/hack/format-changed-files.sh
+++ b/hack/format-changed-files.sh
@@ -5,7 +5,11 @@ set -e
 hack_dir="$(dirname $0)"
 repo_dir="$(dirname $hack_dir)"
 
-parent_branch="$($repo_dir/hack/find-parent-release-branch.sh)"
+# Allow for the parent branch to be passed in as an env var
+if [[ -z "${parent_branch}" ]]; then
+  parent_branch="$($repo_dir/hack/find-parent-release-branch.sh)"
+fi
+
 if [ -z "$parent_branch" ]; then
   echo "No parent branch found."
   exit 1

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -644,7 +644,9 @@ REPO_DIR=$(shell if [ -e hack/format-changed-files.sh ]; then echo '.'; else ech
 # Format changed files only.
 fix-changed go-fmt-changed goimports-changed:
 	$(DOCKER_RUN) -e release_prefix=$(RELEASE_BRANCH_PREFIX)-v \
-	              -e git_repo_slug=$(GIT_REPO_SLUG) $(CALICO_BUILD) $(REPO_DIR)/hack/format-changed-files.sh
+	              -e git_repo_slug=$(GIT_REPO_SLUG) \
+	              -e parent_branch=$(shell $(REPO_REL_DIR)/hack/find-parent-release-branch.sh) \
+	              $(CALICO_BUILD) $(REPO_DIR)/hack/format-changed-files.sh
 
 .PHONY: fix-all go-fmt-all goimports-all
 fix-all go-fmt-all goimports-all:


### PR DESCRIPTION
(This PR is a cherry-pick of #10632.)

Rewrite the `hack/find-parent-release-branch.sh` script to handle a few edge cases:

1. Not all branches have been fetched; this is true when Semaphore CI is running against a branch, in which case we can never find a parent branch
2. A user's github username ends with the same string that the github repo slug starts with (e.g. a username ends with `tigera` and our repo is `tigera/<something>`

In order to do this, a few changes were made to the scripts:

1. `lib.Makefile` will call `hack/find-parent-release-branch.sh` to get the parent branch and pass it to the docker container `hack/format-changed-files.sh` runs in so that we don't have to run our git commands in docker if we can avoid it as this can cause even more edge cases
2. If `hack/format-changed-files.sh` is passed a non-empty parent branch it will use that; otherwise it will call `hack/find-parent-release-branch.sh` (which is the previous behavior)
3. `hack/find-parent-release-branch.sh` will check for a `git_repo_slug` that is a whole "word" and not just a substring by ensuring that we have a non-alphanumeric character before the `git_repo_slug` we find.
4. The same script also now detects if it's running in CI, and, if it is, detects if git is configured to fetch only one branch, and, if it is, updates git to fetch all branches and then does so. This is necessary to ensure we can actually find the parent branch, but we gate this behind CI because we don't want to modify a user's local git clone unexpectedly.