### PR TITLE
Trigger IP allocation sync on Felixconfig change

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/tunnelipsyncer.go
+++ b/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/tunnelipsyncer.go
@@ -35,6 +35,9 @@ func New(client api.Client, callbacks api.SyncerCallbacks, node string) api.Sync
 		{
 			ListInterface: model.ResourceListOptions{Kind: libapiv3.KindNode, Name: node},
 		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv3.KindFelixConfiguration},
+		},
 	}
 
 	return watchersyncer.New(client, resourceTypes, callbacks)

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -194,6 +194,10 @@ func (r *reconciler) OnUpdates(updates []bapi.Update) {
 				}
 				log.Debugf("Updated node resource: %s", u.Key)
 				data = v.Status.WireguardPublicKey
+			case *api.FelixConfiguration:
+				// FelixConfiguration changes may impact whether we allocate wireguard IPs or not.
+				log.Debugf("Updated FelixConfiguration resource: %s", u.Key)
+				data = v.Spec
 			default:
 				// We got an update for an unexpected resource type. Rather than ignore, just treat as updated so that
 				// we reconcile the addresses.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Wireguard configuration controls whether or not tunnel IPs should be allocated, but we don't watch FelixConfig in the IP allocator.

This is leading to a race condition where sometimes IPs do not get allocated when they should.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/10599

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.