### PR TITLE
Override with HOSTNAME env var if set when  hostname-override parameter specified in kubelet

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -715,11 +715,17 @@ func (config *Config) applyDefaults() {
 	for _, param := range knownParams {
 		param.setDefault(config)
 	}
+	// Default hostname
 	hostname, err := names.Hostname()
 	if err != nil {
-		log.Warningf("Failed to get hostname from kernel, "+
-			"trying HOSTNAME variable: %v", err)
+		log.Warningf("Failed to get hostname from kernel: %v", err)
+	}
+	// Override with HOSTNAME env var if set.
+	if os.Getenv("HOSTNAME") != "" {
 		hostname = strings.ToLower(os.Getenv("HOSTNAME"))
+	}
+	if hostname == "" {
+		log.Warningf("Failed to get hostname from kernel or HOSTNAME env variable")
 	}
 	config.FelixHostname = hostname
 }


### PR DESCRIPTION
## Description
When kubelet specifies a hostname using the [hostname-override](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) parameter, for example: `--hostname-override=192.168.0.10`, the result will be different from the result obtained by the `hostname` command.   
This means that the endpointHostnameFilter will filter out node-related event processing. 
In this scenario, the hostname needs to be explicitly defined using the environment variable `HOSTNAME`. 
In the calico-node daemonset yaml file, `HOSTNAME` can be defined using the following configuration:
```
        - name: HOSTNAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
```
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
