### PR TITLE
Fix guardian static checks

### DIFF
--- a/guardian/pkg/conn/forward_test.go
+++ b/guardian/pkg/conn/forward_test.go
@@ -24,11 +24,11 @@ func TestForwardConnections(t *testing.T) {
 		t.Log("Creating two localhost listeners")
 		lst1, err := net.Listen("tcp", "localhost:0")
 		Expect(err).ShouldNot(HaveOccurred())
-		defer lst1.Close()
+		defer func() { _ = lst1.Close() }()
 
 		lst2, err := net.Listen("tcp", "localhost:0")
 		Expect(err).ShouldNot(HaveOccurred())
-		defer lst2.Close()
+		defer func() { _ = lst2.Close() }()
 
 		var wg sync.WaitGroup
 		wg.Add(1)

--- a/guardian/pkg/server/proxy_test.go
+++ b/guardian/pkg/server/proxy_test.go
@@ -81,15 +81,15 @@ func TestProxy(t *testing.T) {
 
 		mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte(fmt.Sprintf("Hello from HTTPS, with expected URL %s", r.URL.Path)))
+			_, err := fmt.Fprintf(w, "Hello from HTTPS, with expected URL %s", r.URL.Path)
 			Expect(err).NotTo(HaveOccurred())
 		}))
 
 		tmpDir := os.TempDir()
 
 		serverCrt, serverKey := utils.CreateKeyCertPair(tmpDir)
