### PR TITLE
Default LoadBalancer config if not set

### DIFF
--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -174,6 +174,8 @@ type NamespaceControllerConfig struct {
 }
 
 type LoadBalancerControllerConfig struct {
+	// AssignIPs controls which LoadBalancer Service gets IP assigned from Calico IPAM.
+	// +kubebuilder:default=AllServices
 	AssignIPs AssignIPs `json:"assignIPs,omitempty" validate:"omitempty,assignIPs"`
 }
 

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -4976,8 +4976,9 @@ func schema_pkg_apis_projectcalico_v3_LoadBalancerControllerConfig(ref common.Re
 				Properties: map[string]spec.Schema{
 					"assignIPs": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "AssignIPs controls which LoadBalancer Service gets IP assigned from Calico IPAM.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/kube-controllers/pkg/config/config_fv_test.go
+++ b/kube-controllers/pkg/config/config_fv_test.go
@@ -196,6 +196,7 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 			Expect(out.Status.RunningConfig.HealthChecks).To(Equal(v3.Enabled))
 			Expect(out.Status.RunningConfig.LogSeverityScreen).To(Equal("Info"))
 			Expect(out.Status.RunningConfig.EtcdV3CompactionPeriod).To(Equal(&metav1.Duration{Duration: time.Minute * 10}))
+			Expect(out.Status.RunningConfig.Controllers.LoadBalancer.AssignIPs).To(Equal(v3.AllServices))
 		})
 	})
 

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -345,6 +345,8 @@ func mergeConfig(envVars map[string]string, envCfg Config, apiCfg v3.KubeControl
 
 	mergeHealthEnabled(envVars, &status, &rCfg, apiCfg)
 
+	mergeLoadBalancer(&status, &rCfg, apiCfg)
+
 	// Merge prometheus information.
 	if apiCfg.PrometheusMetricsPort != nil {
 		rCfg.PrometheusPort = *apiCfg.PrometheusMetricsPort
@@ -387,14 +389,24 @@ func mergeConfig(envVars map[string]string, envCfg Config, apiCfg v3.KubeControl
 		rc.Namespace.NumberOfWorkers = envCfg.ProfileWorkers
 	}
 
-	if rc.LoadBalancer != nil {
+	return rCfg, status
+}
+
+func mergeLoadBalancer(status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {
+	if rCfg.Controllers.LoadBalancer != nil {
 		if apiCfg.Controllers.LoadBalancer != nil {
-			rc.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
+			rCfg.Controllers.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
 			status.RunningConfig.Controllers.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
 		}
+	} else {
+		// We can enable the LoadBalancer controller as it won't be assigning any IPs if IPPool for LoadBalancer is not set
+		rCfg.Controllers.LoadBalancer = &LoadBalancerControllerConfig{
+			AssignIPs: v3.AllServices,
+		}
+		status.RunningConfig.Controllers.LoadBalancer = &v3.LoadBalancerControllerConfig{
+			AssignIPs: v3.AllServices,
+		}
 	}
-
-	return rCfg, status
 }
 
 func mergeAutoHostEndpoints(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {

--- a/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -31,6 +31,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -117,6 +118,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -2816,6 +2816,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2902,6 +2903,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -2826,6 +2826,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2912,6 +2913,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -2827,6 +2827,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2913,6 +2914,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -2811,6 +2811,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2897,6 +2898,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -2811,6 +2811,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2897,6 +2898,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -2828,6 +2828,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2914,6 +2915,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2725,6 +2725,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2811,6 +2812,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -2811,6 +2811,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -2897,6 +2898,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -31421,6 +31421,7 @@ spec:
                     loadBalancer:
                       properties:
                         assignIPs:
+                          default: AllServices
                           type: string
                       type: object
                     namespace:
@@ -31507,6 +31508,7 @@ spec:
                         loadBalancer:
                           properties:
                             assignIPs:
+                              default: AllServices
                               type: string
                           type: object
                         namespace:


### PR DESCRIPTION
Update the kubecontrollersconfiguration for LoadBalancer if not set to AllServices. Users will still have to create a LoadBalancer IPPool to utilize the controller. If using alternative IPAM for loadbalancers, calico will not assign any IPs as long as there is not Calico LoadBalancer IPPool

Cherry-pick of https://github.com/projectcalico/calico/pull/11251

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
https://github.com/projectcalico/calico/issues/11249
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Default KubeControllersConfiguration.LoadBalancer when not set to AllServices
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
