### PR TITLE
[v3.30] Fix performance of IPAM.ReleaseIPs() on disabled/deleted pools.

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -137,13 +137,13 @@ hack-lib:
 
 ## Run a local kubernetes server with API in a container.
 run-kubernetes-server: run-k8s-controller-manager
-	#Create a Node in the API for the tests to use.
+	# Create a Node in the API for the tests to use.
 	docker run \
 		--net=host \
 		--rm \
 		-v  $(CURDIR):/manifests \
 		-v $(CERTS_PATH):/home/user/certs \
-		bitnami/kubectl:$(subst v,,$(K8S_VERSION)) \
+		rancher/kubectl:$(K8S_VERSION) \
 		--kubeconfig=/home/user/certs/kubeconfig \
 		apply -f /manifests/test/mock-node.yaml
 
@@ -154,7 +154,7 @@ run-kubernetes-server: run-k8s-controller-manager
 		--rm \
 		-v  $(CURDIR):/manifests \
 		-v $(CERTS_PATH):/home/user/certs \
-		bitnami/kubectl:$(subst v,,$(K8S_VERSION)) \
+		rancher/kubectl:$(K8S_VERSION) \
 		--kubeconfig=/home/user/certs/kubeconfig \
 		apply -f /manifests/test/namespaces.yaml
 

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -1007,11 +1007,10 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 	unallocated := []net.IP{}
 
 	// Get IP pools up front so we don't need to query for each IP address.
