### PR TITLE
[TSLA-9976] - Whisker Policy Trace UI

### DIFF
--- a/whisker/package.json
+++ b/whisker/package.json
@@ -76,5 +76,6 @@
     "resolutions": {
         "@eslint/plugin-kit": "^0.3.4",
         "brace-expansion": "^2.0.2"
-    }
+    },
+    "packageManager": "yarn@1.22.19"
 }

--- a/whisker/src/components/common/FlowLogActionIndicator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/whisker/src/components/common/FlowLogActionIndicator/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FlowLogActionIndicator should match the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-1tljkm1"
+    class="css-1d0h3sn"
   >
     <div
       class="css-1bjzhfd"

--- a/whisker/src/components/common/PolicyActionIndicator/__tests__/index.test.tsx
+++ b/whisker/src/components/common/PolicyActionIndicator/__tests__/index.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@/test-utils/helper';
+import PolicyActionIndicator from '..';
+
+describe('PolicyActionIndFlowLogActionIndicatoricator', () => {
+    it('renders the action text', () => {
+        render(<PolicyActionIndicator action='Allow' />);
+        expect(screen.getByText('Allow')).toBeInTheDocument();
+    });
+
+    it('falls back to "Unspecified" when action is null', () => {
+        render(<PolicyActionIndicator action={null} />);
+        expect(screen.getByText('Unspecified')).toBeInTheDocument();
+    });
+});

--- a/whisker/src/components/common/PolicyActionIndicator/index.tsx
+++ b/whisker/src/components/common/PolicyActionIndicator/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box, type HTMLChakraProps } from '@chakra-ui/react';
+import { FlowLogAction } from '../../../types/render';
+import styles from './styles';
+
+type UnspecifiedAction = 'Unspecified';
+type Action = FlowLogAction | UnspecifiedAction;
+
+const ActionColorMap: Record<Action, { fg: string; bg: string }> = {
+    Allow: { fg: 'tigeraBlack', bg: 'tigeraGreen.800' },
+    Deny: { fg: 'tigeraWhite', bg: 'tigeraRed.1000' },
+    Pass: { fg: 'tigeraWhite', bg: 'tigeraGrey.600' },
+    Log: { fg: 'tigeraWhite', bg: 'tigeraGrey.600' },
+    Unspecified: { fg: 'tigeraWhite', bg: 'tigeraGrey.600' },
+};
+
+interface PolicyActionIndicatorProps extends HTMLChakraProps<'div'> {
+    action: FlowLogAction | null;
+}
+
+const PolicyActionIndicator: React.FC<PolicyActionIndicatorProps> = ({
+    action,
+    ...rest
+}) => (
+    <Box
+        sx={{
+            ...styles,
+            bg: ActionColorMap[(action || 'Unspecified') as Action].bg,
+            color: ActionColorMap[(action || 'Unspecified') as Action].fg,
+        }}
+        {...rest}
+    >
+        {action || 'Unspecified'}
+    </Box>
+);
+
+export default PolicyActionIndicator;

--- a/whisker/src/components/common/PolicyActionIndicator/styles.ts
+++ b/whisker/src/components/common/PolicyActionIndicator/styles.ts
@@ -1,0 +1,9 @@
+export default {
+    borderRadius: '3',
+    textAlign: 'center',
+    fontSize: 'sm',
+    width: 'fit-content',
+    py: '2px',
+    px: '6px',
+    fontWeight: 'bold',
+};

