### PR TITLE
Remove complexity that's no longer needed for current OpenStack versions

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -246,9 +246,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
         # RPC client for fanning out agent state reports.
         self.state_report_rpc = None
-        # Whether the version of update_port_status() available in this version
-        # of OpenStack has the host argument.  computed on first use.
-        self._cached_update_port_status_has_host_param = None
+
         # Last time we logged about a long port-status queue.  Used for rate
         # limiting.  Note: monotonic_time() uses its own epoch so it's only
         # safe to compare this with other values returned by monotonic_time().
@@ -320,55 +318,13 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 else:
                     LOG.debug("authcfg[%s] = %s", key, authcfg[key])
 
-            # Compatibility with older versions of openstack [mitaka and below]
-            try:
-                user_domain_name = authcfg.user_domain_name
-            except cfg.NoSuchOptError:
-                user_domain_name = "Default"
-                LOG.debug("authcfg[user_domain_name] fallback = %s", user_domain_name)
-
-            try:
-                username = authcfg.username
-            except cfg.NoSuchOptError:
-                username = authcfg.admin_user
-                LOG.debug("authcfg[username] fallback[admin_user] = %s", username)
-
-            try:
-                password = authcfg.password
-            except cfg.NoSuchOptError:
-                password = authcfg.admin_password
-                LOG.debug("authcfg[password] fallback[admin_password] = %s", "***")
-
-            try:
-                project_domain_name = authcfg.project_domain_name
-            except cfg.NoSuchOptError:
-                project_domain_name = "Default"
-                LOG.debug(
-                    "authcfg[project_domain_name] fallback = %s", project_domain_name
-                )
-
-            try:
-                project_name = authcfg.project_name
-            except cfg.NoSuchOptError:
-                project_name = authcfg.admin_tenant_name
-                LOG.debug(
-                    "authcfg[project_name] fallback[admin_tenant_name] = %s",
-                    project_name,
-                )
-
-            try:
-                auth_url = authcfg.auth_url
-            except cfg.NoSuchOptError:
-                auth_url = authcfg.identity_uri
-                LOG.debug("authcfg[auth_url] fallback[identity_uri] = %s", auth_url)
-
             auth = v3.Password(
-                user_domain_name=user_domain_name,
-                username=username,
-                password=password,
-                project_domain_name=project_domain_name,
-                project_name=project_name,
-                auth_url=re.sub(r"/v3/?$", "", auth_url) + "/v3",
+                user_domain_name=authcfg.user_domain_name,
+                username=authcfg.username,
+                password=authcfg.password,
+                project_domain_name=authcfg.project_domain_name,
+                project_name=authcfg.project_name,
+                auth_url=re.sub(r"/v3/?$", "", authcfg.auth_url) + "/v3",
             )
             sess = session.Session(auth=auth)
             keystone_client = KeystoneClient(session=sess)
@@ -592,17 +548,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             LOG.info("Reporting port %s deletion", port_id)
 
         try:
-            if self._update_port_status_has_host_param():
-                # Later OpenStack versions support passing the hostname.
-                LOG.debug("update_port_status() supports host parameter")
-                self.db.update_port_status(
-                    admin_context, port_id, neutron_status, host=hostname
-                )
-            else:
-                # Older versions don't have a way to specify the hostname so
-                # we do our best.
-                LOG.debug("update_port_status() missing host parameter")
-                self.db.update_port_status(admin_context, port_id, neutron_status)
+            self.db.update_port_status(
+                admin_context, port_id, neutron_status, host=hostname
+            )
         except db_exc.DBError as e:
             # Defensive: pre-Liberty, it was easy to cause deadlocks here if
             # any code path (in another loaded plugin, say) failed to take
@@ -640,17 +588,6 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         self._port_status_queue.put(
             ((PRIORITY_RETRY, monotonic_time()), port_status_key)
         )
-
-    def _update_port_status_has_host_param(self):
-        """Check whether update_port_status() supports the host parameter."""
-        if self._cached_update_port_status_has_host_param is None:
-            full_arg_spec = inspect.getfullargspec(self.db.update_port_status)
-            args = full_arg_spec.args
-            varkw = full_arg_spec.varkw
-            has_host_param = varkw or "host" in args
-            self._cached_update_port_status_has_host_param = has_host_param
-            LOG.info("update_port_status() supports host arg: %s", has_host_param)
-        return self._cached_update_port_status_has_host_param
 
     def _get_db(self):
         if not self.db:
@@ -1003,26 +940,15 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             conn_url = str(session.bind.url).lower()
         else:
             conn_url = str(session.connection().engine.url).lower()
