### PR TITLE
fix: DNS resolution in envoy by replacing UBI nsswitch.conf

### DIFF
--- a/third_party/envoy-proxy/Dockerfile
+++ b/third_party/envoy-proxy/Dockerfile
@@ -8,22 +8,8 @@ ARG UBI_IMAGE
 FROM ${ENVOYBINARY_IMAGE} AS envoybinary
 
 FROM ${UBI_IMAGE} AS ubi
-RUN cat > /etc/nsswitch.conf <<EOF
-passwd:     files
-shadow:     files
-group:      files
-hosts:      files dns
-services:   files
-automount:  files
 
-aliases:    files
-ethers:     files
-gshadow:    files
-networks:   files dns
-protocols:  files
-publickey:  files
-rpc:        files
-EOF
+FROM ${CALICO_BASE} as base
 
 FROM scratch AS source
 
@@ -50,7 +36,9 @@ COPY --from=ubi /lib64/libselinux.so.1 /lib64/libselinux.so.1
 COPY --from=ubi /lib64/libsemanage.so.2 /lib64/libsemanage.so.2
 COPY --from=ubi /lib64/libsepol.so.2 /lib64/libsepol.so.2
 COPY --from=ubi /lib64/libtinfo.so.6 /lib64/libtinfo.so.6
-COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
+# explicitly copy nsswitch.conf
+COPY --from=base /etc/nsswitch.conf /etc/nsswitch.conf
 
 COPY --from=envoybinary --chown=0:0 --chmod=644 \
     /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
## Description

UBI is using the following `nssswitch.conf` config:

```
hosts:      files dns myhostname
services:   files sss
netgroup:   sss
automount:  files sss
passwd:     sss files systemd
group:      sss files systemd
```

however, we don't have those modules.

I tried adjusting the modules by adding:

```
COPY --from=ubi /usr/lib64/libnss_myhostname.so.2 /lib64/libnss_myhostname.so.2
COPY --from=ubi /usr/lib64/libnss_sss.so.2 /lib64/libnss_sss.so.2
COPY --from=ubi /usr/lib64/libnss_systemd.so.2 /lib64/libnss_systemd.so.2
```

but `libnss_sss.so.2` is missing.  Tried with just the two out of three, and it still did not work.

Easiest and most effective way was just reusing the nsswtich.conf file from whatever envoy proxy has by default.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests (Done manually, e2es will pass again once this is in)
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
