### PR TITLE
chore: fix nginx config, add nginx self-test after image is built

### DIFF
--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -41,7 +41,7 @@ build:
 image: $(IMAGE_BUILD_MARKER)
 
 image-nginx-test:
-	$(DOCKER_RUN_RM) --rm whisker:latest-$(ARCH) nginx -T
+	$(DOCKER_RUN_RM) whisker:latest-$(ARCH) nginx -T
 
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -32,7 +32,7 @@ bin/LICENSE: ../LICENSE.md
 	cp ../LICENSE.md $@
 
 .PHONY: image build
-image: $(IMAGE_BUILD_MARKER)
+image: $(IMAGE_BUILD_MARKER) image-nginx-test
 
 build:
 	$(DOCKER_RUN_RM) $(BUILD_IMAGE_NAME) yarn install -g
@@ -40,9 +40,13 @@ build:
 
 image: $(IMAGE_BUILD_MARKER)
 
+image-nginx-test:
+	$(DOCKER_RUN_RM) --rm whisker:latest-$(ARCH) nginx -T
+
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
+	$(MAKE) image-nginx-test ARCH=$*
 
 install:
 	$(DOCKER_RUN_RM) -e NODE_OPTIONS=--max_old_space_size=8192 -e CNX_APP_VERSION=$(GIT_VERSION) $(BUILD_IMAGE_NAME) yarn install -g

--- a/whisker/docker-image/default.conf
+++ b/whisker/docker-image/default.conf
@@ -1,7 +1,7 @@
 server {
     # Listen on all.
     listen 0.0.0.0:8081;
-    listen [::]:8081 ipv6only=yes;
+    listen [::]:8081 ipv6only=on;
 
     server_tokens off;
 


### PR DESCRIPTION
## Description

nginx listen config `ipv6only=yes` is wrong, this should fix it + add a self-test

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
