### PR TITLE
Fix app-policy static checks

### DIFF
--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -94,7 +94,7 @@ func runServer(arguments map[string]interface{}) {
 			"err":    err,
 		}).Fatal("Unable to listen.")
 	}
-	defer lis.Close()
+	defer func() { _ = lis.Close() }()
 	err = os.Chmod(filePath, 0o777) // Anyone on system can connect.
 	if err != nil {
 		log.Fatal("Unable to set write permission on socket.")
@@ -172,7 +172,7 @@ func runClient(arguments map[string]interface{}) {
 	if err != nil {
 		log.Fatalf("fail to dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := authz.NewAuthorizationClient(conn)
 	req := authz.CheckRequest{
 		Attributes: &authz.AttributeContext{

--- a/app-policy/cmd/healthz/healthz.go
+++ b/app-policy/cmd/healthz/healthz.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("fail to dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	c := dikastesproto.NewHealthzClient(conn)
 	if len(flag.Args()) == 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "Usage: %s (liveness|readiness)\n", os.Args[0])

--- a/app-policy/syncher/syncserver.go
+++ b/app-policy/syncher/syncserver.go
@@ -120,7 +120,7 @@ func (s *SyncClient) syncStore(cxt context.Context, inSync chan<- struct{}, done
 		return
 	}
 	log.Info("Successfully connected to Policy Sync server")
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := proto.NewPolicySyncClient(conn)
 	stream, err := client.Sync(cxt, &proto.SyncRequest{})
 	if err != nil {


### PR DESCRIPTION
## Description

This changeset fixes static check issues in the app-policy component reported by golangci-lint v2.4.0.

## Related issues/PRs

Prepare for https://github.com/projectcalico/calico/pull/10924.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
