### PR TITLE
Fix test flake due to env pollution

### DIFF
--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -89,11 +89,27 @@ func makeK8sNode(ipv4 string, ipv6 string) *v1.Node {
 	return node
 }
 
+// setEnv sets an environment variable and returns a function to restore the original value.
+func setEnv(k, v string) func() {
+	originalValue, hadOriginalValue := os.LookupEnv(k)
+	err := os.Setenv(k, v)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Error setting env var %s: %v", k, err))
+	return func() {
+		var err error
+		if hadOriginalValue {
+			err = os.Setenv(k, originalValue)
+		} else {
+			err = os.Unsetenv(k)
+		}
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Error restoring env var %s: %v", k, err))
+	}
+}
+
 var _ = DescribeTable("Node IP detection failure cases",
 	func(networkingBackend string, expectedExitCode int, rrCId string, expectedUpdate bool) {
-		os.Setenv("CALICO_NETWORKING_BACKEND", networkingBackend)
-		os.Setenv("IP", "none")
-		os.Setenv("IP6", "")
+		defer setEnv("CALICO_NETWORKING_BACKEND", networkingBackend)()
+		defer setEnv("IP", "none")()
+		defer setEnv("IP6", "")()
 
 		my_ec := 0
 		oldExit := utils.GetExitFunction()
@@ -215,13 +231,8 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			// Set the env variables specified.
 			for _, env := range envList {
-				os.Setenv(env.key, env.value)
+				defer setEnv(env.key, env.value)()
 			}
-			defer func() {
-				for _, env := range envList {
-					os.Unsetenv(env.key)
-				}
-			}()
 
 			poolList, err := c.IPPools().List(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -479,7 +490,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Set the env variables specified.
-		os.Setenv("NO_DEFAULT_POOLS", "true")
+		defer setEnv("NO_DEFAULT_POOLS", "true")()
 
 		// Run the UUT.
 		configureIPPools(ctx, c, kubeadmConfig)
@@ -510,13 +521,8 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			// Set the env variables specified.
 			for _, env := range envList {
-				os.Setenv(env.key, env.value)
+				defer setEnv(env.key, env.value)()
 			}
-			defer func() {
-				for _, env := range envList {
-					os.Unsetenv(env.key)
-				}
-			}()
 
 			// Run the UUT.
 			configureIPPools(ctx, c, kubeadmConfig)
@@ -581,7 +587,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			// Set the env variables specified.
 			for _, env := range envList {
-				os.Setenv(env.key, env.value)
+				defer setEnv(env.key, env.value)()
 			}
 
 			// Run the UUT.
@@ -735,7 +741,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 			nodeName := utils.DetermineNodeName()
 			node := getNode(ctx, c, nodeName)
 
-			os.Setenv("CLUSTER_TYPE", "theType")
+			defer setEnv("CLUSTER_TYPE", "theType")()
 
 			localRancherState := &v1.ConfigMap{Data: map[string]string{"foo": "bar"}}
 			err = ensureDefaultConfig(ctx, cfg, c, node, OSTypeWindows, kubeadmConfig, localRancherState)
@@ -784,7 +790,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			_, err = c.ClusterInformation().Create(ctx, clusterInfo, options.SetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			os.Setenv("CLUSTER_TYPE", "theType")
+			defer setEnv("CLUSTER_TYPE", "theType")()
 
 			err = ensureDefaultConfig(ctx, cfg, c, node, OSTypeLinux, kubeadmConfig, rancherState)
 			By("ensureDefaultConfig", func() {
@@ -834,7 +840,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			_, err = c.ClusterInformation().Create(ctx, clusterInfo, options.SetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			os.Setenv("CLUSTER_TYPE", "theType")
+			defer setEnv("CLUSTER_TYPE", "theType")()
 
 			err = ensureDefaultConfig(ctx, cfg, c, node, OSTypeLinux, kubeadmConfig, rancherState)
 			By("ensureDefaultConfig", func() {
@@ -886,7 +892,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			_, err = c.ClusterInformation().Create(ctx, clusterInfo, options.SetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			os.Setenv("CLUSTER_TYPE", "")
+			defer setEnv("CLUSTER_TYPE", "")()
 
 			err = ensureDefaultConfig(ctx, cfg, c, node, OSTypeLinux, kubeadmConfig, rancherState)
 			By("ensureDefaultConfig", func() {
@@ -934,7 +940,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 			_, err = c.ClusterInformation().Create(ctx, clusterInfo, options.SetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			os.Setenv("CLUSTER_TYPE", "type1,type1")
+			defer setEnv("CLUSTER_TYPE", "type1,type1")()
 
 			err = ensureDefaultConfig(ctx, cfg, c, node, OSTypeLinux, kubeadmConfig, rancherState)
 			By("ensureDefaultConfig", func() {
@@ -959,7 +965,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 				node := &libapi.Node{}
 
 				for _, env := range envs {
-					os.Setenv(env.key, env.value)
+					defer setEnv(env.key, env.value)()
 				}
 
 				Expect(configureNodeRef(node)).To(Equal(true))
@@ -976,15 +982,16 @@ var _ = Describe("FV tests against a real etcd", func() {
 			)
 
 			It("Should not configure any OrchRefs when no valid env vars are passed", func() {
-				os.Setenv("CALICO_UNKNOWN_NODE_REF", "node1")
+				defer setEnv("CALICO_UNKNOWN_NODE_REF", "node1")()
 
 				node := &libapi.Node{}
 				Expect(configureNodeRef(node)).To(Equal(false))
 
 				Expect(node.Spec.OrchRefs).To(HaveLen(0))
 			})
+
 			It("Should not set an OrchRef if it is already set", func() {
-				os.Setenv("CALICO_K8S_NODE_REF", "node1")
+				defer setEnv("CALICO_K8S_NODE_REF", "node1")()
 
 				node := &libapi.Node{}
 				node.Spec.OrchRefs = append(node.Spec.OrchRefs, libapi.OrchRef{NodeName: "node1", Orchestrator: "k8s"})
@@ -1052,7 +1059,7 @@ var _ = Describe("UT for Node IP assignment and conflict checking.", func() {
 	DescribeTable("Test variations on how IPs are detected.",
 		func(node *libapi.Node, items []EnvItem, expected bool) {
 			for _, item := range items {
-				os.Setenv(item.key, item.value)
+				defer setEnv(item.key, item.value)()
 			}
 
 			mockGetInterface := func([]string, []string, ...int) ([]autodetection.Interface, error) {
@@ -1080,7 +1087,7 @@ var _ = Describe("UT for autodetection method k8s-internal-ip", func() {
 	DescribeTable("Test variations on k8s-internal-ip",
 		func(node *libapi.Node, k8sNode *v1.Node, items []EnvItem, expected bool) {
 			for _, item := range items {
-				os.Setenv(item.key, item.value)
+				defer setEnv(item.key, item.value)()
 			}
 
 			mockGetInterface := func([]string, []string, ...int) ([]autodetection.Interface, error) {
@@ -1127,7 +1134,7 @@ var _ = Describe("UT for node interface autodetection", func() {
 	DescribeTable("Test interface is correctly set on Node",
 		func(node *libapi.Node, k8sNode *v1.Node, items []EnvItem) {
 			for _, item := range items {
-				os.Setenv(item.key, item.value)
+				defer setEnv(item.key, item.value)()
 			}
 
 			mockGetInterface := func([]string, []string, ...int) ([]autodetection.Interface, error) {
@@ -1226,12 +1233,12 @@ var _ = Describe("UT for node name determination", func() {
 	DescribeTable("Test variations on how node names are detected.",
 		func(nodenameEnv, hostnameEnv, expectedNodeName string) {
 			if nodenameEnv != "" {
-				os.Setenv("NODENAME", nodenameEnv)
+				defer setEnv("NODENAME", nodenameEnv)()
 			} else {
 				os.Unsetenv("NODENAME")
 			}
 			if hostnameEnv != "" {
-				os.Setenv("HOSTNAME", hostnameEnv)
+				defer setEnv("HOSTNAME", hostnameEnv)()
 			} else {
 				os.Unsetenv("HOSTNAME")
 			}
@@ -1348,11 +1355,11 @@ var _ = DescribeTable("UT for extractKubeadmCIDRs",
 
 var _ = Describe("UTs for monitor-addresses option", func() {
 	It("poll-interval handles invalid values", func() {
-		os.Setenv("AUTODETECT_POLL_INTERVAL", "foobar")
+		defer setEnv("AUTODETECT_POLL_INTERVAL", "foobar")()
 		Expect(getMonitorPollInterval()).To(Equal(DEFAULT_MONITOR_IP_POLL_INTERVAL))
 	})
 	It("poll-interval handles valid values", func() {
-		os.Setenv("AUTODETECT_POLL_INTERVAL", "30m")
+		defer setEnv("AUTODETECT_POLL_INTERVAL", "30m")()
 		Expect(getMonitorPollInterval()).To(Equal(30 * time.Minute))
 	})
 })

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -90,6 +90,12 @@ func makeK8sNode(ipv4 string, ipv6 string) *v1.Node {
 }
 
 // temporarilySetEnv sets an environment variable and returns a function to restore the original value.
+// The returned function should be deferred immediately after calling temporarilySetEnv, in order to
+// guarantee restoration of the original value.
+//
+// For example:
+//
+//	defer temporarilySetEnv("MY_ENV_VAR", "my_value")()
 func temporarilySetEnv(k, v string) func() {
 	originalValue, hadOriginalValue := os.LookupEnv(k)
 	err := os.Setenv(k, v)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Spotted the flake here: https://tigera.semaphoreci.com/jobs/c459125c-606a-42c9-a636-a36520aa284d#L1339-L1367

Tests were leaving behind env changes that impacted other tests,
depending on test ordering.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.