### PR TITLE
Cherry pick OpenStack resync work to release-v3.30 branch

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright 2015 Metaswitch Networks
 # All Rights Reserved.
+# Copyright (c) 2025 Tigera, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -148,6 +149,10 @@ SCENARIO_IMAGE_TYPE=ignore
 # remote: Compressing objects: 100% (9847/9847), done.
 # error: RPC failed; curl 56 GnuTLS recv error (-9): A TLS packet with unexpected length was received.
 GIT_BASE=https://github.com
+
+# Disable ongoing resync.  In principle this isn't needed; disable it in order to build evidence to
+# confirm that.
+CALICO_RESYNC_INTERVAL_SECS=0
 
 EOF
 

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -201,10 +201,26 @@ export FORCE=yes
 ./stack.sh
 EOF
 
-# We use a fresh `sudo -u stack -H -E bash ...` invocation here, because with
-# OpenStack Yoga it appears there is something in the stack.sh setup that
-# closes stdin, and that means that bash doesn't read any further commands from
-# stdin after the exit of the ./stack.sh line.
+# We use fresh `sudo -u stack -H -E bash ...` invocations from here on, because with OpenStack Yoga
+# it appears there is something in the stack.sh setup that closes stdin, and that means that bash
+# doesn't read any further commands from stdin after the exit of the ./stack.sh line.
+
+# Run QoS responsiveness tests
+sudo -u stack -H -E bash -x <<'EOF'
+cd /opt/stack/devstack
+
+echo "Running QoS responsiveness tests..."
+cd /opt/stack/devstack
+. openrc admin admin
+
+# Install required Python packages for QoS tests
+sudo pip install openstacksdk etcd3
+
+export ETCD_HOST=${SERVICE_HOST}
+python3 ../calico/networking-calico/devstack/qos_responsiveness_tests.py -v
+EOF
+
+# Run Tempest tests
 sudo -u stack -H -E bash -x <<'EOF'
 cd /opt/stack/devstack
 if ! ${TEMPEST:-false}; then
@@ -216,10 +232,8 @@ if ! ${TEMPEST:-false}; then
         neutron subnet-create --gateway 10.65.0.1 --enable-dhcp --ip-version 4 --name calico-v4 calico 10.65.0.0/24
     fi
 else
-    # Run mainline Tempest tests.
     source ../calico/devstack/devstackgaterc
     cd /opt/stack/tempest
     tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY
 fi
-
 EOF

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -2,79 +2,79 @@
 # Devstack plugin code for Calico
 # ===============================
 
-mode=$1				# stack, unstack or clean
-phase=$2			# pre-install, install, post-config or extra
+mode=$1                         # stack, unstack or clean
+phase=$2                        # pre-install, install, post-config or extra
 
 if [ "${Q_AGENT}" = calico-felix ]; then
 
     case $mode in
 
-	stack)
-	    # Called by stack.sh four times for different phases of
-	    # its run.
-	    echo Calico plugin: stack
+        stack)
+            # Called by stack.sh four times for different phases of
+            # its run.
+            echo Calico plugin: stack
 
-	    case $phase in
+            case $phase in
 
-		pre-install)
-		    # Called after system (OS) setup is complete and
-		    # before project source is installed.
-		    echo Calico plugin: pre-install
+                pre-install)
+                    # Called after system (OS) setup is complete and
+                    # before project source is installed.
+                    echo Calico plugin: pre-install
 
-		    # Add Calico master PPA as a package source.
-		    sudo apt-add-repository -y ppa:project-calico/master
-		    REPOS_UPDATED=False
+                    # Add Calico master PPA as a package source.
+                    sudo apt-add-repository -y ppa:project-calico/master
+                    REPOS_UPDATED=False
 
-		    # Also add BIRD project PPA as a package source.
-		    LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo add-apt-repository -y ppa:cz.nic-labs/bird
+                    # Also add BIRD project PPA as a package source.
+                    LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo add-apt-repository -y ppa:cz.nic-labs/bird
 
-		    ;;
+                    ;;
 
-		install)
-		    # Called after the layer 1 and 2 projects source
-		    # and their dependencies have been installed.
-		    echo Calico plugin: install
+                install)
+                    # Called after the layer 1 and 2 projects source
+                    # and their dependencies have been installed.
+                    echo Calico plugin: install
 
-		    # Upgrade dnsmasq.
-		    install_package dnsmasq-base dnsmasq-utils
+                    # Upgrade dnsmasq.
+                    install_package dnsmasq-base dnsmasq-utils
 
-		    # Install ipset.
-		    install_package ipset
+                    # Install ipset.
+                    install_package ipset
 
-		    # Install BIRD.
-		    install_package bird
+                    # Install BIRD.
+                    install_package bird
 
-		    # Install the Calico agent.
-		    sudo mkdir -p /etc/calico
-		    sudo sh -c "cat > /etc/calico/felix.cfg" << EOF
+                    # Install the Calico agent.
+                    sudo mkdir -p /etc/calico
+                    sudo sh -c "cat > /etc/calico/felix.cfg" << EOF
 [global]
 DatastoreType = etcdv3
 EtcdEndpoints = http://${SERVICE_HOST}:${ETCD_PORT}
 EOF
-		    if [ "${ENABLE_DEBUG_LOG_LEVEL}" = True ]; then
-			sudo sh -c "cat >> /etc/calico/felix.cfg" << EOF
+                    if [ "${ENABLE_DEBUG_LOG_LEVEL}" = True ]; then
+                        sudo sh -c "cat >> /etc/calico/felix.cfg" << EOF
 LogSeverityFile = info
 EOF
-		    fi
-		    install_package calico-felix
+                    fi
+                    install_package calico-felix
 
-		    # Install Calico common code, that includes BIRD templates.
-		    install_package calico-common
+                    # Install Calico common code, that includes BIRD templates.
+                    install_package calico-common
 
-		    # Install networking-calico.
-		    pip_install "${GITDIR['calico']}/networking-calico"
+                    # Install networking-calico.
+                    pip_install "${GITDIR['calico']}/networking-calico"
 
-		    ;;
+                    ;;
 
-		post-config)
-		    # Called after the layer 1 and 2 services have
-		    # been configured. All configuration files for
-		    # enabled services should exist at this point.
-		    echo Calico plugin: post-config
+                post-config)
+                    # Called after the layer 1 and 2 services have
+                    # been configured. All configuration files for
+                    # enabled services should exist at this point.
+                    echo Calico plugin: post-config
 
