### PR TITLE
Fix lack of CRD defaulting on AssignmentMode

### DIFF
--- a/api/pkg/apis/projectcalico/v3/ippool.go
+++ b/api/pkg/apis/projectcalico/v3/ippool.go
@@ -92,6 +92,7 @@ type IPPoolSpec struct {
 
 	// Determines the mode how IP addresses should be assigned from this pool
 	// +optional
+	// +kubebuilder:default=Automatic
 	AssignmentMode *AssignmentMode `json:"assignmentMode,omitempty" validate:"omitempty,assignmentMode"`
 }
 

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -520,7 +520,9 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 			if pool != nil {
 				// We want to release the address if annotation changed and we are no longer requesting IP from manual pool,
 				// if pool is nil we can skip this and the address will be removed during the next IPAM sync
-				if *pool.Spec.AssignmentMode == api.Manual {
+				//
+				// AssignmentMode should never be nil due to defaulting, but we check it just in case.
+				if pool.Spec.AssignmentMode != nil && *pool.Spec.AssignmentMode == api.Manual {
 					err = c.releaseIP(svcKey, ip)
 					if err != nil {
 						log.WithError(err).Errorf("Failed to release IP for %s/%s", svc.Namespace, svc.Name)

--- a/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_ippools.yaml
@@ -31,6 +31,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -2728,6 +2728,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -2738,6 +2738,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -2739,6 +2739,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -2723,6 +2723,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -2723,6 +2723,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -2740,6 +2740,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2637,6 +2637,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -2723,6 +2723,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -31333,6 +31333,7 @@ spec:
                     type: string
                   type: array
                 assignmentMode:
+                  default: Automatic
                   enum:
                     - Automatic
                     - Manual


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We should have CRD defaulting on new fields (especially when they represent a config toggle for what was previously implied behavior).

This PR adds the defaulting, and also fixes a case where the code assumed the field was non-nil, that was causing a panic.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

fixes https://github.com/projectcalico/calico/issues/11091

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix potential nil pointer dereference in load balancer IP allocation controller
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.