### PR TITLE
Fix kube-controllers static checks

### DIFF
--- a/kube-controllers/cmd/kube-controllers/fv_test.go
+++ b/kube-controllers/cmd/kube-controllers/fv_test.go
@@ -25,7 +25,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -58,7 +57,7 @@ var _ = Describe("[etcd] kube-controllers health check FV tests", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
@@ -95,8 +94,8 @@ var _ = Describe("[etcd] kube-controllers health check FV tests", func() {
 	})
 
 	It("should initialize the datastore at start-of-day", func() {
-		var info *api.ClusterInformation
-		Eventually(func() *api.ClusterInformation {
+		var info *v3.ClusterInformation
+		Eventually(func() *v3.ClusterInformation {
 			info, _ = calicoClient.ClusterInformation().Get(context.Background(), "default", options.GetOptions{})
 			return info
 		}, 10*time.Second).ShouldNot(BeNil())
@@ -186,7 +185,7 @@ var _ = Describe("kube-controllers metrics and pprof FV tests", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
@@ -289,7 +288,7 @@ var _ = Describe("[kdd] kube-controllers health check FV tests", func() {
 		var err error
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
@@ -336,8 +335,8 @@ var _ = Describe("[kdd] kube-controllers health check FV tests", func() {
 	})
 
 	It("should initialize the datastore at start-of-day", func() {
-		var info *api.ClusterInformation
-		Eventually(func() *api.ClusterInformation {
+		var info *v3.ClusterInformation
+		Eventually(func() *v3.ClusterInformation {
 			info, _ = calicoClient.ClusterInformation().Get(context.Background(), "default", options.GetOptions{})
 			return info
 		}, 10*time.Second).ShouldNot(BeNil())

--- a/kube-controllers/pkg/config/config_fv_test.go
+++ b/kube-controllers/pkg/config/config_fv_test.go
@@ -82,7 +82,7 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 
 	AfterEach(func() {
 		_ = c.Close()
-		os.Remove(kconfigFile.Name())
+		_ = os.Remove(kconfigFile.Name())
 		controllerManager.Stop()
 		uut.Stop()
 		apiserver.Stop()

--- a/kube-controllers/pkg/config/config_test.go
+++ b/kube-controllers/pkg/config/config_test.go
@@ -36,43 +36,43 @@ var _ = Describe("Config", func() {
 	// unsetEnv() function that unsets environment variables
 	// required by kube-controllers controller
 	unsetEnv := func() {
-		os.Unsetenv("LOG_LEVEL")
-		os.Unsetenv("RECONCILER_PERIOD")
-		os.Unsetenv("ENABLED_CONTROLLERS")
-		os.Unsetenv("WORKLOAD_ENDPOINT_WORKERS")
-		os.Unsetenv("PROFILE_WORKERS")
-		os.Unsetenv("POLICY_WORKERS")
-		os.Unsetenv("KUBECONFIG")
-		os.Unsetenv("DATASTORE_TYPE")
-		os.Unsetenv("HEALTH_ENABLED")
-		os.Unsetenv("COMPACTION_PERIOD")
-		os.Unsetenv("SYNC_NODE_LABELS")
-		os.Unsetenv("AUTO_HOST_ENDPOINTS")
+		_ = os.Unsetenv("LOG_LEVEL")
+		_ = os.Unsetenv("RECONCILER_PERIOD")
+		_ = os.Unsetenv("ENABLED_CONTROLLERS")
+		_ = os.Unsetenv("WORKLOAD_ENDPOINT_WORKERS")
+		_ = os.Unsetenv("PROFILE_WORKERS")
+		_ = os.Unsetenv("POLICY_WORKERS")
+		_ = os.Unsetenv("KUBECONFIG")
+		_ = os.Unsetenv("DATASTORE_TYPE")
+		_ = os.Unsetenv("HEALTH_ENABLED")
+		_ = os.Unsetenv("COMPACTION_PERIOD")
+		_ = os.Unsetenv("SYNC_NODE_LABELS")
+		_ = os.Unsetenv("AUTO_HOST_ENDPOINTS")
 	}
 
 	// setEnv() function that sets environment variables
 	// to some sensible values
 	setEnv := func() {
-		os.Setenv("LOG_LEVEL", "debug")
-		os.Setenv("RECONCILER_PERIOD", "105s")
-		os.Setenv("ENABLED_CONTROLLERS", "node,policy")
-		os.Setenv("WORKLOAD_ENDPOINT_WORKERS", "2")
-		os.Setenv("PROFILE_WORKERS", "3")
-		os.Setenv("POLICY_WORKERS", "4")
-		os.Setenv("KUBECONFIG", "/home/user/.kube/config")
-		os.Setenv("DATASTORE_TYPE", "etcdv3")
-		os.Setenv("HEALTH_ENABLED", "false")
-		os.Setenv("COMPACTION_PERIOD", "33m")
-		os.Setenv("SYNC_NODE_LABELS", "false")
-		os.Setenv("AUTO_HOST_ENDPOINTS", "enabled")
+		_ = os.Setenv("LOG_LEVEL", "debug")
+		_ = os.Setenv("RECONCILER_PERIOD", "105s")
+		_ = os.Setenv("ENABLED_CONTROLLERS", "node,policy")
+		_ = os.Setenv("WORKLOAD_ENDPOINT_WORKERS", "2")
+		_ = os.Setenv("PROFILE_WORKERS", "3")
+		_ = os.Setenv("POLICY_WORKERS", "4")
+		_ = os.Setenv("KUBECONFIG", "/home/user/.kube/config")
+		_ = os.Setenv("DATASTORE_TYPE", "etcdv3")
+		_ = os.Setenv("HEALTH_ENABLED", "false")
+		_ = os.Setenv("COMPACTION_PERIOD", "33m")
+		_ = os.Setenv("SYNC_NODE_LABELS", "false")
+		_ = os.Setenv("AUTO_HOST_ENDPOINTS", "enabled")
 	}
 
 	// setWrongEnv() function sets environment variables
 	// with values of wrong data type
 	setWrongEnv := func() {
-		os.Setenv("WORKLOAD_ENDPOINT_WORKERS", "somestring")
-		os.Setenv("PROFILE_WORKERS", "somestring")
-		os.Setenv("POLICY_WORKERS", "somestring")
+		_ = os.Setenv("WORKLOAD_ENDPOINT_WORKERS", "somestring")
+		_ = os.Setenv("PROFILE_WORKERS", "somestring")
+		_ = os.Setenv("POLICY_WORKERS", "somestring")
 	}
 
 	Context("with unset env values", func() {

--- a/kube-controllers/pkg/controllers/flannelmigration/config.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/config.go
@@ -116,7 +116,7 @@ func (c *Config) Parse() error {
 
 	// Check pod node name is set.
 	if c.PodNodeName == "" {
-		return fmt.Errorf("Missing PodNodeName config")
+		return fmt.Errorf("missing PodNodeName config")
 	}
 
 	// Check if FlannelSubnetEnv has been populated via ConfigMap.
@@ -127,7 +127,7 @@ func (c *Config) Parse() error {
 	}
 
 	// Restore from json string to subnet.env file content.
-	data := strings.Replace(c.FlannelSubnetEnv, ";", "\n", -1)
+	data := strings.ReplaceAll(c.FlannelSubnetEnv, ";", "\n")
 	if err = c.ReadFlannelConfig(data); err != nil {
 		return err
 	}
@@ -150,28 +150,28 @@ func (c *Config) subnetEnvPopulated() bool {
 func (c *Config) ValidateFlannelConfig() error {
 	// Check cluster pod CIDR
 	if c.FlannelNetwork == "" {
-		return fmt.Errorf("Missing FlannelNetwork config")
+		return fmt.Errorf("missing FlannelNetwork config")
 	}
 	_, _, err := cnet.ParseCIDR(c.FlannelNetwork)
 	if err != nil {
-		return fmt.Errorf("Failed to parse cluster pod CIDR '%s'", c.FlannelNetwork)
+		return fmt.Errorf("failed to parse cluster pod CIDR '%s'", c.FlannelNetwork)
 	}
 
 	if c.FlannelIpv6Network != "" {
 		_, _, err := cnet.ParseCIDR(c.FlannelIpv6Network)
 		if err != nil {
-			return fmt.Errorf("Failed to parse cluster pod CIDR '%s'", c.FlannelIpv6Network)
+			return fmt.Errorf("failed to parse cluster pod CIDR '%s'", c.FlannelIpv6Network)
 		}
 	}
 
 	// Check Flannel daemonset name.
 	if c.FlannelDaemonsetName == "" {
-		return fmt.Errorf("Missing FlannelDaemonsetName config")
+		return fmt.Errorf("missing FlannelDaemonsetName config")
 	}
 
 	// Check Flannel MTU.
 	if c.FlannelMTU == 0 {
-		return fmt.Errorf("Missing FlannelMTU config")
+		return fmt.Errorf("missing FlannelMTU config")
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func (c *Config) ReadFlannelConfig(data string) error {
 
 	var ok bool
 	if c.FlannelNetwork, ok = config["FLANNEL_NETWORK"]; !ok {
-		return fmt.Errorf("Failed to get config item FLANNEL_NETWORK")
+		return fmt.Errorf("failed to get config item FLANNEL_NETWORK")
 	}
 
 	// IPv6 is optional, so don't fail if not present
@@ -195,7 +195,7 @@ func (c *Config) ReadFlannelConfig(data string) error {
 
 	var masq string
 	if masq, ok = config["FLANNEL_IPMASQ"]; !ok {
-		return fmt.Errorf("Failed to get config item FLANNEL_IPMASQ")
+		return fmt.Errorf("failed to get config item FLANNEL_IPMASQ")
 	}
 	if c.FlannelIPMasq, err = strconv.ParseBool(masq); err != nil {
 		return err
@@ -203,7 +203,7 @@ func (c *Config) ReadFlannelConfig(data string) error {
 
 	var mtu string
 	if mtu, ok = config["FLANNEL_MTU"]; !ok {
-		return fmt.Errorf("Failed to get config item FLANNEL_MTU")
+		return fmt.Errorf("failed to get config item FLANNEL_MTU")
 	}
 	if c.FlannelMTU, err = strconv.Atoi(mtu); err != nil {
 		return err

--- a/kube-controllers/pkg/controllers/flannelmigration/config_test.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/config_test.go
@@ -27,35 +27,35 @@ var _ = Describe("flannel migration config", func() {
 	// unsetEnv() function that unsets environment variables.
 	// required by flannel migration controller.
 	unsetEnv := func() {
-		os.Unsetenv("FLANNEL_DAEMONSET_NAME")
-		os.Unsetenv("FLANNEL_SUBNET_LEN")
-		os.Unsetenv("FLANNEL_IPV6_SUBNET_LEN")
-		os.Unsetenv("FLANNEL_ANNOTATION_PREFIX")
-		os.Unsetenv("FLANNEL_VNI")
-		os.Unsetenv("FLANNEL_PORT")
-		os.Unsetenv("CALICO_DAEMONSET_NAME")
-		os.Unsetenv("CNI_CONFIG_DIR")
-		os.Unsetenv("POD_NODE_NAME")
-		os.Unsetenv("FLANNEL_SUBNET_ENV")
+		_ = os.Unsetenv("FLANNEL_DAEMONSET_NAME")
+		_ = os.Unsetenv("FLANNEL_SUBNET_LEN")
+		_ = os.Unsetenv("FLANNEL_IPV6_SUBNET_LEN")
+		_ = os.Unsetenv("FLANNEL_ANNOTATION_PREFIX")
+		_ = os.Unsetenv("FLANNEL_VNI")
+		_ = os.Unsetenv("FLANNEL_PORT")
+		_ = os.Unsetenv("CALICO_DAEMONSET_NAME")
+		_ = os.Unsetenv("CNI_CONFIG_DIR")
+		_ = os.Unsetenv("POD_NODE_NAME")
+		_ = os.Unsetenv("FLANNEL_SUBNET_ENV")
 	}
 
 	// setEnv() function that sets environment variables.
 	setEnv := func() {
-		os.Setenv("FLANNEL_DAEMONSET_NAME", "flannel-daemonset")
-		os.Setenv("FLANNEL_SUBNET_LEN", "25")
-		os.Setenv("FLANNEL_ANNOTATION_PREFIX", "flannel-prefix")
-		os.Setenv("FLANNEL_VNI", "3")
-		os.Setenv("FLANNEL_PORT", "1234")
-		os.Setenv("CALICO_DAEMONSET_NAME", "calico-daemonset")
-		os.Setenv("CNI_CONFIG_DIR", "/cni/config")
-		os.Setenv("POD_NODE_NAME", "test-node")
-		os.Setenv("FLANNEL_SUBNET_ENV", "FLANNEL_NETWORK=10.244.0.0/16;FLANNEL_SUBNET=10.244.1.1/24;FLANNEL_MTU=8951;FLANNEL_IPMASQ=false;")
+		_ = os.Setenv("FLANNEL_DAEMONSET_NAME", "flannel-daemonset")
+		_ = os.Setenv("FLANNEL_SUBNET_LEN", "25")
+		_ = os.Setenv("FLANNEL_ANNOTATION_PREFIX", "flannel-prefix")
+		_ = os.Setenv("FLANNEL_VNI", "3")
+		_ = os.Setenv("FLANNEL_PORT", "1234")
+		_ = os.Setenv("CALICO_DAEMONSET_NAME", "calico-daemonset")
+		_ = os.Setenv("CNI_CONFIG_DIR", "/cni/config")
+		_ = os.Setenv("POD_NODE_NAME", "test-node")
+		_ = os.Setenv("FLANNEL_SUBNET_ENV", "FLANNEL_NETWORK=10.244.0.0/16;FLANNEL_SUBNET=10.244.1.1/24;FLANNEL_MTU=8951;FLANNEL_IPMASQ=false;")
 	}
 
 	// setWrongEnv() function sets environment variables
 	// with values of wrong data type
 	setWrongEnv := func() {
-		os.Setenv("FLANNEL_VNI", "somestring")
+		_ = os.Setenv("FLANNEL_VNI", "somestring")
 	}
 
 	It("default values without POD_NODE_NAME", func() {
@@ -66,7 +66,7 @@ var _ = Describe("flannel migration config", func() {
 	})
 
 	It("default values with POD_NODE_NAME", func() {
-		os.Setenv("POD_NODE_NAME", "test-node")
+		_ = os.Setenv("POD_NODE_NAME", "test-node")
 		defer unsetEnv()
 
 		// Parse config
@@ -120,8 +120,8 @@ var _ = Describe("flannel migration config", func() {
 	It("with valid IPv6 user defined values", func() {
 		// Set environment variables
 		setEnv()
-		os.Setenv("FLANNEL_IPV6_SUBNET_LEN", "66")
-		os.Setenv("FLANNEL_SUBNET_ENV", "FLANNEL_NETWORK=10.244.0.0/16;FLANNEL_SUBNET=10.244.1.1/24;FLANNEL_MTU=8951;FLANNEL_IPMASQ=false;FLANNEL_IPV6_NETWORK=2001:cafe:42::/56;FLANNEL_IPV6_SUBNET=2001:cafe:42::1/64;")
+		_ = os.Setenv("FLANNEL_IPV6_SUBNET_LEN", "66")
+		_ = os.Setenv("FLANNEL_SUBNET_ENV", "FLANNEL_NETWORK=10.244.0.0/16;FLANNEL_SUBNET=10.244.1.1/24;FLANNEL_MTU=8951;FLANNEL_IPMASQ=false;FLANNEL_IPV6_NETWORK=2001:cafe:42::/56;FLANNEL_IPV6_SUBNET=2001:cafe:42::1/64;")
 		defer unsetEnv()
 
 		// Parse config

--- a/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
@@ -152,7 +152,7 @@ var _ = Describe("flannel-migration-controller FV test", func() {
 	AfterEach(func() {
 		_ = calicoClient.Close()
 		flannelCluster.Reset()
-		os.Remove(kconfigfile.Name())
+		_ = os.Remove(kconfigfile.Name())
 		controllerManager.Stop()
 		apiserver.Stop()
 		etcd.Stop()

--- a/kube-controllers/pkg/controllers/flannelmigration/ipam_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/ipam_migrator.go
@@ -74,14 +74,14 @@ func (m ipamMigrator) InitialiseIPPoolAndFelixConfig() error {
 	// Validate config and get pod CIDR.
 	_, cidr, err := cnet.ParseCIDR(m.config.FlannelNetwork)
 	if err != nil {
-		return fmt.Errorf("Failed to parse the CIDR '%s'", m.config.FlannelNetwork)
+		return fmt.Errorf("failed to parse the CIDR '%s'", m.config.FlannelNetwork)
 	}
 
 	var cidrV6 *cnet.IPNet
 	if m.config.FlannelIpv6Network != "" {
 		_, cidrV6, err = cnet.ParseCIDR(m.config.FlannelIpv6Network)
 		if err != nil {
-			return fmt.Errorf("Failed to parse the CIDR '%s'", m.config.FlannelIpv6Network)
+			return fmt.Errorf("failed to parse the CIDR '%s'", m.config.FlannelIpv6Network)
 		}
 	}
 
@@ -105,14 +105,14 @@ func (m ipamMigrator) InitialiseIPPoolAndFelixConfig() error {
 	// Create default IPv4 ippool with VXLAN enabled
 	err = createDefaultVxlanIPPool(m.ctx, m.calicoClient, cidr, blockSize, m.config.FlannelIPMasq, checkVxlan)
 	if err != nil {
-		return fmt.Errorf("Failed to create default IPv4 ippool")
+		return fmt.Errorf("failed to create default IPv4 ippool")
 	}
 
 	if cidrV6 != nil {
 		// Create default IPv6 ippool with vxlan enabled
 		err = createDefaultVxlanIPPool(m.ctx, m.calicoClient, cidrV6, blockSizeV6, m.config.FlannelIPMasq, checkVxlan)
 		if err != nil {
-			return fmt.Errorf("Failed to create default IPv6 ippool")
+			return fmt.Errorf("failed to create default IPv6 ippool")
 		}
 	}
 
@@ -120,7 +120,7 @@ func (m ipamMigrator) InitialiseIPPoolAndFelixConfig() error {
 	err = updateOrCreateDefaultFelixConfiguration(m.ctx, m.calicoClient,
 		m.config.FlannelVNI, m.config.FlannelPort, m.config.FlannelMTU)
 	if err != nil {
-		return fmt.Errorf("Failed to create or update default FelixConfiguration")
+		return fmt.Errorf("failed to create or update default FelixConfiguration")
 	}
 
 	return nil
@@ -241,7 +241,7 @@ func setupCalicoNodeVxlan(ctx context.Context, c client.Interface, nodeName stri
 	} else {
 		// Failed to get assignment attributes, datastore connection issues possible.
 		log.WithError(err).Errorf("Failed to get assignment attributes for vtep IP '%s'", vtepIP.String())
-		return fmt.Errorf("Failed to get vtep IP %s attribute", vtepIP.String())
+		return fmt.Errorf("failed to get vtep IP %s attribute", vtepIP.String())
 	}
 
 	if assign {
@@ -257,7 +257,7 @@ func setupCalicoNodeVxlan(ctx context.Context, c client.Interface, nodeName stri
 			Attrs:    attrs,
 		})
 		if err != nil {
-			return fmt.Errorf("Failed to assign vtep IP %s", vtepIP.String())
+			return fmt.Errorf("failed to assign vtep IP %s", vtepIP.String())
 		}
 		log.Infof("Calico Node %s vtep IP assigned.", nodeName)
 	}
@@ -305,7 +305,7 @@ func createDefaultVxlanIPPool(ctx context.Context, client client.Interface, cidr
 	case 6:
 		poolName = defaultIpv6PoolName
 	default:
-		return fmt.Errorf("Unknown IP version for CIDR: %s", cidr.String())
+		return fmt.Errorf("unknown IP version for CIDR: %s", cidr.String())
 
 	}
 	pool := &api.IPPool{

--- a/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/k8s_resources.go
@@ -489,7 +489,7 @@ func (n k8snode) execCommandInPod(k8sClientset *kubernetes.Clientset, namespace,
 
 	if !isPodRunningAndReady(&pod) {
 		// Pod is not running and ready.
-		return "", fmt.Errorf("failed to execute command in pod. Pod %s is not ready.", pod.Name)
+		return "", fmt.Errorf("failed to execute command in pod. Pod %s is not ready", pod.Name)
 	}
 
 	cmdArgs := []string{"exec", pod.Name, fmt.Sprintf("--namespace=%s", namespace), fmt.Sprintf("-c=%s", containerName), "--"}

--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -303,7 +303,7 @@ func (c *flannelMigrationController) readAndUpdateFlannelEnvConfig() error {
 
 	// Convert subnet.env content to json string and update flannel-migration-config ConfigMap.
 	// So that it could be populated into migration controller pod next time it starts.
-	val := strings.Replace(data, "\n", ";", -1)
+	val := strings.ReplaceAll(data, "\n", ";")
 	err = updateConfigMapValue(c.k8sClientset, c.config.CalicoDaemonsetNamespace, migrationConfigMapName, migrationConfigMapEnvKey, val)
 	if err != nil {
 		return err

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -877,7 +877,7 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 			}
 
 			if ipv6 > 1 || ipv4 > 1 {
-				return nil, nil, nil, fmt.Errorf("at max only one ipv4 and one ipv6 address can be specified. Recieved %d ipv4 and %d ipv6 addresses", ipv4, ipv6)
+				return nil, nil, nil, fmt.Errorf("at max only one ipv4 and one ipv6 address can be specified. Received %d ipv4 and %d ipv6 addresses", ipv4, ipv6)
 			}
 		}
 	}

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -216,7 +216,7 @@ func (c *loadBalancerController) onStatusUpdate(s bapi.SyncStatus) {
 }
 
 func (c *loadBalancerController) onUpdate(update bapi.Update) {
-	switch update.KVPair.Key.(type) {
+	switch update.Key.(type) {
 	case model.ResourceKey:
 		switch update.KVPair.Key.(model.ResourceKey).Kind {
 		case api.KindIPPool:
@@ -866,7 +866,7 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 			for _, ipAddr := range ipAddrs {
 				curr := cnet.ParseIP(ipAddr)
 				if curr == nil {
-					return nil, nil, nil, fmt.Errorf("Could not parse %s as a valid IP address", ipAddr)
+					return nil, nil, nil, fmt.Errorf("could not parse %s as a valid IP address", ipAddr)
 				}
 				if curr.To4() != nil {
 					ipv4++
@@ -877,7 +877,7 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 			}
 
 			if ipv6 > 1 || ipv4 > 1 {
-				return nil, nil, nil, fmt.Errorf("At max only one ipv4 and one ipv6 address can be specified. Recieved %d ipv4 and %d ipv6 addresses", ipv4, ipv6)
+				return nil, nil, nil, fmt.Errorf("at max only one ipv4 and one ipv6 address can be specified. Recieved %d ipv4 and %d ipv6 addresses", ipv4, ipv6)
 			}
 		}
 	}

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_fv_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Calico loadbalancer controller FV tests (etcd mode)", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-loadbalancercontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/controllers/namespace/namespace_controller.go
+++ b/kube-controllers/pkg/controllers/namespace/namespace_controller.go
@@ -117,7 +117,7 @@ func NewNamespaceController(ctx context.Context, k8sClientset *kubernetes.Client
 				if newObj.(*v1.Namespace).Status.Phase == "Terminating" {
 					// Ignore any updates with "Terminating" status, since
 					// we will soon receive a DELETE event to remove this object.
-					log.Debugf("Ignoring 'Terminating' update for Namespace %s.", newObj.(*v1.Namespace).ObjectMeta.GetName())
+					log.Debugf("Ignoring 'Terminating' update for Namespace %s.", newObj.(*v1.Namespace).GetName())
 					return
 				}
 

--- a/kube-controllers/pkg/controllers/namespace/namespace_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/namespace/namespace_controller_fv_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Calico namespace controller FV tests (etcd mode)", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/controllers/networkpolicy/policy_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/networkpolicy/policy_controller_fv_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Calico networkpolicy controller FV tests (etcd mode)", func() 
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Auto Hostendpoint FV tests", func() {
 
 	AfterEach(func() {
 		_ = c.Close()
-		os.Remove(kconfigFile.Name())
+		_ = os.Remove(kconfigFile.Name())
 		controllerManager.Stop()
 		nodeController.Stop()
 		apiserver.Stop()

--- a/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
@@ -102,7 +102,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		_ = c.Close()
-		os.Remove(kconfigFile.Name())
+		_ = os.Remove(kconfigFile.Name())
 		controllerManager.Stop()
 		nodeController.Stop()
 		apiserver.Stop()

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -167,7 +167,7 @@ func (c *autoHostEndpointController) acceptScheduledRequests(stopCh <-chan struc
 }
 
 func (c *autoHostEndpointController) onUpdate(update bapi.Update) {
-	switch update.KVPair.Key.(type) {
+	switch update.Key.(type) {
 	case model.ResourceKey:
 		switch update.KVPair.Key.(model.ResourceKey).Kind {
 		case libapi.KindNode, api.KindHostEndpoint:
@@ -658,8 +658,8 @@ func (c *autoHostEndpointController) updateHostEndpoint(current *api.HostEndpoin
 		logrus.WithField("hep.Name", current.Name).Debug("hostendpoint needs update")
 
 		expected.ResourceVersion = current.ResourceVersion
-		expected.ObjectMeta.CreationTimestamp = current.ObjectMeta.CreationTimestamp
-		expected.ObjectMeta.UID = current.ObjectMeta.UID
+		expected.CreationTimestamp = current.CreationTimestamp
+		expected.UID = current.UID
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -267,7 +267,7 @@ func (c *IPAMController) onStatusUpdate(s bapi.SyncStatus) {
 }
 
 func (c *IPAMController) onUpdate(update bapi.Update) {
-	switch update.KVPair.Key.(type) {
+	switch update.Key.(type) {
 	case model.ResourceKey:
 		switch update.KVPair.Key.(model.ResourceKey).Kind {
 		case libapiv3.KindNode, apiv3.KindIPPool, apiv3.KindClusterInformation:
@@ -1255,7 +1255,7 @@ func (c *IPAMController) nodeIsBeingMigrated(name string) (bool, error) {
 		return false, fmt.Errorf("failed to check node for migration status: %w", err)
 	}
 
-	for labelName, labelVal := range node.ObjectMeta.Labels {
+	for labelName, labelVal := range node.Labels {
 		// Check against labels used by the migration controller
 		for migrationLabelName, migrationLabelValue := range flannelmigration.NodeNetworkCalico {
 			// Only the label value "calico" specifies a migrated node where we can release the affinity

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -224,7 +224,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal("kname2"), "Cache not updated after UPDATE")
 
 		// Send a delete for the node, which should remove the entry from the cache.
-		update.KVPair.Value = nil
+		update.Value = nil
 		c.onUpdate(update)
 		Eventually(func() map[string]string {
 			done := c.pause()
@@ -234,7 +234,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Recreate the Calico node as a non-Kubernetes node.
 		n.Spec.OrchRefs[0].Orchestrator = apiv3.OrchestratorOpenStack
-		update.KVPair.Value = &n
+		update.Value = &n
 		update.UpdateType = bapi.UpdateTypeKVNew
 		c.onUpdate(update)
 
@@ -247,7 +247,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue(), "Cache not updated as expected after ADD of non-k8s node")
 
 		// Send a delete for the non-Kubernetes node, which should remove the entry from the cache.
-		update.KVPair.Value = nil
+		update.Value = nil
 		c.onUpdate(update)
 		Eventually(func() map[string]string {
 			done := c.pause()
@@ -530,7 +530,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(&secondIPPool))
 
 		// Delete second block (associated with second pool). Expect block to be removed from pool maps.
-		secondBlockUpdate.KVPair.Value = nil
+		secondBlockUpdate.Value = nil
 		c.onUpdate(secondBlockUpdate)
 		Eventually(func() string {
 			done := c.pause()
@@ -544,7 +544,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeEmpty())
 
 		// Delete first pool. Expect first block to be associated with unknown pool, and pool removed from pool cache.
-		firstPoolUpdate.KVPair.Value = nil
+		firstPoolUpdate.Value = nil
 		c.onUpdate(firstPoolUpdate)
 		Eventually(func() string {
 			done := c.pause()
@@ -563,7 +563,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 
 		// Delete first block (unassociated with a pool). Expect block to be removed from pool maps.
-		firstBlockUpdate.KVPair.Value = nil
+		firstBlockUpdate.Value = nil
 		c.onUpdate(firstBlockUpdate)
 		Eventually(func() string {
 			done := c.pause()
@@ -681,7 +681,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			return c.datastoreReady
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(true), "Cache not updated after ADD")
 
-		update.KVPair.Value = nil
+		update.Value = nil
 		c.onUpdate(update)
 		Eventually(func() bool {
 			done := c.pause()

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -74,7 +74,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 		var err error
 		kconfigfile, err = os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
@@ -606,7 +606,7 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 		var err error
 		kconfigfile, err = os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/controllers/node/labels.go
+++ b/kube-controllers/pkg/controllers/node/labels.go
@@ -108,7 +108,7 @@ func (c *nodeLabelController) onStatusUpdate(s bapi.SyncStatus) {
 }
 
 func (c *nodeLabelController) onUpdate(update bapi.Update) {
-	switch update.KVPair.Key.(type) {
+	switch update.Key.(type) {
 	case model.ResourceKey:
 		switch update.KVPair.Key.(model.ResourceKey).Kind {
 		case apiv3.KindNode:

--- a/kube-controllers/pkg/controllers/node/metrics_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/metrics_fv_test.go
@@ -64,7 +64,7 @@ var _ = Describe("kube-controllers metrics FV tests", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
@@ -642,7 +642,7 @@ func getMetrics(metricsURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Calico node controller FV tests (KDD mode)", func() {
 		var err error
 		kconfigfile, err = os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
@@ -444,7 +444,7 @@ var _ = Describe("Calico node controller FV tests (etcd mode)", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/controllers/pod/pod_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/pod/pod_controller_fv_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Calico pod controller FV tests (etcd mode)", func() {
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/controllers/serviceaccount/serviceaccount_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/serviceaccount/serviceaccount_controller_fv_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Calico serviceaccount controller FV tests (etcd mode)", func()
 		// Write out a kubeconfig file
 		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(kconfigfile.Name())
+		defer func() { _ = os.Remove(kconfigfile.Name()) }()
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())

--- a/kube-controllers/pkg/status/status_test.go
+++ b/kube-controllers/pkg/status/status_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Status pkg UTs", func() {
 	It("should update the status file when changes happen", func() {
 		f, err := os.CreateTemp("", "test")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(f.Name())
+		defer func() { _ = os.Remove(f.Name()) }()
 		st := New(f.Name())
 
 		By("status file should return proper Status object", func() {

--- a/kube-controllers/tests/testutils/flannel_migration_utils.go
+++ b/kube-controllers/tests/testutils/flannel_migration_utils.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/kube-controllers/tests/testutils/utils.go
+++ b/kube-controllers/tests/testutils/utils.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
## Description

This changeset fixes static check issues in the kube-controllers component reported by golangci-lint v2.4.0.

## Related issues/PRs

Prepare for https://github.com/projectcalico/calico/pull/10924.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
