### PR TITLE
Check DSCP related rules before asserting connectivity

### DIFF
--- a/felix/fv/dscp_test.go
+++ b/felix/fv/dscp_test.go
@@ -196,6 +196,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		extClient.Exec("ip6tables", "-A", "INPUT", "-p", "ipv6-icmp", "-j", "ACCEPT")
 		extClient.Exec("ip6tables", "-A", "INPUT", "-m", "dscp", "!", "--dscp", "0x28", "-j", "DROP")
 
+		verifyQoSPolicies(tc.Felixes[0], nil, nil)
+		verifyQoSPolicies(tc.Felixes[1], nil, nil)
+
 		cc.ResetExpectations()
 		cc.ExpectNone(extClient, hostw)
 		cc.ExpectNone(extClient, ep1_1)
@@ -205,9 +208,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.None, extClient, ep1_2, ccOpts)
 		cc.Expect(connectivity.None, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
-
-		verifyQoSPolicies(tc.Felixes[0], nil, nil)
-		verifyQoSPolicies(tc.Felixes[1], nil, nil)
 
 		By("adding a host endpoint to felix 0")
 		hep := apiv3.NewHostEndpoint()
@@ -243,6 +243,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		}
 		ep2_2.UpdateInInfra(infra)
 
+		verifyQoSPolicies(tc.Felixes[0], []string{"0x14", "0x14"}, nil)
+		verifyQoSPolicies(tc.Felixes[1], []string{"0x28"}, []string{"0x28"})
+
 		cc.ResetExpectations()
 		cc.ExpectSome(extClient, hostw)
 		cc.ExpectSome(extClient, ep1_1)
