### PR TITLE
[EV-6037] Skip policy trace evaluation for deleted eps

### DIFF
--- a/felix/calc/endpoint_lookup_cache.go
+++ b/felix/calc/endpoint_lookup_cache.go
@@ -98,8 +98,6 @@ type EndpointData interface {
 type endpointData interface {
 	EndpointData
 	allIPs() [][16]byte
-	isMarkedToBeDeleted() bool
-	setMarkedToBeDeleted(b bool)
 }
 
 type MatchData struct {
@@ -152,6 +150,9 @@ type EndpointLookupsCache struct {
 
 	endpointDeletionTimers map[model.Key]*time.Timer
 
+	// Map to track which endpoints are marked for deletion
+	markedForDeletion map[model.EndpointKey]bool
+
 	// Node relationship data.
 	// TODO(rlb): We should just treat this as an endpoint
 	nodes         map[string]v3.NodeSpec
@@ -176,6 +177,7 @@ func NewEndpointLookupsCache(opts ...EndpointLookupsCacheOption) *EndpointLookup
 		remoteEndpointData: map[model.EndpointKey]*RemoteEndpointData{},
 
 		endpointDeletionTimers: map[model.Key]*time.Timer{},
+		markedForDeletion:      map[model.EndpointKey]bool{},
 		nodeIPToNames:          make(map[[16]byte][]string),
 		nodes:                  make(map[string]v3.NodeSpec),
 		deletionDelay:          endpointDataDeletionDelay,
@@ -304,13 +306,12 @@ func (ec *EndpointLookupsCache) CreateLocalEndpointData(key model.EndpointKey, e
 
 func CalculateCommonEndpointData(key model.EndpointKey, ep model.Endpoint) CommonEndpointData {
 	generateName, ips := extractEndpointInfo(ep)
-	commonData := CommonEndpointData{
+	return CommonEndpointData{
 		key:          key,
 		labels:       ep.GetLabels(),
 		generateName: generateName,
 		ips:          ips,
 	}
-	return commonData
 }
 
 func extractEndpointInfo(ep model.Endpoint) (string, [][16]byte) {
@@ -403,24 +404,26 @@ func (ec *EndpointLookupsCache) addOrUpdateEndpoint(key model.EndpointKey, incom
 	// any IP that shouldn't be discarded.
 	ipsToUpdate := set.New[[16]byte]()
 	for _, ip := range ipsOfIncomingEndpoint {
-		// If this is an already existing IP, then remove it,
+		// If this is an already existing IP, then remove it
 		if ipsToRemove.Contains(ip) {
 			ipsToRemove.Discard(ip)
 		}
 
-		// capture all incoming IPs as both new and existing ip mappins
+		// capture all incoming IPs as both new and existing ip mappings
 		// need to be updated with incoming endpoint data
 		ipsToUpdate.Add(ip)
 	}
 
 	// update endpoint data lookup by key
 
-	// if there was a previous endpoint with the same key to be deleted,
+	// If there was a previous endpoint with the same key to be deleted,
 	// stop the deletion timer and let the entries be updated with incomingEndpointData
 	deletionTimer, isEndpointSetToBePrevDeleted := ec.endpointDeletionTimers[key]
 	if endpointAlreadyExists && isEndpointSetToBePrevDeleted {
 		deletionTimer.Stop()
 		delete(ec.endpointDeletionTimers, key)
+		// Remove deletion marking since we're updating the endpoint
+		delete(ec.markedForDeletion, key)
 	}
 
 	ec.storeEndpoint(key, incomingEndpointData)
@@ -497,7 +500,7 @@ func (ec *EndpointLookupsCache) updateIPToEndpointMapping(ip [16]byte, incomingE
 	isExistingEp := false
 	i := 0
 	for i < len(existingEpDataForIp) {
-		if existingEpDataForIp[i].isMarkedToBeDeleted() {
+		if epKey, ok := existingEpDataForIp[i].Key().(model.EndpointKey); ok && ec.markedForDeletion[epKey] {
 			existingEpDataForIp = removeEndpointDataFromSlice(existingEpDataForIp, i)
 			continue
 		}
@@ -527,14 +530,14 @@ func removeEndpointDataFromSlice(s []endpointData, i int) []endpointData {
 // removeEndpointWithDelay marks all EndpointData referenced by the
 // (key model.Key) and delegates the removeEndpoint to another
 // goroutine that will be called after endpointDataTTLAfterMarkedAsRemoved
-// has passed.  ipToEndpointDeletionTimers is used to track the all the timers
+// has passed. ipToEndpointDeletionTimers is used to track all the timers
 // created for tentatively deleted endpoints as they are accessed by add/update
 // operations.
 func (ec *EndpointLookupsCache) removeEndpointWithDelay(key model.EndpointKey) {
 	ec.epMutex.Lock()
 	defer ec.epMutex.Unlock()
 
-	ed, endpointExists := ec.lookupEndpoint(key)
+	_, endpointExists := ec.lookupEndpoint(key)
 	if !endpointExists {
 		// for performance improvement - as time.AfterFunc creates a go routine
 		return
@@ -546,13 +549,13 @@ func (ec *EndpointLookupsCache) removeEndpointWithDelay(key model.EndpointKey) {
 	}
 
 	// mark the endpoint to be deleted and attach a timer to delegate the actual deletion
-	ed.setMarkedToBeDeleted(true)
+	ec.markedForDeletion[key] = true
 
 	endpointDeletionTimer := time.AfterFunc(ec.deletionDelay, func() { ec.removeEndpoint(key) })
 	ec.endpointDeletionTimers[key] = endpointDeletionTimer
 }
 
-// removeEndpoint removes all EndpointData markedToBeDeleted from the slice
+// removeEndpoint removes all EndpointData that were previously marked for deletion
 // captures all IPs and removes all correspondoing IP to EndpointData mapping as well.
 func (ec *EndpointLookupsCache) removeEndpoint(key model.EndpointKey) {
 	ec.epMutex.Lock()
@@ -566,7 +569,7 @@ func (ec *EndpointLookupsCache) removeEndpoint(key model.EndpointKey) {
 
 	// If the endpoint has not been marked for deletion ignore it as it may have been
 	// updated before the deletion timer has been triggered.
-	if !currentEndpointData.isMarkedToBeDeleted() {
+	if !ec.markedForDeletion[key] {
 		return
 	}
 
@@ -579,6 +582,7 @@ func (ec *EndpointLookupsCache) removeEndpoint(key model.EndpointKey) {
 	delete(ec.localEndpointData, key)
 	delete(ec.remoteEndpointData, key)
 	delete(ec.endpointDeletionTimers, key)
+	delete(ec.markedForDeletion, key)
 	ec.reportEndpointCacheMetrics()
 }
 
@@ -644,13 +648,34 @@ func (ec *EndpointLookupsCache) GetAllEndpointData() []EndpointData {
 	defer ec.epMutex.RUnlock()
 
 	allEds := []EndpointData{}
-	for _, ed := range ec.allEndpoints() {
-		if ed.isMarkedToBeDeleted() {
+	for key, ed := range ec.allEndpoints() {
+		if ec.markedForDeletion[key] {
 			continue
 		}
 		allEds = append(allEds, ed)
 	}
 	return allEds
+}
+
+// IsEndpointDeleted returns whether the given endpoint is marked for deletion.
+func (ec *EndpointLookupsCache) IsEndpointDeleted(ep EndpointData) bool {
+	ec.epMutex.RLock()
+	defer ec.epMutex.RUnlock()
+
+	if key, ok := ep.Key().(model.EndpointKey); ok {
+		return ec.markedForDeletion[key]
+	}
+	return false
+}
+
+// MarkEndpointForDeletion marks the given endpoint for deletion.
+func (ec *EndpointLookupsCache) MarkEndpointForDeletion(ep EndpointData) {
+	ec.epMutex.Lock()
+	defer ec.epMutex.Unlock()
+
+	if key, ok := ep.Key().(model.EndpointKey); ok {
+		ec.markedForDeletion[key] = true
+	}
 }
 
 // reportEndpointCacheMetrics reports endpoint cache performance metrics to prometheus
@@ -752,7 +777,7 @@ func (ec *EndpointLookupsCache) DumpEndpoints() string {
 		ips := set.New[[16]byte]()
 
 		deleted := "deleted"
-		if !endpointData.isMarkedToBeDeleted() {
+		if !ec.markedForDeletion[key] {
 			ips.AddAll(endpointData.allIPs())
 			deleted = ""
 		}
@@ -853,10 +878,6 @@ type CommonEndpointData struct {
 	// contents of the GenerateName field from the WorkloadEndpoint, which is
 	// used by the collector for determining the aggregation name.
 	generateName string
-
-	// used for deleting an EndpointData, to delegate the actual
-	// deletion endpointDataDeletionDelay later
-	markedToBeDeleted bool
 }
 
 func (e *CommonEndpointData) Key() model.Key {
@@ -882,14 +903,6 @@ func (e *CommonEndpointData) Labels() uniquelabels.Map {
 
 func (e *CommonEndpointData) GenerateName() string {
 	return e.generateName
-}
-
-func (e *CommonEndpointData) isMarkedToBeDeleted() bool {
-	return e.markedToBeDeleted
-}
-
-func (e *CommonEndpointData) setMarkedToBeDeleted(b bool) {
-	e.markedToBeDeleted = b
 }
 
 // LocalEndpointData is the cache entry struct for local endpoints.  We store

--- a/felix/calc/endpoint_lookup_cache_test.go
+++ b/felix/calc/endpoint_lookup_cache_test.go
@@ -17,6 +17,7 @@ package calc_test
 import (
 	"net"
 	"regexp"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -28,6 +29,7 @@ import (
 	v3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 const (
@@ -608,6 +610,70 @@ var _ = Describe("EndpointLookupCache tests: Node lookup", func() {
 		})
 	})
 })
+
+func TestIsEndpointDeleted(t *testing.T) {
+	// Create a cache with a short deletion delay for testing
+	cache := NewEndpointLookupsCache(WithDeletionDelay(50 * time.Millisecond))
+
+	// Create a test endpoint key
+	key := model.WorkloadEndpointKey{
+		Hostname:       "test-node",
+		OrchestratorID: "cni",
+		WorkloadID:     "test-workload",
+		EndpointID:     "eth0",
+	}
+
+	// Create endpoint data using the same pattern as existing tests
+	ip := net.ParseIP("10.0.0.1")
+	cidr := net.IPNet{
+		IP:   ip,
+		Mask: net.CIDRMask(32, 32),
+	}
+
+	endpoint := &model.WorkloadEndpoint{
+		State:      "active",
+		Name:       "test-endpoint",
+		ProfileIDs: []string{"test-profile"},
+		IPv4Nets:   []cnet.IPNet{{IPNet: cidr}},
+	}
+
+	// Add the endpoint to the cache using the correct API pattern
+	ed := cache.CreateLocalEndpointData(key, endpoint, newTierInfoSlice())
+	cache.OnUpdate(api.Update{
+		UpdateType: api.UpdateTypeKVNew,
+		KVPair: model.KVPair{
+			Key:   key,
+			Value: endpoint,
+		},
+	})
+
+	// Check if the endpoint is deleted (should be false)
+	if cache.IsEndpointDeleted(ed) {
+		t.Error("Expected endpoint to not be deleted before deletion")
+	}
+
+	// Remove the endpoint (this should mark it for deletion)
+	cache.OnUpdate(api.Update{
+		UpdateType: api.UpdateTypeKVDeleted,
+		KVPair: model.KVPair{
+			Key:   key,
+			Value: nil,
+		},
+	})
+
+	// Check if the endpoint is now marked as deleted (should be true)
+	if !cache.IsEndpointDeleted(ed) {
+		t.Error("Expected endpoint to be marked as deleted after deletion")
+	}
+
+	// Wait for the deletion delay to pass
+	time.Sleep(100 * time.Millisecond)
+
+	// Check if the endpoint is still marked as deleted (should be false as it's been cleaned up)
+	if cache.IsEndpointDeleted(ed) {
+		t.Error("Expected endpoint to not be marked as deleted after cleanup")
+	}
+}
 
 func newTierInfoSlice() []TierInfo {
 	return nil

--- a/felix/calc/lookups_cache.go
+++ b/felix/calc/lookups_cache.go
@@ -79,6 +79,17 @@ func (lc *LookupsCache) GetNetworkSet(addr [16]byte) (EndpointData, bool) {
 	return lc.nsCache.GetNetworkSetFromIP(addr)
 }
 
+// IsEndpointDeleted returns whether the given endpoint is marked for deletion.
+func (lc *LookupsCache) IsEndpointDeleted(ep EndpointData) bool {
+	return lc.epCache.IsEndpointDeleted(ep)
+}
+
+// MarkEndpointDeleted marks an endpoint as deleted for testing purposes.
+// This should not be called from any mainline code.
+func (lc *LookupsCache) MarkEndpointDeleted(ep EndpointData) {
+	lc.epCache.MarkEndpointForDeletion(ep)
+}
+
 // GetRuleIDFromNFLOGPrefix returns the RuleID associated with the supplied NFLOG prefix.
 func (lc *LookupsCache) GetRuleIDFromNFLOGPrefix(prefix [64]byte) *RuleID {
 	return lc.polCache.GetRuleIDFromNFLOGPrefix(prefix)

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -587,6 +587,16 @@ func (c *collector) expireMetrics(data *Data) {
 	}
 }
 
+// tryReportAndExpire tries to report expired data metrics and clean up the connection entry.
+func (c *collector) tryReportAndExpire(data *Data) {
+	if data.Expired && c.reportMetrics(data, false) {
+		// If the data is expired then attempt to report it now so that we can remove the connection entry. If reported
+		// the data can be expired and deleted immediately, otherwise it will get exported during ticker processing.
+		c.expireMetrics(data)
+		c.deleteDataFromEpStats(data)
+	}
+}
+
 func (c *collector) deleteDataFromEpStats(data *Data) {
 	delete(c.epStats, data.Tuple)
 
@@ -700,6 +710,18 @@ func (c *collector) applyPacketInfo(pktInfo types.PacketInfo) {
 		data.PreDNATPort = originalTuple.L4Dst
 	}
 
+	// Skip processing if either endpoint is marked for deletion.
+	if data.SrcEp != nil && c.luc.IsEndpointDeleted(data.SrcEp) {
+		log.Debugf("Source endpoint: %s marked for deletion, skipping packet info update", data.SrcEp.GenerateName())
+		c.tryReportAndExpire(data)
+		return
+	}
+	if data.DstEp != nil && c.luc.IsEndpointDeleted(data.DstEp) {
+		log.Debugf("Destination endpoint: %s marked for deletion, skipping packet info update", data.DstEp.GenerateName())
+		c.tryReportAndExpire(data)
+		return
+	}
+
 	// Determine the local endpoint for this update.
 	switch pktInfo.Direction {
 	case rules.RuleDirIngress:
@@ -783,12 +805,7 @@ func (c *collector) applyPacketInfo(pktInfo types.PacketInfo) {
 		c.applyNflogStatUpdate(data, ruleID, policyIdx, rule.Hits, rule.Bytes)
 	}
 
-	if data.Expired && c.reportMetrics(data, false) {
-		// If the data is expired then attempt to report it now so that we can remove the connection entry. If reported
-		// the data can be expired and deleted immediately, otherwise it will get exported during ticker processing.
-		c.expireMetrics(data)
-		c.deleteDataFromEpStats(data)
-	}
+	c.tryReportAndExpire(data)
 }
 
 // convertDataplaneStatsAndApplyUpdate merges the proto.DataplaneStatistics into the current

--- a/felix/collector/collector_test.go
+++ b/felix/collector/collector_test.go
@@ -570,6 +570,180 @@ var _ = Describe("NFLOG Datasource", func() {
 			})
 		})
 	})
+
+	// Tests for deleted endpoints - RuleHits should be skipped
+	Describe("NFLOG with deleted endpoints", func() {
+		// Test data for endpoints marked for deletion
+		var c *collector
+		var lm *calc.LookupsCache
+		var nflogReader *NFLogReader
+
+		conf := &Config{
+			AgeTimeout:            time.Duration(10) * time.Second,
+			InitialReportingDelay: time.Duration(5) * time.Second,
+			ExportingInterval:     time.Duration(1) * time.Second,
+			FlowLogsFlushInterval: time.Duration(100) * time.Second,
+			DisplayDebugTraceLogs: true,
+		}
+
+		BeforeEach(func() {
+			epMap := map[[16]byte]calc.EndpointData{
+				localIp1:  localEd1,
+				localIp2:  localEd2,
+				remoteIp1: remoteEd1,
+			}
+			nflogMap := map[[64]byte]*calc.RuleID{}
+
+			for _, rid := range []*calc.RuleID{defTierPolicy1AllowEgressRuleID, defTierPolicy1AllowIngressRuleID, defTierPolicy2DenyIngressRuleID, defTierPolicy2DenyEgressRuleID} {
+				nflogMap[policyIDStrToRuleIDParts(rid)] = rid
+			}
+
+			lm = newMockLookupsCache(epMap, nflogMap, nil, nil)
+			nflogReader = NewNFLogReader(lm, 0, 0, 0, false)
+			Expect(nflogReader.Start()).NotTo(HaveOccurred())
+			c = newCollector(lm, conf).(*collector)
+			c.SetPacketInfoReader(nflogReader)
+			c.SetConntrackInfoReader(dummyConntrackInfoReader{})
+			go func() {
+				Expect(c.Start()).NotTo(HaveOccurred())
+			}()
+		})
+
+		AfterEach(func() {
+			nflogReader.Stop()
+		})
+
+		Describe("Test source endpoint marked for deletion", func() {
+			It("should skip RuleHits processing when source endpoint is marked for deletion", func() {
+				// Set up normal endpoint map
+				epMap := map[[16]byte]calc.EndpointData{
+					localIp1:  localEd1, // src endpoint to be marked for deletion
+					localIp2:  localEd2, // normal dest endpoint
+					remoteIp1: remoteEd1,
+				}
+				nflogMap := map[[64]byte]*calc.RuleID{}
+
+				for _, rid := range []*calc.RuleID{defTierPolicy1AllowEgressRuleID, defTierPolicy1AllowIngressRuleID, defTierPolicy2DenyIngressRuleID, defTierPolicy2DenyEgressRuleID} {
+					nflogMap[policyIDStrToRuleIDParts(rid)] = rid
+				}
+
+				// Update the lookups cache with endpoint map
+				lm.SetMockData(epMap, nflogMap, nil, nil)
+
+				// Mark the source endpoint for deletion
+				lm.MarkEndpointDeleted(localEd1)
+
+				t := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
+
+				// Send NFLOG packet - this should create the tuple but skip RuleHits processing
+				nflogReader.IngressC <- localPktIngress
+				Eventually(c.epStats).Should(HaveKey(*t))
+
+				data := c.epStats[*t]
+				// Verify that RuleHits were not processed (Path should be empty)
+				Expect(len(data.IngressRuleTrace.Path())).To(Equal(0), "IngressRuleTrace Path should be empty when source endpoint is marked for deletion")
+				Expect(len(data.EgressRuleTrace.Path())).To(Equal(0), "EgressRuleTrace Path should be empty when source endpoint is marked for deletion")
+			})
+		})
+
+		Describe("Test destination endpoint marked for deletion", func() {
+			It("should skip RuleHits processing when destination endpoint is marked for deletion", func() {
+				// Set up normal endpoint map
+				epMap := map[[16]byte]calc.EndpointData{
+					localIp1:  localEd1, // normal src endpoint
+					localIp2:  localEd2, // dest endpoint to be marked for deletion
+					remoteIp1: remoteEd1,
+				}
+				nflogMap := map[[64]byte]*calc.RuleID{}
+
+				for _, rid := range []*calc.RuleID{defTierPolicy1AllowEgressRuleID, defTierPolicy1AllowIngressRuleID, defTierPolicy2DenyIngressRuleID, defTierPolicy2DenyEgressRuleID} {
+					nflogMap[policyIDStrToRuleIDParts(rid)] = rid
+				}
+
+				// Update the lookups cache with endpoint map
+				lm.SetMockData(epMap, nflogMap, nil, nil)
+
+				// Mark the destination endpoint for deletion
+				lm.MarkEndpointDeleted(localEd2)
+
+				t := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
+
+				// Send NFLOG packet - this should create the tuple but skip RuleHits processing
+				nflogReader.IngressC <- localPktIngress
+				Eventually(c.epStats).Should(HaveKey(*t))
+
+				data := c.epStats[*t]
+				// Verify that RuleHits were not processed (Path should be empty)
+				Expect(len(data.IngressRuleTrace.Path())).To(Equal(0), "IngressRuleTrace Path should be empty when destination endpoint is marked for deletion")
+				Expect(len(data.EgressRuleTrace.Path())).To(Equal(0), "EgressRuleTrace Path should be empty when destination endpoint is marked for deletion")
+			})
+		})
+
+		Describe("Test remote source endpoint marked for deletion", func() {
+			It("should skip RuleHits processing when remote source endpoint is marked for deletion", func() {
+				// Set up normal endpoint map
+				epMap := map[[16]byte]calc.EndpointData{
+					localIp1:  localEd1,
+					localIp2:  localEd2,
+					remoteIp1: remoteEd1, // remote src endpoint to be marked for deletion
+				}
+				nflogMap := map[[64]byte]*calc.RuleID{}
+
+				for _, rid := range []*calc.RuleID{defTierPolicy1AllowEgressRuleID, defTierPolicy1AllowIngressRuleID, defTierPolicy2DenyIngressRuleID, defTierPolicy2DenyEgressRuleID} {
+					nflogMap[policyIDStrToRuleIDParts(rid)] = rid
+				}
+
+				// Update the lookups cache with endpoint map
+				lm.SetMockData(epMap, nflogMap, nil, nil)
+
+				// Mark the remote source endpoint for deletion
+				lm.MarkEndpointDeleted(remoteEd1)
+
+				t := tuple.New(remoteIp1, localIp1, proto_tcp, srcPort, dstPort)
+
+				// Send NFLOG packet - this should create the tuple but skip RuleHits processing
+				nflogReader.IngressC <- ingressPktAllow
+				Eventually(c.epStats).Should(HaveKey(*t))
+
+				data := c.epStats[*t]
+				// Verify that RuleHits were not processed (Path should be empty)
+				Expect(len(data.IngressRuleTrace.Path())).To(Equal(0), "IngressRuleTrace Path should be empty when remote source endpoint is marked for deletion")
+				Expect(len(data.EgressRuleTrace.Path())).To(Equal(0), "EgressRuleTrace Path should be empty when remote source endpoint is marked for deletion")
+			})
+		})
+
+		// Test to ensure normal functionality is not broken
+		Describe("Test normal RuleHits processing with active endpoints", func() {
+			It("should process RuleHits when endpoints are NOT marked for deletion", func() {
+				// Use normal endpoints (not marked for deletion) by resetting to default state
+				epMap := map[[16]byte]calc.EndpointData{
+					localIp1:  localEd1,
+					localIp2:  localEd2,
+					remoteIp1: remoteEd1,
+				}
+				nflogMap := map[[64]byte]*calc.RuleID{}
+
+				for _, rid := range []*calc.RuleID{defTierPolicy1AllowEgressRuleID, defTierPolicy1AllowIngressRuleID, defTierPolicy2DenyIngressRuleID, defTierPolicy2DenyEgressRuleID} {
+					nflogMap[policyIDStrToRuleIDParts(rid)] = rid
+				}
+
+				// Update the lookups cache with normal (active) endpoint map
+				lm.SetMockData(epMap, nflogMap, nil, nil)
+
+				t := tuple.New(localIp1, localIp2, proto_tcp, srcPort, dstPort)
+
+				// Send NFLOG packet - this should create the tuple AND process RuleHits
+				nflogReader.IngressC <- localPktIngress
+				Eventually(c.epStats).Should(HaveKey(*t))
+
+				data := c.epStats[*t]
+				// Verify that RuleHits were processed (Path should NOT be empty)
+				Eventually(func() int {
+					return len(data.IngressRuleTrace.Path())
+				}, "500ms", "50ms").Should(BeNumerically(">", 0), "IngressRuleTrace Path should NOT be empty when endpoints are active")
+			})
+		})
+	})
 })
 
 // Entry remoteIp1:srcPort -> localIp1:dstPort

--- a/felix/fv/flow_logs_goldmane_test.go
+++ b/felix/fv/flow_logs_goldmane_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/projectcalico/calico/felix/collector/flowlog"
 	"github.com/projectcalico/calico/felix/collector/local"
@@ -793,6 +794,255 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane local server tests
 		for _, felix := range tc.Felixes {
 			if bpfEnabled {
 				felix.Exec("calico-bpf", "connect-time", "clean")
+			}
+		}
+	})
+})
+
+var _ = infrastructure.DatastoreDescribe("flow log with deleted service pod test", []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+	const (
+		wepPort = 8055
+		svcPort = 8066
+	)
+	wepPortStr := fmt.Sprintf("%d", wepPort)
+	svcPortStr := fmt.Sprintf("%d", svcPort)
+	clusterIP := "10.101.0.10"
+
+	var (
+		infra        infrastructure.DatastoreInfra
+		opts         infrastructure.TopologyOptions
+		tc           infrastructure.TopologyContainers
+		client       client.Interface
+		ep1_1, ep2_1 *workload.Workload
+		cc           *connectivity.Checker
+	)
+
+	bpfEnabled := os.Getenv("FELIX_FV_ENABLE_BPF") == "true"
+
+	BeforeEach(func() {
+		infra = getInfra()
+		opts = infrastructure.DefaultTopologyOptions()
+		opts.FlowLogSource = infrastructure.FlowLogSourceLocalSocket
+		opts.IPIPMode = api.IPIPModeNever
+		opts.NATOutgoingEnabled = true
+		opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "25"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSENABLEHOSTENDPOINT"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSFILEINCLUDELABELS"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSFILEINCLUDEPOLICIES"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSCOLLECTORDEBUGTRACE"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSFILEENABLED"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSFILEINCLUDESERVICE"] = "true"
+		opts.ExtraEnvVars["FELIX_FLOWLOGSGOLDMANESERVER"] = local.SocketAddress
+
+		// Start felix instances.
+		tc, client = infrastructure.StartNNodeTopology(2, opts, infra)
+
+		if bpfEnabled {
+			ensureBPFProgramsAttached(tc.Felixes[0])
+			ensureBPFProgramsAttached(tc.Felixes[1])
+		}
+
+		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
+		infra.AddDefaultAllow()
+
+		// Create workload on host 1.
+		infrastructure.AssignIP("ep1-1", "10.65.0.0", tc.Felixes[0].Hostname, client)
+		ep1_1 = workload.Run(tc.Felixes[0], "ep1-1", "default", "10.65.0.0", wepPortStr, "tcp")
+		ep1_1.ConfigureInInfra(infra)
+
+		infrastructure.AssignIP("ep2-1", "10.65.1.0", tc.Felixes[1].Hostname, client)
+		ep2_1 = workload.Run(tc.Felixes[1], "ep2-1", "default", "10.65.1.0", wepPortStr, "tcp")
+		ep2_1.ConfigureInInfra(infra)
+
+		ensureRoutesProgrammed(tc.Felixes)
+
+		// Create a service that maps to ep2_1. Rather than checking connectivity to the endpoint we'll go via
+		// the service to test the destination service name handling.
+		svcName := "test-service"
+		k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
+		tSvc := k8sService(svcName, clusterIP, ep2_1, svcPort, wepPort, 0, "tcp")
+		tSvcNamespace := tSvc.Namespace
+		_, err := k8sClient.CoreV1().Services(tSvcNamespace).Create(context.Background(), tSvc, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for the endpoints to be updated and for the address to be ready.
+		Expect(ep2_1.IP).NotTo(Equal(""))
+		getEpsFunc := k8sGetEpsForServiceFunc(k8sClient, tSvc)
+		epCorrectFn := func() error {
+			eps := getEpsFunc()
+			if len(eps) != 1 {
+				return fmt.Errorf("Wrong number of endpointslices: %#v", eps)
+			}
+			if len(eps[0].Endpoints) != 1 {
+				return fmt.Errorf("Wrong number of endpoints: %#v", eps[0])
+			}
+			endpoints := eps[0].Endpoints
+			addrs := endpoints[0].Addresses
+			if len(addrs) != 1 {
+				return fmt.Errorf("Wrong number of addresses: %#v", eps[0])
+			}
+			if addrs[0] != ep2_1.IP {
+				return fmt.Errorf("Unexpected IP: %s != %s", addrs[0], ep2_1.IP)
+			}
+			ports := eps[0].Ports
+			if len(ports) != 1 {
+				return fmt.Errorf("Wrong number of ports: %#v", eps[0])
+			}
+			if *ports[0].Port != int32(wepPort) {
+				return fmt.Errorf("Wrong port %d != svcPort", *ports[0].Port)
+			}
+			return nil
+		}
+		Eventually(epCorrectFn, "10s").ShouldNot(HaveOccurred())
+
+		// Create a policy that allows ep1-1 to communicate with test-service using label matching
+		gnpServiceAllow := api.NewGlobalNetworkPolicy()
+		gnpServiceAllow.Name = "ep1-1-allow-test-service"
+		gnpServiceAllow.Spec.Order = &float2_0
+		gnpServiceAllow.Spec.Tier = "default"
+		gnpServiceAllow.Spec.Selector = ep1_1.NameSelector()
+		gnpServiceAllow.Spec.Types = []api.PolicyType{api.PolicyTypeEgress}
+		gnpServiceAllow.Spec.Egress = []api.Rule{
+			{
+				Action: api.Allow,
+				Destination: api.EntityRule{
+					Services: &api.ServiceMatch{
+						Namespace: "default",
+						Name:      svcName,
+					},
+				},
+			},
+		}
+		_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, gnpServiceAllow, utils.NoOptions)
+		Expect(err).NotTo(HaveOccurred())
+
+		if !bpfEnabled {
+			// Wait for felix to see and program some expected nflog entries, and for the cluster IP to appear.
+			Eventually(getRuleFunc(tc.Felixes[0], "APE0|default.ep1-1-allow-test-service"), "10s", "1s").ShouldNot(HaveOccurred())
+		} else {
+			checkNat := func() bool {
+				for _, f := range tc.Felixes {
+					if !f.BPFNATHasBackendForService(clusterIP, svcPort, 6, ep2_1.IP, wepPort) {
+						return false
+					}
+				}
+				return true
+			}
+
+			Eventually(checkNat, "10s", "1s").Should(BeTrue(), "Expected NAT to be programmed")
+
+			bpfWaitForPolicy(tc.Felixes[0], ep1_1.InterfaceName,
+				"egress", "default.ep1-1-allow-test-service")
+		}
+
+		if !bpfEnabled {
+			// Mimic the kube-proxy service iptable clusterIP rule.
+			for _, f := range tc.Felixes {
+				f.Exec("iptables", "-t", "nat", "-A", "PREROUTING",
+					"-p", "tcp",
+					"-d", clusterIP,
+					"-m", "tcp", "--dport", svcPortStr,
+					"-j", "DNAT", "--to-destination",
+					ep2_1.IP+":"+wepPortStr)
+			}
+		}
+	})
+
+	It("should get expected flow logs", func() {
+		// Describe the connectivity that we now expect.
+		// For ep1_1 -> ep2_1 we use the service cluster IP to test service info in the flow log
+		cc = &connectivity.Checker{}
+		cc.ExpectSome(ep1_1, connectivity.TargetIP(clusterIP), uint16(svcPort)) // allowed by np1-1
+
+		// Do 3 rounds of connectivity checking.
+		cc.CheckConnectivity()
+		cc.CheckConnectivity()
+		cc.CheckConnectivity()
+
+		flowlogs.WaitForConntrackScan(bpfEnabled)
+
+		// Verify we have allowed flow logs before deleting the backing pod
+		Eventually(func() error {
+			flows, err := tc.Felixes[0].FlowLogs()
+			if err != nil {
+				return err
+			}
+			foundAllowed := false
+			for _, fl := range flows {
+				if fl.Action == "allow" && fl.DstService.PortNum == int(svcPort) {
+					foundAllowed = true
+					break
+				}
+			}
+			if !foundAllowed {
+				return fmt.Errorf("no allowed flow log found for service port %d", svcPort)
+			}
+			return nil
+		}, "20s", "1s").ShouldNot(HaveOccurred())
+
+		// Verify that the workload endpoint for ep2_1 exists
+		Eventually(func() error {
+			wlList, _ := client.WorkloadEndpoints().List(utils.Ctx, options.ListOptions{})
+			for _, wl := range wlList.Items {
+				if strings.Contains(wl.Name, "ep2--1") {
+					return nil
+				}
+			}
+			return fmt.Errorf("workload endpoint default/%s still exists", ep2_1.Name)
+		}, "10s", "1s").ShouldNot(HaveOccurred())
+
+		// Delete the backing pod (ep2_1) to test flow logs when service has no endpoints
+		ep2_1.RemoveFromInfra(infra)
+
+		// Wait a moment for the endpoint deletion to propagate
+		Eventually(func() error {
+			wlList, _ := client.WorkloadEndpoints().List(utils.Ctx, options.ListOptions{})
+			for _, wl := range wlList.Items {
+				if strings.Contains(wl.Name, "ep2--1") {
+					return fmt.Errorf("workload endpoint default/%s still exists", ep2_1.Name)
+				}
+			}
+			return nil
+		}, "10s", "1s").ShouldNot(HaveOccurred())
+
+		// Now expect connectivity to fail since there's no backing pod
+		cc = &connectivity.Checker{}
+		cc.ExpectNone(ep1_1, connectivity.TargetIP(clusterIP), uint16(svcPort))
+
+		// Do more rounds of connectivity checking - these should fail
+		cc.CheckConnectivity()
+		cc.CheckConnectivity()
+		cc.CheckConnectivity()
+
+		flowlogs.WaitForConntrackScan(bpfEnabled)
+
+		// Verify we get denied or failed flow logs after deleting the backing pod
+		Consistently(func() error {
+			var flows []flowlog.FlowLog
+			var err error
+			if flows, err = tc.Felixes[0].FlowLogs(); err != nil {
+				return err
+			}
+			for _, fl := range flows {
+				// After pod deletion, should not see denied flows for the service port
+				if fl.DstService.PortNum == int(svcPort) && fl.Action == "deny" {
+					return fmt.Errorf("found denied flow log for service port %d", svcPort)
+				}
+			}
+			return nil
+		}, "1m", "1s").ShouldNot(HaveOccurred())
+
+		// Delete conntrack state so that we don't keep seeing 0-metric copies of the logs.  This will allow the flows
+		// to expire quickly.
+		for ii := range tc.Felixes {
+			tc.Felixes[ii].Exec("conntrack", "-F")
+		}
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			if bpfEnabled {
+				tc.Felixes[0].Exec("calico-bpf", "policy", "dump", ep1_1.InterfaceName, "all", "--asm")
 			}
 		}
 	})


### PR DESCRIPTION
## Description

**Summary**
This PR implements functionality to skip RuleHits processing in flow logs when endpoints are marked for deletion, preventing unnecessary policy trace evaluation for endpoints that are being cleaned up. As a consequence, the change also ensures that the flow log action is not updated when one of the endpoints is deleted.

**Problem**
A race condition occurs when a pod is deleted while processing packet information for traffic with a pre-DNAT destination IP directed at a service. This leads to a 'deny' action for incoming packets, even when an existing policy would permit the traffic.

**Solution**
Added logic to detect when source or destination endpoints are marked for deletion and skip policy trace processing.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed a race in flow log generation that could mis-report service traffic as denied when a backing pod was deleted while the packet was being processed.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
