### PR TITLE
Maglev: Get UTs into basebranch, Fixes colliding tunnel-IP bug

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -107,6 +107,8 @@
 #error CALI_RES_ values need to be increased above TC_ACT_VALUE_MAX
 #endif
 
+#define HAS_MAGLEV        (CALI_F_FROM_HEP && CALI_F_MAIN)
+
 #ifndef CALI_FIB_LOOKUP_ENABLED
 #define CALI_FIB_LOOKUP_ENABLED true
 #endif

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -198,6 +198,11 @@ enum calico_ct_result_type {
 	 * or for packet that have a conntrack entry that is only approved by the other leg
 	 * (indicating that policy on this leg failed to allow the packet). */
 	CALI_CT_INVALID = 6,
+	/* CALI_CT_MAGLEV_MID_FLOW_MISS is set (in the Maglev program) for packets which were
+	 * originally CALI_CT_MID_FLOW_MISS, but where the maglev-lookup returned a backend.
+	 * It indicates that a midflow Maglev packet should be treated as a failed-over connection.
+	*/
+	CALI_CT_MAGLEV_MID_FLOW_MISS = 7,
 };
 
 #define CT_RES_RELATED         0x100

--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -105,13 +105,11 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_nat_lookup(ipv46_addr_t *i
 		CALI_DEBUG("NAT: nodeport hit");
 	}
 
-# if HAS_MAGLEV_PROG
-	if (nat_lv1_val->flags & NAT_FLG_MAGLEV) {
+	if (HAS_MAGLEV && (nat_lv1_val->flags & NAT_FLG_MAGLEV)) {
 		CALI_DEBUG("NAT: 1st level hit; id=%d, NAT maglev", nat_lv1_val->id);
 		*res = NAT_MAGLEV;
 		return NULL;
 	}
-#endif
 
 	/* With LB source range, we install a drop entry in the NAT FE map
 	 * with count equal to all-ones for both ip4/6. If we hit this entry,

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -474,9 +474,6 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 		CALI_DEBUG("NAT Lookup determined packet handled by maglev");
 		CALI_JUMP_TO(ctx, PROG_INDEX_MAGLEV);
 		CALI_DEBUG("Failed to jump to maglev program");
-		#if !HAS_MAGLEV
-		CALI_DEBUG("Maglev program missing");
-		#endif
 		goto deny;
 	}
 

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -2229,6 +2229,8 @@ int calico_tc_maglev(struct __sk_buff *skb)
 		ctx->state->flags |= CALI_ST_SKIP_REDIR_PEER;
 	}
 
+	// CALI_CT_MID_FLOW_MISS implies traffic is TCP. If that changes,
+	// this condition should be adjusted.
 	if (ct_result_rc(ctx->state->ct_result.rc) == CALI_CT_MID_FLOW_MISS) {
 		/* treat it as if it was a new flow */
 		CALI_DEBUG("Maglev: mid-flow miss, treating as new flow");

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -63,7 +63,6 @@
 #endif
 
 #define HAS_HOST_CONFLICT_PROG CALI_F_TO_HEP
-#define HAS_MAGLEV_PROG        (CALI_F_FROM_HEP && CALI_F_MAIN)
 
 /* calico_tc_main is the main function used in all of the tc programs.  It is specialised
  * for particular hook at build time based on the CALI_F build flags.
@@ -475,7 +474,7 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 		CALI_DEBUG("NAT Lookup determined packet handled by maglev");
 		CALI_JUMP_TO(ctx, PROG_INDEX_MAGLEV);
 		CALI_DEBUG("Failed to jump to maglev program");
-		#if !HAS_MAGLEV_PROG
+		#if !HAS_MAGLEV
 		CALI_DEBUG("Maglev program missing");
 		#endif
 		goto deny;
@@ -2181,7 +2180,7 @@ deny:
 }
 #endif /* !IPVER6 */
 
-#if HAS_MAGLEV_PROG
+#if HAS_MAGLEV
 SEC("tc")
 int calico_tc_maglev(struct __sk_buff *skb)
 {
@@ -2234,6 +2233,7 @@ int calico_tc_maglev(struct __sk_buff *skb)
 		/* treat it as if it was a new flow */
 		CALI_DEBUG("Maglev: mid-flow miss, treating as new flow");
 		/* remember that is was a mid-flow miss so that we can handle it in the new flow program */
+		//ctx->state->ct_result.rc = CALI_CT_MAGLEV_MID_FLOW_MISS;
 	}
 
 	CALI_DEBUG("Maglev: About to jump to policy program.");
@@ -2256,4 +2256,4 @@ int calico_tc_maglev(struct __sk_buff *skb)
 deny:
 	return TC_ACT_SHOT;
 }