@@ -251,9 +254,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.None, extClient, ep1_2, ccOpts)
 		cc.Expect(connectivity.Some, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
-
-		verifyQoSPolicies(tc.Felixes[0], []string{"0x14", "0x14"}, nil)
-		verifyQoSPolicies(tc.Felixes[1], []string{"0x28"}, []string{"0x28"})
 
 		By("updating DSCP values on some workloads")
 		ep2_1.WorkloadEndpoint.Spec.QoSControls = &api.QoSControls{
@@ -266,6 +266,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		}
 		ep1_2.UpdateInInfra(infra)
 
+		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14", "0x14"}, nil)
+		verifyQoSPolicies(tc.Felixes[1], []string{"0x28", "0x28"}, []string{"0x28", "0x28"}) // 0x28 used by two workloads
+
 		cc.ResetExpectations()
 		cc.ExpectSome(extClient, hostw)
 		cc.ExpectSome(extClient, ep1_1)
@@ -274,9 +277,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.Some, extClient, ep1_2, ccOpts)
 		cc.Expect(connectivity.Some, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
-
-		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14", "0x14"}, nil)
-		verifyQoSPolicies(tc.Felixes[1], []string{"0x28", "0x28"}, []string{"0x28", "0x28"}) // 0x28 used by two workloads
 
 		By("updating DSCP values on other workloads")
 		ep1_1.WorkloadEndpoint.Spec.QoSControls = &api.QoSControls{
@@ -289,6 +289,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		}
 		ep1_2.UpdateInInfra(infra)
 
+		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14", "0x20"}, nil)
+		verifyQoSPolicies(tc.Felixes[1], []string{"0x14", "0x28"}, []string{"0x14", "0x28"})
+
 		cc.ResetExpectations()
 		cc.ExpectSome(extClient, hostw)
 		cc.ExpectNone(extClient, ep1_1)
@@ -297,9 +300,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.None, extClient, ep1_2, ccOpts)
 		cc.Expect(connectivity.Some, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
-
-		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14", "0x20"}, nil)
-		verifyQoSPolicies(tc.Felixes[1], []string{"0x14", "0x28"}, []string{"0x14", "0x28"})
 
 		By("reverting the DSCP values")
 		ep1_1.WorkloadEndpoint.Spec.QoSControls = &api.QoSControls{
@@ -312,6 +312,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		}
 		ep1_2.UpdateInInfra(infra)
 
+		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14", "0x14"}, nil)
+		verifyQoSPolicies(tc.Felixes[1], []string{"0x28", "0x28"}, []string{"0x28", "0x28"}) // 0x28 used by two workloads
+
 		cc.ResetExpectations()
 		cc.ExpectSome(extClient, hostw)
 		cc.ExpectSome(extClient, ep1_1)
@@ -321,12 +324,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.Some, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
 
-		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14", "0x14"}, nil)
-		verifyQoSPolicies(tc.Felixes[1], []string{"0x28", "0x28"}, []string{"0x28", "0x28"}) // 0x28 used by two workloads
-
 		By("removing host endpoint")
 		_, err = client.HostEndpoints().Delete(utils.Ctx, hep.Name, options.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14"}, nil)
+		verifyQoSPolicies(tc.Felixes[1], []string{"0x28", "0x28"}, []string{"0x28", "0x28"}) // 0x28 used by two workloads
 
 		cc.ResetExpectations()
 		cc.ExpectNone(extClient, hostw)
@@ -337,15 +340,15 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.Some, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
 
-		verifyQoSPolicies(tc.Felixes[0], []string{"0x0", "0x14"}, nil)
-		verifyQoSPolicies(tc.Felixes[1], []string{"0x28", "0x28"}, []string{"0x28", "0x28"}) // 0x28 used by two workloads
-
 		By("resetting DSCP value on some workloads")
 		ep2_1.WorkloadEndpoint.Spec.QoSControls = &api.QoSControls{}
 		ep2_1.UpdateInInfra(infra)
 
 		ep1_2.WorkloadEndpoint.Spec.QoSControls = &api.QoSControls{}
 		ep1_2.UpdateInInfra(infra)
+
+		verifyQoSPolicies(tc.Felixes[0], []string{"0x14"}, nil)
+		verifyQoSPolicies(tc.Felixes[1], []string{"0x28"}, []string{"0x28"})
 
 		cc.ResetExpectations()
 		cc.ExpectNone(extClient, hostw)
@@ -356,15 +359,15 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.Some, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
 
-		verifyQoSPolicies(tc.Felixes[0], []string{"0x14"}, nil)
-		verifyQoSPolicies(tc.Felixes[1], []string{"0x28"}, []string{"0x28"})
-
 		By("stopping the last workloads")
 		ep1_1.Stop()
 		ep1_1.RemoveFromInfra(infra)
 
 		ep2_2.Stop()
 		ep2_2.RemoveFromInfra(infra)
+
+		verifyQoSPolicies(tc.Felixes[0], nil, nil)
+		verifyQoSPolicies(tc.Felixes[1], nil, nil)
 
 		cc.ResetExpectations()
 		cc.ExpectNone(extClient, hostw)
@@ -374,9 +377,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		cc.Expect(connectivity.None, extClient, ep1_2, ccOpts)
 		cc.Expect(connectivity.None, extClient, ep2_2, ccOpts)
 		cc.CheckConnectivity()
-
-		verifyQoSPolicies(tc.Felixes[0], nil, nil)
-		verifyQoSPolicies(tc.Felixes[1], nil, nil)
 	})
 
 	It("should be able to use all DSCP string values", func() {
@@ -441,7 +441,7 @@ func verifyQoSPoliciesWithIPFamily(felix *infrastructure.Felix, ipv6 bool, value
 		rulePattern = "DSCP --set-dscp"
 	}
 
-	EventuallyWithOffset(2, assertRules, 5*time.Second, 100*time.Millisecond).
+	EventuallyWithOffset(2, assertRules, 10*time.Second, 100*time.Millisecond).
 		Should(BeTrue())
 	ConsistentlyWithOffset(2, assertRules, 3*time.Second, 100*time.Millisecond).
 		Should(BeTrue())


### PR DESCRIPTION
## Description

Verify DSCP related rules are programmed before checking connectivity expectations.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
