### PR TITLE
[cherry-pick][v3.30]Fix block cleanup for blocks with no affinity type (#11179)

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity.go
@@ -94,10 +94,17 @@ func (c *blockAffinityClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
 		}
 	}
 
+	// Default affinity type to "host" if not set. Older versions of Calico's CRD backend
+	// did not set this field, assuming "host" as the default.
+	affinityType := "host"
+	if kvpv3.Value.(*libapiv3.BlockAffinity).Spec.Type != "" {
+		affinityType = kvpv3.Value.(*libapiv3.BlockAffinity).Spec.Type
+	}
+
 	return &model.KVPair{
 		Key: model.BlockAffinityKey{
 			CIDR:         *cidr,
-			AffinityType: kvpv3.Value.(*libapiv3.BlockAffinity).Spec.Type,
+			AffinityType: affinityType,
 			Host:         kvpv3.Value.(*libapiv3.BlockAffinity).Spec.Node,
 		},
 		Value: &model.BlockAffinity{

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -1488,7 +1488,7 @@ func (c ipamClient) ReleaseHostAffinities(ctx context.Context, affinityCfg Affin
 // the specified pool across all hosts.
 func (c ipamClient) ReleasePoolAffinities(ctx context.Context, pool net.IPNet) error {
 	log.Infof("Releasing block affinities within pool '%s'", pool.String())
-	for i := 0; i < ipamKeyErrRetries; i++ {
+	for range datastoreRetries {
 		retry := false
 		pairs, err := c.affinityConfigsByBlocks(ctx, pool)
 		if err != nil {
@@ -1503,7 +1503,7 @@ func (c ipamClient) ReleasePoolAffinities(ctx context.Context, pool net.IPNet) e
 		for blockString, affinityCfg := range pairs {
 			_, blockCIDR, _ := net.ParseCIDR(blockString)
 			logCtx := log.WithField("cidr", blockCIDR)
-			for i := 0; i < datastoreRetries; i++ {
+			for range datastoreRetries {
 				err = c.blockReaderWriter.releaseBlockAffinity(ctx, affinityCfg, *blockCIDR, false)
 				if err != nil {
 					if _, ok := err.(errBlockClaimConflict); ok {

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer.go
@@ -330,7 +330,10 @@ func (rw blockReaderWriter) releaseBlockAffinity(ctx context.Context, affinityCf
 	// Check that the block affinity matches the given affinity.
 	if b.Affinity != nil && !affinityMatches(affinityCfg, b.AllocationBlock) {
 		// This means the affinity is stale - we can delete it.
-		logCtx.Errorf("Mismatched affinity: %s != %s - try to delete stale affinity", *b.Affinity, "host:"+affinityCfg.Host)
+		logCtx.Errorf("Mismatched affinity: %s != %s - try to delete stale affinity",
+			*b.Affinity,
+			fmt.Sprintf("%s:%s", affinityCfg.AffinityType, affinityCfg.Host),
+		)
 		if err := rw.deleteAffinity(ctx, aff); err != nil {
 			logCtx.Warn("Failed to delete stale affinity")
 		}

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -805,6 +805,41 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			Expect(len(blocks.KVPairs)).To(Equal(0))
 		})
 
+		It("should release older blocks created without an explicit affinity type", func() {
+			// Use the backend client to create a block with no affinity type. This simulates a block created by an older version of Calico,
+			// which predate the introduction of affinity types.
+			cidr := "10.0.0.0/24"
+			b := newBlock(cnet.MustParseCIDR(cidr), nil)
+			blockKVP := model.KVPair{
+				Key:   model.BlockKey{CIDR: cnet.MustParseCIDR(cidr)},
+				Value: b.AllocationBlock,
+			}
+			affKVP := model.KVPair{
+				Key: model.BlockAffinityKey{
+					CIDR:         cnet.MustParseCIDR(cidr),
+					Host:         hostname,
+					AffinityType: "",
+				},
+				Value: &model.BlockAffinity{State: "confirmed"},
+			}
+			_, err := bc.Create(context.Background(), &blockKVP)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = bc.Create(context.Background(), &affKVP)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Release the block affinity. It should succeed even though the affinity type is blank.
+			err = ic.ReleasePoolAffinities(context.Background(), cnet.MustParseCIDR("10.0.0.0/16"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// The block and affinity should both be gone.
+			blocks, err := bc.List(context.Background(), model.BlockListOptions{}, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(blocks.KVPairs)).To(Equal(0))
+			affs, err := bc.List(context.Background(), model.BlockAffinityListOptions{}, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(affs.KVPairs)).To(Equal(0))
+		})
+
 		It("should release all non-empty blocks if there are multiple", func() {
 			// Allocate several blocks to the node. The pool is a /30, so 4 addresses
 			// per each block.


### PR DESCRIPTION
 (cherry picked from commit e95ae9f9a1f979c2b0c3a7db8ddf0c899e8d7ee5)

## Description
cherry-pick #11175
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix IPAM block leak of older blocks when deleting IP pools. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
