### PR TITLE
Set BPF_F_ADJ_ROOM_FIXED_GSO during vxlan decap correctly

### DIFF
--- a/felix/bpf-gpl/nat4.h
+++ b/felix/bpf-gpl/nat4.h
@@ -95,7 +95,7 @@ static CALI_BPF_INLINE int vxlan_decap(struct __sk_buff *skb)
 	extra_hdrsz = sizeof(struct ethhdr) + sizeof(struct iphdr) +
 		sizeof(struct udphdr) + sizeof(struct vxlanhdr);
 
-	ret = bpf_skb_adjust_room(skb, -extra_hdrsz, BPF_ADJ_ROOM_MAC | BPF_F_ADJ_ROOM_FIXED_GSO, 0);
+	ret = bpf_skb_adjust_room(skb, -extra_hdrsz, BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_FIXED_GSO);
 
 	return ret;
 }

--- a/felix/bpf-gpl/nat6.h
+++ b/felix/bpf-gpl/nat6.h
@@ -83,7 +83,7 @@ static CALI_BPF_INLINE int vxlan_decap(struct __sk_buff *skb)
 	extra_hdrsz = sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
 		sizeof(struct udphdr) + sizeof(struct vxlanhdr);
 
-	ret = bpf_skb_adjust_room(skb, -extra_hdrsz, BPF_ADJ_ROOM_MAC | BPF_F_ADJ_ROOM_FIXED_GSO, 0);
+	ret = bpf_skb_adjust_room(skb, -extra_hdrsz, BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_FIXED_GSO);
 
 	return ret;
 }


### PR DESCRIPTION
The flag has been added to the mode flag where it is a noop, the GSO size needs to be fixed as otherwise with receive offload/gro enabled and the packets are close to the mtu the gso size will be increased and then dropped by the tcp_gso_segment check skb->len <= gso_size.
The packet is then retransmitted which causes delays.

This can be reproduced with following bpftraces and traffic with appropriately sized packets but the exact conditions are not well understood yet.

```
kprobe:tcp_gso_segment {
    $skb = (struct sk_buff*)arg0;
    $shinfo =(struct skb_shared_info*)($skb->head + $skb->end);
    if ($skb->len <= $shinfo->gso_size) {
        printf("DROP skb->len %ld gso_size %ld %d %d\n", $skb->len, $shinfo->gso_size,
              $shinfo->gso_type, ((struct napi_gro_cb*)$skb->cb)->count);
    }
}
kprobe:bpf_skb_adjust_room {
        $skb = (struct sk_buff*)arg0;
        if (((struct napi_gro_cb*)$skb->cb)->count > 1) {
                $shinfo =(struct skb_shared_info*)($skb->head + $skb->end);
                printf("adj skb->len %ld gso_size %ld len_diff %ld mode %u flags %lu\n", $skb->len, $shinfo->gso_size, (int32) arg1, (uint32) arg2, (uint32) arg3);
        }
}

> adj  skb->len 1466 gso_size 1348 len_diff -50 mode 1 flags 0
> DROP skb->len 1382 gso_size 1398 1027 2

```

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/11160


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Do not adjust gso_size after nodeport tunnel vxlan decap. There is no guarantee that there would be enough data after removing tunnel headers. The packet is shrunk by 50 bytes while the gso_size would grow. Kernel would drop the packet if the original gso packet is too small.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
