### PR TITLE
Speed up IPAM affinity lookup.

### DIFF
--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -184,6 +185,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 			// thundering herd of new pods, acquiring the lock can take a while.
 			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 			defer cancel()
+
+			if err := maybeUpgradeIPAM(ctx, calicoClient.IPAM(), nodename); err != nil {
+				return fmt.Errorf("failed to upgrade IPAM database: %w", err)
+			}
 
 			return calicoClient.IPAM().AssignIP(ctx, assignArgs)
 		}
@@ -366,6 +371,41 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	// Print result to stdout, in the format defined by the requested cniVersion.
 	return cnitypes.PrintResult(r, conf.CNIVersion)
+}
+
+const ipamUpgradedFilePath = "/var/run/calico/cni/ipam_upgraded"
+
+func maybeUpgradeIPAM(ctx context.Context, ipamClient ipam.Interface, nodename string) error {
+	if _, err := os.Stat(ipamUpgradedFilePath); err == nil {
+		return nil
+	}
+
+	err := ipamClient.UpgradeHost(ctx, nodename)
+	if err != nil {
+		return fmt.Errorf("failed to upgrade IPAM database: %w", err)
+	}
+
+	if err := touchFile(ipamUpgradedFilePath); err != nil {
+		return fmt.Errorf("failed to created IPAM upgrade marker file %s: %w", ipamUpgradedFilePath, err)
+	}
+	return nil
+}
+
+func touchFile(filePath string) error {
+	dirPath, _ := path.Split(filePath)
+	err := os.MkdirAll(dirPath, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory for file %s: %w", filePath, err)
+	}
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+	}
+	err = file.Close()
+	if err != nil {
+		return fmt.Errorf("failure when closing file %s: %w", filePath, err)
+	}
+	return nil
 }
 
 type unlockFn func()

--- a/kube-controllers/pkg/controllers/node/fake_client.go
+++ b/kube-controllers/pkg/controllers/node/fake_client.go
@@ -383,3 +383,7 @@ func (f *fakeIPAMClient) GetUtilization(ctx context.Context, args ipam.GetUtiliz
 func (f *fakeIPAMClient) EnsureBlock(ctx context.Context, args ipam.BlockArgs) (*cnet.IPNet, *cnet.IPNet, error) {
 	panic("not implemented") // TODO: Implement
 }
+
+func (c *fakeIPAMClient) UpgradeHost(ctx context.Context, nodeName string) error {
+	return nil
+}

--- a/libcalico-go/lib/apis/v3/blockaffinity.go
+++ b/libcalico-go/lib/apis/v3/blockaffinity.go
@@ -15,6 +15,8 @@
 package v3
 
 import (
+	"strings"
+
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -78,4 +80,20 @@ func NewBlockAffinityList() *BlockAffinityList {
 			APIVersion: apiv3.GroupVersionCurrent,
 		},
 	}
+}
+
+func EnsureBlockAffinityLabels(ba *BlockAffinity) {
+	if ba.Labels == nil {
+		ba.Labels = make(map[string]string)
+	}
+	ba.Labels["host"] = ba.Spec.Node
+	ba.Labels["affinityType"] = ba.Spec.Type
+	ba.Labels["cidr"] = ba.Spec.CIDR
+	var ipVersion string
+	if strings.Contains(ba.Spec.CIDR, ":") {
+		ipVersion = "6"
+	} else {
+		ipVersion = "4"
+	}
+	ba.Labels["ipVersion"] = ipVersion
 }

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -29,6 +29,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/srv"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apimachinery/pkg/labels"
 
 	calicotls "github.com/projectcalico/calico/crypto/pkg/tls"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -478,10 +479,29 @@ func (c *etcdV3Client) List(ctx context.Context, l model.ListInterface, revision
 		list = append(list, resources.DefaultAllowProfile())
 	}
 