-		    # Update qemu configuration (shouldn't be anything
-		    # in there so safe to blow away)
-		    sudo sh -c "cat > /etc/libvirt/qemu.conf" << EOF
+                    # Update qemu configuration (shouldn't be anything
+                    # in there so safe to blow away)
+                    sudo sh -c "cat > /etc/libvirt/qemu.conf" << EOF
 user = "root"
 group = "root"
 cgroup_device_acl = [
@@ -85,85 +85,92 @@ cgroup_device_acl = [
 ]
 EOF
 
-		    # Use the Calico plugin.  We make this change here, instead
-		    # of putting 'Q_PLUGIN=calico' in the settings file,
-		    # because the latter would require adding Calico plugin
-		    # support to the core DevStack repository.
-		    iniset $NEUTRON_CONF DEFAULT core_plugin calico
+                    # Use the Calico plugin.  We make this change here, instead
+                    # of putting 'Q_PLUGIN=calico' in the settings file,
+                    # because the latter would require adding Calico plugin
+                    # support to the core DevStack repository.
+                    iniset $NEUTRON_CONF DEFAULT core_plugin calico
 
-		    # Calico itself implements the 'router' extension, but we need a service plugin
-		    # for QoS.
-		    iniset $NEUTRON_CONF DEFAULT service_plugins qos
+                    # Calico itself implements the 'router' extension, but we need a service plugin
+                    # for QoS.
+                    iniset $NEUTRON_CONF DEFAULT service_plugins qos
 
-		    # Propagate ENABLE_DEBUG_LOG_LEVEL to neutron.conf, so that
-		    # it applies to the Calico DHCP agent on each compute node.
-		    iniset $NEUTRON_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL
+                    # Propagate ENABLE_DEBUG_LOG_LEVEL to neutron.conf, so that
+                    # it applies to the Calico DHCP agent on each compute node.
+                    iniset $NEUTRON_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL
 
-		    # Point the Calico DHCP agent and mechanism driver
-		    # at the etcd server.
-		    iniset $NEUTRON_CONF calico etcd_host $SERVICE_HOST
-		    iniset $NEUTRON_CONF calico etcd_port $ETCD_PORT
+                    # Point the Calico DHCP agent and mechanism driver
+                    # at the etcd server.
+                    iniset $NEUTRON_CONF calico etcd_host $SERVICE_HOST
+                    iniset $NEUTRON_CONF calico etcd_port $ETCD_PORT
 
-		    # If CALICO_ETCD_COMPACTION_PERIOD_MINS is
-		    # defined, set that as the value of the
-		    # etcd_compaction_period_mins setting.
-		    if test -n "$CALICO_ETCD_COMPACTION_PERIOD_MINS"; then
-			iniset $NEUTRON_CONF calico etcd_compaction_period_mins $CALICO_ETCD_COMPACTION_PERIOD_MINS
-		    fi
-		    # If CALICO_ETCD_COMPACTION_MIN_REVISIONS is
-		    # defined, set that as the value of the
-		    # etcd_compaction_min_revisions setting.
-		    if test -n "$CALICO_ETCD_COMPACTION_MIN_REVISIONS"; then
-			iniset $NEUTRON_CONF calico etcd_compaction_min_revisions $CALICO_ETCD_COMPACTION_MIN_REVISIONS
-		    fi
+                    # If CALICO_ETCD_COMPACTION_PERIOD_MINS is
+                    # defined, set that as the value of the
+                    # etcd_compaction_period_mins setting.
+                    if test -n "$CALICO_ETCD_COMPACTION_PERIOD_MINS"; then
+                        iniset $NEUTRON_CONF calico etcd_compaction_period_mins $CALICO_ETCD_COMPACTION_PERIOD_MINS
+                    fi
 
-		    # Give Neutron the admin role so that it can look up
-		    # project name and parent_id fields in the Keystone DB.
-		    openstack role add admin --user neutron --project service --user-domain Default --project-domain Default
-		    ;;
+                    # If CALICO_ETCD_COMPACTION_MIN_REVISIONS is
+                    # defined, set that as the value of the
+                    # etcd_compaction_min_revisions setting.
+                    if test -n "$CALICO_ETCD_COMPACTION_MIN_REVISIONS"; then
+                        iniset $NEUTRON_CONF calico etcd_compaction_min_revisions $CALICO_ETCD_COMPACTION_MIN_REVISIONS
+                    fi
 
-		extra)
-		    # Called near the end after layer 1 and 2 services
-		    # have been started.
-		    echo Calico plugin: extra
+                    # If CALICO_RESYNC_INTERVAL_SECS is defined, set that as the value of the
+                    # resync_interval_secs setting.
+                    if test -n "$CALICO_RESYNC_INTERVAL_SECS"; then
+                        iniset $NEUTRON_CONF calico resync_interval_secs $CALICO_RESYNC_INTERVAL_SECS
+                    fi
 
-		    # Run script to automatically generate and
-		    # maintain BIRD config for the cluster.
-		    export ETCDCTL_API=3
-		    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
-		    run_process calico-bird \
+                    # Give Neutron the admin role so that it can look up
+                    # project name and parent_id fields in the Keystone DB.
+                    openstack role add admin --user neutron --project service --user-domain Default --project-domain Default
+                    ;;
+
+                extra)
+                    # Called near the end after layer 1 and 2 services
+                    # have been started.
+                    echo Calico plugin: extra
+
+                    # Run script to automatically generate and
+                    # maintain BIRD config for the cluster.
+                    export ETCDCTL_API=3
+                    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
+                    run_process calico-bird \
                       "${DEST}/calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
 
-		    # Run the Calico DHCP agent.
-		    sudo mkdir /var/log/neutron || true
-		    sudo chown `whoami` /var/log/neutron
-		    run_process calico-dhcp \
-		      "${DEVSTACK_VENV:-/usr/local}/bin/calico-dhcp-agent --config-file $NEUTRON_CONF"
+                    # Run the Calico DHCP agent.
+                    sudo mkdir /var/log/neutron || true
+                    sudo chown `whoami` /var/log/neutron
+                    run_process calico-dhcp \
+                      "${DEVSTACK_VENV:-/usr/local}/bin/calico-dhcp-agent --config-file $NEUTRON_CONF"
 
-		    ;;
+                    ;;
 
-		*)
-		    echo Calico plugin: unexpected phase $phase
-		    ;;
+                *)
+                    echo Calico plugin: unexpected phase $phase
+                    ;;
 
-	    esac
-	    ;;
+            esac
+            ;;
 
-	unstack)
-	    # Called by unstack.sh before other services are shut
-	    # down.
-	    echo Calico plugin: unstack
-	    ;;
+        unstack)
+            # Called by unstack.sh before other services are shut
+            # down.
+            echo Calico plugin: unstack
+            ;;
 
-	clean)
-	    # Called by clean.sh before other services are cleaned,
-	    # but after unstack.sh has been called.
-	    echo Calico plugin: clean
-	    ;;
+        clean)
+            # Called by clean.sh before other services are cleaned,
+            # but after unstack.sh has been called.
+            echo Calico plugin: clean
+            ;;
 
-	*)
-	    echo Calico plugin: unexpected mode $mode
-	    ;;
+        *)
+            echo Calico plugin: unexpected mode $mode
+            ;;
 
     esac
 fi

