### PR TITLE
[v3.31] start single proxy-health  in dual stack mode

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2831,7 +2831,7 @@ func startBPFDataplaneComponents(
 	ctKey := bpfconntrack.KeyFromBytes
 	ctVal := bpfconntrack.ValueFromBytes
 
-	if config.bpfProxyHealthzServer == nil {
+	if config.bpfProxyHealthzServer == nil && config.KubeProxyHealtzPort != 0 {
 		healthzAddr := fmt.Sprintf(":%d", config.KubeProxyHealtzPort)
 		config.bpfProxyHealthzServer = k8shealthcheck.NewProxyHealthServer(
 			healthzAddr, config.KubeProxyMinSyncPeriod)
@@ -2850,8 +2850,13 @@ func startBPFDataplaneComponents(
 	}
 
 	bpfproxyOpts := []bpfproxy.Option{
-		bpfproxy.WithHealthzServer(config.bpfProxyHealthzServer),
 		bpfproxy.WithMinSyncPeriod(config.KubeProxyMinSyncPeriod),
+	}
+
+	if config.bpfProxyHealthzServer != nil {
+		bpfproxyOpts = append(bpfproxyOpts, bpfproxy.WithHealthzServer(config.bpfProxyHealthzServer))
+	} else {
+		log.Info("No healthz server configured for BPF kube-proxy.")
 	}
 
 	if config.BPFNodePortDSREnabled {

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -544,9 +544,8 @@ func describeBPFDualStackProxyHealthTests() bool {
 			opts := infrastructure.DefaultTopologyOptions()
 			opts.EnableIPv6 = true
 			opts.NATOutgoingEnabled = true
-			opts.IPIPEnabled = false
-			opts.IPIPRoutesEnabled = false
 			opts.BPFProxyHealthzPort = 10256
+			opts.IPIPMode = api.IPIPModeNever
 
 			tc, _ = infrastructure.StartNNodeTopology(1, opts, infra)
 		})

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path"
 	"regexp"
@@ -1344,15 +1343,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						return healthStatus(containerIP(f.Container), "9099", "readiness")
 					}
 					Eventually(felixReady, "10s", "500ms").Should(BeGood())
-					Eventually(func() int {
-						resp, err := http.Get("http://" + containerIP(f.Container) + ":10256" + "/healthz")
-						if err != nil {
-							log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")
-							return -1
-						}
-						defer resp.Body.Close()
-						return resp.StatusCode
-					}, "3s", "500ms").Should(BeGood())
 				}
 			}
 		}

--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -78,6 +78,7 @@ type TopologyOptions struct {
 	IPv6PoolUsages            []api.IPPoolAllowedUse
 	NeedNodeIP                bool
 	FlowLogSource             int
+	BPFProxyHealthzPort       int // zero means disable
 }
 
 // Calico containers created during topology creation.
@@ -308,6 +309,8 @@ func StartNNodeTopology(
 		opts.ExtraEnvVars["FELIX_TYPHAADDR"] = tc.Typha.IP + ":5473"
 		typhaIP = tc.Typha.IP
 	}
+
+	opts.ExtraEnvVars["FELIX_BPFKUBEPROXYHEALTZPORT"] = fmt.Sprintf("%d", opts.BPFProxyHealthzPort)
 
 	tc.Felixes = make([]*Felix, n)
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11223
- Pick onto **master**: projectcalico/calico#11222
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/11213

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: start only a single kube-proxy health-server in dual stack mode
```