### PR TITLE
[v3.30] reduce bpf_jit_harden from 2 to 1 when possible

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -3381,7 +3381,7 @@ func (m *bpfEndpointManager) setJITHardening(val int) error {
 	numval := strconv.Itoa(val)
 	err := writeProcSys(jitHardenPath, numval)
 	if err != nil {
-		log.WithField("err", err).Errorf("Failed to  set %s to %s", jitHardenPath, numval)
+		log.WithField("err", err).Errorf("Failed to set %s to %s", jitHardenPath, numval)
 		return err
 	}
 


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#11015
When bpf_jit_harden is set to 2 it obfuscates userspace provided constants including jumps in the loaded programs. That makes loading policies 10-20x slower. Reducing bpf_jit_harden from 2 (harden always) to 1 (harden only for unpriviledged users only) makes large policies load fast.

In case this is not possible, felix reduces trampoline jump distance so make the programs loadable anyway.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```