-	v4Pools, err := c.pools.GetEnabledPools(ctx, 4)
-	if err != nil {
-		return nil, err
-	}
-	v6Pools, err := c.pools.GetEnabledPools(ctx, 6)
+	// When releasing an IP, we get _all_ pools, even disabled ones.  If we
+	// didn't, then deletion from a disabled pool would still succeed, but it'd
+	// go through the "full scan" path which is inefficient.
+	allPools, err := c.pools.GetAllPools(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1019,6 +1018,7 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 	// Group IP addresses by block to minimize the number of writes
 	// to the datastore required to release the given addresses.
 	ipsByBlock := map[string][]ReleaseOptions{}
+	var cachedBlockKVs *model.KVPairList
 	for _, opts := range ips {
 		var blockCIDR string
 
@@ -1027,27 +1027,19 @@ func (c ipamClient) ReleaseIPs(ctx context.Context, ips ...ReleaseOptions) ([]ne
 			return nil, err
 		}
 
-		// Find the IP pools for this address in the enabled pools if possible.
-		var pool *v3.IPPool
-		switch ip.Version() {
-		case 4:
-			pool, err = c.blockReaderWriter.getPoolForIP(ctx, *ip, v4Pools)
-			if err != nil {
-				log.WithError(err).Warnf("Failed to get pool for IP")
-				return nil, err
-			}
-		case 6:
-			pool, err = c.blockReaderWriter.getPoolForIP(ctx, *ip, v6Pools)
-			if err != nil {
-				log.WithError(err).Warnf("Failed to get pool for IP")
-				return nil, err
-			}
+		// Find the IP pools for this address, if possible.
+		pool, err := c.blockReaderWriter.getPoolForIP(ctx, *ip, allPools)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to get pool for IP")
+			return nil, err
 		}
 
 		if pool == nil {
-			if cidr, err := c.blockReaderWriter.getBlockForIP(ctx, *ip); err != nil {
+			log.Warnf("The IP %s is not in any configured pool, trying to find the block by full scan.", ip.String())
+			if cidr, newCachedKVs, err := c.blockReaderWriter.getBlockForIP(ctx, *ip, cachedBlockKVs); err != nil {
 				return nil, err
 			} else {
+				cachedBlockKVs = newCachedKVs
 				if cidr == nil {
 					// The IP isn't in any block so it's already unallocated.
 					unallocated = append(unallocated, *ip)

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -61,19 +61,29 @@ type pool struct {
 	assignmentMode v3.AssignmentMode
 }
 
+func (i *ipPoolAccessor) GetAllPools(ctx context.Context) ([]v3.IPPool, error) {
+	poolNames := make([]string, 0)
+	// Get a sorted list of pool CIDR strings.
+	for p := range i.pools {
+		poolNames = append(poolNames, p)
+	}
+	return i.getPools(poolNames, 0, "GetAllPools"), nil
+}
+
 func (i *ipPoolAccessor) GetEnabledPools(ctx context.Context, ipVersion int) ([]v3.IPPool, error) {
-	sorted := make([]string, 0)
+	poolNames := make([]string, 0)
 	// Get a sorted list of enabled pool CIDR strings.
 	for p, e := range i.pools {
 		if e.enabled {
-			sorted = append(sorted, p)
+			poolNames = append(poolNames, p)
 		}
 	}
-	return i.getPools(sorted, ipVersion, "GetEnabledPools"), nil
+	return i.getPools(poolNames, ipVersion, "GetEnabledPools"), nil
 }
 
-func (i *ipPoolAccessor) getPools(sorted []string, ipVersion int, caller string) []v3.IPPool {
-	sort.Strings(sorted)
+func (i *ipPoolAccessor) getPools(poolNames []string, ipVersion int, caller string) []v3.IPPool {
+	// Return in sorted order for deterministic tests.
+	sort.Strings(poolNames)
 
 	// Convert to IPNets and sort out the correct IP versions.  Sorting the results
 	// mimics more closely the behavior of etcd and allows the tests to be
@@ -81,7 +91,7 @@ func (i *ipPoolAccessor) getPools(sorted []string, ipVersion int, caller string)
 	pools := make([]v3.IPPool, 0)
 	automatic := v3.Automatic
 	var poolsToPrint []string
-	for _, p := range sorted {
+	for _, p := range poolNames {
 		c := cnet.MustParseCIDR(p)
 		if (ipVersion == 0) || (c.Version() == ipVersion) {
 			pool := v3.IPPool{Spec: v3.IPPoolSpec{
@@ -94,7 +104,7 @@ func (i *ipPoolAccessor) getPools(sorted []string, ipVersion int, caller string)
 				pool.Spec.AllowedUses = []v3.IPPoolAllowedUse{v3.IPPoolAllowedUseWorkload, v3.IPPoolAllowedUseTunnel}
 			}
 			if i.pools[p].blockSize == 0 {
-				if ipVersion == 4 {
+				if c.Version() == 4 {
 					pool.Spec.BlockSize = 26
 				} else {
 					pool.Spec.BlockSize = 122
@@ -110,18 +120,9 @@ func (i *ipPoolAccessor) getPools(sorted []string, ipVersion int, caller string)
 		}
 	}
 
-	log.Infof("%v returns: %v", caller, poolsToPrint)
+	log.Infof("Mock %v returns: %v", caller, poolsToPrint)
 
 	return pools
-}
-
-func (i *ipPoolAccessor) GetAllPools(ctx context.Context) ([]v3.IPPool, error) {
-	sorted := make([]string, 0)
-	// Get a sorted list of pool CIDR strings.
-	for p := range i.pools {
-		sorted = append(sorted, p)
-	}
-	return i.getPools(sorted, 0, "GetAllPools"), nil
 }
 
 var ipPools = &ipPoolAccessor{pools: map[string]pool{}}

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -479,14 +479,15 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 
 		It("should release a multitude of IPs in different blocks", func() {
 			// Create an IP pool with a blocksize such that we'll get multiple blocks per-node.
-			applyPoolWithBlockSize("10.0.0.0/24", true, "all()", 30)
+			applyPoolWithBlockSize("10.0.0.0/24", true, "name in {'node1', 'node2'}", 30)
+			applyPoolWithBlockSize("11.0.0.0/24", true, "name in {'node3', 'node4'}", 30)
 			applyPool("fe80:ba:ad:beef::00/120", true, "all()")
 
 			// Assign a number of IPs in different blocks on different nodes.
 			ips := []cnet.IP{}
 			for _, node := range []string{"node1", "node2", "node3", "node4"} {
 				// 4 nodes
-				applyNode(bc, kc, node, map[string]string{"foo": "bar"})
+				applyNode(bc, kc, node, map[string]string{"foo": "bar", "name": node})
 				for i := 0; i < 6; i++ {
 					// 6 addresses of each family per-node.
 					v4ia, v6ia, err := ic.AutoAssign(context.Background(), AutoAssignArgs{Num4: 1, Num6: 1, Hostname: node, IntendedUse: v3.IPPoolAllowedUseWorkload})
@@ -523,6 +524,9 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			// - 13 IPv4 addresses with the same handle.
 			// for a total of 25 per-node, 100 in all.
 			Expect(len(ips)).To(Equal(100))
+
+			// Disable a pool to ensure we test releasing from a disabled pool.
+			applyPoolWithBlockSize("11.0.0.0/24", false, "name in {'node3', 'node4'}", 30)
 
 			// Release them all. This should complete within a minute easily.
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#10973
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- When listing pools, list all pools, including disabled ones. Avoids the slow scan-all-blocks path for disabled pools.

- When forced to do a full block scan to find the pools, cache the loaded KVs so that bulk release operations only need to load it once.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-11817

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix slow IPAM release performance when releasing IPs from disabled or deleted pools (especially for bulk deletions like those done by IPAM GC). Consider disabled pools as potential IP owners and cache any loaded blocks for fast access.
```