### PR TITLE
Fix cni-plugin static checks

### DIFF
--- a/cni-plugin/internal/pkg/azure/azure_test.go
+++ b/cni-plugin/internal/pkg/azure/azure_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Azure Endpoint/Network tests", func() {
 
 	AfterEach(func() {
 		// Delete the test networks directory created by the test.
-		os.RemoveAll("./network")
+		_ = os.RemoveAll("./network")
 	})
 
 	It("should store and load networks and endpoints", func() {

--- a/cni-plugin/internal/pkg/testutils/utils.go
+++ b/cni-plugin/internal/pkg/testutils/utils.go
@@ -75,9 +75,9 @@ func MustCreateNewIPPool(c client.Interface, cidr string, ipip, natOutgoing, ipa
 
 // MustCreateNewIPPoolBlockSize creates a new Calico IPAM IP Pool with support for setting the block size.
 func MustCreateNewIPPoolBlockSize(c client.Interface, cidr string, ipip, natOutgoing, ipam bool, blockSize int) string {
-	name := strings.Replace(cidr, ".", "-", -1)
-	name = strings.Replace(name, ":", "-", -1)
-	name = strings.Replace(name, "/", "-", -1)
+	name := strings.ReplaceAll(cidr, ".", "-")
+	name = strings.ReplaceAll(name, ":", "-")
+	name = strings.ReplaceAll(name, "/", "-")
 	var mode api.IPIPMode
 	if ipip {
 		mode = api.IPIPModeAlways
@@ -101,9 +101,9 @@ func MustCreateNewIPPoolBlockSize(c client.Interface, cidr string, ipip, natOutg
 }
 
 func MustDeleteIPPool(c client.Interface, cidr string) {
-	name := strings.Replace(cidr, ".", "-", -1)
-	name = strings.Replace(name, ":", "-", -1)
-	name = strings.Replace(name, "/", "-", -1)
+	name := strings.ReplaceAll(cidr, ".", "-")
+	name = strings.ReplaceAll(name, ":", "-")
+	name = strings.ReplaceAll(name, "/", "-")
 
 	_, err := c.IPPools().Delete(context.Background(), name, options.DeleteOptions{})
 	if err != nil {

--- a/cni-plugin/internal/pkg/testutils/utils_linux.go
+++ b/cni-plugin/internal/pkg/testutils/utils_linux.go
@@ -429,7 +429,7 @@ func DeleteContainerWithIdAndIfaceName(netconf, netnspath, podName, podNamespace
 }
 
 func Cmd(cmd string) string {
-	_, _ = ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Running command [%s]\n", cmd)))
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Running command [%s]\n", cmd)
 	out, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		_, writeErr := ginkgo.GinkgoWriter.Write(out)

--- a/cni-plugin/internal/pkg/utils/utils.go
+++ b/cni-plugin/internal/pkg/utils/utils.go
@@ -206,7 +206,8 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
 		"type": conf.IPAM.Type}).Debug("Looking for IPAM plugin in paths")
 
 	var ae *azure.AzureEndpoint
-	if conf.IPAM.Type == "host-local" {
+	switch conf.IPAM.Type {
+	case "host-local":
 		// We need to replace "usePodCidr" with a valid, but dummy podCidr string with "host-local" IPAM.
 		// host-local IPAM releases the IP by ContainerID, so podCidr isn't really used to release the IP.
 		// It just needs a valid CIDR, but it doesn't have to be the CIDR associated with the host.
@@ -233,7 +234,7 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
 			return err
 		}
 		logger.Debug("Updated stdin data for Delete Cmd")
-	} else if conf.IPAM.Type == "azure-vnet-ipam" {
+	case "azure-vnet-ipam":
 		// The azure-vnet-ipam plugin expects two values to be passed in the CNI config in order to
 		// successfully clean up: ipAddress and subnet. Populate these based on data stored to disk.
 		logger.Info("Configured to use Azure IPAM, load network and endpoint")
@@ -434,7 +435,7 @@ func validateStartRange(startRange net.IP, expStartRange net.IP) (net.IP, error)
 	startRange = startRange.To4()
 	expStartRange = expStartRange.To4()
 	if startRange == nil || expStartRange == nil {
-		return nil, fmt.Errorf("Invalid ip address")
+		return nil, fmt.Errorf("invalid ip address")
 	}
 	if bytes.Compare([]byte(startRange), []byte(expStartRange)) < 0 {
 		// if ip is not in given range,return default
@@ -449,7 +450,7 @@ func validateEndRange(endRange net.IP, expEndRange net.IP) (net.IP, error) {
 	endRange = endRange.To4()
 	expEndRange = expEndRange.To4()
 	if endRange == nil || expEndRange == nil {
-		return nil, fmt.Errorf("Invalid ip address")
+		return nil, fmt.Errorf("invalid ip address")
 	}
 	if bytes.Compare([]byte(endRange), []byte(expEndRange)) > 0 {
 		// if ip is not in given range,return default
@@ -483,7 +484,7 @@ func validateRangeOrSetDefault(rangeData string, expRange string, ipnet *net.IPN
 		}
 	}
 	// return default range
-	return expRangeIP.IP.String(), nil
+	return expRangeIP.String(), nil
 
 }
 
@@ -510,7 +511,7 @@ func SanitizeMesosLabel(s string) string {
 	trailingLeadingDotsDashes := regexp.MustCompile("^[.-]*(.*?)[.-]*$")
 
 	// -  Convert [/] to .
-	s = strings.Replace(s, "/", ".", -1)
+	s = strings.ReplaceAll(s, "/", ".")
 
 	// -  Convert any other invalid chars
 	s = invalidChar.ReplaceAllString(s, "-")

--- a/cni-plugin/internal/pkg/utils/utils_test.go
+++ b/cni-plugin/internal/pkg/utils/utils_test.go
@@ -46,11 +46,11 @@ var _ = Describe("MTUFromFile", func() {
 		// Create a temporary file with a valid MTU value
 		file, err := os.CreateTemp("", "mtu_test")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(file.Name())
+		defer func() { _ = os.Remove(file.Name()) }()
 
 		_, err = file.WriteString("1500")
 		Expect(err).NotTo(HaveOccurred())
-		file.Close()
+		_ = file.Close()
 
 		// Call the function and check the result
 		mtu, err := utils.MTUFromFile(file.Name(), types.NetConf{})
@@ -73,11 +73,11 @@ var _ = Describe("MTUFromFile", func() {
 			// Create a temporary file with invalid permissions
 			file, err := os.CreateTemp("", "mtu_test")
 			Expect(err).NotTo(HaveOccurred())
-			defer os.Remove(file.Name())
+			defer func() { _ = os.Remove(file.Name()) }()
 
 			err = os.Chmod(file.Name(), 0o000) // Remove all permissions
 			Expect(err).NotTo(HaveOccurred())
-			file.Close()
+			_ = file.Close()
 
 			// Call the function and check the result
 			_, err = utils.MTUFromFile(file.Name(), types.NetConf{})

--- a/cni-plugin/internal/pkg/utils/winpol/windows_policy.go
+++ b/cni-plugin/internal/pkg/utils/winpol/windows_policy.go
@@ -154,7 +154,7 @@ func convertToHcnEndpointPolicy(policy map[string]interface{}) (hcn.EndpointPoli
 	// Get v2 policy type.
 	policyType, ok := policy["Type"].(string)
 	if !ok {
-		return hcnPolicy, fmt.Errorf("Invalid HNS V2 endpoint policy type: %v", policy["Type"])
+		return hcnPolicy, fmt.Errorf("invalid HNS V2 endpoint policy type: %v", policy["Type"])
 	}
 
 	// Remove the Type key from the map, leaving just the policy settings
@@ -162,7 +162,7 @@ func convertToHcnEndpointPolicy(policy map[string]interface{}) (hcn.EndpointPoli
 	delete(policy, "Type")
 	policySettings, err := json.Marshal(policy)
 	if err != nil {
-		return hcnPolicy, fmt.Errorf("Failed to marshal policy settings.")
+		return hcnPolicy, fmt.Errorf("failed to marshal policy settings")
 	}
 	hcnPolicy.Type = hcn.EndpointPolicyType(policyType)
 	hcnPolicy.Settings = json.RawMessage(policySettings)

--- a/cni-plugin/pkg/dataplane/dataplane.go
+++ b/cni-plugin/pkg/dataplane/dataplane.go
@@ -54,6 +54,6 @@ func GetDataplane(conf types.NetConf, logger *logrus.Entry) (Dataplane, error) {
 	case "grpc":
 		return grpc.NewGrpcDataplane(conf, logger)
 	default:
-		return nil, fmt.Errorf("Invalid dataplane type: %s", name)
+		return nil, fmt.Errorf("invalid dataplane type: %s", name)
 	}
 }

--- a/cni-plugin/pkg/dataplane/grpc/test_server_linux.go
+++ b/cni-plugin/pkg/dataplane/grpc/test_server_linux.go
@@ -97,7 +97,7 @@ func (s *TestServer) SetResult(r bool) {
 
 func (s *TestServer) GracefulStop() {
 	s.grpcServer.GracefulStop()
-	s.lis.Close()
+	_ = s.lis.Close()
 }
 
 func (s *TestServer) startServer() {

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -294,7 +294,7 @@ func Install(version string) error {
 
 		<-done
 
-		watcher.Close()
+		_ = watcher.Close()
 	}
 	return nil
 }
@@ -340,47 +340,47 @@ func writeCNIConfig(c config) {
 	netconf = replacePlatformSpecificVars(c, netconf)
 
 	// Perform replacements of variables.
-	netconf = strings.Replace(netconf, "__LOG_LEVEL__", getEnv("LOG_LEVEL", "info"), -1)
-	netconf = strings.Replace(netconf, "__LOG_FILE_PATH__", getEnv("LOG_FILE_PATH", "/var/log/calico/cni/cni.log"), -1)
-	netconf = strings.Replace(netconf, "__LOG_FILE_MAX_SIZE__", getEnv("LOG_FILE_MAX_SIZE", "100"), -1)
-	netconf = strings.Replace(netconf, "__LOG_FILE_MAX_AGE__", getEnv("LOG_FILE_MAX_AGE", "30"), -1)
-	netconf = strings.Replace(netconf, "__LOG_FILE_MAX_COUNT__", getEnv("LOG_FILE_MAX_COUNT", "10"), -1)
-	netconf = strings.Replace(netconf, "__DATASTORE_TYPE__", getEnv("DATASTORE_TYPE", "kubernetes"), -1)
-	netconf = strings.Replace(netconf, "__KUBERNETES_NODE_NAME__", getEnv("KUBERNETES_NODE_NAME", nodename), -1)
-	netconf = strings.Replace(netconf, "__KUBECONFIG_FILEPATH__", kubeconfigPath, -1)
-	netconf = strings.Replace(netconf, "__CNI_MTU__", getEnv("CNI_MTU", "1500"), -1)
+	netconf = strings.ReplaceAll(netconf, "__LOG_LEVEL__", getEnv("LOG_LEVEL", "info"))
+	netconf = strings.ReplaceAll(netconf, "__LOG_FILE_PATH__", getEnv("LOG_FILE_PATH", "/var/log/calico/cni/cni.log"))
+	netconf = strings.ReplaceAll(netconf, "__LOG_FILE_MAX_SIZE__", getEnv("LOG_FILE_MAX_SIZE", "100"))
+	netconf = strings.ReplaceAll(netconf, "__LOG_FILE_MAX_AGE__", getEnv("LOG_FILE_MAX_AGE", "30"))
+	netconf = strings.ReplaceAll(netconf, "__LOG_FILE_MAX_COUNT__", getEnv("LOG_FILE_MAX_COUNT", "10"))
+	netconf = strings.ReplaceAll(netconf, "__DATASTORE_TYPE__", getEnv("DATASTORE_TYPE", "kubernetes"))
+	netconf = strings.ReplaceAll(netconf, "__KUBERNETES_NODE_NAME__", getEnv("KUBERNETES_NODE_NAME", nodename))
+	netconf = strings.ReplaceAll(netconf, "__KUBECONFIG_FILEPATH__", kubeconfigPath)
+	netconf = strings.ReplaceAll(netconf, "__CNI_MTU__", getEnv("CNI_MTU", "1500"))
 
-	netconf = strings.Replace(netconf, "__KUBERNETES_SERVICE_HOST__", getEnv("KUBERNETES_SERVICE_HOST", ""), -1)
-	netconf = strings.Replace(netconf, "__KUBERNETES_SERVICE_PORT__", getEnv("KUBERNETES_SERVICE_PORT", ""), -1)
+	netconf = strings.ReplaceAll(netconf, "__KUBERNETES_SERVICE_HOST__", getEnv("KUBERNETES_SERVICE_HOST", ""))
+	netconf = strings.ReplaceAll(netconf, "__KUBERNETES_SERVICE_PORT__", getEnv("KUBERNETES_SERVICE_PORT", ""))
 
-	netconf = strings.Replace(netconf, "__SERVICEACCOUNT_TOKEN__", string(c.ServiceAccountToken), -1)
+	netconf = strings.ReplaceAll(netconf, "__SERVICEACCOUNT_TOKEN__", string(c.ServiceAccountToken))
 
 	// Replace etcd datastore variables.
 	hostSecretsDir := c.CNINetDir + "/calico-tls"
 	if fileExists(winutils.GetHostPath("/host/etc/cni/net.d/calico-tls/etcd-cert")) {
 		etcdCertFile := fmt.Sprintf("%s/etcd-cert", hostSecretsDir)
-		netconf = strings.Replace(netconf, "__ETCD_CERT_FILE__", etcdCertFile, -1)
+		netconf = strings.ReplaceAll(netconf, "__ETCD_CERT_FILE__", etcdCertFile)
 	} else {
-		netconf = strings.Replace(netconf, "__ETCD_CERT_FILE__", "", -1)
+		netconf = strings.ReplaceAll(netconf, "__ETCD_CERT_FILE__", "")
 	}
 
 	if fileExists(winutils.GetHostPath("/host/etc/cni/net.d/calico-tls/etcd-ca")) {
 		etcdCACertFile := fmt.Sprintf("%s/etcd-ca", hostSecretsDir)
-		netconf = strings.Replace(netconf, "__ETCD_CA_CERT_FILE__", etcdCACertFile, -1)
+		netconf = strings.ReplaceAll(netconf, "__ETCD_CA_CERT_FILE__", etcdCACertFile)
 	} else {
-		netconf = strings.Replace(netconf, "__ETCD_CA_CERT_FILE__", "", -1)
+		netconf = strings.ReplaceAll(netconf, "__ETCD_CA_CERT_FILE__", "")
 	}
 
 	if fileExists(winutils.GetHostPath("/host/etc/cni/net.d/calico-tls/etcd-key")) {
 		etcdKeyFile := fmt.Sprintf("%s/etcd-key", hostSecretsDir)
-		netconf = strings.Replace(netconf, "__ETCD_KEY_FILE__", etcdKeyFile, -1)
+		netconf = strings.ReplaceAll(netconf, "__ETCD_KEY_FILE__", etcdKeyFile)
 	} else {
-		netconf = strings.Replace(netconf, "__ETCD_KEY_FILE__", "", -1)
+		netconf = strings.ReplaceAll(netconf, "__ETCD_KEY_FILE__", "")
 	}
-	netconf = strings.Replace(netconf, "__ETCD_ENDPOINTS__", getEnv("ETCD_ENDPOINTS", ""), -1)
-	netconf = strings.Replace(netconf, "__ETCD_DISCOVERY_SRV__", getEnv("ETCD_DISCOVERY_SRV", ""), -1)
+	netconf = strings.ReplaceAll(netconf, "__ETCD_ENDPOINTS__", getEnv("ETCD_ENDPOINTS", ""))
+	netconf = strings.ReplaceAll(netconf, "__ETCD_DISCOVERY_SRV__", getEnv("ETCD_DISCOVERY_SRV", ""))
 
-	netconf = strings.Replace(netconf, "__REQUIRE_MTU_FILE__", getEnv("REQUIRE_MTU_FILE", "false"), -1)
+	netconf = strings.ReplaceAll(netconf, "__REQUIRE_MTU_FILE__", getEnv("REQUIRE_MTU_FILE", "false"))
 
 	err = isValidJSON(netconf)
 	if err != nil {
@@ -501,16 +501,16 @@ current-context: calico-context`
 		logrus.WithError(err).Fatal("Unable to create token for CNI kubeconfig")
 	}
 	data = strings.Replace(data, "TOKEN", tu.Token, 1)
-	data = strings.Replace(data, "__KUBERNETES_SERVICE_PROTOCOL__", getEnv("KUBERNETES_SERVICE_PROTOCOL", "https"), -1)
-	data = strings.Replace(data, "__KUBERNETES_SERVICE_HOST__", getEnv("KUBERNETES_SERVICE_HOST", ""), -1)
-	data = strings.Replace(data, "__KUBERNETES_SERVICE_PORT__", getEnv("KUBERNETES_SERVICE_PORT", ""), -1)
+	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_PROTOCOL__", getEnv("KUBERNETES_SERVICE_PROTOCOL", "https"))
+	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_HOST__", getEnv("KUBERNETES_SERVICE_HOST", ""))
+	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_PORT__", getEnv("KUBERNETES_SERVICE_PORT", ""))
 
 	skipTLSVerify := os.Getenv("SKIP_TLS_VERIFY")
 	if skipTLSVerify == "true" {
-		data = strings.Replace(data, "__TLS_CFG__", "insecure-skip-tls-verify: true", -1)
+		data = strings.ReplaceAll(data, "__TLS_CFG__", "insecure-skip-tls-verify: true")
 	} else {
 		ca := "certificate-authority-data: " + base64.StdEncoding.EncodeToString(kubecfg.CAData)
-		data = strings.Replace(data, "__TLS_CFG__", ca, -1)
+		data = strings.ReplaceAll(data, "__TLS_CFG__", ca)
 	}
 
 	if err := os.WriteFile(winutils.GetHostPath("/host/etc/cni/net.d/calico-kubeconfig"), []byte(data), 0o600); err != nil {
@@ -555,13 +555,13 @@ func destinationUptoDate(src, dst string) (bool, error) {
 	if err != nil {
 		logrus.Fatal(err)
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 
 	f2, err := os.Open(dst)
 	if err != nil {
 		logrus.Fatal(err)
 	}
-	defer f2.Close()
+	defer func() { _ = f2.Close() }()
 
 	// Create a buffer, which we'll use to read both files.
 	buf := make([]byte, 64000)

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -237,7 +237,7 @@ PuB/TL+u2y+iQUyXxLy3
 
 	AfterEach(func() {
 		// Cleanup temp directory
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 		// Cleanup calico-node service account
 		err := createKubernetesClient().CoreV1().ServiceAccounts("kube-system").Delete(context.Background(), "calico-cni-plugin", metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -417,7 +417,7 @@ var _ = Describe("file comparison tests", func() {
 
 	AfterEach(func() {
 		// Cleanup temp directory
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	})
 
 	It("should compare two equal files", func() {

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -86,7 +86,8 @@ func testConnection() error {
 	}
 	if !*ci.Spec.DatastoreReady {
 		logrus.Info("Upgrade may be in progress, ready flag is not set")
-		return fmt.Errorf("Calico is currently not ready to process requests")
+		//nolint:staticcheck // Ignore ST1005: error strings should not be capitalized
+		return errors.New("Calico is currently not ready to process requests")
 	}
 
 	// If we have a kubeconfig, test connection to the APIServer
@@ -123,7 +124,7 @@ func isEndpointReady(readyEndpoint string, timeout time.Duration) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return false, fmt.Errorf("endpoint is not ready, response code returned:%d", resp.StatusCode)
 	}
@@ -231,7 +232,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	}
 	if !*ci.Spec.DatastoreReady {
 		logrus.Info("Upgrade may be in progress, ready flag is not set")
-		err = fmt.Errorf("Calico is currently not ready to process requests")
+		//nolint:staticcheck // Ignore ST1005: error strings should not be capitalized
+		err = errors.New("Calico is currently not ready to process requests")
 		return
 	}
 
@@ -322,7 +324,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		logger.Debugf("List of WorkloadEndpoints %v", endpoints.Items)
 		for _, ep := range endpoints.Items {
 			var match bool
-			match, err = wepIDs.WorkloadEndpointIdentifiers.NameMatches(ep.Name)
+			match, err = wepIDs.NameMatches(ep.Name)
 			if err != nil {
 				// We should never hit this error, because it should have already been
 				// caught by CalculateWorkloadEndpointName.
@@ -654,7 +656,8 @@ func cmdDel(args *skel.CmdArgs) (err error) {
 	}
 	if !*ci.Spec.DatastoreReady {
 		logrus.Info("Upgrade may be in progress, ready flag is not set")
-		err = fmt.Errorf("Calico is currently not ready to process requests")
+		//nolint:staticcheck // Ignore ST1005: error strings should not be capitalized
+		err = errors.New("Calico is currently not ready to process requests")
 		return
 	}
 
@@ -739,7 +742,7 @@ func Main(version string) {
 			Msg:     "failed to parse CLI flags",
 			Details: err.Error(),
 		}
-		cniError.Print()
+		_ = cniError.Print()
 		os.Exit(1)
 	}
 	if *versionFlag {
@@ -757,7 +760,7 @@ func Main(version string) {
 			Msg:     "data store connection failed",
 			Details: err.Error(),
 		}
-		cniError.Print()
+		_ = cniError.Print()
 		os.Exit(1)
 	}
 
@@ -768,7 +771,7 @@ func Main(version string) {
 			Msg:     "failed to set IgnoreUnknown=1",
 			Details: err.Error(),
 		}
-		cniError.Print()
+		_ = cniError.Print()
 		os.Exit(1)
 	}
 

--- a/cni-plugin/tests/calico_cni_test.go
+++ b/cni-plugin/tests/calico_cni_test.go
@@ -895,7 +895,7 @@ var _ = Describe("CalicoCni", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			go func() {
-				defer stdin.Close()
+				defer func() { _ = stdin.Close() }()
 				_, _ = io.WriteString(stdin, netconf)
 			}()
 
@@ -926,7 +926,7 @@ var _ = Describe("CalicoCni", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			go func() {
-				defer stdin.Close()
+				defer func() { _ = stdin.Close() }()
 				_, _ = io.WriteString(stdin, netconf)
 			}()
 


### PR DESCRIPTION
## Description

This changeset fixes static check issues in the cni-plugin component reported by golangci-lint v2.4.0.

## Related issues/PRs

Prepare for https://github.com/projectcalico/calico/pull/10924.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
