### PR TITLE
Update birdcl path to /bin/birdcl for liveness probe in calico-node.

### DIFF
--- a/node/pkg/health/health.go
+++ b/node/pkg/health/health.go
@@ -89,7 +89,7 @@ func RunOutput(bird, bird6, felixReady, felixLive, birdLive, bird6Live bool, thr
 			}
 
 			// Check that BIRD is actually responding to commands.
-			out, err := exec.Command("/usr/bin/birdcl", "-s", "/var/run/calico/bird.ctl", "show", "status").Output()
+			out, err := exec.Command("/bin/birdcl", "-s", "/var/run/calico/bird.ctl", "show", "status").Output()
 			if err != nil {
 				return fmt.Errorf("calico/node is not ready: bird is not live: %+v", err)
 			}
@@ -108,7 +108,7 @@ func RunOutput(bird, bird6, felixReady, felixLive, birdLive, bird6Live bool, thr
 			}
 
 			// Check that BIRD is actually responding to commands.
-			out, err := exec.Command("/usr/bin/birdcl", "-s", "/var/run/calico/bird6.ctl", "show", "status").Output()
+			out, err := exec.Command("/bin/birdcl", "-s", "/var/run/calico/bird6.ctl", "show", "status").Output()
 			if err != nil {
 				return fmt.Errorf("calico/node is not ready: bird6 is not live: %+v", err)
 			}


### PR DESCRIPTION
## Description
This PR updates the path for the `birdcl` used in the Liveness Probe check of calico-node, to point to the actual path to which the `bird*` binaries are copied. More information in #10952 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
Fixes: #10952 

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update LivenessProbe of calico-node to point to /bin/birdcl from the existing /usr/bin/birdcl, fixing probe failures on ppc64le and other architectures. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
