### PR TITLE
bpf map batch cachingmap

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -686,7 +686,7 @@ func ObjGet(path string) (int, error) {
 	return int(fd), err
 }
 
-// MapUpdateBatch expects all key, values in a single slice, bytes of a one
+// MapUpdateBatch expects all keys, values in a single slice, bytes of a one
 // key/value appended back to back to the previous value.
 func MapUpdateBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
 	cK := C.CBytes(k)
@@ -695,6 +695,21 @@ func MapUpdateBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
 	defer C.free(cV)
 
 	_, err := C.bpf_map_batch_update(C.int(fd), cK, cV, (*C.__u32)(unsafe.Pointer(&count)), C.__u64(flags))
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// MapDeleteBatch expects all key is in a single slice, bytes of a one
+// key appended back to back to the previous value.
+func MapDeleteBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
+	cK := C.CBytes(k)
+	defer C.free(cK)
+
+	_, err := C.bpf_map_batch_delete(C.int(fd), cK, (*C.__u32)(unsafe.Pointer(&count)), C.__u64(flags))
 
 	if err != nil {
 		return 0, err

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -705,7 +705,7 @@ func MapUpdateBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
 
 // MapDeleteBatch expects all key is in a single slice, bytes of a one
 // key appended back to back to the previous value.
-func MapDeleteBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
+func MapDeleteBatch(fd int, k []byte, count int, flags uint64) (int, error) {
 	cK := C.CBytes(k)
 	defer C.free(cK)
 

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -485,6 +485,14 @@ void bpf_map_batch_update(int fd, const void *keys, const void *values, __u32 *c
 	set_errno(bpf_map_update_batch(fd, keys, values, count, &opts));
 }
 
+void bpf_map_batch_delete(int fd, const void *keys, __u32 *count, __u64 flags)
+{
+	DECLARE_LIBBPF_OPTS(bpf_map_batch_opts, opts,
+		.flags = flags);
+
+	set_errno(bpf_map_delete_batch(fd, keys, count, &opts));
+}
+
 int num_possible_cpu()
 {
     return libbpf_num_possible_cpus();

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -206,6 +206,10 @@ func MapUpdateBatch(fd int, k, v []byte, count int, flags uint64) (int, error) {
 	panic("LIBBPF syscall stub")
 }
 
+func MapDeleteBatch(fd int, k []byte, count int, flags uint64) (int, error) {
+	panic("LIBBPF syscall stub")
+}
+
 func (t *TcGlobalData) Set(m *Map) error {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/cachingmap/caching_map_test.go
+++ b/felix/cachingmap/caching_map_test.go
@@ -367,6 +367,126 @@ func testCachingMap_Resync(t *testing.T, batched bool) {
 	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
 }
 
+// TestCachingMap_BatchUpdateFailures tests that when some updates fail and some succeed
+// during ApplyUpdatesOnly, the successful ones are applied and errors are returned.
+func TestCachingMap_BatchUpdateFailures(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t, false) // Test with non-batched for key-specific failures
+	mockMap.Contents = map[string]string{
+		"existing": "value",
+	}
+
+	// Set up some pending updates
+	cm.Desired().Set("key1", "value1") // This should succeed
+	cm.Desired().Set("key2", "value2") // This will fail
+	cm.Desired().Set("key3", "value3") // This should succeed
+	cm.Desired().Set("key4", "value4") // This will fail
+
+	// Configure specific failures
+	mockMap.UpdateFailures["key2"] = fmt.Errorf("update key2 failed")
+	mockMap.UpdateFailures["key4"] = fmt.Errorf("update key4 failed")
+
+	err := cm.ApplyUpdatesOnly()
+
+	// Should get an error slice with 2 errors
+	Expect(err).To(HaveOccurred())
+	errSlice, ok := err.(ErrSlice)
+	Expect(ok).To(BeTrue(), "Expected ErrSlice type")
+	Expect(len(errSlice)).To(Equal(2), "Expected 2 errors")
+
+	// Check that successful operations were applied
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		"existing": "value",
+		"key1":     "value1", // succeeded
+		"key3":     "value3", // succeeded
+		// key2 and key4 should not be present due to failures
+	}))
+
+	// All update calls should have been attempted
+	Expect(mockMap.UpdateCount).To(Equal(4))
+	Expect(mockMap.LoadCount).To(Equal(1))
+}
+
+// TestCachingMap_BatchDeleteFailures tests that when some deletions fail and some succeed
+// during ApplyDeletionsOnly, the successful ones are applied and errors are returned.
+func TestCachingMap_BatchDeleteFailures(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t, false) // Test with non-batched for key-specific failures
+	mockMap.Contents = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+		"key4": "value4",
+		"keep": "keepvalue",
+	}
+
+	// Set up desired state that will cause deletions
+	cm.Desired().Set("keep", "keepvalue") // This key should remain
+
+	// Configure specific delete failures
+	mockMap.DeleteFailures["key2"] = fmt.Errorf("delete key2 failed")
+	mockMap.DeleteFailures["key4"] = fmt.Errorf("delete key4 failed")
+
+	err := cm.ApplyDeletionsOnly()
+
+	// Should get an error slice with 2 errors
+	Expect(err).To(HaveOccurred())
+	errSlice, ok := err.(ErrSlice)
+	Expect(ok).To(BeTrue(), "Expected ErrSlice type")
+	Expect(len(errSlice)).To(Equal(2), "Expected 2 errors")
+
+	// Check that successful deletions were applied
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		"key2": "value2",    // failed to delete
+		"key4": "value4",    // failed to delete
+		"keep": "keepvalue", // kept as desired
+	}))
+
+	// Deletion attempts should have been made
+	Expect(mockMap.DeleteCount).To(Equal(4)) // key1, key2, key3, key4 deletion attempts
+	Expect(mockMap.LoadCount).To(Equal(1))
+}
+
+// TestCachingMap_BatchAllChangesFailures tests that when both updates and deletions
+// have partial failures during ApplyAllChanges, successful operations are applied
+// and all errors are returned.
+func TestCachingMap_BatchAllChangesFailures(t *testing.T) {
+	mockMap, cm := setupCachingMapTest(t, false) // Test with non-batched for key-specific failures
+	mockMap.Contents = map[string]string{
+		"delete1": "value1",
+		"delete2": "value2", // Will fail to delete
+		"update1": "oldval", // Will be updated
+	}
+
+	// Set up desired state
+	cm.Desired().Set("update1", "newval")  // Update existing (should succeed)
+	cm.Desired().Set("update2", "newval2") // Add new (will fail)
+	cm.Desired().Set("update3", "newval3") // Add new (should succeed)
+
+	// Configure failures
+	mockMap.UpdateFailures["update2"] = fmt.Errorf("update2 failed")
+	mockMap.DeleteFailures["delete2"] = fmt.Errorf("delete2 failed")
+
+	err := cm.ApplyAllChanges()
+
+	// Should get errors from both deletions and updates
+	Expect(err).To(HaveOccurred())
+	errSlice, ok := err.(ErrSlice)
+	Expect(ok).To(BeTrue(), "Expected ErrSlice type")
+	Expect(len(errSlice)).To(Equal(2), "Expected 2 errors (1 delete + 1 update)")
+
+	// Check final state - successful operations should be applied
+	Expect(mockMap.Contents).To(Equal(map[string]string{
+		"delete2": "value2",  // failed to delete
+		"update1": "newval",  // successfully updated
+		"update3": "newval3", // successfully added
+		// update2 not present due to failure
+	}))
+
+	// Verify operation counts
+	Expect(mockMap.DeleteCount).To(Equal(2)) // delete1, delete2 attempts
+	Expect(mockMap.UpdateCount).To(Equal(3)) // update1, update2, update3 attempts
+	Expect(mockMap.LoadCount).To(Equal(1))
+}
+
 func setupCachingMapTest(t *testing.T, batched bool) (*Map, *CachingMap[string, string]) {
 	RegisterTestingT(t)
 
@@ -401,6 +521,10 @@ type Map struct {
 	LoadErr   error
 	UpdateErr error
 	DeleteErr error
+
+	// Maps to specify which specific keys should fail
+	UpdateFailures map[string]error
+	DeleteFailures map[string]error
 }
 
 var errNotExists = fmt.Errorf("does not exist")
@@ -412,6 +536,14 @@ func (m *Map) ErrIsNotExists(err error) bool {
 func (m *Map) Update(k, v string) error {
 	log.Debugf("Update(\"%s\", \"%s\")", k, v)
 	m.UpdateCount++
+
+	// Check for key-specific failure first
+	if m.UpdateFailures != nil {
+		if err, exists := m.UpdateFailures[k]; exists {
+			return err
+		}
+	}
+
 	if m.UpdateErr != nil {
 		return m.UpdateErr
 	}
@@ -435,6 +567,14 @@ func (m *Map) Get(k string) (string, error) {
 func (m *Map) Delete(k string) error {
 	log.Debugf("Delete(\"%s\")", k)
 	m.DeleteCount++
+
+	// Check for key-specific failure first
+	if m.DeleteFailures != nil {
+		if err, exists := m.DeleteFailures[k]; exists {
+			return err
+		}
+	}
+
 	if m.DeleteErr != nil {
 		return m.DeleteErr
 	}
@@ -458,7 +598,9 @@ func (m *Map) OpCount() int {
 
 func newMockMap() *Map {
 	m := &Map{
-		Contents: map[string]string{},
+		Contents:       map[string]string{},
+		UpdateFailures: make(map[string]error),
+		DeleteFailures: make(map[string]error),
 	}
 	return m
 }

--- a/felix/cachingmap/caching_map_test.go
+++ b/felix/cachingmap/caching_map_test.go
@@ -32,7 +32,12 @@ func init() {
 
 // TestCachingMap_Empty verifies loading of an empty map with no changes queued.
 func TestCachingMap_Empty(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_Empty(t, true)
+	testCachingMap_Empty(t, false)
+}
+
+func testCachingMap_Empty(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	err := cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(BeEmpty())
@@ -42,7 +47,12 @@ var ErrFail = fmt.Errorf("fail")
 
 // TestCachingMap_Errors tests returning of errors from the underlying map.
 func TestCachingMap_Errors(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_Errors(t, true)
+	testCachingMap_Errors(t, false)
+}
+
+func testCachingMap_Errors(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	mockMap.LoadErr = ErrFail
 	err := cm.ApplyAllChanges()
 	Expect(err).To(HaveOccurred())
@@ -84,7 +94,12 @@ func TestCachingMap_Errors(t *testing.T) {
 
 // TestCachingMap_CleanUp verifies cleaning up of a whole map.
 func TestCachingMap_CleanUp(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_CleanUp(t, true)
+	testCachingMap_CleanUp(t, false)
+}
+
+func testCachingMap_CleanUp(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	_ = mockMap.Update("1, 2", "1, 2, 3, 4")
 	_ = mockMap.Update("1, 3", "1, 2, 4, 4")
 
@@ -95,7 +110,12 @@ func TestCachingMap_CleanUp(t *testing.T) {
 
 // TestCachingMap_ApplyAll mainline test using separate Apply calls for adds and deletes.
 func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_SplitUpdateAndDelete(t, true)
+	testCachingMap_SplitUpdateAndDelete(t, false)
+}
+
+func testCachingMap_SplitUpdateAndDelete(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	mockMap.Contents = map[string]string{
 		"1, 1": "1, 2, 4, 3",
 		"1, 2": "1, 2, 3, 4",
@@ -145,7 +165,12 @@ func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
 
 // TestCachingMap_ApplyAll mainline test using ApplyAll() to update the dataplane.
 func TestCachingMap_ApplyAll(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_ApplyAll(t, true)
+	testCachingMap_ApplyAll(t, false)
+}
+
+func testCachingMap_ApplyAll(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	mockMap.Contents = map[string]string{
 		"1, 1": "1, 2, 4, 3",
 		"1, 2": "1, 2, 3, 4",
@@ -194,7 +219,12 @@ func TestCachingMap_ApplyAll(t *testing.T) {
 // TestCachingMap_DeleteBeforeLoad does some set and delete calls before loading from
 // the dataplane.
 func TestCachingMap_DeleteBeforeLoad(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_DeleteBeforeLoad(t, true)
+	testCachingMap_DeleteBeforeLoad(t, false)
+}
+
+func testCachingMap_DeleteBeforeLoad(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	mockMap.Contents = map[string]string{
 		"1, 1": "1, 2, 4, 3",
 		"1, 2": "1, 2, 3, 4",
@@ -230,7 +260,12 @@ func TestCachingMap_DeleteBeforeLoad(t *testing.T) {
 
 // TestCachingMap_PreLoad verifies calling LoadCacheFromDataplane before setting values.
 func TestCachingMap_PreLoad(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_PreLoad(t, true)
+	testCachingMap_PreLoad(t, false)
+}
+
+func testCachingMap_PreLoad(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	mockMap.Contents = map[string]string{
 		"1, 1": "1, 2, 4, 3",
 		"1, 2": "1, 2, 3, 4",
@@ -280,7 +315,12 @@ func TestCachingMap_PreLoad(t *testing.T) {
 // changes.  Pending changes should be dropped if the reload finds that they've already
 // been made.
 func TestCachingMap_Resync(t *testing.T) {
-	mockMap, cm := setupCachingMapTest(t)
+	testCachingMap_Resync(t, true)
+	testCachingMap_Resync(t, false)
+}
+
+func testCachingMap_Resync(t *testing.T, batched bool) {
+	mockMap, cm := setupCachingMapTest(t, batched)
 	mockMap.Contents = map[string]string{
 		"1, 1": "1, 2, 4, 3",
 		"1, 2": "1, 2, 3, 4",
@@ -327,13 +367,27 @@ func TestCachingMap_Resync(t *testing.T) {
 	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
 }
 
-func setupCachingMapTest(t *testing.T) (*Map, *CachingMap[string, string]) {
+func setupCachingMapTest(t *testing.T, batched bool) (*Map, *CachingMap[string, string]) {
 	RegisterTestingT(t)
-	mockMap := newMockMap()
+
+	var (
+		mockMap DataplaneMap[string, string]
+		retMap  *Map
+	)
+
+	if batched {
+		m := newMockBatchMap()
+		mockMap = m
+		retMap = m.Map
+	} else {
+		m := newMockMap()
+		mockMap = m
+		retMap = m
+	}
 
 	cm := New[string, string]("mock-map", mockMap)
 
-	return mockMap, cm
+	return retMap, cm
 }
 
 type Map struct {
@@ -407,4 +461,36 @@ func newMockMap() *Map {
 		Contents: map[string]string{},
 	}
 	return m
+}
+
+type BatchMap struct {
+	*Map
+}
+
+func (m *BatchMap) BatchUpdate(ks []string, vs []string) (int, error) {
+	for i, k := range ks {
+		err := m.Update(k, vs[i])
+		if err != nil {
+			return i, err
+		}
+	}
+
+	return len(ks), nil
+}
+
+func (m *BatchMap) BatchDelete(ks []string) (int, error) {
+	for i, k := range ks {
+		err := m.Delete(k)
+		if err != nil {
+			return i, err
+		}
+	}
+
+	return len(ks), nil
+}
+
+func newMockBatchMap() *BatchMap {
+	return &BatchMap{
+		Map: newMockMap(),
+	}
 }


### PR DESCRIPTION
## Description

It is more performant to commit multiple updates or deletes in a single
syscall than one-by-one.

Caching maps accumulate change and then typically apply all the updates followed by all the deletes when sync with the dataplane is triggered. That is an ideal situation for batching updates and deletes as we want to apply many changes at the same time rather than each individually.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: faster interaction with BPF maps from userspace due to batching update and delete operations. Should specifically help on larger and more churny clusters.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
