### PR TITLE
[cherry-pick #10785] Check if RPMs are already uploaded [v3.30]

### DIFF
--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -32,7 +32,7 @@ global_job_config:
       # install-package is a Semaphore-specific script that has a few benefits,
       # notably being much faster because it uses Semaphore's cache to fetch
       # files from.
-      - install-package --no-install-recommends devscripts moreutils patchelf
+      - install-package --no-install-recommends devscripts moreutils patchelf jq
 
 blocks:
   - name: "Publish openstack packages"

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -72,7 +72,7 @@ blocks:
           - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
           # Install more tools
           - sudo apt update
-          - sudo apt install -y moreutils patchelf
+          - sudo apt install -y moreutils patchelf jq
       jobs:
         - name: "Build Openstack Packages"
           execution_time_limit:

--- a/release/packaging/utils/create-update-packages.sh
+++ b/release/packaging/utils/create-update-packages.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -eo pipefail
 
 # Do everything that's needed to create or update the Calico PPA and
 # RPM repo named ${REPO_NAME}, so that those provide packages for the
@@ -50,6 +52,7 @@ function require_commands {
     check_bin ts || error_exit "This script requires the 'ts' command from the 'moreutils' package."
     check_bin dch || error_exit "This script requires the 'dch' command from the 'devscripts' package."
     check_bin patchelf || error_exit "This script requires the 'patchelf' command from the 'patchelf' package."
+    check_bin jq || error_exit "This scruit requires the 'jq' command from the 'jq' package"
 }
 
 function require_version {

--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -136,6 +136,7 @@ ssh_host="gcloud --quiet compute ssh ${GCLOUD_ARGS} ${HOST}"
 scp_host="gcloud --quiet compute scp ${GCLOUD_ARGS}"
 
 upload_artifact="gcloud --quiet --no-user-output-enabled artifacts yum upload ${GCLOUD_REPO_NAME} --location=us-west1 --project=${GCLOUD_PROJECT:-tigera-wp-tcp-redirect}"
+check_artifact="gcloud artifacts files list --repository=${GCLOUD_REPO_NAME} --project=tigera-wp-tcp-redirect --location=us-west1 --format=json --quiet"
 rpmdir=/usr/share/nginx/html/rpm
 
 function ensure_repo_exists {
@@ -156,16 +157,40 @@ function copy_rpms_to_host {
     done
 }
 
+function check_rpm_is_uploaded_to_artifact_registry {
+    rpmfile=$1
+    # Get the package name and version from the RPM file itself,
+    # to avoid having to parse filenames. Make sure we get the epoch
+    # and release, since those are included in the versions that artifact
+    # registry uses. Note that if the epoch is unset GAR treats it as a 0,
+    # so if %{EPOCH} is '(none)' we replace it with 0.
+    rpmfile_package_name=$(rpm -qp --queryformat "%{NAME}" "${rpmfile}")
+    rpmfile_package_version=$(rpm -qp --queryformat "%{EPOCH}:%{VERSION}-%{RELEASE}" "${rpmfile}" | sed -e 's/(none)/0/')
+
+    # Get the list of packages matching the name and version; if this is 0, then we
+    # have not uploaded this package+version combo yet. If it's anything else, we have.
+    matching_package_count=$(${check_artifact} --package="${rpmfile_package_name}" --version="${rpmfile_package_version}" | jq length)
+    if [[ $matching_package_count == 0 ]]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
 function copy_rpms_to_artifact_registry {
     reponame=$1
     rootdir=$(git_repo_root)
     upload_errors=""
     shopt -s nullglob
     echo "Uploading RPMs to Google Artifact Registry"
-    for rpmfile in $(find ${rootdir}/release/packaging/output/dist/rpms-el7 -name "*.rpm" | sort); do
-        filename=$(basename ${rpmfile})
-        echo "  Uploading ${filename}"
-        ${upload_artifact} --source="${rpmfile}" || upload_errors="${upload_errors} ${filename}"
+    for rpmfile in $(find ${rootdir}/release/packaging/output/dist/rpms-el7 -name "*.rpm" -not -name "*.src.rpm" | sort); do
+        filename=$(basename ${rpmfile}) 
+        if check_rpm_is_uploaded_to_artifact_registry "${rpmfile}"; then
+            echo "  Skipping  ${filename} (already uploaded)"
+        else
+            echo "  Uploading ${filename}"
+            ${upload_artifact} --source="${rpmfile}" || upload_errors="${upload_errors} ${filename}"
+        fi
     done
 
     if [[ ${upload_errors} != "" ]]; then

--- a/release/packaging/utils/lib.sh
+++ b/release/packaging/utils/lib.sh
@@ -136,7 +136,7 @@ ssh_host="gcloud --quiet compute ssh ${GCLOUD_ARGS} ${HOST}"
 scp_host="gcloud --quiet compute scp ${GCLOUD_ARGS}"
 
 upload_artifact="gcloud --quiet --no-user-output-enabled artifacts yum upload ${GCLOUD_REPO_NAME} --location=us-west1 --project=${GCLOUD_PROJECT:-tigera-wp-tcp-redirect}"
-check_artifact="gcloud artifacts files list --repository=${GCLOUD_REPO_NAME} --project=tigera-wp-tcp-redirect --location=us-west1 --format=json --quiet"
+check_artifact="gcloud artifacts files list --repository=${GCLOUD_REPO_NAME} --project=${GCLOUD_PROJECT:-tigera-wp-tcp-redirect} --location=us-west1 --format=json --quiet"
 rpmdir=/usr/share/nginx/html/rpm
 
 function ensure_repo_exists {


### PR DESCRIPTION
(This PR is a cherry-pick of #10785.)

Add a simple function to the OpenStack shell scripts to validate if an RPM package has been uploaded already; if so, skip it.

Also, skip uploading `.src.rpm` packages, since we can't. Maybe we need to create separate GAR repositories for those.
