### PR TITLE
[CORE-11858] fix (bpf): enforce QoS packet rate in main codepath of calico_tc_main() 

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -223,14 +223,14 @@ enum calico_skb_mark {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-noreturn"
 static CALI_BPF_INLINE __attribute__((noreturn)) void bpf_exit(int rc) {
-	// Need volatile here because we don't use rc after this assembler fragment.
-	// The BPF assembler rejects an input-only operand so we make r0 an in/out operand.
-	asm volatile ( \
-		"exit" \
-		: "=r0" (rc) /*out*/ \
-		: "0" (rc) /*in*/ \
-		: /*clobber*/ \
+	asm volatile (
+		"r0 = %[rc_arg]\n" //Explicitly move the value of 'rc' into register R0 to prohibit excessive compiler optimization and make the verifier happy
+		"exit"
+		: // No output operands
+		: [rc_arg] "r" (rc) // Input: rc to a general purpose register
+		: "r0" // Clobber list: R0 is modified by the assembly code
 	);
+	__builtin_unreachable(); // Tell the compiler that this function never returns
 }
 #pragma clang diagnostic pop
 

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -55,6 +55,13 @@ int  cali_tc_preamble(struct __sk_buff *skb)
 	/* We do the copy once here so keep the program smaller */
 	globals->data = *globals_data;
 
+	// Clear bypass mark from packet if ingress packet rate QoS is configured
+	if (globals->data.flags & CALI_GLOBALS_INGRESS_PACKET_RATE_CONFIGURED) {
+		if (skb->mark == CALI_SKB_MARK_BYPASS) {
+			skb->mark = CALI_SKB_MARK_SEEN;
+		}
+	}
+
 #if EMIT_LOGS
 	CALI_LOG("tc_preamble iface %s", globals->data.iface_name);
 #endif

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1480,6 +1480,10 @@ func resetRTMapV6(rtMap maps.Map) {
 	resetMap(rtMap)
 }
 
+func resetQoSMap(qosMap maps.Map) {
+	resetMap(qosMap)
+}
+
 func saveRTMap(rtMap maps.Map) routes.MapMem {
 	rt, err := routes.LoadMap(rtMap)
 	Expect(err).NotTo(HaveOccurred())
@@ -1945,6 +1949,7 @@ func resetBPFMaps() {
 	resetMap(fsafeMap)
 	resetMap(natMap)
 	resetMap(natBEMap)
+	resetMap(qosMap)
 }
 
 func TestMapIterWithDelete(t *testing.T) {

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -57,6 +57,8 @@ func TestQoSPacketRate(t *testing.T) {
 	defer resetRTMap(rtMap)
 
 	// Populate QoS map
+	resetQoSMap(qosMap)
+	defer resetQoSMap(qosMap)
 	key1 := qos.NewKey(uint32(ifIndex), 1)
 	key2 := qos.NewKey(uint32(ifIndex), 0)
 	value := qos.NewValue(1, 1, -1, 0)

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -443,10 +443,10 @@ func ModelWorkloadEndpointToProto(ep *model.WorkloadEndpoint, peerData *Endpoint
 
 	var skipRedir *proto.WorkloadBpfSkipRedir
 	// BPF ingress redirect should be skipped for VM workloads and workloads that have ingress BW QoS configured
-	if isVMWorkload(ep.Labels) || (ep.QoSControls != nil && ep.QoSControls.IngressBandwidth > 0) {
+	if isVMWorkload(ep.Labels) || (ep.QoSControls != nil && (ep.QoSControls.IngressBandwidth > 0 || ep.QoSControls.IngressPacketRate > 0)) {
 		skipRedir = &proto.WorkloadBpfSkipRedir{Ingress: true}
 	}
-	if ep.QoSControls != nil && ep.QoSControls.EgressBandwidth > 0 {
+	if ep.QoSControls != nil && (ep.QoSControls.EgressBandwidth > 0 || ep.QoSControls.EgressPacketRate > 0) {
 		if skipRedir == nil {
 			skipRedir = &proto.WorkloadBpfSkipRedir{}
 		}

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -350,7 +350,7 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.CIDR) routes.ValueInterface {
 						"Will choose one route.")
 			}
 			wepIDs.Iter(func(wepID types.WorkloadEndpointID) error {
-				// Route is a local workload look up its name and interface details.
+				// Route is a local workload, look up its name and interface details.
 				wepScore := 0
 				wep := m.wepIDToWorkload[wepID]
 				ifaceName := wep.Name


### PR DESCRIPTION
Skip {ingress,egress} redirect in BPF mode when {ingress,egress} QoS packet rate is configured (in addition to bandwidth).

Enforce QoS packet rate in main codepath of calico_tc_main() instead of the bypass mark path and in calico_tc_skb_accepted_entrypoint().

Clear bypass mark if QoS ingress packet rate is configured so that the limit is correctly enforced.

Add BPFLogLevel dimension to the QoS controls FV test to make sure things work correctly on both 'debug' and 'no_log' BPF programs.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