--- a/whisker/src/features/flowLogs/components/FlowLogDetails/__tests__/index.test.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogDetails/__tests__/index.test.tsx
@@ -53,7 +53,6 @@ const flowLog: FlowLog = {
 describe('FlowLogDetails', () => {
     it('should render the expected columns', () => {
         render(<FlowLogDetails flowLog={flowLog} />);
-
         expect(screen.getByText('start_time')).toBeInTheDocument();
         expect(screen.getByText('source_labels')).toBeInTheDocument();
     });

--- a/whisker/src/features/flowLogs/components/FlowLogDetails/index.tsx
+++ b/whisker/src/features/flowLogs/components/FlowLogDetails/index.tsx
@@ -3,6 +3,7 @@ import { jsonTabStyles, tableStyles } from './styles';
 import { FlowLog } from '@/types/render';
 import FlowLogActionIndicator from '@/components/common/FlowLogActionIndicator';
 import { LogDetailsView } from '@/libs/tigera/ui-components/components/common';
+import PoliciesLogDetails from '../PoliciesLogDetails';
 
 const TABS_HEIGHT = 38;
 const PADDING = 16;
@@ -56,6 +57,12 @@ const FlowLogDetails: React.FC<FlowLogDetailsProps> = ({ flowLog, height }) => {
             }}
             defaultExpandedJsonNodes={2}
             size='lg'
+            customTableDataVisualisers={[
+                {
+                    key: 'policies',
+                    component: PoliciesLogDetails,
+                },
+            ]}
         />
     );
 };

--- a/whisker/src/features/flowLogs/components/PoliciesLogDetails/__tests__/index.test.tsx
+++ b/whisker/src/features/flowLogs/components/PoliciesLogDetails/__tests__/index.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@/test-utils/helper';
+import { Policy } from '@/types/api';
+import PoliciesLogDetails from '..';
+
+const makePolicy = (overrides: Partial<Policy> = {}): Policy => ({
+    kind: 'NetworkPolicy',
+    namespace: 'default',
+    name: 'test-policy',
+    tier: 'default',
+    action: 'Allow',
+    policy_index: 1,
+    rule_index: 2,
+    ...overrides,
+});
+
+describe('PoliciesLogDetails', () => {
+    const baseData = {
+        enforced: [makePolicy()],
+        pending: [makePolicy({ action: 'Deny', name: 'pending-policy' })],
+    };
+
+    it('renders headings and table rows for enforced and pending policies', () => {
+        render(<PoliciesLogDetails tableCellData={baseData} />);
+        expect(screen.getByText('Enforced Policies')).toBeInTheDocument();
+        expect(screen.getByText('Pending Policies')).toBeInTheDocument();
+        expect(screen.getByText('test-policy')).toBeInTheDocument();
+        expect(screen.getByText('pending-policy')).toBeInTheDocument();
+        expect(screen.getByText('Allow')).toBeInTheDocument();
+        expect(screen.getByText('Deny')).toBeInTheDocument();
+        expect(screen.getAllByText('-')).toHaveLength(2); // one for each policy without trigger
+    });
+
+    it('renders trigger info in popover when trigger is provided', () => {
+        const triggeredData = {
+            enforced: [
+                makePolicy({
+                    trigger: {
+                        kind: 'NetworkPolicyTriggerTest',
+                        namespace: 'ns1',
+                        name: 'triggered-policy',
+                    },
+                } as any),
+            ],
+            pending: [],
+        };
+
+        render(<PoliciesLogDetails tableCellData={triggeredData} />);
+
+        expect(screen.getByText('ns1/triggered-policy')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('ns1/triggered-policy'));
+        expect(
+            screen.getByText('NetworkPolicyTriggerTest'),
+        ).toBeInTheDocument();
+    });
+});