-#endif /* HAS_MAGLEV_PROG */
+#endif /* HAS_MAGLEV */

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1625,7 +1625,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		}
 	}
 
-	if (ct_rc == CALI_CT_NEW) {
+	if (ct_rc == CALI_CT_NEW || ct_rc == CALI_CT_MAGLEV_MID_FLOW_MISS) {
 		CALI_JUMP_TO(ctx, PROG_INDEX_NEW_FLOW);
 		/* should not reach here */
 		CALI_DEBUG("jump to new flow failed");
@@ -2233,7 +2233,7 @@ int calico_tc_maglev(struct __sk_buff *skb)
 		/* treat it as if it was a new flow */
 		CALI_DEBUG("Maglev: mid-flow miss, treating as new flow");
 		/* remember that is was a mid-flow miss so that we can handle it in the new flow program */
-		//ctx->state->ct_result.rc = CALI_CT_MAGLEV_MID_FLOW_MISS;
+		ctx->state->ct_result.rc = CALI_CT_MAGLEV_MID_FLOW_MISS;
 	}
 
 	CALI_DEBUG("Maglev: About to jump to policy program.");

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1607,6 +1607,7 @@ func testPacket(family int, eth *layers.Ethernet, l3 gopacket.Layer, l4 gopacket
 		payload: payload,
 		ipv6ext: ipv6ext,
 	}
+
 	err := pkt.Generate()
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -1912,6 +1913,36 @@ func testPacketUDPDefaultNPWithPayload(destIP net.IP, payload []byte) (*layers.E
 
 	e, ip4, l4, p, b, err := testPacket(4, nil, &ip, nil, payload)
 	return e, ip4.(*layers.IPv4), l4, p, b, err
+}
+
+func testPacketTCPV4WithPayload(destIP net.IP, srcPort, dstPort uint16, syn bool, payload []byte) (*layers.Ethernet, *layers.IPv4, *layers.TCP, []byte, []byte, error) {
+	if destIP == nil {
+		log.Panic("destIP must be set")
+	}
+
+	ip := *ipv4Default
+	ip.DstIP = destIP
+	tcp := &layers.TCP{
+		SYN:        syn,
+		SrcPort:    layers.TCPPort(srcPort),
+		DstPort:    layers.TCPPort(dstPort),
+		DataOffset: 5,
+		// Window:  14600,
+	}
+
+	// ip.Options = []layers.IPv4Option{{
+	// 	OptionType:   123,
+	// 	OptionLength: 6,
+	// 	OptionData:   []byte{0xde, 0xad, 0xbe, 0xef},
+	// }}
+	// ip.IHL += 2
+
+	e, ip4, l4, p, b, err := testPacket(4, nil, &ip, tcp, payload, nil)
+	return e, ip4.(*layers.IPv4), l4.(*layers.TCP), p, b, err
+}
+
+func testPacketTCPV4DefaultNP(destIP net.IP, syn bool) (*layers.Ethernet, *layers.IPv4, *layers.TCP, []byte, []byte, error) {
+	return testPacketTCPV4WithPayload(destIP, 1234, 5678, syn, nil)
 }
 
 func ipv6HopByHopExt() gopacket.SerializableLayer {

--- a/felix/bpf/ut/maglev_test.go
+++ b/felix/bpf/ut/maglev_test.go
@@ -1064,8 +1064,8 @@ func TestMaglevNATNodePortTCP(t *testing.T) {
 	// This time, not a SYN, i.e. a failed-over connection.
 	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 
-		// Change the source port
-		_, ipv4, tcp, payload, pktBytes, err = testPacketTCPV4WithPayload(node1ip, 0xdead, 5678, false, nil)
+		// Change the source port (only change the bytes, leave the other vars in their original state).
+		_, _, _, _, pktBytes, err = testPacketTCPV4WithPayload(node1ip, 0xdead, 5678, false, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		res, err := bpfrun(pktBytes)
@@ -1209,8 +1209,8 @@ func TestMaglevNATNodePortTCP(t *testing.T) {
 		tcpL := pktR.Layer(layers.LayerTypeTCP)
 		Expect(tcpL).NotTo(BeNil())
 		tcpR := tcpL.(*layers.TCP)
-		Expect(tcpR.SrcPort).To(Equal(layers.UDPPort(natPort)))
-		Expect(tcpR.DstPort).To(Equal(layers.UDPPort(1234)))
+		Expect(tcpR.SrcPort).To(Equal(layers.TCPPort(natPort)))
+		Expect(tcpR.DstPort).To(Equal(layers.TCPPort(1234)))
 	})
 
 	// TEST host-networked backend
@@ -1284,7 +1284,7 @@ func TestMaglevNATNodePortTCP(t *testing.T) {
 
 			tcpL := pktR.Layer(layers.LayerTypeTCP)
 			Expect(tcpL).NotTo(BeNil())
-			tcpR := tcpL.(*layers.UDP)
+			tcpR := tcpL.(*layers.TCP)
 			Expect(tcpR.SrcPort).To(Equal(layers.TCPPort(tcp.SrcPort)))
 			Expect(tcpR.DstPort).To(Equal(layers.TCPPort(natPort)))
 
@@ -1352,7 +1352,7 @@ func TestMaglevNATNodePortTCP(t *testing.T) {
 	}
 }
 
-func TestMaglevNATNodePort(t *testing.T) {
+func TestMaglevNATNodePortUDP(t *testing.T) {
 	RegisterTestingT(t)
 
 	bpfIfaceName = "MNP-1"

--- a/felix/bpf/ut/maglev_test.go
+++ b/felix/bpf/ut/maglev_test.go
@@ -1503,7 +1503,7 @@ func TestMaglevNATNodePortTCPV6(t *testing.T) {
 	}
 }
 
-func TestMaglevNATNodePortUDP(t *testing.T) {
+func TestMaglevXNodeForwarding(t *testing.T) {
 	RegisterTestingT(t)
 
 	bpfIfaceName = "MNP-1"

--- a/felix/bpf/ut/maglev_test.go
+++ b/felix/bpf/ut/maglev_test.go
@@ -532,7 +532,6 @@ func TestMaglevNATNodePortTCP(t *testing.T) {
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
-
 	}
 
 	node2wCIDR := net.IPNet{
@@ -1349,6 +1348,652 @@ func TestMaglevNATNodePortTCP(t *testing.T) {
 
 			checkVxlan(pktR)
 		}, withHostNetworked())
+	}
+}
+
+func TestMaglevNATNodePortTCPV6(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "MNP-1"
+	defer func() { bpfIfaceName = "" }()
+
+	_, ipv6, tcp, payload, pktBytes, err := testPacketTCPV6DefaultNP(node1ipV6, true)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = natMapV6.Update(
+		nat.NewNATKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
+		nat.NewNATValueV6WithFlags(0, 1, 0, 0, nat.NATFlgConsistentHash).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.ParseIP("abcd::ffff:0808:0808")
+	natPort := uint16(666)
+
+	err = natBEMapV6.Update(
+		nat.NewNATBackendKeyV6(0, 0).AsBytes(),
+		nat.NewNATBackendValueV6(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	mgMap6 := nat.ConsistentHashMapV6()
+	err = mgMap6.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	// Build a maglev LUT and program each item to the BPF map.
+	mglv := consistenthash.New(consistenthash.WithHash(fnv.New32(), fnv.New32()), consistenthash.WithPreferenceLength(31))
+	mglv.AddBackend(chtypes.MockEndpoint{
+		Ip:  natIP.String(),
+		Prt: natPort,
+	})
+	lut := mglv.Generate()
+	for ordinal, ep := range lut {
+		err = mgMap6.Update(
+			nat.NewConsistentHashBackendKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewNATBackendValueV6(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	node2wCIDR := net.IPNet{
+		IP:   natIP,
+		Mask: net.CIDRMask(128, 128),
+	}
+
+	resetCTMapV6(ctMapV6) // ensure it is clean
+
+	var encapedPkt []byte
+
+	resetRTMap(rtMapV6)
+
+	hostIP = node1ipV6
+	skbMark = 0
+
+	// Arriving at node 1 - non-routable -> denied
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	}, withIPv6())
+
+	defer resetRTMapV6(rtMapV6)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node2wCIDR).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6WithNextHop(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool,
+			ip.FromNetIP(node2ipV6).(ip.V6Addr)).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node1CIDRV6).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node2CIDRV6).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	dumpRTMapV6(rtMapV6)
+	rtNode1 := saveRTMapV6(rtMapV6)
+
+	vni := uint32(0)
+
+	// Arriving at node 1
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Or(
+			Equal(resTC_ACT_REDIRECT),
+			Equal(resTC_ACT_UNSPEC),
+		))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R := ipv6L.(*layers.IPv6)
+		Expect(ipv6R.SrcIP.String()).To(Equal(hostIP.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(node2ipV6.String()))
+
+		checkVxlanEncap(pktR, false, ipv6, tcp, payload)
+		vni = getVxlanVNI(pktR)
+
+		encapedPkt = res.dataOut
+
+		ct, err := conntrack.LoadMapMemV6(ctMapV6)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctKey := conntrack.NewKeyV6(uint8(layers.IPProtocolTCP),
+			ipv6.SrcIP, uint16(tcp.SrcPort), ipv6.DstIP, uint16(tcp.DstPort))
+
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr := ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+
+		ctKey = ctr.ReverseNATKey().(conntrack.KeyV6)
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr = ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+
+		// Approved for both sides due to forwarding through the tunnel
+		Expect(ctr.Data().A2B.Approved).To(BeTrue())
+		Expect(ctr.Data().B2A.Approved).To(BeTrue())
+	}, withIPv6())
+
+	dumpCTMapV6(ctMapV6)
+	ct, err := conntrack.LoadMapMemV6(ctMapV6)
+	Expect(err).NotTo(HaveOccurred())
+	v, ok := ct[conntrack.NewKeyV6(uint8(layers.IPProtocolTCP), ipv6.SrcIP, uint16(tcp.SrcPort), natIP, natPort)]
+	Expect(ok).To(BeTrue())
+	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagNATNPFwd))
+
+	expectMark(tcdefs.MarkSeenBypassForward)
+	// Leaving node 1
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		Expect(res.dataOut).To(Equal(encapedPkt))
+	}, withIPv6())
+
+	dumpCTMapV6(ctMapV6)
+	fromHostCT := saveCTMapV6(ctMapV6)
+
+	encapedPktArrivesAtNode2 := make([]byte, len(encapedPkt))
+	copy(encapedPktArrivesAtNode2, encapedPkt)
+
+	resetCTMapV6(ctMapV6)
+
+	var recvPkt []byte
+
+	hostIP = node2ipV6
+
+	// change the routing - it is a local workload now!
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node2wCIDR).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6(routes.FlagsLocalWorkload|routes.FlagInIPAMPool).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// we must know that the encaped packet src ip if from a known host
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node1CIDRV6).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMapV6.Update(
+		routes.NewKeyV6(ip.CIDRFromIPNet(&node2CIDRV6).(ip.V6CIDR)).AsBytes(),
+		routes.NewValueV6(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	dumpRTMapV6(rtMapV6)
+
+	// now we are at the node with local workload
+	err = natMapV6.Update(
+		nat.NewNATKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
+		nat.NewNATValueV6(0 /* id */, 1 /* count */, 1 /* local */, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Arriving at node 2
+	bpfIfaceName = "NP-2"
+
+	arpMapN2 := saveARPMapV6(arpMapV6)
+	Expect(arpMapN2).To(HaveLen(0))
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+		vxlanL := gopacket.NewPacket(payloadL.Payload(), layers.LayerTypeVXLAN, gopacket.Default)
+		Expect(vxlanL).NotTo(BeNil())
+		fmt.Printf("vxlanL = %+v\n", vxlanL)
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		ipv6R := ipv6L.(*layers.IPv6)
+		Expect(ipv6R.SrcIP.String()).To(Equal(ipv6.SrcIP.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(natIP.String()))
+
+		tcpL := pktR.Layer(layers.LayerTypeTCP)
+		Expect(tcpL).NotTo(BeNil())
+		tcpR := tcpL.(*layers.TCP)
+		Expect(tcpR.SrcPort).To(Equal(layers.TCPPort(tcp.SrcPort)))
+		Expect(tcpR.DstPort).To(Equal(layers.TCPPort(natPort)))
+
+		ct, err := conntrack.LoadMapMemV6(ctMapV6)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctKey := conntrack.NewKeyV6(uint8(layers.IPProtocolTCP),
+			ipv6.SrcIP, uint16(tcp.SrcPort), ipv6.DstIP, uint16(tcp.DstPort))
+
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr := ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+		Expect(ctr.NATSPort()).To(Equal(uint16(0)))
+
+		ctKey = ctr.ReverseNATKey().(conntrack.KeyV6)
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr = ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+
+		// Approved source side
+		Expect(ctr.Data().A2B.Approved).To(BeTrue())
+		// Dest not approved yet
+		Expect(ctr.Data().B2A.Approved).NotTo(BeTrue())
+
+		recvPkt = res.dataOut
+	}, withIPv6())
+
+	expectMark(tcdefs.MarkSeen)
+
+	dumpCTMapV6(ctMapV6)
+	ct, err = conntrack.LoadMapMemV6(ctMapV6)
+	Expect(err).NotTo(HaveOccurred())
+	v, ok = ct[conntrack.NewKeyV6(uint8(layers.IPProtocolTCP), ipv6.SrcIP, uint16(tcp.SrcPort), natIP, natPort)]
+	Expect(ok).To(BeTrue())
+	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagExtLocal))
+
+	dumpARPMapV6(arpMapV6)
+
+	arpMapN2 = saveARPMapV6(arpMapV6)
+	Expect(arpMapN2).To(HaveLen(1))
+	arpKey := arp.NewKeyV6(node1ipV6, 1) // ifindex is always 1 in UT
+	Expect(arpMapN2).To(HaveKey(arpKey))
+	macDst := encapedPkt[0:6]
+	macSrc := encapedPkt[6:12]
+	Expect(arpMapN2[arpKey]).To(Equal(arp.NewValue(macDst, macSrc)))
+
+	// try a spoofed tunnel packet, should be dropped and have no effect
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		// modify the only known good src IP, we do not care about csums at this point
+		encapedPkt[26] = 234
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+	}, withIPv6())
+
+	skbMark = tcdefs.MarkSeen
+
+	// Insert the reverse route for backend for RPF check.
+	resetRTMap(rtMapV6)
+	beV4CIDR := ip.CIDRFromNetIP(natIP).(ip.V6CIDR)
+	bertKey := routes.NewKeyV6(beV4CIDR).AsBytes()
+	bertVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	err = rtMapV6.Update(bertKey, bertVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Arriving at workload at node 2
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(recvPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		Expect(res.dataOut).To(Equal(recvPkt))
+
+		ct, err := conntrack.LoadMapMemV6(ctMapV6)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctKey := conntrack.NewKeyV6(uint8(layers.IPProtocolTCP),
+			ipv6.SrcIP, uint16(tcp.SrcPort), ipv6.DstIP, uint16(tcp.DstPort))
+
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr := ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+
+		ctKey = ctr.ReverseNATKey().(conntrack.KeyV6)
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr = ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse),
+			fmt.Sprintf("Expected reverse conntrack entry but got %v", ctr))
+
+		// Approved source side
+		Expect(ctr.Data().A2B.Approved).To(BeTrue())
+		// Approved destination side as well
+		Expect(ctr.Data().B2A.Approved).To(BeTrue())
+	}, withIPv6())
+
+	skbMark = 0
+
+	// Response leaving workload at node 2
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		// SYN,ACK
+		respPkt := tcpResponseRawV6(recvPkt)
+		// Change the MAC addresses so that we can observe that the right
+		// addresses were patched in.
+		copy(respPkt[:6], []byte{1, 2, 3, 4, 5, 6})
+		copy(respPkt[6:12], []byte{6, 5, 4, 3, 2, 1})
+		res, err := bpfrun(respPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Or(
+			Equal(resTC_ACT_REDIRECT),
+			Equal(resTC_ACT_UNSPEC),
+		))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ethL := pktR.Layer(layers.LayerTypeEthernet)
+		Expect(ethL).NotTo(BeNil())
+		ethR := ethL.(*layers.Ethernet)
+		Expect(ethR).To(layersMatchFields(&layers.Ethernet{
+			SrcMAC:       macDst,
+			DstMAC:       macSrc,
+			EthernetType: layers.EthernetTypeIPv6,
+		}))
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R := ipv6L.(*layers.IPv6)
+		Expect(ipv6R.SrcIP.String()).To(Equal(hostIP.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(node1ipV6.String()))
+
+		checkVxlan(pktR)
+
+		encapedPkt = res.dataOut
+	}, withIPv6())
+
+	dumpCTMapV6(ctMapV6)
+
+	expectMark(tcdefs.MarkSeen)
+
+	hostIP = node2ipV6
+
+	// Response leaving node 2
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R := ipv6L.(*layers.IPv6)
+		// check that the IP is fixed up
+		Expect(ipv6R.SrcIP.String()).To(Equal(node2ipV6.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(node1ipV6.String()))
+
+		checkVxlan(pktR)
+
+		encapedPkt = res.dataOut
+	}, withIPv6())
+
+	dumpCTMapV6(ctMapV6)
+	resetCTMapV6(ctMapV6)
+	restoreCTMapV6(ctMapV6, fromHostCT)
+	dumpCTMapV6(ctMapV6)
+
+	hostIP = node1ipV6
+
+	// change to routing again to a remote workload
+	resetRTMap(rtMapV6)
+	restoreRTMapV6(rtMapV6, rtNode1)
+	dumpRTMapV6(rtMapV6)
+
+	// Response arriving at node 1
+	bpfIfaceName = "NP-1"
+	skbMark = 0
+
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(retvalToStr[res.Retval]).To(Equal(retvalToStr[resTC_ACT_UNSPEC]))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R := ipv6L.(*layers.IPv6)
+		Expect(ipv6R.DstIP.String()).To(Equal(ipv6.SrcIP.String()))
+		Expect(ipv6R.SrcIP.String()).To(Equal(ipv6.DstIP.String()))
+
+		tcpL := pktR.Layer(layers.LayerTypeTCP)
+		Expect(tcpL).NotTo(BeNil())
+		tcpR := tcpL.(*layers.TCP)
+		Expect(tcpR.SrcPort).To(Equal(tcp.DstPort))
+		Expect(tcpR.DstPort).To(Equal(tcp.SrcPort))
+
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+		Expect(payload).To(Equal(payloadL.Payload()))
+
+		recvPkt = res.dataOut
+	}, withIPv6())
+
+	expectMark(tcdefs.MarkSeenBypassForward)
+	saveMark := skbMark
+
+	dumpCTMapV6(ctMapV6)
+
+	skbMark = 0
+	// try a spoofed tunnel packet returning back, should be dropped and have no effect
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		// modify the only known good src IP, we do not care about csums at this point
+		encapedPkt[26] = 235
+		res, err := bpfrun(encapedPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(retvalToStr[res.Retval]).To(Equal(retvalToStr[resTC_ACT_SHOT]))
+	}, withIPv6())
+
+	skbMark = saveMark
+	// Response leaving to original source
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(recvPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(retvalToStr[res.Retval]).To(Equal(retvalToStr[resTC_ACT_UNSPEC]))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ct, err := conntrack.LoadMapMemV6(ctMapV6)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctKey := conntrack.NewKeyV6(uint8(layers.IPProtocolTCP),
+			ipv6.SrcIP, uint16(tcp.SrcPort), ipv6.DstIP, uint16(tcp.DstPort))
+
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr := ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+
+		ctKey = ctr.ReverseNATKey().(conntrack.KeyV6)
+		Expect(ct).Should(HaveKey(ctKey))
+		ctr = ct[ctKey]
+		Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+
+		// Approved for both sides due to forwarding through the tunnel
+		Expect(ctr.Data().A2B.Approved).To(BeTrue())
+		Expect(ctr.Data().B2A.Approved).To(BeTrue())
+	}, withIPv6())
+
+	dumpCTMapV6(ctMapV6)
+
+	skbMark = 0
+	// Another pkt arriving at node 1 - uses existing CT entries
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(retvalToStr[res.Retval]).To(Or(
+			Equal(retvalToStr[resTC_ACT_REDIRECT]),
+			Equal(retvalToStr[resTC_ACT_UNSPEC]),
+		))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+		Expect(ipv6L).NotTo(BeNil())
+		ipv6R := ipv6L.(*layers.IPv6)
+		Expect(ipv6R.SrcIP.String()).To(Equal(hostIP.String()))
+		Expect(ipv6R.DstIP.String()).To(Equal(node2ipV6.String()))
+
+		checkVxlanEncap(pktR, false, ipv6, tcp, payload)
+	}, withIPv6())
+
+	expectMark(tcdefs.MarkSeenBypassForward)
+
+	/*
+	 * TEST that unknown VNI is passed through
+	 */
+	testUnrelatedVXLAN(6, t, node2ipV6, vni)
+
+	// TEST host-networked backend
+	{
+		resetCTMapV6(ctMapV6)
+
+		var recvPkt []byte
+
+		hostIP = node2ipV6
+		skbMark = 0
+
+		// we must know that the encaped packet src ip is from a known host
+		err = rtMapV6.Update(
+			routes.NewKeyV6(ip.CIDRFromIPNet(&node1CIDRV6).(ip.V6CIDR)).AsBytes(),
+			routes.NewValueV6(routes.FlagsRemoteHost).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		err = rtMapV6.Update(
+			routes.NewKeyV6(ip.CIDRFromIPNet(&node2CIDRV6).(ip.V6CIDR)).AsBytes(),
+			routes.NewValueV6(routes.FlagsLocalHost).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		dumpRTMapV6(rtMapV6)
+
+		// now we are at the node with local workload
+		err = natMapV6.Update(
+			nat.NewNATKeyV6(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+				uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
+			nat.NewNATValueV6(0 /* count */, 1 /* local */, 1, 0).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// make it point to the local host - host networked backend
+		err = natBEMapV6.Update(
+			nat.NewNATBackendKeyV6(0, 0).AsBytes(),
+			nat.NewNATBackendValueV6(node2ipV6, natPort).AsBytes(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Build a maglev LUT and program each item to the BPF map.
+		// This time it's a host-networked backend.
+		mglv := consistenthash.New(consistenthash.WithHash(fnv.New32(), fnv.New32()), consistenthash.WithPreferenceLength(31))
+		mglv.AddBackend(chtypes.MockEndpoint{
+			Ip:  node2ipV6.String(),
+			Prt: natPort,
+		})
+		lut := mglv.Generate()
+		for ordinal, ep := range lut {
+			err = mgMap6.Update(
+				nat.NewConsistentHashBackendKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+				nat.NewNATBackendValueV6(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// Arriving at node 2
+		bpfIfaceName = "NP-2"
+
+		skbMark = 0
+		runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+			res, err := bpfrun(encapedPktArrivesAtNode2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+			pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+			fmt.Printf("pktR = %+v\n", pktR)
+
+			ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+			ipv6R := ipv6L.(*layers.IPv6)
+			Expect(ipv6R.SrcIP.String()).To(Equal(ipv6.SrcIP.String()))
+			Expect(ipv6R.DstIP.String()).To(Equal(node2ipV6.String()))
+
+			tcpL := pktR.Layer(layers.LayerTypeTCP)
+			Expect(tcpL).NotTo(BeNil())
+			tcpR := tcpL.(*layers.TCP)
+			Expect(tcpR.SrcPort).To(Equal(layers.UDPPort(tcp.SrcPort)))
+			Expect(tcpR.DstPort).To(Equal(layers.UDPPort(natPort)))
+
+			ct, err := conntrack.LoadMapMemV6(ctMapV6)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctKey := conntrack.NewKeyV6(uint8(layers.IPProtocolTCP),
+				ipv6.SrcIP, uint16(tcp.SrcPort), ipv6.DstIP, uint16(tcp.DstPort))
+
+			Expect(ct).Should(HaveKey(ctKey))
+			ctr := ct[ctKey]
+			Expect(ctr.Type()).To(Equal(conntrack.TypeNATForward))
+
+			ctKey = ctr.ReverseNATKey().(conntrack.KeyV6)
+			Expect(ct).Should(HaveKey(ctKey))
+			ctr = ct[ctKey]
+			Expect(ctr.Type()).To(Equal(conntrack.TypeNATReverse))
+
+			// Approved source side
+			Expect(ctr.Data().A2B.Approved).To(BeTrue())
+			// Dest not approved yet
+			Expect(ctr.Data().B2A.Approved).NotTo(BeTrue())
+
+			recvPkt = res.dataOut
+		}, withIPv6())
+
+		dumpCTMapV6(ctMapV6)
+
+		skbMark = 0
+
+		// Response leaving workload at node 2
+		runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+			respPkt := udpResponseRawV6(recvPkt)
+
+			// Change the MAC addresses so that we can observe that the right
+			// addresses were patched in.
+			macUntouched := []byte{6, 5, 4, 3, 2, 1}
+			copy(respPkt[:6], []byte{1, 2, 3, 4, 5, 6})
+			copy(respPkt[6:12], macUntouched)
+
+			res, err := bpfrun(respPkt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+			pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+			fmt.Printf("pktR = %+v\n", pktR)
+
+			ethL := pktR.Layer(layers.LayerTypeEthernet)
+			Expect(ethL).NotTo(BeNil())
+			ethR := ethL.(*layers.Ethernet)
+			Expect(ethR).To(layersMatchFields(&layers.Ethernet{
+				SrcMAC:       macUntouched, // Source is set by net stack and should not be touched.
+				DstMAC:       macSrc,
+				EthernetType: layers.EthernetTypeIPv6,
+			}))
+
+			ipv6L := pktR.Layer(layers.LayerTypeIPv6)
+			Expect(ipv6L).NotTo(BeNil())
+			ipv6R := ipv6L.(*layers.IPv6)
+			Expect(ipv6R.SrcIP.String()).To(Equal(node2ipV6.String()))
+			Expect(ipv6R.DstIP.String()).To(Equal(node1ipV6.String()))
+
+			checkVxlan(pktR)
+		}, withHostNetworked(), withIPv6())
 	}
 }
 

--- a/felix/bpf/ut/maglev_test.go
+++ b/felix/bpf/ut/maglev_test.go
@@ -202,7 +202,7 @@ func TestMaglevMidflowFailoverNoConntrack(t *testing.T) {
 	})
 }
 
-func TestMaglevNATNodePortTCP(t *testing.T) {
+func TestMaglevTCPFailover(t *testing.T) {
 	RegisterTestingT(t)
 
 	bpfIfaceName = "MNP-1"

--- a/go.mod
+++ b/go.mod
@@ -345,7 +345,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect


### PR DESCRIPTION
## Description

TC: handle midflow Maglev packets like new connections.
UT: TCP NodePort tests and midflow TCP failover handling test.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
