### PR TITLE
ci: Move prereqs back to f1-standard-2

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -130,7 +130,7 @@ blocks:
     task:
       agent:
         machine:
-          type: f1-standard-4
+          type: f1-standard-2
           os_image: ubuntu2204
       jobs:
         - name: Pre-flight checks

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -130,7 +130,7 @@ blocks:
     task:
       agent:
         machine:
-          type: f1-standard-4
+          type: f1-standard-2
           os_image: ubuntu2204
       jobs:
         - name: Pre-flight checks

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -3,7 +3,7 @@
   task:
     agent:
       machine:
-        type: f1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2204
     jobs:
       - name: Pre-flight checks


### PR DESCRIPTION
Due to a shortage of f1-standard-4 instances, having the prereqs job depend on f1-standard-4 results in a typically much longer delay than usual for a pipeline to get started, more than we gain by running prereqs in f1-standard-4.

This may not be the most optimal long-term solution, but this will help our pipelines make better use of our available runners for the time being.
