### PR TITLE
ci: Grab crane from github instead of via go-build

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1255,7 +1255,7 @@ bin/yq:
 # This setup is used to download and install the 'crane' binary into the local bin/ directory.
 # The binary will be placed at: ./bin/crane
 # Normalize architecture for go-containerregistry filenames
-CRANE_BUILDARCH := $(shell uname -m | sed 's/amd64/x86_64/;s/x86_64/x86_64/;s/aarch64/arm64/')
+CRANE_BUILDARCH := $(shell uname -m | sed 's/aarch64/arm64/')
 CRANE_OS := $(shell uname -s)
 ifeq ($(CRANE_BUILDARCH),)
   $(error Unsupported or unknown architecture: $(shell uname -m))

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -500,10 +500,9 @@ git-commit:
 ###############################################################################
 
 ifdef LOCAL_CRANE
-CRANE_CMD         = bash -c $(double_quote)crane
+CRANE_CMD         = crane
 else
-CRANE_CMD         = docker run -t --entrypoint /bin/sh -v $(DOCKER_CONFIG):/root/.docker/config.json $(CALICO_BUILD) -c \
-                    $(double_quote)crane
+CRANE_CMD         = $(REPO_ROOT)/bin/crane
 endif
 
 ifdef LOCAL_PYTHON
@@ -524,10 +523,10 @@ GIT           = $(GIT_CMD)
 DOCKER        = $(DOCKER_CMD)
 RELEASE_PY3   = $(PYTHON3_CMD)
 else
-CRANE         = @echo [DRY RUN] $(CRANE_CMD)
-GIT           = @echo [DRY RUN] $(GIT_CMD)
-DOCKER        = @echo [DRY RUN] $(DOCKER_CMD)
-RELEASE_PY3   = @echo [DRY RUN] $(PYTHON3_CMD)
+CRANE         = echo [DRY RUN] $(CRANE_CMD)
+GIT           = echo [DRY RUN] $(GIT_CMD)
+DOCKER        = echo [DRY RUN] $(DOCKER_CMD)
+RELEASE_PY3   = echo [DRY RUN] $(PYTHON3_CMD)
 endif
 
 QUAY_SET_EXPIRY_SCRIPT = $(REPO_ROOT)/hack/set_quay_expiry.py
@@ -1213,7 +1212,7 @@ release-retag-dev-images-in-registry-%:
 # RELEASE_REGISTRIES then the retag is not done
 release-retag-dev-image-in-registry-%:
 	$(if $(filter-out $(RELEASE_REGISTRIES),$(DEV_REGISTRY)),\
-		$(CRANE) cp $(DEV_REGISTRY)/$(call unescapefs,$*):$(DEV_TAG) $(DEV_REGISTRY)/$(call unescapefs,$*):$(RELEASE_TAG))$(double_quote)
+		$(CRANE) cp $(DEV_REGISTRY)/$(call unescapefs,$*):$(DEV_TAG) $(DEV_REGISTRY)/$(call unescapefs,$*):$(RELEASE_TAG))
 
 # release-dev-images-to-registry-% copies and retags all the build / arch images specified by BUILD_IMAGES and
 # VALIDARCHES from the registry specified by DEV_REGISTRY to the registry specified by RELEASE_REGISTRY using the tag
