### PR TITLE
[BPF] Expand conntrack flags memory beyond 16 bits

### DIFF
--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -67,28 +67,30 @@ struct calico_ct_leg {
 #define CT_INVALID_IFINDEX	0
 struct calico_ct_value {
 	__u64 rst_seen;
-	__u64 last_seen; // 8
-	__u8 type;		 // 16
+	__u64 last_seen;	// 8
+	__u8 type;		// 16
 	__u8 flags;
 
+	__u8 flags3;
+	__u8 flags4;
 	// Important to use explicit padding, otherwise the compiler can decide
 	// not to zero the padding bytes, which upsets the verifier.  Worse than
 	// that, debug logging often prevents such optimisation resulting in
 	// failures when debug logging is compiled out only :-).
-	__u8 pad0[5];
+	__u8 pad0[3];
 	__u8 flags2;
 	union {
 		// CALI_CT_TYPE_NORMAL and CALI_CT_TYPE_NAT_REV.
 		struct {
-			struct calico_ct_leg a_to_b; // 24
-			struct calico_ct_leg b_to_a; // 48
+			struct calico_ct_leg a_to_b;	// 24
+			struct calico_ct_leg b_to_a;	// 48
 
 			// CALI_CT_TYPE_NAT_REV
-			ipv46_addr_t tun_ip;                      // 72
-			ipv46_addr_t orig_ip;                     // 76
-			__u16 orig_port;                   // 80
-			__u16 orig_sport;                  // 82
-			ipv46_addr_t orig_sip;                    // 84
+			ipv46_addr_t tun_ip;	// 72
+			ipv46_addr_t orig_ip;	// 76
+			__u16 orig_port;	// 80
+			__u16 orig_sport;	// 82
+			ipv46_addr_t orig_sip;	// 84
 		};
 
 		// CALI_CT_TYPE_NAT_FWD; key for the CALI_CT_TYPE_NAT_REV entry.
@@ -120,12 +122,14 @@ static CALI_BPF_INLINE void __xxx_compile_asserts(void) {
 #define ct_value_set_flags(v, f) do {		\
 	(v)->flags |= ((f) & 0xff);		\
 	(v)->flags2 |= (((f) >> 8) & 0xff);	\
+	(v)->flags3 |= (((f) >> 16) & 0xff);	\
+	(v)->flags4 |= (((f) >> 24) & 0xff);	\
 } while(0)
 
-#define ct_value_get_flags(v) ({			\
-	__u16 ret = (v)->flags | ((v)->flags2 << 8);	\
-							\
-	ret;						\
+#define ct_value_get_flags(v) ({									\
+	__u32 ret = (v)->flags | ((v)->flags2 << 8) | ((v)->flags3 << 16) | ((v)->flags4 << 24);	\
+													\
+	ret;												\
 })
 
 struct ct_lookup_ctx {
@@ -224,7 +228,8 @@ enum calico_ct_result_type {
 
 struct calico_ct_result {
 	__s16 rc;
-	__u16 flags;
+	__u16 pad;
+	__u32 flags;
 	ipv46_addr_t nat_ip;
 	ipv46_addr_t nat_sip;
 	__u16 nat_port;

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -105,7 +105,7 @@ struct cali_tc_state {
 
 	__u64 flags;
 	/* Result of the conntrack lookup. */
-	struct calico_ct_result ct_result; /* 28 bytes */
+	struct calico_ct_result ct_result; /* 32 bytes */
 
 	/* Result of the NAT calculation.  Zeroed if there is no DNAT. */
 	struct calico_nat_dest nat_dest; /* 8 bytes */
@@ -116,7 +116,7 @@ struct cali_tc_state {
 	 */
 	DECLARE_IP_ADDR(ip_src_masq);
 #ifndef IPVER6
-	__u8 __pad_ipv4[48];
+	__u8 __pad_ipv4[44];
 #endif
 };
 

--- a/felix/bpf/conntrack/cleanup.go
+++ b/felix/bpf/conntrack/cleanup.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
-	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/timeshim"
 )
@@ -238,7 +238,7 @@ again:
 			port uint16
 		)
 
-		if v.Flags()&v3.FlagSrcDstBA != 0 {
+		if v.Flags()&v4.FlagSrcDstBA != 0 {
 			ip = k.AddrA()
 			port = k.PortA()
 		} else {

--- a/felix/bpf/conntrack/cttestdata/ct_data.go
+++ b/felix/bpf/conntrack/cttestdata/ct_data.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
-	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	"github.com/projectcalico/calico/felix/timeshim/mocktime"
 )
 
@@ -142,7 +142,7 @@ func init() {
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
 				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
-				tcpRevKey: conntrack.NewValueNATReverse(Now-59*time.Minute, v3.FlagNATFwdDsr,
+				tcpRevKey: conntrack.NewValueNATReverse(Now-59*time.Minute, v4.FlagNATFwdDsr,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: false, AckSeen: false},
 					nil, nil, 5555),
 			},
@@ -154,7 +154,7 @@ func init() {
 				// Note: last seen time on the forward entry should be ignored in
 				// favour of the last-seen time on the reverse entry.
 				tcpFwdKey: conntrack.NewValueNATForward(Now-3*time.Hour, 0, tcpRevKey),
-				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, v3.FlagNATFwdDsr,
+				tcpRevKey: conntrack.NewValueNATReverse(Now-2*time.Hour, v4.FlagNATFwdDsr,
 					conntrack.Leg{SynSeen: true, AckSeen: true}, conntrack.Leg{SynSeen: false, AckSeen: false},
 					nil, nil, 5555),
 			},

--- a/felix/bpf/conntrack/inforeader.go
+++ b/felix/bpf/conntrack/inforeader.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack/timeouts"
-	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	v4 "github.com/projectcalico/calico/felix/bpf/conntrack/v4"
 	collector "github.com/projectcalico/calico/felix/collector/types"
 	"github.com/projectcalico/calico/felix/collector/types/tuple"
 	"github.com/projectcalico/calico/felix/timeshim"
@@ -122,7 +122,7 @@ func (r *InfoReader) makeConntrackInfo(key KeyInterface, val ValueInterface, dna
 		Bytes:   int(data.B2A.Bytes),
 	}
 
-	if val.Flags()&v3.FlagSrcDstBA != 0 {
+	if val.Flags()&v4.FlagSrcDstBA != 0 {
 		ipSrc, ipDst = ipDst, ipSrc
 		portSrc, portDst = portDst, portSrc
 		coutersSrc, coutersDst = coutersDst, coutersSrc

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -74,20 +74,20 @@ const (
 )
 
 // NewValueNormal creates a new Value of type TypeNormal based on the given parameters
-func NewValueNormal(lastSeen time.Duration, flags uint16, legA, legB Leg) Value {
+func NewValueNormal(lastSeen time.Duration, flags uint32, legA, legB Leg) Value {
 	return curVer.NewValueNormal(lastSeen, flags, legA, legB)
 }
 
 // NewValueNATForward creates a new Value of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueNATForward(lastSeen time.Duration, flags uint16, revKey Key) Value {
+func NewValueNATForward(lastSeen time.Duration, flags uint32, revKey Key) Value {
 	return curVer.NewValueNATForward(lastSeen, flags, revKey)
 }
 
 // NewValueNATReverse creates a new Value of type TypeNATReverse for the given
 // arguments and reverse parameters
 func NewValueNATReverse(
-	lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16,
 ) Value {
 	return curVer.NewValueNATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
@@ -95,27 +95,27 @@ func NewValueNATReverse(
 
 // NewValueNATReverseSNAT in addition to NewValueNATReverse sets the orig source IP
 func NewValueNATReverseSNAT(
-	lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16,
 ) Value {
 	return curVer.NewValueNATReverseSNAT(lastSeen, flags, legA, legB, tunnelIP, origIP, origSrcIP, origPort)
 }
 
 // NewValueV6Normal creates a new ValueV6 of type TypeNormal based on the given parameters
-func NewValueV6Normal(lastSeen time.Duration, flags uint16, legA, legB Leg) ValueV6 {
+func NewValueV6Normal(lastSeen time.Duration, flags uint32, legA, legB Leg) ValueV6 {
 	return curVer.NewValueV6Normal(lastSeen, flags, legA, legB)
 }
 
 // NewValueV6NATForward creates a new ValueV6 of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueV6NATForward(lastSeen time.Duration, flags uint16, revKey KeyV6) ValueV6 {
+func NewValueV6NATForward(lastSeen time.Duration, flags uint32, revKey KeyV6) ValueV6 {
 	return curVer.NewValueV6NATForward(lastSeen, flags, revKey)
 }
 
 // NewValueV6NATReverse creates a new ValueV6 of type TypeNATReverse for the given
 // arguments and reverse parameters
 func NewValueV6NATReverse(
-	lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16,
 ) ValueV6 {
 	return curVer.NewValueV6NATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
@@ -123,7 +123,7 @@ func NewValueV6NATReverse(
 
 // NewValueV6NATReverseSNAT in addition to NewValueV6NATReverse sets the orig source IP
 func NewValueV6NATReverseSNAT(
-	lastSeen time.Duration, flags uint16, legA, legB Leg,
+	lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16,
 ) ValueV6 {
 	return curVer.NewValueV6NATReverseSNAT(lastSeen, flags, legA, legB, tunnelIP, origIP, origSrcIP, origPort)

--- a/felix/bpf/conntrack/v4/map.go
+++ b/felix/bpf/conntrack/v4/map.go
@@ -128,6 +128,8 @@ const (
 	VoLastSeen  int = 8
 	VoType      int = 16
 	VoFlags     int = 17
+	VoFlags3    int = 18
+	VoFlags4    int = 19
 	VoFlags2    int = 23
 	VoRevKey    int = 24
 	VoLegAB     int = 24
@@ -146,7 +148,7 @@ type ValueInterface interface {
 	RSTSeen() int64
 	LastSeen() int64
 	Type() uint8
-	Flags() uint16
+	Flags() uint32
 	OrigIP() net.IP
 	OrigPort() uint16
 	OrigSPort() uint16
@@ -171,8 +173,8 @@ func (e Value) Type() uint8 {
 	return e[VoType]
 }
 
-func (e Value) Flags() uint16 {
-	return uint16(e[VoFlags]) | (uint16(e[VoFlags2]) << 8)
+func (e Value) Flags() uint32 {
+	return (uint32(e[VoFlags]) | uint32(e[VoFlags2])<<8 | uint32(e[VoFlags3])<<16 | uint32(e[VoFlags4])<<24)
 }
 
 // OrigIP returns the original destination IP, valid only if Type() is TypeNormal or TypeNATReverse
@@ -206,22 +208,22 @@ const (
 	TypeNATForward
 	TypeNATReverse
 
-	FlagNATOut          uint16 = (1 << 0)
-	FlagNATFwdDsr       uint16 = (1 << 1)
-	FlagNATNPFwd        uint16 = (1 << 2)
-	FlagSkipFIB         uint16 = (1 << 3)
-	FlagReserved4       uint16 = (1 << 4)
-	FlagReserved5       uint16 = (1 << 5)
-	FlagExtLocal        uint16 = (1 << 6)
-	FlagViaNATIf        uint16 = (1 << 7)
-	FlagSrcDstBA        uint16 = (1 << 8)
-	FlagHostPSNAT       uint16 = (1 << 9)
-	FlagSvcSelf         uint16 = (1 << 10)
-	FlagNPLoop          uint16 = (1 << 11)
-	FlagNPRemote        uint16 = (1 << 12)
-	FlagNoDSR           uint16 = (1 << 13)
-	FlagNoRedirPeer     uint16 = (1 << 14)
-	FlagClusterExternal uint16 = (1 << 15)
+	FlagNATOut          uint32 = (1 << 0)
+	FlagNATFwdDsr       uint32 = (1 << 1)
+	FlagNATNPFwd        uint32 = (1 << 2)
+	FlagSkipFIB         uint32 = (1 << 3)
+	FlagReserved4       uint32 = (1 << 4)
+	FlagReserved5       uint32 = (1 << 5)
+	FlagExtLocal        uint32 = (1 << 6)
+	FlagViaNATIf        uint32 = (1 << 7)
+	FlagSrcDstBA        uint32 = (1 << 8)
+	FlagHostPSNAT       uint32 = (1 << 9)
+	FlagSvcSelf         uint32 = (1 << 10)
+	FlagNPLoop          uint32 = (1 << 11)
+	FlagNPRemote        uint32 = (1 << 12)
+	FlagNoDSR           uint32 = (1 << 13)
+	FlagNoRedirPeer     uint32 = (1 << 14)
+	FlagClusterExternal uint32 = (1 << 15)
 )
 
 func (e Value) ReverseNATKey() KeyInterface {
@@ -254,15 +256,17 @@ func (e *Value) SetNATSport(sport uint16) {
 	binary.LittleEndian.PutUint16(e[VoNATSPort:VoNATSPort+2], sport)
 }
 
-func initValue(v *Value, lastSeen time.Duration, typ uint8, flags uint16) {
+func initValue(v *Value, lastSeen time.Duration, typ uint8, flags uint32) {
 	binary.LittleEndian.PutUint64(v[VoLastSeen:VoLastSeen+8], uint64(lastSeen))
 	v[VoType] = typ
 	v[VoFlags] = byte(flags & 0xff)
 	v[VoFlags2] = byte((flags >> 8) & 0xff)
+	v[VoFlags3] = byte((flags >> 16) & 0xff)
+	v[VoFlags4] = byte((flags >> 24) & 0xff)
 }
 
 // NewValueNormal creates a new Value of type TypeNormal based on the given parameters
-func NewValueNormal(lastSeen time.Duration, flags uint16, legA, legB Leg) Value {
+func NewValueNormal(lastSeen time.Duration, flags uint32, legA, legB Leg) Value {
 	v := Value{}
 
 	initValue(&v, lastSeen, TypeNormal, flags)
@@ -275,7 +279,7 @@ func NewValueNormal(lastSeen time.Duration, flags uint16, legA, legB Leg) Value 
 
 // NewValueNATForward creates a new Value of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueNATForward(lastSeen time.Duration, flags uint16, revKey Key) Value {
+func NewValueNATForward(lastSeen time.Duration, flags uint32, revKey Key) Value {
 	v := Value{}
 
 	initValue(&v, lastSeen, TypeNATForward, flags)
@@ -287,7 +291,7 @@ func NewValueNATForward(lastSeen time.Duration, flags uint16, revKey Key) Value 
 
 // NewValueNATReverse creates a new Value of type TypeNATReverse for the given
 // arguments and reverse parameters
-func NewValueNATReverse(lastSeen time.Duration, flags uint16, legA, legB Leg,
+func NewValueNATReverse(lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16) Value {
 	v := Value{}
 
@@ -305,7 +309,7 @@ func NewValueNATReverse(lastSeen time.Duration, flags uint16, legA, legB Leg,
 }
 
 // NewValueNATReverseSNAT in addition to NewValueNATReverse sets the orig source IP
-func NewValueNATReverseSNAT(lastSeen time.Duration, flags uint16, legA, legB Leg,
+func NewValueNATReverseSNAT(lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16) Value {
 	v := NewValueNATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
 	copy(v[VoOrigSIP:VoOrigSIP+4], origIP.To4())

--- a/felix/bpf/conntrack/v4/map6.go
+++ b/felix/bpf/conntrack/v4/map6.go
@@ -117,6 +117,8 @@ const (
 	VoLastSeenV6  int = 8
 	VoTypeV6      int = 16
 	VoFlagsV6     int = 17
+	VoFlags3V6    int = 18
+	VoFlags4V6    int = 19
 	VoFlags2V6    int = 23
 	VoRevKeyV6    int = 24
 	VoLegABV6     int = 24
@@ -143,8 +145,8 @@ func (e ValueV6) Type() uint8 {
 	return e[VoTypeV6]
 }
 
-func (e ValueV6) Flags() uint16 {
-	return uint16(e[VoFlagsV6]) | (uint16(e[VoFlags2]) << 8)
+func (e ValueV6) Flags() uint32 {
+	return (uint32(e[VoFlagsV6]) | uint32(e[VoFlags2])<<8 | uint32(e[VoFlags3])<<16 | uint32(e[VoFlags4])<<24)
 }
 
 // OrigIP returns the original destination IP, valid only if Type() is TypeNormal or TypeNATReverse
@@ -203,7 +205,7 @@ func (e *ValueV6) SetNATSport(sport uint16) {
 	binary.LittleEndian.PutUint16(e[VoNATSPortV6:VoNATSPortV6+2], sport)
 }
 
-func initValueV6(v *ValueV6, lastSeen time.Duration, typ uint8, flags uint16) {
+func initValueV6(v *ValueV6, lastSeen time.Duration, typ uint8, flags uint32) {
 	binary.LittleEndian.PutUint64(v[VoLastSeenV6:VoLastSeenV6+8], uint64(lastSeen))
 	v[VoTypeV6] = typ
 	v[VoFlagsV6] = byte(flags & 0xff)
@@ -211,7 +213,7 @@ func initValueV6(v *ValueV6, lastSeen time.Duration, typ uint8, flags uint16) {
 }
 
 // NewValueV6Normal creates a new ValueV6 of type TypeNormal based on the given parameters
-func NewValueV6Normal(lastSeen time.Duration, flags uint16, legA, legB Leg) ValueV6 {
+func NewValueV6Normal(lastSeen time.Duration, flags uint32, legA, legB Leg) ValueV6 {
 	v := ValueV6{}
 
 	initValueV6(&v, lastSeen, TypeNormal, flags)
@@ -224,7 +226,7 @@ func NewValueV6Normal(lastSeen time.Duration, flags uint16, legA, legB Leg) Valu
 
 // NewValueV6NATForward creates a new ValueV6 of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueV6NATForward(lastSeen time.Duration, flags uint16, revKey KeyV6) ValueV6 {
+func NewValueV6NATForward(lastSeen time.Duration, flags uint32, revKey KeyV6) ValueV6 {
 	v := ValueV6{}
 
 	initValueV6(&v, lastSeen, TypeNATForward, flags)
@@ -236,7 +238,7 @@ func NewValueV6NATForward(lastSeen time.Duration, flags uint16, revKey KeyV6) Va
 
 // NewValueV6NATReverse creates a new ValueV6 of type TypeNATReverse for the given
 // arguments and reverse parameters
-func NewValueV6NATReverse(lastSeen time.Duration, flags uint16, legA, legB Leg,
+func NewValueV6NATReverse(lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16) ValueV6 {
 	v := ValueV6{}
 
@@ -254,7 +256,7 @@ func NewValueV6NATReverse(lastSeen time.Duration, flags uint16, legA, legB Leg,
 }
 
 // NewValueV6NATReverseSNAT in addition to NewValueV6NATReverse sets the orig source IP
-func NewValueV6NATReverseSNAT(lastSeen time.Duration, flags uint16, legA, legB Leg,
+func NewValueV6NATReverseSNAT(lastSeen time.Duration, flags uint32, legA, legB Leg,
 	tunnelIP, origIP, origSrcIP net.IP, origPort uint16) ValueV6 {
 	v := NewValueV6NATReverse(lastSeen, flags, legA, legB, tunnelIP, origIP, origPort)
 	copy(v[VoOrigSIPV6:VoOrigSIPV6+16], origIP.To4())

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -108,8 +108,8 @@ type State struct {
 	RulesHit            uint32
 	RuleIDs             [MaxRuleIDs]uint64
 	Flags               uint64
-	ConntrackRCFlags    uint32
-	_                   uint32
+	ConntrackRCPadding  uint32
+	ConntrackFlags      uint32
 	ConntrackNATIPPort  uint64
 	ConntrackTunIP      uint32
 	ConntrackIfIndexFwd uint32


### PR DESCRIPTION
## Description

We've run out of `calico_ct_value->flags` flag bits.
Expand the flag memory without requiring a conntrack upgrade.
Original first 16 flags are in the same location.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
