### PR TITLE
Libcalico-go: Prevent segfault when network/ip is not valid

### DIFF
--- a/libcalico-go/lib/backend/model/rule.go
+++ b/libcalico-go/lib/backend/model/rule.go
@@ -127,10 +127,14 @@ func (r Rule) AllNotDstNets() []*net.IPNet {
 	return combineNets(r.NotDstNet, r.NotDstNets)
 }
 
+var JoinNetsForTest = joinNets
+
 func joinNets(nets []*net.IPNet) string {
 	parts := make([]string, len(nets))
 	for i, n := range nets {
-		parts[i] = n.String()
+		if n != nil {
+			parts[i] = n.String()
+		}
 	}
 	return strings.Join(parts, ",")
 }

--- a/libcalico-go/lib/backend/model/rule_test.go
+++ b/libcalico-go/lib/backend/model/rule_test.go
@@ -124,3 +124,21 @@ var _ = Describe("Rule", func() {
 		})
 	}
 })
+
+var _ = Describe("joinNets", func() {
+	mustCIDR := func(s string) *net.IPNet {
+		_, ipnet, err := net.ParseCIDR(s)
+		Expect(err).NotTo(HaveOccurred(), "bad CIDR in test: %s", s)
+		return ipnet
+	}
+	nets := []*net.IPNet{
+		mustCIDR("10.0.0.0/8"),
+		mustCIDR("192.168.0.0/24"),
+		nil,
+	}
+
+	It("Should return only valid CIDR", func() {
+		out := model.JoinNetsForTest(nets)
+		Expect(out).To(Equal("10.0.0.0/8,192.168.0.0/24,"))
+	})
+})

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/rules.go
@@ -278,7 +278,9 @@ func NormalizeIPNets(nets []string) []*cnet.IPNet {
 	}
 	out := make([]*cnet.IPNet, len(nets))
 	for i, n := range nets {
-		out[i] = normalizeIPNet(n)
+		if x := normalizeIPNet(n); x != nil {
+			out[i] = x
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Description

When a GlobalNetworkPolicy is created using the internal API group crd.projectcalico.org/v1, invalid CIDRs/IPs are not rejected. The conversion logic in libcalico-go then produces a nil *net.IPNet. Later, when Typha (or Felix) dereferences this pointer (e.g. in model.Rule.String()), a segfault occurs.

This PR changes:
- Add `nil` check to avoid segfault
- Make sure that processor code doesn't produce `nil *net.IPNet`

Normally users should not create objects via `crd.projectcalico.org/v1`, the supported API is `projectcalico.org/v3`, which performs proper validation. This change just makes the system more robust against unexpected nils.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes #7697
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
