### PR TITLE
Make OpenStack resync interval configurable and disable-able

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -97,11 +97,11 @@ fi
 # different version of Tempest than the version that DevStack would naturally use.
 case "${DEVSTACK_BRANCH}" in
     unmaintained/yoga )
-	export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga
-	;;
-    stable/2024.1 )		# Caracal
-	export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
-	;;
+        export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/yoga
+        ;;
+    stable/2024.1 )             # Caracal
+        export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/openstack/requirements/refs/heads/stable/2024.1/upper-constraints.txt
+        ;;
 esac
 
 : ${NC_PLUGIN_REPO:=https://github.com/projectcalico/calico}

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright 2015 Metaswitch Networks
 # All Rights Reserved.
+# Copyright (c) 2025 Tigera, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -161,6 +162,10 @@ SCENARIO_IMAGE_TYPE=ignore
 GIT_BASE=https://github.com
 
 LIBVIRT_TYPE=qemu
+
+# Disable ongoing resync.  In principle this isn't needed; disable it in order to build evidence to
+# confirm that.
+CALICO_RESYNC_INTERVAL_SECS=0
 
 EOF
 

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -2,79 +2,79 @@
 # Devstack plugin code for Calico
 # ===============================
 
-mode=$1				# stack, unstack or clean
-phase=$2			# pre-install, install, post-config or extra
+mode=$1                         # stack, unstack or clean
+phase=$2                        # pre-install, install, post-config or extra
 
 if [ "${Q_AGENT}" = calico-felix ]; then
 
     case $mode in
 
-	stack)
-	    # Called by stack.sh four times for different phases of
-	    # its run.
-	    echo Calico plugin: stack
+        stack)
+            # Called by stack.sh four times for different phases of
+            # its run.
+            echo Calico plugin: stack
 
-	    case $phase in
+            case $phase in
 
-		pre-install)
-		    # Called after system (OS) setup is complete and
-		    # before project source is installed.
-		    echo Calico plugin: pre-install
+                pre-install)
+                    # Called after system (OS) setup is complete and
+                    # before project source is installed.
+                    echo Calico plugin: pre-install
 
-		    # Add Calico master PPA as a package source.
-		    sudo apt-add-repository -y ppa:project-calico/master
-		    REPOS_UPDATED=False
+                    # Add Calico master PPA as a package source.
+                    sudo apt-add-repository -y ppa:project-calico/master
+                    REPOS_UPDATED=False
 
-		    # Also add BIRD project PPA as a package source.
-		    LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo add-apt-repository -y ppa:cz.nic-labs/bird
+                    # Also add BIRD project PPA as a package source.
+                    LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo add-apt-repository -y ppa:cz.nic-labs/bird
 
-		    ;;
+                    ;;
 
-		install)
-		    # Called after the layer 1 and 2 projects source
-		    # and their dependencies have been installed.
-		    echo Calico plugin: install
+                install)
+                    # Called after the layer 1 and 2 projects source
+                    # and their dependencies have been installed.
+                    echo Calico plugin: install
 
-		    # Upgrade dnsmasq.
-		    install_package dnsmasq-base dnsmasq-utils
+                    # Upgrade dnsmasq.
+                    install_package dnsmasq-base dnsmasq-utils
 
-		    # Install ipset.
-		    install_package ipset
+                    # Install ipset.
+                    install_package ipset
 
-		    # Install BIRD.
-		    install_package bird
+                    # Install BIRD.
+                    install_package bird
 
-		    # Install the Calico agent.
-		    sudo mkdir -p /etc/calico
-		    sudo sh -c "cat > /etc/calico/felix.cfg" << EOF
+                    # Install the Calico agent.
+                    sudo mkdir -p /etc/calico
+                    sudo sh -c "cat > /etc/calico/felix.cfg" << EOF
 [global]
 DatastoreType = etcdv3
 EtcdEndpoints = http://${SERVICE_HOST}:${ETCD_PORT}
 EOF
-		    if [ "${ENABLE_DEBUG_LOG_LEVEL}" = True ]; then
-			sudo sh -c "cat >> /etc/calico/felix.cfg" << EOF
+                    if [ "${ENABLE_DEBUG_LOG_LEVEL}" = True ]; then
+                        sudo sh -c "cat >> /etc/calico/felix.cfg" << EOF
 LogSeverityFile = info
 EOF
