### PR TITLE
Fix conntrack upgrade for ipv6

### DIFF
--- a/felix/bpf/conntrack/v3/map6.go
+++ b/felix/bpf/conntrack/v3/map6.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
@@ -66,7 +67,9 @@ func (k KeyV6) String() string {
 }
 
 func (k KeyV6) Upgrade() maps.Upgradable {
-	panic("conntrack map key already at its latest version")
+	var key6 v4.KeyV6
+	copy(key6[:], k[:])
+	return key6
 }
 
 func NewKeyV6(proto uint8, ipA net.IP, portA uint16, ipB net.IP, portB uint16) KeyV6 {
@@ -372,7 +375,9 @@ func (e ValueV6) IsForwardDSR() bool {
 }
 
 func (e ValueV6) Upgrade() maps.Upgradable {
-	panic("conntrack map value already at its latest version")
+	var val6 v4.ValueV6
+	copy(val6[:], e[:])
+	return val6
 }
 
 var MapParamsV6 = maps.MapParameters{

--- a/felix/bpf/conntrack/v3/map6.go
+++ b/felix/bpf/conntrack/v3/map6.go
@@ -23,7 +23,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
-	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
@@ -67,9 +66,7 @@ func (k KeyV6) String() string {
 }
 
 func (k KeyV6) Upgrade() maps.Upgradable {
-	var key6 v4.KeyV6
-	copy(key6[:], k[:])
-	return key6
+	panic("conntrack map key already at its latest version")
 }
 
 func NewKeyV6(proto uint8, ipA net.IP, portA uint16, ipB net.IP, portB uint16) KeyV6 {
@@ -375,9 +372,7 @@ func (e ValueV6) IsForwardDSR() bool {
 }
 
 func (e ValueV6) Upgrade() maps.Upgradable {
-	var val6 v4.ValueV6
-	copy(val6[:], e[:])
-	return val6
+	panic("conntrack map value already at its latest version")
 }
 
 var MapParamsV6 = maps.MapParameters{

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1717,7 +1717,8 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 		var err error
 		if m.v6 != nil {
 			err = m.v6.CtMap.CopyDeltaFromOldMap()
-		} else {
+		}
+		if m.v4 != nil {
 			err = m.v4.CtMap.CopyDeltaFromOldMap()
 		}
 		if err != nil {


### PR DESCRIPTION
## Description

Add missing upgrade methods for conntrack ipv6 and copy conntrack entries in dual stack.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