--- a/whisker/src/features/flowLogs/components/PoliciesLogDetails/index.tsx
+++ b/whisker/src/features/flowLogs/components/PoliciesLogDetails/index.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import {
+    Table,
+    Tbody,
+    Tr,
+    Td,
+    Heading,
+    Th,
+    Tooltip,
+    Icon,
+    Flex,
+    Box,
+    Popover,
+    PopoverTrigger,
+    PopoverContent,
+    PopoverBody,
+    Portal,
+} from '@chakra-ui/react';
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import {
+    headingStyles,
+    infoIconStyles,
+    tableStyles,
+    triggerButtonStyles,
+    triggerTableStyles,
+} from './styles';
+import { Policy, PoliciesLogEntries } from '@/types/api';
+import { TriggeredIcon } from '@/icons';
+import PolicyActionIndicator from '@/components/common/PolicyActionIndicator';
+import { FlowLogAction } from '@/types/render';
+
+type PoliciesLogDetails = {
+    tableCellData: PoliciesLogEntries;
+};
+
+const POLICY_ENTRIES = [
+    {
+        key: 'enforced',
+        title: 'Enforced Policies',
+        description: 'Policies that were enforced for this flow',
+    },
+    {
+        key: 'pending',
+        title: 'Pending Policies',
+        description:
+            'Policies that will be enforced if a similar flow was initiated now',
+    },
+];
+
+const transformPolicyLog = (tableCellData: PoliciesLogEntries) =>
+    POLICY_ENTRIES.reduce((acc: PoliciesLogEntries, { key }) => {
+        acc[key] = tableCellData[key].map((policy: Policy) =>
+            policy.kind === 'Profile'
+                ? {
+                      ...policy,
+                      kind: 'EndofTier',
+                      tier: 'default',
+                      name: '',
+                      policy_index: null,
+                      rule_index: null,
+                  }
+                : policy,
+        );
+
+        return acc;
+    }, {} as PoliciesLogEntries);
+
+const PoliciesLogDetails: React.FC<PoliciesLogDetails> = ({
+    tableCellData,
+}) => {
+    const policyLogData = React.useMemo(
+        () => transformPolicyLog(tableCellData),
+        [tableCellData],
+    );
+
+    return (
+        <>
+            {POLICY_ENTRIES.map(({ key, title, description }, index) => {
+                return (
+                    <Box key={key} mb={2}>
+                        <Heading
+                            as='h3'
+                            {...headingStyles}
+                            mt={index === 0 ? 2 : 4}
+                        >
+                            <span>{title}</span>
+
+                            <Tooltip
+                                label={description}
+                                hasArrow
+                                placement='top'
+                            >
+                                <Icon
+                                    as={InfoOutlineIcon}
+                                    sx={infoIconStyles}
+                                />
+                            </Tooltip>
+                        </Heading>
+
+                        <Table
+                            variant='inline'
+                            data-testid='enforced-policies-table'
+                            sx={tableStyles}
+                        >
+                            <Tbody>
+                                <Tr>
+                                    <Th>Kind</Th>
+                                    <Th>Namespace</Th>
+                                    <Th>Policy Name</Th>
+                                    <Th>Tier</Th>
+                                    <Th>Action</Th>
+                                    <Th>Policy Index</Th>
+                                    <Th>Rule Index</Th>
+                                    <Th>Triggered By</Th>
+                                </Tr>
+                                {policyLogData[key].map((policy: Policy) => {
+                                    return (
+                                        <Tr
+                                            key={`${policy.kind}:${policy.name}:${policy.namespace}`}
+                                        >
+                                            <Td>{policy.kind}</Td>
+                                            <Td>{policy.namespace}</Td>
+                                            <Td>{policy.name}</Td>
+                                            <Td>{policy.tier}</Td>
+                                            <Td>
+                                                <PolicyActionIndicator
+                                                    action={
+                                                        policy.action as FlowLogAction
+                                                    }
+                                                />
+                                            </Td>
+                                            <Td>{policy.policy_index ?? ''}</Td>
+                                            <Td>{policy.rule_index ?? ''}</Td>
+                                            <Td>
+                                                {policy.trigger ? (
+                                                    <Popover>
+                                                        <PopoverTrigger>
+                                                            <Flex
+                                                                sx={
+                                                                    triggerButtonStyles
+                                                                }
+                                                            >
+                                                                <TriggeredIcon />
+
+                                                                <span>
+                                                                    {`${policy.trigger.namespace}/${policy.trigger.name}`}
+                                                                </span>
+                                                            </Flex>
+                                                        </PopoverTrigger>
+                                                        <Portal>
+                                                            <PopoverContent fontFamily='monospace'>
+                                                                <PopoverBody>
+                                                                    <Table
+                                                                        sx={
+                                                                            triggerTableStyles
+                                                                        }
+                                                                    >
+                                                                        <tbody>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    Kind
+                                                                                </td>
+                                                                                <td>
+                                                                                    {
+                                                                                        policy
+                                                                                            .trigger
+                                                                                            .kind
+                                                                                    }
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    Namespace
+                                                                                </td>
+                                                                                <td>
+                                                                                    {
+                                                                                        policy
+                                                                                            .trigger
+                                                                                            .namespace
+                                                                                    }
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    Policy
+                                                                                    Name
+                                                                                </td>
+                                                                                <td>
+                                                                                    {
+                                                                                        policy
+                                                                                            .trigger
+                                                                                            .name
+                                                                                    }
+                                                                                </td>
+                                                                            </tr>
+                                                                        </tbody>
+                                                                    </Table>
+                                                                </PopoverBody>
+                                                            </PopoverContent>
+                                                        </Portal>
+                                                    </Popover>
+                                                ) : (
+                                                    <span>-</span>
+                                                )}
+                                            </Td>
+                                        </Tr>
+                                    );
+                                })}
+                            </Tbody>
+                        </Table>
+                    </Box>
+                );
+            })}
+        </>
+    );
+};
+
+export default PoliciesLogDetails;

