### PR TITLE
Add a new manager for all-hosts ipset even when IPIP is not enabled

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1120,11 +1120,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	dp.endpointsSourceV4 = epManager
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4, config.FloatingIPsEnabled))
 	dp.RegisterManager(newMasqManager(ipSetsV4, natTableV4, ruleRenderer, config.MaxIPSetSize, 4))
+
+	// Add a manager to keep the all-hosts IPv4 set up to date.
+	dp.RegisterManager(newHostsIPSetManager(ipSetsV4, 4, config))
+
 	if config.RulesConfig.IPIPEnabled {
 		log.Info("IPIP enabled, starting thread to keep tunnel configuration in sync.")
 		// Add a manager to keep the all-hosts IP set up to date.
 		dp.ipipManager = newIPIPManager(
-			ipSetsV4,
 			routeTableV4,
 			dataplanedefs.IPIPIfaceName,
 			4,
@@ -1222,6 +1225,9 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.rawTables = append(dp.rawTables, rawTableV6)
 		dp.mangleTables = append(dp.mangleTables, mangleTableV6)
 		dp.filterTables = append(dp.filterTables, filterTableV6)
+
+		// Add a manager to keep the all-hosts IPv6 set up to date.
+		dp.RegisterManager(newHostsIPSetManager(ipSetsV6, 6, config))
 
 		if config.RulesConfig.VXLANEnabledV6 {
 			vxlanName := dataplanedefs.VXLANIfaceNameV6

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1120,8 +1120,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	dp.endpointsSourceV4 = epManager
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4, config.FloatingIPsEnabled))
 	dp.RegisterManager(newMasqManager(ipSetsV4, natTableV4, ruleRenderer, config.MaxIPSetSize, 4))
-
-	// Add a manager to keep the all-hosts IPv4 set up to date.
 	dp.RegisterManager(newHostsIPSetManager(ipSetsV4, 4, config))
 
 	if config.RulesConfig.IPIPEnabled {
@@ -1226,9 +1224,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.mangleTables = append(dp.mangleTables, mangleTableV6)
 		dp.filterTables = append(dp.filterTables, filterTableV6)
 
-		// Add a manager to keep the all-hosts IPv6 set up to date.
-		dp.RegisterManager(newHostsIPSetManager(ipSetsV6, 6, config))
-
 		if config.RulesConfig.VXLANEnabledV6 {
 			vxlanName := dataplanedefs.VXLANIfaceNameV6
 
@@ -1322,6 +1317,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.RegisterManager(newFloatingIPManager(natTableV6, ruleRenderer, 6, config.FloatingIPsEnabled))
 		dp.RegisterManager(newMasqManager(ipSetsV6, natTableV6, ruleRenderer, config.MaxIPSetSize, 6))
 		dp.RegisterManager(newServiceLoopManager(filterTableV6, ruleRenderer, 6))
+		dp.RegisterManager(newHostsIPSetManager(ipSetsV6, 6, config))
 
 		// Add a manager for IPv6 wireguard configuration. This is added irrespective of whether wireguard is actually enabled
 		// because it may need to tidy up some of the routing rules when disabled.

--- a/felix/dataplane/linux/ipset_hosts_mgr.go
+++ b/felix/dataplane/linux/ipset_hosts_mgr.go
@@ -15,6 +15,8 @@
 package intdataplane
 
 import (
+	"strings"
+
 	"github.com/sirupsen/logrus"
 
 	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
@@ -77,11 +79,13 @@ func (m *hostsIPSetManager) OnUpdate(protoBufMsg interface{}) {
 		}
 
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		ipAddr := msg.Ipv4Addr
+		addr := msg.Ipv4Addr
 		if m.ipVersion == 6 {
-			ipAddr = msg.Ipv6Addr
+			addr = msg.Ipv6Addr
 		}
-		m.activeHostnameToIP[msg.Hostname] = ipAddr
+		// Remove subnet mask.
+		parts := strings.Split(addr, "/")
+		m.activeHostnameToIP[msg.Hostname] = parts[0]
 		m.ipSetDirty = true
 	case *proto.HostMetadataV4V6Remove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")

--- a/felix/dataplane/linux/ipset_hosts_mgr.go
+++ b/felix/dataplane/linux/ipset_hosts_mgr.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	"github.com/sirupsen/logrus"
+
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
+	"github.com/projectcalico/calico/felix/ipsets"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/rules"
+)
+
+// hostsIPSetManager manages the all-hosts IP set, which is used by some rules in our static chains.
+// It doesn't actually program the rules, because they are part of the top-level static chains.
+type hostsIPSetManager struct {
+	// Our dependencies.
+	hostname  string
+	ipVersion uint8
+
+	// activeHostnameToIP maps hostname to string IP address. We don't bother to parse into
+	// net.IPs because we're going to pass them directly to the IPSet API.
+	activeHostnameToIP map[string]string
+	ipsetsDataplane    dpsets.IPSetsDataplane
+	ipSetMetadata      ipsets.IPSetMetadata
+
+	// Indicates if configuration has changed since the last apply.
+	ipSetDirty bool
+	dpConfig   Config
+
+	// Log context
+	logCtx *logrus.Entry
+}
+
+func newHostsIPSetManager(
+	ipsetsDataplane dpsets.IPSetsDataplane,
+	ipVersion uint8,
+	dpConfig Config,
+) *hostsIPSetManager {
+	return &hostsIPSetManager{
+		ipsetsDataplane: ipsetsDataplane,
+		ipSetMetadata: ipsets.IPSetMetadata{
+			MaxSize: dpConfig.MaxIPSetSize,
+			SetID:   rules.IPSetIDAllHostNets,
+			Type:    ipsets.IPSetTypeHashNet,
+		},
+		activeHostnameToIP: map[string]string{},
+		hostname:           dpConfig.Hostname,
+		ipVersion:          ipVersion,
+		ipSetDirty:         true,
+		dpConfig:           dpConfig,
+		logCtx: logrus.WithFields(logrus.Fields{
+			"ipVersion": ipVersion,
+		}),
+	}
+}
+
+func (m *hostsIPSetManager) OnUpdate(protoBufMsg interface{}) {
+	switch msg := protoBufMsg.(type) {
+	case *proto.HostMetadataV4V6Update:
+		if (m.ipVersion == 4 && msg.Ipv4Addr == "") || (m.ipVersion == 6 && msg.Ipv6Addr == "") {
+			// Skip since the update is for a mismatched IP version
+			m.logCtx.WithField("msg", msg).Debug("Skipping mismatched IP version update")
+			return
+		}
+
+		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
+		ipAddr := msg.Ipv4Addr
+		if m.ipVersion == 6 {
+			ipAddr = msg.Ipv6Addr
+		}
+		m.activeHostnameToIP[msg.Hostname] = ipAddr
+		m.ipSetDirty = true
+	case *proto.HostMetadataV4V6Remove:
+		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
+		delete(m.activeHostnameToIP, msg.Hostname)
+		m.ipSetDirty = true
+	}
+}
+
+func (m *hostsIPSetManager) CompleteDeferredWork() error {
+	if m.ipSetDirty {
+		m.updateAllHostsIPSet()
+		m.ipSetDirty = false
+	}
+	return nil
+}
+
+func (m *hostsIPSetManager) updateAllHostsIPSet() {
+	var externalNodeCIDRs []string
+	// We allow IPIP packets from configured external sources as well as
+	// each Calico node. However, IPIP encapsulation is only supported with IPv4.
+	if m.ipVersion == 4 {
+		externalNodeCIDRs = m.dpConfig.ExternalNodesCidrs
+	}
+
+	// For simplicity (and on the assumption that host add/removes are rare) rewrite
+	// the whole IP set whenever we get a change. To replace this with delta handling
+	// would require reference counting the IPs because it's possible for two hosts
+	// to (at least transiently) share an IP. That would add occupancy and make the
+	// code more complex.
+	m.logCtx.Info("All-hosts IP set out-of sync, refreshing it.")
+	members := make([]string, 0, len(m.activeHostnameToIP)+len(externalNodeCIDRs))
+	for _, ip := range m.activeHostnameToIP {
+		members = append(members, ip)
+	}
+	members = append(members, externalNodeCIDRs...)
+	m.ipsetsDataplane.AddOrReplaceIPSet(m.ipSetMetadata, members)
+}

--- a/felix/dataplane/linux/ipset_hosts_mgr_test.go
+++ b/felix/dataplane/linux/ipset_hosts_mgr_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intdataplane
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+)
+
+var _ = Describe("IPSet all-hosts manager", func() {
+	var (
+		manager *hostsIPSetManager
+		ipSets  *dpsets.MockIPSets
+	)
+
+	const (
+		externalCIDR = "10.10.10.0/24"
+	)
+
+	BeforeEach(func() {
+		ipSets = dpsets.NewMockIPSets()
+		manager = newHostsIPSetManager(
+			ipSets,
+			4,
+			Config{
+				MaxIPSetSize:       1024,
+				Hostname:           "node1",
+				ExternalNodesCidrs: []string{"10.10.10.0/24"},
+			},
+		)
+	})
+
+	allHostsSet := func() set.Set[string] {
+		logrus.Info(ipSets.Members)
+		Expect(ipSets.Members).To(HaveLen(1))
+		return ipSets.Members["all-hosts-net"]
+	}
+
+	It("should handle IPSet updates correctly", func() {
+		By("checking the the IP set is not created until first call to CompleteDeferredWork()")
+		Expect(ipSets.AddOrReplaceCalled).To(BeFalse())
+		err := manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipSets.AddOrReplaceCalled).To(BeTrue())
+
+		By("adding host1")
+		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+			Hostname: "host1",
+			Ipv4Addr: "10.0.0.1",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", externalCIDR)))
+
+		By("adding host2")
+		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+			Hostname: "host2",
+			Ipv4Addr: "10.0.0.2",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2", externalCIDR)))
+
+		By("testing tolerance for duplicate ip")
+		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+			Hostname: "host3",
+			Ipv4Addr: "10.0.0.2",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2", externalCIDR)))
+
+		By("removing the duplicate ip should keep the ip")
+		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+			Hostname: "host3",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2", externalCIDR)))
+
+		By("removing the initial copy of ip")
+		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+			Hostname: "host2",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", externalCIDR)))
+
+		By("adding/removing a duplicate IP in one batch")
+		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+			Hostname: "host2",
+			Ipv4Addr: "10.0.0.1",
+		})
+		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+			Hostname: "host2",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", externalCIDR)))
+
+		By("changing ip of host1")
+		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+			Hostname: "host1",
+			Ipv4Addr: "10.0.0.2",
+		})
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.2", externalCIDR)))
+
+		By("sending a no-op batch")
+		ipSets.AddOrReplaceCalled = false
+		err = manager.CompleteDeferredWork()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipSets.AddOrReplaceCalled).To(BeFalse())
+		Expect(allHostsSet()).To(Equal(set.From("10.0.0.2", externalCIDR)))
+	})
+})

