### PR TITLE
[v3.31] Advertise externalIPs even for type=ClusterIP services

### DIFF
--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -158,7 +159,6 @@ func (rg *routeGenerator) getServiceForEndpoints(ep *discoveryv1.EndpointSlice) 
 	// construct a dummy svc using the service name from endpointslice to get the key
 	svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: ep.Namespace}}
 	key, err := cache.MetaNamespaceKeyFunc(svc)
-
 	if err != nil {
 		log.WithField("ep", ep.Name).WithError(err).Warn("getServiceForEndpoints: error on retrieving key for endpoint, passing")
 		return nil, ""
@@ -479,20 +479,17 @@ func (rg *routeGenerator) advertiseThisService(svc *v1.Service, eps []*discovery
 	// we need to announce single IPs for services of type externalTrafficPolicy Cluster.
 	// There are 2 cases inside this type:
 	// - LoadBalancer with a single IP.
-	// - Any one of externalIPs in service of type LoadBalancer or NodePort with a single IP.
+	// - Any one of the externalIPs are a single IP.
 	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
 		if svc.Spec.Type == v1.ServiceTypeLoadBalancer && rg.isSingleLoadBalancerIP(svc.Spec.LoadBalancerIP) {
 			logc.Debug("Advertising load balancer of type cluster because of single IP definition")
 			return true
 		}
 
-		if svc.Spec.Type == v1.ServiceTypeLoadBalancer || svc.Spec.Type == v1.ServiceTypeNodePort {
-			for _, extIP := range svc.Spec.ExternalIPs {
-				if rg.isSingleExternalIP(extIP) {
-					logc.Debug("Advertising external IP of type cluster because of single IP definition")
-					return true
-				}
-			}
+		// Advertise if there is a fully qualified (i.e., /32 or /128) external IP defined.
+		if slices.ContainsFunc(svc.Spec.ExternalIPs, rg.isSingleExternalIP) {
+			logc.Debug("Advertising external IP of type cluster because of single IP definition")
+			return true
 		}
 	}
 

--- a/node/tests/k8st/test_base.py
+++ b/node/tests/k8st/test_base.py
@@ -121,7 +121,7 @@ class TestBase(TestCase):
     def create_namespace(self, ns_name):
         self.cluster.create_namespace(client.V1Namespace(metadata=client.V1ObjectMeta(name=ns_name)))
 
-    def deploy(self, image, name, ns, port, replicas=1, svc_type="NodePort", traffic_policy="Local", cluster_ip=None, ipv6=False):
+    def deploy(self, image, name, ns, port, replicas=1, svc_type="NodePort", traffic_policy="Local", cluster_ip=None, ext_ip=None, ipv6=False):
         """
         Creates a deployment and corresponding service with the given
         parameters.
@@ -166,7 +166,7 @@ class TestBase(TestCase):
 
         # Create a service called <name> whose endpoints are the pods
         # with "app": <name>; i.e. those just created above.
-        self.create_service(name, name, ns, port, svc_type, traffic_policy, ipv6=ipv6)
+        self.create_service(name, name, ns, port, svc_type, traffic_policy, ext_ip=ext_ip, ipv6=ipv6)
 
     def wait_for_deployment(self, name, ns):
         """
@@ -176,7 +176,7 @@ class TestBase(TestCase):
         kubectl("-n %s rollout status deployment/%s" % (ns, name))
         kubectl("get pods -n %s -o wide" % ns)
 
-    def create_service(self, name, app, ns, port, svc_type="NodePort", traffic_policy="Local", cluster_ip=None, ipv6=False):
+    def create_service(self, name, app, ns, port, svc_type="NodePort", traffic_policy="Local", cluster_ip=None, ext_ip=None, ipv6=False):
         service = client.V1Service(
             metadata=client.V1ObjectMeta(
                 name=name,
@@ -191,6 +191,8 @@ class TestBase(TestCase):
         )
         if cluster_ip:
           service.spec["clusterIP"] = cluster_ip
+        if ext_ip:
+          service.spec["externalIPs"] = [ext_ip]
         if ipv6:
           service.spec["ipFamilies"] = ["IPv6"]
 

--- a/node/tests/k8st/tests/test_bgp_advert.py
+++ b/node/tests/k8st/tests/test_bgp_advert.py
@@ -570,13 +570,10 @@ EOF
             # externalTrafficPolicy=Cluster. This should trigger advertisement
             # from all nodes.
             svc_name = "nginx-svc"
-            self.deploy(NGINX_IMAGE, svc_name, self.ns, 80, traffic_policy="Cluster", svc_type="NodePort")
+            ext_ip = "90.15.0.1"
+            self.deploy(NGINX_IMAGE, svc_name, self.ns, 80, traffic_policy="Cluster", svc_type="ClusterIP", ext_ip=ext_ip)
             self.wait_until_exists(svc_name, "svc", self.ns)
             self.wait_for_deployment(svc_name, self.ns)
-
-            # Add the external IP to the service.
-            ext_ip = "90.15.0.1"
-            self.add_svc_external_ips(svc_name, self.ns, [ext_ip])
 
             # Verify the ext IP address is advertised from all nodes.
             retry_until_success(lambda: self.assert_ecmp_routes(ext_ip, [self.ips[0], self.ips[1], self.ips[2], self.ips[3]]))


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11204
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/10945

This behavior was broken as part of https://github.com/projectcalico/calico/pull/9422

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix BGP advertisement of externalIP addresses on Services with type=ClusterIP.
```