### PR TITLE
[WIP]Added e2e test images and build targets

### DIFF
--- a/.semaphore/push-images/e2e-test.yml
+++ b/.semaphore/push-images/e2e-test.yml
@@ -1,0 +1,27 @@
+version: v1.0
+name: Publish e2e test images
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+
+execution_time_limit:
+  minutes: 30
+
+global_job_config:
+  secrets:
+    - name: k8s-e2e-push
+  prologue:
+    commands:
+      - checkout
+
+blocks:
+  - name: Publish e2e test utility images
+    dependencies: []
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C e2e publish-test-images CONFIRM=true; fi

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -80,3 +80,7 @@ promotions:
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  - name: Push E2E images
+    pipeline_file: push-images/e2e-test.yml
+    auto_promote:
+      when: "branch =~ 'master|release-'"

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,7 +3,10 @@ include ../metadata.mk
 PACKAGE_NAME=github.com/projectcalico/calico/e2e
 include ../lib.Makefile
 
-SRC_FILES=$(shell find . -name '*.go')
+QUAY_REGISTRY ?= quay.io/tigeradev
+TAG_NAME ?= $(shell git branch --show-current)
+
+SRC_FILES=$(shell find pkg -name '*.go')
 build: bin/k8s/e2e.test bin/adminpolicy/e2e.test $(SRC_FILES)
 bin/k8s/e2e.test: $(SRC_FILES)
 	mkdir -p bin
@@ -12,6 +15,30 @@ bin/k8s/e2e.test: $(SRC_FILES)
 bin/adminpolicy/e2e.test: $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/adminpolicy -c -o $@
+
+bin/rapidclient: images/rapidclient/main.go
+	mkdir -p bin
+	$(DOCKER_RUN) -e CGO_ENABLED=0 $(CALICO_BUILD) go build -o $@ -ldflags "-s -w" ./images/rapidclient
+
+###############################################################################
+# test images
+###############################################################################
+test-images: bin/rapidclient
+	docker buildx build --load --platform=linux/$(ARCH) --pull \
+		--build-arg BINARY_PATH=bin/rapidclient \
+		-f images/rapidclient/Dockerfile \
+		-t $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) .
+	@if [ "$(TAG_NAME)" = "master" ]; then \
+		docker tag $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME) $(QUAY_REGISTRY)/rapidclient:latest; \
+		echo "Tagged $(QUAY_REGISTRY)/rapidclient:latest"; \
+	fi
+
+publish-test-images: test-images
+	docker push $(QUAY_REGISTRY)/rapidclient:$(TAG_NAME)
+	@if [ "$(TAG_NAME)" = "master" ]; then \
+		docker push $(QUAY_REGISTRY)/rapidclient:latest; \
+		echo "Pushed $(QUAY_REGISTRY)/rapidclient:latest"; \
+	fi
 
 clean:
 	rm -rf bin/

--- a/e2e/images/rapidclient/Dockerfile
+++ b/e2e/images/rapidclient/Dockerfile
@@ -1,0 +1,7 @@
+FROM scratch
+
+ARG BINARY_PATH=rapidclient
+
+COPY ${BINARY_PATH} /rapidclient
+
+ENTRYPOINT ["/rapidclient"]

