### PR TITLE
ci: Add quay.io credentials to e2e push

### DIFF
--- a/.semaphore/push-images/e2e-test.yml
+++ b/.semaphore/push-images/e2e-test.yml
@@ -21,6 +21,8 @@ global_job_config:
 blocks:
   - name: Publish e2e test utility images
     dependencies: []
+    skip:
+      when: "branch !~ '.+'"
     task:
       jobs:
         - name: Linux multi-arch


### PR DESCRIPTION
Verified in a debug session that the credentials work correctly for pushing e2e images.