### PR TITLE
[v3.29] Avoid IPAM handle leak when context expires during assignment.

### DIFF
--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -166,8 +166,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
-	defer cancel()
 
 	r := &cniv1.Result{}
 	if ipamArgs.IP != nil {
@@ -183,6 +181,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 		assignIPWithLock := func() error {
 			unlock := acquireIPAMLockBestEffort(conf.IPAMLockFile)
 			defer unlock()
+
+			// Only start the timeout after we get the lock. When there's a
+			// thundering herd of new pods, acquiring the lock can take a while.
+			ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+			defer cancel()
+
 			return calicoClient.IPAM().AssignIP(ctx, assignArgs)
 		}
 		err := assignIPWithLock()
@@ -224,12 +228,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		logger.Infof("Calico CNI IPAM request count IPv4=%d IPv6=%d", num4, num6)
 
-		v4pools, err := utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv4Pools, true)
+		rctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		defer cancel()
+		v4pools, err := utils.ResolvePools(rctx, calicoClient, conf.IPAM.IPv4Pools, true)
 		if err != nil {
 			return err
 		}
 
-		v6pools, err := utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv6Pools, false)
+		v6pools, err := utils.ResolvePools(rctx, calicoClient, conf.IPAM.IPv6Pools, false)
 		if err != nil {
 			return err
 		}
@@ -263,16 +269,22 @@ func cmdAdd(args *skel.CmdArgs) error {
 			assignArgs.HostReservedAttrIPv4s = rsvdAttrWindows
 		}
 		logger.WithField("assignArgs", assignArgs).Info("Auto assigning IP")