--- a/networking-calico/devstack/qos_responsiveness_tests.py
+++ b/networking-calico/devstack/qos_responsiveness_tests.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""
+QoS Responsiveness Tests for Calico OpenStack Integration
+
+This script tests the responsiveness of Calico's integration code in converting
+QoS parameters from the Neutron API to the Calico WorkloadEndpoint API.
+
+The tests verify that WorkloadEndpoint objects are correctly updated within
+a few seconds when QoS policies are applied to networks and ports.
+"""
+
+import json
+import logging
+import os
+import time
+import unittest
+
+import etcd3
+
+import openstack
+
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# openstack.enable_logging(debug=True, http_debug=True)
+
+
+# Copied from
+# https://github.com/tigera/calico-test/blob/bobcat/calicotest/common/testutils.py.
+def retry_until_success(
+    function,
+    retries=10,
+    wait_time=1,
+    ex_class=None,
+    log_exception=True,
+    context_string="",
+    function_args=None,
+    function_kwargs=None,
+):
+    """
+    Retries function until no exception is thrown. If exception continues,
+    it is reraised.
+
+    :param function: the function to be repeatedly called
+    :param retries: the maximum number of times to retry the function.  A value
+    of 0 will run the function once with no retries.
+    :param wait_time: the time to wait between retries (in s)
+    :param ex_class: The class of expected exceptions.
+    :param log_exception: By default this function logs the exception if the
+    function is still failing after max retries.   This log can sometimes be
+    superfluous -- if e.g. the calling code is going to make a better log --
+    and can be suppressed by setting this parameter to False.
+    :param context_string: A string used to flag the context of a specific call
+    in logs.
+    :param function_args: A list of arguments to pass to function
+    :param function_kwargs: A dictionary of keyword arguments to pass to
+                            function
+    :returns: the value returned by function
+    """
+    if function_args is None:
+        function_args = []
+    if function_kwargs is None:
+        function_kwargs = {}
+    for retry in range(int(retries) + 1):
+        try:
+            result = function(*function_args, **function_kwargs)
+        except Exception as e:
+            if ex_class and e.__class__ is not ex_class:
+                logger.exception("Hit unexpected exception in function - not retrying.")
+                raise
+            if retry < retries:
+                logger.debug("Hit exception in function - retrying: %s", e)
+                time.sleep(wait_time)
+            else:
+                if log_exception:
+                    logger.exception(
+                        "Function %s did not succeed before timeout.", function
+                    )
+                raise
+        else:
+            # Successfully ran the function
+            return result
+
+
+class QoSResponsivenessTest(unittest.TestCase):
+    """Test suite for QoS responsiveness in Calico OpenStack integration."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.next_subnet_byte = 0
+
+        # Set up OpenStack connection
+        cls.conn = openstack.connection.Connection(
+            auth_url=os.environ.get("OS_AUTH_URL", "http://localhost/identity"),
+            project_name=os.environ.get("OS_PROJECT_NAME", "admin"),
+            username=os.environ.get("OS_USERNAME", "admin"),
+            password=os.environ.get("OS_PASSWORD", "015133ea2bdc46ed434c"),
+            region_name=os.environ.get("OS_REGION_NAME", "RegionOne"),
+            project_domain_id=os.environ.get("OS_PROJECT_DOMAIN_ID", "default"),
+            user_domain_id=os.environ.get("OS_USER_DOMAIN_ID", "default"),
+            identity_api_version=3,
+        )
+        logger.info("OpenStack connection established")
+
+        # Set up etcd client for Calico datastore access
+        etcd_host = os.environ.get("ETCD_HOST", "localhost")
+        etcd_port = int(os.environ.get("ETCD_PORT", "2379"))
+        cls.etcd_client = etcd3.client(host=etcd_host, port=etcd_port)
+        logger.info(f"etcd3 client established: {etcd_host}:{etcd_port}")
+        status = cls.etcd_client.status()
+        logger.info(f"status.version = {status.version}")
+        logger.info(f"status.db_size = {status.db_size}")
+        logger.info(f"status.leader = {status.leader}")
+        logger.info(f"status.raft_index = {status.raft_index}")
+        logger.info(f"status.raft_term = {status.raft_term}")
+
+        # Define possible QoS rules that we will use in this test.
+        cls.qos_rules = [
+            {
+                "rule": {
+                    "type": "bandwidth_limit",
+                    "max_kbps": 10200,
+                    "max_burst_kbps": 20300,
+                    "direction": "egress",
+                },
+                "controls": {
+                    "egressBandwidth": 10200000,
+                    "egressPeakrate": 20300000,
+                    "egressBurst": 4294967296,
+                },
+            },
+            {
+                "rule": {
+                    "type": "bandwidth_limit",
+                    "max_kbps": 30400,
+                    "max_burst_kbps": 40500,
+                    "direction": "ingress",
+                },
+                "controls": {
+                    "ingressBandwidth": 30400000,
+                    "ingressPeakrate": 40500000,
+                    "ingressBurst": 4294967296,
+                },
+            },
+        ]
+        # The Yoga version of openstacksdk does not support creating packet
+        # rate limit rules.  Caracal and onwards do support this.
+        if hasattr(cls.conn.network, "create_qos_packet_rate_limit_rule"):
+            logger.info("openstacksdk can create packet rate limit rules")
+            cls.qos_rules.extend(
+                [
+                    {
+                        "rule": {
+                            "type": "packet_rate_limit",
+                            "max_kpps": 6,
+                            "direction": "egress",
+                        },
+                        "controls": {
+                            "egressPacketRate": 6000,
+                            "egressPacketBurst": 5,
+                        },
+                    },
+                    {
+                        "rule": {
+                            "type": "packet_rate_limit",
+                            "max_kpps": 7,
+                            "direction": "ingress",
+                        },
+                        "controls": {
+                            "ingressPacketRate": 7000,
+                            "ingressPacketBurst": 5,
+                        },
+                    },
+                ]
+            )
+
+        # Define possible combination sets of those rules.  If there are N
+        # possible rules, there are 2**N possible combinations of them, formed
+        # by each set including or not including each rule.
+        cls.qos_rule_sets = []
+        for i in range(2 ** len(cls.qos_rules)):
+            rule_set = []
+            for j in range(len(cls.qos_rules)):
+                if i & (2**j) != 0:
+                    rule_set.append(cls.qos_rules[j])
+            cls.qos_rule_sets.append(rule_set)
+
+    def test_qos_policy_id(self):
+        # Test that a WorkloadEndpoint always gets the correct QoS settings as
+        # we change the qos_policy_id on the corresponding port and on that
+        # port's network.
+        #
+        # In this test, the rule set for a given qos_policy_id stays the same.
+
+        # Form a set of states, in which transitioning between two of that
+        # states means changing the qos_policy_id on the port and/or on the
+        # network - including the possibilities that qos_policy_id might be not
+        # set on either of those.
+        policy_id_to_rule_set = {
+            "A": self.qos_rule_sets[1],
+            "B": self.qos_rule_sets[2],
+            "C": self.qos_rule_sets[3],
+        }
+        states = []
+        for net_qos_name in [None, "A", "B"]:
+            for port_qos_name in [None, "B", "C"]:
+                state = {
+                    "net_qos_name": net_qos_name,
+                    "port_qos_name": port_qos_name,
+                }
+                if port_qos_name is not None:
+                    state["port_qos_rules"] = policy_id_to_rule_set[port_qos_name]
+                else:
+                    state["port_qos_rules"] = []
+                if net_qos_name is not None:
+                    state["net_qos_rules"] = policy_id_to_rule_set[net_qos_name]
+                else:
+                    state["net_qos_rules"] = []
+                states.append(state)
+
+        # Test transitions between those states.
+        self._test_transitions(states)
+
+    def test_qos_rule_change(self):
+        # Test that a WorkloadEndpoint always gets the correct QoS settings as
+        # we change the QoS rules for the qos_policy_id on the corresponding
+        # port and on that port's network.
+        #
+        # In this test, the qos_policy_id values themselves stay the same.
+
+        # Form a set of states, in which transitioning between two of that
+        # states means changing the QoS rules for the effective qos_policy_id.
+        state_base = {
+            "net_qos_name": None,
+            "port_qos_name": "D",
+        }
+        states = []
+        for rules in self.qos_rule_sets:
+            state = state_base.copy()
+            state["port_qos_rules"] = rules
+            state["net_qos_rules"] = []
+            states.append(state)
+
+        # Test transitions between those states.
+        self._test_transitions(states)
+
+    def _test_transitions(self, states):
+        # Calculate the possible transitions from each state, such that only
+        # one thing is changing in each transition.
+        transitions_remaining = 0
+        for i in range(len(states)):
+            states[i]["transitions"] = []
+            states[i]["transitions_covered"] = []
+            for j in range(len(states)):
+                if i == j:
+                    continue
+                if self._only_one_change(states[i], states[j]):
+                    states[i]["transitions"].append(j)
+                    transitions_remaining += 1
+
+        # Calculate a set of state sequences that will cover all of the
+        # possible single-change transitions.
+        sequences = []
+        while transitions_remaining:
+            logger.info(
+                "%d transitions remaining, start new sequence", transitions_remaining
+            )
+            sequence = []
+            # Find an initial state.
+            for i in range(len(states)):
+                if len(states[i]["transitions_covered"]) < len(
+                    states[i]["transitions"]
+                ):
+                    sequence.append(i)
+                    break
+            making_progress = True
+            while making_progress:
+                i = sequence[-1]
+                making_progress = False
+                for j in states[i]["transitions"]:
+                    if j in states[i]["transitions_covered"]:
+                        continue
+                    state_transitions_remaining = len(states[i]["transitions"]) - len(
+                        states[i]["transitions_covered"]
+                    )
+                    if (
+                        state_transitions_remaining > 1
+                        and len(sequence) > 1
+                        and j == sequence[-2]
+                    ):
+                        continue
+                    sequence.append(j)
+                    states[i]["transitions_covered"].append(j)
+                    transitions_remaining -= 1
+                    making_progress = True
+                    break
+            logger.info(
+                "Calculated sequence with length %d = %r", len(sequence), sequence
+            )
+            sequences.append(sequence)
+
+        # Test each sequence in turn.
+        for sequence in sequences:
+            self._test_sequence([states[i] for i in sequence])
+
+    def _only_one_change(self, a, b):
+        changes = []
+        if a["net_qos_name"] != b["net_qos_name"]:
+            changes.append(f"change net_qos_name to {b['net_qos_name']}")
+        if a["port_qos_name"] != b["port_qos_name"]:
+            changes.append(f"change port_qos_name to {b['port_qos_name']}")
+        if len(changes) > 1:
+            return False
+        # Only compare the rules when IDs are not changing.
+        if len(changes) == 0:
+            if b["port_qos_name"] is not None:
+                relevant_rules = "port_qos_rules"
+            else:
+                relevant_rules = "net_qos_rules"
+            a_rules = a[relevant_rules]
+            b_rules = b[relevant_rules]
+            for r in a_rules:
+                if r not in b_rules:
+                    changes.append(f"remove rule {r}")
+            for r in b_rules:
+                if r not in a_rules:
+                    changes.append(f"add rule {r}")
+        if len(changes) > 1:
+            return False
+        if len(changes) == 0:
+            return False
+        return changes[0]
+
+    def _test_sequence(self, sequence):
+        current = None
+        for nxt in sequence:
+            if current is None:
+                port_id = self._create_initial_state(nxt)
+            else:
+                self._apply_change(current, nxt)
+                self._verify_wep_qos(port_id, nxt)
+            current = nxt
+        self.tearDown()
+
+    def _create_initial_state(self, state):
+        logger.info(f"Create initial state -> {state}")
+
+        # Create the QoS rules and policies that we need.
+        if state["port_qos_name"] is not None:
+            port_qos_id = self._ensure_qos_policy(
+                state["port_qos_name"],
+                state["port_qos_rules"],
+            )
+        else:
+            port_qos_id = None
+
+        if state["net_qos_name"] is not None:
+            net_qos_id = self._ensure_qos_policy(
+                state["net_qos_name"],
+                state["net_qos_rules"],
+            )
+        else:
+            net_qos_id = None
+
+        # Create the network and subnet.
+        network, subnet = self.create_test_network("test-network", net_qos_id)
+
+        # Create the VM.
+        cirros = [i for i in self.conn.image.images() if i.name.startswith("cirros")][0]
+        tiny = [i for i in self.conn.compute.flavors() if "tiny" in i.name][0]
+        vm = self.conn.compute.create_server(
+            name="test-vm",
+            image_id=cirros.id,
+            flavor_id=tiny.id,
+            networks=[{"uuid": network.id}],
+        )
+        vm = self.conn.compute.wait_for_server(vm)
+        port = list(self.conn.network.ports(device_id=vm.id))[0]
+
+        # Maybe set port-level QoS.
+        if port_qos_id is not None:
+            self.conn.network.update_port(port.id, qos_policy_id=port_qos_id)
+
+        return port.id
+
+    def _ensure_qos_policy(self, name, rules):
+        full_name = "test-qos-policy" + name
+        qos_policy = self.conn.network.find_qos_policy(full_name)
+        if qos_policy is None:
+            qos_policy = self.conn.network.create_qos_policy(name=full_name)
+
+        significant_keys = [
+            "type",
+            "direction",
+            "max_burst_kbps",
+            "max_kbps",
+            "max_kpps",
+        ]
+        existing_rules = [
+            {k: v for k, v in r.items() if k in significant_keys}
+            for r in qos_policy.rules
+        ]
+        desired_rules = [
+            {k: v for k, v in r["rule"].items() if k in significant_keys} for r in rules
+        ]
+
+        for i, r in enumerate(existing_rules):
+            if r not in desired_rules:
+                logger.info(f"Delete rule {r} for policy {name}")
+                if r["type"] == "bandwidth_limit":
+                    self.conn.network.delete_qos_bandwidth_limit_rule(
+                        qos_policy.rules[i]["id"], qos_policy.id
+                    )
+                elif r["type"] == "packet_rate_limit":
+                    self.conn.network.delete_qos_packet_rate_limit_rule(
+                        qos_policy.rules[i]["id"], qos_policy.id
+                    )
+
+        for r in desired_rules:
+            if r not in existing_rules:
+                logger.info(f"Add rule {r} for policy {name}")
+                if r["type"] == "bandwidth_limit":
+                    r2 = r.copy()
+                    del r2["type"]
+                    self.conn.network.create_qos_bandwidth_limit_rule(
+                        qos_policy.id, **r2
+                    )
+                elif r["type"] == "packet_rate_limit":
+                    r2 = r.copy()
+                    del r2["type"]
+                    self.conn.network.create_qos_packet_rate_limit_rule(
+                        qos_policy.id, **r2
+                    )
+
+        return qos_policy.id
+
+    def create_test_network(self, name, qos_policy_id=None):
+        """Create a test network and subnet."""
+        network_args = {
+            "name": name,
+            "shared": True,
+            "provider:network_type": "local",
+        }
+        if qos_policy_id:
+            network_args["qos_policy_id"] = qos_policy_id
+
+        network = self.conn.network.create_network(**network_args)
+
+        subnet = self.conn.network.create_subnet(
+            name=f"{name}-subnet",
+            network_id=network.id,
+            cidr="10.63.%d.0/24" % self.next_subnet_byte,
+            ip_version=4,
+            enable_dhcp=True,
+        )
+        logger.info(
+            f"Created network: {name}"
+            f" {'with QoS policy' if qos_policy_id else 'without QoS policy'}"
+        )
+        self.next_subnet_byte += 1
+        self.assertLess(self.next_subnet_byte, 256)
+
+        return network, subnet
+
+    def _apply_change(self, current, nxt):
+        change = self._only_one_change(current, nxt)
+        logger.info(f" {change} -> {nxt}")
+        if change.startswith("change net_qos_name"):
+            if nxt["net_qos_name"] is not None:
+                net_qos_id = self._ensure_qos_policy(
+                    nxt["net_qos_name"], nxt["net_qos_rules"]
+                )
+            else:
+                net_qos_id = None
+            network = self.conn.network.find_network("test-network")
+            self.conn.network.update_network(network.id, qos_policy_id=net_qos_id)
+        elif change.startswith("change port_qos_name"):
+            if nxt["port_qos_name"] is not None:
+                port_qos_id = self._ensure_qos_policy(
+                    nxt["port_qos_name"], nxt["port_qos_rules"]
+                )
+            else:
+                port_qos_id = None
+            vm = self.conn.compute.find_server("test-vm")
+            port = list(self.conn.network.ports(device_id=vm.id))[0]
+            self.conn.network.update_port(port.id, qos_policy_id=port_qos_id)
+        elif change.startswith("remove rule") or change.startswith("add rule"):
+            if nxt["net_qos_name"] is not None:
+                self._ensure_qos_policy(nxt["net_qos_name"], nxt["net_qos_rules"])
+            if nxt["port_qos_name"] is not None:
+                self._ensure_qos_policy(nxt["port_qos_name"], nxt["port_qos_rules"])
+
+    def _verify_wep_qos(self, port_id, state):
+        logger.info(f"Verify WEP QoS for state {state}")
+        expected_qos = {}
+        if state["port_qos_name"] is not None:
+            for r in state["port_qos_rules"]:
+                expected_qos.update(r["controls"])
+        elif state["net_qos_name"] is not None:
+            for r in state["net_qos_rules"]:
+                expected_qos.update(r["controls"])
+        logger.info(f"Expected QoS is {expected_qos}")
+        retry_until_success(
+            self._assert_wep_qos,
+            function_args=(port_id, expected_qos),
+        )
+
+    def _assert_wep_qos(self, port_id, expected_qos):
+        """
+        Assert that WorkloadEndpoint QoS controls are as expected.
+
+        Args:
+            port_id: Neutron port ID
+            expected_qos: Expected QoS controls dictionary
+        """
+        wep = None
+        for value, metadata in self.etcd_client.get_prefix(
+            "/calico/resources/v3/projectcalico.org/workloadendpoints/"
+        ):
+            logger.info(f"Metadata = {metadata}")
+            if port_id.replace("-", "--") in metadata.key.decode():
+                wep = json.loads(value.decode())
+                break
+
+        logger.info(f"WEP for port {port_id} is {wep}")
+        self.assertIsNotNone(wep)
+        self.assertIn("spec", wep)
+        if expected_qos:
+            self.assertIn("qosControls", wep["spec"])
+            qos_controls = wep["spec"]["qosControls"]
+            self.assertDictEqual(qos_controls, expected_qos)
+        else:
+            self.assertNotIn("qosControls", wep["spec"])
+
+    def setUp(self):
+        self.tearDown()
+
+    def tearDown(self):
+        logger.info("Delete VM")
+        vm = self.conn.compute.find_server("test-vm")
+        if vm is not None:
+            self.conn.compute.delete_server(vm.id)
+            retry_until_success(
+                lambda: self.assertIsNone(self.conn.compute.find_server("test-vm")),
+                wait_time=5,
+            )
+
+        logger.info("Delete subnet")
+        subnet = self.conn.network.find_subnet("test-network-subnet")
+        if subnet is not None:
+            self.conn.network.delete_subnet(subnet.id)
+
+        logger.info("Delete network")
+        network = self.conn.network.find_network("test-network")
+        if network is not None:
+            self.conn.network.delete_network(network.id)
+
+        logger.info("Delete QoS")
+        for name in ["A", "B", "C", "D"]:
+            full_name = "test-qos-policy" + name
+            policy = self.conn.network.find_qos_policy(full_name)
+            if policy:
+                self.conn.network.delete_qos_policy(policy.id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/networking-calico/networking_calico/plugins/calico/plugin.py
+++ b/networking-calico/networking_calico/plugins/calico/plugin.py
@@ -53,10 +53,13 @@ class CalicoPlugin(Ml2Plugin, l3_db.L3_NAT_db_mixin):
 
         # Here we add, rather than forcing the entire value, because DevStack
         # testing configures 'port-security' here.
-        LOG.info("Add 'qos' to ML2 extension_drivers")
-        cfg.CONF.set_override('extension_drivers',
-                              cfg.CONF.ml2.extension_drivers + ['qos'],
-                              group='ml2')
+        LOG.info("Add 'qos' to ML2 extension_drivers, if not already present")
+        if "qos" not in cfg.CONF.ml2.extension_drivers:
+            cfg.CONF.set_override(
+                "extension_drivers",
+                cfg.CONF.ml2.extension_drivers + ["qos"],
+                group="ml2",
+            )
 
         # This is a bit of a hack to get the models_v2.Port attributes setup in such
         # a way as to avoid tracebacks in the neutron-server log.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -49,7 +49,6 @@ class PortExtra(object):
         self.floating_ips = None
         self.interface_name = None
         self.network_name = None
-        self.network_qos_policy_id = None
         self.project_data = None
         self.qos = None
         self.security_groups = None
@@ -251,9 +250,6 @@ class WorkloadEndpointSyncer(ResourceSyncer):
         except Exception:
             LOG.warning(f"Failed to find network name for port {port['id']}")
 
-        if 'qos_policy_id' in network:
-            port_extra.network_qos_policy_id = network['qos_policy_id']
-
     def get_extra_port_information(self, context, port):
         """get_extra_port_information
 
@@ -348,7 +344,7 @@ class WorkloadEndpointSyncer(ResourceSyncer):
                 setting = max
             return setting
 
-        qos_policy_id = port.get('qos_policy_id') or port_extra.network_qos_policy_id
+        qos_policy_id = port.get("qos_policy_id") or port.get("qos_network_policy_id")
         LOG.debug("QoS Policy ID = %r", qos_policy_id)
         if qos_policy_id:
             rules = context.session.query(

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2014, 2015 Metaswitch Networks
 # Copyright (c) 2013 OpenStack Foundation
-# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -97,6 +97,9 @@ config.register_agent_state_opts_helper(cfg.CONF)
 
 LOG = log.getLogger(__name__)
 
+# The default interval between periodic resyncs, in seconds.
+DEFAULT_RESYNC_INTERVAL_SECS = 60
+
 calico_opts = [
     cfg.IntOpt('num_port_status_threads', default=4,
                help="Number of threads to use for writing port status "
@@ -113,6 +116,16 @@ calico_opts = [
                     "of the previous etcd_compaction_period_mins interval."),
     cfg.IntOpt('project_name_cache_max', default=100,
                help="The maximum allowed size of our cache of project names."),
+    cfg.IntOpt(
+        "resync_interval_secs",
+        default=DEFAULT_RESYNC_INTERVAL_SECS,
+        help=(
+            "If non-zero, configures how frequently Calico rechecks its state against"
+            " the Neutron DB.  Zero means to disable any periodic rechecking.  Please"
+            " note that Calico _always_ performs an _initial_ check when the Neutron"
+            " server starts or is restarted."
+        ),
+    ),
 ]
 cfg.CONF.register_opts(calico_opts, 'calico')
 
@@ -132,9 +145,6 @@ PORT_STATUS_MAPPING = {
     datamodel_v1.ENDPOINT_STATUS_ERROR: constants.PORT_STATUS_ERROR,
 }
 
-# The interval between period resyncs, in seconds.
-# TODO(nj): Increase this to a longer interval for product code.
-RESYNC_INTERVAL_SECS = 60
 # When we're not the master, how often we check if we have become the master.
 MASTER_CHECK_INTERVAL_SECS = 5
 # Delay before retrying a failed port status update to the Neutron DB.
@@ -937,7 +947,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             LOG.info("Port unbound, attempting delete if needed.")
             self.endpoint_syncer.delete_endpoint(port)
 
-    def periodic_resync_thread(self, expected_epoch):
+    def periodic_resync_thread(self, launch_epoch):
         """Periodic Neutron DB -> etcd resynchronization logic.
 
         On a fixed interval, spin over relevant Neutron DB objects and
@@ -946,8 +956,8 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         """
         try:
             LOG.info("Periodic resync thread started")
-            while self._epoch == expected_epoch:
-                # Only do the resync logic if we're actually the master node.
+            while self._epoch == launch_epoch:
+                # Only do the resync if we are the master node.
                 if self.elector.master():
                     LOG.info("I am master: doing periodic resync")
 
@@ -976,11 +986,16 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                         check_request_etcd_compaction()
                     except Exception:
                         LOG.exception("Error in periodic resync thread.")
+
+                    if cfg.CONF.calico.resync_interval_secs == 0:
+                        # No continuing periodic resync.
+                        break
+
                     # Reschedule ourselves.
-                    eventlet.sleep(RESYNC_INTERVAL_SECS)
+                    eventlet.sleep(cfg.CONF.calico.resync_interval_secs)
                 else:
                     # Shorter sleep interval before we check if we've become
-                    # the master.  Avoids waiting a whole RESYNC_INTERVAL_SECS
+                    # the master.  Avoids waiting a whole resync_interval_secs
                     # if we just miss the master update.
                     LOG.debug("I am not master")
                     eventlet.sleep(MASTER_CHECK_INTERVAL_SECS)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -53,6 +53,12 @@ except ImportError:
     # Neutron code prior to a2c36d7e (10th November 2017).
     from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2.drivers import mech_agent
+
+from neutron.objects import ports as ports_object
+from neutron.objects.qos import policy as policy_object
+
+from neutron_lib.db import api as db_api
+
 from sqlalchemy import exc as sa_exc
 
 # Monkeypatch import
@@ -74,14 +80,13 @@ from networking_calico import datamodel_v3
 from networking_calico import etcdv3
 from networking_calico.logutils import logging_exceptions
 from networking_calico.monotonic import monotonic_time
+from networking_calico.plugins.ml2.drivers.calico import qos_driver
 from networking_calico.plugins.ml2.drivers.calico.election import Elector
 from networking_calico.plugins.ml2.drivers.calico.endpoints import \
     _port_is_endpoint_port
 from networking_calico.plugins.ml2.drivers.calico.endpoints import \
     WorkloadEndpointSyncer
 from networking_calico.plugins.ml2.drivers.calico.policy import PolicySyncer
-from networking_calico.plugins.ml2.drivers.calico.qos_driver import register \
-    as register_qos_driver
 from networking_calico.plugins.ml2.drivers.calico.status import StatusWatcher
 from networking_calico.plugins.ml2.drivers.calico.subnets import SubnetSyncer
 
@@ -207,7 +212,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             'tap',
             {'port_filter': True,
              'mac_address': '00:61:fe:ed:ca:fe'})
-        register_qos_driver()
+        qos_driver.register(self)
         # Lock to prevent concurrent initialisation.
         self._init_lock = Semaphore()
         # Generally initialize attributes to nil values.  They get initialized
@@ -684,16 +689,91 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         # check_segment_for_agent.
         assert False
 
-    # For network and subnet actions we have nothing to do, so we provide these
-    # no-op methods.
     def create_network_postcommit(self, context):
         LOG.info("CREATE_NETWORK_POSTCOMMIT: %s" % context)
+        # Nothing else needed here.  There cannot yet be any ports on a network that has
+        # only just been created.
 
+    @requires_state
     def update_network_postcommit(self, context):
         LOG.info("UPDATE_NETWORK_POSTCOMMIT: %s" % context)
 
+        # Determine if qos_policy_id is changing.  If not, no-op.
+        old_qos_policy_id = context.original.get("qos_policy_id", None)
+        new_qos_policy_id = context.current.get("qos_policy_id", None)
+        if old_qos_policy_id == new_qos_policy_id:
+            return
+
+        network_id = context.current["id"]
+        LOG.info(
+            "qos_policy_id for network %r changing from %r to %r",
+            network_id,
+            old_qos_policy_id,
+            new_qos_policy_id,
+        )
+
+        # Update the existing ports for this network and which don't have their own
+        # qos_policy_id.
+        plugin_context = context._plugin_context
+        with self._txn_from_context(plugin_context, tag="update-network"):
+            ports = self.db.get_ports(
+                plugin_context,
+                filters={
+                    "network_id": [network_id],
+                },
+            )
+            self.update_existing_ports(
+                [p for p in ports if not p["qos_policy_id"]],
+                plugin_context,
+                "network changing qos_policy_id",
+            )
+
+    def update_existing_ports(self, ports, plugin_context, reason):
+        # For each port, recompute and emit the WorkloadEndpoint for that port.
+        LOG.info("Update %d port(s) for %s", len(ports), reason)
+        for p in ports:
+            if _port_is_endpoint_port(p):
+                self.endpoint_syncer.write_endpoint(p, plugin_context, must_update=True)
+
+    @requires_state
+    def handle_qos_policy_update(self, context, policy_id):
+        LOG.info("HANDLE_QOS_POLICY_UPDATE: %s %s", context, policy_id)
+
+        with db_api.CONTEXT_READER.using(context):
+            policy = policy_object.QosPolicy.get_policy_obj(context, policy_id)
+
+            # Find ports whose network use this QoS policy and that don't have a
+            # port-specific QoS policy.
+            networks_ids = policy.get_bound_networks()
+            ports_with_net_policy = (
+                ports_object.Port.get_objects(context, network_id=networks_ids)
+                if networks_ids
+                else []
+            )
+            ports = [
+                port.to_dict()
+                for port in ports_with_net_policy
+                if port.qos_policy_id is None
+            ]
+
+            # Add the ports that directly use this QoS policy.
+            port_ids = policy.get_bound_ports()
+            if port_ids:
+                ports.extend(
+                    [
+                        p.to_dict()
+                        for p in ports_object.Port.get_objects(context, id=port_ids)
+                    ]
+                )
+
+            self.update_existing_ports(
+                ports, context, "network QoS policy rules changing"
+            )
+
     def delete_network_postcommit(self, context):
         LOG.info("DELETE_NETWORK_POSTCOMMIT: %s" % context)
+        # Nothing else needed here.  If there were ports on this network, we would have
+        # got separate callbacks for those ports being deleted.
 
     @requires_state
     def create_subnet_postcommit(self, context):

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/qos_driver.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/qos_driver.py
@@ -51,18 +51,32 @@ SUPPORTED_RULES = {
 class CalicoQoSDriver(base.DriverBase):
 
     @staticmethod
-    def create():
-        return CalicoQoSDriver(
+    def create(mechanism_driver):
+        qd = CalicoQoSDriver(
             name='calico',
             vif_types=[portbindings.VIF_TYPE_TAP],
             vnic_types=[portbindings.VNIC_NORMAL],
             supported_rules=SUPPORTED_RULES,
             requires_rpc_notifications=False)
+        qd.mechanism_driver = mechanism_driver
+        return qd
+
+    def update_policy(self, context, policy):
+        """Update policy invocation.
+
+        This method can be implemented by the specific driver subclass
+        to update the backend where necessary.
+
+        :param context: current running context information
+        :param policy: a QoSPolicy object being updated.
+        """
+        LOG.info("update_policy: context=%r policy=%r", context, policy)
+        self.mechanism_driver.handle_qos_policy_update(context, policy.id)
 
 
-def register():
+def register(mechanism_driver):
     """Register the driver."""
     global DRIVER
     if not DRIVER:
-        DRIVER = CalicoQoSDriver.create()
+        DRIVER = CalicoQoSDriver.create(mechanism_driver)
     LOG.debug('Calico QoS driver registered')

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
@@ -43,6 +43,8 @@ sys.modules['neutron.db'] = m_neutron.db
 sys.modules['neutron.db.models'] = m_neutron.db.models
 sys.modules['neutron.db.models.l3'] = m_neutron.db.models.l3
 sys.modules['neutron.db.qos'] = m_neutron.db.qos
+sys.modules["neutron.objects"] = m_neutron.objects
+sys.modules["neutron.objects.qos"] = m_neutron.objects.qos
 sys.modules['neutron.openstack'] = m_neutron.openstack
 sys.modules['neutron.openstack.common'] = m_neutron.openstack.common
 sys.modules['neutron.openstack.common.db'] = m_neutron.openstack.common.db
@@ -50,6 +52,8 @@ sys.modules['neutron.plugins'] = m_neutron.plugins
 sys.modules['neutron.plugins.ml2'] = m_neutron.plugins.ml2
 sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
 sys.modules['neutron.plugins.ml2.rpc'] = m_neutron.plugins.ml2.rpc
+sys.modules["neutron_lib"] = m_neutron_lib = mock.MagicMock()
+sys.modules["neutron_lib.db"] = m_neutron_lib.db
 sys.modules['sqlalchemy'] = m_sqlalchemy = mock.Mock()
 sys.modules['sqlalchemy.orm'] = m_sqlalchemy.orm
 sys.modules['sqlalchemy.orm.exc'] = m_sqlalchemy.orm.exc

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1014,13 +1014,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_compat.cfg.CONF.calico.egress_burst_packets = 0
 
         # Set a QoS policy on the network instead of directly on the port.
-        #
-        # Note that the network_id at this point is 'calico-other-network-id'.
         _log.debug("Test getting QoS policy from network object")
         del self.osdb_ports[0]['qos_policy_id']
-        self.assertEqual(context._port['network_id'], 'calico-other-network-id')
-        self.assertEqual(self.osdb_networks[1]['id'], 'calico-other-network-id')
-        self.osdb_networks[1]['qos_policy_id'] = '1'
+        self.osdb_ports[0]["qos_network_policy_id"] = "1"
         self.driver.update_port_postcommit(context)
 
         # Expected changes
@@ -1037,7 +1033,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
 
         # Remove the QoS policy from the network again.
         _log.debug("Retest after removing all QoS policy")
-        del self.osdb_networks[1]['qos_policy_id']
+        del self.osdb_ports[0]["qos_network_policy_id"]
         self.driver.update_port_postcommit(context)
 
         # Expected changes
@@ -1105,10 +1101,8 @@ class TestPluginEtcd(TestPluginEtcdBase):
         implemented as no-ops (because Calico function does not need
         them).
         """
-        self.driver.update_network_postcommit(None)
         self.driver.delete_network_postcommit(None)
         self.driver.create_network_postcommit(None)
-        self.driver.update_network_postcommit(None)
 
     def test_subnet_hooks(self):
         """Test subnet creation, update and deletion hooks."""

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Metaswitch Networks
-# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -361,6 +361,9 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_compat.cfg.CONF.calico.egress_minburst_bytes = 0
         lib.m_compat.cfg.CONF.calico.ingress_burst_packets = 0
         lib.m_compat.cfg.CONF.calico.egress_burst_packets = 0
+        lib.m_compat.cfg.CONF.calico.resync_interval_secs = (
+            mech_calico.DEFAULT_RESYNC_INTERVAL_SECS
+        )
         calico_config._reset_globals()
         datamodel_v2._reset_globals()
 
@@ -526,7 +529,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # Allow it to run again, this time auditing against the etcd data that
         # was written on the first iteration.
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
@@ -550,7 +553,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
 
         # Do another resync - expect no changes to the etcd data.
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
@@ -590,7 +593,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # resync will now discover that.
         _log.info("Resync with existing etcd data")
         self.osdb_ports[0]['binding:host_id'] = 'felix-host-1'
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
 
         self.assertEtcdDeletes(set([ep_deadbeef_key_v3]))
         ep_deadbeef_key_v3 = ep_deadbeef_key_v3.replace('new--host',
@@ -807,7 +810,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
 
         # Resync with all latest data - expect no etcd writes or deletes.
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set([]))
 
@@ -859,7 +862,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
         # cleaned up.
         self.osdb_ports = [context.original]
         _log.info("Resync with existing etcd data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set([
             ep_deadbeef_key_v3,
@@ -896,7 +899,7 @@ class TestPluginEtcdBase(_TestEtcdBase):
              'ip_address': '10.65.0.188'}
         ]
         _log.info("Resync with edited data")
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
 
         ep_hello_value_v3['spec']['ipNetworks'] = ["10.65.0.188/32"]
         ep_hello_value_v3['spec']['ipv4Gateway'] = "10.65.0.1"
