### PR TITLE
refactor: ensure all release tool flags have env var sources

### DIFF
--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -51,7 +51,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				releaseBranchPrefixFlag,
 				devTagSuffixFlag,
 				operatorBranchFlag,
-				publishBranchFlag,
+				gitPublishFlag,
 				skipValidationFlag,
 			},
 			Action: func(_ context.Context, c *cli.Command) error {
@@ -75,7 +75,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					branch.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					branch.WithRepoManager(calicoManager),
 					branch.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					branch.WithPublish(c.Bool(publishBranchFlag.Name)))
+					branch.WithPublish(c.Bool(gitPublishFlag.Name)))
 				return m.CutReleaseBranch()
 			},
 		},
@@ -88,7 +88,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				operatorReleaseBranchPrefixFlag,
 				operatorDevTagSuffixFlag,
 				newBranchFlag,
-				publishBranchFlag,
+				gitPublishFlag,
 				skipValidationFlag,
 			),
 			Action: func(_ context.Context, c *cli.Command) error {
@@ -110,7 +110,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					operator.WithDevTagIdentifier(operatorDevTagSuffixFlag.Name),
 					operator.WithReleaseBranchPrefix(c.String(operatorReleaseBranchPrefixFlag.Name)),
 					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					operator.WithPublish(c.Bool(publishBranchFlag.Name)),
+					operator.WithPublish(c.Bool(gitPublishFlag.Name)),
 				)
 
 				return m.CutBranch(c.String(newBranchFlag.Name))

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -81,15 +81,17 @@ var (
 		Sources: cli.EnvVars("DEV_TAG_SUFFIX"),
 		Value:   "0.dev",
 	}
-	publishBranchFlag = &cli.BoolFlag{
+	gitPublishFlag = &cli.BoolFlag{
 		Name:    "git-publish",
-		Aliases: []string{"publish-branch"},
-		Usage:   "Push branch git. If false, all changes are local.",
+		Aliases: []string{"publish-git"},
+		Usage:   "Push git changes to remote. If false, all changes are local.",
+		Sources: cli.EnvVars("PUBLISH_GIT"),
 		Value:   true,
 	}
 	newBranchFlag = &cli.StringFlag{
-		Name:  "branch-stream",
-		Usage: fmt.Sprintf("The new major and minor versions for the branch to create e.g. vX.Y to create a <release-branch-prefix>-vX.Y branch e.g. v1.37 for %s-v1.37 branch", releaseBranchPrefixFlag.Value),
+		Name:    "branch-stream",
+		Sources: cli.EnvVars("RELEASE_BRANCH_STREAM"),
+		Usage:   fmt.Sprintf("The new major and minor versions for the branch to create e.g. vX.Y to create a <release-branch-prefix>-vX.Y branch e.g. v1.37 for %s-v1.37 branch", releaseBranchPrefixFlag.Value),
 	}
 	baseBranchFlag = &cli.StringFlag{
 		Name:    "base-branch",
@@ -379,14 +381,16 @@ var (
 var (
 	// Publishing flags.
 	publishGitTagFlag = &cli.BoolFlag{
-		Name:  "publish-git-tag",
-		Usage: "Push the git tag to the remote",
-		Value: true,
+		Name:    "publish-git-tag",
+		Usage:   "Push the git tag to the remote",
+		Sources: cli.EnvVars("PUBLISH_GIT_TAG"),
+		Value:   true,
 	}
 	publishGitHubReleaseFlag = &cli.BoolFlag{
-		Name:  "publish-github-release",
-		Usage: "Publish the release to GitHub",
-		Value: true,
+		Name:    "publish-github-release",
+		Usage:   "Publish the release to GitHub",
+		Sources: cli.EnvVars("PUBLISH_GITHUB_RELEASE"),
+		Value:   true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && c.String(githubTokenFlag.Name) == "" {
 				return fmt.Errorf("GitHub token is required to publish release")
@@ -414,9 +418,10 @@ var (
 	// Hashrelease server configuration flags.
 	hashreleaseServerFlags = []cli.Flag{hashreleaseServerBucketFlag}
 	publishHashreleaseFlag = &cli.BoolFlag{
-		Name:  "publish-to-hashrelease-server",
-		Usage: "Publish the hashrelease to the hashrelease server",
-		Value: true,
+		Name:    "publish-to-hashrelease-server",
+		Usage:   "Publish the hashrelease to the hashrelease server",
+		Sources: cli.EnvVars("PUBLISH_TO_HASHRELEASE_SERVER"),
+		Value:   true,
 	}
 	latestFlag = &cli.BoolFlag{
 		Name:    "latest",


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