--- a/whisker/src/features/flowLogs/components/PoliciesLogDetails/styles.ts
+++ b/whisker/src/features/flowLogs/components/PoliciesLogDetails/styles.ts
@@ -1,0 +1,46 @@
+export const tableStyles = {
+    fontFamily: 'monospace, monospace',
+    bg: 'tigera-color-surface',
+    w: '95%',
+};
+
+export const headingStyles = {
+    size: 'xs',
+    mb: 4,
+    fontFamily: 'inherit',
+    display: 'flex',
+    alignItems: 'center',
+};
+
+export const infoIconStyles = {
+    color: 'tigera-color-primary',
+    ml: 2,
+    cursor: 'pointer',
+    _hover: {
+        color: 'tigeraGoldDark',
+    },
+};
+
+export const triggerButtonStyles = {
+    color: 'tigera-color-primary',
+
+    alignItems: 'center',
+    cursor: 'pointer',
+
+    _hover: {
+        color: 'tigeraGoldDark',
+        svg: {
+            color: 'tigeraGoldDark',
+        },
+    },
+
+    svg: { h: 4, w: 4, color: 'tigera-color-primary', mr: 2 },
+};
+
+export const triggerTableStyles = {
+    bg: 'transparent',
+    'td:first-child': {
+        fontWeight: 'bold',
+        width: '35%',
+    },
+};

--- a/whisker/src/icons/TriggeredIcon.tsx
+++ b/whisker/src/icons/TriggeredIcon.tsx
@@ -1,0 +1,22 @@
+import { createIcon } from '@chakra-ui/icons';
+
+const TriggeredIcon = createIcon({
+    viewBox: '0 0 24 24',
+    defaultProps: {
+        h: '24px',
+        w: '24px',
+        stroke: 'currentColor',
+        strokeWidth: '2',
+        strokeLinecap: 'round',
+        strokeLinejoin: 'round',
+    },
+    path: (
+        <>
+            <circle cx='12' cy='12' r='10' />
+            <path d='m12 16 4-4-4-4' />
+            <path d='M8 12h8' />
+        </>
+    ),
+});
+
+export default TriggeredIcon;

--- a/whisker/src/icons/index.tsx
+++ b/whisker/src/icons/index.tsx
@@ -6,6 +6,7 @@ import ArrowRightIcon from './ArrowRightIcon';
 import PlayIcon from './PlayIcon';
 import PauseIcon from './PauseIcon';
 import DndIcon from './DndIcon';
+import TriggeredIcon from './TriggeredIcon';
 
 export {
     CalicoCatIcon,
@@ -16,4 +17,5 @@ export {
     PlayIcon,
     PauseIcon,
     DndIcon,
+    TriggeredIcon,
 };

--- a/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/__test__/__snapshots__/index.test.tsx.snap
+++ b/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/__test__/__snapshots__/index.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`FlowLogDetails should render 1`] = `
           tabindex="0"
         >
           <table
-            class="chakra-table css-1iy5a85"
+            class="chakra-table css-akwolm"
           >
             <tbody
               class="css-0"
@@ -1194,7 +1194,7 @@ exports[`FlowLogDetails should render json 1`] = `
           tabindex="0"
         >
           <table
-            class="chakra-table css-1iy5a85"
+            class="chakra-table css-akwolm"
           >
             <tbody
               class="css-0"

--- a/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/components/LogDetailsTable/index.tsx
+++ b/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/components/LogDetailsTable/index.tsx
@@ -1,15 +1,22 @@
-import { Table, TableProps, Tbody, Td, Th, Tr } from '@chakra-ui/react';
 import React from 'react';
