### PR TITLE
Unencap routing: Update routes only when local address changes

### DIFF
--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -101,21 +101,24 @@ func (m *noEncapManager) OnUpdate(protoBufMsg interface{}) {
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
 		if msg.Hostname == m.hostname {
 			if m.ipVersion == 6 {
-				m.routeMgr.updateParentIfaceAddr(msg.Ipv6Addr)
+				m.routesNeedUpdate(msg.Ipv6Addr)
 			} else {
-				m.routeMgr.updateParentIfaceAddr(msg.Ipv4Addr)
+				m.routesNeedUpdate(msg.Ipv4Addr)
 			}
 		}
-		m.routeMgr.triggerRouteUpdate()
 	case *proto.HostMetadataV4V6Remove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
 		if msg.Hostname == m.hostname {
-			m.routeMgr.updateParentIfaceAddr("")
+			m.routesNeedUpdate("")
 		}
-		m.routeMgr.triggerRouteUpdate()
 	default:
 		m.routeMgr.OnUpdate(msg)
 	}
+}
+
+func (m *noEncapManager) routesNeedUpdate(parentAddr string) {
+	m.routeMgr.updateParentIfaceAddr(parentAddr)
+	m.routeMgr.triggerRouteUpdate()
 }
 
 func (m *noEncapManager) CompleteDeferredWork() error {


### PR DESCRIPTION
## Description

Update unencap routes in noencap manager only when local parent address changes.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
