### PR TITLE
feat: implement node selector for nodeport svc

### DIFF
--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -178,7 +178,6 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 }
 
 func (kp *KubeProxy) start() error {
-	kp.nodeLabels = kp.fetchNodeLabels()
 	var withLocalNP []net.IP
 	if kp.ipFamily == 4 {
 		withLocalNP = append(withLocalNP, podNPIP)
@@ -186,7 +185,8 @@ func (kp *KubeProxy) start() error {
 		withLocalNP = append(withLocalNP, podNPIPV6)
 	}
 
-	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt, kp.excludedCIDRs, kp.nodeLabels)
+	// Node labels will be fetched in run() when we have the actual host IPs
+	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt, kp.excludedCIDRs, nil)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -15,11 +15,14 @@
 package proxy
 
 import (
+	"context"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
@@ -43,6 +46,8 @@ type KubeProxy struct {
 
 	k8s         kubernetes.Interface
 	hostname    string
+	nodeLabels  map[string]string
+	lastHostIPs []net.IP
 	frontendMap maps.MapWithExistsCheck
 	backendMap  maps.MapWithExistsCheck
 	affinityMap maps.Map
@@ -107,6 +112,29 @@ func (kp *KubeProxy) Stop() {
 	})
 }
 
+func (kp *KubeProxy) fetchNodeLabels() map[string]string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	node, err := kp.k8s.CoreV1().Nodes().Get(ctx, kp.hostname, metav1.GetOptions{})
+	if err != nil {
+		log.WithError(err).WithField("hostname", kp.hostname).Warn("Failed to fetch node labels, using empty labels")
+		return make(map[string]string)
+	}
+
+	labels := make(map[string]string, len(node.Labels))
+	for k, v := range node.Labels {
+		labels[k] = v
+	}
+
+	log.WithFields(log.Fields{
+		"hostname": kp.hostname,
+		"labels":   labels,
+	}).Debug("Fetched node labels")
+
+	return labels
+}
+
 func (kp *KubeProxy) run(hostIPs []net.IP) error {
 
 	ips := make([]net.IP, 0, len(hostIPs))
@@ -123,6 +151,9 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 	kp.lock.Lock()
 	defer kp.lock.Unlock()
 
+	kp.lastHostIPs = hostIPs
+	kp.nodeLabels = kp.fetchNodeLabels()
+
 	withLocalNP := make([]net.IP, len(hostIPs), len(hostIPs)+1)
 	copy(withLocalNP, hostIPs)
 	if kp.ipFamily == 4 {
@@ -132,7 +163,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 	}
 
 	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap,
-		kp.rt, kp.excludedCIDRs)
+		kp.rt, kp.excludedCIDRs, kp.nodeLabels)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}
@@ -147,6 +178,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 }
 
 func (kp *KubeProxy) start() error {
+	kp.nodeLabels = kp.fetchNodeLabels()
 	var withLocalNP []net.IP
 	if kp.ipFamily == 4 {
 		withLocalNP = append(withLocalNP, podNPIP)
@@ -154,7 +186,7 @@ func (kp *KubeProxy) start() error {
 		withLocalNP = append(withLocalNP, podNPIPV6)
 	}
 
-	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt, kp.excludedCIDRs)
+	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt, kp.excludedCIDRs, kp.nodeLabels)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}
@@ -217,6 +249,45 @@ func (kp *KubeProxy) OnHostIPsUpdate(IPs []net.IP) {
 		kp.hostIPUpdates <- IPs
 	}
 	log.Debugf("kube-proxy OnHostIPsUpdate: %+v", IPs)
+}
+
+// OnNodeLabelsUpdate should be used by an external user to update the node's labels.
+// This will trigger a resync to update NodePort service programming based on the new labels.
+func (kp *KubeProxy) OnNodeLabelsUpdate(labels map[string]string) {
+	kp.lock.Lock()
+	oldLabels := kp.nodeLabels
+	kp.nodeLabels = labels
+	hostIPs := kp.lastHostIPs
+	kp.lock.Unlock()
+
+	// Check if labels actually changed
+	labelsChanged := len(oldLabels) != len(labels)
+	if !labelsChanged {
+		for k, v := range labels {
+			if oldLabels[k] != v {
+				labelsChanged = true
+				break
+			}
+		}
+	}
+
+	if !labelsChanged {
+		log.Debug("Node labels unchanged, skipping resync")
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"oldLabels": oldLabels,
+		"newLabels": labels,
+	}).Info("Node labels changed, triggering kube-proxy resync")
+
+	// Trigger a resync with the current host IPs
+	// This will recreate the syncer with updated node labels
+	if len(hostIPs) > 0 {
+		kp.OnHostIPsUpdate(hostIPs)
+	} else {
+		log.Warn("No host IPs available for resync after label update")
+	}
 }
 
 // OnRouteUpdate should be used to update the internal state of routing tables