@@ -1225,14 +1224,14 @@ release-dev-images-to-registry-%:
 # the dev repo specified by DEV_TAG and RELEASE.
 release-dev-image-to-registry-%:
 	$(if $(SKIP_MANIFEST_RELEASE),,\
-		$(CRANE) cp $(DEV_REGISTRY)/$(call unescapefs,$*):$(DEV_TAG) $(RELEASE_REGISTRY)/$(call unescapefs,$*):$(RELEASE_TAG))$(double_quote)
+		$(CRANE) cp $(DEV_REGISTRY)/$(call unescapefs,$*):$(DEV_TAG) $(RELEASE_REGISTRY)/$(call unescapefs,$*):$(RELEASE_TAG))
 	$(if $(SKIP_ARCH_RELEASE),,\
 		$(MAKE) $(addprefix release-dev-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(call unescapefs,$*))
 
 # release-dev-image-to-registry-% copies the build arch image specified by BUILD_IMAGE and ARCH from the dev repo
 # specified by DEV_TAG and RELEASE.
 release-dev-image-arch-to-registry-%:
-	$(CRANE) cp $(DEV_REGISTRY)/$(BUILD_IMAGE):$(DEV_TAG)-$* $(RELEASE_REGISTRY)/$(BUILD_IMAGE):$(RELEASE_TAG)-$*$(double_quote)
+	$(CRANE) cp $(DEV_REGISTRY)/$(BUILD_IMAGE):$(DEV_TAG)-$* $(RELEASE_REGISTRY)/$(BUILD_IMAGE):$(RELEASE_TAG)-$*
 
 # release-prereqs checks that the environment is configured properly to create a release.
 .PHONY: release-prereqs
@@ -1253,23 +1252,9 @@ bin/yq:
 	tar -zxvf $(TMP)/yq4.tar.gz -C $(TMP)
 	mv $(TMP)/yq_linux_$(BUILDARCH) bin/yq
 
-# This setup is used to download and install the 'crane' binary into the local bin/ directory.
-# The binary will be placed at: ./bin/crane
-# Normalize architecture for go-containerregistry filenames
-CRANE_BUILDARCH := $(shell uname -m | sed 's/amd64/x86_64/;s/x86_64/x86_64/;s/aarch64/arm64/')
-ifeq ($(CRANE_BUILDARCH),)
-  $(error Unsupported or unknown architecture: $(shell uname -m))
-endif
-CRANE_FILENAME := go-containerregistry_Linux_$(CRANE_BUILDARCH).tar.gz
-CRANE_URL := https://github.com/google/go-containerregistry/releases/download/$(CRANE_VERSION)/$(CRANE_FILENAME)
-
-# Install crane binary into bin/
+# Build and install crane binary into $(REPO_ROOT)/bin
 bin/crane:
-	mkdir -p bin
-	$(eval CRANE_TMP := $(shell mktemp -d))
-	curl -sSfL --retry 5 -o $(CRANE_TMP)/crane.tar.gz $(CRANE_URL)
-	tar -xzf $(CRANE_TMP)/crane.tar.gz -C $(CRANE_TMP) crane
-	mv $(CRANE_TMP)/crane bin/crane
+	GOBIN=$(REPO_ROOT)/bin go install github.com/google/go-containerregistry/cmd/crane@$(CRANE_VERSION)
 
 ###############################################################################
 # Common functions for launching a local Kubernetes control plane.
@@ -1480,32 +1465,6 @@ help:
 # Common functions for building windows images.
 ###############################################################################
 
-# When running on semaphore, just copy the docker config, otherwise run
-# 'docker-credential-gcr configure-docker' as well.
-ifdef SEMAPHORE
-DOCKER_CREDENTIAL_CMD = cp /root/.docker/config.json_host /root/.docker/config.json
-else
-DOCKER_CREDENTIAL_CMD = cp /root/.docker/config.json_host /root/.docker/config.json && \
-						docker-credential-gcr configure-docker
-endif
-
-# This needs the $(WINDOWS_DIST)/bin/docker-credential-gcr binary in $PATH and
-# also the local ~/.config/gcloud dir to be able to push to gcr.io.  It mounts
-# $(DOCKER_CONFIG) and copies it so that it can be written to on the container,
-# but not have any effect on the host config.
-CRANE_BINDMOUNT_CMD := \
-	docker run --rm \
-		--net=host \
-		--init \
-		--entrypoint /bin/sh \
-		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
-		-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
-		-v $(DOCKER_CONFIG):/root/.docker/config.json_host:ro \
-		-e PATH=$${PATH}:/go/src/$(PACKAGE_NAME)/$(WINDOWS_DIST)/bin \
-		-v $(HOME)/.config/gcloud:/root/.config/gcloud \
-		-w /go/src/$(PACKAGE_NAME) \
-		$(CALICO_BUILD) -c $(double_quote)$(DOCKER_CREDENTIAL_CMD) && crane
-
 DOCKER_MANIFEST_CMD := docker manifest
 
 ifdef CONFIRM
@@ -1613,7 +1572,7 @@ image-windows: setup-windows-builder var-require-all-WINDOWS_VERSIONS
 		$(MAKE) windows-sub-image-$${version}; \
 	done;
 
-release-windows-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-IMAGETAG-DEV_REGISTRIES image-windows docker-credential-gcr-binary
+release-windows-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-IMAGETAG-DEV_REGISTRIES image-windows docker-credential-gcr-binary bin/crane
 	for registry in $(DEV_REGISTRIES); do \
 		echo Pushing Windows images to $${registry}; \
 		all_images=""; \
@@ -1622,7 +1581,7 @@ release-windows-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-IMAG
 			image_tar="$(WINDOWS_DIST)/$(WINDOWS_IMAGE)-$(GIT_VERSION)-$${win_ver}.tar"; \
 			image="$${registry}/$(WINDOWS_IMAGE):$(IMAGETAG)-windows-$${win_ver}"; \
 			echo Pushing image $${image} ...; \
-			$(CRANE_BINDMOUNT) push $${image_tar} $${image}$(double_quote) & \
+			$(CRANE) push $${image_tar} $${image} & \
 			all_images="$${all_images} $${image}"; \
 		done; \
 		wait; \
@@ -1641,5 +1600,5 @@ release-windows: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_REGISTRIE
 	release_tag=$(if $(VERSION),$(VERSION),$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME)); \
 	$(MAKE) release-windows-with-tag IMAGETAG=$${describe_tag}; \
 	for registry in $(DEV_REGISTRIES); do \
-		$(CRANE_BINDMOUNT) cp $${registry}/$(WINDOWS_IMAGE):$${describe_tag} $${registry}/$(WINDOWS_IMAGE):$${release_tag}$(double_quote); \
+		$(CRANE) cp $${registry}/$(WINDOWS_IMAGE):$${describe_tag} $${registry}/$(WINDOWS_IMAGE):$${release_tag}; \
 	done;


### PR DESCRIPTION
Instead of using go-build for crane, which involves bind-mounting an ever-increasing number of directories and files into the go-build container and performing various copy operations on files in the container every time, simply:

1. Pull down crane from github (via github releases) into `bin/crane`
2. Use that

This should enable all the functionality we need now and going forward, as well as simplifying the process since we won't need to debug it every time things change.

We already depend on being able to pull go libraries from github in order to do our builds so this doesn't add additional external requirements to the build process, and we already had a makefile target to pull `bin/crane` anyway; now we're just using it consistently.