### PR TITLE
CORE-11946: Consider local_as_num (if not empty) instead of node_as_num

### DIFF
--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -216,6 +216,10 @@ template bgp bgp_template {
 # ------------- Global peers -------------
 {{if ls "/bgp/v1/global/peer_v4"}}
 {{range gets "/bgp/v1/global/peer_v4/*"}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 {{- if $data.local_bgp_peer }}
 # Skipping local bgp peer ({{$data.ip}})
@@ -264,7 +268,7 @@ protocol bgp Global_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -277,14 +281,14 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}
@@ -308,6 +312,10 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{if ls "/bgp/v1/global/peer_v4"}}
 {{$first := true}}
 {{range gets "/bgp/v1/global/peer_v4/*"}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 {{- if not $data.local_bgp_peer }}
 {{/* Skipping global bgp peer */}}
@@ -357,7 +365,7 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -370,14 +378,14 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}
@@ -402,6 +410,10 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
 {{$node_peers_key := printf "/bgp/v1/host/%s/peer_v4" (getenv "NODENAME")}}
 {{if ls $node_peers_key}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 {{- if $data.local_bgp_peer }}
 # Skipping local bgp peer ({{$data.ip}})
@@ -450,7 +462,7 @@ protocol bgp Node_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -460,14 +472,14 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}
@@ -492,6 +504,10 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{if ls $node_peers_key}}
 {{$first := true}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}
 {{- if not $data.local_bgp_peer }}
 {{/* Skipping non local bgp peer */}}
@@ -541,7 +557,7 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -551,14 +567,14 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}

--- a/confd/etc/calico/confd/templates/bird6.cfg.template
+++ b/confd/etc/calico/confd/templates/bird6.cfg.template
@@ -218,6 +218,10 @@ template bgp bgp_template {
 # ------------- Global peers -------------
 {{if ls "/bgp/v1/global/peer_v6"}}
 {{range gets "/bgp/v1/global/peer_v6/*"}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip ":"}}{{$id := join $nums "_"}}
 {{- if $data.local_bgp_peer }}
 # Skipping local bgp peer ({{$data.ip}})
@@ -266,7 +270,7 @@ protocol bgp Global_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -279,14 +283,14 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}
@@ -310,6 +314,10 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{if ls "/bgp/v1/global/peer_v6"}}
 {{$first := true}}
 {{range gets "/bgp/v1/global/peer_v6/*"}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip ":"}}{{$id := join $nums "_"}}
 {{- if not $data.local_bgp_peer }}
 {{/* Skipping global bgp peer */}}
@@ -359,7 +367,7 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -372,14 +380,14 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}
@@ -403,6 +411,10 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
 {{$node_peers_key := printf "/bgp/v1/host/%s/peer_v6" (getenv "NODENAME")}}
 {{if ls $node_peers_key}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{- if $data.local_bgp_peer }}
 # Skipping local bgp peer ({{$data.ip}})
 {{- else}}
@@ -451,7 +463,7 @@ protocol bgp Node_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -461,14 +473,14 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}
@@ -493,6 +505,10 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{if ls $node_peers_key}}
 {{$first := true}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
+{{- $effective_node_as_num := $node_as_num }}
+{{- if ne $data.local_as_num "0" }}
+  {{- $effective_node_as_num = $data.local_as_num }}
+{{- end }}
 {{$nums := split $data.ip ":"}}{{$id := join $nums "_"}}
 {{- if not $data.local_bgp_peer }}
 {{/* Skipping non local bgp peer */}}
@@ -542,7 +558,7 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
     {{- end }}
     {{- end }}
     {{- end }}
-    calico_export_to_bgp_peers({{eq $data.as_num $node_as_num}});
+    calico_export_to_bgp_peers({{eq $data.as_num $effective_node_as_num}});
     reject;{{/* Prior to introduction of BGP Filters anything not explicitly exported through calico_export_to_bgp_peers()
                 was rejected so use default reject behaviour on export */}}
   };  # Only want to export routes for workloads.