-		defer serverCrt.Close()
-		defer serverKey.Close()
+		defer func() { _ = serverCrt.Close() }()
+		defer func() { _ = serverKey.Close() }()
 
 		cert, err := tls.LoadX509KeyPair(serverCrt.Name(), serverKey.Name())
 		if err != nil {

--- a/guardian/pkg/tunnel/dial.go
+++ b/guardian/pkg/tunnel/dial.go
@@ -205,7 +205,7 @@ func tlsDialViaHTTPProxy(d *net.Dialer, destination string, proxyTargetURL *url.
 	// Negotiate mTLS on top of our passthrough connection.
 	mtlsC := tls.Client(c, tunnelTLS)
 	if err := mtlsC.HandshakeContext(context.Background()); err != nil {
-		mtlsC.Close()
+		_ = mtlsC.Close()
 		return nil, err
 	}
 	return mtlsC, nil

--- a/guardian/pkg/tunnel/dial_test.go
+++ b/guardian/pkg/tunnel/dial_test.go
@@ -20,17 +20,17 @@ func handleConnection(t *testing.T, listener net.Listener) {
 	conn, err := listener.Accept()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(conn).NotTo(BeNil())
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	t.Log("Accepted connection from client")
 
 	// Create a yamux server session
 	session, err := yamux.Server(conn, nil)
 	Expect(err).NotTo(HaveOccurred())
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	stream, err := session.Accept()
 	Expect(err).NotTo(HaveOccurred())
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	buf := make([]byte, 1024)
 	n, err := stream.Read(buf)
@@ -50,7 +50,7 @@ func TestDial(t *testing.T) {
 	t.Run("Dial Plain TCP", func(t *testing.T) {
 		listener, err := net.Listen("tcp", address)
 		Expect(err).NotTo(HaveOccurred())
-		defer listener.Close()
+		defer func() { _ = listener.Close() }()
 
 		go func() {
 			handleConnection(t, listener)
@@ -66,8 +66,8 @@ func TestDial(t *testing.T) {
 		tmpDir := os.TempDir()
 
 		serverCrt, serverKey := utils.CreateKeyCertPair(tmpDir)
-		defer serverCrt.Close()
-		defer serverKey.Close()
+		defer func() { _ = serverCrt.Close() }()
+		defer func() { _ = serverKey.Close() }()
 
 		cert, err := tls.LoadX509KeyPair(serverCrt.Name(), serverKey.Name())
 		if err != nil {
@@ -76,7 +76,7 @@ func TestDial(t *testing.T) {
 
 		listener, err := tls.Listen("tcp", address, &tls.Config{Certificates: []tls.Certificate{cert}})
 		Expect(err).NotTo(HaveOccurred())
-		defer listener.Close()
+		defer func() { _ = listener.Close() }()
 
 		go func() {
 			handleConnection(t, listener)

--- a/guardian/test/utils/util.go
+++ b/guardian/test/utils/util.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
 )
 
@@ -47,11 +48,11 @@ func CreateKeyCertPair(dir string) (*os.File, *os.File) {
 	// Write the certificate and key to temporary files
 	certFile, err := os.CreateTemp(dir, "cert.pem")
 	Expect(err).ShouldNot(HaveOccurred())
-	defer certFile.Close()
+	defer func() { _ = certFile.Close() }()
 
 	keyFile, err := os.CreateTemp(dir, "key.pem")
 	Expect(err).ShouldNot(HaveOccurred())
-	defer keyFile.Close()
+	defer func() { _ = keyFile.Close() }()
 
 	_, err = certFile.Write(certPEM)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/guardian/tests/fv/fv_test.go
+++ b/guardian/tests/fv/fv_test.go
@@ -36,11 +36,11 @@ func TestRequestsFromGuardianToUpstream(t *testing.T) {
 
 	mgmtCertFile, err := os.Create(tmpDir + "/" + "management-cluster.crt")
 	Expect(err).ShouldNot(HaveOccurred())
-	defer mgmtCertFile.Close()
+	defer func() { _ = mgmtCertFile.Close() }()
 
 	mgmtKeyFile, err := os.Create(tmpDir + "/" + "management-cluster.key")
 	Expect(err).ShouldNot(HaveOccurred())
-	defer mgmtKeyFile.Close()
+	defer func() { _ = mgmtKeyFile.Close() }()
 
 	ca, err := cryptoutils.NewCA("test")
 	Expect(err).ShouldNot(HaveOccurred())
@@ -87,7 +87,7 @@ func TestRequestsFromGuardianToUpstream(t *testing.T) {
 	tlsCfg := getTLSConfig(mgmtCertFile.Name(), mgmtKeyFile.Name())
 
 	upstreamSrv := newUpstreamServer(":8443", tlsCfg)
-	defer upstreamSrv.listener.Close()
+	defer func() { _ = upstreamSrv.listener.Close() }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	daemonDoneSig := make(chan struct{})
@@ -115,7 +115,7 @@ func TestRequestsFromGuardianToUpstream(t *testing.T) {
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var rspObj obj
 	Expect(json.NewDecoder(resp.Body).Decode(&rspObj)).ShouldNot(HaveOccurred())
@@ -124,7 +124,7 @@ func TestRequestsFromGuardianToUpstream(t *testing.T) {
 	// Close the mux and allow guardian to try to reconnect, as we want to test that we can still use the tunnel after
 	// reconnecting.
 	t.Log("testing that we can use the tunnel after reconnecting")
-	mux.Close()
+	_ = mux.Close()
 	upstreamSrv.Close()
 	time.Sleep(10 * time.Second)
 
@@ -140,7 +140,7 @@ func TestRequestsFromGuardianToUpstream(t *testing.T) {
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	rspObj = obj{}
 	Expect(json.NewDecoder(resp.Body).Decode(&rspObj)).ShouldNot(HaveOccurred())

--- a/guardian/tests/fv/util_test.go
+++ b/guardian/tests/fv/util_test.go
@@ -17,11 +17,11 @@ func createKeyCertPair(dir, certFileName, keyFileName string) (string, string) {
 
 	certFile, err := os.Create(dir + "/" + certFileName)
 	Expect(err).ShouldNot(HaveOccurred())
-	defer certFile.Close()
+	defer func() { _ = certFile.Close() }()
 
 	keyFile, err := os.Create(dir + "/" + keyFileName)
 	Expect(err).ShouldNot(HaveOccurred())
-	defer keyFile.Close()
+	defer func() { _ = keyFile.Close() }()
 
 	_, err = certFile.Write(certPEM)
 	Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
## Description

This changeset fixes static check issues in the guardian component reported by golangci-lint v2.4.0.

## Related issues/PRs

Prepare for https://github.com/projectcalico/calico/pull/10924.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