-        if conn_url.startswith("mysql:") or conn_url.startswith("mysql+mysqldb:"):
-            # Neutron is using the mysqldb driver for accessing the database.
-            # This has a known incompatibility with eventlet that leads to
-            # deadlock.  Take the neutron-wide db-access lock as a workaround.
-            # See https://bugs.launchpad.net/oslo.db/+bug/1350149 for a
-            # description of the issue.
-            LOG.debug("Waiting for db-access lock tag=%s...", tag)
-            try:
-                with lockutils.lock("db-access"):
-                    LOG.debug("...acquired db-access lock tag=%s", tag)
-                    with context.session.begin(subtransactions=True) as txn:
-                        yield txn
-            finally:
-                LOG.debug("Released db-access lock tag=%s", tag)
-        else:
-            # Liberty or later uses an eventlet-safe mysql library.  (Or, we're
-            # not using mysql at all.)
-            LOG.debug("Not using mysqldb driver, skipping db-access lock")
-            with context.session.begin(subtransactions=True) as txn:
-                yield txn
+
+        # Since 2015 it has been expected that anyone using MySQL also uses the PyMySQL
+        # driver, to avoid the problem described in
+        # https://bugs.launchpad.net/oslo.db/+bug/1350149.  Assert that here.
+        assert not conn_url.startswith("mysql:")
+        assert not conn_url.startswith("mysql+mysqldb:")
+
+        with context.session.begin(subtransactions=True) as txn:
+            yield txn
 
     def _update_port(self, plugin_context, port):
         """_update_port

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -944,8 +944,19 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         # Since 2015 it has been expected that anyone using MySQL also uses the PyMySQL
         # driver, to avoid the problem described in
         # https://bugs.launchpad.net/oslo.db/+bug/1350149.  Assert that here.
-        assert not conn_url.startswith("mysql:")
-        assert not conn_url.startswith("mysql+mysqldb:")
+        if conn_url.startswith("mysql:") or conn_url.startswith("mysql+mysqldb:"):
+            LOG.error(
+                "Unsupported MySQL driver detected in SQLAlchemy connection URL: %s. "
+                "Please use the 'mysql+pymysql' driver to avoid known issues. "
+                "See https://bugs.launchpad.net/oslo.db/+bug/1350149 for details.",
+                conn_url
+            )
+            raise RuntimeError(
+                "Unsupported MySQL driver detected in SQLAlchemy connection URL: %s. "
+                "Please use the 'mysql+pymysql' driver to avoid known issues. "
+                "See https://bugs.launchpad.net/oslo.db/+bug/1350149 for details."
+                % conn_url
+            )
 
         with context.session.begin(subtransactions=True) as txn:
             yield txn

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -25,7 +25,6 @@
 #
 # It is implemented as a Neutron/ML2 mechanism driver.
 import contextlib
-import inspect
 import os
 import re
 import uuid
@@ -54,8 +53,6 @@ from neutron_lib.agent import topics
 from neutron_lib.db import api as db_api
 from neutron_lib.plugins import directory as plugin_dir
 from neutron_lib.plugins.ml2 import api
-
-from oslo_concurrency import lockutils
 
 from oslo_config import cfg
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -949,7 +949,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 "Unsupported MySQL driver detected in SQLAlchemy connection URL: %s. "
                 "Please use the 'mysql+pymysql' driver to avoid known issues. "
                 "See https://bugs.launchpad.net/oslo.db/+bug/1350149 for details.",
-                conn_url
+                conn_url,
             )
             raise RuntimeError(
                 "Unsupported MySQL driver detected in SQLAlchemy connection URL: %s. "

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1991,37 +1991,29 @@ class TestDriverStatusReporting(lib.Lib, unittest.TestCase):
         )
 
     def test_try_to_update_port_status(self):
-        # New OpenStack releases have a host parameter.
         self.driver._get_db()
 
-        # Driver uses reflection to check the function sig so we have to put
-        # a real function here.
         mock_calls = []
 
-        def m_update_port_status(context, port_id, status):
-            """Older version of OpenStack; no host parameter"""
-            mock_calls.append(mock.call(context, port_id, status))
+        def m_update_port_status(context, port_id, status, host=None):
+            mock_calls.append(mock.call(context, port_id, status, host=host))
 
         self.db.update_port_status = m_update_port_status
         context = mock.Mock()
         with mock.patch("eventlet.spawn_after", autospec=True) as m_spawn:
             self.driver._try_to_update_port_status(context, ("host", "p1"))
         self.assertEqual(
-            [mock.call(context, "p1", mech_calico.constants.PORT_STATUS_ERROR)],
+            [mock.call(context, "p1", mech_calico.constants.PORT_STATUS_ERROR, host="host")],
             mock_calls,
         )
         self.assertEqual([], m_spawn.mock_calls)  # No retry on success
 
     def test_try_to_update_port_status_fail(self):
-        # New OpenStack releases have a host parameter.
         self.driver._get_db()
 
-        # Driver uses reflection to check the function sig so we have to put
-        # a real function here.
         mock_calls = []
 
         def m_update_port_status(context, port_id, status, host=None):
-            """Newer version of OpenStack; host parameter"""
             mock_calls.append(mock.call(context, port_id, status, host=host))
             raise lib.DBError()
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -2003,7 +2003,11 @@ class TestDriverStatusReporting(lib.Lib, unittest.TestCase):
         with mock.patch("eventlet.spawn_after", autospec=True) as m_spawn:
             self.driver._try_to_update_port_status(context, ("host", "p1"))
         self.assertEqual(
-            [mock.call(context, "p1", mech_calico.constants.PORT_STATUS_ERROR, host="host")],
+            [
+                mock.call(
+                    context, "p1", mech_calico.constants.PORT_STATUS_ERROR, host="host"
+                )
+            ],
             mock_calls,
         )
         self.assertEqual([], m_spawn.mock_calls)  # No retry on success


### PR DESCRIPTION
We now support only the two most recent LTS OpenStack versions, which are currently Yoga and Caracal.

- For older versions we needed to check if `update_port_status()` method supported the `host` parameter.  All current OpenStack versions do, so we no longer need to check this.

- Remove ancient workaround for https://bugs.launchpad.net/oslo.db/+bug/1350149, which has been fixed since 2015 by people using the PyMySQL driver instead of mysqldb.

- Remove support for much older versions where the following modern authtoken properties were not available: user_domain_name, username, password, project_domain_name, project_name and auth_url.

Note, in this commit I have:

- unconditionally removed code when it is provable that Yoga/Caracal OpenStack code does not require it, for example because we know the method signature in those versions

- left assertions where something is exceedingly likely but not strictly provable, because someone could in theory use configuration that is considered to be wrong.
