### PR TITLE
Fix networking-calico problems reported by flake8

### DIFF
--- a/networking-calico/.flake8
+++ b/networking-calico/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+ignore = E203,E402,W503
+application-import-names = networking_calico

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -22,3 +22,9 @@ upper-constraints-caracal.txt:
 fmtpy:
 	docker build -t networking-calico-test .
 	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT --rm networking-calico-test tox -e black
+
+flake8:
+	flake8 networking_calico setup.py
+
+flake8-count:
+	flake8 networking_calico setup.py | wc -l

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -1,6 +1,6 @@
 # Copyright 2012 OpenStack Foundation
 # Copyright 2015 Metaswitch Networks
-# Copyright 2016, 2018, 2022 Tigera, Inc.
+# Copyright 2016-2025 Tigera, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,8 +15,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import logging
-import netaddr
+# It's advised always to do eventlet monkey-patching before anything else.
+# https://eventlet.readthedocs.io/en/latest/patching.html
+import eventlet
+
+eventlet.monkey_patch()
+
+import logging  # noqa
 import os
 import re
 import socket
@@ -24,9 +29,13 @@ import subprocess
 import sys
 import time
 
-import eventlet
+from etcd3gw.exceptions import Etcd3Exception
 
-eventlet.monkey_patch()
+from eventlet.event import Event
+from eventlet.queue import Empty
+from eventlet.queue import LightQueue
+
+import netaddr
 
 from neutron.agent.dhcp.agent import DhcpAgent
 from neutron.agent.dhcp_agent import register_options
@@ -43,22 +52,16 @@ except ImportError:
     # Neutron code prior to 7f23ccc (15th March 2017).
     from neutron.agent.common import config
 
-from networking_calico.agent.linux.dhcp import DnsmasqRouted
-from networking_calico.common import config as calico_config
-from networking_calico.common import mkdir_p
-from networking_calico.compat import cfg
-from networking_calico.compat import constants
-from networking_calico.compat import DHCPV6_STATEFUL
 from networking_calico import datamodel_v1
 from networking_calico import datamodel_v2
 from networking_calico import datamodel_v3
 from networking_calico import etcdutils
-
-from etcd3gw.exceptions import Etcd3Exception
-
-from eventlet.event import Event
-from eventlet.queue import Empty
-from eventlet.queue import LightQueue
+from networking_calico.agent.linux.dhcp import DnsmasqRouted
+from networking_calico.common import config as calico_config
+from networking_calico.common import mkdir_p
+from networking_calico.compat import DHCPV6_STATEFUL
+from networking_calico.compat import cfg
+from networking_calico.compat import constants
 
 LOG = logging.getLogger(__name__)
 
@@ -296,7 +299,7 @@ class DnsmasqUpdater(object):
                 # but better to be more resilient here.
                 try:
                     self.really_update_dnsmasq(network_id)
-                except Exception as e:
+                except Exception:
                     LOG.exception("really_update_dnsmasq")
 
     def really_update_dnsmasq(self, network_id):

--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -14,16 +14,17 @@
 #    under the License.
 
 import copy
-import netaddr
 import os
 import re
-import sys
-import time
+
+import netaddr
 
 from neutron.agent.linux import dhcp
+
 from oslo_log import log as logging
 
 from networking_calico.compat import constants
+
 
 LOG = logging.getLogger(__name__)
 

