### PR TITLE
De 3727 branch cut

### DIFF
--- a/.semaphore/release/cut-branch.yml
+++ b/.semaphore/release/cut-branch.yml
@@ -24,8 +24,4 @@ blocks:
       jobs:
         - name: Cut Branch
           commands:
-            - ./bin/release branch cut
-      prologue:
-        commands:
-          - cd release
-          - make build
+            - make create-release-branch

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ release-public: bin/gh release/bin/release
 
 # Create a release branch.
 create-release-branch: release/bin/release
-	@release/bin/release branch cut -git-publish
+	@release/bin/release branch cut
 
 # Test the release code
 release-test:

--- a/manifests/alp/istio-inject-configmap-1.1.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.0.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.1.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.10.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.11.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.11.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.12.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.12.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.13.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.13.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.14.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.14.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.15.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.16.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.16.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.17.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.17.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.2.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.3.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.4.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.5.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.6.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.7.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.8.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.9.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.10.yaml
@@ -433,7 +433,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: quay.io/calico/dikastes:master
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -720,7 +720,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: quay.io/calico/dikastes:master
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.15.yaml
@@ -434,7 +434,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: quay.io/calico/dikastes:master
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -719,7 +719,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: quay.io/calico/dikastes:master
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.0.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.1.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.2.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.3.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.4.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.5.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.6.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.7.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.8.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.9.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.0.yaml
@@ -327,7 +327,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.1.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.2.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.3.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.4.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.5.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.0.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.1.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.2.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.6.yaml
@@ -363,7 +363,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.7.yaml
@@ -369,7 +369,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: quay.io/calico/dikastes:master
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.9.yaml
@@ -428,7 +428,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: quay.io/calico/dikastes:master
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -714,7 +714,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: quay.io/calico/dikastes:master
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/apiserver.yaml
+++ b/manifests/apiserver.yaml
@@ -74,7 +74,7 @@ spec:
           env:
             - name: DATASTORE_TYPE
               value: kubernetes
-          image: calico/apiserver:master
+          image: quay.io/calico/apiserver:master
           name: calico-apiserver
           readinessProbe:
             httpGet:

--- a/manifests/calicoctl-etcd.yaml
+++ b/manifests/calicoctl-etcd.yaml
@@ -14,7 +14,7 @@ spec:
   hostNetwork: true
   containers:
     - name: calicoctl
-      image: calico/ctl:master
+      image: quay.io/calico/ctl:master
       command:
         - calicoctl
       args:

--- a/manifests/calicoctl.yaml
+++ b/manifests/calicoctl.yaml
@@ -22,7 +22,7 @@ spec:
   serviceAccountName: calicoctl
   containers:
     - name: calicoctl
-      image: calico/ctl:master
+      image: quay.io/calico/ctl:master
       command:
         - calicoctl
       args:

--- a/manifests/csi-driver.yaml
+++ b/manifests/csi-driver.yaml
@@ -46,7 +46,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: calico-csi
-          image: calico/csi:master
+          image: quay.io/calico/csi:master
           imagePullPolicy: IfNotPresent
           args:
             - --nodeid=$(KUBE_NODE_NAME)
@@ -71,7 +71,7 @@ spec:
               mountPath: /var/lib/kubelet/
               mountPropagation: "Bidirectional"
         - name: csi-node-driver-registrar
-          image: calico/node-driver-registrar:master
+          image: quay.io/calico/node-driver-registrar:master
           imagePullPolicy: IfNotPresent
           args:
             - --v=5

--- a/manifests/flannel-migration/migration-job.yaml
+++ b/manifests/flannel-migration/migration-job.yaml
@@ -159,7 +159,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: flannel-migration-controller
-          image: calico/flannel-migration-controller:master
+          image: quay.io/calico/flannel-migration-controller:master
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/metadata.mk
+++ b/metadata.mk
@@ -67,7 +67,7 @@ LIBBPF_VERSION=v1.4.6
 BPFTOOL_IMAGE=calico/bpftool:v7.5.0
 
 # The operator branch corresponding to this branch.
