### PR TITLE
Disable bpf kube-proxy healthz server in fv tests

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2828,7 +2828,7 @@ func startBPFDataplaneComponents(
 	ctKey := bpfconntrack.KeyFromBytes
 	ctVal := bpfconntrack.ValueFromBytes
 
-	if config.bpfProxyHealthzServer == nil {
+	if config.bpfProxyHealthzServer == nil && config.KubeProxyHealtzPort != 0 {
 		healthzAddr := fmt.Sprintf(":%d", config.KubeProxyHealtzPort)
 		config.bpfProxyHealthzServer = k8shealthcheck.NewProxyHealthServer(
 			healthzAddr, config.KubeProxyMinSyncPeriod)
@@ -2846,8 +2846,13 @@ func startBPFDataplaneComponents(
 	}
 
 	bpfproxyOpts := []bpfproxy.Option{
-		bpfproxy.WithHealthzServer(config.bpfProxyHealthzServer),
 		bpfproxy.WithMinSyncPeriod(config.KubeProxyMinSyncPeriod),
+	}
+
+	if config.bpfProxyHealthzServer != nil {
+		bpfproxyOpts = append(bpfproxyOpts, bpfproxy.WithHealthzServer(config.bpfProxyHealthzServer))
+	} else {
+		log.Info("No healthz server configured for BPF kube-proxy.")
 	}
 
 	if config.BPFNodePortDSREnabled {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path"
 	"regexp"
@@ -1344,15 +1343,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						return healthStatus(containerIP(f.Container), "9099", "readiness")
 					}
 					Eventually(felixReady, "10s", "500ms").Should(BeGood())
-					Eventually(func() int {
-						resp, err := http.Get("http://" + containerIP(f.Container) + ":10256" + "/healthz")
-						if err != nil {
-							log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")
-							return -1
-						}
-						defer resp.Body.Close()
-						return resp.StatusCode
-					}, "3s", "500ms").Should(BeGood())
 				}
 			}
 		}

--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -80,6 +80,7 @@ type TopologyOptions struct {
 	IPv6PoolUsages            []api.IPPoolAllowedUse
 	NeedNodeIP                bool
 	FlowLogSource             int
+	BPFProxyHealthzPort       int // zero means disable
 }
 
 // Calico containers created during topology creation.
@@ -310,6 +311,8 @@ func StartNNodeTopology(
 		opts.ExtraEnvVars["FELIX_TYPHAADDR"] = tc.Typha.IP + ":5473"
 		typhaIP = tc.Typha.IP
 	}
+
+	opts.ExtraEnvVars["FELIX_BPFKUBEPROXYHEALTZPORT"] = fmt.Sprintf("%d", opts.BPFProxyHealthzPort)
 
 	tc.Felixes = make([]*Felix, n)
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