+	if ls, ok := l.(model.LabelSelectingListInterface); ok {
+		selector := ls.GetLabelSelector()
+		if selector != nil {
+			list = filterListByLabelSelector(list, selector)
+		}
+	}
+
 	return &model.KVPairList{
 		KVPairs:  list,
 		Revision: strconv.FormatInt(resp.Header.Revision, 10),
 	}, nil
+}
+
+func filterListByLabelSelector(input []*model.KVPair, sel labels.Selector) []*model.KVPair {
+	output := input[:0]
+	for _, kv := range input {
+		if labeled, ok := kv.Value.(interface{ GetLabels() map[string]string }); ok {
+			if sel.Matches(labels.Set(labeled.GetLabels())) {
+				output = append(output, kv)
+			}
+		}
+	}
+	return output
 }
 
 func calculateListKeyAndOptions(logCxt *log.Entry, l model.ListInterface) (string, []clientv3.OpOption) {

--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -140,28 +141,31 @@ func (c *blockAffinityClient) parseKey(k model.Key) (name, cidr, host, affinityT
 func (c *blockAffinityClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
 	name, cidr, host, affinityType := c.parseKey(kvpv1.Key)
 	state := kvpv1.Value.(*model.BlockAffinity).State
+	value := &libapiv3.BlockAffinity{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       libapiv3.KindBlockAffinity,
+			APIVersion: "crd.projectcalico.org/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			ResourceVersion: kvpv1.Revision,
+		},
+		Spec: libapiv3.BlockAffinitySpec{
+			State:   string(state),
+			Node:    host,
+			Type:    affinityType,
+			CIDR:    cidr,
+			Deleted: fmt.Sprintf("%t", kvpv1.Value.(*model.BlockAffinity).Deleted),
+		},
+	}
+	libapiv3.EnsureBlockAffinityLabels(value)
+
 	return &model.KVPair{
 		Key: model.ResourceKey{
 			Name: name,
 			Kind: libapiv3.KindBlockAffinity,
 		},
-		Value: &libapiv3.BlockAffinity{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       libapiv3.KindBlockAffinity,
-				APIVersion: "crd.projectcalico.org/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            name,
-				ResourceVersion: kvpv1.Revision,
-			},
-			Spec: libapiv3.BlockAffinitySpec{
-				State:   string(state),
-				Node:    host,
-				Type:    affinityType,
-				CIDR:    cidr,
-				Deleted: fmt.Sprintf("%t", kvpv1.Value.(*model.BlockAffinity).Deleted),
-			},
-		},
+		Value:    value,
 		Revision: kvpv1.Revision,
 	}
 }
