### PR TITLE
[v3.30] enable kube-proxy healthz server

### DIFF
--- a/felix/bpf/proxy/health_check_nodeport_test.go
+++ b/felix/bpf/proxy/health_check_nodeport_test.go
@@ -15,6 +15,7 @@
 package proxy_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 
 	"github.com/projectcalico/calico/felix/bpf/proxy"
 )
@@ -38,12 +40,18 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 	testNodeName := "testnode"
 	testNodeNameOther := "anothertestnode"
 
+	healthzServer := healthcheck.NewProxierHealthServer(":10256", 200*time.Millisecond)
+	go func() {
+		_ = healthzServer.Run(context.Background())
+	}()
+
 	BeforeEach(func() {
 		By("creating proxy with fake client and mock syncer", func() {
 			var err error
 
 			p, err = proxy.New(k8s, &mockDummySyncer{},
-				testNodeName, proxy.WithMinSyncPeriod(200*time.Millisecond))
+				testNodeName, proxy.WithMinSyncPeriod(200*time.Millisecond),
+				proxy.WithHealthzServer(healthzServer))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/felix/bpf/proxy/health_check_nodeport_test.go
+++ b/felix/bpf/proxy/health_check_nodeport_test.go
@@ -241,6 +241,23 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 			})
 		})
 	})
+
+	It("should expose proxy health check endpoint", func() {
+		proxyHealthPort := 10256
+
+		By("checking that the health endpoint is accessible", func() {
+			Eventually(func() error {
+				result, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", proxyHealthPort))
+				if err != nil {
+					return err
+				}
+				if result.StatusCode != 200 {
+					return fmt.Errorf("Unexpected status code %d; expected 200", result.StatusCode)
+				}
+				return nil
+			}, "5s", "200ms").Should(Succeed())
+		})
+	})
 })
 
 type mockDummySyncer struct {

--- a/felix/bpf/proxy/options.go
+++ b/felix/bpf/proxy/options.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 
 	"github.com/projectcalico/calico/felix/ip"
 )
@@ -109,6 +110,13 @@ func WithExcludedCIDRs(cidrs []string) Option {
 			kp.excludedCIDRs.Update(cidr, &excludeCIDRsMatch)
 		}
 
+		return nil
+	})
+}
+
+func WithHealthzServer(hs *healthcheck.ProxierHealthServer) Option {
+	return makeOption(func(p *proxy) error {
+		p.healthzServer = hs
 		return nil
 	})
 }

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -111,9 +111,11 @@ type proxy struct {
 	svcHealthServer healthcheck.ServiceHealthServer
 	healthzServer   *healthcheck.ProxierHealthServer
 
-	stopCh   chan struct{}
-	stopWg   sync.WaitGroup
-	stopOnce sync.Once
+	stopCh      chan struct{}
+	stopWg      sync.WaitGroup
+	stopOnce    sync.Once
+	cancelCtx   context.Context
+	cancelCtxFn context.CancelFunc
 }
 
 type stoppableRunner interface {
@@ -145,6 +147,8 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 
 		stopCh: make(chan struct{}),
 	}
+
+	p.cancelCtx, p.cancelCtxFn = context.WithCancel(context.Background())
 
 	for _, o := range opts {
 		if err := o(p); err != nil {
@@ -206,6 +210,21 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 	p.startRoutine(func() { informerFactory.Start(p.stopCh) })
 	p.startRoutine(func() { svcConfig.Run(p.stopCh) })
 
+	// We cannot wait for the healthz server as we cannot stop it.
+	go func() {
+		for {
+			err := p.healthzServer.Run(p.cancelCtx)
+			if err != nil {
+				log.WithError(err).Error("Healthz server failed, restarting")
+			}
+			select {
+			case <-p.cancelCtx.Done():
+				return
+			default:
+			}
+		}
+	}()
+
 	return p, nil
 }
 
@@ -225,6 +244,7 @@ func (p *proxy) setIpFamily(ipFamily int) {
 func (p *proxy) Stop() {
 	p.stopOnce.Do(func() {
 		log.Info("Proxy stopping")
+		p.cancelCtxFn()
 		// Pass empty update to close all the health checks.
 		_ = p.svcHealthServer.SyncServices(map[types.NamespacedName]uint16{})
 		_ = p.svcHealthServer.SyncEndpoints(map[types.NamespacedName]int{})

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"k8s.io/client-go/kubernetes"
+	k8shealthcheck "k8s.io/kubernetes/pkg/proxy/healthcheck"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
@@ -191,10 +192,11 @@ type Config struct {
 	ConfigChangedRestartCallback func()
 	FatalErrorRestartCallback    func(error)
 
-	PostInSyncCallback func()
-	HealthAggregator   *health.HealthAggregator
-	WatchdogTimeout    time.Duration
-	RouteTableManager  *idalloc.IndexAllocator
+	PostInSyncCallback    func()
+	HealthAggregator      *health.HealthAggregator
+	WatchdogTimeout       time.Duration
+	RouteTableManager     *idalloc.IndexAllocator
+	bpfProxyHealthzServer *k8shealthcheck.ProxierHealthServer
 
 	DebugSimulateDataplaneHangAfter  time.Duration
 	DebugSimulateDataplaneApplyDelay time.Duration
@@ -2675,7 +2677,23 @@ func startBPFDataplaneComponents(
 	ctKey := bpfconntrack.KeyFromBytes
 	ctVal := bpfconntrack.ValueFromBytes
 
+	if config.bpfProxyHealthzServer == nil {
+		config.bpfProxyHealthzServer = k8shealthcheck.NewProxierHealthServer(
+			":10256", config.KubeProxyMinSyncPeriod)
+
+		// We cannot wait for the healthz server as we cannot stop it.
+		go func() {
+			for {
+				err := config.bpfProxyHealthzServer.Run(context.Background()) // context is mosstly ignored inside
+				if err != nil {
+					log.WithError(err).Error("BPF Proxy Healthz server failed, restarting")
+				}
+			}
+		}()
+	}
+
 	bpfproxyOpts := []bpfproxy.Option{
+		bpfproxy.WithHealthzServer(config.bpfProxyHealthzServer),
 		bpfproxy.WithMinSyncPeriod(config.KubeProxyMinSyncPeriod),
 	}
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"regexp"
 	"sort"
@@ -1377,6 +1378,14 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						return healthStatus(containerIP(f.Container), "9099", "readiness")
 					}
 					Eventually(felixReady, "10s", "500ms").Should(BeGood())
+					Eventually(func() int {
+						resp, err := http.Get("http://" + containerIP(f.Container) + ":10256" + "/healthz")
+						if err != nil {
+							log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")
+							return -1
+						}
+						return resp.StatusCode
+					}, "3s", "500ms").Should(BeGood())
 				}
 			}
 		}


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#10947
Up until now we were only running the service health, but not the proxy health. The service listeners were started within the healthz server, but the main LIstener for the proxy needs to kick off Run().

refs https://github.com/projectcalico/calico/issues/10748

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: enable kube-proxy healthz server
```