### PR TITLE
fix: update pipeline for branch cut

### DIFF
--- a/.semaphore/release/cut-branch.yml
+++ b/.semaphore/release/cut-branch.yml
@@ -9,13 +9,12 @@ execution_time_limit:
 
 global_job_config:
   secrets:
-    # Secret for GitHub access
     - name: marvin-github-ssh-private-key
   prologue:
     commands:
       - chmod 0600 ~/.keys/*
-      - ssh-add ~/
-      # Unshallow the git repository to get latest tags
+      - ssh-add ~/.keys/*
+      - checkout
       - retry git fetch --quiet --unshallow
 
 blocks:


### PR DESCRIPTION
## Description

- limit to only adding keys dir for ssh
- missing checking out the repo

pipeline added in #9268 and update was not done in #11143

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
