### PR TITLE
Merge pull request #10876 from kristiangronas/calico-dhcp-agent-slaac

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -829,6 +829,12 @@ class SubnetWatcher(etcdutils.EtcdWatcher):
         if ip_version == 6:
             subnet["ipv6_address_mode"] = constants.DHCPV6_STATEFUL
             subnet["ipv6_ra_mode"] = constants.DHCPV6_STATEFUL
+            if (
+                data.get("ipv6_address_mode") == constants.IPV6_SLAAC
+                and data.get("ipv6_ra_mode") == constants.IPV6_SLAAC
+            ):
+                subnet["ipv6_address_mode"] = constants.IPV6_SLAAC
+                subnet["ipv6_ra_mode"] = constants.IPV6_SLAAC
 
         return dhcp.DictModel(subnet)
 

--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -99,7 +99,11 @@ class DnsmasqRouted(dhcp.Dnsmasq):
                     and not ra_mode
                 ):
                     mode = "static"
-
+                if (
+                    addr_mode == constants.IPV6_SLAAC
+                    and ra_mode == constants.IPV6_SLAAC
+                ):
+                    mode = "slaac,ra-only"
             cidr = netaddr.IPNetwork(subnet.cidr)
 
             if self.conf.dhcp_lease_duration == -1:

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/subnets.py
@@ -99,4 +99,8 @@ def subnet_etcd_data(subnet):
     }
     if subnet["dns_nameservers"]:
         data["dns_servers"] = subnet["dns_nameservers"]
+    if subnet.get("ipv6_ra_mode") and subnet.get("ipv6_address_mode"):
+        data["ipv6_ra_mode"] = subnet["ipv6_ra_mode"]
+        data["ipv6_address_mode"] = subnet["ipv6_address_mode"]
+
     return data


### PR DESCRIPTION
Cherry pick #10876 for v3.31: Add slaac support for calico-dhcp-agent

## Description

Currently calico-dhcp-agent only supports dhcp6_stateful, but this can introduce a failure mode where leases get stuck after for example an openstack rebuild. SLAAC allows the machine to assign it's own IP, based on the mac address, which is already decided by neutron and passed into the VM

For ipv4 it already works similarly, since dnsmasq can simply bind the leases to ipv4 mac addresses

From what i can tell you still need a normal subnet to make nova happy, but the main goal of this PR is having a SLAAC address with higher reliability

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
OpenStack: support IPv6 subnets using SLAAC
```