-		    fi
-		    install_package calico-felix
+                    fi
+                    install_package calico-felix
 
-		    # Install Calico common code, that includes BIRD templates.
-		    install_package calico-common
+                    # Install Calico common code, that includes BIRD templates.
+                    install_package calico-common
 
-		    # Install networking-calico.
-		    pip_install "${GITDIR['calico']}/networking-calico"
+                    # Install networking-calico.
+                    pip_install "${GITDIR['calico']}/networking-calico"
 
-		    ;;
+                    ;;
 
-		post-config)
-		    # Called after the layer 1 and 2 services have
-		    # been configured. All configuration files for
-		    # enabled services should exist at this point.
-		    echo Calico plugin: post-config
+                post-config)
+                    # Called after the layer 1 and 2 services have
+                    # been configured. All configuration files for
+                    # enabled services should exist at this point.
+                    echo Calico plugin: post-config
 
-		    # Update qemu configuration (shouldn't be anything
-		    # in there so safe to blow away)
-		    sudo sh -c "cat > /etc/libvirt/qemu.conf" << EOF
+                    # Update qemu configuration (shouldn't be anything
+                    # in there so safe to blow away)
+                    sudo sh -c "cat > /etc/libvirt/qemu.conf" << EOF
 user = "root"
 group = "root"
 cgroup_device_acl = [
@@ -85,92 +85,92 @@ cgroup_device_acl = [
 ]
 EOF
 
-		    # Use the Calico plugin.  We make this change here, instead
-		    # of putting 'Q_PLUGIN=calico' in the settings file,
-		    # because the latter would require adding Calico plugin
-		    # support to the core DevStack repository.
-		    iniset $NEUTRON_CONF DEFAULT core_plugin calico
+                    # Use the Calico plugin.  We make this change here, instead
+                    # of putting 'Q_PLUGIN=calico' in the settings file,
+                    # because the latter would require adding Calico plugin
+                    # support to the core DevStack repository.
+                    iniset $NEUTRON_CONF DEFAULT core_plugin calico
 
-		    # Calico itself implements the 'router' extension, but we need a service plugin
-		    # for QoS.
-		    iniset $NEUTRON_CONF DEFAULT service_plugins qos
+                    # Calico itself implements the 'router' extension, but we need a service plugin
+                    # for QoS.
+                    iniset $NEUTRON_CONF DEFAULT service_plugins qos
 
-		    # Propagate ENABLE_DEBUG_LOG_LEVEL to neutron.conf, so that
-		    # it applies to the Calico DHCP agent on each compute node.
-		    iniset $NEUTRON_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL
+                    # Propagate ENABLE_DEBUG_LOG_LEVEL to neutron.conf, so that
+                    # it applies to the Calico DHCP agent on each compute node.
+                    iniset $NEUTRON_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL
 
-		    # Point the Calico DHCP agent and mechanism driver
-		    # at the etcd server.
-		    iniset $NEUTRON_CONF calico etcd_host $SERVICE_HOST
-		    iniset $NEUTRON_CONF calico etcd_port $ETCD_PORT
+                    # Point the Calico DHCP agent and mechanism driver
+                    # at the etcd server.
+                    iniset $NEUTRON_CONF calico etcd_host $SERVICE_HOST
+                    iniset $NEUTRON_CONF calico etcd_port $ETCD_PORT
 
-		    # If CALICO_ETCD_COMPACTION_PERIOD_MINS is
-		    # defined, set that as the value of the
-		    # etcd_compaction_period_mins setting.
-		    if test -n "$CALICO_ETCD_COMPACTION_PERIOD_MINS"; then
-			iniset $NEUTRON_CONF calico etcd_compaction_period_mins $CALICO_ETCD_COMPACTION_PERIOD_MINS
-		    fi
+                    # If CALICO_ETCD_COMPACTION_PERIOD_MINS is
+                    # defined, set that as the value of the
+                    # etcd_compaction_period_mins setting.
+                    if test -n "$CALICO_ETCD_COMPACTION_PERIOD_MINS"; then
+                        iniset $NEUTRON_CONF calico etcd_compaction_period_mins $CALICO_ETCD_COMPACTION_PERIOD_MINS
+                    fi
 
-		    # If CALICO_ETCD_COMPACTION_MIN_REVISIONS is
-		    # defined, set that as the value of the
-		    # etcd_compaction_min_revisions setting.
-		    if test -n "$CALICO_ETCD_COMPACTION_MIN_REVISIONS"; then
-			iniset $NEUTRON_CONF calico etcd_compaction_min_revisions $CALICO_ETCD_COMPACTION_MIN_REVISIONS
-		    fi
+                    # If CALICO_ETCD_COMPACTION_MIN_REVISIONS is
+                    # defined, set that as the value of the
+                    # etcd_compaction_min_revisions setting.
+                    if test -n "$CALICO_ETCD_COMPACTION_MIN_REVISIONS"; then
+                        iniset $NEUTRON_CONF calico etcd_compaction_min_revisions $CALICO_ETCD_COMPACTION_MIN_REVISIONS
+                    fi
 
-		    # If CALICO_RESYNC_INTERVAL_SECS is defined, set that as the value of the
-		    # resync_interval_secs setting.
-		    if test -n "$CALICO_RESYNC_INTERVAL_SECS"; then
-			iniset $NEUTRON_CONF calico resync_interval_secs $CALICO_RESYNC_INTERVAL_SECS
-		    fi
+                    # If CALICO_RESYNC_INTERVAL_SECS is defined, set that as the value of the
+                    # resync_interval_secs setting.
+                    if test -n "$CALICO_RESYNC_INTERVAL_SECS"; then
+                        iniset $NEUTRON_CONF calico resync_interval_secs $CALICO_RESYNC_INTERVAL_SECS
+                    fi
 
-		    # Give Neutron the admin role so that it can look up
-		    # project name and parent_id fields in the Keystone DB.
-		    openstack role add admin --user neutron --project service --user-domain Default --project-domain Default
-		    ;;
+                    # Give Neutron the admin role so that it can look up
+                    # project name and parent_id fields in the Keystone DB.
+                    openstack role add admin --user neutron --project service --user-domain Default --project-domain Default
+                    ;;
 
-		extra)
-		    # Called near the end after layer 1 and 2 services
-		    # have been started.
-		    echo Calico plugin: extra
+                extra)
+                    # Called near the end after layer 1 and 2 services
+                    # have been started.
+                    echo Calico plugin: extra
 
