### PR TITLE
Omit dwz when building Debian packages for Felix

### DIFF
--- a/felix/debian/rules
+++ b/felix/debian/rules
@@ -28,12 +28,9 @@ override_dh_install:
 	install -m 644 bpf-apache/bin/*.o bpf-gpl/bin/*.o debian/tmp/usr/lib/calico/bpf/
 	dh_install
 
-# We need to decompress the debug sections in order for dh_dwz to do its thing
-# without error.
-# See Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931891
 override_dh_dwz:
-	objcopy --decompress-debug-sections debian/calico-felix/usr/bin/calico-felix
-	dh_dwz
+	# dwz only slightly compresses the debug sections and is not fully compatible with DWARF5,
+	# used by Golang 1.25+, so skip this.
 
 # Hide the 'useless dependency' warnings, which are just about libc libs anyway
 override_dh_shlibdeps:


### PR DESCRIPTION
## Description

Openstack builds are all failing after the move to Golang 1.25 with https://launchpadlibrarian.net/820358715/buildlog_ubuntu-jammy-amd64.felix_3%3A3.32.0~rc0.post37-jammy_BUILDING.txt.gz .

Golang 1.25+ moves to DWARF 5, which dwz is not fully compatible with.  There's a Go experiment to revert this, but it may not be available forever and I'd prefer to keep the code itself to the mainline.

https://groups.google.com/g/linux.debian.devel/c/BdkfKzS8Z70 is the main reference I found for this, and we've clearly required past workarounds in our project (see the previous override).

I haven't tested this and I'm not sure I'll be able to find the time to either, but given it's totally broken now and the change looks simple I made this PR anyway.

## Release Note

```release-note
Openstack: Stop compressing DWARF debugging information with dwz because Golang 1.25 has moved to the unsupported DWARF 5
```

