### PR TITLE
[v3.31] Handle ENOLINK when updating an existing tcx program

### DIFF
--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -26,6 +26,7 @@ import (
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
@@ -117,10 +118,17 @@ func (ap *AttachPoint) attachTCXProgram(binaryToLoad string) error {
 		}
 		defer link.Close()
 		if err := link.Update(obj, "cali_tc_preamble"); err != nil {
+			if errors.Is(err, unix.ENOLINK) {
+				// The link was deleted out from under us, so try attaching a new one.
+				logCxt.Debug("Link severed from interface, re-attaching")
+				os.Remove(progPinPath)
+				goto attachNew
+			}
 			return fmt.Errorf("error updating program %s : %w", progPinPath, err)
 		}
 		return nil
 	}
+attachNew:
 	link, err := obj.AttachTCX("cali_tc_preamble", ap.Iface)
 	if err != nil {
 		return err

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -185,7 +185,7 @@ func (ap *AttachPoint) AttachProgram() error {
 	}
 	logCxt.Info("Program attached to tc.")
 	// Remove any tcx program.
-	err = ap.detachTcxProgram()
+	err = ap.DetachTcxProgram()
 	if err != nil {
 		logCxt.Warnf("error removing tcx program from %s", err)
 	}
@@ -196,7 +196,7 @@ func (ap *AttachPoint) progPinPath() string {
 	return path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_%s", strings.Replace(ap.Iface, ".", "", -1), ap.Hook))
 }
 
-func (ap *AttachPoint) detachTcxProgram() error {
+func (ap *AttachPoint) DetachTcxProgram() error {
 	progPinPath := ap.progPinPath()
 	if _, err := os.Stat(progPinPath); os.IsNotExist(err) {
 		return nil
@@ -223,7 +223,7 @@ func (ap *AttachPoint) detachTcProgram() error {
 }
 
 func (ap *AttachPoint) DetachProgram() error {
-	err := ap.detachTcxProgram()
+	err := ap.DetachTcxProgram()
 	if err != nil {
 		log.Warnf("error detaching tcx program from %s hook %s : %s", ap.Iface, ap.Hook, err)
 	}

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -1124,6 +1124,78 @@ func TestCTLBAttach(t *testing.T) {
 	testCtlbAttach(true, true)
 }
 
+func TestAttachInterfaceRecreate(t *testing.T) {
+	RegisterTestingT(t)
+	bpfmaps, err := bpfmap.CreateBPFMaps(false)
+	Expect(err).NotTo(HaveOccurred())
+
+	loglevel := "off"
+	bpfEpMgr, err := newBPFTestEpMgr(
+		&linux.Config{
+			Hostname:              "uthost",
+			BPFLogLevel:           loglevel,
+			BPFDataIfacePattern:   regexp.MustCompile("^hostep[12]"),
+			VXLANMTU:              1000,
+			VXLANPort:             1234,
+			BPFNodePortDSREnabled: false,
+			RulesConfig: rules.Config{
+				EndpointToHostAction: "RETURN",
+			},
+			BPFExtToServiceConnmark: 0,
+			BPFPolicyDebugEnabled:   true,
+			BPFAttachType:           apiv3.BPFAttachOptionTCX,
+		},
+		bpfmaps,
+		regexp.MustCompile("^workloadep[0123]"),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	workload0 := createVethName("workloadep0")
+	defer func() {
+		if workload0 != nil {
+			deleteLink(workload0)
+		}
+	}()
+
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
+	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
+	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+		Id: &proto.WorkloadEndpointID{
+			OrchestratorId: "k8s",
+			WorkloadId:     "workloadep0",
+			EndpointId:     "workloadep0",
+		},
+		Endpoint: &proto.WorkloadEndpoint{Name: "workloadep0"},
+	})
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+	_, err = os.Stat(bpfdefs.TcxPinDir + "/workloadep0_ingress")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = os.Stat(bpfdefs.TcxPinDir + "/workloadep0_egress")
+	Expect(err).NotTo(HaveOccurred())
+
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateNotPresent, workload0.Attrs().Index))
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+	_, err = os.Stat(bpfdefs.TcxPinDir + "/workloadep0_ingress")
+	Expect(err).To(HaveOccurred())
+	_, err = os.Stat(bpfdefs.TcxPinDir + "/workloadep0_egress")
+	Expect(err).To(HaveOccurred())
+
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+	// Now simulate interface being deleted and recreated.
+	deleteLink(workload0)
+	workload0 = nil
+	workload0_new := createVethName("workloadep0")
+	defer deleteLink(workload0_new)
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0_new.Attrs().Index))
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func TestAttachTcx(t *testing.T) {
 	RegisterTestingT(t)
 	bpfmaps, err := bpfmap.CreateBPFMaps(false)

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1090,9 +1090,7 @@ func cleanupTcxPins(iface string) {
 				Hook:  attachHook,
 			},
 		}
-		if err := ap.DetachTcxProgram(); err != nil {
-			log.WithError(err).Warnf("Failed to detach old tcx program from now gone device '%s' hook %s", iface, attachHook)
-		}
+		os.Remove(ap.ProgPinPath())
 	}
 }
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1149,8 +1149,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 
 	if update.State == ifacemonitor.StateNotPresent && m.bpfAttachType == apiv3.BPFAttachOptionTCX {
 		// Delete the tcx pins if the interface is gone.
-		if err := m.cleanupOldTcAttach(update.Name); err != nil {
-			log.WithError(err).Warnf("Failed to detach old tc programs from now gone device '%s'", update.Name)
+		// Check if the interface still exists, as we might get events out of order.
+		_, err := m.dp.getIfaceLink(update.Name)
+		if err != nil {
+			if err := m.cleanupOldTcAttach(update.Name); err != nil {
+				log.WithError(err).Warnf("Failed to detach old tc programs from now gone device '%s'", update.Name)
+			}
 		}
 	}
 	// Should be safe without the lock since there shouldn't be any active background threads

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1147,6 +1147,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 		return
 	}
 
+	if update.State == ifacemonitor.StateNotPresent && m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+		// Delete the tcx pins if the interface is gone.
+		if err := m.cleanupOldTcAttach(update.Name); err != nil {
+			log.WithError(err).Warnf("Failed to detach old tc programs from now gone device '%s'", update.Name)
+		}
+	}
 	// Should be safe without the lock since there shouldn't be any active background threads
 	// but taking it now makes us robust to refactoring.
 	m.ifacesLock.Lock()


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11012
## Description

This PR handles
1. ENOLINK when updating an existing link while attaching tcx program.
2. If the interface is deleted, remove the tcx pins.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```