### PR TITLE
Move DevStack-related setup from Semaphore to bootstrap script

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -995,9 +995,10 @@ blocks:
             - sudo umount /boot
             - sudo rsync -av /boot2/ /boot/ --exclude "*.new" --exclude "*.dpkg-bak" --delete --inplace
             - sudo rm -rf /boot2/
+            # Set NC_PLUGIN_REPO and NC_PLUGIN_REF so that DevStack will use the networking-calico
+            # code from the current PR or branch.  The following checkout is to make sure of having a
+            # local ref that we can specify.
             - git checkout -b devstack-test
-            - export LIBVIRT_TYPE=qemu
-            - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga
             - export NC_PLUGIN_REPO=$(dirname $(pwd))
             - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
             - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
@@ -1033,9 +1034,10 @@ blocks:
             # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
             # or replace the existing version.  Happily we do know that, so let's do it upfront here.
             - sudo apt-get remove -y python3-wrapt || true
+            # Set NC_PLUGIN_REPO and NC_PLUGIN_REF so that DevStack will use the networking-calico
+            # code from the current PR or branch.  The following checkout is to make sure of having a
+            # local ref that we can specify.
             - git checkout -b devstack-test
-            - export LIBVIRT_TYPE=qemu
-            - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
             - export NC_PLUGIN_REPO=$(dirname $(pwd))
             - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
             - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -995,9 +995,10 @@ blocks:
             - sudo umount /boot
             - sudo rsync -av /boot2/ /boot/ --exclude "*.new" --exclude "*.dpkg-bak" --delete --inplace
             - sudo rm -rf /boot2/
+            # Set NC_PLUGIN_REPO and NC_PLUGIN_REF so that DevStack will use the networking-calico
+            # code from the current PR or branch.  The following checkout is to make sure of having a
+            # local ref that we can specify.
             - git checkout -b devstack-test
-            - export LIBVIRT_TYPE=qemu
-            - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga
             - export NC_PLUGIN_REPO=$(dirname $(pwd))
             - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
             - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
@@ -1033,9 +1034,10 @@ blocks:
             # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
             # or replace the existing version.  Happily we do know that, so let's do it upfront here.
             - sudo apt-get remove -y python3-wrapt || true
+            # Set NC_PLUGIN_REPO and NC_PLUGIN_REF so that DevStack will use the networking-calico
+            # code from the current PR or branch.  The following checkout is to make sure of having a
+            # local ref that we can specify.
             - git checkout -b devstack-test
-            - export LIBVIRT_TYPE=qemu
-            - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
             - export NC_PLUGIN_REPO=$(dirname $(pwd))
             - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
             - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -31,9 +31,10 @@
           - sudo umount /boot
           - sudo rsync -av /boot2/ /boot/ --exclude "*.new" --exclude "*.dpkg-bak" --delete --inplace
           - sudo rm -rf /boot2/
+          # Set NC_PLUGIN_REPO and NC_PLUGIN_REF so that DevStack will use the networking-calico
+          # code from the current PR or branch.  The following checkout is to make sure of having a
+          # local ref that we can specify.
           - git checkout -b devstack-test
-          - export LIBVIRT_TYPE=qemu
-          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git
@@ -69,9 +70,10 @@
           # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall
           # or replace the existing version.  Happily we do know that, so let's do it upfront here.
           - sudo apt-get remove -y python3-wrapt || true
+          # Set NC_PLUGIN_REPO and NC_PLUGIN_REF so that DevStack will use the networking-calico
+          # code from the current PR or branch.  The following checkout is to make sure of having a
+          # local ref that we can specify.
           - git checkout -b devstack-test
-          - export LIBVIRT_TYPE=qemu
-          - export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
           - export NC_PLUGIN_REPO=$(dirname $(pwd))
           - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - sudo git config --system --add safe.directory ${NC_PLUGIN_REPO}/.git

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -92,6 +92,17 @@ if [ "${DEVSTACK_BRANCH}" = unmaintained/yoga ]; then
     export REQUIREMENTS_BRANCH=unmaintained/yoga
 fi
 
+# Set correct constraints for Tempest to use.  We need to do this because we're pinning to a
+# different version of Tempest than the version that DevStack would naturally use.
+case "${DEVSTACK_BRANCH}" in
+    unmaintained/yoga )
+	export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga
+	;;
+    stable/2024.1 )		# Caracal
+	export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
+	;;
+esac
+
 : ${NC_PLUGIN_REPO:=https://github.com/projectcalico/calico}
 : ${NC_PLUGIN_REF:=master}
 
@@ -148,6 +159,8 @@ SCENARIO_IMAGE_TYPE=ignore
 # remote: Compressing objects: 100% (9847/9847), done.
 # error: RPC failed; curl 56 GnuTLS recv error (-9): A TLS packet with unexpected length was received.
 GIT_BASE=https://github.com
+
+LIBVIRT_TYPE=qemu
 
 EOF
 


### PR DESCRIPTION
So that the bootstrap script is self-contained and can be used without prior steps that were previously encoded in the Semaphore YAML.