-		    # Run script to automatically generate and
-		    # maintain BIRD config for the cluster.
-		    export ETCDCTL_API=3
-		    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
-		    run_process calico-bird \
+                    # Run script to automatically generate and
+                    # maintain BIRD config for the cluster.
+                    export ETCDCTL_API=3
+                    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
+                    run_process calico-bird \
                       "${DEST}/calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
 
-		    # Run the Calico DHCP agent.
-		    sudo mkdir /var/log/neutron || true
-		    sudo chown `whoami` /var/log/neutron
-		    run_process calico-dhcp \
-		      "${DEVSTACK_VENV:-/usr/local}/bin/calico-dhcp-agent --config-file $NEUTRON_CONF"
+                    # Run the Calico DHCP agent.
+                    sudo mkdir /var/log/neutron || true
+                    sudo chown `whoami` /var/log/neutron
+                    run_process calico-dhcp \
+                      "${DEVSTACK_VENV:-/usr/local}/bin/calico-dhcp-agent --config-file $NEUTRON_CONF"
 
-		    ;;
+                    ;;
 
-		*)
-		    echo Calico plugin: unexpected phase $phase
-		    ;;
+                *)
+                    echo Calico plugin: unexpected phase $phase
+                    ;;
 
-	    esac
-	    ;;
+            esac
+            ;;
 
-	unstack)
-	    # Called by unstack.sh before other services are shut
-	    # down.
-	    echo Calico plugin: unstack
-	    ;;
+        unstack)
+            # Called by unstack.sh before other services are shut
+            # down.
+            echo Calico plugin: unstack
+            ;;
 
-	clean)
-	    # Called by clean.sh before other services are cleaned,
-	    # but after unstack.sh has been called.
-	    echo Calico plugin: clean
-	    ;;
+        clean)
+            # Called by clean.sh before other services are cleaned,
+            # but after unstack.sh has been called.
+            echo Calico plugin: clean
+            ;;
 