-OPERATOR_BRANCH=master
+OPERATOR_BRANCH ?= master
 
 # quay.io expiry time for hashrelease/dev images
 QUAY_EXPIRE_DAYS=90

--- a/release/Makefile
+++ b/release/Makefile
@@ -6,7 +6,8 @@ include ../lib.Makefile
 
 export ORGANIZATION
 export GIT_REPO
-export GIT_REPO_SLUG
+export RELEASE_BRANCH_PREFIX
+export DEV_TAG_SUFFIX
 export DEV_REGISTRIES
 export OPERATOR_BRANCH
 

--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/pkg/manager/branch"
+	"github.com/projectcalico/calico/release/pkg/manager/calico"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
 
@@ -49,11 +50,21 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				baseBranchFlag,
 				releaseBranchPrefixFlag,
 				devTagSuffixFlag,
+				operatorBranchFlag,
 				publishBranchFlag,
 				skipValidationFlag,
 			},
 			Action: func(_ context.Context, c *cli.Command) error {
 				configureLogging("branch-cut.log")
+
+				calicoManager := calico.NewManager(
+					calico.WithGithubOrg(c.String(orgFlag.Name)),
+					calico.WithRepoName(c.String(repoFlag.Name)),
+					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
+					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
+					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+				)
 
 				m := branch.NewManager(
 					branch.WithRepoRoot(cfg.RepoRootDir),
@@ -61,6 +72,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					branch.WithMainBranch(c.String(baseBranchFlag.Name)),
 					branch.WithDevTagIdentifier(c.String(devTagSuffixFlag.Name)),
 					branch.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
+					branch.WithRepoManager(calicoManager),
 					branch.WithValidate(!c.Bool(skipValidationFlag.Name)),
 					branch.WithPublish(c.Bool(publishBranchFlag.Name)))
 				return m.CutReleaseBranch()

--- a/release/pkg/manager/branch/manager.go
+++ b/release/pkg/manager/branch/manager.go
@@ -24,6 +24,10 @@ import (
 	"github.com/projectcalico/calico/release/internal/version"
 )
 
+type RepoManager interface {
+	SetupReleaseBranch(branch string) error
+}
+
 type BranchManager struct {
 	// repoRoot is the absolute path to the root directory of the repository
 	repoRoot string
@@ -45,6 +49,9 @@ type BranchManager struct {
 
 	// publish indicates if we should push the branch changes to the remote repository
 	publish bool
+
+	// repoManager indicates if we are setting up a new release branch
+	repoManager RepoManager
 }
 
 func NewManager(opts ...Option) *BranchManager {
@@ -101,7 +108,14 @@ func (b *BranchManager) CutVersionedBranch(stream string) error {
 	if _, err := b.git("checkout", "-b", newBranchName); err != nil {
 		return err
 	}
+	if b.repoManager != nil {
+		logrus.Infof("Performing setup necessary for %s branch", newBranchName)
+		if err := b.repoManager.SetupReleaseBranch(newBranchName); err != nil {
+			return fmt.Errorf("failed to set up release branch: %s", err)
+		}
+	}
 	if b.publish {
+		logrus.WithField("branch", newBranchName).Infof("Pushing new release branch to remote '%s'", b.remote)
 		if _, err := b.git("push", b.remote, newBranchName); err != nil {
 			return err
 		}
@@ -109,10 +123,16 @@ func (b *BranchManager) CutVersionedBranch(stream string) error {
 	return nil
 }
 
+// CutReleaseBranch creates a new release branch from the main branch,
+// run branch cut setup by the RepoManager,
+// and updates the main branch to the next development version.
 func (b *BranchManager) CutReleaseBranch() error {
 	if b.validate {
 		if err := b.PreBranchCutValidation(); err != nil {
 			return fmt.Errorf("pre-branch cut validation failed: %s", err)
+		}
+		if b.repoManager == nil {
+			return fmt.Errorf("no repository manager configured")
 		}
 	}
 	if _, err := b.git("fetch", b.remote); err != nil {
@@ -142,6 +162,10 @@ func (b *BranchManager) CutReleaseBranch() error {
 		return err
 	}
 	if b.publish {
+		logrus.WithFields(logrus.Fields{
+			"branch": b.mainBranch,
+			"tag":    nextVersionTag,
+		}).Infof("Pushing updated main branch and new development tag to remote '%s'", b.remote)
 		if _, err := b.git("push", b.remote, b.mainBranch); err != nil {
 			return err
 		}

--- a/release/pkg/manager/branch/options.go
+++ b/release/pkg/manager/branch/options.go
@@ -64,3 +64,10 @@ func WithPublish(publish bool) Option {
 		return nil
 	}
 }
+
+func WithRepoManager(m RepoManager) Option {
+	return func(b *BranchManager) error {
+		b.repoManager = m
+		return nil
+	}
+}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -140,18 +140,6 @@ func NewManager(opts ...Option) *CalicoManager {
 	}
 	logrus.WithField("repoRoot", b.repoRoot).Info("Using repo root")
 
-	if b.calicoVersion == "" {
-		logrus.Fatal("No calico version specified")
-	}
-	logrus.WithField("version", b.calicoVersion).Info("Using product version")
-
-	if b.operatorVersion == "" {
-		logrus.Fatal("No operator version specified")
-	}
-	if (b.buildImages || b.publishImages || b.archiveImages) && len(b.imageRegistries) == 0 {
-		logrus.Fatal("No image registries specified")
-	}
-	logrus.WithField("operatorVersion", b.operatorVersion).Info("Using operator version")
 	return b
 }
 
@@ -187,6 +175,9 @@ type CalicoManager struct {
 	operatorImage    string
 	operatorRegistry string
 	operatorVersion  string
+
+	// new release branch cut variables
+	operatorBranch string
 
 	// outputDir is the directory to which we should write release artifacts, and from
 	// which we should read them for publishing.
@@ -246,6 +237,18 @@ func (r *CalicoManager) helmChartVersion() string {
 }
 
 func (r *CalicoManager) PreBuildValidation() error {
+	if r.calicoVersion == "" {
+		logrus.Fatal("No calico version specified")
+	}
+	logrus.WithField("version", r.calicoVersion).Info("Using product version")
+
+	if r.operatorVersion == "" {
+		logrus.Fatal("No operator version specified")
+	}
+	logrus.WithField("operatorVersion", r.operatorVersion).Info("Using operator version")
+	if (r.buildImages || r.archiveImages) && len(r.imageRegistries) == 0 {
+		logrus.Fatal("No image registries specified")
+	}
 	if r.isHashRelease {
 		return r.PreHashreleaseValidate()
 	}
@@ -493,16 +496,16 @@ func (r *CalicoManager) TagRelease(ver string) error {
 }
 
 // modifyHelmChartsValues modifies values in helm charts to use the correct version.
-// This is only necessary for hashreleases.
+// This is only necessary for hashreleases or new branch cut.
 func (r *CalicoManager) modifyHelmChartsValues() error {
-	valuesYAML := filepath.Join(r.repoRoot, "charts", "tigera-operator", "values.yaml")
-	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.operatorVersion), valuesYAML}, nil); err != nil {
-		logrus.WithError(err).Error("Failed to update operator version in values.yaml")
-		return fmt.Errorf("failed to update operator version in %s: %w", valuesYAML, err)
+	operatorChartFilePath := filepath.Join(r.repoRoot, "charts", "tigera-operator", "values.yaml")
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.operatorVersion), operatorChartFilePath}, nil); err != nil {
+		logrus.WithError(err).Errorf("Failed to update operator version in %s", operatorChartFilePath)
+		return fmt.Errorf("failed to update operator version in %s: %w", operatorChartFilePath, err)
 	}
-	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, r.calicoVersion), valuesYAML}, nil); err != nil {
-		logrus.WithError(err).Error("Failed to update calicoctl version in values.yaml")
-		return fmt.Errorf("failed to update calicoctl version in %s: %w", valuesYAML, err)
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, r.calicoVersion), operatorChartFilePath}, nil); err != nil {
+		logrus.WithError(err).Errorf("Failed to update calicoctl version in %s", operatorChartFilePath)
+		return fmt.Errorf("failed to update calicoctl version in %s: %w", operatorChartFilePath, err)
 	}
 	return nil
 }