--- a/networking-calico/networking_calico/common/__init__.py
+++ b/networking-calico/networking_calico/common/__init__.py
@@ -18,9 +18,10 @@
 Calico common utilities.
 """
 import errno
+import os
+
 import netaddr
 import netaddr.core
-import os
 
 
 def validate_cidr(cidr, version):

--- a/networking-calico/networking_calico/common/config.py
+++ b/networking-calico/networking_calico/common/config.py
@@ -72,23 +72,23 @@ SHARED_OPTS = [
     # The complete mapping between OpenStack-level config/API and the Calico
     # WorkloadEndpoint.QoSControls is as follows.
     #
-    # | QoSControls field     | Neutron API field     | Config field                     |
-    # |-----------------------+-----------------------+----------------------------------|
-    # | IngressBandwidth      | max_kbps * 1000       |                                  |
-    # | EgressBandwidth       | max_kbps * 1000       |                                  |
-    # | IngressBurst          |                       | ingress_burst_bits               |
-    # | EgressBurst           |                       | egress_burst_bits                |
-    # | IngressPeakrate       | max_burst_kbps * 1000 |                                  |
-    # | EgressPeakrate        | max_burst_kbps * 1000 |                                  |
-    # | IngressMinburst       |                       | ingress_minburst_bytes           |
-    # | EgressMinburst        |                       | egress_minburst_bytes            |
-    # | IngressPacketRate     | max_kpps * 1000       |                                  |
-    # | EgressPacketRate      | max_kpps * 1000       |                                  |
-    # | IngressPacketBurst    |                       | ingress_burst_packets            |
-    # | EgressPacketBurst     |                       | egress_burst_packets             |
-    # |  (not implemented)    | max_burst_kpps        |                                  |
-    # | IngressMaxConnections |                       | max_ingress_connections_per_port |
-    # | EgressMaxConnections  |                       | max_egress_connections_per_port  |
+    #  QoSControls field     | Neutron API field     | Config field
+    # -----------------------+-----------------------+----------------------------------
+    #  IngressBandwidth      | max_kbps * 1000       |
+    #  EgressBandwidth       | max_kbps * 1000       |
+    #  IngressBurst          |                       | ingress_burst_bits
+    #  EgressBurst           |                       | egress_burst_bits
+    #  IngressPeakrate       | max_burst_kbps * 1000 |
+    #  EgressPeakrate        | max_burst_kbps * 1000 |
+    #  IngressMinburst       |                       | ingress_minburst_bytes
+    #  EgressMinburst        |                       | egress_minburst_bytes
+    #  IngressPacketRate     | max_kpps * 1000       |
+    #  EgressPacketRate      | max_kpps * 1000       |
+    #  IngressPacketBurst    |                       | ingress_burst_packets
+    #  EgressPacketBurst     |                       | egress_burst_packets
+    #   (not implemented)    | max_burst_kpps        |
+    #  IngressMaxConnections |                       | max_ingress_connections_per_port
+    #  EgressMaxConnections  |                       | max_egress_connections_per_port
     #
     # Note, max_burst_kpps is not currently implemented, because we have not
     # yet found a reasonable way to do that.

--- a/networking-calico/networking_calico/datamodel_v3.py
+++ b/networking-calico/networking_calico/datamodel_v3.py
@@ -17,9 +17,9 @@ import json
 import re
 import uuid
 
-from networking_calico.compat import log
 from networking_calico import datamodel_v2
 from networking_calico import etcdv3
+from networking_calico.compat import log
 from networking_calico.timestamp import timestamp_now
 
 # Particular JSON key strings.

--- a/networking-calico/networking_calico/etcdutils.py
+++ b/networking-calico/networking_calico/etcdutils.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 
 import collections
-import eventlet
 import json
 import re
 
 from etcd3gw.exceptions import ConnectionFailedError
+
+import eventlet
+
+from networking_calico import etcdv3
 from networking_calico.common import intern_string
 from networking_calico.compat import log
-from networking_calico import etcdv3
 from networking_calico.monotonic import monotonic_time
 
 LOG = log.getLogger(__name__)
@@ -439,14 +441,14 @@ def intern_dict(d):
     return out
 
 
-def intern_list(l):
+def intern_list(ls):
     """intern_list
 
     Returns a new list with interned versions of the input list's contents.
     Non-strings are copied to the new list verbatim.
     """
     out = []
-    for item in l:
+    for item in ls:
         if _is_string_instance(item):
             item = intern_string(item)
         out.append(item)

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -15,13 +15,14 @@
 
 import functools
 from importlib.metadata import version
-from packaging.version import Version
 
 from etcd3gw.client import Etcd3Client
 from etcd3gw.exceptions import Etcd3Exception
 from etcd3gw.lease import Lease
 from etcd3gw.utils import _encode
 from etcd3gw.utils import _increment_last_byte
+
+from packaging.version import Version
 
 from networking_calico.compat import cfg
 from networking_calico.compat import log

--- a/networking-calico/networking_calico/plugins/calico/plugin.py
+++ b/networking-calico/networking_calico/plugins/calico/plugin.py
@@ -12,7 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-# Import Ml2Plugin before l3_db to fix https://github.com/projectcalico/calico/issues/8494
+# Import Ml2Plugin before l3_db to fix
+# https://github.com/projectcalico/calico/issues/8494
 from neutron.plugins.ml2.plugin import Ml2Plugin
 from neutron.db import l3_db
 from neutron.db.models import l3
@@ -61,51 +62,53 @@ class CalicoPlugin(Ml2Plugin, l3_db.L3_NAT_db_mixin):
         # This is a bit of a hack to get the models_v2.Port attributes setup in such
         # a way as to avoid tracebacks in the neutron-server log.
         #
-        # The tracebacks are not purely cosmetic as they cause all tests run after TestFloatingIPs
-        # to fail, presumably as a result of the neutron-server being left in a bad state. The bad
-        # state is likely because the error occurs during a cleanup action ("_clean_garbage") which
-        # leaves important resources orphaned with no known way to recover.
+        # The tracebacks are not purely cosmetic as they cause all tests run after
+        # TestFloatingIPs to fail, presumably as a result of the neutron-server being
+        # left in a bad state. The bad state is likely because the error occurs during a
+        # cleanup action ("_clean_garbage") which leaves important resources orphaned
+        # with no known way to recover.
         #
-        # The side-effects within the Router setup that we care about likely have to do with the
-        # "orm.relationship" calls but rather than port those directly here and risk any changes that might
-        # occur in the future that could render this assumption false we can just rely
-        # on the maintainers of this class to keep things up-to-date on our behalf.
+        # The side-effects within the Router setup that we care about likely have to do
+        # with the "orm.relationship" calls but rather than port those directly here and
+        # risk any changes that might occur in the future that could render this
+        # assumption false we can just rely on the maintainers of this class to keep
+        # things up-to-date on our behalf.
         #
         # An example of the traceback looks like this:
         # Traceback (most recent call last):
-        #   File "/usr/lib/python3/dist-packages/oslo_service/loopingcall.py", line 150, in _run_loop
+        #   .../oslo_service/loopingcall.py", line 150, in _run_loop
         #     result = func(*self.args, **self.kw)
-        #   File "/usr/lib/python3/dist-packages/neutron/db/l3_db.py", line 163, in _clean_garbage
+        #   .../neutron/db/l3_db.py", line 163, in _clean_garbage
         #     candidates = self._get_dead_floating_port_candidates(context)
-        #   File "/usr/lib/python3/dist-packages/neutron/db/l3_db.py", line 198, in _get_dead_floating_port_candidates
+        #   .../neutron/db/l3_db.py", line 198, in _get_dead_floating_port_candidates
         #     return {p['id'] for p in self._core_plugin.get_ports(context, filters)}
-        #   File "/usr/lib/python3/dist-packages/neutron_lib/db/api.py", line 218, in wrapped
+        #   .../neutron_lib/db/api.py", line 218, in wrapped
         #     return method(*args, **kwargs)
-        #   File "/usr/lib/python3/dist-packages/neutron_lib/db/api.py", line 139, in wrapped
+        #   .../neutron_lib/db/api.py", line 139, in wrapped
         #     setattr(e, '_RETRY_EXCEEDED', True)
-        #   File "/usr/lib/python3/dist-packages/oslo_utils/excutils.py", line 227, in __exit__
+        #   .../oslo_utils/excutils.py", line 227, in __exit__
         #     self.force_reraise()
-        #   File "/usr/lib/python3/dist-packages/oslo_utils/excutils.py", line 200, in force_reraise
+        #   .../oslo_utils/excutils.py", line 200, in force_reraise
         #     raise self.value
-        #   File "/usr/lib/python3/dist-packages/neutron_lib/db/api.py", line 135, in wrapped
+        #   .../neutron_lib/db/api.py", line 135, in wrapped
         #     return f(*args, **kwargs)
-        #   File "/usr/lib/python3/dist-packages/oslo_db/api.py", line 154, in wrapper
+        #   .../oslo_db/api.py", line 154, in wrapper
         #     ectxt.value = e.inner_exc
-        #   File "/usr/lib/python3/dist-packages/oslo_utils/excutils.py", line 227, in __exit__
+        #   .../oslo_utils/excutils.py", line 227, in __exit__
         #     self.force_reraise()
-        #   File "/usr/lib/python3/dist-packages/oslo_utils/excutils.py", line 200, in force_reraise
+        #   .../oslo_utils/excutils.py", line 200, in force_reraise
         #     raise self.value
-        #   File "/usr/lib/python3/dist-packages/oslo_db/api.py", line 142, in wrapper
+        #   .../oslo_db/api.py", line 142, in wrapper
         #     return f(*args, **kwargs)
-        #   File "/usr/lib/python3/dist-packages/neutron_lib/db/api.py", line 183, in wrapped
+        #   .../neutron_lib/db/api.py", line 183, in wrapped
         #     LOG.debug("Retry wrapper got retriable exception: %s", e)
-        #   File "/usr/lib/python3/dist-packages/oslo_utils/excutils.py", line 227, in __exit__
+        #   .../oslo_utils/excutils.py", line 227, in __exit__
         #     self.force_reraise()
-        #   File "/usr/lib/python3/dist-packages/oslo_utils/excutils.py", line 200, in force_reraise
+        #   .../oslo_utils/excutils.py", line 200, in force_reraise
         #     raise self.value
-        #   File "/usr/lib/python3/dist-packages/neutron_lib/db/api.py", line 179, in wrapped
+        #   .../neutron_lib/db/api.py", line 179, in wrapped
         #     return f(*dup_args, **dup_kwargs)
-        #   File "/usr/lib/python3/dist-packages/neutron/db/db_base_plugin_v2.py", line 1601, in get_ports
+        #   .../neutron/db/db_base_plugin_v2.py", line 1601, in get_ports
         #     lazy_fields = [models_v2.Port.port_forwardings,
         # AttributeError: type object 'Port' has no attribute 'port_forwardings'
         _ = l3.Router()

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/election.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/election.py
@@ -18,19 +18,22 @@
 """
 Calico election code.
 """
-from etcd3gw.exceptions import Etcd3Exception
-import eventlet
-import greenlet
 import os
 import random
 import re
 import socket
 import sys
 
+from etcd3gw.exceptions import Etcd3Exception
+
+import eventlet
+
+import greenlet
+
+from networking_calico import etcdv3
 from networking_calico.common import config as calico_config
 from networking_calico.compat import cfg
 from networking_calico.compat import log
-from networking_calico import etcdv3
 
 
 LOG = log.getLogger(__name__)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -23,12 +23,12 @@ except ImportError:
 
 from neutron.db.qos import models as qos_models
 
+from networking_calico import datamodel_v3
+from networking_calico import etcdv3
 from networking_calico.common import config as calico_config
 from networking_calico.compat import cfg
 from networking_calico.compat import log
 from networking_calico.compat import n_exc
-from networking_calico import datamodel_v3
-from networking_calico import etcdv3
 from networking_calico.plugins.ml2.drivers.calico.policy import SG_LABEL_PREFIX
 from networking_calico.plugins.ml2.drivers.calico.policy import SG_NAME_LABEL_PREFIX
 from networking_calico.plugins.ml2.drivers.calico.policy import SG_NAME_MAX_LENGTH

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -25,16 +25,17 @@
 #
 # It is implemented as a Neutron/ML2 mechanism driver.
 import contextlib
-from functools import wraps
 import inspect
 import os
 import re
 import uuid
+from functools import wraps
 
 # OpenStack imports.
 import eventlet
 from eventlet.queue import PriorityQueue
 from eventlet.semaphore import Semaphore
+
 from neutron.agent import rpc as agent_rpc
 
 try:
@@ -53,12 +54,17 @@ except ImportError:
     # Neutron code prior to a2c36d7e (10th November 2017).
     from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2.drivers import mech_agent
+
 from sqlalchemy import exc as sa_exc
 
 # Monkeypatch import
 import neutron.plugins.ml2.rpc as rpc
 
 # Calico imports.
+from networking_calico import datamodel_v1
+from networking_calico import datamodel_v2
+from networking_calico import datamodel_v3
+from networking_calico import etcdv3
 from networking_calico.common import config as calico_config
 from networking_calico.common import intern_string
 from networking_calico.compat import cfg
@@ -68,18 +74,12 @@ from networking_calico.compat import lockutils
 from networking_calico.compat import log
 from networking_calico.compat import n_exc
 from networking_calico.compat import plugin_dir
-from networking_calico import datamodel_v1
-from networking_calico import datamodel_v2
-from networking_calico import datamodel_v3
-from networking_calico import etcdv3
 from networking_calico.logutils import logging_exceptions
 from networking_calico.monotonic import monotonic_time
 from networking_calico.plugins.ml2.drivers.calico.election import Elector
 from networking_calico.plugins.ml2.drivers.calico.endpoints import (
-    _port_is_endpoint_port,
-)
-from networking_calico.plugins.ml2.drivers.calico.endpoints import (
     WorkloadEndpointSyncer,
+    _port_is_endpoint_port,
 )
 from networking_calico.plugins.ml2.drivers.calico.policy import PolicySyncer
 from networking_calico.plugins.ml2.drivers.calico.qos_driver import (
@@ -89,8 +89,9 @@ from networking_calico.plugins.ml2.drivers.calico.status import StatusWatcher
 from networking_calico.plugins.ml2.drivers.calico.subnets import SubnetSyncer
 
 # Imports for a Keystone client.
-from keystoneauth1.identity import v3
 from keystoneauth1 import session
+from keystoneauth1.identity import v3
+
 from keystoneclient.v3.client import Client as KeystoneClient
 
 # Register [AGENT] options, which we need in order to successfully use

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from networking_calico import datamodel_v3
 from networking_calico.common import config as calico_config
 from networking_calico.compat import IP_PROTOCOL_MAP
 from networking_calico.compat import log
-from networking_calico import datamodel_v3
 from networking_calico.plugins.ml2.drivers.calico.syncer import ResourceSyncer
 
 LOG = log.getLogger(__name__)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/qos_driver.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/qos_driver.py
@@ -15,13 +15,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from networking_calico.compat import log
-
 from neutron_lib import constants
 from neutron_lib.api.definitions import portbindings
 from neutron_lib.db import constants as db_consts
 from neutron_lib.services.qos import base
 from neutron_lib.services.qos import constants as qos_consts
+
+from networking_calico.compat import log
 
 
 LOG = log.getLogger(__name__)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/status.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/status.py
@@ -21,10 +21,10 @@
 import collections
 import json
 
-from networking_calico.common import config as calico_config
-from networking_calico.compat import log
 from networking_calico import datamodel_v2
 from networking_calico import etcdutils
+from networking_calico.common import config as calico_config
+from networking_calico.compat import log
 
 
 LOG = log.getLogger(__name__)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
@@ -14,13 +14,14 @@
 # limitations under the License.
 
 import json
+
 import netaddr
 
-from networking_calico.common import config as calico_config
-from networking_calico.compat import log
 from networking_calico import datamodel_v1
 from networking_calico import datamodel_v2
 from networking_calico import etcdv3
+from networking_calico.common import config as calico_config
+from networking_calico.compat import log
 from networking_calico.plugins.ml2.drivers.calico.syncer import ResourceGone
 from networking_calico.plugins.ml2.drivers.calico.syncer import ResourceSyncer
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
@@ -18,12 +18,14 @@ networking_calico.plugins.ml2.drivers.calico.test.lib
 
 Common code for Neutron driver UT.
 """
