### PR TITLE
[release-v3.31] Auto pick #11023: WatcherCache handles missing APIs gracefully

### DIFF
--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -240,8 +240,12 @@ func (wc *watcherCache) maybeResyncAndCreateWatcher(ctx context.Context) {
 					// The resource type doesn't exist yet.  This is possible if the CRD backing this API has not been installed.
 					// This is a valid long-term state, so we don't want to keep retrying rapidly.
 					// Consider ourselves in sync, and then sleep for a long time.
-					wc.logger.Info("Resource type not found, will not watch until resource exists.")
-					wc.finishResync()
+					if !wc.hasSynced {
+						wc.logger.Info("Backing API not installed, marking as in-sync and retrying later.")
+						wc.finishResync()
+					} else {
+						wc.logger.Debug("Backing API still not installed, retrying later.")
+					}
 					wc.resyncBlockedUntil = time.Now().Add(MissingAPIRetryTime)
 					continue
 				}

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -63,6 +63,7 @@ var (
 	ListRetryInterval        = 1000 * time.Millisecond
 	WatchPollInterval        = 5000 * time.Millisecond
 	DefaultWatchRetryTimeout = 600 * time.Second
+	MissingAPIRetryTime      = 10 * time.Minute
 )
 
 // cacheEntry is an entry in our cache.  It groups the a key with the last known
@@ -235,8 +236,19 @@ func (wc *watcherCache) maybeResyncAndCreateWatcher(ctx context.Context) {
 			// be 0 at start of day or the latest received revision.
 			l, err := wc.client.List(ctx, wc.resourceType.ListInterface, wc.currentWatchRevision)
 			if err != nil {
+				if kerrors.IsNotFound(err) {
+					// The resource type doesn't exist yet.  This is possible if the CRD backing this API has not been installed.
+					// This is a valid long-term state, so we don't want to keep retrying rapidly.
+					// Consider ourselves in sync, and then sleep for a long time.
+					wc.logger.Info("Resource type not found, will not watch until resource exists.")
+					wc.finishResync()
+					wc.resyncBlockedUntil = time.Now().Add(MissingAPIRetryTime)
+					continue
+				}
+
 				// Failed to perform the list.  Pause briefly (so we don't tight loop) and retry.
 				wc.logger.WithError(err).Info("Failed to perform list of current data during resync")
+
 				if kerrors.IsResourceExpired(err) || isTooLargeResourceVersionError(err) {
 					// Our current watch revision is out of sync. Start again without a revision.
 					wc.logger.Info("Resource too old/new error from server, clearing cached watch revision.")

--- a/libcalico-go/lib/backend/watchersyncer/watchercache.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchercache.go
@@ -69,8 +69,8 @@ var (
 	DefaultWatchRetryTimeout = 600 * time.Second
 
 	// If the backing API is not installed, we consider ourselves in-sync but retry
-	// infrequently. If the API is installed, we will eventually resync. However, it's good practice
-	// to restart Calico when installing a new API to expedite this.
+	// infrequently. If the API is eventually installed, we will resync after this timer pops.
+	// However, it's good practice to restart Calico when installing a new API to expedite this.
 	MissingAPIRetryTime = 30 * time.Minute
 )
 

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -151,7 +151,6 @@ func (ws *watcherSyncer) Stop() {
 	// the results chan
 	close(ws.results)
 	ws.wgws.Wait()
-
 }
 
 // Send a status update and store the status.
@@ -204,7 +203,6 @@ func (ws *watcherSyncer) run(ctx context.Context) {
 // instead start grouping them together so that we can send a larger single update to
 // Felix.
 func (ws *watcherSyncer) processResult(updates []api.Update, result interface{}) []api.Update {
-
 	// Switch on the result type.
 	switch r := result.(type) {
 	case []api.Update:
@@ -250,6 +248,10 @@ func (ws *watcherSyncer) processResult(updates []api.Update, result interface{})
 
 			// Increment the count of synced events.
 			ws.numSynced++
+			log.WithFields(log.Fields{
+				"NumSynced":     ws.numSynced,
+				"TotalWatchers": len(ws.watcherCaches),
+			}).Info("Watcher cache sync'd")
 
 			// If we have now received synced events from all of our watchers then we are in
 			// sync.  If we have any updates, send them first and then send the status update.

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer.go
@@ -248,10 +248,6 @@ func (ws *watcherSyncer) processResult(updates []api.Update, result interface{})
 
 			// Increment the count of synced events.
 			ws.numSynced++
-			log.WithFields(log.Fields{
-				"NumSynced":     ws.numSynced,
-				"TotalWatchers": len(ws.watcherCaches),
-			}).Info("Watcher cache sync'd")
 
 			// If we have now received synced events from all of our watchers then we are in
 			// sync.  If we have any updates, send them first and then send the status update.

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	}
 
 	It("should receive a sync event when the watchers have listed current settings", func() {
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, emptyList)
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
@@ -106,7 +106,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("should not change status if watch returns multiple ErrorOperationNotSupported errors", func() {
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, emptyList)
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
@@ -124,7 +124,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("should not change status if watch returns multiple ErrorResourceDoesNotExist errors", func() {
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, emptyList)
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
@@ -150,7 +150,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
 		By("Getting to the initial in-sync")
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, k8sTooOldRV)
 		rs.clientListResponse(r1, emptyList)
@@ -185,8 +185,10 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// If an API isn't installed, the List will return a NotFound error. We expect the watcher cache to handle this gracefully,
 		// makring itself in sync and not retrying for an extended period.
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
-		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, apierrors.NewNotFound(apiv3.Resource("networkpolicies"), ""))
+		rs.watcherSyncer.Start()
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
 		rs.ExpectStatusUpdate(api.InSync)
 	})
 
@@ -197,7 +199,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		// All of the events should have been consumed within a time frame dictated by the
@@ -293,7 +295,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		// All of the events should have been consumed within a time frame dictated by the
@@ -342,7 +344,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		before := time.Now()
@@ -395,7 +397,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		rs.clientListResponse(r1, emptyList)
@@ -430,7 +432,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 500*time.Millisecond, 2000*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
 		rs.clientListResponse(r1, emptyList)
@@ -469,7 +471,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		eventL1Added1 := addEvent(l1Key1)
 		eventL2Added1 := addEvent(l2Key1)
 		eventL2Added2 := addEvent(l2Key2)
@@ -552,7 +554,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		defer setWatchIntervals(watchersyncer.MinResyncInterval, watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
 		setWatchIntervals(100*time.Millisecond, 100*time.Millisecond, 500*time.Millisecond)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1})
 		eventL1Added1 := addEvent(l1Key1)
 		eventL1Deleted1 := deleteEvent(l1Key1)
 		eventL1Added2 := addEvent(l1Key2)
@@ -665,7 +667,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should accumulate updates into a single update when the handler thread is blocked", func() {
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2})
 		eventL1Added1 := addEvent(l1Key1)
 		eventL2Added1 := addEvent(l2Key1)
 		eventL2Added2 := addEvent(l2Key2)
@@ -735,7 +737,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		eventL2Added1 := addEvent(l2Key1)
 		eventL2Added2 := addEvent(l2Key2)
 
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, emptyList)
 		rs.clientListResponse(r2, emptyList)
