### PR TITLE
Merge pull request #11052 from nelljerram/maintain-static-arp

### DIFF
--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -955,6 +955,27 @@ func addNeighs(family int, neighMap map[NeighKey]*netlink.Neigh, neighs []netlin
 	}
 }
 
+// RemoveNeighs allows test code to remove neighbours from the mock dataplane
+// without going through the netlink API.
+func (d *MockNetlinkDataplane) RemoveNeighs(family int, neighs ...netlink.Neigh) {
+	err := d.checkNeighFamily(family)
+	if err != nil {
+		panic(err)
+	}
+	if d.NeighsByFamily[family] == nil {
+		return
+	}
+	removeNeighs(family, d.NeighsByFamily[family], neighs)
+}
+
+func removeNeighs(family int, neighMap map[NeighKey]*netlink.Neigh, neighs []netlink.Neigh) {
+	for _, neigh := range neighs {
+		neigh := neigh
+		nk := NeighKeyForFamily(family, neigh.LinkIndex, neigh.HardwareAddr, ip.FromNetIP(neigh.IP))
+		delete(neighMap, nk)
+	}
+}
+
 // NeighKeyForFamily returns an appropriate NeighKey for the given family.
 // Different families are keyed in different ways by the kernel.  ARP/NDP
 // entries are keyed on IP address, but FDB entries are keyed on MAC address

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -356,6 +356,52 @@ var _ = Describe("RouteTable", func() {
 					HardwareAddr: mac1,
 				})
 			})
+			Context("after initial route programming", func() {
+				var cidr *net.IPNet
+				var linkIndex int
+				BeforeEach(func() {
+					// Initial route programming...
+					addLink := dataplane.AddIface(6, "cali6", true, true)
+					linkIndex = addLink.LinkAttrs.Index
+					rt.SetRoutes(RouteClassLocalWorkload, addLink.LinkAttrs.Name, []Target{
+						{CIDR: ip.MustParseCIDROrIP("10.0.0.6"), DestMAC: mac1},
+					})
+					err := rt.Apply()
+					Expect(err).ToNot(HaveOccurred())
+					cidr = mustParseCIDR("10.0.0.6/32")
+				})
+				It("ARP entry should exist", func() {
+					dataplane.ExpectNeighs(unix.AF_INET, netlink.Neigh{
+						Family:       unix.AF_INET,
+						LinkIndex:    linkIndex,
+						State:        netlink.NUD_PERMANENT,
+						Type:         unix.RTN_UNICAST,
+						IP:           cidr.IP,
+						HardwareAddr: mac1,
+					})
+				})
+				It("ARP entry should be reestablished by a resync", func() {
+					dataplane.RemoveNeighs(unix.AF_INET, netlink.Neigh{
+						Family:       unix.AF_INET,
+						LinkIndex:    linkIndex,
+						State:        netlink.NUD_PERMANENT,
+						Type:         unix.RTN_UNICAST,
+						IP:           cidr.IP,
+						HardwareAddr: mac1,
+					})
+					rt.QueueResync()
+					err := rt.Apply()
+					Expect(err).NotTo(HaveOccurred())
+					dataplane.ExpectNeighs(unix.AF_INET, netlink.Neigh{
+						Family:       unix.AF_INET,
+						LinkIndex:    linkIndex,
+						State:        netlink.NUD_PERMANENT,
+						Type:         unix.RTN_UNICAST,
+						IP:           cidr.IP,
+						HardwareAddr: mac1,
+					})
+				})
+			})
 			It("Should skip adding an ARP entry if route is deleted via SetRoutes before sync", func() {
 				// Route that needs to be added
 				link := dataplane.AddIface(6, "cali6", true, true)


### PR DESCRIPTION
Maintain static ARP programming beyond endpoint start of day

(cherry-pick for v3.31 branch)

## Description

Before Calico v3.29 we refreshed the static ARP programming for a workload endpoint whenever the endpoint interface state changed, or when the dataplane performed a full route refresh - which by default means every 90 seconds (RouteRefreshInterval).  We accidentally lost that logic in https://github.com/projectcalico/calico/pull/8418.  After that change, Calico only programs static ARP when first configuring a workload endpoint, and does not refresh it after that point.

For most VMs (with Calico for OpenStack) and possibly all Kubernetes usage, that doesn't matter, because the host kernel sends a dynamic ARP request when it needs to, and most VMs and pods respond to that.  However it's possible for a VM to be configured such that it does not respond to such ARP requests - e.g. with `arp_ignore` set to 2.  Connectivity to VMs like that worked before Calico v3.29, but was broken from v3.29 onwards.

This PR reinstates the logic to refresh static ARP programming when the endpoint interface state changes or when the dataplane performs a full resync.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Bugfix: reinstate support for VMs that are configured not to respond to ARP requests.
```