### PR TITLE
[DE-3759] Update semaphore os_agent from Ubuntu 20 to Ubuntu 22

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -318,7 +318,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-4
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       jobs:
         - name: Conformance e2e tests
           commands:
@@ -810,7 +810,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-4
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       prologue:
         commands:
           - cd node
@@ -1023,7 +1023,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-2
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       prologue:
         commands:
           - cd networking-calico

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -318,7 +318,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-4
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       jobs:
         - name: Conformance e2e tests
           commands:
@@ -810,7 +810,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-4
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       prologue:
         commands:
           - cd node
@@ -1023,7 +1023,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-2
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       prologue:
         commands:
           - cd networking-calico

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
@@ -7,7 +7,7 @@
     agent:
       machine:
         type: f1-standard-4
-        os_image: ubuntu2004
+        os_image: ubuntu2204
     jobs:
       - name: Conformance e2e tests
         commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -7,7 +7,7 @@
     agent:
       machine:
         type: f1-standard-4
-        os_image: ubuntu2004
+        os_image: ubuntu2204
     prologue:
       commands:
         - cd node

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -7,7 +7,7 @@
     agent:
       machine:
         type: f1-standard-2
-        os_image: ubuntu2004
+        os_image: ubuntu2204
     prologue:
       commands:
         - cd networking-calico

--- a/whisker/.semaphore/semaphore.yml
+++ b/whisker/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Calico OSS UI CI Build
 agent:
     machine:
         type: f1-standard-4
-        os_image: ubuntu2004
+        os_image: ubuntu2204
 blocks:
     - name: CI Build
       task:


### PR DESCRIPTION
## Description

Updating semaphore ci os_agent to Ubuntu 22 from ubuntu 20

Semaphore is retiring support for Ubuntu 20.04

Note: to the reviewer. Ubuntu 22 out of the box comes with go 1.25.1. Potential to cause impacts to our build jobs.

## Related issues/PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

N/A

## Reminder for the reviewer

N/A
