### PR TITLE
[BPF] kube-proxy binds service health probes to node IPs

### DIFF
--- a/felix/bpf/proxy/health_check_nodeport_test.go
+++ b/felix/bpf/proxy/health_check_nodeport_test.go
@@ -17,6 +17,7 @@ package proxy_test
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -33,7 +34,7 @@ import (
 )
 
 var _ = Describe("BPF Proxy healthCheckNodeport", func() {
-	var p proxy.Proxy
+	var p proxy.ProxyFrontend
 	k8s := fake.NewClientset()
 
 	testNodeName := "testnode"
@@ -46,6 +47,7 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 			p, err = proxy.New(k8s, &mockDummySyncer{}, testNodeName,
 				proxy.WithMinSyncPeriod(200*time.Millisecond), proxy.WithMaxSyncPeriod(1*time.Second))
 			Expect(err).NotTo(HaveOccurred())
+			p.SetHostIPs([]net.IP{net.ParseIP("127.0.0.1")})
 		})
 	})
 

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -140,6 +140,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 		return errors.WithMessage(err, "new bpf syncer")
 	}
 
+	kp.proxy.SetHostIPs(hostIPs)
 	kp.proxy.SetSyncer(syncer)
 
 	log.Infof("kube-proxy v%d node info updated, hostname=%q hostIPs=%+v", kp.ipFamily, kp.hostname, hostIPs)

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -15,9 +15,7 @@
 package proxy_test
 
 import (
-	"fmt"
 	"net"
-	"net/http"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -111,21 +109,9 @@ var _ = Describe("BPF kube-proxy", func() {
 			}).Should(BeTrue())
 		})
 
-		By("checking that the healthCheckNodePort is accessible", func() {
-			Eventually(func() error {
-				result, err := http.Get(fmt.Sprintf("http://localhost:%d", healthCheckNodePort))
-				if err != nil {
-					return err
-				}
-				if result.StatusCode != 503 {
-					return fmt.Errorf("Unexpected status code %d; expected 503", result.StatusCode)
-				}
-				return nil
-			}, "5s", "200ms").Should(Succeed())
-		})
+		updatedIP := net.IPv4(2, 2, 2, 2)
 
 		By("checking nodeport has the updated IP and not the initial IP", func() {
-			updatedIP := net.IPv4(2, 2, 2, 2)
 			p.OnHostIPsUpdate([]net.IP{updatedIP})
 
 			Eventually(func() bool {
@@ -142,19 +128,6 @@ var _ = Describe("BPF kube-proxy", func() {
 				}
 				return false
 			}).Should(BeTrue())
-		})
-
-		By("checking that the healthCheckNodePort is still accessible", func() {
-			Eventually(func() error {
-				result, err := http.Get(fmt.Sprintf("http://localhost:%d", healthCheckNodePort))
-				if err != nil {
-					return err
-				}
-				if result.StatusCode != 503 {
-					return fmt.Errorf("Unexpected status code %d; expected 503", result.StatusCode)
-				}
-				return nil
-			}, "5s", "200ms").Should(Succeed())
 		})
 
 		By("checking nodeport has 2 updated IPs", func() {


### PR DESCRIPTION
We were listening to any IP, but that makes the servers collide in dual stack setup. Since we implement nodeports and loadbalancers only for a set of known host IPs, we can also limit the binding to these IPs only. v4 and v6 then do not collide.

We do not start the servers until kube-proxy lears about the host IPs, but it will eventually, soon after start.

fixes https://github.com/projectcalico/calico/issues/11264

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: kube-proxy binds service health probes to node IPs instead of "any"
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