@@ -552,14 +568,14 @@ protocol bgp Local_Workload_{{$id}} from bgp_template {
 {{- if ne $data.keepalive_time ""}}
   keepalive time {{$data.keepalive_time}};
 {{- end}}
-{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $effective_node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
 {{- if $data.password}}
   password "{{$data.password}}";
 {{- end}}
-{{- if and (ne $data.as_num $node_as_num) ($data.keep_next_hop)}}
+{{- if and (ne $data.as_num $effective_node_as_num) ($data.keep_next_hop)}}
   next hop keep;
 {{- end}}
 {{- if eq $data.next_hop_mode "Self"}}

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global-ipv6/bird6.cfg
@@ -74,6 +74,7 @@ template bgp bgp_template {
 protocol bgp Global_2001__102 from bgp_template {
   ttl security off;
   multihop;
+  local as 64567;
   neighbor 2001::102 as 64567;
   import filter {
     accept; # Prior to introduction of BGP Filters we used "import all" so use default accept behaviour on import
@@ -96,7 +97,7 @@ protocol bgp Global_2001__104 from bgp_template {
     accept; # Prior to introduction of BGP Filters we used "import all" so use default accept behaviour on import
   };
   export filter {
-    calico_export_to_bgp_peers(true);
+    calico_export_to_bgp_peers(false);
     reject;
   };  # Only want to export routes for workloads.
   passive on; # Peering is unidirectional, peer will connect to us.

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird.cfg
@@ -76,7 +76,7 @@ template bgp bgp_template {
 protocol bgp Global_10_192_0_1_port_150 from bgp_template {
   ttl security off;
   multihop;
-  local as 65001;
+  local as 64567;
   neighbor 10.192.0.1 port 150 as 64567;
   source address 10.192.0.2;  # The local address we use for the TCP connection
   import filter {
@@ -94,7 +94,7 @@ protocol bgp Global_10_192_0_1_port_150 from bgp_template {
 protocol bgp Global_10_192_0_1_port_166 from bgp_template {
   ttl security off;
   multihop;
-  local as 65002;
+  local as 64567;
   neighbor 10.192.0.1 port 166 as 64567;
   source address 10.192.0.2;  # The local address we use for the TCP connection
   import filter {
@@ -111,12 +111,13 @@ protocol bgp Global_10_192_0_1_port_166 from bgp_template {
 protocol bgp Global_10_192_0_3_port_150 from bgp_template {
   ttl security off;
   multihop;
+  local as 64515;
   neighbor 10.192.0.3 port 150 as 64567;
   import filter {
     accept; # Prior to introduction of BGP Filters we used "import all" so use default accept behaviour on import
   };
   export filter {
-    calico_export_to_bgp_peers(true);
+    calico_export_to_bgp_peers(false);
     reject;
   };  # Only want to export routes for workloads.
   passive on; # Peering is unidirectional, peer will connect to us.
@@ -128,4 +129,3 @@ protocol bgp Global_10_192_0_3_port_150 from bgp_template {
 # ------------- Node-specific peers -------------
 
 # No node-specific peers configured.
-

--- a/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird6.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-ipv6/bird6.cfg
@@ -96,7 +96,7 @@ protocol bgp Node_2001__101 from bgp_template {
 protocol bgp Node_2001__102 from bgp_template {
   ttl security off;
   multihop;
-  local as 65002;
+  local as 64512;
   neighbor 2001::102 as 64512;
   source address 2001::103;  # The local address we use for the TCP connection
   import filter {

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird.cfg
@@ -79,7 +79,7 @@ template bgp bgp_template {
 protocol bgp Node_10_192_0_3 from bgp_template {
   ttl security off;
   multihop;
-  local as 65002;
+  local as 64512;
   neighbor 10.192.0.3 as 64512;
   source address 10.192.0.2;  # The local address we use for the TCP connection
   import filter {

--- a/confd/tests/mock_data/calicoctl/explicit_peering/local-as-global-ipv6/input.yaml
+++ b/confd/tests/mock_data/calicoctl/explicit_peering/local-as-global-ipv6/input.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   peerIP: 2001::102
   asNumber: 64567
+  localASNumber: 64567
   sourceAddress: None
 
 ---

--- a/confd/tests/mock_data/calicoctl/explicit_peering/local-as-global/input.yaml
+++ b/confd/tests/mock_data/calicoctl/explicit_peering/local-as-global/input.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   peerIP: 10.192.0.3
   asNumber: 64567
+  localASNumber: 64515
   sourceAddress: None
 
 ---
@@ -26,7 +27,7 @@ metadata:
 spec:
   peerIP: 10.192.0.1:166
   asNumber: 64567
-  localASNumber: 65002
+  localASNumber: 64567
 
 ---
 kind: BGPPeer
@@ -36,7 +37,7 @@ metadata:
 spec:
   peerIP: 10.192.0.1
   asNumber: 64567
-  localASNumber: 65001
+  localASNumber: 64567
   numAllowedLocalASNumbers: 1
 
 ---

--- a/confd/tests/mock_data/calicoctl/explicit_peering/local-as-ipv6/input.yaml
+++ b/confd/tests/mock_data/calicoctl/explicit_peering/local-as-ipv6/input.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   peerIP: 2001::102
   asNumber: 64512
-  localASNumber: 65002
+  localASNumber: 64512
   node: kube-master
   numAllowedLocalASNumbers: 1
 

--- a/confd/tests/mock_data/calicoctl/explicit_peering/local-as/input.yaml
+++ b/confd/tests/mock_data/calicoctl/explicit_peering/local-as/input.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   peerIP: 10.192.0.3
   asNumber: 64512
-  localASNumber: 65002
+  localASNumber: 64512
   node: kube-master
   numAllowedLocalASNumbers: 1
 


### PR DESCRIPTION
## Description

Consider `local_as_num` bgp field (if not empty) instead of global `node_as_num`



## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
