### PR TITLE
Adding null check for VTEPInfo and IPaddress

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -150,12 +150,15 @@ func (i l3rrNodeInfo) AddressesAsCIDRs() []ip.CIDR {
 	addrs[i.V6Addr] = struct{}{}
 
 	for _, a := range i.Addresses {
-		addrs[a] = struct{}{}
+		// Skip nil address to prevent panic
+		if a != nil {
+			addrs[a] = struct{}{}
+		}
 	}
 
 	// Clean up empty (uninitialized) addresses
 	for a := range addrs {
-		if a == emptyV4Addr || a == emptyV6Addr {
+		if a == nil || a == emptyV4Addr || a == emptyV6Addr {
 			delete(addrs, a)
 		}
 	}
@@ -163,11 +166,14 @@ func (i l3rrNodeInfo) AddressesAsCIDRs() []ip.CIDR {
 	cidrs := make([]ip.CIDR, len(addrs))
 	idx := 0
 	for a := range addrs {
-		cidrs[idx] = a.AsCIDR()
-		idx++
+		// Addtional safety check before calling AsCIDR
+		if a != nil {
+			cidrs[idx] = a.AsCIDR()
+			idx++
+		}
 	}
 
-	return cidrs
+	return cidrs[:idx]
 }
 
 func NewL3RouteResolver(hostname string, callbacks routeCallbacks, useNodeResourceUpdates bool, routeSource string) *L3RouteResolver {
@@ -431,7 +437,13 @@ func (c *L3RouteResolver) OnResourceUpdate(update api.Update) (_ bool) {
 			for _, a := range node.Spec.Addresses {
 				parsed, _, err := cnet.ParseCIDROrIP(a.Address)
 				if err == nil && parsed != nil {
-					nodeInfo.Addresses = append(nodeInfo.Addresses, ip.FromCalicoIP(*parsed))
+					addr := ip.FromCalicoIP(*parsed)
+					// Add nil check
+					if addr != nil {
+						nodeInfo.Addresses = append(nodeInfo.Addresses, addr)
+					} else {
+						logrus.WithField("addr", a.Address).Warn("FromCalicoIP parsed address is nil")
+					}
 				} else {
 					logrus.WithError(err).WithField("addr", a.Address).Warn("not an IP")
 				}

--- a/felix/calc/vxlan_resolver.go
+++ b/felix/calc/vxlan_resolver.go
@@ -262,20 +262,20 @@ func (c *VXLANResolver) hasVTEPInfo(node string) (bool, bool) {
 	logCtx := logrus.WithField("node", node)
 	hasV4Info, hasV6Info := true, true
 
-	if _, ok := c.nodeNameToVXLANTunnelAddr[node]; !ok {
-		logCtx.Debug("Missing IPv4 VXLAN tunnel address for node")
+	if _, ok := c.nodeNameToVXLANTunnelAddr[node]; !ok || addr == "" || addr == "<nil>" {
+		logCtx.Debug("Missing or Invalid IPv4 VXLAN tunnel address for node")
 		hasV4Info = false
 	}
-	if _, ok := c.nodeNameToIPv4Addr[node]; !ok {
+	if _, ok := c.nodeNameToIPv4Addr[node]; !ok || addr == "" || addr == "<nil>" {
 		logCtx.Debug("Missing IPv4 address for node")
 		hasV4Info = false
 	}
 
-	if _, ok := c.nodeNameToVXLANTunnelAddrV6[node]; !ok {
+	if _, ok := c.nodeNameToVXLANTunnelAddrV6[node]; !ok || addr == "" || addr == "<nil>" {
 		logCtx.Debug("Missing IPv6 VXLAN tunnel address for node")
 		hasV6Info = false
 	}
-	if _, ok := c.nodeNameToIPv6Addr[node]; !ok {
+	if _, ok := c.nodeNameToIPv6Addr[node]; !ok || addr == "" || addr == "<nil>" {
 		logCtx.Debug("Missing IPv6 address for node")
 		hasV6Info = false
 	}


### PR DESCRIPTION
## Description

Missing both IPv4 and IPv6 VTEP information
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
github.com/projectcalico/calico/felix/calc.l3rrNodeInfo.AddressAsCIDR

/go/src/github.com/projectcalico/calico/felix/calc/l3_route_resolver.go:166

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Adding nil checks
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