@@ -180,7 +184,7 @@ func isV1BlockAffinityKey(key model.Key) bool {
 }
 
 func (c *blockAffinityClient) createV1(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp, err := c.rc.Create(ctx, c.toV3(kvp))
+	nkvp, err := c.createV3(ctx, c.toV3(kvp))
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +197,17 @@ func (c *blockAffinityClient) createV1(ctx context.Context, kvp *model.KVPair) (
 }
 
 func (c *blockAffinityClient) createV3(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	return c.rc.Create(ctx, kvp)
+	return c.rc.Create(ctx, ensureV3Labels(kvp))
+}
+
+func ensureV3Labels(kvp *model.KVPair) *model.KVPair {
+	v3Value := kvp.Value.(*libapiv3.BlockAffinity)
+	v3Value = v3Value.DeepCopy()
+	libapiv3.EnsureBlockAffinityLabels(v3Value)
+	return &model.KVPair{
+		Key:   kvp.Key,
+		Value: &v3Value,
+	}
 }
 
 func (c *blockAffinityClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -207,7 +221,7 @@ func (c *blockAffinityClient) Create(ctx context.Context, kvp *model.KVPair) (*m
 }
 
 func (c *blockAffinityClient) updateV1(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	nkvp, err := c.rc.Update(ctx, c.toV3(kvp))
+	nkvp, err := c.updateV3(ctx, c.toV3(kvp))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +234,7 @@ func (c *blockAffinityClient) updateV1(ctx context.Context, kvp *model.KVPair) (
 }
 
 func (c *blockAffinityClient) updateV3(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	return c.rc.Update(ctx, kvp)
+	return c.rc.Update(ctx, ensureV3Labels(kvp))
 }
 
 func (c *blockAffinityClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -358,8 +372,11 @@ func isV1List(list model.ListInterface) bool {
 }
 
 func (c *blockAffinityClient) listV1(ctx context.Context, list model.BlockAffinityListOptions, revision string) (*model.KVPairList, error) {
-	l := model.ResourceListOptions{Kind: libapiv3.KindBlockAffinity}
-	v3list, err := c.rc.List(ctx, l, revision)
+	l := model.ResourceListOptions{
+		Kind:          libapiv3.KindBlockAffinity,
+		LabelSelector: calculateBlockAffinityLabelSelector(list),
+	}
+	v3list, err := c.listV3(ctx, l, revision)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +394,8 @@ func (c *blockAffinityClient) listV1(ctx context.Context, list model.BlockAffini
 		if err != nil {
 			return nil, err
 		}
-		if (host == "" || v1kvp.Key.(model.BlockAffinityKey).Host == host) && (affinityType == "" || v1kvp.Key.(model.BlockAffinityKey).AffinityType == affinityType) {
+		if (host == "" || v1kvp.Key.(model.BlockAffinityKey).Host == host) &&
+			(affinityType == "" || v1kvp.Key.(model.BlockAffinityKey).AffinityType == affinityType) {
 			cidr := v1kvp.Key.(model.BlockAffinityKey).CIDR
 			cidrPtr := &cidr
 			if (requestedIPVersion == 0 || requestedIPVersion == cidrPtr.Version()) && !v1kvp.Value.(*model.BlockAffinity).Deleted {
@@ -387,6 +405,24 @@ func (c *blockAffinityClient) listV1(ctx context.Context, list model.BlockAffini
 		}
 	}
 	return kvpl, nil
+}
+
+func calculateBlockAffinityLabelSelector(list model.BlockAffinityListOptions) labels.Selector {
+	labelsToMatch := map[string]string{}
+	if list.Host != "" {
+		labelsToMatch["host"] = list.Host
+	}
+	if list.AffinityType != "" {
+		labelsToMatch["affinityType"] = list.AffinityType
+	}
+	if list.IPVersion != 0 {
+		labelsToMatch["ipVersion"] = strconv.Itoa(list.IPVersion)
+	}
+	var labelSelector labels.Selector
+	if len(labelsToMatch) > 0 {
+		labelSelector = labels.SelectorFromSet(labelsToMatch)
+	}
+	return labelSelector
 }
 
 func (c *blockAffinityClient) listV3(ctx context.Context, list model.ResourceListOptions, revision string) (*model.KVPairList, error) {

--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -25,6 +25,7 @@ import (
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/json"
@@ -85,6 +86,11 @@ type ListInterface interface {
 	// Key type for this list.  It returns nil if passed a different kind
 	// of path.
 	KeyFromDefaultPath(key string) Key
+}
+
+type LabelSelectingListInterface interface {
+	ListInterface
+	GetLabelSelector() labels.Selector
 }
 
 // KVPair holds a typed key and value object as well as datastore specific

--- a/libcalico-go/lib/backend/model/resource.go
+++ b/libcalico-go/lib/backend/model/resource.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/namespace"
@@ -257,9 +258,21 @@ type ResourceListOptions struct {
 	Namespace string
 	// The resource kind.
 	Kind string
-	// Whether the name is prefix rather than the full name.
+	// Whether the name is prefix rather than the full name.  This is only
+	// supported efficiently by the etcd API.  When using the Kubernetes API,
+	// a full list operation is performed and then filtered client-side.
 	Prefix bool
+	// LabelSelector allows filtering on the labels of the resource. This is
+	// supported efficiently by the Kuberentes backend, but the etcd backend
+	// implements it client-side.
+	LabelSelector labels.Selector
 }
+
+func (options ResourceListOptions) GetLabelSelector() labels.Selector {
+	return options.LabelSelector
+}
+
+var _ LabelSelectingListInterface = ResourceListOptions{}
 
 // If the Kind, Namespace and Name are specified, but the Name is a prefix then the
 // last segment of this path is a prefix.

--- a/libcalico-go/lib/ipam/interface.go
+++ b/libcalico-go/lib/ipam/interface.go
@@ -105,4 +105,8 @@ type Interface interface {
 	// Otherwise, return the CIDR of the IPAM block allocated for this host.
 	// It returns IPv4, IPv6 block CIDR and any error encountered.
 	EnsureBlock(ctx context.Context, args BlockArgs) (*cnet.IPNet, *cnet.IPNet, error)
+
+	// UpgradeHost checks the resources related to the given node and, if it
+	// finds any that are in older formats, upgrades them.
+	UpgradeHost(ctx context.Context, nodeName string) error
 }

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -26,6 +26,7 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
+	"k8s.io/apimachinery/pkg/labels"
 
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -2349,4 +2350,76 @@ func (c ipamClient) getReservedIPs(ctx context.Context) (addrFilter, error) {
 		}
 	}
 	return cidrs, nil
+}
+
+func (c ipamClient) UpgradeHost(ctx context.Context, nodeName string) error {
+	delay := 100 * time.Millisecond
+	for {
+		err := c.attemptUpgradeHost(ctx, nodeName)
+		if err == nil {
+			return nil
+		}
+		log.WithError(err).Errorf("Failed to upgrade qIPAM blocks of this host.")
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(delay):
+			delay *= 2
+		}
+		log.WithError(err).Error("Retrying...")
+	}
+}
+
+func (c ipamClient) attemptUpgradeHost(ctx context.Context, nodeName string) error {
+	// Upgrade the block affinities that belong to this host.  Add labels that
+	// allow for efficient lookups in KDD.  Note that etcd still stores the
+	// old "v1" model.BlockAffinity objects directly so this List() will
+	// return no results in etcd.
+	log.Info("Upgrading any IPAM affinities from older versions....")
+
+	// We know that already-upgraded blocks will have the affinityType label,
+	// we can list only non-upgraded blocks.  We can't limit to any particular
+	// host here because that's the whole point of adding the new labels!
+	ls, err := labels.Parse("!affinityType")
+	if err != nil {
+		return err
+	}
+	kvs, err := c.client.List(ctx, model.ResourceListOptions{
+		Kind:          libapiv3.KindBlockAffinity,
+		LabelSelector: ls,
+	}, "")
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	numUpgraded := 0
+	for _, kv := range kvs.KVPairs {
+		if val, ok := kv.Value.(*libapiv3.BlockAffinity); ok {
+			if val.Spec.Node != nodeName {
+				// Only do _our_ affinities to avoid n x n conflicts with other
+				// nodes also doing this operation.
+				continue
+			}
+			libapiv3.EnsureBlockAffinityLabels(val)
+			_, err := c.client.Update(ctx, kv)
+			if err != nil {
+				errs = append(errs, err)
+				if errors.Is(err, context.DeadlineExceeded) {
+					break
+				}
+				continue
+			}
+			numUpgraded++
+		}
+	}
+	if numUpgraded == 0 && len(errs) == 0 {
+		log.Info("No affinities needed to be upgraded.")
+	}
+
+	log.Infof("Upgraded %d block affinities belonging to this host.", numUpgraded)
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to upgrade some block affinities: %v", errs)
+	}
+	return nil
 }


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add labels to the Kubernetes encoding of IPAM block affinities so that they can be looked up efficiently with a label selector.

The KDD block affinity client automatically adds the labels on write.

To handle pre-existing bloacks, each node upgrades its own block affinities the first time the CNI IPAM plugin runs after upgrade.

For compatibility, add support for label selectors in the etcd backend (but these are implemented client-side).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-11745
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
