### PR TITLE
Fix confd static checks

### DIFF
--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1139,7 +1139,7 @@ func (c *client) onUpdates(updates []api.Update, needUpdatePeersV1 bool) {
 	for _, u := range updates {
 		if v3key, ok := u.Key.(model.ResourceKey); ok && v3key.Kind == apiv3.KindBGPConfiguration {
 			// Convert v3 BGPConfiguration to equivalent v1 cache values
-			v3res, _ := u.KVPair.Value.(*apiv3.BGPConfiguration)
+			v3res, _ := u.Value.(*apiv3.BGPConfiguration)
 			c.updateBGPConfigCache(v3key.Name, v3res, &needServiceAdvertisementUpdates, &needUpdatePeersV1, &needUpdatePeersReasons)
 		}
 		c.updateCache(u.UpdateType, &u.KVPair)
@@ -1495,7 +1495,7 @@ func (c *client) getNodeMeshRestartTimeKVPair(v3res *apiv3.BGPConfiguration, key
 
 	if v3res != nil && v3res.Spec.NodeMeshMaxRestartTime != nil {
 		restartTime := *v3res.Spec.NodeMeshMaxRestartTime
-		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(meshRestartKey, fmt.Sprintf("%v", int(math.Round(restartTime.Duration.Seconds())))))
+		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(meshRestartKey, fmt.Sprintf("%v", int(math.Round(restartTime.Seconds())))))
 	} else {
 		c.updateCache(api.UpdateTypeKVDeleted, getKVPair(meshRestartKey))
 	}
@@ -2013,7 +2013,7 @@ func (c *client) setPeerConfigFieldsFromV3Resource(peers []*bgpPeer, v3res *apiv
 		peer.Password = password
 		peer.SourceAddr = withDefault(string(v3res.Spec.SourceAddress), string(apiv3.SourceAddressUseNodeIP))
 		if v3res.Spec.MaxRestartTime != nil {
-			peer.RestartTime = fmt.Sprintf("%v", int(math.Round(v3res.Spec.MaxRestartTime.Duration.Seconds())))
+			peer.RestartTime = fmt.Sprintf("%v", int(math.Round(v3res.Spec.MaxRestartTime.Seconds())))
 		}
 	}
 }

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -233,7 +233,8 @@ var _ = Describe("RouteGenerator", func() {
 				err := rg.epIndexer.Add(ep)
 				Expect(err).NotTo(HaveOccurred())
 				rg.setRouteForSvc(svc, nil)
-				fmt.Fprintln(GinkgoWriter, rg.svcRouteMap)
+				_, err = fmt.Fprintln(GinkgoWriter, rg.svcRouteMap)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				rg.unsetRouteForSvc(ep)
 				Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
@@ -555,7 +556,7 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cache["/calico/staticroutes/"+externalIP2+"-32"]).To(BeEmpty())
 
 				// It should also reject the full range into the data plane.
-				Expect(rg.client.cache["/calico/rejectcidrs/"+strings.Replace(externalIPRange1, "/", "-", -1)]).To(Equal(externalIPRange1))
+				Expect(rg.client.cache["/calico/rejectcidrs/"+strings.ReplaceAll(externalIPRange1, "/", "-")]).To(Equal(externalIPRange1))
 
 				// Simulate an event from the syncer which updates to use the second range (removing the first)
 				rg.client.onExternalIPsUpdate([]string{externalIPRange2})
@@ -566,7 +567,7 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cache["/calico/staticroutes/"+externalIP2+"-32"]).To(Equal(externalIP2 + "/32"))
 
 				// It should now allow the range in the data plane.
