### PR TITLE
Wireguard: Prevent unnecessary module loading

### DIFF
--- a/felix/dataplane/driver.go
+++ b/felix/dataplane/driver.go
@@ -449,8 +449,8 @@ func SupportsBPF() error {
 }
 
 func ConfigurePrometheusMetrics(configParams *config.Config) {
-	if configParams.PrometheusGoMetricsEnabled && configParams.PrometheusProcessMetricsEnabled && configParams.PrometheusWireGuardMetricsEnabled {
-		log.Info("Including Golang, Process and WireGuard metrics")
+	if configParams.PrometheusGoMetricsEnabled && configParams.PrometheusProcessMetricsEnabled {
+		log.Info("Including Golang and Process metrics")
 	} else {
 		if !configParams.PrometheusGoMetricsEnabled {
 			log.Info("Discarding Golang metrics")
@@ -460,10 +460,14 @@ func ConfigurePrometheusMetrics(configParams *config.Config) {
 			log.Info("Discarding process metrics")
 			prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 		}
-		if !configParams.PrometheusWireGuardMetricsEnabled || (!configParams.WireguardEnabled && !configParams.WireguardEnabledV6) {
-			log.Info("Discarding WireGuard metrics")
-			prometheus.Unregister(wireguard.MustNewWireguardMetrics())
-		}
+	}
+
+	if configParams.PrometheusWireGuardMetricsEnabled && (configParams.WireguardEnabled || configParams.WireguardEnabledV6) {
+		log.Info("Including Wireguard metrics")
+		prometheus.MustRegister(wireguard.MustNewWireguardMetrics())
+	} else {
+		log.Info("Discarding WireGuard metrics")
+		prometheus.Unregister(wireguard.MustNewWireguardMetrics())
 	}
 }
 

--- a/felix/wireguard/metrics_linux.go
+++ b/felix/wireguard/metrics_linux.go
@@ -55,12 +55,6 @@ const (
 	defaultCollectionRatelimit = time.Second
 )
 
-func init() {
-	prometheus.MustRegister(
-		MustNewWireguardMetrics(),
-	)
-}
-
 type Metrics struct {
 	hostname           string
 	newWireguardClient func() (netlinkshim.Wireguard, error)


### PR DESCRIPTION
## Description

Fixes issue with loading WireGuard module when WireGuard is disabled in Felix config.

This PR changes:
- It adds typha post discovery filter only if wireguard is enabled in config
- Register wireguard related metrics in Prometheus only if wiregaurd is enabled in config

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/7833

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Avoid loading wireguard kernel module when Wireguard is disabled.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
