### PR TITLE
libcalico-go test fixes/improvements

### DIFF
--- a/apiserver/test/integration/clientset_test.go
+++ b/apiserver/test/integration/clientset_test.go
@@ -2109,13 +2109,14 @@ func testBlockAffinityClient(client calicoclient.Interface, name string) error {
 	timeout := time.After(500 * time.Millisecond)
 	var timeoutErr error
 	// watch for 2 events
+loop:
 	for i := 0; i < 2; i++ {
 		select {
 		case e := <-w.ResultChan():
 			events = append(events, e)
 		case <-timeout:
 			timeoutErr = fmt.Errorf("timed out waiting for events")
-			break
+			break loop
 		}
 	}
 	if timeoutErr != nil {

--- a/libcalico-go/lib/backend/k8s/k8s.go
+++ b/libcalico-go/lib/backend/k8s/k8s.go
@@ -19,13 +19,17 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
+	"sync"
+	"time"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -44,6 +48,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
 	"github.com/projectcalico/calico/libcalico-go/lib/winutils"
 )
 
@@ -387,8 +392,8 @@ func CreateKubernetesClientset(ca *apiconfig.CalicoAPIConfigSpec) (*rest.Config,
 		return nil, nil, resources.K8sErrorToCalico(err, nil)
 	}
 
-	config.AcceptContentTypes = strings.Join([]string{runtime.ContentTypeProtobuf, runtime.ContentTypeJSON}, ",")
-	config.ContentType = runtime.ContentTypeProtobuf
+	config.AcceptContentTypes = strings.Join([]string{k8sruntime.ContentTypeProtobuf, k8sruntime.ContentTypeJSON}, ",")
+	config.ContentType = k8sruntime.ContentTypeProtobuf
 
 	// Overwrite the QPS if provided. Default QPS is 5.
 	if ca.K8sClientQPS != float32(0) {
@@ -458,6 +463,13 @@ func (c *KubeClient) EnsureInitialized() error {
 // test framework.
 func (c *KubeClient) Clean() error {
 	log.Warning("Cleaning KDD of all Calico-creatable data")
+
+	// Cleanup IPAM resources that have slightly different backend semantics.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	var eg errgroup.Group
+	eg.SetLimit(runtime.NumCPU())
 	kinds := []string{
 		apiv3.KindBGPConfiguration,
 		apiv3.KindBGPPeer,
@@ -480,36 +492,94 @@ func (c *KubeClient) Clean() error {
 		libapiv3.KindBlockAffinity,
 		apiv3.KindBGPFilter,
 	}
-	ctx := context.Background()
-	for _, k := range kinds {
-		lo := model.ResourceListOptions{Kind: k}
-		if rs, err := c.List(ctx, lo, ""); err != nil {
-			log.WithError(err).WithField("Kind", k).Warning("Failed to list resources")
-		} else {
-			for _, r := range rs.KVPairs {
-				if _, err = c.Delete(ctx, r.Key, r.Revision); err != nil {
-					log.WithField("Key", r.Key).Warning("Failed to delete entry from KDD")
-				}
-			}
+
+	// Deletion can fail due to CAS conflicts if multiple resources are
+	// being deleted in parallel, so we do plenty of retries.
+	kindsWithProblems := set.New[string]()
+	var lock sync.Mutex
+	for attempt := 1; attempt <= 20; attempt++ {
+		recordKindProblem := func(k string) {
+			lock.Lock()
+			defer lock.Unlock()
+			kindsWithProblems.Add(k)
 		}
+
+		for _, k := range kinds {
+			eg.Go(func() error {
+				lo := model.ResourceListOptions{Kind: k}
+				if rs, err := c.List(ctx, lo, ""); err != nil {
+					log.WithError(err).WithField("Kind", k).Warning("Failed to list resources")
+					recordKindProblem(k)
+					return nil // Problems are reported through kindsWithProblems set.
+				} else {
+					for _, r := range rs.KVPairs {
+						eg.Go(func() error {
+							if _, err := c.DeleteKVP(ctx, r); err != nil {
+								log.WithField("Key", r.Key).Warning("Failed to delete entry from KDD")
+								recordKindProblem(k)
+							}
+							return nil // Problems are reported through kindsWithProblems set.
+						})
+					}
+				}
+				return nil
+			})
+		}
+		_ = eg.Wait()
+
+		if len(kindsWithProblems) == 0 {
+			break
+		}
+		kinds = kindsWithProblems.Slice()
+		kindsWithProblems.Clear()
+	}
+	if kindsWithProblems.Len() > 0 {
+		log.WithField("kinds", kindsWithProblems).Error("Failed to delete all resources of these kinds")
 	}
 
-	// Cleanup IPAM resources that have slightly different backend semantics.
-	for _, li := range []model.ListInterface{
+	listIfaceProblems := set.New[model.ListInterface]()
+	listIfaces := []model.ListInterface{
 		model.BlockListOptions{},
 		model.BlockAffinityListOptions{},
-		model.BlockAffinityListOptions{},
 		model.IPAMHandleListOptions{},
-	} {
-		if rs, err := c.List(ctx, li, ""); err != nil {
-			log.WithError(err).WithField("Kind", li).Warning("Failed to list resources")
-		} else {
-			for _, r := range rs.KVPairs {
-				if _, err = c.DeleteKVP(ctx, r); err != nil {
-					log.WithError(err).WithField("Key", r.Key).Warning("Failed to delete entry from KDD")
-				}
-			}
+	}
+	for attempt := 1; attempt <= 20; attempt++ {
+		recordLIProblem := func(l model.ListInterface) {
+			lock.Lock()
+			defer lock.Unlock()
+			listIfaceProblems.Add(l)
 		}
+
+		for _, li := range listIfaces {
+			eg.Go(func() error {
+				if rs, err := c.List(ctx, li, ""); err != nil {
+					log.WithError(err).WithField("Kind", li).Warning("Failed to list resources")
+					recordLIProblem(li)
+				} else {
+					for _, r := range rs.KVPairs {
+						eg.Go(func() error {
+							if _, err = c.DeleteKVP(ctx, r); err != nil {
+								log.WithError(err).WithField("Key", r.Key).Warning("Failed to delete entry from KDD")
+								recordLIProblem(li)
+							}
+							return nil
+						})
+					}
+				}
+				return nil
+			})
+		}
+		_ = eg.Wait()
+
+		if listIfaceProblems.Len() == 0 {
+			break
+		}
+		listIfaces = listIfaceProblems.Slice()
+		listIfaceProblems.Clear()
+	}
+
+	if listIfaceProblems.Len() > 0 {
+		log.WithField("listInterfaces", listIfaceProblems).Error("Failed to delete all resources of these list interfaces")
 	}
 
 	// Get a list of Nodes and remove all BGP configuration from the nodes.
@@ -551,7 +621,7 @@ func buildCRDClientV1(cfg rest.Config) (*rest.RESTClient, error) {
 		Version: "v1",
 	}
 	cfg.APIPath = "/apis"
-	cfg.ContentType = runtime.ContentTypeJSON
+	cfg.ContentType = k8sruntime.ContentTypeJSON
 	cfg.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
 
 	cli, err := rest.RESTClientFor(&cfg)

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -134,29 +134,20 @@ var (
 // cb implements the callback interface required for the
 // backend Syncer API.
 type cb struct {
-	// Stores the current state for comparison by the tests.
-	State map[string]api.Update
-	Lock  *sync.Mutex
-
+	Lock       *sync.Mutex
+	state      map[string]api.Update
 	status     api.SyncStatus
-	updateChan chan api.Update
+	updateChan chan any
 }
 
-func (c cb) OnStatusUpdated(status api.SyncStatus) {
+func (c *cb) OnStatusUpdated(status api.SyncStatus) {
 	defer GinkgoRecover()
 
-	// Keep latest status up to date.
-	log.Warnf("[TEST] Received status update: %+v", status)
-	c.status = status
-
-	// Once we get in sync, we don't ever expect to not
-	// be in sync.
-	if c.status == api.InSync {
-		Expect(status).To(Equal(api.InSync))
-	}
+	log.Infof("[TEST] Syncer status received: %v", status)
+	c.updateChan <- status
 }
 
-func (c cb) OnUpdates(updates []api.Update) {
+func (c *cb) OnUpdates(updates []api.Update) {
 	defer GinkgoRecover()
 
 	// Ensure the given updates are valid.
@@ -182,28 +173,44 @@ func (c cb) OnUpdates(updates []api.Update) {
 	}
 }
 
-func (c cb) ProcessUpdates() {
+func (c *cb) ProcessUpdates() {
 	for u := range c.updateChan {
 		// Store off the update so it can be checked by the test.
 		// Use a mutex for safe cross-goroutine reads/writes.
 		c.Lock.Lock()
-		if u.UpdateType == api.UpdateTypeKVUnknown {
-			// We should never get this!
-			log.Panic("Received Unknown update type")
-		} else if u.UpdateType == api.UpdateTypeKVDeleted {
-			// Deleted.
-			delete(c.State, u.Key.String())
-			log.Infof("[TEST] Delete update %s", u.Key.String())
-		} else {
-			// Add or modified.
-			c.State[u.Key.String()] = u
-			log.Infof("[TEST] Stored update (type %d) %s", u.UpdateType, u.Key.String())
+
+		switch u := u.(type) {
+		case api.SyncStatus:
+			if c.status == api.InSync {
+				Expect(u).To(Equal(api.InSync), "Should not transition out of InSync state")
+			}
+			c.status = u
+		case api.Update:
+			if u.UpdateType == api.UpdateTypeKVUnknown {
+				// We should never get this!
+				log.Panic("Received Unknown update type")
+			} else if u.UpdateType == api.UpdateTypeKVDeleted {
+				// Deleted.
+				delete(c.state, u.Key.String())
+				log.Infof("[TEST] Delete update %s", u.Key.String())
+			} else {
+				// Add or modified.
+				c.state[u.Key.String()] = u
+				log.Infof("[TEST] Stored update (type %d) %s", u.UpdateType, u.Key.String())
+			}
 		}
+
 		c.Lock.Unlock()
 	}
 }
 
-func (c cb) ExpectExists(updates []api.Update) {
+func (c *cb) GetStatus() api.SyncStatus {
+	c.Lock.Lock()
+	defer c.Lock.Unlock()
+	return c.status
+}
+
+func (c *cb) ExpectExists(updates []api.Update) {
 	// For each Key, wait for it to exist.
 	for _, update := range updates {
 		log.Infof("[TEST] Expecting key: %v", update.Key)
@@ -212,7 +219,7 @@ func (c cb) ExpectExists(updates []api.Update) {
 		_ = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 			// Get the update.
 			c.Lock.Lock()
-			u, ok := c.State[update.Key.String()]
+			u, ok := c.state[update.Key.String()]
 			c.Lock.Unlock()
 
 			// See if we've got a matching update. For now, we just check
@@ -244,7 +251,7 @@ func (c cb) ExpectDeleted(kvps []model.KVPair) {
 		_ = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 			// Get the update.
 			c.Lock.Lock()
-			update, ok := c.State[kvp.Key.String()]
+			update, ok := c.state[kvp.Key.String()]
 			exists = ok
 			c.Lock.Unlock()
 
@@ -298,14 +305,12 @@ poll:
 //
 // The returned function returns the cached entry or nil if the entry does not
 // exist in the cache.
-func (c cb) GetSyncerValueFunc(key model.Key) func() interface{} {
+func (c *cb) GetSyncerValueFunc(key model.Key) func() interface{} {
 	return func() interface{} {
 		log.Infof("Checking entry in cache: %v", key)
 		c.Lock.Lock()
-		defer func() {
-			c.Lock.Unlock()
-		}()
-		if entry, ok := c.State[key.String()]; ok {
+		defer c.Lock.Unlock()
+		if entry, ok := c.state[key.String()]; ok {
 			return entry.Value
 		}
 		return nil
@@ -319,12 +324,12 @@ func (c cb) GetSyncerValueFunc(key model.Key) func() interface{} {
 // the Value may itself by nil.
 //
 // The returned function returns true if the entry is present.
-func (c cb) GetSyncerValuePresentFunc(key model.Key) func() interface{} {
+func (c *cb) GetSyncerValuePresentFunc(key model.Key) func() interface{} {
 	return func() interface{} {
 		log.Infof("Checking entry in cache: %v", key)
 		c.Lock.Lock()
-		defer func() { c.Lock.Unlock() }()
-		_, ok := c.State[key.String()]
+		defer c.Lock.Unlock()
+		_, ok := c.state[key.String()]
 		return ok
 	}
 }
@@ -342,15 +347,15 @@ func CreateClientAndSyncer(cfg apiconfig.KubeConfig) (*KubeClient, *cb, api.Sync
 	Expect(err).NotTo(HaveOccurred(), "Failed to initialize the backend.")
 
 	// Start the syncer.
-	updateChan := make(chan api.Update)
-	callback := cb{
-		State:      map[string]api.Update{},
+	updateChan := make(chan any)
+	callback := &cb{
+		state:      map[string]api.Update{},
 		status:     api.WaitForDatastore,
 		Lock:       &sync.Mutex{},
 		updateChan: updateChan,
 	}
 	syncer := felixsyncer.New(c, caCfg, callback, true)
-	return c.(*KubeClient), &callback, syncer
+	return c.(*KubeClient), callback, syncer
 }
 
 var _ = testutils.E2eDatastoreDescribe("Test UIDs and owner references", testutils.DatastoreK8s, func(cfg apiconfig.CalicoAPIConfig) {
@@ -479,10 +484,13 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 
 		// Start processing updates.
 		go cb.ProcessUpdates()
+
+		Eventually(cb.GetStatus).Should(Equal(api.InSync))
 	})
 
 	AfterEach(func() {
 		// Clean up all Calico resources.
+		By("AfterEach")
 		err := c.Clean()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -2544,13 +2552,13 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Listing all BlockAffinity for all Nodes", func() {
 			objs, err := c.List(ctx, model.BlockAffinityListOptions{}, "")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(objs.KVPairs)).To(Equal(2))
+			Expect(objs.KVPairs).To(HaveLen(2))
 		})
 
 		By("Listing all BlockAffinity for a specific Node", func() {
 			objs, err := c.List(ctx, model.BlockAffinityListOptions{Host: nodename, AffinityType: string(ipam.AffinityTypeHost)}, "")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(objs.KVPairs)).To(Equal(1))
+			Expect(objs.KVPairs).To(HaveLen(1))
 		})
 	})
 
@@ -2931,6 +2939,12 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		By("AfterEach")
+		err := c.Clean()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Describe("watching Profiles", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

While working on #10855 I found several test bugs and inefficiencies (largely because I totally broke watches at one point and that exposed a lot of test bugs :-P).  This PR addresses those to avoid scope creep in the other PR.

- Speed up KDD cleanup (used only in tests to delete everything in the datastore).
- Fix a test that used break in a `select{}`.
- Fix concurrency handling in KDD callback and wait for in-sync at start of test (makes diags cleaner when there's a failure).
- Add missing cleanup in KDD tests.
- Fix test pollution in IPAM tests.
- Tune logging in IPAM tests.  Avoid logging Cleanup() at debug. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
