### PR TITLE
bpf: deprecate map repinning

### DIFF
--- a/felix/bpf/ut/maps_test.go
+++ b/felix/bpf/ut/maps_test.go
@@ -55,9 +55,6 @@ func TestMapResize(t *testing.T) {
 	conntrack.SetMapSize(600)
 	defer bpfmaps.ResetSizes()
 
-	bpfmaps.EnableRepin()
-	defer bpfmaps.DisableRepin()
-
 	maps, err := bpfmap.CreateBPFMaps(false)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -231,7 +231,7 @@ type Config struct {
 	// are configured for cgroup v1, which prevents all but the root cgroup v2 from working so this is only useful
 	// for development right now.
 	DebugBPFCgroupV2 string `config:"string;;local"`
-	// DebugBPFMapRepinEnabled can be used to prevent Felix from repinning its BPF maps at startup.  This is useful for
+	// [deprecated] DebugBPFMapRepinEnabled can be used to prevent Felix from repinning its BPF maps at startup.  This is useful for
 	// testing with multiple Felix instances running on one host.
 	DebugBPFMapRepinEnabled bool `config:"bool;false;local"`
 

--- a/felix/dataplane/driver.go
+++ b/felix/dataplane/driver.go
@@ -375,7 +375,6 @@ func StartDataplaneDriver(
 			BPFDataIfacePattern:                configParams.BPFDataIfacePattern,
 			BPFL3IfacePattern:                  configParams.BPFL3IfacePattern,
 			BPFCgroupV2:                        configParams.DebugBPFCgroupV2,
-			BPFMapRepin:                        configParams.DebugBPFMapRepinEnabled,
 			KubeProxyMinSyncPeriod:             configParams.BPFKubeProxyMinSyncPeriod,
 			BPFPSNATPorts:                      configParams.BPFPSNATPorts,
 			BPFMapSizeRoute:                    configParams.BPFMapSizeRoute,

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -402,8 +402,6 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		vxlanMTU = 0
 		nodePortDSR = true
 
-		bpfmaps.EnableRepin()
-
 		maps = new(bpfmap.Maps)
 
 		v4Maps = new(bpfmap.IPMaps)
@@ -465,10 +463,6 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		ruleRenderer = rules.NewRenderer(rrConfigNormal)
 		filterTableV4 = newMockTable("filter")
 		filterTableV6 = newMockTable("filter")
-	})
-
-	AfterEach(func() {
-		bpfmaps.DisableRepin()
 	})
 
 	newBpfEpMgr := func(ipv6Enabled bool) {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -229,7 +229,6 @@ type Config struct {
 	BPFConnTimeLBEnabled               bool
 	BPFConnTimeLB                      string
 	BPFHostNetworkedNAT                string
-	BPFMapRepin                        bool
 	BPFNodePortDSREnabled              bool
 	BPFDSROptoutCIDRs                  []string
 	BPFPSNATPorts                      numorstring.Port
@@ -880,12 +879,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	if err != nil {
 		log.Warn("could not determine default rp_filter setting, defaulting to strict")
 		defaultRPFilter = []byte{'1'}
-	}
-
-	if config.BPFMapRepin {
-		bpfmaps.EnableRepin()
-	} else {
-		bpfmaps.DisableRepin()
 	}
 
 	bpfMapSizeConntrack := config.BPFMapSizeConntrack

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -968,32 +968,32 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						options.ExtraEnvVars["FELIX_DebugBPFMapRepinEnabled"] = "true"
 					})
 
-					It("should repin maps", func() {
+					It("should not repin maps (option is deprecated)", func() {
 						// Wait for the first felix to create its maps.
 						mapID := mustGetMapIDByPath(tc.Felixes[0], mapPath)
 
 						// Now, start a completely independent felix, which will get its own bpffs.  It should re-pin the
 						// maps, picking up the ones from the first felix.
-						tc, _ := infrastructure.StartSingleNodeTopology(options, infra)
-						defer tc.Stop()
+						tc2, _ := infrastructure.StartSingleNodeTopology(options, infra)
+						defer tc2.Stop()
 
-						secondMapID := mustGetMapIDByPath(tc.Felixes[0], mapPath)
+						secondMapID := mustGetMapIDByPath(tc2.Felixes[0], mapPath)
 						Expect(mapID).NotTo(BeNumerically("==", 0))
-						Expect(mapID).To(BeNumerically("==", secondMapID))
+						Expect(mapID).NotTo(BeNumerically("==", secondMapID))
 					})
 				})
 
 				Describe("with map repinning disabled", func() {
-					It("should repin maps", func() {
+					It("should not repin maps", func() {
 						// Wait for the first felix to create its maps.
 						mapID := mustGetMapIDByPath(tc.Felixes[0], mapPath)
 
 						// Now, start a completely independent felix, which will get its own bpffs.  It should make its own
 						// maps.
-						tc, _ := infrastructure.StartSingleNodeTopology(options, infra)
-						defer tc.Stop()
+						tc2, _ := infrastructure.StartSingleNodeTopology(options, infra)
+						defer tc2.Stop()
 
-						secondMapID := mustGetMapIDByPath(tc.Felixes[0], mapPath)
+						secondMapID := mustGetMapIDByPath(tc2.Felixes[0], mapPath)
 						Expect(mapID).NotTo(BeNumerically("==", 0))
 						Expect(mapID).NotTo(BeNumerically("==", secondMapID))
 					})


### PR DESCRIPTION
Remove map repinning code and deprecate the felix 'DebugBPFMapRepinEnabled' config option.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The felix 'DebugBPFMapRepinEnabled' config option is now deprecated and maps are no longer repinned by name.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
