### PR TITLE
HACK: report dataplane update events back to Typha for aggregation

### DIFF
--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -88,6 +88,8 @@ type passthruCallbacks interface {
 	OnGlobalBGPConfigUpdate(*v3.BGPConfiguration)
 	OnServiceUpdate(*proto.ServiceUpdate)
 	OnServiceRemove(*proto.ServiceRemove)
+	OnTyphaRevisionRemove()
+	OnTyphaRevisionUpdate(tr *model.TyphaRevision)
 }
 
 type routeCallbacks interface {

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -53,6 +53,7 @@ func (h *DataplanePassthru) RegisterWith(dispatcher *dispatcher.Dispatcher) {
 	dispatcher.Register(model.IPPoolKey{}, h.OnUpdate)
 	dispatcher.Register(model.WireguardKey{}, h.OnUpdate)
 	dispatcher.Register(model.ResourceKey{}, h.OnUpdate)
+	dispatcher.Register(model.TyphaRevisionKey{}, h.OnUpdate)
 }
 
 func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
@@ -94,6 +95,15 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 			log.WithField("update", update).Debug("Passing-through Wireguard update")
 			wg := update.Value.(*model.Wireguard)
 			h.callbacks.OnWireguardUpdate(key.NodeName, wg)
+		}
+	case model.TyphaRevisionKey:
+		if update.Value == nil {
+			log.WithField("update", update).Debug("Passing-through typha revision deletion")
+			h.callbacks.OnTyphaRevisionRemove()
+		} else {
+			log.WithField("update", update).Debug("Passing-through typha revision updatee")
+			tr := update.Value.(*model.TyphaRevision)
+			h.callbacks.OnTyphaRevisionUpdate(tr)
 		}
 	case model.ResourceKey:
 		if key.Kind == v3.KindBGPConfiguration && key.Name == "default" {

--- a/felix/calc/profile_decoder_test.go
+++ b/felix/calc/profile_decoder_test.go
@@ -138,6 +138,14 @@ type passthruCallbackRecorder struct {
 	nsRemoves []types.NamespaceID
 }
 
+func (p *passthruCallbackRecorder) OnTyphaRevisionRemove() {
+	Fail("OnTyphaRevisionRemove received")
+}
+
+func (p *passthruCallbackRecorder) OnTyphaRevisionUpdate(tr *model.TyphaRevision) {
+	Fail("OnTyphaRevisionUpdate received")
+}
+
 func (p *passthruCallbackRecorder) OnHostIPUpdate(hostname string, ip *net.IP) {
 	Fail("HostIPUpdate received")
 }

--- a/felix/dataplane/driver.go
+++ b/felix/dataplane/driver.go
@@ -65,6 +65,7 @@ func StartDataplaneDriver(
 	fatalErrorCallback func(error),
 	k8sClientSet *kubernetes.Clientset,
 	lc *calc.LookupsCache,
+	typhaRevisionListener intdataplane.TyphaRevisionListener,
 ) (DataplaneDriver, *exec.Cmd) {
 	if !configParams.IsLeader() {
 		// Return an inactive dataplane, since we're not the leader.
@@ -417,6 +418,8 @@ func StartDataplaneDriver(
 			FlowLogsEnabled:    configParams.FlowLogsEnabled(),
 
 			RequireMTUFile: configParams.RequireMTUFile,
+
+			TyphaRevisionListener: typhaRevisionListener,
 		}
 
 		if configParams.BPFExternalServiceMode == "dsr" {

--- a/felix/dataplane/external/ext_dataplane.go
+++ b/felix/dataplane/external/ext_dataplane.go
@@ -250,6 +250,8 @@ func WrapPayloadWithEnvelope(msg interface{}, seqNo uint64) (*proto.ToDataplane,
 		envelope.Payload = &proto.ToDataplane_ServiceUpdate{ServiceUpdate: msg}
 	case *proto.ServiceRemove:
 		envelope.Payload = &proto.ToDataplane_ServiceRemove{ServiceRemove: msg}
+	case *proto.TyphaRevisionUpdate:
+		envelope.Payload = &proto.ToDataplane_TyphaRevisionUpdate{TyphaRevisionUpdate: msg}
 
 	default:
 		return nil, fmt.Errorf("Unknown message type: %T", msg)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -137,6 +137,15 @@ var (
 		Help: "Number of interface address messages processed in each batch. Higher " +
 			"values indicate we're doing more batching to try to keep up.",
 	})
+	gaugeLastAppliedTyphaTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "felix_int_dataplane_last_typha_timestamp_seconds",
+		Help: "Timestamp of the last Typha revision update that was applied to the dataplane.",
+	})
+	summaryTyphaBatchLatency = cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "felix_int_dataplane_typha_batch_latency_seconds",
+		Help: "Latency between Typha receiving events from the datastore (and producing an " +
+			"update batch) and completion of dataplane update.",
+	})
 
 	processStartTime time.Time
 	zeroKey          = wgtypes.Key{}
@@ -152,7 +161,18 @@ func init() {
 	prometheus.MustRegister(summaryBatchSize)
 	prometheus.MustRegister(summaryIfaceBatchSize)
 	prometheus.MustRegister(summaryAddrBatchSize)
+	prometheus.MustRegister(gaugeLastAppliedTyphaTimestamp)
+	prometheus.MustRegister(summaryTyphaBatchLatency)
 	processStartTime = time.Now()
+}
+
+var registerTyphaStatsOnce sync.Once
+
+func ensureTyphaStatsRegistered() {
+	registerTyphaStatsOnce.Do(func() {
+		prometheus.MustRegister(gaugeLastAppliedTyphaTimestamp)
+		prometheus.MustRegister(summaryTyphaBatchLatency)
+	})
 }
 
 type Config struct {
@@ -411,14 +431,16 @@ type InternalDataplane struct {
 	linkUpdateBatchSize  int
 	addrsUpdateBatchSize int
 
-	actions               generictables.ActionFactory
-	newMatch              func() generictables.MatchCriteria
-	typhaRevision         *string
-	typhaRevisionListener TyphaRevisionListener
+	actions  generictables.ActionFactory
+	newMatch func() generictables.MatchCriteria
+
+	typhaRevisionListener      TyphaRevisionListener
+	lastTyphaRevisionUpdate    *proto.TyphaRevisionUpdate
+	typhaRevisionUpdatePending bool
 }
 
 type TyphaRevisionListener interface {
-	OnDataplaneUpdateComplete(revision string)
+	OnDataplaneUpdateComplete(serverID, revision string)
 }
 
 const (
@@ -489,6 +511,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		actions:               actionSet,
 		newMatch:              newMatchFn,
 		typhaRevisionListener: config.TyphaRevisionListener,
+	}
+	if dp.typhaRevisionListener != nil {
+		log.Info("Typha revision listener configured, registering stats.")
+		ensureTyphaStatsRegistered()
 	}
 	dp.applyThrottle.Refill() // Allow the first apply() immediately.
 	dp.ifaceMonitor.StateCallback = dp.onIfaceStateChange
@@ -2366,7 +2392,8 @@ func (d *InternalDataplane) processMsgFromCalcGraph(msg interface{}) {
 			"Datastore in sync, flushing the dataplane for the first time...")
 		d.datastoreInSync = true
 	case *proto.TyphaRevisionUpdate:
-		d.typhaRevision = &msg.Revision
+		d.lastTyphaRevisionUpdate = msg
+		d.typhaRevisionUpdatePending = true
 	}
 }
 
