### PR TITLE
[v3.30] nftables: properly mark base chains as dirty after a flush

### DIFF
--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -458,7 +458,7 @@ func (t *NftablesTable) UpdateChain(chain *generictables.Chain) {
 	numRulesDelta := len(chain.Rules) - oldNumRules
 	t.gaugeNumRules.Add(float64(numRulesDelta))
 	if t.chainIsReferenced(chain.Name) {
-		t.dirtyChains.Add(chain.Name)
+		t.markChainDirty(chain.Name)
 	}
 }
 
@@ -475,7 +475,7 @@ func (t *NftablesTable) RemoveChainByName(name string) {
 		t.maybeDecrefReferredChains(name, oldChain.Rules)
 		delete(t.chainNameToChain, name)
 		if t.chainIsReferenced(name) {
-			t.dirtyChains.Add(name)
+			t.markChainDirty(name)
 		}
 	}
 }
@@ -519,7 +519,7 @@ func (t *NftablesTable) increfChain(chainName string) {
 	t.chainRefCounts[chainName] += 1
 	if t.chainRefCounts[chainName] == 1 {
 		t.updateRateLimitedLog.WithField("chainName", chainName).Info("Chain became referenced, marking it for programming")
-		t.dirtyChains.Add(chainName)
+		t.markChainDirty(chainName)
 		if chain := t.chainNameToChain[chainName]; chain != nil {
 			// Recursively incref chains that this chain refers to.  If
 			// chain == nil then the chain is likely about to be added, in
@@ -542,7 +542,7 @@ func (t *NftablesTable) decrefChain(chainName string) {
 			t.maybeDecrefReferredChains(chainName, chain.Rules)
 		}
 		delete(t.chainRefCounts, chainName)
-		t.dirtyChains.Add(chainName)
+		t.markChainDirty(chainName)
 		return
 	}
 
@@ -571,7 +571,7 @@ func (t *NftablesTable) loadDataplaneState() {
 	// chains for refresh.
 	for chainName, expectedHashes := range t.chainToDataplaneHashes {
 		logCxt := t.logCxt.WithField("chainName", chainName)
-		if t.dirtyChains.Contains(chainName) || t.dirtyBaseChains.Contains(chainName) {
+		if t.isDirty(chainName) {
 			// Already an update pending for this chain; no point in flagging it as
 			// out-of-sync.
 			logCxt.Debug("Skipping known-dirty chain")
@@ -581,7 +581,7 @@ func (t *NftablesTable) loadDataplaneState() {
 			// This doesn't match the regex for chains programmed by us. Mark it as dirty so
 			// that we clean it up on the next apply.
 			logCxt.WithField("chain", chainName).Warn("Found chain that doesn't belong to us, marking for cleanup")
-			t.dirtyChains.Add(chainName)
+			t.markChainDirty(chainName)
 		} else {
 			// One of our chains, should match exactly.
 			dpHashes := dataplaneHashes[chainName]
@@ -590,7 +590,7 @@ func (t *NftablesTable) loadDataplaneState() {
 					"dpHashes":       dpHashes,
 					"expectedHashes": expectedHashes,
 				}).Warn("Detected out-of-sync Calico chain, marking for resync")
-				t.dirtyChains.Add(chainName)
+				t.markChainDirty(chainName)
 			}
 		}
 	}
@@ -599,7 +599,7 @@ func (t *NftablesTable) loadDataplaneState() {
 	t.logCxt.Debug("Scanning for unexpected nftables chains")
 	for chainName := range dataplaneHashes {
 		logCxt := t.logCxt.WithField("chainName", chainName)
-		if t.dirtyChains.Contains(chainName) || t.dirtyBaseChains.Contains(chainName) {
+		if t.isDirty(chainName) {
 			// Already an update pending for this chain.
 			logCxt.Debug("Skipping known-dirty chain")
 			continue
@@ -612,13 +612,28 @@ func (t *NftablesTable) loadDataplaneState() {
 
 		// Chain exists in dataplane but not in memory, mark as dirty so we'll clean it up.
 		logCxt.WithField("chainName", chainName).Info("Found unexpected chain, marking for cleanup")
-		t.dirtyChains.Add(chainName)
+		t.markChainDirty(chainName)
 	}
 
 	t.logCxt.Debug("Finished loading nftables state")
 	t.chainToDataplaneHashes = dataplaneHashes
 	t.chainToFullRules = dataplaneRules
 	t.inSyncWithDataPlane = true
+}
+
+// markChainDirty marks the given chain as dirty, causing it to be re-written on the next Apply.
+// It handles adding the chain to dirtyBaseChains if it's a base chain, otherwise to dirtyChains.
+func (t *NftablesTable) markChainDirty(chainName string) {
+	if _, isBase := baseChains[chainName]; isBase {
+		t.dirtyBaseChains.Add(chainName)
+	} else {
+		t.dirtyChains.Add(chainName)
+	}
+}
+
+// isDirty returns true if the given chain is marked as dirty.
+func (t *NftablesTable) isDirty(chainName string) bool {
+	return t.dirtyBaseChains.Contains(chainName) || t.dirtyChains.Contains(chainName)
 }
 
 // expectedHashesForInsertAppendChain calculates the expected hashes for a whole top-level chain
@@ -939,6 +954,7 @@ func (t *NftablesTable) applyUpdates() error {
 				"previous":  previousHashes,
 				"current":   currentHashes,
 			}).Debug("Comparing chain hashes")
+
 			for i := 0; i < len(previousHashes) || i < len(currentHashes); i++ {
 				if i < len(previousHashes) && i < len(currentHashes) {
 					if previousHashes[i] == currentHashes[i] {
@@ -1016,7 +1032,7 @@ func (t *NftablesTable) applyUpdates() error {
 			}
 		}
 
-		// Add appended rules if there is any
+		// Add appended rules if there are any.
 		rules = t.chainToAppendedRules[chainName]
 		if len(rules) > 0 {
 			t.logCxt.Debug("Rendering specific append rules.")

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -249,6 +249,54 @@ var _ = Describe("Table with an empty dataplane", func() {
 			})
 		})
 
+		Describe("after another process removes an append", func() {
+			BeforeEach(func() {
+				// Append a rule to the filter-FORWARD base chain, and trigger programming.
+				table.AppendRules("filter-FORWARD", []generictables.Rule{
+					{Match: nftables.Match(), Action: AcceptAction{}},
+				})
+				table.Apply()
+
+				// It should be there now.
+				rules, err := f.ListRules(context.TODO(), "filter-FORWARD")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rules).To(HaveLen(2), "Failed to append rule!")
+
+				// Remove all the rules out-of-band.
+				tx := f.NewTransaction()
+				for _, r := range rules {
+					cp := *r
+					tx.Delete(&cp)
+				}
+				Expect(f.Run(context.TODO(), tx)).NotTo(HaveOccurred())
+
+				// Check it is gone.
+				rules, err = f.ListRules(context.TODO(), "filter-FORWARD")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rules).To(HaveLen(0), "Failed to clean up rules!")
+			})
+
+			It("should put it back on the next explicit refresh", func() {
+				table.InvalidateDataplaneCache("test")
+				table.Apply()
+				rules, err := f.ListRules(context.TODO(), "filter-FORWARD")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rules).To(EqualRules([]knftables.Rule{
+					{
+						Chain:   "filter-FORWARD",
+						Rule:    "counter drop",
+						Comment: ptr("cali:DCGauXoHP5A9-AIO;"),
+					},
+
+					{
+						Chain:   "filter-FORWARD",
+						Rule:    "counter accept",
+						Comment: ptr("cali:Q43zYEHuKfFnJfs1;"),
+					},
+				}))
+			})
+		})
+
 		Describe("after another process replaces the insertion (non-empty chain)", func() {
 			BeforeEach(func() {
 				// Remove the chains out-of-band from the Table.


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#10936
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This fixes an issue where, in nftables mode, after an `nft flush ruleset`, Calico would fail to reprogram its top level jump rules into its nftables base chains.

This was occurring because the nftables Table structure uses two separate dirty trackers: `dirtyChains` and `dirtyBaseChains`.

The separate trackers are used because the logic within the dataplane `apply` is different. But since the base chains were being marked as dirty in `dirtyChains` and not `dirtyBaseChains`, the correct logic was not being executed for these chains.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/10872#issuecomment-3241031834

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
nftables: fix reprogramming of base chain rules after out-of-band flush.
```