### PR TITLE
Fix pod2daemon static checks

### DIFF
--- a/pod2daemon/binder/binder.go
+++ b/pod2daemon/binder/binder.go
@@ -89,7 +89,7 @@ EventLoop:
 	stopWatch <- true
 	// Close any open sockets
 	for _, wl := range b.workloads.getAll() {
-		wl.listener.Close()
+		_ = wl.listener.Close()
 	}
 	stopWG.Done()
 }
@@ -163,6 +163,6 @@ func readCredentials(path string, c *Credentials) error {
 func (b *binder) removeListener(uid string) {
 	w := b.workloads.get(uid)
 	// Closing the listener automatically removes it from the gRPC server.
-	w.listener.Close()
+	_ = w.listener.Close()
 	b.workloads.delete(uid)
 }

--- a/pod2daemon/csidriver/driver/driver.go
+++ b/pod2daemon/csidriver/driver/driver.go
@@ -109,12 +109,12 @@ func RetrieveConfig() (*ConfigurationOptions, error) {
 		// Read the config from the file.
 		bytes, err := os.ReadFile(configFile)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to read configuration at %s: %v", configFile, err)
+			return nil, fmt.Errorf("unable to read configuration at %s: %v", configFile, err)
 		}
 
 		err = json.Unmarshal(bytes, &config)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse configuration at %s: %v", configFile, err)
+			return nil, fmt.Errorf("unable to parse configuration at %s: %v", configFile, err)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
@@ -142,7 +142,7 @@ func RetrieveConfig() (*ConfigurationOptions, error) {
 	}
 
 	// Convert to absolute paths.
-	var prefix string = ""
+	prefix := ""
 	if !strings.HasPrefix(config.NodeAgentWorkloadHomeDir, "/") {
 		prefix = "/"
 	}

--- a/pod2daemon/csidriver/driver/driver_test.go
+++ b/pod2daemon/csidriver/driver/driver_test.go
@@ -97,7 +97,7 @@ func createRealTempJSONFile(name, contents string) error {
 	if err != nil {
 		return fmt.Errorf("Couldn't create temp JSON file: %w", err)
 	}
-	defer tmpFile.Close()
+	defer func() { _ = tmpFile.Close() }()
 
 	_, err = tmpFile.Write([]byte(contents))
 	if err != nil {

--- a/pod2daemon/flexvol/flexvoldriver.go
+++ b/pod2daemon/flexvol/flexvoldriver.go
@@ -133,7 +133,7 @@ var (
 		Long:  "Flex volume init command.",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 0 {
-				return fmt.Errorf("init takes no arguments.")
+				return fmt.Errorf("init takes no arguments")
 			}
 			return initCommand()
 		},
@@ -145,7 +145,7 @@ var (
 		Long:  "Flex volume mount command.",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) < 2 {
-				return fmt.Errorf("mount takes 2 args.")
+				return fmt.Errorf("mount takes 2 args")
 			}
 			return mount(args[0], args[1])
 		},
@@ -157,7 +157,7 @@ var (
 		Long:  "Flex volume unmount command.",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("unmount takes 1 args.")
+				return fmt.Errorf("unmount takes 1 args")
 			}
 			return unmount(args[0])
 		},
@@ -222,7 +222,7 @@ func doMount(destinationDir string, ninputs *creds.Credentials, workloadPath str
 	cmdMount := exec.Command("/bin/mount", "-t", "tmpfs", "-o", "size=8K", "tmpfs", destinationDir)
 	err = cmdMount.Run()
 	if err != nil {
-		os.RemoveAll(newDir)
+		_ = os.RemoveAll(newDir)
 		return err
 	}
 
@@ -468,7 +468,7 @@ func initConfiguration() {
 	}
 
 	// Convert to absolute paths.
-	var prefix string = ""
+	prefix := ""
 	if !strings.HasPrefix(config.NodeAgentWorkloadHomeDir, "/") {
 		prefix = "/"
 	}
@@ -495,7 +495,7 @@ func main() {
 	var err error
 	logWriter, err = syslog.New(syslog.LOG_WARNING|syslog.LOG_DAEMON, SYSLOGTAG)
 	if err == nil {
-		defer logWriter.Close()
+		defer func() { _ = logWriter.Close() }()
 	}
 
 	initConfiguration()


### PR DESCRIPTION
## Description

This changeset fixes static check issues in the pod2daemon component reported by golangci-lint v2.4.0.

## Related issues/PRs

Prepare for https://github.com/projectcalico/calico/pull/10924.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