--- a/felix/bpf/proxy/lb_src_range_test.go
+++ b/felix/bpf/proxy/lb_src_range_test.go
@@ -47,7 +47,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 	externalIP := makeIPs([]net.IP{net.IPv4(35, 0, 0, 2)})
 	twoExternalIPs := makeIPs([]net.IP{net.IPv4(35, 0, 0, 2), net.IPv4(45, 0, 1, 2)})
 
-	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil, nil)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -210,7 +210,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 				externalIP,
 				proxy.K8sSvcWithLBSourceRangeIPs([]*net.IPNet{&ipnet}),
 			)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil, nil)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(3))
@@ -223,7 +223,7 @@ func testfn(makeIPs func(ips []net.IP) proxy.K8sServicePortOption) {
 				v1.ProtocolTCP,
 				externalIP,
 			)
-			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil, nil)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(2))
@@ -253,7 +253,7 @@ func test0000SourceRange() {
 
 	externalIP := net.IPv4(35, 0, 0, 2)
 
-	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt, nil, nil)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -394,16 +394,19 @@ const (
 	ReapTerminatingUDPImmediatelly = "TerminatingImmediately"
 
 	ExcludeServiceAnnotation = "projectcalico.org/natExcludeService"
+	NodeSelectorAnnotation   = "projectcalico.org/nodeSelector"
 )
 
 type ServiceAnnotations interface {
 	ReapTerminatingUDP() bool
 	ExcludeService() bool
+	NodeSelector() string
 }
 
 type servicePortAnnotations struct {
 	reapTerminatingUDP bool
 	excludeService     bool
+	nodeSelector       string
 }
 
 func (s *servicePortAnnotations) ReapTerminatingUDP() bool {
@@ -412,6 +415,10 @@ func (s *servicePortAnnotations) ReapTerminatingUDP() bool {
 
 func (s *servicePortAnnotations) ExcludeService() bool {
 	return s.excludeService
+}
+
+func (s *servicePortAnnotations) NodeSelector() string {
+	return s.nodeSelector
 }
 
 type servicePort struct {
@@ -433,6 +440,10 @@ func makeServiceInfo(_ *v1.ServicePort, s *v1.Service, baseSvc *k8sp.BaseService
 		if v, ok := s.Annotations[ReapTerminatingUDPAnnotation]; ok && strings.EqualFold(v, ReapTerminatingUDPImmediatelly) {
 			svc.reapTerminatingUDP = true
 		}
+	}
+
+	if v, ok := s.Annotations[NodeSelectorAnnotation]; ok {
+		svc.nodeSelector = strings.TrimSpace(v)
 	}
 
 out:

--- a/felix/bpf/proxy/proxy_bench_test.go
+++ b/felix/bpf/proxy/proxy_bench_test.go
@@ -49,6 +49,7 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 			&mock.DummyMap{},
 			proxy.NewRTCache(),
 			nil,
+			nil,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/felix/bpf/proxy/syncer_bench_test.go
+++ b/felix/bpf/proxy/syncer_bench_test.go
@@ -173,6 +173,7 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 			&mock.DummyMap{},
 			NewRTCache(),
 			nil,
+			nil,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	} else {
@@ -189,6 +190,7 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 			&mock.DummyMap{},
 			&mock.DummyMap{},
 			NewRTCache(),
+			nil,
 			nil,
 		)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2935,6 +2935,7 @@ func startBPFDataplaneComponents(
 
 		bpfRTMgr.setHostIPUpdatesCallBack(kp.OnHostIPsUpdate)
 		bpfRTMgr.setRoutesCallBacks(kp.OnRouteUpdate, kp.OnRouteDelete)
+		bpfRTMgr.setNodeLabelsUpdateCallBack(kp.OnNodeLabelsUpdate)
 		conntrackScanner.AddUnlocked(bpfconntrack.NewStaleNATScanner(kp))
 	} else {
 		log.Info("BPF enabled but no Kubernetes client available, unable to run kube-proxy module.")


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds a `projectcalico.org/nodeSelector` annotation to selectively expose NodePort services on specific nodes based on node labels. Designed for multi-tenant clusters where tenants have dedicated nodes.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.


If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
fixes https://github.com/projectcalico/calico/issues/5495
## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: expose annotated nodeports on selected nodes only
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