-				Expect(rg.client.cache["/calico/rejectcidrs/"+strings.Replace(externalIPRange1, "/", "-", -1)]).To(BeEmpty())
+				Expect(rg.client.cache["/calico/rejectcidrs/"+strings.ReplaceAll(externalIPRange1, "/", "-")]).To(BeEmpty())
 			})
 
 			It("should not advertise cluster IPs unless a range is specified", func() {

--- a/confd/pkg/resource/template/fileStat_posix.go
+++ b/confd/pkg/resource/template/fileStat_posix.go
@@ -39,5 +39,5 @@ func fileStat(name string) (fi fileInfo, err error) {
 		fi.Md5 = fmt.Sprintf("%x", h.Sum(nil))
 		return fi, nil
 	}
-	return fi, errors.New("File not found")
+	return fi, errors.New("file not found")
 }

--- a/confd/pkg/resource/template/resource.go
+++ b/confd/pkg/resource/template/resource.go
@@ -64,7 +64,7 @@ var ErrEmptySrc = errors.New("empty src template")
 // NewTemplateResource creates a TemplateResource.
 func NewTemplateResource(path string, config Config) (*TemplateResource, error) {
 	if config.StoreClient == nil {
-		return nil, errors.New("A valid StoreClient is required.")
+		return nil, errors.New("a valid StoreClient is required")
 	}
 
 	// Set the default uid and gid so we can determine if it was
@@ -74,7 +74,7 @@ func NewTemplateResource(path string, config Config) (*TemplateResource, error) 
 	log.Debug("Loading template resource from " + path)
 	_, err := toml.DecodeFile(path, &tc)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot process template resource %s - %s", path, err.Error())
+		return nil, fmt.Errorf("cannot process template resource %s - %s", path, err.Error())
 	}
 
 	tr := &tc.TemplateResource
@@ -93,11 +93,11 @@ func NewTemplateResource(path string, config Config) (*TemplateResource, error) 
 			path := os.Getenv("PATH")
 			err = os.Setenv("PATH", path+";C:/Windows/System32/WindowsPowerShell/v1.0/")
 			if err != nil {
-				return nil, fmt.Errorf("Cannot add powershell to Windows PATH: %s", err.Error())
+				return nil, fmt.Errorf("cannot add powershell to Windows PATH: %s", err.Error())
 			}
 			_, err = exec.LookPath("powershell.exe")
 			if err != nil {
-				return nil, fmt.Errorf("Cannot find powershell.exe after addding default path to Windows PATH: %s", err.Error())
+				return nil, fmt.Errorf("cannot find powershell.exe after addding default path to Windows PATH: %s", err.Error())
 			}
 		}
 		tr.shellCmd = "powershell.exe"
@@ -169,7 +169,7 @@ func (t *TemplateResource) createStageFile() error {
 
 	tmpl, err := template.New(filepath.Base(t.Src)).Funcs(t.funcMap).ParseFiles(t.Src)
 	if err != nil {
-		return fmt.Errorf("Unable to process template %s, %s", t.Src, err)
+		return fmt.Errorf("unable to process template %s, %s", t.Src, err)
 	}
 
 	// create TempFile in Dest directory to avoid cross-filesystem issues

--- a/confd/pkg/resource/template/template_funcs.go
+++ b/confd/pkg/resource/template/template_funcs.go
@@ -168,7 +168,7 @@ func filterMatchSource(source v3.BGPFilterMatchSource) (string, error) {
 
 func filterMatchInterface(iface string) (string, error) {
 	if iface == "" {
-		return "", fmt.Errorf("Empty interface found in BGPFilter")
+		return "", fmt.Errorf("empty interface found in BGPFilter")
 	}
 	return fmt.Sprintf("((defined(ifname))&&(ifname ~ \"%s\"))", iface), nil
 }

--- a/confd/pkg/resource/template/template_funcs_test.go
+++ b/confd/pkg/resource/template/template_funcs_test.go
@@ -54,7 +54,7 @@ func Test_bgpFilterFunctionName(t *testing.T) {
 
 func Test_BGPFilterBIRDFuncs(t *testing.T) {
 	testFilter := v3.BGPFilter{}
-	testFilter.ObjectMeta.Name = "test-bgpfilter"
+	testFilter.Name = "test-bgpfilter"
 	testFilter.Spec = v3.BGPFilterSpec{
 		ImportV4: []v3.BGPFilterRuleV4{
 			{Action: "Accept", Source: "RemotePeers", Interface: "vxlan.calico", MatchOperator: "NotIn", CIDR: "55.4.0.0/16"},


### PR DESCRIPTION
## Description

This changeset fixes static check issues in the confd component reported by golangci-lint v2.4.0.

## Related issues/PRs

Prepare for https://github.com/projectcalico/calico/pull/10924.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
