### PR TITLE
Revert "[master] Sync operator CRDs as part of generate"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,6 @@ generate:
 	$(MAKE) -C libcalico-go gen-files
 	$(MAKE) -C felix gen-files
 	$(MAKE) -C goldmane gen-files
-	$(MAKE) get-operator-crds
 	$(MAKE) gen-manifests
 	$(MAKE) fix-changed
 


### PR DESCRIPTION
I don't think we should be getting operator CRDs in the pre-flight check job (which runs `make generate`).  It has a big ripple effect when it starts failing due to a change in another repo:

* PRs all start failing
* Everyone investigates
* Multiple folks tend to fix it in parallel, wasting work and creating conflicts.

Reverts projectcalico/calico#11062