### PR TITLE
[release-v3.31] Auto pick #11173: Make sure we clean up our HEP in e2e test

### DIFF
--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -107,6 +107,7 @@ var _ = describe.CalicoDescribe(
 		var checker conncheck.ConnectionTester
 		var hepServer1 *conncheck.Server
 		var client1 *conncheck.Client
+		var hep *v3.HostEndpoint
 
 		BeforeEach(func() {
 			var err error
@@ -185,18 +186,22 @@ var _ = describe.CalicoDescribe(
 			Expect(err).NotTo(HaveOccurred())
 
 			// Create our hostEndpoint - it is created with the same name as the GNP.
-			createHostEndpoint(cli, hepPolicyName, hepNodeName, hepPort1, pod.Status.HostIP)
+			hep = createHostEndpoint(cli, hepPolicyName, hepNodeName, hepPort1, pod.Status.HostIP)
 		})
 
 		AfterEach(func() {
 			checker.Stop()
 
-			// Clean up any policies we created.
+			// Clean up any policies / heps we created.
 			err := cli.Delete(context.Background(), defaultAllow)
 			if err != nil && !errors.IsNotFound(err) {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			err = cli.Delete(context.Background(), allowLogCollection)
+			if err != nil && !errors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			err = cli.Delete(context.Background(), hep)
 			if err != nil && !errors.IsNotFound(err) {
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -480,7 +485,7 @@ var _ = describe.CalicoDescribe(
 		})
 	})
 
-func createHostEndpoint(cli ctrlclient.Client, policyName string, nodeName string, port int, ip string) {
+func createHostEndpoint(cli ctrlclient.Client, policyName string, nodeName string, port int, ip string) *v3.HostEndpoint {
 	hep := &v3.HostEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: policyName,
@@ -504,4 +509,5 @@ func createHostEndpoint(cli ctrlclient.Client, policyName string, nodeName strin
 
 	err := cli.Create(context.Background(), hep)
 	Expect(err).NotTo(HaveOccurred())
+	return hep
 }


### PR DESCRIPTION
Cherry pick of #11173 on release-v3.31.

#11173: Make sure we clean up our HEP in e2e test

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We weren't cleaning this up, which could lead to flakes.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.