-		autoAssignWithLock := func(calicoClient client.Interface, ctx context.Context, assignArgs ipam.AutoAssignArgs) (*ipam.IPAMAssignments, *ipam.IPAMAssignments, error) {
+		autoAssignWithLock := func(calicoClient client.Interface, assignArgs ipam.AutoAssignArgs) (*ipam.IPAMAssignments, *ipam.IPAMAssignments, error) {
 			// Acquire a best-effort host-wide lock to prevent multiple copies of the CNI plugin trying to assign
 			// concurrently. AutoAssign is concurrency safe already but serialising the CNI plugins means that
 			// we only attempt one IPAM claim at a time on the host's active IPAM block.  This reduces the load
 			// on the API server by a factor of the number of concurrent requests.
 			unlock := acquireIPAMLockBestEffort(conf.IPAMLockFile)
 			defer unlock()
+
+			// Only start the timeout after we get the lock. When there's a
+			// thundering herd of new pods, acquiring the lock can take a while.
+			ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+			defer cancel()
+
 			return calicoClient.IPAM().AutoAssign(ctx, assignArgs)
 		}
-		v4Assignments, v6Assignments, err := autoAssignWithLock(calicoClient, ctx, assignArgs)
+		v4Assignments, v6Assignments, err := autoAssignWithLock(calicoClient, assignArgs)
 		var v4ips, v6ips []cnet.IPNet
 		if v4Assignments != nil {
 			v4ips = v4Assignments.IPs
@@ -294,7 +306,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 				for _, v6 := range v6Assignments.IPs {
 					v6IPs = append(v6IPs, ipam.ReleaseOptions{Address: v6.IP.String()})
 				}
-				_, err := calicoClient.IPAM().ReleaseIPs(ctx, v6IPs...)
+
+				// Fresh timeout for cleanup.
+				cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				defer cancel()
+				_, err := calicoClient.IPAM().ReleaseIPs(cleanupCtx, v6IPs...)
 				if err != nil {
 					logrus.Errorf("Error releasing IPv6 addresses %+v on IPv4 address assignment failure: %s", v6IPs, err)
 				}
@@ -310,7 +326,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 				for _, v4 := range v4Assignments.IPs {
 					v4IPs = append(v4IPs, ipam.ReleaseOptions{Address: v4.IP.String()})
 				}
-				_, err := calicoClient.IPAM().ReleaseIPs(ctx, v4IPs...)
+
+				// Fresh timeout for cleanup.
+				cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				defer cancel()
+				_, err := calicoClient.IPAM().ReleaseIPs(cleanupCtx, v4IPs...)
 				if err != nil {
 					logrus.Errorf("Error releasing IPv4 addresses %+v on IPv6 address assignment failure: %s", v4IPs, err)
 				}

--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -165,8 +165,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		attrs[ipam.AttributeNamespace] = epIDs.Namespace
 	}
 
-	ctx := context.Background()
-
 	r := &cniv1.Result{}
 	if ipamArgs.IP != nil {
 		logger.Infof("Calico CNI IPAM request IP: %v", ipamArgs.IP)
@@ -184,7 +182,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 			// Only start the timeout after we get the lock. When there's a
 			// thundering herd of new pods, acquiring the lock can take a while.
-			ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 			defer cancel()
 
 			return calicoClient.IPAM().AssignIP(ctx, assignArgs)
@@ -228,16 +226,22 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		logger.Infof("Calico CNI IPAM request count IPv4=%d IPv6=%d", num4, num6)
 
-		rctx, cancel := context.WithTimeout(ctx, 90*time.Second)
-		defer cancel()
-		v4pools, err := utils.ResolvePools(rctx, calicoClient, conf.IPAM.IPv4Pools, true)
-		if err != nil {
-			return err
+		var v4pools, v6pools []cnet.IPNet
+		{
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			v4pools, err = utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv4Pools, true)
+			if err != nil {
+				return err
+			}
 		}
-
-		v6pools, err := utils.ResolvePools(rctx, calicoClient, conf.IPAM.IPv6Pools, false)
-		if err != nil {
-			return err
+		{
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			v6pools, err = utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv6Pools, false)
+			if err != nil {
+				return err
+			}
 		}
 
 		logger.Debugf("Calico CNI IPAM handle=%s", handleID)
@@ -279,7 +283,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 			// Only start the timeout after we get the lock. When there's a
 			// thundering herd of new pods, acquiring the lock can take a while.
-			ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 			defer cancel()
 
 			return calicoClient.IPAM().AutoAssign(ctx, assignArgs)
@@ -308,7 +312,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				}
 
 				// Fresh timeout for cleanup.
-				cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
 				_, err := calicoClient.IPAM().ReleaseIPs(cleanupCtx, v6IPs...)
 				if err != nil {
@@ -328,7 +332,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				}
 
 				// Fresh timeout for cleanup.
-				cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
 				_, err := calicoClient.IPAM().ReleaseIPs(cleanupCtx, v4IPs...)
 				if err != nil {

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -622,14 +622,14 @@ func (i *IPAMAssignments) PartialFulfillmentError() error {
 	if len(i.IPs) < i.NumRequested {
 		var b strings.Builder
 
-		fmt.Fprintf(&b, "Assigned %d out of %d requested IPv%d addresses", len(i.IPs), i.NumRequested, i.IPVersion)
+		_, _ = fmt.Fprintf(&b, "Assigned %d out of %d requested IPv%d addresses", len(i.IPs), i.NumRequested, i.IPVersion)
 
 		for _, m := range i.Msgs {
-			fmt.Fprintf(&b, "; %v", m)
+			_, _ = fmt.Fprintf(&b, "; %v", m)
 		}
 
 		if i.HostReservedAttr != nil {
-			fmt.Fprintf(&b, "; HostReservedAttr: %v", i.HostReservedAttr.Handle)
+			_, _ = fmt.Fprintf(&b, "; HostReservedAttr: %v", i.HostReservedAttr.Handle)
 		}
 
 		return errors.New(b.String())
@@ -924,7 +924,11 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 
 		// Increment handle.
 		if args.HandleID != nil {
-			c.incrementHandle(ctx, *args.HandleID, blockCIDR, 1)
+			err := c.incrementHandle(ctx, *args.HandleID, blockCIDR, 1)
+			if err != nil {
+				log.WithError(err).Warn("Failed to increment handle")
+				return fmt.Errorf("failed to increment handle: %w", err)
+			}
 		}
 
 		// Update the block using the original KVPair to do a CAS.  No need to
@@ -939,9 +943,12 @@ func (c ipamClient) AssignIP(ctx context.Context, args AssignIPArgs) error {
 
 			log.WithError(err).Warningf("Update failed on block %s", block.CIDR.String())
 			if args.HandleID != nil {
-				if err := c.decrementHandle(ctx, *args.HandleID, blockCIDR, 1, nil); err != nil {
+				// Extend timeout for the cleanup, if needed.
+				cleanupCtx, cancel := contextForCleanup(ctx)
+				if err := c.decrementHandle(cleanupCtx, *args.HandleID, blockCIDR, 1, nil); err != nil {
 					log.WithError(err).Warn("Failed to decrement handle")
 				}
+				cancel()
 			}
 			return err
 		}
@@ -1195,7 +1202,11 @@ func (c ipamClient) assignFromExistingBlock(ctx context.Context, block *model.KV
 	// Increment handle count.
 	if handleID != nil {
 		logCtx.Debug("Incrementing handle")
-		c.incrementHandle(ctx, *handleID, blockCIDR, num)
+		err := c.incrementHandle(ctx, *handleID, blockCIDR, num)
+		if err != nil {
+			log.WithError(err).Warn("Failed to increment handle")
+			return nil, fmt.Errorf("failed to increment handle: %w", err)
+		}
 	}
 
 	// Update the block using CAS by passing back the original
@@ -1207,14 +1218,27 @@ func (c ipamClient) assignFromExistingBlock(ctx context.Context, block *model.KV
 		logCtx.WithError(err).Infof("Failed to update block")
 		if handleID != nil {
 			logCtx.Debug("Decrementing handle since we failed to allocate IP(s)")
-			if err := c.decrementHandle(ctx, *handleID, blockCIDR, num, nil); err != nil {
+			// Extend timeout for the cleanup, if needed.
+			cleanupCtx, cancel := contextForCleanup(ctx)
+			if err := c.decrementHandle(cleanupCtx, *handleID, blockCIDR, num, nil); err != nil {
 				logCtx.WithError(err).Warnf("Failed to decrement handle")
 			}
+			cancel()
 		}
 		return nil, err
 	}
 	logCtx.Infof("Successfully claimed IPs: %v", ips)
 	return ips, nil
+}
+
+// contextForCleanup returns a derived context with at least 30s remaining before the deadline.
+func contextForCleanup(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if ok && time.Until(deadline) < 30*time.Second {
+		// Less than 30 seconds remaining, so extend the context deadline.
+		return context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	}
+	return context.WithCancel(ctx)
 }
 
 // ClaimAffinity makes a best effort to claim affinity to the given host for all blocks
@@ -1750,15 +1774,13 @@ func (c ipamClient) decrementHandle(ctx context.Context, handleID string, blockC
 		if handle.empty() {
 			log.Debugf("Deleting handle: %s", handleID)
 			if err = c.blockReaderWriter.deleteHandle(ctx, obj); err != nil {
-				if err != nil {
-					if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
-						// Update conflict - retry.
-						continue
-					} else if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
-						return err
-					}
-					// Already deleted.
+				if _, ok := err.(cerrors.ErrorResourceUpdateConflict); ok {
+					// Update conflict - retry.
+					continue
+				} else if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+					return err
 				}
+				// Already deleted.
 			}
 		} else {
 			log.Debugf("Updating handle: %s", handleID)


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.29**: projectcalico/calico#11096
- Pick onto **release-v3.30**: projectcalico/calico#10658


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Don't include time to acquire IPAM lock in the timeout. Under heavy load, IPAM allocation calls could get stacked up. As the lock acquisition time approaches 90s, it gets into an equilibrium where each IPAM call succeeds in creating a handle but times out while doing the actual assignment.  This leaks handles at a rapid rate.

  Speeding up IPAM requires a significant rework so this is a pragmatic fix for now.

- Belt and braces: use extended context timeouts for cleanup operations. If the context expires during IPAM allocation and hence we need to clean up a handle, use a fresh context so that the cleanup doesn't immediately time out.

- Clean up some unhandled errors and remove a duplicate conditional.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-11632
CORE-11840
CI-1807

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that IPAM allocation could leak handles when many workloads are scheduled to the same node at the same time, causing timeouts by "thundering herd".
```