@@ -794,7 +796,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		// Send in another 6 events to cover the different branches of the fake converter.
 		//
 		// See fakeConverter for details on what is returned each invocation.
-		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{rc1})
+		rs := newStartedWatcherSyncerTester([]watchersyncer.ResourceType{rc1})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, emptyList)
 		rs.ExpectStatusUpdate(api.ResyncInProgress)
@@ -1010,6 +1012,12 @@ func modifiedEvent(key model.Key) api.WatchEvent {
 
 // Create a new watcherSyncerTester - this creates and starts a WatcherSyncer with
 // client and sync consumer interfaces implemented and controlled by the test.
+func newStartedWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
+	rst := newWatcherSyncerTester(l)
+	rst.watcherSyncer.Start()
+	return rst
+}
+
 func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester {
 	// Create the required watchers.  This hs methods that we use to drive
 	// responses.
@@ -1039,7 +1047,6 @@ func newWatcherSyncerTester(l []watchersyncer.ResourceType) *watcherSyncerTester
 		watcherSyncer: watchersyncer.New(fc, l, st),
 		lws:           lws,
 	}
-	rst.watcherSyncer.Start()
 	return rst
 }
 

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -181,6 +181,15 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		Eventually(rs.fc.getLatestWatchRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(emptyList.Revision))
 	})
 
+	It("should handle when an API is not installed", func() {
+		// If an API isn't installed, the List will return a NotFound error. We expect the watcher cache to handle this gracefully,
+		// makring itself in sync and not retrying for an extended period.
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, apierrors.NewNotFound(apiv3.Resource("networkpolicies"), ""))
+		rs.ExpectStatusUpdate(api.InSync)
+	})
+
 	It("should handle reconnection if watchers fail to be created", func() {
 		// Temporarily reduce the watch and list poll interval to make the tests faster.
 		// Since we are timing the processing, we still need the interval to be sufficiently

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -16,8 +16,9 @@ include ../lib.Makefile
 
 ###############################################################################
 
-# All Typha go files.
+# All Typha go files and those in libcalico-go.
 SRC_FILES:=$(shell find . $(foreach dir,$(NON_TYPHA_DIRS),-path ./$(dir) -prune -o) -type f -name '*.go' -print)
+SRC_FILES += $(shell find ../libcalico-go/ -type f -name '*.go' -print)
 
 # Touchfile created when we make the typha image.
 TYPHA_CONTAINER_CREATED=.calico_typha.created-$(ARCH)


### PR DESCRIPTION
Cherry pick of #11023 on release-v3.31.

#11023: WatcherCache handles missing APIs gracefully

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This change allows Calico to run successfully even if one of its backing APIs is not installed in the cluster. 

Instead, Calico will treat the API as if it has successfully sync'd (with no resources) and retry to see if the API exists in 30 minutes.

Note - it is not expected that users will be adding / removing these APIs as a frequent occurrence. Rather, API should be set at install time and not modified afterwards. The implementation matches this expectation - we do not watch the CRDs themselves to see if they are added / removed. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Make Calico's backing CRDs optional. Calico will no longer fail to start is a CRD is missing. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.