### PR TITLE
chore: Add non-OCI docker image labels

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -35,6 +35,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Aggregated API server which enables calico resources to be managed via kubectl"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico API server"
+LABEL release=1
+LABEL summary="Aggregated API server which enables calico resources to be managed via kubectl"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 USER 10001:10001

--- a/app-policy/Dockerfile
+++ b/app-policy/Dockerfile
@@ -47,6 +47,15 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+# Labels for RedHat OCP certification
+LABEL description="Calico Dikastes enables Application Layer Policy"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico Dikastes"
+LABEL release=1
+LABEL summary="Calico Dikastes enables Application Layer Policy"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 USER 999

--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -33,6 +33,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="calicoctl(1) is a command line tool used to interface with the Calico datastore"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico CLI tool"
+LABEL release=1
+LABEL summary="calicoctl(1) is a command line tool used to interface with the Calico datastore"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 ENV CALICO_CTL_CONTAINER=TRUE
 
 COPY --from=source / /

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -33,6 +33,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico Networking for CNI"
+LABEL release=1
+LABEL summary="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 ENV PATH=/opt/cni/bin:$PATH
 
 COPY --from=source / /

--- a/felix/docker-image/Dockerfile
+++ b/felix/docker-image/Dockerfile
@@ -20,8 +20,6 @@ FROM ${BPFTOOL_IMAGE} AS bpftool
 
 FROM debian:12-slim AS source
 
-LABEL maintainer="Shaun Crampton <shaun@tigera.io>"
-
 # Install remaining runtime deps required for felix from the global repository
 RUN apt-get update && apt-get install -y \
     ipset \
@@ -75,6 +73,23 @@ FROM scratch
 COPY --from=source / /
 
 WORKDIR /code
+
+LABEL org.opencontainers.image.description="Calico's per-host daemon"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico Felix"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Labels for RedHat OCP certification
+LABEL description="Calico's per-host daemon"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico Felix"
+LABEL release=1
+LABEL summary="Calico's per-host daemon"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
 
 # Run felix (via the wrapper script) by default
 CMD ["/usr/bin/calico-felix-wrapper"]

--- a/kube-controllers/Dockerfile
+++ b/kube-controllers/Dockerfile
@@ -48,6 +48,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico Kubernetes controllers"
+LABEL release=1
+LABEL summary="Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 USER 999

--- a/kube-controllers/docker-image/flannel-migration/Dockerfile
+++ b/kube-controllers/docker-image/flannel-migration/Dockerfile
@@ -45,6 +45,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Calico Flannel migration controller updates a flannel cluster to Calico"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico Flannel migration controller"
+LABEL release=1
+LABEL summary="Calico Flannel migration controller updates a flannel cluster to Calico"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 USER 999

--- a/pod2daemon/csidriver/Dockerfile
+++ b/pod2daemon/csidriver/Dockerfile
@@ -33,6 +33,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Calico CSI driver to setup secure connections from Kubernetes pods to local daemons"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico CSI Driver"
+LABEL release=1
+LABEL summary="Calico CSI driver to setup secure connections from Kubernetes pods to local daemons"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 ENTRYPOINT ["/usr/bin/csi-driver"]

--- a/pod2daemon/flexvol/docker-image/Dockerfile
+++ b/pod2daemon/flexvol/docker-image/Dockerfile
@@ -57,6 +57,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Calico FlexVolume driver installer to setup secure connections from Kubernetes pods to local daemons"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico FlexVolume driver installer"
+LABEL release=1
+LABEL summary="Calico FlexVolume driver installer to setup secure connections from Kubernetes pods to local daemons"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 ENTRYPOINT ["/usr/local/bin/flexvol.sh"]

--- a/pod2daemon/node-driver-registrar-docker/Dockerfile
+++ b/pod2daemon/node-driver-registrar-docker/Dockerfile
@@ -34,6 +34,13 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${UPSTREAM_VER}+calico-${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="CSI Node driver registrar handles registration of CSI drivers with the kubelet. This is the upstream version repackaged for Calico."
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="CSI Node driver registrar"
+LABEL release=1
+LABEL summary="CSI Node driver registrar handles registration of CSI drivers with the kubelet. This is the upstream version repackaged for Calico."
+LABEL vendor="Project Calico"
+LABEL version="${UPSTREAM_VER}+calico-${GIT_VERSION}"
 
 COPY --from=source / /
 

--- a/test-tools/mocknode/Dockerfile
+++ b/test-tools/mocknode/Dockerfile
@@ -27,12 +27,20 @@ ARG GIT_VERSION=unknown
 
 # Required labels for certification
 LABEL org.opencontainers.image.description="Calico mock node for scale testing"
-LABEL org.opencontainers.image.authors="shaun@tigera.io"
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
 LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
 LABEL org.opencontainers.image.title="Calico mock node"
 LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+LABEL description="Calico mock node for scale testing"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico mock node"
+LABEL release=1
+LABEL summary="Calico mock node for scale testing"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
 
 COPY --from=source / /
 

--- a/typha/docker-image/Dockerfile
+++ b/typha/docker-image/Dockerfile
@@ -35,6 +35,14 @@ LABEL org.opencontainers.image.vendor="Project Calico"
 LABEL org.opencontainers.image.version="${GIT_VERSION}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+LABEL description="Calico Typha is a fan-out datastore proxy"
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico Typha"
+LABEL release=1
+LABEL summary="Calico Typha is a fan-out datastore proxy"
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
 COPY --from=source / /
 
 USER 999


### PR DESCRIPTION
Add back the non-OCI labels to our docker images, which were removed in #10181 but are still required by RedHat OCP certification.

