### PR TITLE
Grant write permission to Stale Issues GitHub actions

### DIFF
--- a/.github/workflows/inactive_issues.yml
+++ b/.github/workflows/inactive_issues.yml
@@ -9,6 +9,8 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      # Grant write permission to actions to delete cache after a run (this is needed so that we don't leave certain issue states out of date and block them from being closed)
+      actions: write
     steps:
       # This step marks support issues and PRs as stale.
       - uses: actions/stale@v9


### PR DESCRIPTION
## Description

Added write permission for actions to delete cache, so that the Stale Issues action doesn't get stuck on certain issues due to using old state information.

See this issue on the action/stale repo for more context: 
- https://github.com/actions/stale/issues/1131

An indication of this happening for us is in the GitHub action execution logs: 
```
Warning: Error delete _state: [403] Resource not accessible by integration
```
E.g. [this recent run](https://github.com/projectcalico/calico/actions/runs/18693307834/job/53304220051#step:2:2642).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