@@ -1179,7 +1182,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         # Allow the etcd transport's resync thread to run again.  Expect no
         # change in etcd subnet data.
         self.give_way()
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({})
         self.assertEtcdDeletes(set())
 
@@ -1209,7 +1212,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         with lib.FixedUUID('uuid-subnet-hooks-2'):
             self.give_way()
             self.etcd_data = {}
-            self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+            self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
 
         expected_writes[
             '/calico/resources/v3/projectcalico.org/clusterinformations/' +
@@ -1230,7 +1233,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         subnet1['enable_dhcp'] = True
         subnet2['enable_dhcp'] = False
         self.give_way()
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({
             '/calico/dhcp/v2/no-region/subnet/subnet-id-10.65.0--24': {
                 'network_id': 'net-id-1',
@@ -1247,7 +1250,7 @@ class TestPluginEtcd(TestPluginEtcdBase):
         # changed a Calico-relevant property of a DHCP-enabled subnet.
         subnet1['gateway_ip'] = '10.65.0.2'
         self.give_way()
-        self.simulated_time_advance(mech_calico.RESYNC_INTERVAL_SECS)
+        self.simulated_time_advance(mech_calico.DEFAULT_RESYNC_INTERVAL_SECS)
         self.assertEtcdWrites({
             '/calico/dhcp/v2/no-region/subnet/subnet-id-10.65.0--24': {
                 'network_id': 'net-id-1',


### PR DESCRIPTION
## Description

Cherry pick #10856 and #10931 to the release-v3.30 branch.  Following are those PRs' own descriptions.

### Make OpenStack resync interval configurable and disable-able

In principle the ongoing resync isn't needed at all, so let's make it possible to switch it off, and do our DevStack (FV) testing like that, to confirm the principle.

On the other hand, if it is wanted, let's make the period configurable. For now we continue to default to the same as before, i.e. 60s.

Plus a small variable naming improvement.

### OpenStack: Respond immediately to all QoS configuration changes

In particular to these two classes of change for which we previously relied on eventual consistency via the resync process:

1. Adding/updating/removing `qos_policy_id` value to/in/from a Network with ports that don't have their own `qos_policy_id` field.

2. Adding/updating/removing a QoS rule to/in/from a QoS policy that is already in use.

Implementation details:

- Implement `update_network_postcommit` method in the mechanism driver, to detect when `qos_policy_id` value is changing and re-emit the WorkloadEndpoint data for each affected port. This covers case (1).

- Implement `update_policy` method in `CalicoQoSDriver` class, to call on to the mechanism driver and re-emit the WorkloadEndpoint data for each affected port.  This is called whenever the rules change for an existing QoS policy, and so covers case (2).

Testing details:

- Add a new step into our DevStack CI to run Calico-specific FV tests, before the existing Tempest tests.  The first FV tests, in this PR, test that WorkloadEndpoint QoSControls are correctly and promptly updated for all possible transitions that:

  - Modify the `qos_policy_id` value for a port, or for that port's network.

  - Modify the rules for an existing QoS policy.

Related fixes, discovered by the new testing:

- Calico plugin init should only add 'qos' to ML2 extension_drivers if not already present. Otherwise QoS handling code gets called twice per operation, which causes it to fail:

      2025-08-27 18:06:19,989 - ERROR - Test execution failed: ConflictException: 409: Client Error for url: http://192.168.122.233:9696/networking/v2.0/networks, Failed to create a duplicate QosPolicyNetworkBinding: for attribute(s) ['qos_network_policy_bindings.network_id'] with value(s) 9bf10a53-926e-4511-ab3c-756faca44c29

  Apparently DevStack setup includes 'qos', and then our plugin was adding it again:

      Aug 27 14:30:24 semaphore-vm neutron-server[71036]: DEBUG oslo_service.service [-] ml2.extension_drivers          = ['port_security', 'qos', 'qos'] {{(pid=71036) log_opt_values /opt/stack/data/venv/lib/python3.10/site-packages/oslo_config/cfg.py:2620}}

- For some reason it works better to get the QoS policy ID for a port's network as `port.get("qos_network_policy_id")` than it does as `network["qos_policy_id"]`, so I've modified the code to try both.  Example of the `qos_network_policy_id` attribute:

      Aug 28 22:29:51 semaphore-vm neutron-server[69834]: DEBUG networking_calico.plugins.ml2.drivers.calico.endpoints [None req-ecf3bc4e-e1c7-426c-862c-6611c3ad0c3e None None] port = {'id': '35d29ef7-38b6-4a99-b8cf-684a75fb4e71', 'name': 'test-port-network-qos-62416584', 'network_id': '22fca5e7-85c7-4267-8af1-8972b56b0184', 'tenant_id': '2503291a80764895813deda9dc8b082b', 'mac_address': 'fa:16:3e:e4:d0:e9', 'admin_state_up': True, 'status': 'DOWN', 'device_id': '', 'device_owner': 'compute:', 'standard_attr_id': 216, 'fixed_ips': [{'subnet_id': '02c83fed-e0c7-45f6-9aa9-a7711448f198', 'ip_address': '192.168.100.215'}], 'allowed_address_pairs': [], 'extra_dhcp_opts': [], 'security_groups': ['38323e51-1163-4c39-9904-979441de45a6'], 'description': '', 'binding:vnic_type': 'normal', 'binding:profile': {}, 'binding:host_id': '', 'binding:vif_type': 'unbound', 'binding:vif_details': {}, 'port_security_enabled': True, 'qos_policy_id': None, 'qos_network_policy_id': 'a8eb0869-a39e-480c-b003-24f8c1f762e7', 'resource_request': None, 'tags': [], 'created_at': '2025-08-28T22:29:32Z', 'updated_at': '2025-08-28T22:29:32Z', 'revision_number': 1, 'project_id': '2503291a80764895813deda9dc8b082b'} {{(pid=69834) get_extra_port_information /opt/stack/data/venv/lib/python3.10/site-packages/networking_calico/plugins/ml2/drivers/calico/endpoints.py:257}}

## Release Note

```release-note
OpenStack QoS handling has been improved to respond immediately to all kinds of QoS changes on the Neutron API.  In particular when rules are added, updated or deleted for a QoS policy that is already in use, and when a QoS policy is added, updated or deleted for a Neutron network that is already in use.  Calico's handling of these changes previously relied on a periodic resync, which could in practice take a long time; now those changes are handled immediately (within a few seconds).
```