@@ -2806,13 +2833,25 @@ func (d *InternalDataplane) reportHealth() {
 }
 
 func (d *InternalDataplane) reportTyphaRevision() {
-	if d.typhaRevision == nil {
-		return
-	}
 	if d.typhaRevisionListener == nil {
 		return
 	}
-	d.typhaRevisionListener.OnDataplaneUpdateComplete(*d.typhaRevision)
+	if d.lastTyphaRevisionUpdate == nil {
+		return
+	}
+	if !d.typhaRevisionUpdatePending {
+		return
+	}
+	d.typhaRevisionListener.OnDataplaneUpdateComplete(d.lastTyphaRevisionUpdate.ServerID, d.lastTyphaRevisionUpdate.Revision)
+	ts := d.lastTyphaRevisionUpdate.Timestamp
+	gaugeLastAppliedTyphaTimestamp.Set(float64(ts.Seconds)*1e9 + float64(ts.Nanos))
+	t := ts.AsTime()
+	if t.After(processStartTime) {
+		// Avoid reporting a huge latency spike when the process starts. The
+		// initial Typha breadcrumb may be hours old if the datastore is quiet!
+		summaryTyphaBatchLatency.Observe(time.Since(t).Seconds())
+	}
+	d.typhaRevisionUpdatePending = false
 }
 
 type dummyLock struct{}

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -11,6 +11,7 @@ import (
 	sync "sync"
 	unsafe "unsafe"
 
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
@@ -6261,7 +6262,9 @@ func (x *ServiceRemove) GetNamespace() string {
 
 type TyphaRevisionUpdate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	ServerID      string                 `protobuf:"bytes,2,opt,name=serverID,proto3" json:"serverID,omitempty"`
 	Revision      string                 `protobuf:"bytes,1,opt,name=revision,proto3" json:"revision,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6296,11 +6299,25 @@ func (*TyphaRevisionUpdate) Descriptor() ([]byte, []int) {
 	return file_felixbackend_proto_rawDescGZIP(), []int{78}
 }
 
+func (x *TyphaRevisionUpdate) GetServerID() string {
+	if x != nil {
+		return x.ServerID
+	}
+	return ""
+}
+
 func (x *TyphaRevisionUpdate) GetRevision() string {
 	if x != nil {
 		return x.Revision
 	}
 	return ""
+}
+
+func (x *TyphaRevisionUpdate) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
 }
 
 type HTTPMatch_PathMatch struct {
@@ -6389,7 +6406,7 @@ var File_felixbackend_proto protoreflect.FileDescriptor
 
 const file_felixbackend_proto_rawDesc = "" +
 	"\n" +
-	"\x12felixbackend.proto\x12\x05felix\"\r\n" +
+	"\x12felixbackend.proto\x12\x05felix\x1a\x1fgoogle/protobuf/timestamp.proto\"\r\n" +
 	"\vSyncRequest\"\x9d\x17\n" +
 	"\vToDataplane\x12'\n" +
 	"\x0fsequence_number\x18\x0f \x01(\x04R\x0esequenceNumber\x12(\n" +
@@ -6846,9 +6863,11 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x05ports\x18\a \x03(\v2\x12.felix.ServicePortR\x05ports\"A\n" +
 	"\rServiceRemove\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
-	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"1\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"\x87\x01\n" +
 	"\x13TyphaRevisionUpdate\x12\x1a\n" +
-	"\brevision\x18\x01 \x01(\tR\brevision*(\n" +
+	"\bserverID\x18\x02 \x01(\tR\bserverID\x12\x1a\n" +
+	"\brevision\x18\x01 \x01(\tR\brevision\x128\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp*(\n" +
 	"\tIPVersion\x12\a\n" +
 	"\x03ANY\x10\x00\x12\b\n" +
 	"\x04IPV4\x10\x04\x12\b\n" +
@@ -6989,6 +7008,7 @@ var file_felixbackend_proto_goTypes = []any{
 	nil,                                  // 94: felix.HostMetadataV4V6Update.LabelsEntry
 	nil,                                  // 95: felix.ServiceAccountUpdate.LabelsEntry
 	nil,                                  // 96: felix.NamespaceUpdate.LabelsEntry
+	(*timestamp.Timestamp)(nil),          // 97: google.protobuf.Timestamp
 }
 var file_felixbackend_proto_depIdxs = []int32{
 	14,  // 0: felix.ToDataplane.in_sync:type_name -> felix.InSync
@@ -7113,16 +7133,17 @@ var file_felixbackend_proto_depIdxs = []int32{
 	20,  // 119: felix.RuleTrace.profile:type_name -> felix.ProfileID
 	8,   // 120: felix.RuleTrace.direction:type_name -> felix.RuleTrace.Direction
 	84,  // 121: felix.ServiceUpdate.ports:type_name -> felix.ServicePort
-	13,  // 122: felix.ConfigUpdate.SourceToRawConfigEntry.value:type_name -> felix.RawConfig
-	9,   // 123: felix.PolicySync.Sync:input_type -> felix.SyncRequest
-	76,  // 124: felix.PolicySync.Report:input_type -> felix.DataplaneStats
-	10,  // 125: felix.PolicySync.Sync:output_type -> felix.ToDataplane
-	75,  // 126: felix.PolicySync.Report:output_type -> felix.ReportResult
-	125, // [125:127] is the sub-list for method output_type
-	123, // [123:125] is the sub-list for method input_type
-	123, // [123:123] is the sub-list for extension type_name
-	123, // [123:123] is the sub-list for extension extendee
-	0,   // [0:123] is the sub-list for field type_name
+	97,  // 122: felix.TyphaRevisionUpdate.timestamp:type_name -> google.protobuf.Timestamp
+	13,  // 123: felix.ConfigUpdate.SourceToRawConfigEntry.value:type_name -> felix.RawConfig
+	9,   // 124: felix.PolicySync.Sync:input_type -> felix.SyncRequest
+	76,  // 125: felix.PolicySync.Report:input_type -> felix.DataplaneStats
+	10,  // 126: felix.PolicySync.Sync:output_type -> felix.ToDataplane
+	75,  // 127: felix.PolicySync.Report:output_type -> felix.ReportResult
+	126, // [126:128] is the sub-list for method output_type
+	124, // [124:126] is the sub-list for method input_type
+	124, // [124:124] is the sub-list for extension type_name
+	124, // [124:124] is the sub-list for extension extendee
+	0,   // [0:124] is the sub-list for field type_name
 }
 
 func init() { file_felixbackend_proto_init() }

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -556,6 +556,7 @@ type ToDataplane struct {
 	//	*ToDataplane_WireguardEndpointV6Remove
 	//	*ToDataplane_HostMetadataV6Update
 	//	*ToDataplane_HostMetadataV6Remove
+	//	*ToDataplane_TyphaRevisionUpdate
 	Payload       isToDataplane_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -938,6 +939,15 @@ func (x *ToDataplane) GetHostMetadataV6Remove() *HostMetadataV6Remove {
 	return nil
 }
 
+func (x *ToDataplane) GetTyphaRevisionUpdate() *TyphaRevisionUpdate {
+	if x != nil {
+		if x, ok := x.Payload.(*ToDataplane_TyphaRevisionUpdate); ok {
+			return x.TyphaRevisionUpdate
+		}
+	}
+	return nil
+}
+
 type isToDataplane_Payload interface {
 	isToDataplane_Payload()
 }
@@ -1134,6 +1144,10 @@ type ToDataplane_HostMetadataV6Remove struct {
 	HostMetadataV6Remove *HostMetadataV6Remove `protobuf:"bytes,36,opt,name=host_metadata_v6_remove,json=hostMetadataV6Remove,proto3,oneof"`
 }
 
+type ToDataplane_TyphaRevisionUpdate struct {
+	TyphaRevisionUpdate *TyphaRevisionUpdate `protobuf:"bytes,39,opt,name=typha_revision_update,json=typhaRevisionUpdate,proto3,oneof"`
+}
+
 func (*ToDataplane_InSync) isToDataplane_Payload() {}
 
 func (*ToDataplane_IpsetUpdate) isToDataplane_Payload() {}
@@ -1207,6 +1221,8 @@ func (*ToDataplane_WireguardEndpointV6Remove) isToDataplane_Payload() {}
 func (*ToDataplane_HostMetadataV6Update) isToDataplane_Payload() {}
 
 func (*ToDataplane_HostMetadataV6Remove) isToDataplane_Payload() {}
+
+func (*ToDataplane_TyphaRevisionUpdate) isToDataplane_Payload() {}
 
 type FromDataplane struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
@@ -6243,6 +6259,50 @@ func (x *ServiceRemove) GetNamespace() string {
 	return ""
 }
 
+type TyphaRevisionUpdate struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Revision      string                 `protobuf:"bytes,1,opt,name=revision,proto3" json:"revision,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TyphaRevisionUpdate) Reset() {
+	*x = TyphaRevisionUpdate{}
+	mi := &file_felixbackend_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TyphaRevisionUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TyphaRevisionUpdate) ProtoMessage() {}
+
+func (x *TyphaRevisionUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_felixbackend_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TyphaRevisionUpdate.ProtoReflect.Descriptor instead.
+func (*TyphaRevisionUpdate) Descriptor() ([]byte, []int) {
+	return file_felixbackend_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *TyphaRevisionUpdate) GetRevision() string {
+	if x != nil {
+		return x.Revision
+	}
+	return ""
+}
+
 type HTTPMatch_PathMatch struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to PathMatch:
@@ -6256,7 +6316,7 @@ type HTTPMatch_PathMatch struct {
 
 func (x *HTTPMatch_PathMatch) Reset() {
 	*x = HTTPMatch_PathMatch{}
-	mi := &file_felixbackend_proto_msgTypes[81]
+	mi := &file_felixbackend_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6268,7 +6328,7 @@ func (x *HTTPMatch_PathMatch) String() string {
 func (*HTTPMatch_PathMatch) ProtoMessage() {}
 
 func (x *HTTPMatch_PathMatch) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[81]
+	mi := &file_felixbackend_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6330,7 +6390,7 @@ var File_felixbackend_proto protoreflect.FileDescriptor
 const file_felixbackend_proto_rawDesc = "" +
 	"\n" +
 	"\x12felixbackend.proto\x12\x05felix\"\r\n" +
-	"\vSyncRequest\"\xcb\x16\n" +
+	"\vSyncRequest\"\x9d\x17\n" +
 	"\vToDataplane\x12'\n" +
 	"\x0fsequence_number\x18\x0f \x01(\x04R\x0esequenceNumber\x12(\n" +
 	"\ain_sync\x18\x01 \x01(\v2\r.felix.InSyncH\x00R\x06inSync\x127\n" +
@@ -6372,7 +6432,8 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x1cwireguard_endpoint_v6_update\x18! \x01(\v2 .felix.WireguardEndpointV6UpdateH\x00R\x19wireguardEndpointV6Update\x12c\n" +
 	"\x1cwireguard_endpoint_v6_remove\x18\" \x01(\v2 .felix.WireguardEndpointV6RemoveH\x00R\x19wireguardEndpointV6Remove\x12T\n" +
 	"\x17host_metadata_v6_update\x18# \x01(\v2\x1b.felix.HostMetadataV6UpdateH\x00R\x14hostMetadataV6Update\x12T\n" +
-	"\x17host_metadata_v6_remove\x18$ \x01(\v2\x1b.felix.HostMetadataV6RemoveH\x00R\x14hostMetadataV6RemoveB\t\n" +
+	"\x17host_metadata_v6_remove\x18$ \x01(\v2\x1b.felix.HostMetadataV6RemoveH\x00R\x14hostMetadataV6Remove\x12P\n" +
+	"\x15typha_revision_update\x18' \x01(\v2\x1a.felix.TyphaRevisionUpdateH\x00R\x13typhaRevisionUpdateB\t\n" +
 	"\apayload\"\xd3\x05\n" +
 	"\rFromDataplane\x12'\n" +
 	"\x0fsequence_number\x18\b \x01(\x04R\x0esequenceNumber\x12P\n" +
@@ -6785,7 +6846,9 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x05ports\x18\a \x03(\v2\x12.felix.ServicePortR\x05ports\"A\n" +
 	"\rServiceRemove\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
-	"\tnamespace\x18\x02 \x01(\tR\tnamespace*(\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"1\n" +
+	"\x13TyphaRevisionUpdate\x12\x1a\n" +
+	"\brevision\x18\x01 \x01(\tR\brevision*(\n" +
 	"\tIPVersion\x12\a\n" +
 	"\x03ANY\x10\x00\x12\b\n" +
 	"\x04IPV4\x10\x04\x12\b\n" +
@@ -6827,7 +6890,7 @@ func file_felixbackend_proto_rawDescGZIP() []byte {
 }
 
 var file_felixbackend_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_felixbackend_proto_msgTypes = make([]protoimpl.MessageInfo, 87)
+var file_felixbackend_proto_msgTypes = make([]protoimpl.MessageInfo, 88)
 var file_felixbackend_proto_goTypes = []any{
 	(IPVersion)(0),                       // 0: felix.IPVersion
 	(RouteType)(0),                       // 1: felix.RouteType
@@ -6916,15 +6979,16 @@ var file_felixbackend_proto_goTypes = []any{
 	(*ServicePort)(nil),                  // 84: felix.ServicePort
 	(*ServiceUpdate)(nil),                // 85: felix.ServiceUpdate
 	(*ServiceRemove)(nil),                // 86: felix.ServiceRemove
-	nil,                                  // 87: felix.ConfigUpdate.ConfigEntry
-	nil,                                  // 88: felix.ConfigUpdate.SourceToRawConfigEntry
-	nil,                                  // 89: felix.RawConfig.ConfigEntry
-	(*HTTPMatch_PathMatch)(nil),          // 90: felix.HTTPMatch.PathMatch
-	nil,                                  // 91: felix.RuleMetadata.AnnotationsEntry
-	nil,                                  // 92: felix.WorkloadEndpoint.AnnotationsEntry
-	nil,                                  // 93: felix.HostMetadataV4V6Update.LabelsEntry
-	nil,                                  // 94: felix.ServiceAccountUpdate.LabelsEntry
-	nil,                                  // 95: felix.NamespaceUpdate.LabelsEntry
+	(*TyphaRevisionUpdate)(nil),          // 87: felix.TyphaRevisionUpdate
+	nil,                                  // 88: felix.ConfigUpdate.ConfigEntry
+	nil,                                  // 89: felix.ConfigUpdate.SourceToRawConfigEntry
+	nil,                                  // 90: felix.RawConfig.ConfigEntry
+	(*HTTPMatch_PathMatch)(nil),          // 91: felix.HTTPMatch.PathMatch
+	nil,                                  // 92: felix.RuleMetadata.AnnotationsEntry
+	nil,                                  // 93: felix.WorkloadEndpoint.AnnotationsEntry
+	nil,                                  // 94: felix.HostMetadataV4V6Update.LabelsEntry
+	nil,                                  // 95: felix.ServiceAccountUpdate.LabelsEntry
+	nil,                                  // 96: felix.NamespaceUpdate.LabelsEntry
 }
 var file_felixbackend_proto_depIdxs = []int32{
 	14,  // 0: felix.ToDataplane.in_sync:type_name -> felix.InSync
@@ -6964,100 +7028,101 @@ var file_felixbackend_proto_depIdxs = []int32{
 	82,  // 34: felix.ToDataplane.wireguard_endpoint_v6_remove:type_name -> felix.WireguardEndpointV6Remove
 	58,  // 35: felix.ToDataplane.host_metadata_v6_update:type_name -> felix.HostMetadataV6Update
 	59,  // 36: felix.ToDataplane.host_metadata_v6_remove:type_name -> felix.HostMetadataV6Remove
-	46,  // 37: felix.FromDataplane.process_status_update:type_name -> felix.ProcessStatusUpdate
-	47,  // 38: felix.FromDataplane.host_endpoint_status_update:type_name -> felix.HostEndpointStatusUpdate
-	49,  // 39: felix.FromDataplane.host_endpoint_status_remove:type_name -> felix.HostEndpointStatusRemove
-	50,  // 40: felix.FromDataplane.workload_endpoint_status_update:type_name -> felix.WorkloadEndpointStatusUpdate
-	51,  // 41: felix.FromDataplane.workload_endpoint_status_remove:type_name -> felix.WorkloadEndpointStatusRemove
-	52,  // 42: felix.FromDataplane.wireguard_status_update:type_name -> felix.WireguardStatusUpdate
-	53,  // 43: felix.FromDataplane.dataplane_in_sync:type_name -> felix.DataplaneInSync
-	87,  // 44: felix.ConfigUpdate.config:type_name -> felix.ConfigUpdate.ConfigEntry
-	88,  // 45: felix.ConfigUpdate.source_to_raw_config:type_name -> felix.ConfigUpdate.SourceToRawConfigEntry
-	89,  // 46: felix.RawConfig.config:type_name -> felix.RawConfig.ConfigEntry
-	4,   // 47: felix.IPSetUpdate.type:type_name -> felix.IPSetUpdate.IPSetType
-	20,  // 48: felix.ActiveProfileUpdate.id:type_name -> felix.ProfileID
-	21,  // 49: felix.ActiveProfileUpdate.profile:type_name -> felix.Profile
-	20,  // 50: felix.ActiveProfileRemove.id:type_name -> felix.ProfileID
-	26,  // 51: felix.Profile.inbound_rules:type_name -> felix.Rule
-	26,  // 52: felix.Profile.outbound_rules:type_name -> felix.Rule
-	24,  // 53: felix.ActivePolicyUpdate.id:type_name -> felix.PolicyID
-	25,  // 54: felix.ActivePolicyUpdate.policy:type_name -> felix.Policy
-	24,  // 55: felix.ActivePolicyRemove.id:type_name -> felix.PolicyID
-	26,  // 56: felix.Policy.inbound_rules:type_name -> felix.Rule
-	26,  // 57: felix.Policy.outbound_rules:type_name -> felix.Rule
-	0,   // 58: felix.Rule.ip_version:type_name -> felix.IPVersion
-	31,  // 59: felix.Rule.protocol:type_name -> felix.Protocol
-	32,  // 60: felix.Rule.src_ports:type_name -> felix.PortRange
-	32,  // 61: felix.Rule.dst_ports:type_name -> felix.PortRange
-	30,  // 62: felix.Rule.icmp_type_code:type_name -> felix.IcmpTypeAndCode
-	31,  // 63: felix.Rule.not_protocol:type_name -> felix.Protocol
-	32,  // 64: felix.Rule.not_src_ports:type_name -> felix.PortRange
-	32,  // 65: felix.Rule.not_dst_ports:type_name -> felix.PortRange
-	30,  // 66: felix.Rule.not_icmp_type_code:type_name -> felix.IcmpTypeAndCode
-	27,  // 67: felix.Rule.src_service_account_match:type_name -> felix.ServiceAccountMatch
-	27,  // 68: felix.Rule.dst_service_account_match:type_name -> felix.ServiceAccountMatch
-	28,  // 69: felix.Rule.http_match:type_name -> felix.HTTPMatch
-	29,  // 70: felix.Rule.metadata:type_name -> felix.RuleMetadata
-	90,  // 71: felix.HTTPMatch.paths:type_name -> felix.HTTPMatch.PathMatch
-	91,  // 72: felix.RuleMetadata.annotations:type_name -> felix.RuleMetadata.AnnotationsEntry
-	33,  // 73: felix.WorkloadEndpointUpdate.id:type_name -> felix.WorkloadEndpointID
-	36,  // 74: felix.WorkloadEndpointUpdate.endpoint:type_name -> felix.WorkloadEndpoint
-	44,  // 75: felix.WorkloadEndpoint.tiers:type_name -> felix.TierInfo
-	45,  // 76: felix.WorkloadEndpoint.ipv4_nat:type_name -> felix.NatInfo
-	45,  // 77: felix.WorkloadEndpoint.ipv6_nat:type_name -> felix.NatInfo
-	92,  // 78: felix.WorkloadEndpoint.annotations:type_name -> felix.WorkloadEndpoint.AnnotationsEntry
-	37,  // 79: felix.WorkloadEndpoint.qos_controls:type_name -> felix.QoSControls
-	38,  // 80: felix.WorkloadEndpoint.local_bgp_peer:type_name -> felix.LocalBGPPeer
-	35,  // 81: felix.WorkloadEndpoint.skip_redir:type_name -> felix.WorkloadBpfSkipRedir
-	33,  // 82: felix.WorkloadEndpointRemove.id:type_name -> felix.WorkloadEndpointID
-	40,  // 83: felix.HostEndpointUpdate.id:type_name -> felix.HostEndpointID
-	42,  // 84: felix.HostEndpointUpdate.endpoint:type_name -> felix.HostEndpoint
-	44,  // 85: felix.HostEndpoint.tiers:type_name -> felix.TierInfo
-	44,  // 86: felix.HostEndpoint.untracked_tiers:type_name -> felix.TierInfo
-	44,  // 87: felix.HostEndpoint.pre_dnat_tiers:type_name -> felix.TierInfo
-	44,  // 88: felix.HostEndpoint.forward_tiers:type_name -> felix.TierInfo
-	40,  // 89: felix.HostEndpointRemove.id:type_name -> felix.HostEndpointID
-	40,  // 90: felix.HostEndpointStatusUpdate.id:type_name -> felix.HostEndpointID
-	48,  // 91: felix.HostEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
-	40,  // 92: felix.HostEndpointStatusRemove.id:type_name -> felix.HostEndpointID
-	33,  // 93: felix.WorkloadEndpointStatusUpdate.id:type_name -> felix.WorkloadEndpointID
-	48,  // 94: felix.WorkloadEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
-	36,  // 95: felix.WorkloadEndpointStatusUpdate.endpoint:type_name -> felix.WorkloadEndpoint
-	33,  // 96: felix.WorkloadEndpointStatusRemove.id:type_name -> felix.WorkloadEndpointID
-	0,   // 97: felix.WireguardStatusUpdate.ip_version:type_name -> felix.IPVersion
-	93,  // 98: felix.HostMetadataV4V6Update.labels:type_name -> felix.HostMetadataV4V6Update.LabelsEntry
-	62,  // 99: felix.IPAMPoolUpdate.pool:type_name -> felix.IPAMPool
-	66,  // 100: felix.ServiceAccountUpdate.id:type_name -> felix.ServiceAccountID
-	94,  // 101: felix.ServiceAccountUpdate.labels:type_name -> felix.ServiceAccountUpdate.LabelsEntry
-	66,  // 102: felix.ServiceAccountRemove.id:type_name -> felix.ServiceAccountID
-	69,  // 103: felix.NamespaceUpdate.id:type_name -> felix.NamespaceID
-	95,  // 104: felix.NamespaceUpdate.labels:type_name -> felix.NamespaceUpdate.LabelsEntry
-	69,  // 105: felix.NamespaceRemove.id:type_name -> felix.NamespaceID
-	1,   // 106: felix.RouteUpdate.types:type_name -> felix.RouteType
-	2,   // 107: felix.RouteUpdate.ip_pool_type:type_name -> felix.IPPoolType
-	70,  // 108: felix.RouteUpdate.tunnel_type:type_name -> felix.TunnelType
-	31,  // 109: felix.DataplaneStats.protocol:type_name -> felix.Protocol
-	77,  // 110: felix.DataplaneStats.stats:type_name -> felix.Statistic
-	78,  // 111: felix.DataplaneStats.rules:type_name -> felix.RuleTrace
-	3,   // 112: felix.DataplaneStats.action:type_name -> felix.Action
-	5,   // 113: felix.Statistic.direction:type_name -> felix.Statistic.Direction
-	6,   // 114: felix.Statistic.relativity:type_name -> felix.Statistic.Relativity
-	7,   // 115: felix.Statistic.kind:type_name -> felix.Statistic.Kind
-	3,   // 116: felix.Statistic.action:type_name -> felix.Action
-	24,  // 117: felix.RuleTrace.policy:type_name -> felix.PolicyID
-	20,  // 118: felix.RuleTrace.profile:type_name -> felix.ProfileID
-	8,   // 119: felix.RuleTrace.direction:type_name -> felix.RuleTrace.Direction
-	84,  // 120: felix.ServiceUpdate.ports:type_name -> felix.ServicePort
-	13,  // 121: felix.ConfigUpdate.SourceToRawConfigEntry.value:type_name -> felix.RawConfig
-	9,   // 122: felix.PolicySync.Sync:input_type -> felix.SyncRequest
-	76,  // 123: felix.PolicySync.Report:input_type -> felix.DataplaneStats
-	10,  // 124: felix.PolicySync.Sync:output_type -> felix.ToDataplane
-	75,  // 125: felix.PolicySync.Report:output_type -> felix.ReportResult
-	124, // [124:126] is the sub-list for method output_type
-	122, // [122:124] is the sub-list for method input_type
-	122, // [122:122] is the sub-list for extension type_name
-	122, // [122:122] is the sub-list for extension extendee
-	0,   // [0:122] is the sub-list for field type_name
+	87,  // 37: felix.ToDataplane.typha_revision_update:type_name -> felix.TyphaRevisionUpdate
+	46,  // 38: felix.FromDataplane.process_status_update:type_name -> felix.ProcessStatusUpdate
+	47,  // 39: felix.FromDataplane.host_endpoint_status_update:type_name -> felix.HostEndpointStatusUpdate
+	49,  // 40: felix.FromDataplane.host_endpoint_status_remove:type_name -> felix.HostEndpointStatusRemove
+	50,  // 41: felix.FromDataplane.workload_endpoint_status_update:type_name -> felix.WorkloadEndpointStatusUpdate
+	51,  // 42: felix.FromDataplane.workload_endpoint_status_remove:type_name -> felix.WorkloadEndpointStatusRemove
+	52,  // 43: felix.FromDataplane.wireguard_status_update:type_name -> felix.WireguardStatusUpdate
+	53,  // 44: felix.FromDataplane.dataplane_in_sync:type_name -> felix.DataplaneInSync
+	88,  // 45: felix.ConfigUpdate.config:type_name -> felix.ConfigUpdate.ConfigEntry
+	89,  // 46: felix.ConfigUpdate.source_to_raw_config:type_name -> felix.ConfigUpdate.SourceToRawConfigEntry
+	90,  // 47: felix.RawConfig.config:type_name -> felix.RawConfig.ConfigEntry
+	4,   // 48: felix.IPSetUpdate.type:type_name -> felix.IPSetUpdate.IPSetType
+	20,  // 49: felix.ActiveProfileUpdate.id:type_name -> felix.ProfileID
+	21,  // 50: felix.ActiveProfileUpdate.profile:type_name -> felix.Profile
+	20,  // 51: felix.ActiveProfileRemove.id:type_name -> felix.ProfileID
+	26,  // 52: felix.Profile.inbound_rules:type_name -> felix.Rule
+	26,  // 53: felix.Profile.outbound_rules:type_name -> felix.Rule
+	24,  // 54: felix.ActivePolicyUpdate.id:type_name -> felix.PolicyID
+	25,  // 55: felix.ActivePolicyUpdate.policy:type_name -> felix.Policy
+	24,  // 56: felix.ActivePolicyRemove.id:type_name -> felix.PolicyID
+	26,  // 57: felix.Policy.inbound_rules:type_name -> felix.Rule
+	26,  // 58: felix.Policy.outbound_rules:type_name -> felix.Rule
+	0,   // 59: felix.Rule.ip_version:type_name -> felix.IPVersion
+	31,  // 60: felix.Rule.protocol:type_name -> felix.Protocol
+	32,  // 61: felix.Rule.src_ports:type_name -> felix.PortRange
+	32,  // 62: felix.Rule.dst_ports:type_name -> felix.PortRange
+	30,  // 63: felix.Rule.icmp_type_code:type_name -> felix.IcmpTypeAndCode
+	31,  // 64: felix.Rule.not_protocol:type_name -> felix.Protocol
+	32,  // 65: felix.Rule.not_src_ports:type_name -> felix.PortRange
+	32,  // 66: felix.Rule.not_dst_ports:type_name -> felix.PortRange
+	30,  // 67: felix.Rule.not_icmp_type_code:type_name -> felix.IcmpTypeAndCode
+	27,  // 68: felix.Rule.src_service_account_match:type_name -> felix.ServiceAccountMatch
+	27,  // 69: felix.Rule.dst_service_account_match:type_name -> felix.ServiceAccountMatch
+	28,  // 70: felix.Rule.http_match:type_name -> felix.HTTPMatch
+	29,  // 71: felix.Rule.metadata:type_name -> felix.RuleMetadata
+	91,  // 72: felix.HTTPMatch.paths:type_name -> felix.HTTPMatch.PathMatch
+	92,  // 73: felix.RuleMetadata.annotations:type_name -> felix.RuleMetadata.AnnotationsEntry
+	33,  // 74: felix.WorkloadEndpointUpdate.id:type_name -> felix.WorkloadEndpointID
+	36,  // 75: felix.WorkloadEndpointUpdate.endpoint:type_name -> felix.WorkloadEndpoint
+	44,  // 76: felix.WorkloadEndpoint.tiers:type_name -> felix.TierInfo
+	45,  // 77: felix.WorkloadEndpoint.ipv4_nat:type_name -> felix.NatInfo
+	45,  // 78: felix.WorkloadEndpoint.ipv6_nat:type_name -> felix.NatInfo
+	93,  // 79: felix.WorkloadEndpoint.annotations:type_name -> felix.WorkloadEndpoint.AnnotationsEntry
+	37,  // 80: felix.WorkloadEndpoint.qos_controls:type_name -> felix.QoSControls
+	38,  // 81: felix.WorkloadEndpoint.local_bgp_peer:type_name -> felix.LocalBGPPeer
+	35,  // 82: felix.WorkloadEndpoint.skip_redir:type_name -> felix.WorkloadBpfSkipRedir
+	33,  // 83: felix.WorkloadEndpointRemove.id:type_name -> felix.WorkloadEndpointID
+	40,  // 84: felix.HostEndpointUpdate.id:type_name -> felix.HostEndpointID
+	42,  // 85: felix.HostEndpointUpdate.endpoint:type_name -> felix.HostEndpoint
+	44,  // 86: felix.HostEndpoint.tiers:type_name -> felix.TierInfo
+	44,  // 87: felix.HostEndpoint.untracked_tiers:type_name -> felix.TierInfo
+	44,  // 88: felix.HostEndpoint.pre_dnat_tiers:type_name -> felix.TierInfo
+	44,  // 89: felix.HostEndpoint.forward_tiers:type_name -> felix.TierInfo
+	40,  // 90: felix.HostEndpointRemove.id:type_name -> felix.HostEndpointID
+	40,  // 91: felix.HostEndpointStatusUpdate.id:type_name -> felix.HostEndpointID
+	48,  // 92: felix.HostEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
+	40,  // 93: felix.HostEndpointStatusRemove.id:type_name -> felix.HostEndpointID
+	33,  // 94: felix.WorkloadEndpointStatusUpdate.id:type_name -> felix.WorkloadEndpointID
+	48,  // 95: felix.WorkloadEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
+	36,  // 96: felix.WorkloadEndpointStatusUpdate.endpoint:type_name -> felix.WorkloadEndpoint
+	33,  // 97: felix.WorkloadEndpointStatusRemove.id:type_name -> felix.WorkloadEndpointID
+	0,   // 98: felix.WireguardStatusUpdate.ip_version:type_name -> felix.IPVersion
+	94,  // 99: felix.HostMetadataV4V6Update.labels:type_name -> felix.HostMetadataV4V6Update.LabelsEntry
+	62,  // 100: felix.IPAMPoolUpdate.pool:type_name -> felix.IPAMPool
+	66,  // 101: felix.ServiceAccountUpdate.id:type_name -> felix.ServiceAccountID
+	95,  // 102: felix.ServiceAccountUpdate.labels:type_name -> felix.ServiceAccountUpdate.LabelsEntry
+	66,  // 103: felix.ServiceAccountRemove.id:type_name -> felix.ServiceAccountID
+	69,  // 104: felix.NamespaceUpdate.id:type_name -> felix.NamespaceID
+	96,  // 105: felix.NamespaceUpdate.labels:type_name -> felix.NamespaceUpdate.LabelsEntry
+	69,  // 106: felix.NamespaceRemove.id:type_name -> felix.NamespaceID
+	1,   // 107: felix.RouteUpdate.types:type_name -> felix.RouteType
+	2,   // 108: felix.RouteUpdate.ip_pool_type:type_name -> felix.IPPoolType
+	70,  // 109: felix.RouteUpdate.tunnel_type:type_name -> felix.TunnelType
+	31,  // 110: felix.DataplaneStats.protocol:type_name -> felix.Protocol
+	77,  // 111: felix.DataplaneStats.stats:type_name -> felix.Statistic
+	78,  // 112: felix.DataplaneStats.rules:type_name -> felix.RuleTrace
+	3,   // 113: felix.DataplaneStats.action:type_name -> felix.Action
+	5,   // 114: felix.Statistic.direction:type_name -> felix.Statistic.Direction
+	6,   // 115: felix.Statistic.relativity:type_name -> felix.Statistic.Relativity
+	7,   // 116: felix.Statistic.kind:type_name -> felix.Statistic.Kind
+	3,   // 117: felix.Statistic.action:type_name -> felix.Action
+	24,  // 118: felix.RuleTrace.policy:type_name -> felix.PolicyID
+	20,  // 119: felix.RuleTrace.profile:type_name -> felix.ProfileID
+	8,   // 120: felix.RuleTrace.direction:type_name -> felix.RuleTrace.Direction
+	84,  // 121: felix.ServiceUpdate.ports:type_name -> felix.ServicePort
+	13,  // 122: felix.ConfigUpdate.SourceToRawConfigEntry.value:type_name -> felix.RawConfig
+	9,   // 123: felix.PolicySync.Sync:input_type -> felix.SyncRequest
+	76,  // 124: felix.PolicySync.Report:input_type -> felix.DataplaneStats
+	10,  // 125: felix.PolicySync.Sync:output_type -> felix.ToDataplane
+	75,  // 126: felix.PolicySync.Report:output_type -> felix.ReportResult
+	125, // [125:127] is the sub-list for method output_type
+	123, // [123:125] is the sub-list for method input_type
+	123, // [123:123] is the sub-list for extension type_name
+	123, // [123:123] is the sub-list for extension extendee
+	0,   // [0:123] is the sub-list for field type_name
 }
 
 func init() { file_felixbackend_proto_init() }
@@ -7103,6 +7168,7 @@ func file_felixbackend_proto_init() {
 		(*ToDataplane_WireguardEndpointV6Remove)(nil),
 		(*ToDataplane_HostMetadataV6Update)(nil),
 		(*ToDataplane_HostMetadataV6Remove)(nil),
+		(*ToDataplane_TyphaRevisionUpdate)(nil),
 	}
 	file_felixbackend_proto_msgTypes[2].OneofWrappers = []any{
 		(*FromDataplane_ProcessStatusUpdate)(nil),
@@ -7128,7 +7194,7 @@ func file_felixbackend_proto_init() {
 		(*RuleTrace_Profile)(nil),
 		(*RuleTrace_None)(nil),
 	}
-	file_felixbackend_proto_msgTypes[81].OneofWrappers = []any{
+	file_felixbackend_proto_msgTypes[82].OneofWrappers = []any{
 		(*HTTPMatch_PathMatch_Exact)(nil),
 		(*HTTPMatch_PathMatch_Prefix)(nil),
 	}
@@ -7138,7 +7204,7 @@ func file_felixbackend_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_felixbackend_proto_rawDesc), len(file_felixbackend_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   87,
+			NumMessages:   88,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package felix;
 option go_package = "./proto";
 
+import "google/protobuf/timestamp.proto";
+
 service PolicySync {
   // On this API, only the following payloads will be sent:
   //  - InSync
@@ -822,5 +824,7 @@ message ServiceRemove {
 }
 
 message TyphaRevisionUpdate {
+  string serverID = 2;
   string revision = 1;
+  google.protobuf.Timestamp timestamp = 3;
 }

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -142,6 +142,8 @@ message ToDataplane {
     HostMetadataV6Update host_metadata_v6_update = 35;
     // HostMetadataV6Remove is sent when a host IPv6 address is removed.
     HostMetadataV6Remove host_metadata_v6_remove = 36;
+
+    TyphaRevisionUpdate typha_revision_update = 39;
   }
 }
 
@@ -817,4 +819,8 @@ message ServiceUpdate {
 message ServiceRemove {
 	string name = 1;
 	string namespace = 2;
+}
+
+message TyphaRevisionUpdate {
+  string revision = 1;
 }

--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -349,6 +349,17 @@ func keyFromDefaultPathInner(path string, parts []string) Key {
 					return ProfileLabelsKey{ProfileKey: ProfileKey{pk}}
 				}
 			}
+		case "typha":
+			if len(parts) < 4 {
+				return nil
+			}
+			switch parts[3] {
+			case "revision":
+				if len(parts) != 4 {
+					return nil
+				}
+				return TyphaRevisionKey{}
+			}
 		}
 	case "bgp":
 		switch parts[2] {

--- a/libcalico-go/lib/backend/model/typha.go
+++ b/libcalico-go/lib/backend/model/typha.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	matchTyphaRevision = regexp.MustCompile("^/?calico/v1/netset/([^/]+)$")
+	typeTyphaRevision  = reflect.TypeOf(TyphaRevision{})
+)
+
+type TyphaRevisionKey struct{}
+
+func (key TyphaRevisionKey) defaultPath() (string, error) {
+	e := fmt.Sprintf("/calico/v1/typha/revision")
+	return e, nil
+}
+
+func (key TyphaRevisionKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
+}
+
+func (key TyphaRevisionKey) defaultDeleteParentPaths() ([]string, error) {
+	return nil, nil
+}
+
+func (key TyphaRevisionKey) valueType() (reflect.Type, error) {
+	return typeTyphaRevision, nil
+}
+
+func (key TyphaRevisionKey) String() string {
+	return fmt.Sprintf("TyphaRevision()")
+}
+
+type TyphaRevisionListOptions struct {
+}
+
+func (options TyphaRevisionListOptions) defaultPathRoot() string {
+	return "/calico/v1/typha/revision"
+}
+
+func (options TyphaRevisionListOptions) KeyFromDefaultPath(path string) Key {
+	log.Debugf("Get TyphaRevision key from %s", path)
+	if path == "/calico/v1/typha/revision" {
+		return TyphaRevisionKey{}
+	}
+	return nil
+}
+
+type TyphaRevision struct {
+	Revision string `json:"revision,omitempty"`
+}

--- a/libcalico-go/lib/backend/model/typha.go
+++ b/libcalico-go/lib/backend/model/typha.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/lib/std/time"
 )
 
 var (
@@ -64,5 +66,7 @@ func (options TyphaRevisionListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type TyphaRevision struct {
-	Revision string `json:"revision,omitempty"`
+	ServerID  string    `json:"serverID,omitempty"`
+	Revision  string    `json:"revision,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
 }

--- a/libcalico-go/lib/backend/model/typha.go
+++ b/libcalico-go/lib/backend/model/typha.go
@@ -17,14 +17,12 @@ package model
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 
 	log "github.com/sirupsen/logrus"
 )
 
 var (
-	matchTyphaRevision = regexp.MustCompile("^/?calico/v1/netset/([^/]+)$")
-	typeTyphaRevision  = reflect.TypeOf(TyphaRevision{})
+	typeTyphaRevision = reflect.TypeOf(TyphaRevision{})
 )
 
 type TyphaRevisionKey struct{}

--- a/typha/fv-tests/server_harness_test.go
+++ b/typha/fv-tests/server_harness_test.go
@@ -103,12 +103,10 @@ type ClientState struct {
 }
 
 func (h *ServerHarness) Start() {
-	h.Server = syncserver.New(
-		map[syncproto.SyncerType]syncserver.BreadcrumbProvider{
-			syncproto.SyncerTypeFelix: h.FelixCache,
-			syncproto.SyncerTypeBGP:   h.BGPCache,
-		},
-		h.Config)
+	h.Server = syncserver.New(map[syncproto.SyncerType]syncserver.BreadcrumbProvider{
+		syncproto.SyncerTypeFelix: h.FelixCache,
+		syncproto.SyncerTypeBGP:   h.BGPCache,
+	}, nil, h.Config)
 
 	go h.Decoupler.SendToContext(h.cacheCxt, h.ValFilter)
 	go h.BGPDecoupler.SendToContext(h.cacheCxt, h.BGPCache)

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -1471,18 +1471,16 @@ var _ = Describe("with server requiring TLS", func() {
 		cacheCxt, cacheCancel = context.WithCancel(context.Background())
 		valFilter = calc.NewValidationFilter(cache)
 		go decoupler.SendToContext(cacheCxt, valFilter)
-		server = syncserver.New(
-			map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache},
-			syncserver.Config{
-				PingInterval: 10 * time.Second,
-				Port:         syncserver.PortRandom,
-				DropInterval: 50 * time.Millisecond,
-				KeyFile:      filepath.Join(certDir, serverCertName+".key"),
-				CertFile:     filepath.Join(certDir, serverCertName+".crt"),
-				CAFile:       filepath.Join(certDir, "ca.crt"),
-				ClientCN:     requiredClientCN,
-				ClientURISAN: requiredClientURISAN,
-			})
+		server = syncserver.New(map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache}, nil, syncserver.Config{
+			PingInterval: 10 * time.Second,
+			Port:         syncserver.PortRandom,
+			DropInterval: 50 * time.Millisecond,
+			KeyFile:      filepath.Join(certDir, serverCertName+".key"),
+			CertFile:     filepath.Join(certDir, serverCertName+".crt"),
+			CAFile:       filepath.Join(certDir, "ca.crt"),
+			ClientCN:     requiredClientCN,
+			ClientURISAN: requiredClientURISAN,
+		})
 		cache.Start(cacheCxt)
 		serverCxt, serverCancel = context.WithCancel(context.Background())
 		server.Start(serverCxt)

--- a/typha/pkg/latencytracker/latency_tracker.go
+++ b/typha/pkg/latencytracker/latency_tracker.go
@@ -1,0 +1,181 @@
+package latencytracker
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/typha/pkg/syncproto"
+)
+
+type LatencyTracker struct {
+	lock       sync.Mutex
+	clients    map[uint64]*ClientTracker
+	crumbs     map[uint64]time.Time // Maps breadcrumb sequence number to creation time
+	syncerType syncproto.SyncerType
+}
+
+func New(syncerType syncproto.SyncerType) *LatencyTracker {
+	return &LatencyTracker{
+		clients:    make(map[uint64]*ClientTracker),
+		crumbs:     make(map[uint64]time.Time),
+		syncerType: syncerType,
+	}
+}
+
+func (l *LatencyTracker) RegisterClient(connID uint64, address string) *ClientTracker {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	logrus.Infof("Registering client %d at %s for syncer type %s", connID, address, l.syncerType)
+
+	c := &ClientTracker{
+		latencyTracker: l,
+		connID:         connID,
+		address:        address,
+		creationTime:   time.Now(),
+	}
+	l.clients[connID] = c
+	return c
+}
+
+func (l *LatencyTracker) RecordBreadcrumbCreation(breadcrumbSeqNo uint64) {
+	now := time.Now()
+
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.crumbs[breadcrumbSeqNo] = now
+}
+
+func (l *LatencyTracker) recordClientClose(id uint64) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	delete(l.clients, id)
+}
+
+func (l *LatencyTracker) Start(ctx context.Context) {
+	go l.loop(ctx)
+}
+
+func (l *LatencyTracker) loop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(10 * time.Second):
+			l.ReportLatencies()
+		}
+	}
+}
+
+func (l *LatencyTracker) ReportLatencies() {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	const maxPower = 6                   // We will use log10 of latency in milliseconds, capped at 10
+	histogram := make([]int, maxPower+1) // Buckets for log10 of latency in milliseconds (0-10)
+	noReports := 0
+	missingCrumb := 0
+	var minCrumb uint64 = math.MaxUint64
+	maxBucketUsed := -1
+	for _, c := range l.clients {
+		lastUpdate := c.lastUpdate.Load()
+		if lastUpdate == nil {
+			noReports++
+			minCrumb = 0
+			continue
+		}
+		crumbCreationTime := l.crumbs[lastUpdate.breadcrumbSeqNo]
+		if crumbCreationTime.IsZero() {
+			missingCrumb++
+			minCrumb = 0
+			continue
+		}
+		if crumbCreationTime.Before(c.creationTime) {
+			// If the crumb was created before the client was registered,
+			// use the client's creation time.
+			crumbCreationTime = c.creationTime
+		}
+		latency := lastUpdate.timestamp.Sub(crumbCreationTime)
+		if latency < 0 {
+			latency = 0
+		}
+		if lastUpdate.breadcrumbSeqNo < minCrumb {
+			minCrumb = lastUpdate.breadcrumbSeqNo
+		}
+
+		log10Millis := math.Log10(latency.Seconds() * 1000)
+		if log10Millis < 0 {
+			log10Millis = 0
+		}
+		log10Millis = math.Min(log10Millis, maxPower)
+		bucket := int(log10Millis) // Convert to bucket index
+		histogram[bucket] = histogram[bucket] + 1
+		if bucket > maxBucketUsed {
+			maxBucketUsed = bucket
+		}
+	}
+
+	output := fmt.Sprintf("Latency Report %v:", l.syncerType)
+	for i, count := range histogram {
+		if i > maxBucketUsed {
+			break
+		}
+		// Output each bucket's range in milliseconds, e.g., 0-10ms, 10-100ms, etc.
+		lowerBound := int(math.Pow(10, float64(i-1)))
+		upperBound := int(math.Pow(10, float64(i)))
+		if i == maxPower {
+			output += fmt.Sprintf("\n%d+ms-∞: ", lowerBound)
+		} else {
+			output += fmt.Sprintf("\n%d-%dms: ", lowerBound, upperBound)
+		}
+		output += fmt.Sprintf("%d clients", count)
+	}
+	if noReports > 0 {
+		output += fmt.Sprintf("\nNo report (yet): %d clients", noReports)
+	}
+	if missingCrumb > 0 {
+		output += fmt.Sprintf("\nMissing crumb: %d clients", missingCrumb)
+	}
+	logrus.Info(output)
+
+	// Make sure we don't leak crumbs forever.
+	for crumbSeqNo, creationTime := range l.crumbs {
+		if time.Since(creationTime) > 10*time.Minute && crumbSeqNo < minCrumb {
+			delete(l.crumbs, crumbSeqNo)
+		}
+	}
+}
+
+type ClientTracker struct {
+	latencyTracker *LatencyTracker
+
+	connID       uint64
+	address      string
+	creationTime time.Time
+
+	lastUpdate atomic.Pointer[update]
+}
+
+type update struct {
+	breadcrumbSeqNo uint64
+	timestamp       time.Time
+}
+
+func (c *ClientTracker) RecordDataplaneUpdate(breadcrumbSeqNo uint64, timestamp time.Time) {
+	c.lastUpdate.Store(&update{
+		breadcrumbSeqNo: breadcrumbSeqNo,
+		timestamp:       timestamp,
+	})
+}
+
+func (c *ClientTracker) Close() {
+	c.latencyTracker.recordClientClose(c.connID)
+}

--- a/typha/pkg/snapcache/cache.go
+++ b/typha/pkg/snapcache/cache.go
@@ -458,6 +458,7 @@ func (c *Cache) publishBreadcrumb() {
 			Value: &model.TyphaRevision{
 				Revision: fmt.Sprint(newCrumb.SequenceNumber),
 			},
+			Revision: fmt.Sprint(newCrumb.SequenceNumber),
 		},
 		UpdateType: api.UpdateTypeKVUpdated,
 	})

--- a/typha/pkg/snapcache/cache.go
+++ b/typha/pkg/snapcache/cache.go
@@ -16,6 +16,7 @@ package snapcache
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -27,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
 	"github.com/projectcalico/calico/typha/pkg/jitter"
@@ -397,7 +399,7 @@ func (c *Cache) publishBreadcrumb() {
 		Timestamp:      time.Now(),
 		SyncStatus:     oldCrumb.SyncStatus,
 		nextCond:       c.breadcrumbCond,
-		Deltas:         make([]syncproto.SerializedUpdate, 0, len(updates)),
+		Deltas:         make([]syncproto.SerializedUpdate, 0, len(updates)+1),
 
 		counterBreadcrumbBlock:    c.counterBreadcrumbBlock,
 		counterBreadcrumbNonBlock: c.counterBreadcrumbNonBlock,
@@ -450,7 +452,20 @@ func (c *Cache) publishBreadcrumb() {
 		newCrumb.Deltas = append(newCrumb.Deltas, newUpd)
 		somethingChanged = true
 	}
-
+	revUpd, err := syncproto.SerializeUpdate(api.Update{
+		KVPair: model.KVPair{
+			Key: model.TyphaRevisionKey{},
+			Value: &model.TyphaRevision{
+				Revision: fmt.Sprint(newCrumb.SequenceNumber),
+			},
+		},
+		UpdateType: api.UpdateTypeKVUpdated,
+	})
+	if err != nil {
+		log.WithError(err).Error("Failed to serialize Typha revision update")
+	} else {
+		newCrumb.Deltas = append(newCrumb.Deltas, revUpd)
+	}
 	// Even if all updates were filtered out, report that to Prometheus; we
 	// want the stat to decay to zero if the event stream is quiet.
 	c.summaryUpdateSize.Observe(float64(len(newCrumb.Deltas)))

--- a/typha/pkg/syncproto/sync_proto.go
+++ b/typha/pkg/syncproto/sync_proto.go
@@ -287,7 +287,6 @@ type MsgDecoderRestart struct {
 // MsgACK is a general-purpose ACK message, currently used during the initial handshake to acknowledge the
 // switch to compressed mode.
 type MsgACK struct {
-	LastAppliedRevision string
 }
 type MsgSyncStatus struct {
 	SyncStatus api.SyncStatus
@@ -298,6 +297,10 @@ type MsgPing struct {
 type MsgPong struct {
 	PingTimestamp time.Time
 	PongTimestamp time.Time
+}
+type MsgDataplaneRevision struct {
+	Timestamp time.Time
+	Revision  string
 }
 type MsgKVs struct {
 	KVs []SerializedUpdate
@@ -334,6 +337,7 @@ func init() {
 	gob.RegisterName("github.com/projectcalico/typha/pkg/syncproto.MsgPing", MsgPing{})
 	gob.RegisterName("github.com/projectcalico/typha/pkg/syncproto.MsgPong", MsgPong{})
 	gob.RegisterName("github.com/projectcalico/typha/pkg/syncproto.MsgKVs", MsgKVs{})
+	gob.RegisterName("github.com/projectcalico/typha/pkg/syncproto.MsgDataplaneRevision", MsgDataplaneRevision{})
 }
 
 func SerializeUpdate(u api.Update) (su SerializedUpdate, err error) {

--- a/typha/pkg/syncproto/sync_proto.go
+++ b/typha/pkg/syncproto/sync_proto.go
@@ -287,6 +287,7 @@ type MsgDecoderRestart struct {
 // MsgACK is a general-purpose ACK message, currently used during the initial handshake to acknowledge the
 // switch to compressed mode.
 type MsgACK struct {
+	LastAppliedRevision string
 }
 type MsgSyncStatus struct {
 	SyncStatus api.SyncStatus

--- a/typha/pkg/syncproto/sync_proto.go
+++ b/typha/pkg/syncproto/sync_proto.go
@@ -299,6 +299,7 @@ type MsgPong struct {
 	PongTimestamp time.Time
 }
 type MsgDataplaneRevision struct {
+	ServerID  string
 	Timestamp time.Time
 	Revision  string
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Hackathon entry.  

- Send a new message from Typha to Felix with Typha's breadcrumb sequence number
- Plumb that through Felix all the way to the dataplane and then report it back to Typha after each apply (with rate limiting).
- In Typha, aggregate the stats and emit a histogram of dataplane apply latency every 10s.

Could lead on to:

- Adding OTEL for Typha updates.
- Adding prometheus metrics.
- Figuring out when the whole cluster is fully converged.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
