### PR TITLE
[v3.30] Fix serviceaccount name in helm chart

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator-secrets.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator-secrets.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{.Release.Namespace}}
-    namespace: {{.Release.Namespace}}
+    name: tigera-operator
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: tigera-operator-secrets


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#10516
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/10507

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Helm: fix role binding to use correct serviceaccount name when deployed in an alternative namespace. 
```