@@ -804,6 +807,13 @@ func (r *CalicoManager) publishPrereqs() error {
 		logrus.Warn("Skipping pre-publish validation")
 		return nil
 	}
+	if r.calicoVersion == "" {
+		logrus.Fatal("No calico version specified")
+	}
+	logrus.WithField("version", r.calicoVersion).Info("Using product version")
+	if r.publishImages && len(r.imageRegistries) == 0 {
+		logrus.Fatal("No image registries specified")
+	}
 	if dirty, err := utils.GitIsDirty(r.repoRoot); dirty || err != nil {
 		return fmt.Errorf("there are uncommitted changes in the repository, please commit or stash them before publishing the release")
 	}
@@ -820,16 +830,11 @@ func (r *CalicoManager) publishPrereqs() error {
 // Collect artifacts to be included on each release to GitHub.
 // It builds the metadata file.
 // It assumes that all other artifacts already been built, and simply wraps them up.
-//
-// - release-vX.Y.Z.tgz: contains images, manifests, and binaries.
-//
-// - ocp-vX.Y.Z.tgz: contains the OCP bundle.
-//
-// - tigera-operator-vX.Y.Z.tgz: contains the helm v3 chart.
-//
-// - calico-windows-vX.Y.Z.zip: Calico for Windows zip archive for non-HPC installation.
-//
-// - calicoctl/bin: All calicoctl binaries.
+//   - release-vX.Y.Z.tgz: contains images, manifests, and binaries.
+//   - ocp-vX.Y.Z.tgz: contains the OCP bundle.
+//   - tigera-operator-vX.Y.Z.tgz: contains the helm v3 chart.
+//   - calico-windows-vX.Y.Z.zip: Calico for Windows zip archive for non-HPC installation.
+//   - calicoctl/bin: All calicoctl binaries.
 //
 // For hashreleases, include the manifests directly.
 //
@@ -1279,4 +1284,93 @@ func (r *CalicoManager) makeInDirectoryWithOutput(dir, target string, env ...str
 func (r *CalicoManager) makeInDirectoryIgnoreOutput(dir, target string, env ...string) error {
 	_, err := r.makeInDirectoryWithOutput(dir, target, env...)
 	return err
+}
+
+func (r *CalicoManager) releaseBranchPrerreqs(branch string) error {
+	if !r.validate {
+		logrus.Warn("Skipping pre-release branch validation")
+		return nil
+	}
+	if dirty, err := utils.GitIsDirty(r.repoRoot); err != nil {
+		return fmt.Errorf("failed to check if git is dirty: %s", err)
+	} else if dirty {
+		return fmt.Errorf("there are uncommitted changes in the repository, please commit or stash them before cutting a release branch")
+	}
+	if branch == "" {
+		return fmt.Errorf("no branch specified")
+	}
+	if r.operatorBranch == "" {
+		return fmt.Errorf("operator branch not specified")
+	}
+	return nil
+}
+
+// SetupReleaseBranch runs the steps necessary when cutting a new release branch
+//
+// For a newly created release branch, it will:
+//   - Update the versions in the helm charts, metadata.mk.
+//   - Run code generation to update generated files based on the new versions.
+//   - Commit the changes.
+func (r *CalicoManager) SetupReleaseBranch(branch string) error {
+	if err := r.releaseBranchPrerreqs(branch); err != nil {
+		return err
+	}
+
+	// Set calico version and operator version to their respective branches for pre-release branch.
+	r.calicoVersion = branch
+	r.operatorVersion = r.operatorBranch
+
+	// Modify values in charts
+	logrus.WithFields(logrus.Fields{
+		"calico_version":   r.calicoVersion,
+		"operator_version": r.operatorVersion,
+	}).Debug("Updating versions in helm charts to release branches")
+	calicoChartFilePath := filepath.Join(r.repoRoot, "charts", "calico", "values.yaml")
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, branch), calicoChartFilePath}, nil); err != nil {
+		logrus.WithError(err).Errorf("Failed to update version in %s", calicoChartFilePath)
+		return fmt.Errorf("failed to update operator version in %s: %w", calicoChartFilePath, err)
+	}
+	if err := r.modifyHelmChartsValues(); err != nil {
+		return err
+	}
+
+	// Modify values in metadata.mk
+	logrus.WithField("operator_branch", r.operatorBranch).Debug("Updating variables in metadata.mk")
+	makeMetadataFilePath := filepath.Join(r.repoRoot, "metadata.mk")
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/^OPERATOR_BRANCH.*/OPERATOR_BRANCH ?= %s/g`, r.operatorBranch), makeMetadataFilePath}, nil); err != nil {
+		logrus.WithError(err).Errorf("Failed to update operator branch in %s", makeMetadataFilePath)
+		return fmt.Errorf("failed to update operator branch in %s: %w", makeMetadataFilePath, err)
+	}
+
+	// Update branch used for CAPZ - Windows FV tests.
+	logrus.WithField("branch", branch).Debug("Updating branch in setup script for CAPZ Windows FV tests")
+	scriptFilePath := filepath.Join(r.repoRoot, "process", "testing", "winfv-felix", "setup-fv-capz.sh")
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/RELEASE_STREAM=.*HASH_RELEASE/RELEASE_STREAM=%s HASH_RELEASE/g`, branch), scriptFilePath}, nil); err != nil {
+		logrus.WithError(err).Errorf("Failed to update release branch in %s", scriptFilePath)
+		return fmt.Errorf("failed to update release branch in %s: %w", scriptFilePath, err)
+	}
+
+	// Run code generation.
+	logrus.Debug("Running code generation")
+	env := append(os.Environ(), fmt.Sprintf("DEFAULT_BRANCH_OVERRIDE=%s", branch))
+	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "generate", env...); err != nil {
+		logrus.WithError(err).Error("Failed to run code generation for branch cut")
+		return fmt.Errorf("failed to run code generation: %w", err)
+	}
+
+	// Commit the changes.
+	if _, err := r.git("add",
+		filepath.Join(r.repoRoot, ".semaphore"),
+		filepath.Join(r.repoRoot, "charts"),
+		filepath.Join(r.repoRoot, "manifests"),
+		filepath.Join(r.repoRoot, "metadata.mk"),
+		filepath.Join(r.repoRoot, "process/testing/winfv-felix/setup-fv-capz.sh"),
+	); err != nil {
+		return fmt.Errorf("failed to add files to git: %s", err)
+	}
+	if _, err := r.git("commit", "-m", fmt.Sprintf("Updates for %s release branch", branch)); err != nil {
+		return fmt.Errorf("failed to commit changes: %s", err)
+	}
+
+	return nil
 }

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -208,3 +208,10 @@ func WithArchiveImages(archive bool) Option {
 		return nil
 	}
 }
+
+func WithOperatorBranch(branch string) Option {
+	return func(r *CalicoManager) error {
+		r.operatorBranch = branch
+		return nil
+	}
+}


### PR DESCRIPTION
## Description

This updates the mechanism for performing branch cut to have the release tool handle creating the new branch and updating the necessary files on that branch. Using #11014 (most recent branch cut) as guide for what changes to make, see radTuti/calico#1 for a comparison.

To make this feasible, a new interface `RepoManager` is defined to allow setting up the necessary changes via `SetupReleaseBranch`. This function is defined in the calico manager with the right calls to updated necessary files.
Also the pipeline for running branch cut via CI is updated to use the make target in the repo.

A few additional changes:

- moved around validations in the calico manager.
- fix calico images in static manifests to use the default registry `quay.io` so they get updated during manifest generation.
- make error logging and comments better.
 

## Related issues/PRs

N/A

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
not required
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