+import { Table, TableProps, Tbody, Td, Th, Tr } from '@chakra-ui/react';
 import { LogDocument } from '../..';
+
+export type CustomTableDataVisualiser<TProps = any> = {
+    key: string;
+    component: React.ComponentType<TProps>;
+};
 
 type LogDetailsTableProps = {
     logDocument: LogDocument;
     stringifyTableData: boolean;
+    customTableDataVisualisers?: Array<CustomTableDataVisualiser>;
 } & TableProps;
 
 const LogDetailsTable: React.FC<LogDetailsTableProps> = ({
     logDocument,
     stringifyTableData,
+    customTableDataVisualisers,
     ...rest
 }) => {
     return (
@@ -17,6 +24,7 @@ const LogDetailsTable: React.FC<LogDetailsTableProps> = ({
             <Tbody>
                 {Object.entries(logDocument).map(([key, value]) => {
                     let info = value as string | React.ReactNode;
+                    let infoJSON;
 
                     if (stringifyTableData) {
                         info = Array.isArray(value)
@@ -24,10 +32,34 @@ const LogDetailsTable: React.FC<LogDetailsTableProps> = ({
                             : JSON.stringify(value);
                     }
 
+                    const CustomDataVisualiser =
+                        customTableDataVisualisers?.find(
+                            (tableDataCustom) => tableDataCustom.key === key,
+                        )?.component;
+
+                    if (CustomDataVisualiser) {
+                        try {
+                            infoJSON = JSON.parse(info as string);
+                        } catch (e) {
+                            console.error(
+                                'Failed to parse expected JSON from flow logs stream',
+                                e,
+                            );
+                        }
+                    }
+
                     return (
                         <Tr key={key}>
                             <Th>{key}</Th>
-                            <Td>{info}</Td>
+                            <Td>
+                                {CustomDataVisualiser && infoJSON ? (
+                                    <CustomDataVisualiser
+                                        tableCellData={infoJSON}
+                                    />
+                                ) : (
+                                    info
+                                )}
+                            </Td>
                         </Tr>
                     );
                 })}

--- a/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/index.tsx
+++ b/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/index.tsx
@@ -3,7 +3,9 @@ import { Box, TableProps, useMultiStyleConfig } from '@chakra-ui/react';
 import React from 'react';
 import JsonPrettier from '../JsonPrettier';
 import Tabs from '../Tabs';
-import LogDetailsTable from './components/LogDetailsTable';
+import LogDetailsTable, {
+    CustomTableDataVisualiser,
+} from './components/LogDetailsTable';
 
 export interface LogDocument {
     [name: string]:
@@ -28,6 +30,7 @@ interface LogDetailsViewProps extends HTMLChakraProps<'div'> {
     stringifyTableData?: boolean;
     defaultExpandedJsonNodes?: number;
     size?: string;
+    customTableDataVisualisers?: Array<CustomTableDataVisualiser>;
 }
 
 const LogDetailsView: React.FC<LogDetailsViewProps> = ({
@@ -40,6 +43,7 @@ const LogDetailsView: React.FC<LogDetailsViewProps> = ({
     showTableOnly = false,
     stringifyTableData = true,
     defaultExpandedJsonNodes,
+    customTableDataVisualisers,
     ...rest
 }) => {
     const logViewStyles = useMultiStyleConfig('LogDetailsView', rest);
@@ -48,10 +52,11 @@ const LogDetailsView: React.FC<LogDetailsViewProps> = ({
     const Table = (
         <LogDetailsTable
             __css={logViewStyles.table}
-            sx={{ ...tableStyles }}
+            sx={tableStyles}
             size={size}
             logDocument={logDocument}
             stringifyTableData={stringifyTableData}
+            customTableDataVisualisers={customTableDataVisualisers}
         />
     );
 

--- a/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/styles.ts
+++ b/whisker/src/libs/tigera/ui-components/components/common/LogDetailsView/styles.ts
@@ -9,16 +9,16 @@ export default {
             fontWeight: '900',
             letterSpacing: 'normal',
             minWidth: '100%',
-            td: {
+            '& > tbody > tr > td': {
                 borderBottom: 'none',
                 whiteSpace: 'normal',
             },
-            th: {
+            '& > tbody > tr > th': {
                 border: '0px',
                 background: 'unset',
                 textTransform: 'none',
                 fontWeight: 700,
-                fontSize: 'xs',
+                fontSize: 'sm',
                 verticalAlign: 'top',
                 color: 'tigera-color-on-surface',
                 lineHeight: '19px',

--- a/whisker/src/libs/tigera/ui-components/components/common/StatusIndicator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/whisker/src/libs/tigera/ui-components/components/common/StatusIndicator/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<StatusIndicator/> it renders 1`] = `
 <DocumentFragment>
   <div
-    class="css-1tljkm1"
+    class="css-1d0h3sn"
   >
     <div
       class="css-fw3qcu"

--- a/whisker/src/libs/tigera/ui-components/components/common/StatusIndicator/styles.ts
+++ b/whisker/src/libs/tigera/ui-components/components/common/StatusIndicator/styles.ts
@@ -6,6 +6,7 @@ export default {
             borderRadius: '50%',
             width: '0.5em',
             height: '0.5em',
+            minWidth: '0.5em',
         },
         gap: 2,
     },

--- a/whisker/src/theme/components/Popover.ts
+++ b/whisker/src/theme/components/Popover.ts
@@ -4,6 +4,25 @@ const { definePartsStyle, defineMultiStyleConfig } =
     createMultiStyleConfigHelpers(parts.keys);
 
 export default defineMultiStyleConfig({
+    baseStyle: {
+        content: {
+            _dark: {
+                backgroundColor: 'tigeraGrey.1000',
+                boxShadow: 'none!important',
+                border: 'none',
+            },
+        },
+        header: {
+            _dark: {
+                borderBottomColor: 'tigeraGrey.600',
+            },
+        },
+        footer: {
+            _dark: {
+                borderTopColor: 'tigeraGrey.600',
+            },
+        },
+    },
     variants: {
         omniFilter: definePartsStyle({
             header: {

--- a/whisker/src/theme/components/Table.ts
+++ b/whisker/src/theme/components/Table.ts
@@ -190,5 +190,32 @@ export default {
                 },
             },
         },
+        // inline: aka table within a table
+        inline: {
+            table: {
+                bg: 'transparent',
+                border: '1px solid',
+                borderColor: 'tigera-color-table-row',
+                borderRadius: 4,
+                borderSpacing: 0,
+                borderCollapse: 'separate',
+                overflow: 'hidden',
+            },
+            th: {
+                verticalAlign: 'top',
+                border: 0,
+                bg: 'tigera-color-table-row',
+                fontSize: 'sm',
+                fontFamily: 'inherit',
+            },
+            tr: {
+                border: 0,
+            },
+            td: {
+                border: 0,
+                fontFamily: 'inherit',
+                fontSize: 'sm',
+            },
+        },
     },
 };

--- a/whisker/src/types/api.ts
+++ b/whisker/src/types/api.ts
@@ -2,15 +2,19 @@ import { OmniFilterOption as ListOmniFilterOption } from '@/libs/tigera/ui-compo
 import { ListOmniFilterParam, OmniFilterParam } from '@/utils/omniFilter';
 import { FlowLogAction } from './render';
 
-type Policy = {
+export type Policy = {
     kind: string;
     name: string;
     namespace: string;
     tier: string;
     action: string;
-    policy_index: number;
-    rule_index: number;
-    trigger: null;
+    policy_index: number | null;
+    rule_index: number | null;
+    trigger?: Policy | null;
+};
+
+export type PoliciesLogEntries = {
+    [key: string]: Policy[];
 };
 
 export type FlowLog = {
@@ -30,10 +34,7 @@ export type FlowLog = {
     packets_out: string;
     bytes_in: string;
     bytes_out: string;
-    policies: {
-        enforced: Policy[];
-        pending: Policy[];
-    };
+    policies: PoliciesLogEntries;
 };
 
 export type ApiError = {


### PR DESCRIPTION
## Description

Improve visuals for network policies in Whisker by clearly displaying Enforced and Pending categories, with access to trigger details with color-coded action badges and tabular formatting.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Policy Trace UI
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
