### PR TITLE
[BPF] reduce bpf_jit_harden from 2 to 1 when possible

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -675,6 +675,13 @@ func NewBPFEndpointManager(
 		m.updatePolicyProgramFn = m.updatePolicyProgram
 	}
 
+	if v, err := m.getJITHardening(); err == nil && v == 2 {
+		err := m.setJITHardening(1)
+		if err != nil {
+			log.WithError(err).Warn("Failed to set jit hardening to 1, conrtinuing with 2 - performance may be degraded")
+		}
+	}
+
 	return m, nil
 }
 
@@ -3488,6 +3495,32 @@ func (m *bpfEndpointManager) setRPFilter(iface string, val int) error {
 
 	log.Infof("%s set to %s", path, numval)
 	return nil
+}
+
+const jitHardenPath = "/proc/sys/net/core/bpf_jit_harden"
+
+func (m *bpfEndpointManager) setJITHardening(val int) error {
+	numval := strconv.Itoa(val)
+	err := writeProcSys(jitHardenPath, numval)
+	if err != nil {
+		log.WithField("err", err).Errorf("Failed to  set %s to %s", jitHardenPath, numval)
+		return err
+	}
+
+	log.Infof("%s set to %s", jitHardenPath, numval)
+	return nil
+}
+
+func (m *bpfEndpointManager) getJITHardening() (int, error) {
+	data, err := os.ReadFile(jitHardenPath)
+	if err != nil {
+		return 0, err
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
 }
 
 func (m *bpfEndpointManager) ensureStarted() {


### PR DESCRIPTION
When bpf_jit_harden is set to 2 it obfuscates userspace provided constants including jumps in the loaded programs. That makes loading policies 10-20x slower. Reducing bpf_jit_harden from 2 (harden always) to 1 (harden only for unpriviledged users only) makes large policies load fast.

In case this is not possible, felix reduces trampoline jump distance so make the programs loadable anyway.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
