### PR TITLE
[release tool] fix: branch cut to use release stream instead of branch for CAPZ windows FV tests

### DIFF
--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -62,6 +62,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
 					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 				)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1356,12 +1356,13 @@ func (r *CalicoManager) SetupReleaseBranch(branch string) error {
 		return fmt.Errorf("failed to update operator branch in %s: %w", makeMetadataFilePath, err)
 	}
 
-	// Update branch used for CAPZ - Windows FV tests.
-	logrus.WithField("branch", branch).Debug("Updating branch in setup script for CAPZ Windows FV tests")
+	// Update release stream used for CAPZ - Windows FV tests.
+	releaseStream := strings.TrimPrefix(branch, r.releaseBranchPrefix+"-")
+	logrus.WithField("releaseStream", releaseStream).Debug("Updating release stream in setup script for CAPZ Windows FV tests")
 	scriptFilePath := filepath.Join(r.repoRoot, "process", "testing", "winfv-felix", "setup-fv-capz.sh")
-	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/RELEASE_STREAM=.*HASH_RELEASE/RELEASE_STREAM=%s HASH_RELEASE/g`, branch), scriptFilePath}, nil); err != nil {
-		logrus.WithError(err).Errorf("Failed to update release branch in %s", scriptFilePath)
-		return fmt.Errorf("failed to update release branch in %s: %w", scriptFilePath, err)
+	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/RELEASE_STREAM=.*HASH_RELEASE/RELEASE_STREAM=%s HASH_RELEASE/g`, releaseStream), scriptFilePath}, nil); err != nil {
+		logrus.WithError(err).Errorf("Failed to update release stream in %s", scriptFilePath)
+		return fmt.Errorf("failed to update release stream in %s: %w", scriptFilePath, err)
 	}
 
 	// Run code generation.


### PR DESCRIPTION
## Description

When a new branch is cut, the release stream in the `process/testing/winfv-felix/setup-fv-capz.sh` script is replaced with the release branch instead of release stream. This will result in the script being unable to get the hashrelease to use for testing.

## Related issues/PRs

- error introduced in #11143 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