-	*)
-	    echo Calico plugin: unexpected mode $mode
-	    ;;
+        *)
+            echo Calico plugin: unexpected mode $mode
+            ;;
 
     esac
 fi

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -110,11 +110,18 @@ EOF
 		    if test -n "$CALICO_ETCD_COMPACTION_PERIOD_MINS"; then
 			iniset $NEUTRON_CONF calico etcd_compaction_period_mins $CALICO_ETCD_COMPACTION_PERIOD_MINS
 		    fi
+
 		    # If CALICO_ETCD_COMPACTION_MIN_REVISIONS is
 		    # defined, set that as the value of the
 		    # etcd_compaction_min_revisions setting.
 		    if test -n "$CALICO_ETCD_COMPACTION_MIN_REVISIONS"; then
 			iniset $NEUTRON_CONF calico etcd_compaction_min_revisions $CALICO_ETCD_COMPACTION_MIN_REVISIONS
+		    fi
+
+		    # If CALICO_RESYNC_INTERVAL_SECS is defined, set that as the value of the
+		    # resync_interval_secs setting.
+		    if test -n "$CALICO_RESYNC_INTERVAL_SECS"; then
+			iniset $NEUTRON_CONF calico resync_interval_secs $CALICO_RESYNC_INTERVAL_SECS
 		    fi
 
 		    # Give Neutron the admin role so that it can look up

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Metaswitch Networks
-# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -366,6 +366,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_oslo_config.cfg.CONF.calico.egress_minburst_bytes = 0
         lib.m_oslo_config.cfg.CONF.calico.ingress_burst_packets = 0
         lib.m_oslo_config.cfg.CONF.calico.egress_burst_packets = 0
+        lib.m_oslo_config.cfg.CONF.calico.resync_interval_secs = (
+            mech_calico.DEFAULT_RESYNC_INTERVAL_SECS
+        )
         calico_config._reset_globals()
         datamodel_v2._reset_globals()
 
@@ -548,7 +551,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # Allow it to run again, this time auditing against the etcd data that
         # was written on the first iteration.
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
@@ -572,7 +575,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
 
         # Do another resync - expect no changes to the etcd data.
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
@@ -615,7 +618,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # resync will now discover that.
         _log.info("Resync with existing etcd data")
         self.osdb_ports[0]["binding:host_id"] = "felix-host-1"
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
 
         self.assertEtcdDeletes(set([ep_deadbeef_key_v3]))
         ep_deadbeef_key_v3 = ep_deadbeef_key_v3.replace("new--host", "felix--host--1")
@@ -866,7 +869,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
 
         # Resync with all latest data - expect no etcd writes or deletes.
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set([]))
 
@@ -921,7 +924,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # cleaned up.
         self.osdb_ports = [context.original]
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(
             set(
@@ -964,7 +967,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
             {"subnet_id": "subnet-id-10.65.0--24", "ip_address": "10.65.0.188"}
         ]
         _log.info("Resync with edited data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
 
         ep_hello_value_v3["spec"]["ipNetworks"] = ["10.65.0.188/32"]
         ep_hello_value_v3["spec"]["ipv4Gateway"] = "10.65.0.1"
@@ -1264,7 +1267,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         # Allow the etcd transport's resync thread to run again.  Expect no
         # change in etcd subnet data.
         self.give_way()
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
@@ -1296,7 +1299,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         with lib.FixedUUID("uuid-subnet-hooks-2"):
             self.give_way()
             self.etcd_data = {}
-            self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+            self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
 
         expected_writes[
             "/calico/resources/v3/projectcalico.org/clusterinformations/" + "default"
@@ -1320,7 +1323,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         subnet1["enable_dhcp"] = True
         subnet2["enable_dhcp"] = False
         self.give_way()
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites(
             {
                 "/calico/dhcp/v2/no-region/subnet/subnet-id-10.65.0--24": {
@@ -1341,7 +1344,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         # changed a Calico-relevant property of a DHCP-enabled subnet.
         subnet1["gateway_ip"] = "10.65.0.2"
         self.give_way()
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites(
             {
                 "/calico/dhcp/v2/no-region/subnet/subnet-id-10.65.0--24": {


### PR DESCRIPTION
In principle the ongoing resync isn't needed at all, so let's make it possible to switch it off, and do our DevStack (FV) testing like that, to confirm the principle.

On the other hand, if it is wanted, let's make the period configurable.  For now we continue to default to the same as before, i.e. 60s.

Plus a small variable naming improvement.