--- a/e2e/images/rapidclient/README.md
+++ b/e2e/images/rapidclient/README.md
@@ -1,0 +1,97 @@
+# RapidClient
+
+A simple HTTP client tool that forces source port reuse by bypassing TIME_WAIT state, designed for testing Maglev consistent hashing and load balancer behavior.
+
+## Features
+
+- **Source Port Reuse**: Forces connections to use a specific source port, bypassing TIME_WAIT
+- **New TCP Connection**: Each call establishes a fresh TCP connection (no connection reuse)
+- **Socket Options**: Sets SO_REUSEADDR for rapid port reuse
+- **Simple Output**: Sends a single request and prints the raw response
+- **Configurable**: Command-line options for URL, source port, and timeout
+
+## Usage
+
+### Docker Run
+```bash
+# Basic Docker usage with host networking
+docker run --rm --network host rapidclient:latest -url "http://10.103.218.83:8080/shell?cmd=hostname"
+
+# With verbose output
+docker run --rm --network host rapidclient:latest -url "http://10.103.218.83:8080/shell?cmd=hostname" -v
+
+# With custom source port
+docker run --rm --network host rapidclient:latest -url "http://10.103.218.83:8080/shell?cmd=hostname" -port 54321
+
+# With custom timeout
+docker run --rm --network host rapidclient:latest -url "http://10.103.218.83:8080/shell?cmd=hostname" -timeout 10s
+```
+
+### Basic Usage
+```bash
+# Send a single request to a service
+./rapidclient -url "http://10.96.0.1:8080/shell?cmd=hostname"
+
+# Use a specific source port
+./rapidclient -url "http://10.96.0.1:8080/shell?cmd=hostname" -port 12345
+
+# Verbose output with status information
+./rapidclient -url "http://10.96.0.1:8080/shell?cmd=hostname" -v
+```
+
+### Command Line Options
+
+- `-url string`: Target URL to send request to (required)
+- `-port int`: Source port to use for connection (default: 12345)
+- `-timeout duration`: Request timeout (default: 30s)
+- `-v`: Verbose logging (shows status and debug info)
+
+### Examples
+
+```bash
+# Test Maglev load balancing with consistent source port
+./rapidclient -url "http://service-ip:8080/shell?cmd=hostname" -port 12345
+
+# Test with custom timeout
+./rapidclient -url "http://service-ip:8080/api/health" -timeout 10s
+
+# Verbose mode for debugging
+./rapidclient -url "http://service-ip:8080/shell?cmd=hostname" -port 12345 -v
+```
+
+## Technical Details
+
+- Uses `SO_REUSEADDR` socket option to allow rapid port reuse
+- Disables HTTP keep-alive to force new connections
+- Custom dialer with specific source port binding
+- Handles both IPv4 and IPv6 connections
+
+## Output
+
+### Normal Mode
+```bash
+$ ./rapidclient -url "http://10.96.0.1:8080/shell?cmd=hostname"
+{"output":"backend-pod-5\n"}
+```
+
+### Verbose Mode
+```bash
+$ ./rapidclient -url "http://10.96.0.1:8080/shell?cmd=hostname" -v
+2025/09/04 10:30:00 Sending request to: http://10.96.0.1:8080/shell?cmd=hostname
+2025/09/04 10:30:00 Using source port: 12345
+2025/09/04 10:30:00 Timeout: 30s
+Status: 200 OK
+Response: {"output":"backend-pod-5\n"}
+```
+
+## Integration with Tests
+
+This tool can replace curl commands in tests for better reliability:
+
+```bash
+# Instead of:
+curl --local-port 12345 -s http://service:8080/shell?cmd=hostname
+
+# Use:
+./rapidclient -url "http://service:8080/shell?cmd=hostname" -port 12345
+```

--- a/e2e/images/rapidclient/main.go
+++ b/e2e/images/rapidclient/main.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+func main() {
+	// Command line flags
+	var (
+		targetURL  = flag.String("url", "", "Target URL to send request to (required)")
+		sourcePort = flag.Int("port", 12345, "Source port to use for connection")
+		timeout    = flag.Duration("timeout", 30*time.Second, "Request timeout")
+		verbose    = flag.Bool("v", false, "Verbose logging")
+	)
+	flag.Parse()
+
+	if *targetURL == "" {
+		fmt.Fprintf(os.Stderr, "Error: -url is required\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *verbose {
+		log.Printf("Sending request to: %s", *targetURL)
+		log.Printf("Using source port: %d", *sourcePort)
+		log.Printf("Timeout: %v", *timeout)
+	}
+
+	client := createRapidClient(*sourcePort, *timeout)
+
+	// Send a single request
+	resp, err := client.Get(*targetURL)
+	if err != nil {
+		log.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read and print the response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Failed to read response: %v", err)
+	}
+
+	if *verbose {
+		fmt.Printf("Status: %s\n", resp.Status)
+		fmt.Printf("Response: %s", string(body))
+	} else {
+		// Just print the raw response body
+		fmt.Print(string(body))
+	}
+}
+
+// createRapidClient creates an HTTP client configured for rapid connections with source port reuse
+func createRapidClient(sourcePort int, timeout time.Duration) *http.Client {
+	// 1. Create a custom dialer function
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 0, // Disable keep-alive to force new connections
+		// Control function to set socket options before connection
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				// Set SO_REUSEADDR to allow reusing the port more quickly
+				err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+				if err != nil {
+					log.Printf("Warning: Failed to set SO_REUSEADDR: %v", err)
+				}
+			})
+		},
+	}
+
+	// 2. Define the local address and port to use for every outgoing connection
+	localAddr := &net.TCPAddr{
+		IP:   net.ParseIP("0.0.0.0"), // Bind to all local IPs
+		Port: sourcePort,             // Use the specified source port
+	}
+	dialer.LocalAddr = localAddr
+
+	// 3. Create an HTTP client that uses the custom dialer
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext:           dialer.DialContext,
+			DisableKeepAlives:     true,             // Force new connections
+			MaxIdleConnsPerHost:   0,                // No connection pooling
+			IdleConnTimeout:       1 * time.Second,  // Short idle timeout
+			TLSHandshakeTimeout:   10 * time.Second, // TLS timeout
+			ExpectContinueTimeout: 1 * time.Second,  // Expect 100-continue timeout
+		},
+	}
+
+	return client
+}

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -25,6 +25,7 @@ const (
 	Porter        = "calico/porter"
 	TestWebserver = "gcr.io/kubernetes-e2e-test-images/test-webserver:1.0"
 	Iperf         = "registry.k8s.io/e2e-test-images/agnhost:2.47"
+	RapidClient   = "quay.io/tigeradev/rapidclient"
 )
 
 // Get client image and powershell command based on windows OS version


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR adds infrastructure for building and publishing E2E test images, specifically introducing a RapidClient utility for network testing scenarios.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note

```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
