### PR TITLE
[v3.30] chore: split image build and image test

### DIFF
--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -35,7 +35,7 @@ build:
 	$(DOCKER_RUN_RM) -e NODE_OPTIONS=--max_old_space_size=8192 -e CNX_APP_VERSION=$(GIT_VERSION) $(BUILD_IMAGE_NAME) yarn build
 
 image-nginx-test: $(IMAGE_BUILD_MARKER)
-	$(DOCKER_RUN_RM) whisker:latest-$(ARCH) nginx -T
+	docker run --rm whisker:latest-$(ARCH) test
 
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -28,15 +28,13 @@ $(IMAGE_BUILD_MARKER): register build
 	touch $@
 
 .PHONY: image build
-image: $(IMAGE_BUILD_MARKER) image-nginx-test
+image: $(IMAGE_BUILD_MARKER)
 
 build:
 	$(DOCKER_RUN_RM) $(BUILD_IMAGE_NAME) yarn install -g
 	$(DOCKER_RUN_RM) -e NODE_OPTIONS=--max_old_space_size=8192 -e CNX_APP_VERSION=$(GIT_VERSION) $(BUILD_IMAGE_NAME) yarn build
 
-image: $(IMAGE_BUILD_MARKER)
-
-image-nginx-test:
+image-nginx-test: $(IMAGE_BUILD_MARKER)
 	$(DOCKER_RUN_RM) whisker:latest-$(ARCH) nginx -T
 
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
@@ -56,7 +54,9 @@ format: install
 lint: install
 	$(DOCKER_RUN_RM) -e NODE_OPTIONS=--max_old_space_size=8192 -e CNX_APP_VERSION=$(GIT_VERSION) $(BUILD_IMAGE_NAME) yarn lint --quiet
 
-ci: install format lint yarn-test
+ci: ut install format lint yarn-test
+
+ut: image-nginx-test
 
 clean:
 

--- a/whisker/docker-image/Dockerfile
+++ b/whisker/docker-image/Dockerfile
@@ -88,4 +88,4 @@ COPY --from=source / /
 
 USER 10001:10001
 
-CMD ["/usr/bin/nginx-start.sh"]
+ENTRYPOINT ["/usr/bin/nginx-start.sh"]

--- a/whisker/docker-image/nginx-start.sh
+++ b/whisker/docker-image/nginx-start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 
 # Updates the config options according to environment variables
 # received via the configMap.
@@ -22,4 +23,15 @@ sed -i 's!/var/run/nginx.pid!/tmp/nginx.pid!g' /etc/nginx/nginx.conf
 sed -i '/user  nginx;/d' /etc/nginx/nginx.conf
 
 # Start nginx
-exec /usr/sbin/nginx -g "daemon off;"
+case "$1" in
+  ""|up)
+    exec /usr/sbin/nginx -g "daemon off;"
+    ;;
+  test)
+    exec /usr/sbin/nginx -T 2>&1
+    ;;
+  *)
+    echo "Usage: $0 [up|test]"
+    exit 1
+    ;;
+esac

--- a/whisker/docker-image/nginx-start.sh
+++ b/whisker/docker-image/nginx-start.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -x
 
 # Updates the config options according to environment variables
 # received via the configMap.
@@ -34,4 +33,4 @@ case "$1" in
     echo "Usage: $0 [up|test]"
     exit 1
     ;;
-esac
+  esac


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#10850
## Description

Fixes for https://github.com/projectcalico/calico/pull/10848


1.  perform nginx -T in the start script itself 

- this is so that the expected pid setup is also tested
- divert both stderr and stdout to stdout so that we see the errors with the config dump
- use the nginx start script as entrypoint instead of cmd

2. use regular docker run
- this is because we have baked in user 10001:10001. this is incompatible with $(DOCKER_RUN_RM) because that automatically sets uid:gid to something else corresponding to the local env

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```