### PR TITLE
Add slaac support for calico-dhcp-agent 

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -829,6 +829,9 @@ class SubnetWatcher(etcdutils.EtcdWatcher):
         if ip_version == 6:
             subnet["ipv6_address_mode"] = constants.DHCPV6_STATEFUL
             subnet["ipv6_ra_mode"] = constants.DHCPV6_STATEFUL
+            if data.get("ipv6_address_mode") == constants.IPV6_SLAAC && data.get("ipv6_ra_mode") == constants.IPV6_SLAAC:
+                subnet["ipv6_address_mode"] = constants.IPV6_SLAAC
+                subnet["ipv6_ra_mode"] = constants.IPV6_SLAAC
 
         return dhcp.DictModel(subnet)
 

--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -99,6 +99,8 @@ class DnsmasqRouted(dhcp.Dnsmasq):
                     and not ra_mode
                 ):
                     mode = "static"
+                if (addr_mode == constants.IPV6_SLAAC && ra_mode == constants.IPV6_SLAAC):
+                    mode = "slaac,ra-only"
 
             cidr = netaddr.IPNetwork(subnet.cidr)
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
@@ -99,4 +99,8 @@ def subnet_etcd_data(subnet):
     }
     if subnet["dns_nameservers"]:
         data["dns_servers"] = subnet["dns_nameservers"]
+    if subnet['ipv6_ra_mode'] and subnet['ipv6_address_mode']:
+        data['ipv6_ra_mode'] = subnet['ipv6_ra_mode']
+        data['ipv6_address_mode'] = subnet['ipv6_address_mode']
+
     return data


### PR DESCRIPTION
## Description

Currently calico-dhcp-agent only supports dhcp6_stateful, but this can introduce a failure mode where leases get stuck after for example an openstack rebuild. SLAAC allows the machine to assign it's own IP, based on the mac address, which is already decided by neutron and passed into the VM

For ipv4 it already works similarly, since dnsmasq can simply bind the leases to ipv4 mac addresses

From what i can tell you still need a normal subnet to make nova happy, but the main goal of this PR is having a SLAAC address with higher reliability

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