--- a/felix/fv/nat_outgoing_test.go
+++ b/felix/fv/nat_outgoing_test.go
@@ -48,6 +48,7 @@ var _ = infrastructure.DatastoreDescribe("NATOutgoing rule rendering test", []ap
 		dumpedDiags = false
 		opts := infrastructure.DefaultTopologyOptions()
 		opts.IPIPMode = api.IPIPModeNever
+		opts.EnableIPv6 = true
 
 		if NFTMode() {
 			Skip("NFT mode not supported in this test")

--- a/felix/fv/nat_outgoing_test.go
+++ b/felix/fv/nat_outgoing_test.go
@@ -47,6 +47,7 @@ var _ = infrastructure.DatastoreDescribe("NATOutgoing rule rendering test", []ap
 
 		dumpedDiags = false
 		opts := infrastructure.DefaultTopologyOptions()
+		opts.IPIPMode = api.IPIPModeNever
 
 		if NFTMode() {
 			Skip("NFT mode not supported in this test")
@@ -54,6 +55,7 @@ var _ = infrastructure.DatastoreDescribe("NATOutgoing rule rendering test", []ap
 
 		opts.ExtraEnvVars = map[string]string{
 			"FELIX_IptablesNATOutgoingInterfaceFilter": "eth+",
+			"FELIX_NATOutgoingExclusions":              "IPPoolsAndHostIPs",
 		}
 		tc, client = infrastructure.StartSingleNodeTopology(opts, infra)
 


### PR DESCRIPTION
## Description

Previously, we only used `all-hosts-net` ipset for ipip encapsulation. However, we need it now for more features listed below:
- For QoS policy to set DSCP on traffic leaving a cluster (including hosts): https://github.com/projectcalico/calico/pull/10825
- Also with [introduction](https://github.com/projectcalico/calico/pull/8961) of `IPPoolsAndHostIPs` for `natOutgoingExclusions` option, `all-hosts-net` ipset needs to be present. Since ATM, this ipset is only managed by IPIP manager, using the mentioned value in any routing setup except IPIP leads to Felix not being able to program rules, and eventually panicing. The change made in the NAT outgoing FV test simply triggers the panic.
- Additionally, using `IPPoolsAndHostIPs` with IPv6 pools, would panic Felix even in IPIP, since IPIP encap does not support IPv6.

This PR adds a new manager to manage `all-hosts-net` ipset by separating the functionality from IPIP manager. The new manager will always be running since the ipset is needed by IPIP encapsulation, NAT outgoing, and QoS Policy.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