-import eventlet
-import eventlet.queue
 import inspect
 import logging
-import mock
 import sys
+
+import eventlet
+import eventlet.queue
+
+import mock
 
 # When you're working on a test and need to see logging - both from the test
 # code and the code _under_ test - uncomment the following line.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/stub_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/stub_etcd.py
@@ -16,10 +16,12 @@
 """
 Stub version of the etcd interface.
 """
+import logging
+
 from etcd3gw.utils import _decode
+
 import eventlet
 from eventlet.event import Event
-import logging
 
 from networking_calico import etcdv3
 
@@ -94,9 +96,9 @@ class Client(object):
         return {"succeeded": succeeded}
 
     def lease(self, ttl):
-        l = Lease(self.next_lease_id, self)
+        ls = Lease(self.next_lease_id, self)
         self.next_lease_id += 1
-        return l
+        return ls
 
     def write(self, path, value, **kwargs):
         log.debug("Write of %s to %s", value, path)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_compaction.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_compaction.py
@@ -17,14 +17,14 @@ Test compaction code.
 """
 
 import logging
-import mock
 import os
 import unittest
 
 from etcd3gw.exceptions import Etcd3Exception
 
-import networking_calico.plugins.ml2.drivers.calico.test.lib as lib
+import mock
 
+import networking_calico.plugins.ml2.drivers.calico.test.lib as lib
 from networking_calico import etcdv3
 from networking_calico.plugins.ml2.drivers.calico import mech_calico
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
@@ -16,14 +16,15 @@
 """
 Test election code.
 """
-
-from etcd3gw import exceptions as e3e
-import eventlet
 import logging
-import mock
 import unittest
 
-from networking_calico.compat import log
+from etcd3gw import exceptions as e3e
+
+import eventlet
+
+import mock
+
 from networking_calico import etcdv3
 from networking_calico.plugins.ml2.drivers.calico import election
 from networking_calico.plugins.ml2.drivers.calico.test import stub_etcd

--- a/networking-calico/networking_calico/tests/test_common.py
+++ b/networking-calico/networking_calico/tests/test_common.py
@@ -11,8 +11,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import logging
 import unittest
+from collections import namedtuple
 
+import mock
+
+import networking_calico.common as common
 from networking_calico.common import config
 from networking_calico.compat import cfg
 
@@ -24,13 +29,6 @@ class TestConfig(unittest.TestCase):
         config.register_options(cfg.CONF, additional_options=[add_opt])
         self.assertEqual(cfg.CONF["calico"]["test_option"], "test")
 
-
-from collections import namedtuple
-import logging
-import mock
-
-
-import networking_calico.common as common
 
 Config = namedtuple("Config", ["IFACE_PREFIX", "HOSTNAME"])
 

--- a/networking-calico/networking_calico/tests/test_dhcp_agent.py
+++ b/networking-calico/networking_calico/tests/test_dhcp_agent.py
@@ -13,25 +13,27 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from collections import namedtuple
-import eventlet
 import json
 import logging
-import mock
 import socket
+from collections import namedtuple
+
+import eventlet
+
+import mock
 
 from neutron.agent.dhcp_agent import register_options
 from neutron.agent.linux import dhcp
 from neutron.tests import base
 
+from networking_calico import datamodel_v1
+from networking_calico import datamodel_v2
 from networking_calico.agent.dhcp_agent import CalicoDhcpAgent
 from networking_calico.agent.dhcp_agent import FakePlugin
 from networking_calico.agent.linux.dhcp import DnsmasqRouted
 from networking_calico.common import config as calico_config
-from networking_calico.compat import cfg
 from networking_calico.compat import DHCPV6_STATEFUL
-from networking_calico import datamodel_v1
-from networking_calico import datamodel_v2
+from networking_calico.compat import cfg
 from networking_calico.etcdutils import EtcdWatcher
 
 LOG = logging.getLogger(__name__)

--- a/networking-calico/networking_calico/tests/test_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_etcdutils.py
@@ -23,15 +23,15 @@ Tests for etcd utility function.
 import logging
 import unittest
 
-from mock import call
 from mock import Mock
+from mock import call
 from mock import patch
 
-from networking_calico.etcdutils import _is_string_instance
+from networking_calico import etcdv3
 from networking_calico.etcdutils import EtcdWatcher
 from networking_calico.etcdutils import PathDispatcher
 from networking_calico.etcdutils import Response
-from networking_calico import etcdv3
+from networking_calico.etcdutils import _is_string_instance
 
 _log = logging.getLogger(__name__)
 

--- a/networking-calico/networking_calico/tests/test_etcdv3.py
+++ b/networking-calico/networking_calico/tests/test_etcdv3.py
@@ -13,14 +13,15 @@
 #    under the License.
 
 import logging
+
+from etcd3gw.exceptions import Etcd3Exception
+
 import mock
 
 from neutron.tests import base
 
-from networking_calico.compat import log
 from networking_calico import etcdv3
-
-from etcd3gw.exceptions import Etcd3Exception
+from networking_calico.compat import log
 
 
 LOG = logging.getLogger(__name__)

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -21,20 +21,22 @@ Tests for etcdutils with a real etcd server.
 
 from __future__ import print_function
 
-import logging
-import os
-import shutil
-import subprocess
-import unittest
-
+# It's advised always to do eventlet monkey-patching as early as possible; but
+# __future__ imports are required to be at the very top of the file, so we must come
+# after those.  https://eventlet.readthedocs.io/en/latest/patching.html
 import eventlet
 
 eventlet.monkey_patch()
 
-from networking_calico.common import config as calico_config
-from networking_calico.compat import cfg
+import logging  # noqa
+import shutil
+import subprocess
+import unittest
+
 from networking_calico import etcdutils
 from networking_calico import etcdv3
+from networking_calico.common import config as calico_config
+from networking_calico.compat import cfg
 
 _log = logging.getLogger(__name__)
 

--- a/networking-calico/networking_calico/tests/test_subnet_watcher.py
+++ b/networking-calico/networking_calico/tests/test_subnet_watcher.py
@@ -13,14 +13,15 @@
 #    under the License.
 
 import logging
+
+from etcd3gw.exceptions import Etcd3Exception
+
 import mock
 
 from neutron.tests import base
 
 from networking_calico.agent.dhcp_agent import SubnetWatcher
 from networking_calico.etcdutils import EtcdWatcher
-
-from etcd3gw.exceptions import Etcd3Exception
 
 
 LOG = logging.getLogger(__name__)

--- a/networking-calico/setup.py
+++ b/networking-calico/setup.py
@@ -25,7 +25,7 @@ setup(
             'calico-dhcp-agent = networking_calico.agent.dhcp_agent:main',
         ],
         'neutron.ml2.mechanism_drivers': [
-            'calico = networking_calico.plugins.ml2.drivers.calico.' +
+            'calico = networking_calico.plugins.ml2.drivers.calico.'
             'mech_calico:CalicoMechanismDriver',
         ],
         'neutron.core_plugins': [


### PR DESCRIPTION
In my editor setup (Emacs), the editor uses `pylsp` to identify and flag coding issues.  `pylsp` uses `flake8` to identify PEP8/lint violations.  flake8 can also be run directly with

    make -C networking-calico flake8

This commit reduces the total number of flake8 moans (`flake8 | wc -l`) from 472 to 14, with the fixed moans being as follows.

- Line too long.  We configure line length 88 in `.flake8` to match black's default, instead of 79. Some lines then still needed manual attention to get them within 88.

- Import ordering.  We now follow flake8's "cryptography" default, which means stdlib first in one group, then 3rd party packages each in their own group, then networking-calico itself.

- E203, E402 and W503 moans.  We suppress these because they explicitly disagree from what black does.

- A few trivial other issues.

There are two places where we need eventlet monkey-patching, and this causes moans because it breaks
import ordering and involves a non-import call before other imports.  Also we weren't doing this as
early as possible, which is what is advised.  Those are now addressed by:

1. moving the monkey-patch as early as possible
2. adding `noqa` to the following import line, to suppress the moan there.