### PR TITLE
Remove duplicate host metadata updates

### DIFF
--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
@@ -1563,9 +1563,9 @@ func BenchmarkAttachProgram(b *testing.B) {
 	err = ap.AttachProgram()
 	Expect(err).NotTo(HaveOccurred())
 
-	logLevel := log.GetLevel()
-	log.SetLevel(log.PanicLevel)
-	defer log.SetLevel(logLevel)
+	logLevel := logrus.GetLevel()
+	logrus.SetLevel(logrus.PanicLevel)
+	defer logrus.SetLevel(logLevel)
 
 	b.StartTimer()
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -157,7 +157,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 		}
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1.2.3.4"))
-		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		err = bpfEpMgr.CompleteDeferredWork()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -215,7 +215,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		if ipv6Enabled {
 			// IPv6 address update
 			bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1::4"))
-			bpfEpMgr.OnUpdate(&proto.HostMetadataV6Update{Hostname: "uthost", Ipv6Addr: "1::4"})
+			bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv6Addr: "1::4"})
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -672,7 +672,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(attached2).To(Equal(attached))
 
-		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep2", ifacemonitor.StateUp, workload2.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep2", "1.6.6.1"))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep2", ifacemonitor.StateUp, host2.Attrs().Index))
@@ -756,7 +756,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(pmIng).To(HaveLen(0))
 		Expect(pmEgr).To(HaveLen(0))
 
-		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep2", ifacemonitor.StateUp, workload2.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep2", "1.6.6.1"))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep2", ifacemonitor.StateUp, host2.Attrs().Index))
@@ -817,7 +817,7 @@ func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
 	workload1 := createVethName("workloadep1")
 	defer deleteLink(workload1)
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep1", ifacemonitor.StateUp, workload1.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep1", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -998,7 +998,7 @@ func TestRepeatedAttach(t *testing.T) {
 		regexp.MustCompile("^workloadep[123]"),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep1", ifacemonitor.StateUp, iface.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep1", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1148,7 +1148,7 @@ func TestAttachInterfaceRecreate(t *testing.T) {
 		}
 	}()
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1242,7 +1242,7 @@ func TestAttachTcx(t *testing.T) {
 	workload0 := createVethName("workloadep0")
 	defer deleteLink(workload0)
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1282,7 +1282,7 @@ func TestAttachTcx(t *testing.T) {
 		regexp.MustCompile("^workloadep[0123]"),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1311,7 +1311,7 @@ func TestAttachTcx(t *testing.T) {
 		regexp.MustCompile("^workloadep[0123]"),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1374,7 +1374,7 @@ func TestAttachNetkit(t *testing.T) {
 	workload0 := createNetkitName("workloadep0")
 	defer deleteLink(workload0)
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1455,7 +1455,7 @@ func TestLogFilters(t *testing.T) {
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep1", ifacemonitor.StateUp, host1.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1.2.3.4"))
-		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		err = bpfEpMgr.CompleteDeferredWork()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1485,7 +1485,7 @@ func TestLogFilters(t *testing.T) {
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep1", ifacemonitor.StateUp, host1.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1.2.3.4"))
-		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		err = bpfEpMgr.CompleteDeferredWork()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -28,7 +28,6 @@ import (
 	"github.com/projectcalico/calico/felix/types"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 var gaugeNumActiveSelectors = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -72,11 +71,7 @@ type encapCallbacks interface {
 }
 
 type passthruCallbacks interface {
-	OnHostIPUpdate(hostname string, ip *net.IP)
-	OnHostIPRemove(hostname string)
-	OnHostIPv6Update(hostname string, ip *net.IP)
-	OnHostIPv6Remove(hostname string)
-	OnHostMetadataUpdate(hostname string, ip4 *net.IPNet, ip6 *net.IPNet, asnumber string, labels map[string]string)
+	OnHostMetadataUpdate(hostname string, info *HostInfo)
 	OnHostMetadataRemove(hostname string)
 	OnIPPoolUpdate(model.IPPoolKey, *model.IPPool)
 	OnIPPoolRemove(model.IPPoolKey)

--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	googleproto "google.golang.org/protobuf/proto"
 
 	. "github.com/projectcalico/calico/felix/calc"
@@ -638,7 +638,7 @@ func testExpanders() (testExpanders []func(baseTest StateList) (desc string, map
 
 	if os.Getenv("DISABLE_TEST_EXPANSION") == "true" {
 		logOnce.Do(func() {
-			log.Info("Test expansion disabled")
+			logrus.Info("Test expansion disabled")
 		})
 		return
 	}
@@ -701,7 +701,7 @@ var _ = Describe("Calculation graph state sequencing tests:", func() {
 // deterministic test!
 var _ = Describe("Async calculation graph state sequencing tests:", func() {
 	if os.Getenv("DISABLE_ASYNC_TESTS") == "true" {
-		log.Info("Async tests disabled")
+		logrus.Info("Async tests disabled")
 		return
 	}
 	for _, test := range baseTests {
@@ -737,10 +737,10 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 					done := make(chan bool, 2)
 					// Start a thread to inject the KVs.
 					go func() {
-						log.Info("Input injector thread started")
+						logrus.Info("Input injector thread started")
 						lastState := empty
 						for _, state := range test {
-							log.WithField("state", state).Info("Injecting next state")
+							logrus.WithField("state", state).Info("Injecting next state")
 							_, _ = fmt.Fprintf(GinkgoWriter, "       -> Injecting state (single update): %v\n", state)
 							kvDeltas := state.KVDeltas(lastState)
 							for _, kv := range kvDeltas {
@@ -765,11 +765,11 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 					for {
 						select {
 						case <-done:
-							log.Info("Got done message, stopping.")
+							logrus.Info("Got done message, stopping.")
 							Expect(inSyncReceived).To(BeTrue(), "Timed out before we got an in-sync message")
 							break readLoop
 						case update := <-outputChan:
-							log.WithField("update", update).Info("Update from channel")
+							logrus.WithField("update", update).Info("Update from channel")
 							Expect(inSyncReceived).To(BeFalse(), "Unexpected update after in-sync")
 							mockDataplane.OnEvent(update)
 							if _, ok := update.(*proto.InSync); ok {
@@ -793,7 +793,7 @@ var _ = Describe("Async calculation graph state sequencing tests:", func() {
 })
 
 func expectCorrectDataplaneState(mockDataplane *mock.MockDataplane, state State) {
-	log.WithField("state", state.Name).Info("Doing assertions on state")
+	logrus.WithField("state", state.Name).Info("Doing assertions on state")
 	Expect(mockDataplane.IPSets()).To(Equal(state.ExpectedIPSets),
 		"IP sets didn't match expected state after moving to state: %v",
 		state.Name)
@@ -890,7 +890,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 		conf.Encapsulation = config.Encapsulation{VXLANEnabled: true, VXLANEnabledV6: true}
 		calcGraph = NewCalculationGraph(eventBuf, lookupsCache, conf, func() {})
 		statsCollector := NewStatsCollector(func(stats StatsUpdate) error {
-			log.WithField("stats", stats).Info("Stats update")
+			logrus.WithField("stats", stats).Info("Stats update")
 			lastStats = stats
 			return nil
 		})

--- a/felix/calc/calc_graph_test.go
+++ b/felix/calc/calc_graph_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/calc/calc_graph_test.go
+++ b/felix/calc/calc_graph_test.go
@@ -69,8 +69,8 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 		switch messageReceived.(type) {
 		case *proto.IPAMPoolUpdate:
 			Expect(googleproto.Equal(messageReceived.(*proto.IPAMPoolUpdate), expUpdate.(*proto.IPAMPoolUpdate))).To(BeTrue())
-		case *proto.HostMetadataUpdate:
-			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataUpdate), expUpdate.(*proto.HostMetadataUpdate))).To(BeTrue())
+		case *proto.HostMetadataV4V6Update:
+			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataV4V6Update), expUpdate.(*proto.HostMetadataV4V6Update))).To(BeTrue())
 		case *proto.GlobalBGPConfigUpdate:
 			Expect(googleproto.Equal(messageReceived.(*proto.GlobalBGPConfigUpdate), expUpdate.(*proto.GlobalBGPConfigUpdate))).To(BeTrue())
 		case *proto.WireguardEndpointUpdate:
@@ -95,8 +95,8 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 		switch messageReceived.(type) {
 		case *proto.IPAMPoolRemove:
 			Expect(googleproto.Equal(messageReceived.(*proto.IPAMPoolRemove), expRemove.(*proto.IPAMPoolRemove))).To(BeTrue())
-		case *proto.HostMetadataRemove:
-			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataRemove), expRemove.(*proto.HostMetadataRemove))).To(BeTrue())
+		case *proto.HostMetadataV4V6Remove:
+			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataV4V6Remove), expRemove.(*proto.HostMetadataV4V6Remove))).To(BeTrue())
 		case *proto.GlobalBGPConfigUpdate:
 			Expect(googleproto.Equal(messageReceived.(*proto.GlobalBGPConfigUpdate), expRemove.(*proto.GlobalBGPConfigUpdate))).To(BeTrue())
 		case *proto.WireguardEndpointRemove:
@@ -141,11 +141,11 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 	Entry("HostIP",
 		model.HostIPKey{Hostname: "foo"},
 		&testIP,
-		&proto.HostMetadataUpdate{
+		&proto.HostMetadataV4V6Update{
 			Hostname: "foo",
-			Ipv4Addr: "10.0.0.1",
+			Ipv4Addr: "10.0.0.1/32",
 		},
-		&proto.HostMetadataRemove{
+		&proto.HostMetadataV4V6Remove{
 			Hostname: "foo",
 		}),
 	Entry("Global BGPConfiguration",
@@ -263,9 +263,9 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 		})
 		eb.Flush()
 		Expect(messagesReceived).To(HaveLen(1))
-		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
+		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
 			Hostname: "foo",
-			Ipv4Addr: "10.0.0.1",
+			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
 	})
 	It("should pass on genuine changes", func() {
@@ -286,13 +286,13 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 		})
 		eb.Flush()
 		Expect(messagesReceived).To(HaveLen(2))
-		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
+		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
 			Hostname: "foo",
-			Ipv4Addr: "10.0.0.1",
+			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
-		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
+		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
 			Hostname: "foo",
-			Ipv4Addr: "10.0.0.2",
+			Ipv4Addr: "10.0.0.2/32",
 		})).To(BeTrue())
 	})
 	It("should pass on delete and recreate", func() {
@@ -320,16 +320,16 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 		})
 		eb.Flush()
 		Expect(messagesReceived).To(HaveLen(3))
-		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
+		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
 			Hostname: "foo",
-			Ipv4Addr: "10.0.0.1",
+			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
-		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataRemove), &proto.HostMetadataRemove{
+		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataV4V6Remove), &proto.HostMetadataV4V6Remove{
 			Hostname: "foo",
 		})).To(BeTrue())
-		Expect(googleproto.Equal(messagesReceived[2].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
+		Expect(googleproto.Equal(messagesReceived[2].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
 			Hostname: "foo",
-			Ipv4Addr: "10.0.0.1",
+			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
 	})
 })

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -15,8 +15,6 @@
 package calc
 
 import (
-	"maps"
-
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
@@ -121,6 +119,7 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 func (h *DataplanePassthru) processModelHostIP(key model.HostIPKey, update api.Update) {
 	hostname := key.Hostname
 	before := h.merge(hostname)
+
 	if update.Value == nil {
 		logrus.WithField("update", update).Debug("Passing-through HostIP deletion")
 		delete(h.hostIPv4, hostname)
@@ -163,14 +162,14 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 		// CRD validation (`cidrv4`/`cidrv6` tags). Bare IPs are dropped silently
 		// here so the dataplane never sees an ambiguous address.
 		if addr := bgpSpec.IPv4Address; addr != "" {
-			if s, ok := parseBGPCIDR(addr); ok {
+			if s, ok := parseCIDR(addr); ok {
 				info.ip4Addr = s
 			} else {
 				logrus.WithField("addr", addr).Warn("Ignoring Node BGP IPv4Address: not a CIDR")
 			}
 		}
 		if addr := bgpSpec.IPv6Address; addr != "" {
-			if s, ok := parseBGPCIDR(addr); ok {
+			if s, ok := parseCIDR(addr); ok {
 				info.ip6Addr = s
 			} else {
 				logrus.WithField("addr", addr).Warn("Ignoring Node BGP IPv6Address: not a CIDR")
@@ -179,7 +178,8 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 		if node.Spec.BGP.ASNumber != nil {
 			info.asnumber = node.Spec.BGP.ASNumber.String()
 		}
-	} else { // node.Spec.BGP is nil
+	} else {
+		// node.Spec.BGP is nil
 		if h.ipv6Support {
 			// BGP is turned off; fall back to the Node's address list for IPv6.
 			// Mirrors how HostIPKey is generated for IPv4 in
@@ -206,13 +206,15 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 // states.
 func (h *DataplanePassthru) emitTransition(hostname string, before *HostInfo) {
 	after := h.merge(hostname)
+
 	if after == nil {
 		if before != nil {
 			h.callbacks.OnHostMetadataRemove(hostname)
 		}
 		return
 	}
-	if before != nil && hostInfoEqual(before, after) {
+
+	if before != nil && before.equals(after) {
 		return
 	}
 	h.callbacks.OnHostMetadataUpdate(hostname, after)
@@ -223,14 +225,14 @@ func (h *DataplanePassthru) emitTransition(hostname string, before *HostInfo) {
 // are present; the HostIPKey-derived /32 only fills in IPv4 when there is no
 // Node-derived value for it.
 func (h *DataplanePassthru) merge(hostname string) *HostInfo {
-	node, hasNode := h.nodeInfo[hostname]
+	node := h.nodeInfo[hostname]
 	hostIP, hasHostIP := h.hostIPv4[hostname]
 
-	if !hasNode && !hasHostIP {
+	if node == nil && !hasHostIP {
 		return nil
 	}
 
-	if hasNode {
+	if node != nil {
 		merged := *node
 		if merged.ip4Addr == "" && hasHostIP {
 			merged.ip4Addr = hostIP
@@ -240,17 +242,10 @@ func (h *DataplanePassthru) merge(hostname string) *HostInfo {
 	return &HostInfo{ip4Addr: hostIP}
 }
 
-func hostInfoEqual(a, b *HostInfo) bool {
-	return a.ip4Addr == b.ip4Addr &&
-		a.ip6Addr == b.ip6Addr &&
-		a.asnumber == b.asnumber &&
-		maps.Equal(a.labels, b.labels)
-}
-
-// parseBGPCIDR strictly parses a CIDR string and returns it normalized to "host
+// parseCIDR strictly parses a CIDR string and returns it normalized to "host
 // IP / mask" form (e.g. "192.168.0.2/24" rather than "192.168.0.0/24"). Returns
 // false if the string is not a valid CIDR — bare IPs are rejected.
-func parseBGPCIDR(s string) (string, bool) {
+func parseCIDR(s string) (string, bool) {
 	ip, ipnet, err := net.ParseCIDR(s)
 	if err != nil || ipnet == nil {
 		return "", false

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017,2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package calc
 
 import (
+	"maps"
+
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
@@ -31,20 +33,36 @@ import (
 // DataplanePassthru passes through some datamodel updates to the dataplane layer, removing some
 // duplicates along the way.  It maps OnUpdate() calls to dedicated method calls for consistency
 // with the rest of the dataplane API.
+//
+// HostMetadataV4V6Update is sourced from two streams that may both be live for the
+// same host:
+//   - HostIPKey (IPv4 only, derived from Node BGP by the syncer): provides a /32 fallback.
+//   - Node resource (BGP IPv4/IPv6 + labels + ASN): authoritative when present.
+//
+// We track each source separately so a delete on one side doesn't clobber data
+// from the other side, then recompute and emit the merged view.
 type DataplanePassthru struct {
 	ipv6Support bool
 	callbacks   passthruCallbacks
 
-	hostIPs   map[string]*net.IP
-	hostIPv6s map[string]*net.IP
+	// hostIPv4 is the /32 derived from a HostIPKey update, keyed by hostname.
+	hostIPv4 map[string]string
+	// nodeInfo is the per-host info derived from a Node resource. A non-nil entry
+	// means the Node resource currently exists for that host; nil/missing means it
+	// has been deleted (or was treated as deleted because its BGP spec was empty).
+	nodeInfo map[string]*HostInfo
+	// lastEmitted records the last HostInfo we sent for each host, so we can skip
+	// no-op updates and only emit when the merged view actually changed.
+	lastEmitted map[string]*HostInfo
 }
 
 func NewDataplanePassthru(callbacks passthruCallbacks, ipv6Support bool) *DataplanePassthru {
 	return &DataplanePassthru{
 		ipv6Support: ipv6Support,
 		callbacks:   callbacks,
-		hostIPs:     map[string]*net.IP{},
-		hostIPv6s:   map[string]*net.IP{},
+		hostIPv4:    map[string]string{},
+		nodeInfo:    map[string]*HostInfo{},
+		lastEmitted: map[string]*HostInfo{},
 	}
 }
 
@@ -58,25 +76,7 @@ func (h *DataplanePassthru) RegisterWith(dispatcher *dispatcher.Dispatcher) {
 func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 	switch key := update.Key.(type) {
 	case model.HostIPKey:
-		hostname := key.Hostname
-		if update.Value == nil {
-			log.WithField("update", update).Debug("Passing-through HostIP deletion")
-			delete(h.hostIPs, hostname)
-			h.callbacks.OnHostIPRemove(hostname)
-		} else {
-			ip := update.Value.(*net.IP)
-			oldIP := h.hostIPs[hostname]
-			// libcalico-go's IP struct wraps a standard library IP struct.  To
-			// compare two IPs, we need to unwrap them and use Equal() since standard
-			// library IPs have multiple, equivalent, representations.
-			if oldIP != nil && ip.Equal(oldIP.IP) {
-				log.WithField("update", update).Debug("Ignoring duplicate HostIP update")
-				return
-			}
-			log.WithField("update", update).Debug("Passing-through HostIP update")
-			h.hostIPs[hostname] = ip
-			h.callbacks.OnHostIPUpdate(hostname, ip)
-		}
+		h.processModelHostIP(key, update)
 	case model.IPPoolKey:
 		if update.Value == nil {
 			log.WithField("update", update).Debug("Passing-through IPPool deletion")
@@ -96,99 +96,169 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 			h.callbacks.OnWireguardUpdate(key.NodeName, wg)
 		}
 	case model.ResourceKey:
-		if key.Kind == v3.KindBGPConfiguration && key.Name == "default" {
-			log.WithField("update", update).Debug("Passing through global BGPConfiguration")
-			bgpConfig, _ := update.Value.(*v3.BGPConfiguration)
-			h.callbacks.OnGlobalBGPConfigUpdate(bgpConfig)
-		} else if key.Kind == model.KindKubernetesService {
+		switch key.Kind {
+		case v3.KindBGPConfiguration:
+			if key.Name == "default" {
+				log.WithField("update", update).Debug("Passing through global BGPConfiguration")
+				bgpConfig, _ := update.Value.(*v3.BGPConfiguration)
+				h.callbacks.OnGlobalBGPConfigUpdate(bgpConfig)
+			}
+		case model.KindKubernetesService:
 			log.WithField("update", update).Debug("Passing through a Service")
 			if update.Value == nil {
 				h.callbacks.OnServiceRemove(&proto.ServiceRemove{Name: key.Name, Namespace: key.Namespace})
 			} else {
 				h.callbacks.OnServiceUpdate(kubernetesServiceToProto(update.Value.(*kapiv1.Service)))
 			}
-		} else if key.Kind == internalapi.KindNode {
-			// Handle node resource to pass-through HostMetadataV6Update/HostMetadataV6Remove messages
-			// with IPv6 node address updates. IPv4 updates are handled above my model.HostIPKey updates.
-			log.WithField("update", update).Debug("Passing-through a Node IPv6 address update")
-			log.WithField("update", update).Debug("Passing-through a Node update")
-			hostname := key.Name
-			if update.Value == nil {
-				log.WithField("update", update).Debug("Passing-through Node IPv6 address remove")
-				delete(h.hostIPv6s, hostname)
-				h.callbacks.OnHostIPv6Remove(hostname)
-				log.WithField("update", update).Debug("Passing-through Node remove")
-				h.callbacks.OnHostMetadataRemove(hostname)
-			} else {
-				node, _ := update.Value.(*internalapi.Node)
-				log.WithField("update", update).Debug("Passing-through Node update")
-				bgpIp4net := &net.IPNet{} // required for print in event sequencer
-				bgpIp6net := &net.IPNet{} // required for print in event sequencer
-				asnumber := ""
-				if node.Spec.BGP != nil {
-					ip4, ip4net, _ := net.ParseCIDR(node.Spec.BGP.IPv4Address)
-					ip6, ip6net, _ := net.ParseCIDR(node.Spec.BGP.IPv6Address)
-					if ip4net != nil {
-						ip4net.IP = ip4.IP
-						bgpIp4net = ip4net
-					}
-					if ip6net != nil {
-						ip6net.IP = ip6.IP
-						bgpIp6net = ip6net
-					}
-					if node.Spec.BGP.ASNumber != nil {
-						asnumber = node.Spec.BGP.ASNumber.String()
-					}
-				}
-				h.callbacks.OnHostMetadataUpdate(hostname, bgpIp4net, bgpIp6net, asnumber, node.Labels)
-				if node.Spec.BGP != nil {
-					if node.Spec.BGP.IPv6Address != "" {
-						ip, _, _ := net.ParseCIDR(node.Spec.BGP.IPv6Address)
-						oldIP := h.hostIPv6s[hostname]
-						if oldIP != nil && ip.Equal(oldIP.IP) {
-							log.WithField("update", update).Debug("Ignoring duplicate Node IPv6 address update")
-							return
-						}
-						log.WithField("update", update).Debug("Passing-through Node IPv6 address update")
-						h.hostIPv6s[hostname] = ip
-						h.callbacks.OnHostIPv6Update(hostname, ip)
-					} else if h.hostIPv6s[hostname] != nil {
-						log.WithField("update", update).Debug("Passing-through Node IPv6 address remove")
-						delete(h.hostIPv6s, hostname)
-						h.callbacks.OnHostIPv6Remove(hostname)
-					}
-				}
-
-				if h.ipv6Support && node.Spec.BGP == nil {
-					// BGP is turned off, try to get one from the node resource. This is a
-					// similar fallback as for IPv4, see how HostIPKey is generated in
-					// libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
-					var ip *net.IP
-					ip, _ = cresources.FindNodeAddress(node, internalapi.InternalIP, 6)
-					if ip == nil {
-						ip, _ = cresources.FindNodeAddress(node, internalapi.ExternalIP, 6)
-					}
-					if ip != nil {
-						oldIP := h.hostIPv6s[hostname]
-						if oldIP != nil && ip.Equal(oldIP.IP) {
-							log.WithField("update", update).Debug("Ignoring duplicate Node IPv6 address update")
-							return
-						}
-						log.WithField("update", update).Debug("Passing-through Node IPv6 address update")
-						h.hostIPv6s[hostname] = ip
-						h.callbacks.OnHostIPv6Update(hostname, ip)
-					} else if h.hostIPv6s[hostname] != nil {
-						log.WithField("update", update).Debug("Passing-through Node IPv6 address remove")
-						delete(h.hostIPv6s, hostname)
-						h.callbacks.OnHostIPv6Remove(hostname)
-					}
-				}
-			}
-		} else {
+		case internalapi.KindNode:
+			h.processKindNode(key, update)
+		default:
 			log.WithField("key", key).Debugf("Ignoring v3 resource of kind %s", key.Kind)
 		}
 	}
 	return
+}
+
+// processModelHostIP handles HostIPKey updates. The value is a bare IPv4 address;
+// store it as a host CIDR (/32) so the format matches the Node-resource path.
+func (h *DataplanePassthru) processModelHostIP(key model.HostIPKey, update api.Update) {
+	hostname := key.Hostname
+	if update.Value == nil {
+		log.WithField("update", update).Debug("Passing-through HostIP deletion")
+		delete(h.hostIPv4, hostname)
+	} else {
+		ip := update.Value.(*net.IP)
+		log.WithField("update", update).Debug("Passing-through HostIP update")
+		h.hostIPv4[hostname] = ip.String() + "/32"
+	}
+	h.recomputeAndEmit(hostname)
+}
+
+func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Update) {
+	hostname := key.Name
+	if update.Value == nil {
+		log.WithField("update", update).Debug("Passing-through Node remove")
+		delete(h.nodeInfo, hostname)
+		h.recomputeAndEmit(hostname)
+		return
+	}
+
+	node, _ := update.Value.(*internalapi.Node)
+	log.WithField("update", update).Debug("Passing-through Node update")
+
+	// An explicitly-empty BGP spec (`BGP: &NodeBGPSpec{}`) is treated as if the
+	// Node had been deleted from this stream — there is no useful metadata to
+	// pass through. A nil BGP, by contrast, leaves the Node entry alive (with
+	// empty IPs) since other Node info such as labels may still be relevant.
+	if bgp := node.Spec.BGP; bgp != nil &&
+		bgp.IPv4Address == "" && bgp.IPv6Address == "" && bgp.ASNumber == nil {
+		delete(h.nodeInfo, hostname)
+		h.recomputeAndEmit(hostname)
+		return
+	}
+
+	info := &HostInfo{labels: node.Labels}
+	if node.Spec.BGP != nil {
+		// BGP IPv4Address/IPv6Address must already be in CIDR form per the v3
+		// CRD validation (`cidrv4`/`cidrv6` tags). Bare IPs are dropped silently
+		// here so the dataplane never sees an ambiguous address.
+		if addr := node.Spec.BGP.IPv4Address; addr != "" {
+			if s, ok := parseBGPCIDR(addr); ok {
+				info.ip4Addr = s
+			} else {
+				log.WithField("addr", addr).Warn("Ignoring Node BGP IPv4Address: not a CIDR")
+			}
+		}
+		if addr := node.Spec.BGP.IPv6Address; addr != "" {
+			if s, ok := parseBGPCIDR(addr); ok {
+				info.ip6Addr = s
+			} else {
+				log.WithField("addr", addr).Warn("Ignoring Node BGP IPv6Address: not a CIDR")
+			}
+		}
+		if node.Spec.BGP.ASNumber != nil {
+			info.asnumber = node.Spec.BGP.ASNumber.String()
+		}
+	} else if h.ipv6Support {
+		// BGP is turned off; fall back to the Node's address list for IPv6.
+		// Mirrors how HostIPKey is generated for IPv4 in
+		// libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go.
+		ipv6, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, 6)
+		if ipnet == nil {
+			ipv6, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, 6)
+		}
+		if ipnet != nil {
+			ipnet.IP = ipv6.IP
+			info.ip6Addr = ipnet.String()
+		}
+	}
+
+	h.nodeInfo[hostname] = info
+	h.recomputeAndEmit(hostname)
+}
+
+// recomputeAndEmit derives the merged HostInfo for hostname from the per-source
+// state and emits an Update or Remove only when the merged view differs from
+// what was last sent.
+func (h *DataplanePassthru) recomputeAndEmit(hostname string) {
+	merged := h.merge(hostname)
+	last, hadLast := h.lastEmitted[hostname]
+
+	if merged == nil {
+		if hadLast {
+			delete(h.lastEmitted, hostname)
+			h.callbacks.OnHostMetadataRemove(hostname)
+		}
+		return
+	}
+
+	if hadLast && hostInfoEqual(merged, last) {
+		return
+	}
+
+	h.lastEmitted[hostname] = merged
+	h.callbacks.OnHostMetadataUpdate(hostname, merged)
+}
+
+// merge returns the HostInfo to publish for hostname, or nil if neither source
+// has live data for it. Node data wins over the HostIPKey fallback when both
+// are present; the HostIPKey-derived /32 only fills in IPv4 when there is no
+// Node-derived value for it.
+func (h *DataplanePassthru) merge(hostname string) *HostInfo {
+	node, hasNode := h.nodeInfo[hostname]
+	hostIP, hasHostIP := h.hostIPv4[hostname]
+
+	if !hasNode && !hasHostIP {
+		return nil
+	}
+
+	if hasNode {
+		merged := *node
+		if merged.ip4Addr == "" && hasHostIP {
+			merged.ip4Addr = hostIP
+		}
+		return &merged
+	}
+	return &HostInfo{ip4Addr: hostIP}
+}
+
+func hostInfoEqual(a, b *HostInfo) bool {
+	return a.ip4Addr == b.ip4Addr &&
+		a.ip6Addr == b.ip6Addr &&
+		a.asnumber == b.asnumber &&
+		maps.Equal(a.labels, b.labels)
+}
+
+// parseBGPCIDR strictly parses a CIDR string and returns it normalized to "host
+// IP / mask" form (e.g. "192.168.0.2/24" rather than "192.168.0.0/24"). Returns
+// false if the string is not a valid CIDR — bare IPs are rejected.
+func parseBGPCIDR(s string) (string, bool) {
+	ip, ipnet, err := net.ParseCIDR(s)
+	if err != nil || ipnet == nil {
+		return "", false
+	}
+	ipnet.IP = ip.IP
+	return ipnet.String(), true
 }
 
 func kubernetesServiceToProto(s *kapiv1.Service) *proto.ServiceUpdate {
@@ -210,7 +280,6 @@ func kubernetesServiceToProto(s *kapiv1.Service) *proto.ServiceUpdate {
 		case kapiv1.ProtocolSCTP:
 			return "SCTP"
 		}
-
 		return "TCP"
 	}
 
@@ -223,6 +292,5 @@ func kubernetesServiceToProto(s *kapiv1.Service) *proto.ServiceUpdate {
 	}
 
 	up.Ports = ports
-
 	return up
 }

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -34,7 +34,7 @@ import (
 // duplicates along the way.  It maps OnUpdate() calls to dedicated method calls for consistency
 // with the rest of the dataplane API.
 //
-// HostMetadataV4V6Update is sourced from two streams that may both be live for the
+// HostMetadataUpdate is sourced from two streams that may both be live for the
 // same host:
 //   - HostIPKey (IPv4 only, derived from Node BGP by the syncer): provides a /32 fallback.
 //   - Node resource (BGP IPv4/IPv6 + labels + ASN): authoritative when present.
@@ -52,10 +52,6 @@ type DataplanePassthru struct {
 	// means the Node resource currently exists for that host; nil/missing means it
 	// has been deleted (or was treated as deleted because its BGP spec was empty).
 	nodeInfo map[string]*HostInfo
-
-	// lastEmitted records the last HostInfo we sent for each host, so we can skip
-	// no-op updates and only emit when the merged view actually changed.
-	lastEmitted map[string]*HostInfo
 }
 
 func NewDataplanePassthru(callbacks passthruCallbacks, ipv6Support bool) *DataplanePassthru {
@@ -64,7 +60,6 @@ func NewDataplanePassthru(callbacks passthruCallbacks, ipv6Support bool) *Datapl
 		callbacks:   callbacks,
 		hostIPv4:    map[string]string{},
 		nodeInfo:    map[string]*HostInfo{},
-		lastEmitted: map[string]*HostInfo{},
 	}
 }
 
@@ -125,6 +120,7 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 // store it as a host CIDR (/32) so the format matches the Node-resource path.
 func (h *DataplanePassthru) processModelHostIP(key model.HostIPKey, update api.Update) {
 	hostname := key.Hostname
+	before := h.merge(hostname)
 	if update.Value == nil {
 		logrus.WithField("update", update).Debug("Passing-through HostIP deletion")
 		delete(h.hostIPv4, hostname)
@@ -133,15 +129,17 @@ func (h *DataplanePassthru) processModelHostIP(key model.HostIPKey, update api.U
 		logrus.WithField("update", update).Debug("Passing-through HostIP update")
 		h.hostIPv4[hostname] = ip.String() + "/32"
 	}
-	h.recomputeAndEmit(hostname)
+	h.emitTransition(hostname, before)
 }
 
 func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Update) {
 	hostname := key.Name
+	before := h.merge(hostname)
+
 	if update.Value == nil {
 		logrus.WithField("update", update).Debug("Passing-through Node remove")
 		delete(h.nodeInfo, hostname)
-		h.recomputeAndEmit(hostname)
+		h.emitTransition(hostname, before)
 		return
 	}
 
@@ -155,7 +153,7 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	bgpSpec := node.Spec.BGP
 	if bgpSpec != nil && bgpSpec.IPv4Address == "" && bgpSpec.IPv6Address == "" && bgpSpec.ASNumber == nil {
 		delete(h.nodeInfo, hostname)
-		h.recomputeAndEmit(hostname)
+		h.emitTransition(hostname, before)
 		return
 	}
 
@@ -198,30 +196,26 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	}
 
 	h.nodeInfo[hostname] = info
-	h.recomputeAndEmit(hostname)
+	h.emitTransition(hostname, before)
 }
 
-// recomputeAndEmit derives the merged HostInfo for hostname from the per-source
-// state and emits an Update or Remove only when the merged view differs from
-// what was last sent.
-func (h *DataplanePassthru) recomputeAndEmit(hostname string) {
-	merged := h.merge(hostname)
-	last, hadLast := h.lastEmitted[hostname]
-
-	if merged == nil {
-		if hadLast {
-			delete(h.lastEmitted, hostname)
+// emitTransition emits an Update or Remove based on how the merged view changed
+// for hostname. before is the merged HostInfo computed before the source maps
+// were mutated; the post-mutation view is recomputed here. Caller must invoke
+// this after every change so consecutive calls see consistent before/after
+// states.
+func (h *DataplanePassthru) emitTransition(hostname string, before *HostInfo) {
+	after := h.merge(hostname)
+	if after == nil {
+		if before != nil {
 			h.callbacks.OnHostMetadataRemove(hostname)
 		}
 		return
 	}
-
-	if hadLast && hostInfoEqual(merged, last) {
+	if before != nil && hostInfoEqual(before, after) {
 		return
 	}
-
-	h.lastEmitted[hostname] = merged
-	h.callbacks.OnHostMetadataUpdate(hostname, merged)
+	h.callbacks.OnHostMetadataUpdate(hostname, after)
 }
 
 // merge returns the HostInfo to publish for hostname, or nil if neither source

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -47,10 +47,12 @@ type DataplanePassthru struct {
 
 	// hostIPv4 is the /32 derived from a HostIPKey update, keyed by hostname.
 	hostIPv4 map[string]string
+
 	// nodeInfo is the per-host info derived from a Node resource. A non-nil entry
 	// means the Node resource currently exists for that host; nil/missing means it
 	// has been deleted (or was treated as deleted because its BGP spec was empty).
 	nodeInfo map[string]*HostInfo
+
 	// lastEmitted records the last HostInfo we sent for each host, so we can skip
 	// no-op updates and only emit when the merged view actually changed.
 	lastEmitted map[string]*HostInfo
@@ -150,26 +152,26 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	// Node had been deleted from this stream — there is no useful metadata to
 	// pass through. A nil BGP, by contrast, leaves the Node entry alive (with
 	// empty IPs) since other Node info such as labels may still be relevant.
-	if bgp := node.Spec.BGP; bgp != nil &&
-		bgp.IPv4Address == "" && bgp.IPv6Address == "" && bgp.ASNumber == nil {
+	bgpSpec := node.Spec.BGP
+	if bgpSpec != nil && bgpSpec.IPv4Address == "" && bgpSpec.IPv6Address == "" && bgpSpec.ASNumber == nil {
 		delete(h.nodeInfo, hostname)
 		h.recomputeAndEmit(hostname)
 		return
 	}
 
 	info := &HostInfo{labels: node.Labels}
-	if node.Spec.BGP != nil {
+	if bgpSpec != nil {
 		// BGP IPv4Address/IPv6Address must already be in CIDR form per the v3
 		// CRD validation (`cidrv4`/`cidrv6` tags). Bare IPs are dropped silently
 		// here so the dataplane never sees an ambiguous address.
-		if addr := node.Spec.BGP.IPv4Address; addr != "" {
+		if addr := bgpSpec.IPv4Address; addr != "" {
 			if s, ok := parseBGPCIDR(addr); ok {
 				info.ip4Addr = s
 			} else {
 				log.WithField("addr", addr).Warn("Ignoring Node BGP IPv4Address: not a CIDR")
 			}
 		}
-		if addr := node.Spec.BGP.IPv6Address; addr != "" {
+		if addr := bgpSpec.IPv6Address; addr != "" {
 			if s, ok := parseBGPCIDR(addr); ok {
 				info.ip6Addr = s
 			} else {
@@ -179,17 +181,19 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 		if node.Spec.BGP.ASNumber != nil {
 			info.asnumber = node.Spec.BGP.ASNumber.String()
 		}
-	} else if h.ipv6Support {
-		// BGP is turned off; fall back to the Node's address list for IPv6.
-		// Mirrors how HostIPKey is generated for IPv4 in
-		// libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go.
-		ipv6, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, 6)
-		if ipnet == nil {
-			ipv6, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, 6)
-		}
-		if ipnet != nil {
-			ipnet.IP = ipv6.IP
-			info.ip6Addr = ipnet.String()
+	} else { // node.Spec.BGP is nil
+		if h.ipv6Support {
+			// BGP is turned off; fall back to the Node's address list for IPv6.
+			// Mirrors how HostIPKey is generated for IPv4 in
+			// libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go.
+			ipv6, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, 6)
+			if ipnet == nil {
+				ipv6, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, 6)
+			}
+			if ipnet != nil {
+				ipnet.IP = ipv6.IP
+				info.ip6Addr = ipnet.String()
+			}
 		}
 	}
 

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -18,7 +18,7 @@ import (
 	"maps"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 
 	"github.com/projectcalico/calico/felix/dispatcher"
@@ -81,19 +81,19 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 		h.processModelHostIP(key, update)
 	case model.IPPoolKey:
 		if update.Value == nil {
-			log.WithField("update", update).Debug("Passing-through IPPool deletion")
+			logrus.WithField("update", update).Debug("Passing-through IPPool deletion")
 			h.callbacks.OnIPPoolRemove(key)
 		} else {
-			log.WithField("update", update).Debug("Passing-through IPPool update")
+			logrus.WithField("update", update).Debug("Passing-through IPPool update")
 			pool := update.Value.(*model.IPPool)
 			h.callbacks.OnIPPoolUpdate(key, pool)
 		}
 	case model.WireguardKey:
 		if update.Value == nil {
-			log.WithField("update", update).Debug("Passing-through Wireguard deletion")
+			logrus.WithField("update", update).Debug("Passing-through Wireguard deletion")
 			h.callbacks.OnWireguardRemove(key.NodeName)
 		} else {
-			log.WithField("update", update).Debug("Passing-through Wireguard update")
+			logrus.WithField("update", update).Debug("Passing-through Wireguard update")
 			wg := update.Value.(*model.Wireguard)
 			h.callbacks.OnWireguardUpdate(key.NodeName, wg)
 		}
@@ -101,12 +101,12 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 		switch key.Kind {
 		case v3.KindBGPConfiguration:
 			if key.Name == "default" {
-				log.WithField("update", update).Debug("Passing through global BGPConfiguration")
+				logrus.WithField("update", update).Debug("Passing through global BGPConfiguration")
 				bgpConfig, _ := update.Value.(*v3.BGPConfiguration)
 				h.callbacks.OnGlobalBGPConfigUpdate(bgpConfig)
 			}
 		case model.KindKubernetesService:
-			log.WithField("update", update).Debug("Passing through a Service")
+			logrus.WithField("update", update).Debug("Passing through a Service")
 			if update.Value == nil {
 				h.callbacks.OnServiceRemove(&proto.ServiceRemove{Name: key.Name, Namespace: key.Namespace})
 			} else {
@@ -115,7 +115,7 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 		case internalapi.KindNode:
 			h.processKindNode(key, update)
 		default:
-			log.WithField("key", key).Debugf("Ignoring v3 resource of kind %s", key.Kind)
+			logrus.WithField("key", key).Debugf("Ignoring v3 resource of kind %s", key.Kind)
 		}
 	}
 	return
@@ -126,11 +126,11 @@ func (h *DataplanePassthru) OnUpdate(update api.Update) (filterOut bool) {
 func (h *DataplanePassthru) processModelHostIP(key model.HostIPKey, update api.Update) {
 	hostname := key.Hostname
 	if update.Value == nil {
-		log.WithField("update", update).Debug("Passing-through HostIP deletion")
+		logrus.WithField("update", update).Debug("Passing-through HostIP deletion")
 		delete(h.hostIPv4, hostname)
 	} else {
 		ip := update.Value.(*net.IP)
-		log.WithField("update", update).Debug("Passing-through HostIP update")
+		logrus.WithField("update", update).Debug("Passing-through HostIP update")
 		h.hostIPv4[hostname] = ip.String() + "/32"
 	}
 	h.recomputeAndEmit(hostname)
@@ -139,14 +139,14 @@ func (h *DataplanePassthru) processModelHostIP(key model.HostIPKey, update api.U
 func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Update) {
 	hostname := key.Name
 	if update.Value == nil {
-		log.WithField("update", update).Debug("Passing-through Node remove")
+		logrus.WithField("update", update).Debug("Passing-through Node remove")
 		delete(h.nodeInfo, hostname)
 		h.recomputeAndEmit(hostname)
 		return
 	}
 
 	node, _ := update.Value.(*internalapi.Node)
-	log.WithField("update", update).Debug("Passing-through Node update")
+	logrus.WithField("update", update).Debug("Passing-through Node update")
 
 	// An explicitly-empty BGP spec (`BGP: &NodeBGPSpec{}`) is treated as if the
 	// Node had been deleted from this stream — there is no useful metadata to
@@ -168,14 +168,14 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 			if s, ok := parseBGPCIDR(addr); ok {
 				info.ip4Addr = s
 			} else {
-				log.WithField("addr", addr).Warn("Ignoring Node BGP IPv4Address: not a CIDR")
+				logrus.WithField("addr", addr).Warn("Ignoring Node BGP IPv4Address: not a CIDR")
 			}
 		}
 		if addr := bgpSpec.IPv6Address; addr != "" {
 			if s, ok := parseBGPCIDR(addr); ok {
 				info.ip6Addr = s
 			} else {
-				log.WithField("addr", addr).Warn("Ignoring Node BGP IPv6Address: not a CIDR")
+				logrus.WithField("addr", addr).Warn("Ignoring Node BGP IPv6Address: not a CIDR")
 			}
 		}
 		if node.Spec.BGP.ASNumber != nil {

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -15,8 +15,8 @@
 package calc
 
 import (
-	"strings"
 	"maps"
+	"strings"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -16,6 +16,7 @@ package calc
 
 import (
 	"strings"
+	"maps"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
@@ -121,6 +122,13 @@ type HostInfo struct {
 	ip6Addr  string
 	labels   map[string]string
 	asnumber string
+}
+
+func (h *HostInfo) equals(a *HostInfo) bool {
+	return h.ip4Addr == a.ip4Addr &&
+		h.ip6Addr == a.ip6Addr &&
+		h.asnumber == a.asnumber &&
+		maps.Equal(h.labels, a.labels)
 }
 
 type serviceID struct {

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,11 +74,7 @@ type EventSequencer struct {
 	pendingEncapUpdate           *config.Encapsulation
 	pendingEndpointUpdates       map[model.Key]endpointUpdate
 	pendingEndpointDeletes       set.Set[model.Key]
-	pendingHostIPUpdates         map[string]*net.IP
-	pendingHostIPDeletes         set.Set[string]
-	pendingHostIPv6Updates       map[string]*net.IP
-	pendingHostIPv6Deletes       set.Set[string]
-	pendingHostMetadataUpdates   map[string]*hostInfo
+	pendingHostMetadataUpdates   map[string]*HostInfo
 	pendingHostMetadataDeletes   set.Set[string]
 	pendingIPPoolUpdates         map[ip.CIDR]*model.IPPool
 	pendingIPPoolDeletes         set.Set[ip.CIDR]
@@ -120,9 +116,9 @@ type EventSequencer struct {
 	Callback EventHandler
 }
 
-type hostInfo struct {
-	ip4Addr  *net.IPNet
-	ip6Addr  *net.IPNet
+type HostInfo struct {
+	ip4Addr  string
+	ip6Addr  string
 	labels   map[string]string
 	asnumber string
 }
@@ -131,16 +127,6 @@ type serviceID struct {
 	Name      string
 	Namespace string
 }
-
-// func (buf *EventSequencer) HasPendingUpdates() {
-//	return buf.pendingAddedIPSets.Len() > 0 ||
-//		buf.pendingRemovedIPSets.Len() > 0 ||
-//		buf.pendingAddedIPSetMembers.Len() > 0 ||
-//		buf.pendingRemovedIPSetMembers.Len() > 0 ||
-//		len(buf.pendingPolicyUpdates) > 0 ||
-//		buf.pendingPolicyDeletes.Len() > 0 ||
-//
-// }
 
 func NewEventSequencer(conf configInterface) *EventSequencer {
 	buf := &EventSequencer{
@@ -156,11 +142,7 @@ func NewEventSequencer(conf configInterface) *EventSequencer {
 		pendingProfileDeletes:        set.New[model.ProfileRulesKey](),
 		pendingEndpointUpdates:       map[model.Key]endpointUpdate{},
 		pendingEndpointDeletes:       set.New[model.Key](),
-		pendingHostIPUpdates:         map[string]*net.IP{},
-		pendingHostIPDeletes:         set.New[string](),
-		pendingHostIPv6Updates:       map[string]*net.IP{},
-		pendingHostIPv6Deletes:       set.New[string](),
-		pendingHostMetadataUpdates:   map[string]*hostInfo{},
+		pendingHostMetadataUpdates:   map[string]*HostInfo{},
 		pendingHostMetadataDeletes:   set.New[string](),
 		pendingIPPoolUpdates:         map[ip.CIDR]*model.IPPool{},
 		pendingIPPoolDeletes:         set.New[ip.CIDR](),
@@ -621,115 +603,21 @@ func (buf *EventSequencer) flushEncapUpdate() {
 	}
 }
 
-func (buf *EventSequencer) OnHostIPUpdate(hostname string, ip *net.IP) {
+func (buf *EventSequencer) OnHostMetadataUpdate(hostname string, info *HostInfo) {
 	log.WithFields(log.Fields{
 		"hostname": hostname,
-		"ip":       ip,
-	}).Debug("HostIP update")
-	buf.pendingHostIPDeletes.Discard(hostname)
-	buf.pendingHostIPUpdates[hostname] = ip
-}
-
-func (buf *EventSequencer) flushHostIPUpdates() {
-	for hostname, hostIP := range buf.pendingHostIPUpdates {
-		hostAddr := ""
-		if hostIP != nil {
-			hostAddr = hostIP.String()
-		}
-		buf.Callback(&proto.HostMetadataUpdate{
-			Hostname: hostname,
-			Ipv4Addr: hostAddr,
-		})
-		buf.sentHostIPs.Add(hostname)
-		delete(buf.pendingHostIPUpdates, hostname)
-	}
-}
-
-func (buf *EventSequencer) OnHostIPRemove(hostname string) {
-	log.WithField("hostname", hostname).Debug("HostIP removed")
-	delete(buf.pendingHostIPUpdates, hostname)
-	if buf.sentHostIPs.Contains(hostname) {
-		buf.pendingHostIPDeletes.Add(hostname)
-	}
-}
-
-func (buf *EventSequencer) flushHostIPDeletes() {
-	for item := range buf.pendingHostIPDeletes.All() {
-		buf.Callback(&proto.HostMetadataRemove{
-			Hostname: item,
-		})
-		buf.sentHostIPs.Discard(item)
-		buf.pendingHostIPDeletes.Discard(item)
-	}
-}
-
-func (buf *EventSequencer) OnHostIPv6Update(hostname string, ip *net.IP) {
-	log.WithFields(log.Fields{
-		"hostname": hostname,
-		"ip":       ip,
-	}).Debug("Host IPv6 update")
-	buf.pendingHostIPv6Deletes.Discard(hostname)
-	buf.pendingHostIPv6Updates[hostname] = ip
-}
-
-func (buf *EventSequencer) flushHostIPv6Updates() {
-	for hostname, hostIP := range buf.pendingHostIPv6Updates {
-		hostIPv6Addr := ""
-		if hostIP != nil {
-			hostIPv6Addr = hostIP.String()
-		}
-		buf.Callback(&proto.HostMetadataV6Update{
-			Hostname: hostname,
-			Ipv6Addr: hostIPv6Addr,
-		})
-		buf.sentHostIPv6s.Add(hostname)
-		delete(buf.pendingHostIPv6Updates, hostname)
-	}
-}
-
-func (buf *EventSequencer) OnHostIPv6Remove(hostname string) {
-	log.WithField("hostname", hostname).Debug("Host IPv6 removed")
-	delete(buf.pendingHostIPv6Updates, hostname)
-	if buf.sentHostIPv6s.Contains(hostname) {
-		buf.pendingHostIPv6Deletes.Add(hostname)
-	}
-}
-
-func (buf *EventSequencer) flushHostIPv6Deletes() {
-	for item := range buf.pendingHostIPv6Deletes.All() {
-		buf.Callback(&proto.HostMetadataV6Remove{
-			Hostname: item,
-		})
-		buf.sentHostIPv6s.Discard(item)
-		buf.pendingHostIPv6Deletes.Discard(item)
-	}
-}
-
-func (buf *EventSequencer) OnHostMetadataUpdate(hostname string, ip4 *net.IPNet, ip6 *net.IPNet, asnumber string, labels map[string]string) {
-	log.WithFields(log.Fields{
-		"hostname": hostname,
-		"ip4":      ip4,
-		"ip6":      ip6,
-		"labels":   labels,
-		"asnumber": asnumber,
+		"update":   info,
 	}).Debug("Host update")
 	buf.pendingHostMetadataDeletes.Discard(hostname)
-	buf.pendingHostMetadataUpdates[hostname] = &hostInfo{ip4Addr: ip4, ip6Addr: ip6, labels: labels, asnumber: asnumber}
+	buf.pendingHostMetadataUpdates[hostname] = info
 }
 
 func (buf *EventSequencer) flushHostUpdates() {
 	for hostname, hostInfo := range buf.pendingHostMetadataUpdates {
-		var ip4str, ip6str string
-		if hostInfo.ip4Addr.IP != nil {
-			ip4str = hostInfo.ip4Addr.String()
-		}
-		if hostInfo.ip6Addr.IP != nil {
-			ip6str = hostInfo.ip6Addr.String()
-		}
 		buf.Callback(&proto.HostMetadataV4V6Update{
 			Hostname: hostname,
-			Ipv4Addr: ip4str,
-			Ipv6Addr: ip6str,
+			Ipv4Addr: hostInfo.ip4Addr,
+			Ipv6Addr: hostInfo.ip6Addr,
 			Asnumber: hostInfo.asnumber,
 			Labels:   hostInfo.labels,
 		})
@@ -926,10 +814,6 @@ func (buf *EventSequencer) Flush() {
 	// as well do deletions first to minimise occupancy.
 	buf.flushHostWireguardDeletes()
 	buf.flushHostWireguardUpdates()
-	buf.flushHostIPDeletes()
-	buf.flushHostIPUpdates()
-	buf.flushHostIPv6Deletes()
-	buf.flushHostIPv6Updates()
 	buf.flushHostDeletes()
 	buf.flushHostUpdates()
 	buf.flushIPPoolDeletes()

--- a/felix/calc/profile_decoder_test.go
+++ b/felix/calc/profile_decoder_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018,2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 var _ = Describe("profileDecoder", func() {
@@ -138,23 +137,7 @@ type passthruCallbackRecorder struct {
 	nsRemoves []types.NamespaceID
 }
 
-func (p *passthruCallbackRecorder) OnHostIPUpdate(hostname string, ip *net.IP) {
-	Fail("HostIPUpdate received")
-}
-
-func (p *passthruCallbackRecorder) OnHostIPRemove(hostname string) {
-	Fail("HostIPRemove received")
-}
-
-func (p *passthruCallbackRecorder) OnHostIPv6Update(hostname string, ip *net.IP) {
-	Fail("HostIPv6Update received")
-}
-
-func (p *passthruCallbackRecorder) OnHostIPv6Remove(hostname string) {
-	Fail("HostIPv6Remove received")
-}
-
-func (p *passthruCallbackRecorder) OnHostMetadataUpdate(hostname string, ip4 *net.IPNet, ip6 *net.IPNet, asnumber string, labels map[string]string) {
+func (p *passthruCallbackRecorder) OnHostMetadataUpdate(hostname string, info *calc.HostInfo) {
 	Fail("HostUpdate received")
 }
 

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -1639,6 +1639,11 @@ var vxlanWithWEPIPs = empty.withKVUpdates(
 	routeUpdateRemoteHost2,
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname2,
+		Ipv4Addr: remoteHost2IP.String() + "/32",
+	},
 )
 
 // Adds in an workload on remoteHost2 and expected route.
@@ -1689,6 +1694,15 @@ var vxlanWithWEPIPsAndWEPDuplicate = vxlanWithWEPIPsAndWEP.withKVUpdates(
 		DstNodeIp:   remoteHostIP.String(),
 		NatOutgoing: true,
 	},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname2,
+		Ipv4Addr: remoteHost2IP.String() + "/32",
+	},
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
 )
 
 // Minimal VXLAN set-up using Calico IPAM, all the data needed for a remote VTEP, a pool and a block.
@@ -1707,7 +1721,12 @@ var vxlanWithBlock = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
-).withRoutes(vxlanWithBlockRoutes...)
+).withRoutes(vxlanWithBlockRoutes...).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
+)
 
 var vxlanWithBlockRoutes = []types.RouteUpdate{
 	routeUpdateIPPoolVXLAN,
@@ -1731,11 +1750,25 @@ var (
 // As vxlanWithBlock but with a host sharing the same IP.  No route update because we tie-break on host name.
 var vxlanWithBlockDupNodeIP = vxlanWithBlock.withKVUpdates(
 	KVPair{Key: remoteHost2IPKey, Value: &remoteHostIP},
-).withName("VXLAN with dup node IP")
+).withName("VXLAN with dup node IP").withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname2,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
+)
 
 var vxlanWithDupNodeIPRemoved = vxlanWithBlockDupNodeIP.withKVUpdates(
 	KVPair{Key: remoteHostIPKey, Value: nil},
-).withName("VXLAN with dup node IP removed").withVTEPs().withRoutes(
+).withName("VXLAN with dup node IP removed").withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname2,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
+).withVTEPs().withRoutes(
 	routeUpdateIPPoolVXLAN,
 	// Remote host 2 but with remotehost's IP:
 	types.RouteUpdate{
@@ -1849,6 +1882,15 @@ var vxlanWithBlockAndBorrows = vxlanWithBlock.withKVUpdates(
 		NatOutgoing: true,
 		Borrowed:    true,
 	},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname2,
+		Ipv4Addr: remoteHost2IP.String() + "/32",
+	},
 )
 
 // vxlanWithBlock but with a different tunnel IP.
@@ -1892,6 +1934,11 @@ var vxlanWithBlockAndDifferentNodeIP = vxlanWithBlock.withKVUpdates(
 		DstNodeName: remoteHostname,
 		DstNodeIp:   remoteHost2IP.String(),
 		NatOutgoing: true,
+	},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHost2IP.String() + "/32",
 	},
 )
 
@@ -1978,6 +2025,15 @@ var vxlanLocalBlockWithBorrows = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: localHostname,
+		Ipv4Addr: localHostIP.String() + "/32",
+	},
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
 )
 
 var localVXLANWep1Route1 = types.RouteUpdate{
@@ -2167,7 +2223,12 @@ var vxlanLocalBlockWithBorrowsDifferentSubnetNodeRes = vxlanLocalBlockWithBorrow
 // vxlanWithBlockAndBorrows but missing the VTEP information for the first host.
 var vxlanWithBlockAndBorrowsAndMissingFirstVTEP = vxlanWithBlockAndBorrows.withKVUpdates(
 	KVPair{Key: remoteHostIPKey, Value: nil},
-).withName("VXLAN borrow missing VTEP").withVTEPs(
+).withName("VXLAN borrow missing VTEP").withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname2,
+		Ipv4Addr: remoteHost2IP.String() + "/32",
+	},
+).withVTEPs(
 	types.VXLANTunnelEndpointUpdate{
 		Node:           remoteHostname2,
 		Mac:            "66:40:18:59:1f:16",
@@ -2232,7 +2293,7 @@ var vxlanBlockDelete = vxlanWithBlock.withKVUpdates(
 
 var vxlanHostIPDelete = vxlanWithBlock.withKVUpdates(
 	KVPair{Key: remoteHostIPKey, Value: nil},
-).withName("VXLAN host IP removed").withRoutes(
+).withName("VXLAN host IP removed").withHostMetadataV4V6().withRoutes(
 	routeUpdateIPPoolVXLAN,
 	// Host removed but keep the route without the node IP.
 	types.RouteUpdate{
@@ -2277,6 +2338,11 @@ var vxlanSlash32 = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
 )
 
 var vxlanSlash32NoBlock = empty.withKVUpdates(
@@ -2296,6 +2362,11 @@ var vxlanSlash32NoBlock = empty.withKVUpdates(
 	routeUpdateRemoteHost,
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
+	},
 )
 
 var vxlanSlash32NoPool = empty.withKVUpdates(
@@ -2319,6 +2390,11 @@ var vxlanSlash32NoPool = empty.withKVUpdates(
 		Dst:         "10.0.0.0/32",
 		DstNodeName: remoteHostname,
 		DstNodeIp:   remoteHostIP.String(),
+	},
+).withHostMetadataV4V6(
+	&proto.HostMetadataV4V6Update{
+		Hostname: remoteHostname,
+		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
 )
 

--- a/felix/dataplane/external/ext_dataplane.go
+++ b/felix/dataplane/external/ext_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -202,14 +202,6 @@ func WrapPayloadWithEnvelope(msg any, seqNo uint64) (*proto.ToDataplane, error) 
 		envelope.Payload = &proto.ToDataplane_WorkloadEndpointUpdate{WorkloadEndpointUpdate: msg}
 	case *proto.WorkloadEndpointRemove:
 		envelope.Payload = &proto.ToDataplane_WorkloadEndpointRemove{WorkloadEndpointRemove: msg}
-	case *proto.HostMetadataUpdate:
-		envelope.Payload = &proto.ToDataplane_HostMetadataUpdate{HostMetadataUpdate: msg}
-	case *proto.HostMetadataRemove:
-		envelope.Payload = &proto.ToDataplane_HostMetadataRemove{HostMetadataRemove: msg}
-	case *proto.HostMetadataV6Update:
-		envelope.Payload = &proto.ToDataplane_HostMetadataV6Update{HostMetadataV6Update: msg}
-	case *proto.HostMetadataV6Remove:
-		envelope.Payload = &proto.ToDataplane_HostMetadataV6Remove{HostMetadataV6Remove: msg}
 	case *proto.HostMetadataV4V6Update:
 		envelope.Payload = &proto.ToDataplane_HostMetadataV4V6Update{HostMetadataV4V6Update: msg}
 	case *proto.HostMetadataV4V6Remove:

--- a/felix/dataplane/external/ext_dataplane.go
+++ b/felix/dataplane/external/ext_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -943,16 +943,6 @@ func (m *bpfEndpointManager) OnUpdate(msg any) {
 	case *proto.ActiveProfileRemove:
 		m.onProfileRemove(msg)
 
-	case *proto.HostMetadataUpdate:
-		if m.v4 != nil && msg.Hostname == m.hostname {
-			logrus.WithField("HostMetadataUpdate", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
-			m.updateHostIP(msg.Ipv4Addr, 4)
-		}
-	case *proto.HostMetadataV6Update:
-		if m.v6 != nil && msg.Hostname == m.hostname {
-			logrus.WithField("HostMetadataV6Update", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
-			m.updateHostIP(msg.Ipv6Addr, 6)
-		}
 	case *proto.HostMetadataV4V6Update:
 		if msg.Hostname != m.hostname {
 			break

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -662,7 +662,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 
 	genHostMetadataUpdate := func(ip string) func() {
 		return func() {
-			bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{
+			bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 				Hostname: "uthost",
 				Ipv4Addr: ip,
 			})
@@ -673,7 +673,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 
 	genHostMetadataV6Update := func(ip string) func() {
 		return func() {
-			bpfEpMgr.OnUpdate(&proto.HostMetadataV6Update{
+			bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 				Hostname: "uthost",
 				Ipv6Addr: ip,
 			})

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/dataplane/linux/ipip_mgr.go
+++ b/felix/dataplane/linux/ipip_mgr.go
@@ -122,15 +122,15 @@ func newIPIPManagerWithShims(
 
 func (m *ipipManager) OnUpdate(protoBufMsg any) {
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataUpdate:
+	case *proto.HostMetadataV4V6Update:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		if msg.Hostname == m.hostname {
+		if msg.Hostname == m.hostname && msg.Ipv4Addr != "" {
 			m.routeMgr.updateParentIfaceAddr(msg.Ipv4Addr)
 		} else {
 			m.activeHostnameToIP[msg.Hostname] = msg.Ipv4Addr
 		}
 		m.maybeUpdateRoutes()
-	case *proto.HostMetadataRemove:
+	case *proto.HostMetadataV4V6Remove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
 		if msg.Hostname == m.hostname {
 			m.routeMgr.updateParentIfaceAddr("")
@@ -171,7 +171,7 @@ func (m *ipipManager) tunnelRoute(cidr ip.CIDR, r *proto.RouteUpdate) *routetabl
 		RouteKey: routetable.RouteKey{
 			CIDR: cidr,
 		},
-		GW:       ip.FromString(remoteAddr),
+		GW:       ip.FromIPOrCIDRString(remoteAddr),
 		Protocol: m.routeProtocol,
 		MTU:      m.dpConfig.IPIPMTU,
 	}

--- a/felix/dataplane/linux/ipip_mgr.go
+++ b/felix/dataplane/linux/ipip_mgr.go
@@ -124,8 +124,14 @@ func (m *ipipManager) OnUpdate(protoBufMsg any) {
 	switch msg := protoBufMsg.(type) {
 	case *proto.HostMetadataV4V6Update:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		if msg.Hostname == m.hostname && msg.Ipv4Addr != "" {
+		if msg.Hostname == m.hostname {
 			m.routeMgr.updateParentIfaceAddr(msg.Ipv4Addr)
+		}
+		// An empty Ipv4Addr means the host has no v4 BGP/host IP (e.g. its BGP
+		// spec was cleared). Drop the map entry so tunnelRoute won't try to
+		// install onlink routes via a nil gateway.
+		if msg.Ipv4Addr == "" {
+			delete(m.activeHostnameToIP, msg.Hostname)
 		} else {
 			m.activeHostnameToIP[msg.Hostname] = msg.Ipv4Addr
 		}

--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -73,7 +73,7 @@ var _ = Describe("IPIPManager", func() {
 	})
 
 	It("should configure tunnel properly", func() {
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
@@ -133,11 +133,11 @@ var _ = Describe("IPIPManager", func() {
 	})
 
 	It("successfully adds a route to the noEncap interface", func() {
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -215,7 +215,7 @@ var _ = Describe("IPIPManager", func() {
 		go ipipMgr.keepIPIPDeviceInSync(ctx, 1400, false, 1*time.Second, dataDeviceC)
 
 		By("Sending another node's route.")
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv4Addr: "10.0.0.2",
 		})
@@ -235,7 +235,7 @@ var _ = Describe("IPIPManager", func() {
 		Expect(rt.currentRoutes[dataplanedefs.IPIPIfaceName]).To(HaveLen(1))
 
 		By("Sending another local node update.")
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
@@ -260,11 +260,11 @@ var _ = Describe("IPIPManager", func() {
 
 	It("should program routes for remote endpoints with borrowed IP addresses", func() {
 		By("Sending host updates")
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -307,11 +307,11 @@ var _ = Describe("IPIPManager", func() {
 	})
 
 	It("should only program black hole routes for local endpoints", func() {
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -368,11 +368,11 @@ var _ = Describe("IPIPManager", func() {
 
 	It("should program routes for remote tunnel endpoint", func() {
 		By("Sending host updates")
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
+		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Masquerade manager", func() {
 		})
 		It("an unrelated update shouldn't trigger work", func() {
 			natTable.UpdateCalled = false
-			masqMgr.OnUpdate(&proto.HostMetadataUpdate{
+			masqMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 				Hostname: "foo",
 				Ipv4Addr: "10.0.0.17",
 			})

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -91,24 +91,19 @@ func newNoEncapManagerWithSims(
 
 func (m *noEncapManager) OnUpdate(protoBufMsg any) {
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataUpdate:
+	case *proto.HostMetadataV4V6Update:
+		if msg.Hostname != m.hostname {
+			break
+		}
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		if msg.Hostname == m.hostname && m.ipVersion == 4 {
+		if m.ipVersion == 4 && msg.Ipv4Addr != "" {
 			m.routesNeedUpdate(msg.Ipv4Addr)
-		}
-	case *proto.HostMetadataRemove:
-		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
-		if msg.Hostname == m.hostname && m.ipVersion == 4 {
-			m.routesNeedUpdate("")
-		}
-	case *proto.HostMetadataV6Update:
-		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		if msg.Hostname == m.hostname && m.ipVersion == 6 {
+		} else if m.ipVersion == 6 && msg.Ipv6Addr != "" {
 			m.routesNeedUpdate(msg.Ipv6Addr)
 		}
-	case *proto.HostMetadataV6Remove:
+	case *proto.HostMetadataV4V6Remove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
-		if msg.Hostname == m.hostname && m.ipVersion == 6 {
+		if msg.Hostname == m.hostname {
 			m.routesNeedUpdate("")
 		}
 	default:

--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -96,11 +96,20 @@ func (m *noEncapManager) OnUpdate(protoBufMsg any) {
 			break
 		}
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		if m.ipVersion == 4 && msg.Ipv4Addr != "" {
-			m.routesNeedUpdate(msg.Ipv4Addr)
-		} else if m.ipVersion == 6 && msg.Ipv6Addr != "" {
-			m.routesNeedUpdate(msg.Ipv6Addr)
+		var addrStr string
+		if m.ipVersion == 4 {
+			addrStr = msg.Ipv4Addr
+		} else {
+			addrStr = msg.Ipv6Addr
 		}
+		if addrStr == "" {
+			m.logCtx.WithFields(logrus.Fields{
+				"hostname":  msg.Hostname,
+				"ipVersion": m.ipVersion,
+			}).Debug("Ignoring HostMetadataV4V6Update with no address for this IP version")
+			return
+		}
+		m.routesNeedUpdate(addrStr)
 	case *proto.HostMetadataV4V6Remove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
 		if msg.Hostname == m.hostname {

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -76,11 +76,11 @@ var _ = Describe("NoEncap Manager", func() {
 	})
 
 	It("successfully adds a route to the noEncap interface", func() {
-		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
+		noencapMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
+		noencapMgr.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -162,11 +162,11 @@ var _ = Describe("NoEncap Manager", func() {
 	})
 
 	It("successfully adds a IPv6 route to the noEncap interface", func() {
-		noencapMgrV6.OnUpdate(&proto.HostMetadataV6Update{
+		noencapMgrV6.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node1",
 			Ipv6Addr: "fc00:10:96::2",
 		})
-		noencapMgrV6.OnUpdate(&proto.HostMetadataV6Update{
+		noencapMgrV6.OnUpdate(&proto.HostMetadataV4V6Update{
 			Hostname: "node2",
 			Ipv6Addr: "fc00:10:10::1",
 		})

--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -436,9 +436,9 @@ func (m *routeManager) detectParentIface() (netlink.Link, error) {
 
 	// Keep only the address, and remove subnet mask part if there is any.
 	parts := strings.Split(parentAddr, "/")
-	normaliasedAddr := parts[0]
+	normalisedAddr := parts[0]
 
-	m.logCtx.WithField("address", normaliasedAddr).Debug("Getting parent interface")
+	m.logCtx.WithField("address", normalisedAddr).Debug("Getting parent interface")
 	links, err := m.nlHandle.LinkList()
 	if err != nil {
 		return nil, err
@@ -456,13 +456,13 @@ func (m *routeManager) detectParentIface() (netlink.Link, error) {
 		}
 		for _, addr := range addrs {
 			// Match address with or without subnet mask
-			if addr.IP.String() == normaliasedAddr {
+			if addr.IP.String() == normalisedAddr {
 				m.logCtx.Debugf("Found parent interface: %+v", link)
 				return link, nil
 			}
 		}
 	}
-	return nil, fmt.Errorf("unable to find parent interface with address %s", normaliasedAddr)
+	return nil, fmt.Errorf("unable to find parent interface with address %s", normalisedAddr)
 }
 
 // KeepDeviceInSync runs in a loop and checks that the device is still correctly configured, and updates it if necessary.

--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -434,7 +434,11 @@ func (m *routeManager) detectParentIface() (netlink.Link, error) {
 		return nil, fmt.Errorf("parent interface not yet known")
 	}
 
-	m.logCtx.WithField("address", parentAddr).Debug("Getting parent interface")
+	// Keep only the address, and remove subnet mask part if there is any.
+	parts := strings.Split(parentAddr, "/")
+	normaliasedAddr := parts[0]
+
+	m.logCtx.WithField("address", normaliasedAddr).Debug("Getting parent interface")
 	links, err := m.nlHandle.LinkList()
 	if err != nil {
 		return nil, err
@@ -452,13 +456,13 @@ func (m *routeManager) detectParentIface() (netlink.Link, error) {
 		}
 		for _, addr := range addrs {
 			// Match address with or without subnet mask
-			if addr.IP.String() == parentAddr || addr.IPNet.String() == parentAddr {
+			if addr.IP.String() == normaliasedAddr {
 				m.logCtx.Debugf("Found parent interface: %+v", link)
 				return link, nil
 			}
 		}
 	}
-	return nil, fmt.Errorf("unable to find parent interface with address %s", parentAddr)
+	return nil, fmt.Errorf("unable to find parent interface with address %s", normaliasedAddr)
 }
 
 // KeepDeviceInSync runs in a loop and checks that the device is still correctly configured, and updates it if necessary.

--- a/felix/dataplane/linux/wireguard_mgr.go
+++ b/felix/dataplane/linux/wireguard_mgr.go
@@ -15,7 +15,7 @@
 package intdataplane
 
 import (
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/projectcalico/calico/felix/ip"
@@ -50,7 +50,7 @@ func newWireguardManager(
 	ipVersion uint8,
 ) *wireguardManager {
 	if ipVersion != 4 && ipVersion != 6 {
-		log.Panicf("Unknown IP version: %d", ipVersion)
+		logrus.Panicf("Unknown IP version: %d", ipVersion)
 	}
 	return &wireguardManager{
 		wireguardRouteTable: wireguardRouteTable,
@@ -60,16 +60,34 @@ func newWireguardManager(
 }
 
 func (m *wireguardManager) OnUpdate(protoBufMsg any) {
-	logCtx := log.WithField("ipVersion", m.ipVersion)
+	logCtx := logrus.WithField("ipVersion", m.ipVersion)
 	logCtx.WithField("msg", protoBufMsg).Debug("Received message")
 	switch msg := protoBufMsg.(type) {
 	case *proto.HostMetadataV4V6Update:
 		logCtx.WithField("msg", msg).Debug("HostMetadataV4V6Update update")
+		var addrStr string
 		if m.ipVersion == 4 {
-			m.wireguardRouteTable.EndpointUpdate(msg.Hostname, ip.FromIPOrCIDRString(msg.Ipv4Addr))
+			addrStr = msg.Ipv4Addr
 		} else {
-			m.wireguardRouteTable.EndpointUpdate(msg.Hostname, ip.FromIPOrCIDRString(msg.Ipv6Addr))
+			addrStr = msg.Ipv6Addr
 		}
+		if addrStr == "" {
+			logCtx.WithFields(logrus.Fields{
+				"hostname":  msg.Hostname,
+				"ipVersion": m.ipVersion,
+			}).Debug("Ignoring HostMetadataV4V6Update with no address for this IP version")
+			return
+		}
+		addr := ip.FromIPOrCIDRString(addrStr)
+		if addr == nil || addr.Version() != m.ipVersion {
+			logCtx.WithFields(logrus.Fields{
+				"hostname":  msg.Hostname,
+				"address":   addrStr,
+				"ipVersion": m.ipVersion,
+			}).Warn("Ignoring HostMetadataV4V6Update with invalid or mismatched address for this IP version")
+			return
+		}
+		m.wireguardRouteTable.EndpointUpdate(msg.Hostname, addr)
 	case *proto.HostMetadataV4V6Remove:
 		logCtx.WithField("msg", msg).Debug("HostMetadataV4V6Remove update")
 		m.wireguardRouteTable.EndpointRemove(msg.Hostname)

--- a/felix/dataplane/linux/wireguard_mgr.go
+++ b/felix/dataplane/linux/wireguard_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,33 +63,15 @@ func (m *wireguardManager) OnUpdate(protoBufMsg any) {
 	logCtx := log.WithField("ipVersion", m.ipVersion)
 	logCtx.WithField("msg", protoBufMsg).Debug("Received message")
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataUpdate:
-		logCtx.WithField("msg", msg).Debug("HostMetadataUpdate update")
-		if m.ipVersion != 4 {
-			logCtx.WithField("hostname", msg.Hostname).Debug("ignore update for mismatched IP version")
-			return
+	case *proto.HostMetadataV4V6Update:
+		logCtx.WithField("msg", msg).Debug("HostMetadataV4V6Update update")
+		if m.ipVersion == 4 {
+			m.wireguardRouteTable.EndpointUpdate(msg.Hostname, ip.FromIPOrCIDRString(msg.Ipv4Addr))
+		} else {
+			m.wireguardRouteTable.EndpointUpdate(msg.Hostname, ip.FromIPOrCIDRString(msg.Ipv6Addr))
 		}
-		m.wireguardRouteTable.EndpointUpdate(msg.Hostname, ip.FromString(msg.Ipv4Addr))
-	case *proto.HostMetadataRemove:
-		logCtx.WithField("msg", msg).Debug("HostMetadataRemove update")
-		if m.ipVersion != 4 {
-			logCtx.WithField("hostname", msg.Hostname).Debug("ignore update for mismatched IP version")
-			return
-		}
-		m.wireguardRouteTable.EndpointRemove(msg.Hostname)
-	case *proto.HostMetadataV6Update:
-		logCtx.WithField("msg", msg).Debug("HostMetadataV6Update update")
-		if m.ipVersion != 6 {
-			logCtx.WithField("hostname", msg.Hostname).Debug("ignore update for mismatched IP version")
-			return
-		}
-		m.wireguardRouteTable.EndpointUpdate(msg.Hostname, ip.FromString(msg.Ipv6Addr))
-	case *proto.HostMetadataV6Remove:
-		if m.ipVersion != 6 {
-			logCtx.WithField("hostname", msg.Hostname).Debug("ignore update for mismatched IP version")
-			return
-		}
-		logCtx.WithField("msg", msg).Debug("HostMetadataV6Remove update")
+	case *proto.HostMetadataV4V6Remove:
+		logCtx.WithField("msg", msg).Debug("HostMetadataV4V6Remove update")
 		m.wireguardRouteTable.EndpointRemove(msg.Hostname)
 	case *proto.RouteUpdate:
 		logCtx.WithField("msg", msg).Debug("RouteUpdate update")

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -378,7 +378,7 @@ func (x Statistic_Direction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Statistic_Direction.Descriptor instead.
 func (Statistic_Direction) EnumDescriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{69, 0}
+	return file_felixbackend_proto_rawDescGZIP(), []int{65, 0}
 }
 
 // Whether the data is relative. ABSOLUTE data gives the total for the flow
@@ -427,7 +427,7 @@ func (x Statistic_Relativity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Statistic_Relativity.Descriptor instead.
 func (Statistic_Relativity) EnumDescriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{69, 1}
+	return file_felixbackend_proto_rawDescGZIP(), []int{65, 1}
 }
 
 // Kind indicates what this statistic is about.
@@ -474,7 +474,7 @@ func (x Statistic_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Statistic_Kind.Descriptor instead.
 func (Statistic_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{69, 2}
+	return file_felixbackend_proto_rawDescGZIP(), []int{65, 2}
 }
 
 // Whether the rule appears in INBOUND or OUTBOUND rules for the policy /
@@ -522,7 +522,7 @@ func (x RuleTrace_Direction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RuleTrace_Direction.Descriptor instead.
 func (RuleTrace_Direction) EnumDescriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{70, 0}
+	return file_felixbackend_proto_rawDescGZIP(), []int{66, 0}
 }
 
 type SyncRequest struct {
@@ -581,8 +581,6 @@ type ToDataplane struct {
 	//	*ToDataplane_WorkloadEndpointUpdate
 	//	*ToDataplane_WorkloadEndpointRemove
 	//	*ToDataplane_ConfigUpdate
-	//	*ToDataplane_HostMetadataUpdate
-	//	*ToDataplane_HostMetadataRemove
 	//	*ToDataplane_HostMetadataV4V6Update
 	//	*ToDataplane_HostMetadataV4V6Remove
 	//	*ToDataplane_IpamPoolUpdate
@@ -603,8 +601,6 @@ type ToDataplane struct {
 	//	*ToDataplane_ServiceRemove
 	//	*ToDataplane_WireguardEndpointV6Update
 	//	*ToDataplane_WireguardEndpointV6Remove
-	//	*ToDataplane_HostMetadataV6Update
-	//	*ToDataplane_HostMetadataV6Remove
 	Payload       isToDataplane_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -766,24 +762,6 @@ func (x *ToDataplane) GetConfigUpdate() *ConfigUpdate {
 	if x != nil {
 		if x, ok := x.Payload.(*ToDataplane_ConfigUpdate); ok {
 			return x.ConfigUpdate
-		}
-	}
-	return nil
-}
-
-func (x *ToDataplane) GetHostMetadataUpdate() *HostMetadataUpdate {
-	if x != nil {
-		if x, ok := x.Payload.(*ToDataplane_HostMetadataUpdate); ok {
-			return x.HostMetadataUpdate
-		}
-	}
-	return nil
-}
-
-func (x *ToDataplane) GetHostMetadataRemove() *HostMetadataRemove {
-	if x != nil {
-		if x, ok := x.Payload.(*ToDataplane_HostMetadataRemove); ok {
-			return x.HostMetadataRemove
 		}
 	}
 	return nil
@@ -969,24 +947,6 @@ func (x *ToDataplane) GetWireguardEndpointV6Remove() *WireguardEndpointV6Remove 
 	return nil
 }
 
-func (x *ToDataplane) GetHostMetadataV6Update() *HostMetadataV6Update {
-	if x != nil {
-		if x, ok := x.Payload.(*ToDataplane_HostMetadataV6Update); ok {
-			return x.HostMetadataV6Update
-		}
-	}
-	return nil
-}
-
-func (x *ToDataplane) GetHostMetadataV6Remove() *HostMetadataV6Remove {
-	if x != nil {
-		if x, ok := x.Payload.(*ToDataplane_HostMetadataV6Remove); ok {
-			return x.HostMetadataV6Remove
-		}
-	}
-	return nil
-}
-
 type isToDataplane_Payload interface {
 	isToDataplane_Payload()
 }
@@ -1065,25 +1025,14 @@ type ToDataplane_ConfigUpdate struct {
 	ConfigUpdate *ConfigUpdate `protobuf:"bytes,13,opt,name=config_update,json=configUpdate,proto3,oneof"`
 }
 
-type ToDataplane_HostMetadataUpdate struct {
-	// HostMetadataUpdate is sent when a host IP is added or updated.  I.e. the
-	// IP used for BGP peering/IPIP.
-	HostMetadataUpdate *HostMetadataUpdate `protobuf:"bytes,14,opt,name=host_metadata_update,json=hostMetadataUpdate,proto3,oneof"`
-}
-
-type ToDataplane_HostMetadataRemove struct {
-	// HostIPRemove is sent when a host IP is removed.
-	HostMetadataRemove *HostMetadataRemove `protobuf:"bytes,18,opt,name=host_metadata_remove,json=hostMetadataRemove,proto3,oneof"`
-}
-
 type ToDataplane_HostMetadataV4V6Update struct {
 	// HostMetadataV4V6Update is sent when a host is added or updated.
-	HostMetadataV4V6Update *HostMetadataV4V6Update `protobuf:"bytes,37,opt,name=host_metadata_v4v6_update,json=hostMetadataV4v6Update,proto3,oneof"`
+	HostMetadataV4V6Update *HostMetadataV4V6Update `protobuf:"bytes,14,opt,name=host_metadata_v4v6_update,json=hostMetadataV4v6Update,proto3,oneof"`
 }
 
 type ToDataplane_HostMetadataV4V6Remove struct {
 	// HostIPRemove is sent when a host is removed.
-	HostMetadataV4V6Remove *HostMetadataV4V6Remove `protobuf:"bytes,38,opt,name=host_metadata_v4v6_remove,json=hostMetadataV4v6Remove,proto3,oneof"`
+	HostMetadataV4V6Remove *HostMetadataV4V6Remove `protobuf:"bytes,18,opt,name=host_metadata_v4v6_remove,json=hostMetadataV4v6Remove,proto3,oneof"`
 }
 
 type ToDataplane_IpamPoolUpdate struct {
@@ -1173,16 +1122,6 @@ type ToDataplane_WireguardEndpointV6Remove struct {
 	WireguardEndpointV6Remove *WireguardEndpointV6Remove `protobuf:"bytes,34,opt,name=wireguard_endpoint_v6_remove,json=wireguardEndpointV6Remove,proto3,oneof"`
 }
 
-type ToDataplane_HostMetadataV6Update struct {
-	// HostMetadataV6Update is sent when a host IPv6 address is added or updated.
-	HostMetadataV6Update *HostMetadataV6Update `protobuf:"bytes,35,opt,name=host_metadata_v6_update,json=hostMetadataV6Update,proto3,oneof"`
-}
-
-type ToDataplane_HostMetadataV6Remove struct {
-	// HostMetadataV6Remove is sent when a host IPv6 address is removed.
-	HostMetadataV6Remove *HostMetadataV6Remove `protobuf:"bytes,36,opt,name=host_metadata_v6_remove,json=hostMetadataV6Remove,proto3,oneof"`
-}
-
 func (*ToDataplane_InSync) isToDataplane_Payload() {}
 
 func (*ToDataplane_IpsetUpdate) isToDataplane_Payload() {}
@@ -1208,10 +1147,6 @@ func (*ToDataplane_WorkloadEndpointUpdate) isToDataplane_Payload() {}
 func (*ToDataplane_WorkloadEndpointRemove) isToDataplane_Payload() {}
 
 func (*ToDataplane_ConfigUpdate) isToDataplane_Payload() {}
-
-func (*ToDataplane_HostMetadataUpdate) isToDataplane_Payload() {}
-
-func (*ToDataplane_HostMetadataRemove) isToDataplane_Payload() {}
 
 func (*ToDataplane_HostMetadataV4V6Update) isToDataplane_Payload() {}
 
@@ -1252,10 +1187,6 @@ func (*ToDataplane_ServiceRemove) isToDataplane_Payload() {}
 func (*ToDataplane_WireguardEndpointV6Update) isToDataplane_Payload() {}
 
 func (*ToDataplane_WireguardEndpointV6Remove) isToDataplane_Payload() {}
-
-func (*ToDataplane_HostMetadataV6Update) isToDataplane_Payload() {}
-
-func (*ToDataplane_HostMetadataV6Remove) isToDataplane_Payload() {}
 
 type FromDataplane struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
@@ -4487,214 +4418,6 @@ func (x *HostMetadataV4V6Remove) GetIpv4Addr() string {
 	return ""
 }
 
-type HostMetadataUpdate struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hostname      string                 `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Ipv4Addr      string                 `protobuf:"bytes,2,opt,name=ipv4_addr,json=ipv4Addr,proto3" json:"ipv4_addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *HostMetadataUpdate) Reset() {
-	*x = HostMetadataUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[48]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *HostMetadataUpdate) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*HostMetadataUpdate) ProtoMessage() {}
-
-func (x *HostMetadataUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[48]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use HostMetadataUpdate.ProtoReflect.Descriptor instead.
-func (*HostMetadataUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{48}
-}
-
-func (x *HostMetadataUpdate) GetHostname() string {
-	if x != nil {
-		return x.Hostname
-	}
-	return ""
-}
-
-func (x *HostMetadataUpdate) GetIpv4Addr() string {
-	if x != nil {
-		return x.Ipv4Addr
-	}
-	return ""
-}
-
-type HostMetadataRemove struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hostname      string                 `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Ipv4Addr      string                 `protobuf:"bytes,2,opt,name=ipv4_addr,json=ipv4Addr,proto3" json:"ipv4_addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *HostMetadataRemove) Reset() {
-	*x = HostMetadataRemove{}
-	mi := &file_felixbackend_proto_msgTypes[49]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *HostMetadataRemove) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*HostMetadataRemove) ProtoMessage() {}
-
-func (x *HostMetadataRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[49]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use HostMetadataRemove.ProtoReflect.Descriptor instead.
-func (*HostMetadataRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{49}
-}
-
-func (x *HostMetadataRemove) GetHostname() string {
-	if x != nil {
-		return x.Hostname
-	}
-	return ""
-}
-
-func (x *HostMetadataRemove) GetIpv4Addr() string {
-	if x != nil {
-		return x.Ipv4Addr
-	}
-	return ""
-}
-
-type HostMetadataV6Update struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hostname      string                 `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Ipv6Addr      string                 `protobuf:"bytes,2,opt,name=ipv6_addr,json=ipv6Addr,proto3" json:"ipv6_addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *HostMetadataV6Update) Reset() {
-	*x = HostMetadataV6Update{}
-	mi := &file_felixbackend_proto_msgTypes[50]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *HostMetadataV6Update) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*HostMetadataV6Update) ProtoMessage() {}
-
-func (x *HostMetadataV6Update) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[50]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use HostMetadataV6Update.ProtoReflect.Descriptor instead.
-func (*HostMetadataV6Update) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{50}
-}
-
-func (x *HostMetadataV6Update) GetHostname() string {
-	if x != nil {
-		return x.Hostname
-	}
-	return ""
-}
-
-func (x *HostMetadataV6Update) GetIpv6Addr() string {
-	if x != nil {
-		return x.Ipv6Addr
-	}
-	return ""
-}
-
-type HostMetadataV6Remove struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hostname      string                 `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Ipv6Addr      string                 `protobuf:"bytes,2,opt,name=ipv6_addr,json=ipv6Addr,proto3" json:"ipv6_addr,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *HostMetadataV6Remove) Reset() {
-	*x = HostMetadataV6Remove{}
-	mi := &file_felixbackend_proto_msgTypes[51]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *HostMetadataV6Remove) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*HostMetadataV6Remove) ProtoMessage() {}
-
-func (x *HostMetadataV6Remove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[51]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use HostMetadataV6Remove.ProtoReflect.Descriptor instead.
-func (*HostMetadataV6Remove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{51}
-}
-
-func (x *HostMetadataV6Remove) GetHostname() string {
-	if x != nil {
-		return x.Hostname
-	}
-	return ""
-}
-
-func (x *HostMetadataV6Remove) GetIpv6Addr() string {
-	if x != nil {
-		return x.Ipv6Addr
-	}
-	return ""
-}
-
 type IPAMPoolUpdate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -4705,7 +4428,7 @@ type IPAMPoolUpdate struct {
 
 func (x *IPAMPoolUpdate) Reset() {
 	*x = IPAMPoolUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[52]
+	mi := &file_felixbackend_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4717,7 +4440,7 @@ func (x *IPAMPoolUpdate) String() string {
 func (*IPAMPoolUpdate) ProtoMessage() {}
 
 func (x *IPAMPoolUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[52]
+	mi := &file_felixbackend_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4730,7 +4453,7 @@ func (x *IPAMPoolUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPAMPoolUpdate.ProtoReflect.Descriptor instead.
 func (*IPAMPoolUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{52}
+	return file_felixbackend_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *IPAMPoolUpdate) GetId() string {
@@ -4756,7 +4479,7 @@ type IPAMPoolRemove struct {
 
 func (x *IPAMPoolRemove) Reset() {
 	*x = IPAMPoolRemove{}
-	mi := &file_felixbackend_proto_msgTypes[53]
+	mi := &file_felixbackend_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4768,7 +4491,7 @@ func (x *IPAMPoolRemove) String() string {
 func (*IPAMPoolRemove) ProtoMessage() {}
 
 func (x *IPAMPoolRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[53]
+	mi := &file_felixbackend_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4781,7 +4504,7 @@ func (x *IPAMPoolRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPAMPoolRemove.ProtoReflect.Descriptor instead.
 func (*IPAMPoolRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{53}
+	return file_felixbackend_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *IPAMPoolRemove) GetId() string {
@@ -4803,7 +4526,7 @@ type IPAMPool struct {
 
 func (x *IPAMPool) Reset() {
 	*x = IPAMPool{}
-	mi := &file_felixbackend_proto_msgTypes[54]
+	mi := &file_felixbackend_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4815,7 +4538,7 @@ func (x *IPAMPool) String() string {
 func (*IPAMPool) ProtoMessage() {}
 
 func (x *IPAMPool) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[54]
+	mi := &file_felixbackend_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4828,7 +4551,7 @@ func (x *IPAMPool) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPAMPool.ProtoReflect.Descriptor instead.
 func (*IPAMPool) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{54}
+	return file_felixbackend_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *IPAMPool) GetCidr() string {
@@ -4870,7 +4593,7 @@ type Encapsulation struct {
 
 func (x *Encapsulation) Reset() {
 	*x = Encapsulation{}
-	mi := &file_felixbackend_proto_msgTypes[55]
+	mi := &file_felixbackend_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4882,7 +4605,7 @@ func (x *Encapsulation) String() string {
 func (*Encapsulation) ProtoMessage() {}
 
 func (x *Encapsulation) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[55]
+	mi := &file_felixbackend_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4895,7 +4618,7 @@ func (x *Encapsulation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Encapsulation.ProtoReflect.Descriptor instead.
 func (*Encapsulation) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{55}
+	return file_felixbackend_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *Encapsulation) GetIpipEnabled() bool {
@@ -4929,7 +4652,7 @@ type ServiceAccountUpdate struct {
 
 func (x *ServiceAccountUpdate) Reset() {
 	*x = ServiceAccountUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[56]
+	mi := &file_felixbackend_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4941,7 +4664,7 @@ func (x *ServiceAccountUpdate) String() string {
 func (*ServiceAccountUpdate) ProtoMessage() {}
 
 func (x *ServiceAccountUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[56]
+	mi := &file_felixbackend_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4954,7 +4677,7 @@ func (x *ServiceAccountUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAccountUpdate.ProtoReflect.Descriptor instead.
 func (*ServiceAccountUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{56}
+	return file_felixbackend_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ServiceAccountUpdate) GetId() *ServiceAccountID {
@@ -4980,7 +4703,7 @@ type ServiceAccountRemove struct {
 
 func (x *ServiceAccountRemove) Reset() {
 	*x = ServiceAccountRemove{}
-	mi := &file_felixbackend_proto_msgTypes[57]
+	mi := &file_felixbackend_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4992,7 +4715,7 @@ func (x *ServiceAccountRemove) String() string {
 func (*ServiceAccountRemove) ProtoMessage() {}
 
 func (x *ServiceAccountRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[57]
+	mi := &file_felixbackend_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5005,7 +4728,7 @@ func (x *ServiceAccountRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAccountRemove.ProtoReflect.Descriptor instead.
 func (*ServiceAccountRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{57}
+	return file_felixbackend_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ServiceAccountRemove) GetId() *ServiceAccountID {
@@ -5025,7 +4748,7 @@ type ServiceAccountID struct {
 
 func (x *ServiceAccountID) Reset() {
 	*x = ServiceAccountID{}
-	mi := &file_felixbackend_proto_msgTypes[58]
+	mi := &file_felixbackend_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5037,7 +4760,7 @@ func (x *ServiceAccountID) String() string {
 func (*ServiceAccountID) ProtoMessage() {}
 
 func (x *ServiceAccountID) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[58]
+	mi := &file_felixbackend_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5050,7 +4773,7 @@ func (x *ServiceAccountID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAccountID.ProtoReflect.Descriptor instead.
 func (*ServiceAccountID) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{58}
+	return file_felixbackend_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ServiceAccountID) GetNamespace() string {
@@ -5077,7 +4800,7 @@ type NamespaceUpdate struct {
 
 func (x *NamespaceUpdate) Reset() {
 	*x = NamespaceUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[59]
+	mi := &file_felixbackend_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5089,7 +4812,7 @@ func (x *NamespaceUpdate) String() string {
 func (*NamespaceUpdate) ProtoMessage() {}
 
 func (x *NamespaceUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[59]
+	mi := &file_felixbackend_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5102,7 +4825,7 @@ func (x *NamespaceUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamespaceUpdate.ProtoReflect.Descriptor instead.
 func (*NamespaceUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{59}
+	return file_felixbackend_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *NamespaceUpdate) GetId() *NamespaceID {
@@ -5128,7 +4851,7 @@ type NamespaceRemove struct {
 
 func (x *NamespaceRemove) Reset() {
 	*x = NamespaceRemove{}
-	mi := &file_felixbackend_proto_msgTypes[60]
+	mi := &file_felixbackend_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5140,7 +4863,7 @@ func (x *NamespaceRemove) String() string {
 func (*NamespaceRemove) ProtoMessage() {}
 
 func (x *NamespaceRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[60]
+	mi := &file_felixbackend_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5153,7 +4876,7 @@ func (x *NamespaceRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamespaceRemove.ProtoReflect.Descriptor instead.
 func (*NamespaceRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{60}
+	return file_felixbackend_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *NamespaceRemove) GetId() *NamespaceID {
@@ -5172,7 +4895,7 @@ type NamespaceID struct {
 
 func (x *NamespaceID) Reset() {
 	*x = NamespaceID{}
-	mi := &file_felixbackend_proto_msgTypes[61]
+	mi := &file_felixbackend_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5184,7 +4907,7 @@ func (x *NamespaceID) String() string {
 func (*NamespaceID) ProtoMessage() {}
 
 func (x *NamespaceID) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[61]
+	mi := &file_felixbackend_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5197,7 +4920,7 @@ func (x *NamespaceID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamespaceID.ProtoReflect.Descriptor instead.
 func (*NamespaceID) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{61}
+	return file_felixbackend_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *NamespaceID) GetName() string {
@@ -5218,7 +4941,7 @@ type TunnelType struct {
 
 func (x *TunnelType) Reset() {
 	*x = TunnelType{}
-	mi := &file_felixbackend_proto_msgTypes[62]
+	mi := &file_felixbackend_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5230,7 +4953,7 @@ func (x *TunnelType) String() string {
 func (*TunnelType) ProtoMessage() {}
 
 func (x *TunnelType) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[62]
+	mi := &file_felixbackend_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5243,7 +4966,7 @@ func (x *TunnelType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelType.ProtoReflect.Descriptor instead.
 func (*TunnelType) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{62}
+	return file_felixbackend_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *TunnelType) GetIpip() bool {
@@ -5288,7 +5011,7 @@ type RouteUpdate struct {
 
 func (x *RouteUpdate) Reset() {
 	*x = RouteUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[63]
+	mi := &file_felixbackend_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5300,7 +5023,7 @@ func (x *RouteUpdate) String() string {
 func (*RouteUpdate) ProtoMessage() {}
 
 func (x *RouteUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[63]
+	mi := &file_felixbackend_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5313,7 +5036,7 @@ func (x *RouteUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteUpdate.ProtoReflect.Descriptor instead.
 func (*RouteUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{63}
+	return file_felixbackend_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *RouteUpdate) GetTypes() RouteType {
@@ -5395,7 +5118,7 @@ type RouteRemove struct {
 
 func (x *RouteRemove) Reset() {
 	*x = RouteRemove{}
-	mi := &file_felixbackend_proto_msgTypes[64]
+	mi := &file_felixbackend_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5407,7 +5130,7 @@ func (x *RouteRemove) String() string {
 func (*RouteRemove) ProtoMessage() {}
 
 func (x *RouteRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[64]
+	mi := &file_felixbackend_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5420,7 +5143,7 @@ func (x *RouteRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteRemove.ProtoReflect.Descriptor instead.
 func (*RouteRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{64}
+	return file_felixbackend_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RouteRemove) GetDst() string {
@@ -5445,7 +5168,7 @@ type VXLANTunnelEndpointUpdate struct {
 
 func (x *VXLANTunnelEndpointUpdate) Reset() {
 	*x = VXLANTunnelEndpointUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[65]
+	mi := &file_felixbackend_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5457,7 +5180,7 @@ func (x *VXLANTunnelEndpointUpdate) String() string {
 func (*VXLANTunnelEndpointUpdate) ProtoMessage() {}
 
 func (x *VXLANTunnelEndpointUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[65]
+	mi := &file_felixbackend_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5470,7 +5193,7 @@ func (x *VXLANTunnelEndpointUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VXLANTunnelEndpointUpdate.ProtoReflect.Descriptor instead.
 func (*VXLANTunnelEndpointUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{65}
+	return file_felixbackend_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *VXLANTunnelEndpointUpdate) GetNode() string {
@@ -5531,7 +5254,7 @@ type VXLANTunnelEndpointRemove struct {
 
 func (x *VXLANTunnelEndpointRemove) Reset() {
 	*x = VXLANTunnelEndpointRemove{}
-	mi := &file_felixbackend_proto_msgTypes[66]
+	mi := &file_felixbackend_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5543,7 +5266,7 @@ func (x *VXLANTunnelEndpointRemove) String() string {
 func (*VXLANTunnelEndpointRemove) ProtoMessage() {}
 
 func (x *VXLANTunnelEndpointRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[66]
+	mi := &file_felixbackend_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5556,7 +5279,7 @@ func (x *VXLANTunnelEndpointRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VXLANTunnelEndpointRemove.ProtoReflect.Descriptor instead.
 func (*VXLANTunnelEndpointRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{66}
+	return file_felixbackend_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *VXLANTunnelEndpointRemove) GetNode() string {
@@ -5576,7 +5299,7 @@ type ReportResult struct {
 
 func (x *ReportResult) Reset() {
 	*x = ReportResult{}
-	mi := &file_felixbackend_proto_msgTypes[67]
+	mi := &file_felixbackend_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5588,7 +5311,7 @@ func (x *ReportResult) String() string {
 func (*ReportResult) ProtoMessage() {}
 
 func (x *ReportResult) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[67]
+	mi := &file_felixbackend_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5601,7 +5324,7 @@ func (x *ReportResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportResult.ProtoReflect.Descriptor instead.
 func (*ReportResult) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{67}
+	return file_felixbackend_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ReportResult) GetSuccessful() bool {
@@ -5635,7 +5358,7 @@ type DataplaneStats struct {
 
 func (x *DataplaneStats) Reset() {
 	*x = DataplaneStats{}
-	mi := &file_felixbackend_proto_msgTypes[68]
+	mi := &file_felixbackend_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5647,7 +5370,7 @@ func (x *DataplaneStats) String() string {
 func (*DataplaneStats) ProtoMessage() {}
 
 func (x *DataplaneStats) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[68]
+	mi := &file_felixbackend_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5660,7 +5383,7 @@ func (x *DataplaneStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataplaneStats.ProtoReflect.Descriptor instead.
 func (*DataplaneStats) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{68}
+	return file_felixbackend_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *DataplaneStats) GetSrcIp() string {
@@ -5736,7 +5459,7 @@ type Statistic struct {
 
 func (x *Statistic) Reset() {
 	*x = Statistic{}
-	mi := &file_felixbackend_proto_msgTypes[69]
+	mi := &file_felixbackend_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5748,7 +5471,7 @@ func (x *Statistic) String() string {
 func (*Statistic) ProtoMessage() {}
 
 func (x *Statistic) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[69]
+	mi := &file_felixbackend_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5761,7 +5484,7 @@ func (x *Statistic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Statistic.ProtoReflect.Descriptor instead.
 func (*Statistic) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{69}
+	return file_felixbackend_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *Statistic) GetDirection() Statistic_Direction {
@@ -5817,7 +5540,7 @@ type RuleTrace struct {
 
 func (x *RuleTrace) Reset() {
 	*x = RuleTrace{}
-	mi := &file_felixbackend_proto_msgTypes[70]
+	mi := &file_felixbackend_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5829,7 +5552,7 @@ func (x *RuleTrace) String() string {
 func (*RuleTrace) ProtoMessage() {}
 
 func (x *RuleTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[70]
+	mi := &file_felixbackend_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5842,7 +5565,7 @@ func (x *RuleTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleTrace.ProtoReflect.Descriptor instead.
 func (*RuleTrace) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{70}
+	return file_felixbackend_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *RuleTrace) GetId() isRuleTrace_Id {
@@ -5934,7 +5657,7 @@ type WireguardEndpointUpdate struct {
 
 func (x *WireguardEndpointUpdate) Reset() {
 	*x = WireguardEndpointUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[71]
+	mi := &file_felixbackend_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5946,7 +5669,7 @@ func (x *WireguardEndpointUpdate) String() string {
 func (*WireguardEndpointUpdate) ProtoMessage() {}
 
 func (x *WireguardEndpointUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[71]
+	mi := &file_felixbackend_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5959,7 +5682,7 @@ func (x *WireguardEndpointUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WireguardEndpointUpdate.ProtoReflect.Descriptor instead.
 func (*WireguardEndpointUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{71}
+	return file_felixbackend_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *WireguardEndpointUpdate) GetHostname() string {
@@ -5993,7 +5716,7 @@ type WireguardEndpointRemove struct {
 
 func (x *WireguardEndpointRemove) Reset() {
 	*x = WireguardEndpointRemove{}
-	mi := &file_felixbackend_proto_msgTypes[72]
+	mi := &file_felixbackend_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6005,7 +5728,7 @@ func (x *WireguardEndpointRemove) String() string {
 func (*WireguardEndpointRemove) ProtoMessage() {}
 
 func (x *WireguardEndpointRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[72]
+	mi := &file_felixbackend_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6018,7 +5741,7 @@ func (x *WireguardEndpointRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WireguardEndpointRemove.ProtoReflect.Descriptor instead.
 func (*WireguardEndpointRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{72}
+	return file_felixbackend_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *WireguardEndpointRemove) GetHostname() string {
@@ -6042,7 +5765,7 @@ type WireguardEndpointV6Update struct {
 
 func (x *WireguardEndpointV6Update) Reset() {
 	*x = WireguardEndpointV6Update{}
-	mi := &file_felixbackend_proto_msgTypes[73]
+	mi := &file_felixbackend_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6054,7 +5777,7 @@ func (x *WireguardEndpointV6Update) String() string {
 func (*WireguardEndpointV6Update) ProtoMessage() {}
 
 func (x *WireguardEndpointV6Update) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[73]
+	mi := &file_felixbackend_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6067,7 +5790,7 @@ func (x *WireguardEndpointV6Update) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WireguardEndpointV6Update.ProtoReflect.Descriptor instead.
 func (*WireguardEndpointV6Update) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{73}
+	return file_felixbackend_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *WireguardEndpointV6Update) GetHostname() string {
@@ -6101,7 +5824,7 @@ type WireguardEndpointV6Remove struct {
 
 func (x *WireguardEndpointV6Remove) Reset() {
 	*x = WireguardEndpointV6Remove{}
-	mi := &file_felixbackend_proto_msgTypes[74]
+	mi := &file_felixbackend_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6113,7 +5836,7 @@ func (x *WireguardEndpointV6Remove) String() string {
 func (*WireguardEndpointV6Remove) ProtoMessage() {}
 
 func (x *WireguardEndpointV6Remove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[74]
+	mi := &file_felixbackend_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6126,7 +5849,7 @@ func (x *WireguardEndpointV6Remove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WireguardEndpointV6Remove.ProtoReflect.Descriptor instead.
 func (*WireguardEndpointV6Remove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{74}
+	return file_felixbackend_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *WireguardEndpointV6Remove) GetHostname() string {
@@ -6149,7 +5872,7 @@ type GlobalBGPConfigUpdate struct {
 
 func (x *GlobalBGPConfigUpdate) Reset() {
 	*x = GlobalBGPConfigUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[75]
+	mi := &file_felixbackend_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6161,7 +5884,7 @@ func (x *GlobalBGPConfigUpdate) String() string {
 func (*GlobalBGPConfigUpdate) ProtoMessage() {}
 
 func (x *GlobalBGPConfigUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[75]
+	mi := &file_felixbackend_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6174,7 +5897,7 @@ func (x *GlobalBGPConfigUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlobalBGPConfigUpdate.ProtoReflect.Descriptor instead.
 func (*GlobalBGPConfigUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{75}
+	return file_felixbackend_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GlobalBGPConfigUpdate) GetServiceClusterCidrs() []string {
@@ -6223,7 +5946,7 @@ type ServicePort struct {
 
 func (x *ServicePort) Reset() {
 	*x = ServicePort{}
-	mi := &file_felixbackend_proto_msgTypes[76]
+	mi := &file_felixbackend_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6235,7 +5958,7 @@ func (x *ServicePort) String() string {
 func (*ServicePort) ProtoMessage() {}
 
 func (x *ServicePort) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[76]
+	mi := &file_felixbackend_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6248,7 +5971,7 @@ func (x *ServicePort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServicePort.ProtoReflect.Descriptor instead.
 func (*ServicePort) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{76}
+	return file_felixbackend_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ServicePort) GetProtocol() string {
@@ -6287,7 +6010,7 @@ type ServiceUpdate struct {
 
 func (x *ServiceUpdate) Reset() {
 	*x = ServiceUpdate{}
-	mi := &file_felixbackend_proto_msgTypes[77]
+	mi := &file_felixbackend_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6299,7 +6022,7 @@ func (x *ServiceUpdate) String() string {
 func (*ServiceUpdate) ProtoMessage() {}
 
 func (x *ServiceUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[77]
+	mi := &file_felixbackend_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6312,7 +6035,7 @@ func (x *ServiceUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceUpdate.ProtoReflect.Descriptor instead.
 func (*ServiceUpdate) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{77}
+	return file_felixbackend_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ServiceUpdate) GetName() string {
@@ -6374,7 +6097,7 @@ type ServiceRemove struct {
 
 func (x *ServiceRemove) Reset() {
 	*x = ServiceRemove{}
-	mi := &file_felixbackend_proto_msgTypes[78]
+	mi := &file_felixbackend_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6386,7 +6109,7 @@ func (x *ServiceRemove) String() string {
 func (*ServiceRemove) ProtoMessage() {}
 
 func (x *ServiceRemove) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[78]
+	mi := &file_felixbackend_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6399,7 +6122,7 @@ func (x *ServiceRemove) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceRemove.ProtoReflect.Descriptor instead.
 func (*ServiceRemove) Descriptor() ([]byte, []int) {
-	return file_felixbackend_proto_rawDescGZIP(), []int{78}
+	return file_felixbackend_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ServiceRemove) GetName() string {
@@ -6429,7 +6152,7 @@ type HTTPMatch_PathMatch struct {
 
 func (x *HTTPMatch_PathMatch) Reset() {
 	*x = HTTPMatch_PathMatch{}
-	mi := &file_felixbackend_proto_msgTypes[82]
+	mi := &file_felixbackend_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6441,7 +6164,7 @@ func (x *HTTPMatch_PathMatch) String() string {
 func (*HTTPMatch_PathMatch) ProtoMessage() {}
 
 func (x *HTTPMatch_PathMatch) ProtoReflect() protoreflect.Message {
-	mi := &file_felixbackend_proto_msgTypes[82]
+	mi := &file_felixbackend_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6503,7 +6226,7 @@ var File_felixbackend_proto protoreflect.FileDescriptor
 const file_felixbackend_proto_rawDesc = "" +
 	"\n" +
 	"\x12felixbackend.proto\x12\x05felix\"\r\n" +
-	"\vSyncRequest\"\xcb\x16\n" +
+	"\vSyncRequest\"\x81\x14\n" +
 	"\vToDataplane\x12'\n" +
 	"\x0fsequence_number\x18\x0f \x01(\x04R\x0esequenceNumber\x12(\n" +
 	"\ain_sync\x18\x01 \x01(\v2\r.felix.InSyncH\x00R\x06inSync\x127\n" +
@@ -6519,11 +6242,9 @@ const file_felixbackend_proto_rawDesc = "" +
 	" \x01(\v2\x19.felix.HostEndpointRemoveH\x00R\x12hostEndpointRemove\x12Y\n" +
 	"\x18workload_endpoint_update\x18\v \x01(\v2\x1d.felix.WorkloadEndpointUpdateH\x00R\x16workloadEndpointUpdate\x12Y\n" +
 	"\x18workload_endpoint_remove\x18\f \x01(\v2\x1d.felix.WorkloadEndpointRemoveH\x00R\x16workloadEndpointRemove\x12:\n" +
-	"\rconfig_update\x18\r \x01(\v2\x13.felix.ConfigUpdateH\x00R\fconfigUpdate\x12M\n" +
-	"\x14host_metadata_update\x18\x0e \x01(\v2\x19.felix.HostMetadataUpdateH\x00R\x12hostMetadataUpdate\x12M\n" +
-	"\x14host_metadata_remove\x18\x12 \x01(\v2\x19.felix.HostMetadataRemoveH\x00R\x12hostMetadataRemove\x12Z\n" +
-	"\x19host_metadata_v4v6_update\x18% \x01(\v2\x1d.felix.HostMetadataV4V6UpdateH\x00R\x16hostMetadataV4v6Update\x12Z\n" +
-	"\x19host_metadata_v4v6_remove\x18& \x01(\v2\x1d.felix.HostMetadataV4V6RemoveH\x00R\x16hostMetadataV4v6Remove\x12A\n" +
+	"\rconfig_update\x18\r \x01(\v2\x13.felix.ConfigUpdateH\x00R\fconfigUpdate\x12Z\n" +
+	"\x19host_metadata_v4v6_update\x18\x0e \x01(\v2\x1d.felix.HostMetadataV4V6UpdateH\x00R\x16hostMetadataV4v6Update\x12Z\n" +
+	"\x19host_metadata_v4v6_remove\x18\x12 \x01(\v2\x1d.felix.HostMetadataV4V6RemoveH\x00R\x16hostMetadataV4v6Remove\x12A\n" +
 	"\x10ipam_pool_update\x18\x10 \x01(\v2\x15.felix.IPAMPoolUpdateH\x00R\x0eipamPoolUpdate\x12A\n" +
 	"\x10ipam_pool_remove\x18\x11 \x01(\v2\x15.felix.IPAMPoolRemoveH\x00R\x0eipamPoolRemove\x12S\n" +
 	"\x16service_account_update\x18\x13 \x01(\v2\x1b.felix.ServiceAccountUpdateH\x00R\x14serviceAccountUpdate\x12S\n" +
@@ -6543,9 +6264,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x0eservice_update\x18\x1f \x01(\v2\x14.felix.ServiceUpdateH\x00R\rserviceUpdate\x12=\n" +
 	"\x0eservice_remove\x18  \x01(\v2\x14.felix.ServiceRemoveH\x00R\rserviceRemove\x12c\n" +
 	"\x1cwireguard_endpoint_v6_update\x18! \x01(\v2 .felix.WireguardEndpointV6UpdateH\x00R\x19wireguardEndpointV6Update\x12c\n" +
-	"\x1cwireguard_endpoint_v6_remove\x18\" \x01(\v2 .felix.WireguardEndpointV6RemoveH\x00R\x19wireguardEndpointV6Remove\x12T\n" +
-	"\x17host_metadata_v6_update\x18# \x01(\v2\x1b.felix.HostMetadataV6UpdateH\x00R\x14hostMetadataV6Update\x12T\n" +
-	"\x17host_metadata_v6_remove\x18$ \x01(\v2\x1b.felix.HostMetadataV6RemoveH\x00R\x14hostMetadataV6RemoveB\t\n" +
+	"\x1cwireguard_endpoint_v6_remove\x18\" \x01(\v2 .felix.WireguardEndpointV6RemoveH\x00R\x19wireguardEndpointV6RemoveB\t\n" +
 	"\apayload\"\xd3\x05\n" +
 	"\rFromDataplane\x12'\n" +
 	"\x0fsequence_number\x18\b \x01(\x04R\x0esequenceNumber\x12P\n" +
@@ -6813,19 +6532,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"Q\n" +
 	"\x16HostMetadataV4V6Remove\x12\x1a\n" +
 	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
-	"\tipv4_addr\x18\x02 \x01(\tR\bipv4Addr\"M\n" +
-	"\x12HostMetadataUpdate\x12\x1a\n" +
-	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
-	"\tipv4_addr\x18\x02 \x01(\tR\bipv4Addr\"M\n" +
-	"\x12HostMetadataRemove\x12\x1a\n" +
-	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
-	"\tipv4_addr\x18\x02 \x01(\tR\bipv4Addr\"O\n" +
-	"\x14HostMetadataV6Update\x12\x1a\n" +
-	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
-	"\tipv6_addr\x18\x02 \x01(\tR\bipv6Addr\"O\n" +
-	"\x14HostMetadataV6Remove\x12\x1a\n" +
-	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
-	"\tipv6_addr\x18\x02 \x01(\tR\bipv6Addr\"E\n" +
+	"\tipv4_addr\x18\x02 \x01(\tR\bipv4Addr\"E\n" +
 	"\x0eIPAMPoolUpdate\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12#\n" +
 	"\x04pool\x18\x02 \x01(\v2\x0f.felix.IPAMPoolR\x04pool\" \n" +
@@ -7019,7 +6726,7 @@ func file_felixbackend_proto_rawDescGZIP() []byte {
 }
 
 var file_felixbackend_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_felixbackend_proto_msgTypes = make([]protoimpl.MessageInfo, 88)
+var file_felixbackend_proto_msgTypes = make([]protoimpl.MessageInfo, 84)
 var file_felixbackend_proto_goTypes = []any{
 	(IPVersion)(0),                       // 0: felix.IPVersion
 	(LiveMigrationRole)(0),               // 1: felix.LiveMigrationRole
@@ -7079,46 +6786,42 @@ var file_felixbackend_proto_goTypes = []any{
 	(*DataplaneInSync)(nil),              // 55: felix.DataplaneInSync
 	(*HostMetadataV4V6Update)(nil),       // 56: felix.HostMetadataV4V6Update
 	(*HostMetadataV4V6Remove)(nil),       // 57: felix.HostMetadataV4V6Remove
-	(*HostMetadataUpdate)(nil),           // 58: felix.HostMetadataUpdate
-	(*HostMetadataRemove)(nil),           // 59: felix.HostMetadataRemove
-	(*HostMetadataV6Update)(nil),         // 60: felix.HostMetadataV6Update
-	(*HostMetadataV6Remove)(nil),         // 61: felix.HostMetadataV6Remove
-	(*IPAMPoolUpdate)(nil),               // 62: felix.IPAMPoolUpdate
-	(*IPAMPoolRemove)(nil),               // 63: felix.IPAMPoolRemove
-	(*IPAMPool)(nil),                     // 64: felix.IPAMPool
-	(*Encapsulation)(nil),                // 65: felix.Encapsulation
-	(*ServiceAccountUpdate)(nil),         // 66: felix.ServiceAccountUpdate
-	(*ServiceAccountRemove)(nil),         // 67: felix.ServiceAccountRemove
-	(*ServiceAccountID)(nil),             // 68: felix.ServiceAccountID
-	(*NamespaceUpdate)(nil),              // 69: felix.NamespaceUpdate
-	(*NamespaceRemove)(nil),              // 70: felix.NamespaceRemove
-	(*NamespaceID)(nil),                  // 71: felix.NamespaceID
-	(*TunnelType)(nil),                   // 72: felix.TunnelType
-	(*RouteUpdate)(nil),                  // 73: felix.RouteUpdate
-	(*RouteRemove)(nil),                  // 74: felix.RouteRemove
-	(*VXLANTunnelEndpointUpdate)(nil),    // 75: felix.VXLANTunnelEndpointUpdate
-	(*VXLANTunnelEndpointRemove)(nil),    // 76: felix.VXLANTunnelEndpointRemove
-	(*ReportResult)(nil),                 // 77: felix.ReportResult
-	(*DataplaneStats)(nil),               // 78: felix.DataplaneStats
-	(*Statistic)(nil),                    // 79: felix.Statistic
-	(*RuleTrace)(nil),                    // 80: felix.RuleTrace
-	(*WireguardEndpointUpdate)(nil),      // 81: felix.WireguardEndpointUpdate
-	(*WireguardEndpointRemove)(nil),      // 82: felix.WireguardEndpointRemove
-	(*WireguardEndpointV6Update)(nil),    // 83: felix.WireguardEndpointV6Update
-	(*WireguardEndpointV6Remove)(nil),    // 84: felix.WireguardEndpointV6Remove
-	(*GlobalBGPConfigUpdate)(nil),        // 85: felix.GlobalBGPConfigUpdate
-	(*ServicePort)(nil),                  // 86: felix.ServicePort
-	(*ServiceUpdate)(nil),                // 87: felix.ServiceUpdate
-	(*ServiceRemove)(nil),                // 88: felix.ServiceRemove
-	nil,                                  // 89: felix.ConfigUpdate.ConfigEntry
-	nil,                                  // 90: felix.ConfigUpdate.SourceToRawConfigEntry
-	nil,                                  // 91: felix.RawConfig.ConfigEntry
-	(*HTTPMatch_PathMatch)(nil),          // 92: felix.HTTPMatch.PathMatch
-	nil,                                  // 93: felix.RuleMetadata.AnnotationsEntry
-	nil,                                  // 94: felix.WorkloadEndpoint.AnnotationsEntry
-	nil,                                  // 95: felix.HostMetadataV4V6Update.LabelsEntry
-	nil,                                  // 96: felix.ServiceAccountUpdate.LabelsEntry
-	nil,                                  // 97: felix.NamespaceUpdate.LabelsEntry
+	(*IPAMPoolUpdate)(nil),               // 58: felix.IPAMPoolUpdate
+	(*IPAMPoolRemove)(nil),               // 59: felix.IPAMPoolRemove
+	(*IPAMPool)(nil),                     // 60: felix.IPAMPool
+	(*Encapsulation)(nil),                // 61: felix.Encapsulation
+	(*ServiceAccountUpdate)(nil),         // 62: felix.ServiceAccountUpdate
+	(*ServiceAccountRemove)(nil),         // 63: felix.ServiceAccountRemove
+	(*ServiceAccountID)(nil),             // 64: felix.ServiceAccountID
+	(*NamespaceUpdate)(nil),              // 65: felix.NamespaceUpdate
+	(*NamespaceRemove)(nil),              // 66: felix.NamespaceRemove
+	(*NamespaceID)(nil),                  // 67: felix.NamespaceID
+	(*TunnelType)(nil),                   // 68: felix.TunnelType
+	(*RouteUpdate)(nil),                  // 69: felix.RouteUpdate
+	(*RouteRemove)(nil),                  // 70: felix.RouteRemove
+	(*VXLANTunnelEndpointUpdate)(nil),    // 71: felix.VXLANTunnelEndpointUpdate
+	(*VXLANTunnelEndpointRemove)(nil),    // 72: felix.VXLANTunnelEndpointRemove
+	(*ReportResult)(nil),                 // 73: felix.ReportResult
+	(*DataplaneStats)(nil),               // 74: felix.DataplaneStats
+	(*Statistic)(nil),                    // 75: felix.Statistic
+	(*RuleTrace)(nil),                    // 76: felix.RuleTrace
+	(*WireguardEndpointUpdate)(nil),      // 77: felix.WireguardEndpointUpdate
+	(*WireguardEndpointRemove)(nil),      // 78: felix.WireguardEndpointRemove
+	(*WireguardEndpointV6Update)(nil),    // 79: felix.WireguardEndpointV6Update
+	(*WireguardEndpointV6Remove)(nil),    // 80: felix.WireguardEndpointV6Remove
+	(*GlobalBGPConfigUpdate)(nil),        // 81: felix.GlobalBGPConfigUpdate
+	(*ServicePort)(nil),                  // 82: felix.ServicePort
+	(*ServiceUpdate)(nil),                // 83: felix.ServiceUpdate
+	(*ServiceRemove)(nil),                // 84: felix.ServiceRemove
+	nil,                                  // 85: felix.ConfigUpdate.ConfigEntry
+	nil,                                  // 86: felix.ConfigUpdate.SourceToRawConfigEntry
+	nil,                                  // 87: felix.RawConfig.ConfigEntry
+	(*HTTPMatch_PathMatch)(nil),          // 88: felix.HTTPMatch.PathMatch
+	nil,                                  // 89: felix.RuleMetadata.AnnotationsEntry
+	nil,                                  // 90: felix.WorkloadEndpoint.AnnotationsEntry
+	nil,                                  // 91: felix.HostMetadataV4V6Update.LabelsEntry
+	nil,                                  // 92: felix.ServiceAccountUpdate.LabelsEntry
+	nil,                                  // 93: felix.NamespaceUpdate.LabelsEntry
 }
 var file_felixbackend_proto_depIdxs = []int32{
 	15,  // 0: felix.ToDataplane.in_sync:type_name -> felix.InSync
@@ -7134,129 +6837,125 @@ var file_felixbackend_proto_depIdxs = []int32{
 	35,  // 10: felix.ToDataplane.workload_endpoint_update:type_name -> felix.WorkloadEndpointUpdate
 	41,  // 11: felix.ToDataplane.workload_endpoint_remove:type_name -> felix.WorkloadEndpointRemove
 	13,  // 12: felix.ToDataplane.config_update:type_name -> felix.ConfigUpdate
-	58,  // 13: felix.ToDataplane.host_metadata_update:type_name -> felix.HostMetadataUpdate
-	59,  // 14: felix.ToDataplane.host_metadata_remove:type_name -> felix.HostMetadataRemove
-	56,  // 15: felix.ToDataplane.host_metadata_v4v6_update:type_name -> felix.HostMetadataV4V6Update
-	57,  // 16: felix.ToDataplane.host_metadata_v4v6_remove:type_name -> felix.HostMetadataV4V6Remove
-	62,  // 17: felix.ToDataplane.ipam_pool_update:type_name -> felix.IPAMPoolUpdate
-	63,  // 18: felix.ToDataplane.ipam_pool_remove:type_name -> felix.IPAMPoolRemove
-	66,  // 19: felix.ToDataplane.service_account_update:type_name -> felix.ServiceAccountUpdate
-	67,  // 20: felix.ToDataplane.service_account_remove:type_name -> felix.ServiceAccountRemove
-	69,  // 21: felix.ToDataplane.namespace_update:type_name -> felix.NamespaceUpdate
-	70,  // 22: felix.ToDataplane.namespace_remove:type_name -> felix.NamespaceRemove
-	73,  // 23: felix.ToDataplane.route_update:type_name -> felix.RouteUpdate
-	74,  // 24: felix.ToDataplane.route_remove:type_name -> felix.RouteRemove
-	75,  // 25: felix.ToDataplane.vtep_update:type_name -> felix.VXLANTunnelEndpointUpdate
-	76,  // 26: felix.ToDataplane.vtep_remove:type_name -> felix.VXLANTunnelEndpointRemove
-	81,  // 27: felix.ToDataplane.wireguard_endpoint_update:type_name -> felix.WireguardEndpointUpdate
-	82,  // 28: felix.ToDataplane.wireguard_endpoint_remove:type_name -> felix.WireguardEndpointRemove
-	85,  // 29: felix.ToDataplane.global_bgp_config_update:type_name -> felix.GlobalBGPConfigUpdate
-	65,  // 30: felix.ToDataplane.encapsulation:type_name -> felix.Encapsulation
-	87,  // 31: felix.ToDataplane.service_update:type_name -> felix.ServiceUpdate
-	88,  // 32: felix.ToDataplane.service_remove:type_name -> felix.ServiceRemove
-	83,  // 33: felix.ToDataplane.wireguard_endpoint_v6_update:type_name -> felix.WireguardEndpointV6Update
-	84,  // 34: felix.ToDataplane.wireguard_endpoint_v6_remove:type_name -> felix.WireguardEndpointV6Remove
-	60,  // 35: felix.ToDataplane.host_metadata_v6_update:type_name -> felix.HostMetadataV6Update
-	61,  // 36: felix.ToDataplane.host_metadata_v6_remove:type_name -> felix.HostMetadataV6Remove
-	48,  // 37: felix.FromDataplane.process_status_update:type_name -> felix.ProcessStatusUpdate
-	49,  // 38: felix.FromDataplane.host_endpoint_status_update:type_name -> felix.HostEndpointStatusUpdate
-	51,  // 39: felix.FromDataplane.host_endpoint_status_remove:type_name -> felix.HostEndpointStatusRemove
-	52,  // 40: felix.FromDataplane.workload_endpoint_status_update:type_name -> felix.WorkloadEndpointStatusUpdate
-	53,  // 41: felix.FromDataplane.workload_endpoint_status_remove:type_name -> felix.WorkloadEndpointStatusRemove
-	54,  // 42: felix.FromDataplane.wireguard_status_update:type_name -> felix.WireguardStatusUpdate
-	55,  // 43: felix.FromDataplane.dataplane_in_sync:type_name -> felix.DataplaneInSync
-	89,  // 44: felix.ConfigUpdate.config:type_name -> felix.ConfigUpdate.ConfigEntry
-	90,  // 45: felix.ConfigUpdate.source_to_raw_config:type_name -> felix.ConfigUpdate.SourceToRawConfigEntry
-	91,  // 46: felix.RawConfig.config:type_name -> felix.RawConfig.ConfigEntry
-	5,   // 47: felix.IPSetUpdate.type:type_name -> felix.IPSetUpdate.IPSetType
-	21,  // 48: felix.ActiveProfileUpdate.id:type_name -> felix.ProfileID
-	22,  // 49: felix.ActiveProfileUpdate.profile:type_name -> felix.Profile
-	21,  // 50: felix.ActiveProfileRemove.id:type_name -> felix.ProfileID
-	27,  // 51: felix.Profile.inbound_rules:type_name -> felix.Rule
-	27,  // 52: felix.Profile.outbound_rules:type_name -> felix.Rule
-	25,  // 53: felix.ActivePolicyUpdate.id:type_name -> felix.PolicyID
-	26,  // 54: felix.ActivePolicyUpdate.policy:type_name -> felix.Policy
-	25,  // 55: felix.ActivePolicyRemove.id:type_name -> felix.PolicyID
-	27,  // 56: felix.Policy.inbound_rules:type_name -> felix.Rule
-	27,  // 57: felix.Policy.outbound_rules:type_name -> felix.Rule
-	0,   // 58: felix.Rule.ip_version:type_name -> felix.IPVersion
-	32,  // 59: felix.Rule.protocol:type_name -> felix.Protocol
-	33,  // 60: felix.Rule.src_ports:type_name -> felix.PortRange
-	33,  // 61: felix.Rule.dst_ports:type_name -> felix.PortRange
-	31,  // 62: felix.Rule.icmp_type_code:type_name -> felix.IcmpTypeAndCode
-	32,  // 63: felix.Rule.not_protocol:type_name -> felix.Protocol
-	33,  // 64: felix.Rule.not_src_ports:type_name -> felix.PortRange
-	33,  // 65: felix.Rule.not_dst_ports:type_name -> felix.PortRange
-	31,  // 66: felix.Rule.not_icmp_type_code:type_name -> felix.IcmpTypeAndCode
-	28,  // 67: felix.Rule.src_service_account_match:type_name -> felix.ServiceAccountMatch
-	28,  // 68: felix.Rule.dst_service_account_match:type_name -> felix.ServiceAccountMatch
-	29,  // 69: felix.Rule.http_match:type_name -> felix.HTTPMatch
-	30,  // 70: felix.Rule.metadata:type_name -> felix.RuleMetadata
-	92,  // 71: felix.HTTPMatch.paths:type_name -> felix.HTTPMatch.PathMatch
-	93,  // 72: felix.RuleMetadata.annotations:type_name -> felix.RuleMetadata.AnnotationsEntry
-	34,  // 73: felix.WorkloadEndpointUpdate.id:type_name -> felix.WorkloadEndpointID
-	37,  // 74: felix.WorkloadEndpointUpdate.endpoint:type_name -> felix.WorkloadEndpoint
-	46,  // 75: felix.WorkloadEndpoint.tiers:type_name -> felix.TierInfo
-	47,  // 76: felix.WorkloadEndpoint.ipv4_nat:type_name -> felix.NatInfo
-	47,  // 77: felix.WorkloadEndpoint.ipv6_nat:type_name -> felix.NatInfo
-	94,  // 78: felix.WorkloadEndpoint.annotations:type_name -> felix.WorkloadEndpoint.AnnotationsEntry
-	38,  // 79: felix.WorkloadEndpoint.qos_controls:type_name -> felix.QoSControls
-	40,  // 80: felix.WorkloadEndpoint.local_bgp_peer:type_name -> felix.LocalBGPPeer
-	36,  // 81: felix.WorkloadEndpoint.skip_redir:type_name -> felix.WorkloadBpfSkipRedir
-	39,  // 82: felix.WorkloadEndpoint.qos_policies:type_name -> felix.QoSPolicy
-	1,   // 83: felix.WorkloadEndpoint.live_migration_role:type_name -> felix.LiveMigrationRole
-	34,  // 84: felix.WorkloadEndpointRemove.id:type_name -> felix.WorkloadEndpointID
-	42,  // 85: felix.HostEndpointUpdate.id:type_name -> felix.HostEndpointID
-	44,  // 86: felix.HostEndpointUpdate.endpoint:type_name -> felix.HostEndpoint
-	46,  // 87: felix.HostEndpoint.tiers:type_name -> felix.TierInfo
-	46,  // 88: felix.HostEndpoint.untracked_tiers:type_name -> felix.TierInfo
-	46,  // 89: felix.HostEndpoint.pre_dnat_tiers:type_name -> felix.TierInfo
-	46,  // 90: felix.HostEndpoint.forward_tiers:type_name -> felix.TierInfo
-	39,  // 91: felix.HostEndpoint.qos_policies:type_name -> felix.QoSPolicy
-	42,  // 92: felix.HostEndpointRemove.id:type_name -> felix.HostEndpointID
-	25,  // 93: felix.TierInfo.ingress_policies:type_name -> felix.PolicyID
-	25,  // 94: felix.TierInfo.egress_policies:type_name -> felix.PolicyID
-	42,  // 95: felix.HostEndpointStatusUpdate.id:type_name -> felix.HostEndpointID
-	50,  // 96: felix.HostEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
-	42,  // 97: felix.HostEndpointStatusRemove.id:type_name -> felix.HostEndpointID
-	34,  // 98: felix.WorkloadEndpointStatusUpdate.id:type_name -> felix.WorkloadEndpointID
-	50,  // 99: felix.WorkloadEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
-	37,  // 100: felix.WorkloadEndpointStatusUpdate.endpoint:type_name -> felix.WorkloadEndpoint
-	34,  // 101: felix.WorkloadEndpointStatusRemove.id:type_name -> felix.WorkloadEndpointID
-	0,   // 102: felix.WireguardStatusUpdate.ip_version:type_name -> felix.IPVersion
-	95,  // 103: felix.HostMetadataV4V6Update.labels:type_name -> felix.HostMetadataV4V6Update.LabelsEntry
-	64,  // 104: felix.IPAMPoolUpdate.pool:type_name -> felix.IPAMPool
-	68,  // 105: felix.ServiceAccountUpdate.id:type_name -> felix.ServiceAccountID
-	96,  // 106: felix.ServiceAccountUpdate.labels:type_name -> felix.ServiceAccountUpdate.LabelsEntry
-	68,  // 107: felix.ServiceAccountRemove.id:type_name -> felix.ServiceAccountID
-	71,  // 108: felix.NamespaceUpdate.id:type_name -> felix.NamespaceID
-	97,  // 109: felix.NamespaceUpdate.labels:type_name -> felix.NamespaceUpdate.LabelsEntry
-	71,  // 110: felix.NamespaceRemove.id:type_name -> felix.NamespaceID
-	2,   // 111: felix.RouteUpdate.types:type_name -> felix.RouteType
-	3,   // 112: felix.RouteUpdate.ip_pool_type:type_name -> felix.IPPoolType
-	72,  // 113: felix.RouteUpdate.tunnel_type:type_name -> felix.TunnelType
-	32,  // 114: felix.DataplaneStats.protocol:type_name -> felix.Protocol
-	79,  // 115: felix.DataplaneStats.stats:type_name -> felix.Statistic
-	80,  // 116: felix.DataplaneStats.rules:type_name -> felix.RuleTrace
-	4,   // 117: felix.DataplaneStats.action:type_name -> felix.Action
-	6,   // 118: felix.Statistic.direction:type_name -> felix.Statistic.Direction
-	7,   // 119: felix.Statistic.relativity:type_name -> felix.Statistic.Relativity
-	8,   // 120: felix.Statistic.kind:type_name -> felix.Statistic.Kind
-	4,   // 121: felix.Statistic.action:type_name -> felix.Action
-	25,  // 122: felix.RuleTrace.policy:type_name -> felix.PolicyID
-	21,  // 123: felix.RuleTrace.profile:type_name -> felix.ProfileID
-	9,   // 124: felix.RuleTrace.direction:type_name -> felix.RuleTrace.Direction
-	86,  // 125: felix.ServiceUpdate.ports:type_name -> felix.ServicePort
-	14,  // 126: felix.ConfigUpdate.SourceToRawConfigEntry.value:type_name -> felix.RawConfig
-	10,  // 127: felix.PolicySync.Sync:input_type -> felix.SyncRequest
-	78,  // 128: felix.PolicySync.Report:input_type -> felix.DataplaneStats
-	11,  // 129: felix.PolicySync.Sync:output_type -> felix.ToDataplane
-	77,  // 130: felix.PolicySync.Report:output_type -> felix.ReportResult
-	129, // [129:131] is the sub-list for method output_type
-	127, // [127:129] is the sub-list for method input_type
-	127, // [127:127] is the sub-list for extension type_name
-	127, // [127:127] is the sub-list for extension extendee
-	0,   // [0:127] is the sub-list for field type_name
+	56,  // 13: felix.ToDataplane.host_metadata_v4v6_update:type_name -> felix.HostMetadataV4V6Update
+	57,  // 14: felix.ToDataplane.host_metadata_v4v6_remove:type_name -> felix.HostMetadataV4V6Remove
+	58,  // 15: felix.ToDataplane.ipam_pool_update:type_name -> felix.IPAMPoolUpdate
+	59,  // 16: felix.ToDataplane.ipam_pool_remove:type_name -> felix.IPAMPoolRemove
+	62,  // 17: felix.ToDataplane.service_account_update:type_name -> felix.ServiceAccountUpdate
+	63,  // 18: felix.ToDataplane.service_account_remove:type_name -> felix.ServiceAccountRemove
+	65,  // 19: felix.ToDataplane.namespace_update:type_name -> felix.NamespaceUpdate
+	66,  // 20: felix.ToDataplane.namespace_remove:type_name -> felix.NamespaceRemove
+	69,  // 21: felix.ToDataplane.route_update:type_name -> felix.RouteUpdate
+	70,  // 22: felix.ToDataplane.route_remove:type_name -> felix.RouteRemove
+	71,  // 23: felix.ToDataplane.vtep_update:type_name -> felix.VXLANTunnelEndpointUpdate
+	72,  // 24: felix.ToDataplane.vtep_remove:type_name -> felix.VXLANTunnelEndpointRemove
+	77,  // 25: felix.ToDataplane.wireguard_endpoint_update:type_name -> felix.WireguardEndpointUpdate
+	78,  // 26: felix.ToDataplane.wireguard_endpoint_remove:type_name -> felix.WireguardEndpointRemove
+	81,  // 27: felix.ToDataplane.global_bgp_config_update:type_name -> felix.GlobalBGPConfigUpdate
+	61,  // 28: felix.ToDataplane.encapsulation:type_name -> felix.Encapsulation
+	83,  // 29: felix.ToDataplane.service_update:type_name -> felix.ServiceUpdate
+	84,  // 30: felix.ToDataplane.service_remove:type_name -> felix.ServiceRemove
+	79,  // 31: felix.ToDataplane.wireguard_endpoint_v6_update:type_name -> felix.WireguardEndpointV6Update
+	80,  // 32: felix.ToDataplane.wireguard_endpoint_v6_remove:type_name -> felix.WireguardEndpointV6Remove
+	48,  // 33: felix.FromDataplane.process_status_update:type_name -> felix.ProcessStatusUpdate
+	49,  // 34: felix.FromDataplane.host_endpoint_status_update:type_name -> felix.HostEndpointStatusUpdate
+	51,  // 35: felix.FromDataplane.host_endpoint_status_remove:type_name -> felix.HostEndpointStatusRemove
+	52,  // 36: felix.FromDataplane.workload_endpoint_status_update:type_name -> felix.WorkloadEndpointStatusUpdate
+	53,  // 37: felix.FromDataplane.workload_endpoint_status_remove:type_name -> felix.WorkloadEndpointStatusRemove
+	54,  // 38: felix.FromDataplane.wireguard_status_update:type_name -> felix.WireguardStatusUpdate
+	55,  // 39: felix.FromDataplane.dataplane_in_sync:type_name -> felix.DataplaneInSync
+	85,  // 40: felix.ConfigUpdate.config:type_name -> felix.ConfigUpdate.ConfigEntry
+	86,  // 41: felix.ConfigUpdate.source_to_raw_config:type_name -> felix.ConfigUpdate.SourceToRawConfigEntry
+	87,  // 42: felix.RawConfig.config:type_name -> felix.RawConfig.ConfigEntry
+	5,   // 43: felix.IPSetUpdate.type:type_name -> felix.IPSetUpdate.IPSetType
+	21,  // 44: felix.ActiveProfileUpdate.id:type_name -> felix.ProfileID
+	22,  // 45: felix.ActiveProfileUpdate.profile:type_name -> felix.Profile
+	21,  // 46: felix.ActiveProfileRemove.id:type_name -> felix.ProfileID
+	27,  // 47: felix.Profile.inbound_rules:type_name -> felix.Rule
+	27,  // 48: felix.Profile.outbound_rules:type_name -> felix.Rule
+	25,  // 49: felix.ActivePolicyUpdate.id:type_name -> felix.PolicyID
+	26,  // 50: felix.ActivePolicyUpdate.policy:type_name -> felix.Policy
+	25,  // 51: felix.ActivePolicyRemove.id:type_name -> felix.PolicyID
+	27,  // 52: felix.Policy.inbound_rules:type_name -> felix.Rule
+	27,  // 53: felix.Policy.outbound_rules:type_name -> felix.Rule
+	0,   // 54: felix.Rule.ip_version:type_name -> felix.IPVersion
+	32,  // 55: felix.Rule.protocol:type_name -> felix.Protocol
+	33,  // 56: felix.Rule.src_ports:type_name -> felix.PortRange
+	33,  // 57: felix.Rule.dst_ports:type_name -> felix.PortRange
+	31,  // 58: felix.Rule.icmp_type_code:type_name -> felix.IcmpTypeAndCode
+	32,  // 59: felix.Rule.not_protocol:type_name -> felix.Protocol
+	33,  // 60: felix.Rule.not_src_ports:type_name -> felix.PortRange
+	33,  // 61: felix.Rule.not_dst_ports:type_name -> felix.PortRange
+	31,  // 62: felix.Rule.not_icmp_type_code:type_name -> felix.IcmpTypeAndCode
+	28,  // 63: felix.Rule.src_service_account_match:type_name -> felix.ServiceAccountMatch
+	28,  // 64: felix.Rule.dst_service_account_match:type_name -> felix.ServiceAccountMatch
+	29,  // 65: felix.Rule.http_match:type_name -> felix.HTTPMatch
+	30,  // 66: felix.Rule.metadata:type_name -> felix.RuleMetadata
+	88,  // 67: felix.HTTPMatch.paths:type_name -> felix.HTTPMatch.PathMatch
+	89,  // 68: felix.RuleMetadata.annotations:type_name -> felix.RuleMetadata.AnnotationsEntry
+	34,  // 69: felix.WorkloadEndpointUpdate.id:type_name -> felix.WorkloadEndpointID
+	37,  // 70: felix.WorkloadEndpointUpdate.endpoint:type_name -> felix.WorkloadEndpoint
+	46,  // 71: felix.WorkloadEndpoint.tiers:type_name -> felix.TierInfo
+	47,  // 72: felix.WorkloadEndpoint.ipv4_nat:type_name -> felix.NatInfo
+	47,  // 73: felix.WorkloadEndpoint.ipv6_nat:type_name -> felix.NatInfo
+	90,  // 74: felix.WorkloadEndpoint.annotations:type_name -> felix.WorkloadEndpoint.AnnotationsEntry
+	38,  // 75: felix.WorkloadEndpoint.qos_controls:type_name -> felix.QoSControls
+	40,  // 76: felix.WorkloadEndpoint.local_bgp_peer:type_name -> felix.LocalBGPPeer
+	36,  // 77: felix.WorkloadEndpoint.skip_redir:type_name -> felix.WorkloadBpfSkipRedir
+	39,  // 78: felix.WorkloadEndpoint.qos_policies:type_name -> felix.QoSPolicy
+	1,   // 79: felix.WorkloadEndpoint.live_migration_role:type_name -> felix.LiveMigrationRole
+	34,  // 80: felix.WorkloadEndpointRemove.id:type_name -> felix.WorkloadEndpointID
+	42,  // 81: felix.HostEndpointUpdate.id:type_name -> felix.HostEndpointID
+	44,  // 82: felix.HostEndpointUpdate.endpoint:type_name -> felix.HostEndpoint
+	46,  // 83: felix.HostEndpoint.tiers:type_name -> felix.TierInfo
+	46,  // 84: felix.HostEndpoint.untracked_tiers:type_name -> felix.TierInfo
+	46,  // 85: felix.HostEndpoint.pre_dnat_tiers:type_name -> felix.TierInfo
+	46,  // 86: felix.HostEndpoint.forward_tiers:type_name -> felix.TierInfo
+	39,  // 87: felix.HostEndpoint.qos_policies:type_name -> felix.QoSPolicy
+	42,  // 88: felix.HostEndpointRemove.id:type_name -> felix.HostEndpointID
+	25,  // 89: felix.TierInfo.ingress_policies:type_name -> felix.PolicyID
+	25,  // 90: felix.TierInfo.egress_policies:type_name -> felix.PolicyID
+	42,  // 91: felix.HostEndpointStatusUpdate.id:type_name -> felix.HostEndpointID
+	50,  // 92: felix.HostEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
+	42,  // 93: felix.HostEndpointStatusRemove.id:type_name -> felix.HostEndpointID
+	34,  // 94: felix.WorkloadEndpointStatusUpdate.id:type_name -> felix.WorkloadEndpointID
+	50,  // 95: felix.WorkloadEndpointStatusUpdate.status:type_name -> felix.EndpointStatus
+	37,  // 96: felix.WorkloadEndpointStatusUpdate.endpoint:type_name -> felix.WorkloadEndpoint
+	34,  // 97: felix.WorkloadEndpointStatusRemove.id:type_name -> felix.WorkloadEndpointID
+	0,   // 98: felix.WireguardStatusUpdate.ip_version:type_name -> felix.IPVersion
+	91,  // 99: felix.HostMetadataV4V6Update.labels:type_name -> felix.HostMetadataV4V6Update.LabelsEntry
+	60,  // 100: felix.IPAMPoolUpdate.pool:type_name -> felix.IPAMPool
+	64,  // 101: felix.ServiceAccountUpdate.id:type_name -> felix.ServiceAccountID
+	92,  // 102: felix.ServiceAccountUpdate.labels:type_name -> felix.ServiceAccountUpdate.LabelsEntry
+	64,  // 103: felix.ServiceAccountRemove.id:type_name -> felix.ServiceAccountID
+	67,  // 104: felix.NamespaceUpdate.id:type_name -> felix.NamespaceID
+	93,  // 105: felix.NamespaceUpdate.labels:type_name -> felix.NamespaceUpdate.LabelsEntry
+	67,  // 106: felix.NamespaceRemove.id:type_name -> felix.NamespaceID
+	2,   // 107: felix.RouteUpdate.types:type_name -> felix.RouteType
+	3,   // 108: felix.RouteUpdate.ip_pool_type:type_name -> felix.IPPoolType
+	68,  // 109: felix.RouteUpdate.tunnel_type:type_name -> felix.TunnelType
+	32,  // 110: felix.DataplaneStats.protocol:type_name -> felix.Protocol
+	75,  // 111: felix.DataplaneStats.stats:type_name -> felix.Statistic
+	76,  // 112: felix.DataplaneStats.rules:type_name -> felix.RuleTrace
+	4,   // 113: felix.DataplaneStats.action:type_name -> felix.Action
+	6,   // 114: felix.Statistic.direction:type_name -> felix.Statistic.Direction
+	7,   // 115: felix.Statistic.relativity:type_name -> felix.Statistic.Relativity
+	8,   // 116: felix.Statistic.kind:type_name -> felix.Statistic.Kind
+	4,   // 117: felix.Statistic.action:type_name -> felix.Action
+	25,  // 118: felix.RuleTrace.policy:type_name -> felix.PolicyID
+	21,  // 119: felix.RuleTrace.profile:type_name -> felix.ProfileID
+	9,   // 120: felix.RuleTrace.direction:type_name -> felix.RuleTrace.Direction
+	82,  // 121: felix.ServiceUpdate.ports:type_name -> felix.ServicePort
+	14,  // 122: felix.ConfigUpdate.SourceToRawConfigEntry.value:type_name -> felix.RawConfig
+	10,  // 123: felix.PolicySync.Sync:input_type -> felix.SyncRequest
+	74,  // 124: felix.PolicySync.Report:input_type -> felix.DataplaneStats
+	11,  // 125: felix.PolicySync.Sync:output_type -> felix.ToDataplane
+	73,  // 126: felix.PolicySync.Report:output_type -> felix.ReportResult
+	125, // [125:127] is the sub-list for method output_type
+	123, // [123:125] is the sub-list for method input_type
+	123, // [123:123] is the sub-list for extension type_name
+	123, // [123:123] is the sub-list for extension extendee
+	0,   // [0:123] is the sub-list for field type_name
 }
 
 func init() { file_felixbackend_proto_init() }
@@ -7278,8 +6977,6 @@ func file_felixbackend_proto_init() {
 		(*ToDataplane_WorkloadEndpointUpdate)(nil),
 		(*ToDataplane_WorkloadEndpointRemove)(nil),
 		(*ToDataplane_ConfigUpdate)(nil),
-		(*ToDataplane_HostMetadataUpdate)(nil),
-		(*ToDataplane_HostMetadataRemove)(nil),
 		(*ToDataplane_HostMetadataV4V6Update)(nil),
 		(*ToDataplane_HostMetadataV4V6Remove)(nil),
 		(*ToDataplane_IpamPoolUpdate)(nil),
@@ -7300,8 +6997,6 @@ func file_felixbackend_proto_init() {
 		(*ToDataplane_ServiceRemove)(nil),
 		(*ToDataplane_WireguardEndpointV6Update)(nil),
 		(*ToDataplane_WireguardEndpointV6Remove)(nil),
-		(*ToDataplane_HostMetadataV6Update)(nil),
-		(*ToDataplane_HostMetadataV6Remove)(nil),
 	}
 	file_felixbackend_proto_msgTypes[2].OneofWrappers = []any{
 		(*FromDataplane_ProcessStatusUpdate)(nil),
@@ -7322,12 +7017,12 @@ func file_felixbackend_proto_init() {
 		(*Protocol_Number)(nil),
 		(*Protocol_Name)(nil),
 	}
-	file_felixbackend_proto_msgTypes[70].OneofWrappers = []any{
+	file_felixbackend_proto_msgTypes[66].OneofWrappers = []any{
 		(*RuleTrace_Policy)(nil),
 		(*RuleTrace_Profile)(nil),
 		(*RuleTrace_None)(nil),
 	}
-	file_felixbackend_proto_msgTypes[82].OneofWrappers = []any{
+	file_felixbackend_proto_msgTypes[78].OneofWrappers = []any{
 		(*HTTPMatch_PathMatch_Exact)(nil),
 		(*HTTPMatch_PathMatch_Prefix)(nil),
 	}
@@ -7337,7 +7032,7 @@ func file_felixbackend_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_felixbackend_proto_rawDesc), len(file_felixbackend_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   88,
+			NumMessages:   84,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -1027,12 +1027,12 @@ type ToDataplane_ConfigUpdate struct {
 
 type ToDataplane_HostMetadataV4V6Update struct {
 	// HostMetadataV4V6Update is sent when a host is added or updated.
-	HostMetadataV4V6Update *HostMetadataV4V6Update `protobuf:"bytes,14,opt,name=host_metadata_v4v6_update,json=hostMetadataV4v6Update,proto3,oneof"`
+	HostMetadataV4V6Update *HostMetadataV4V6Update `protobuf:"bytes,37,opt,name=host_metadata_v4v6_update,json=hostMetadataV4v6Update,proto3,oneof"`
 }
 
 type ToDataplane_HostMetadataV4V6Remove struct {
 	// HostIPRemove is sent when a host is removed.
-	HostMetadataV4V6Remove *HostMetadataV4V6Remove `protobuf:"bytes,18,opt,name=host_metadata_v4v6_remove,json=hostMetadataV4v6Remove,proto3,oneof"`
+	HostMetadataV4V6Remove *HostMetadataV4V6Remove `protobuf:"bytes,38,opt,name=host_metadata_v4v6_remove,json=hostMetadataV4v6Remove,proto3,oneof"`
 }
 
 type ToDataplane_IpamPoolUpdate struct {
@@ -6243,8 +6243,8 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x18workload_endpoint_update\x18\v \x01(\v2\x1d.felix.WorkloadEndpointUpdateH\x00R\x16workloadEndpointUpdate\x12Y\n" +
 	"\x18workload_endpoint_remove\x18\f \x01(\v2\x1d.felix.WorkloadEndpointRemoveH\x00R\x16workloadEndpointRemove\x12:\n" +
 	"\rconfig_update\x18\r \x01(\v2\x13.felix.ConfigUpdateH\x00R\fconfigUpdate\x12Z\n" +
-	"\x19host_metadata_v4v6_update\x18\x0e \x01(\v2\x1d.felix.HostMetadataV4V6UpdateH\x00R\x16hostMetadataV4v6Update\x12Z\n" +
-	"\x19host_metadata_v4v6_remove\x18\x12 \x01(\v2\x1d.felix.HostMetadataV4V6RemoveH\x00R\x16hostMetadataV4v6Remove\x12A\n" +
+	"\x19host_metadata_v4v6_update\x18% \x01(\v2\x1d.felix.HostMetadataV4V6UpdateH\x00R\x16hostMetadataV4v6Update\x12Z\n" +
+	"\x19host_metadata_v4v6_remove\x18& \x01(\v2\x1d.felix.HostMetadataV4V6RemoveH\x00R\x16hostMetadataV4v6Remove\x12A\n" +
 	"\x10ipam_pool_update\x18\x10 \x01(\v2\x15.felix.IPAMPoolUpdateH\x00R\x0eipamPoolUpdate\x12A\n" +
 	"\x10ipam_pool_remove\x18\x11 \x01(\v2\x15.felix.IPAMPoolRemoveH\x00R\x0eipamPoolRemove\x12S\n" +
 	"\x16service_account_update\x18\x13 \x01(\v2\x1b.felix.ServiceAccountUpdateH\x00R\x14serviceAccountUpdate\x12S\n" +
@@ -6265,7 +6265,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x0eservice_remove\x18  \x01(\v2\x14.felix.ServiceRemoveH\x00R\rserviceRemove\x12c\n" +
 	"\x1cwireguard_endpoint_v6_update\x18! \x01(\v2 .felix.WireguardEndpointV6UpdateH\x00R\x19wireguardEndpointV6Update\x12c\n" +
 	"\x1cwireguard_endpoint_v6_remove\x18\" \x01(\v2 .felix.WireguardEndpointV6RemoveH\x00R\x19wireguardEndpointV6RemoveB\t\n" +
-	"\apayload\"\xd3\x05\n" +
+	"\apayload\"\xbf\x06\n" +
 	"\rFromDataplane\x12'\n" +
 	"\x0fsequence_number\x18\b \x01(\x04R\x0esequenceNumber\x12P\n" +
 	"\x15process_status_update\x18\x03 \x01(\v2\x1a.felix.ProcessStatusUpdateH\x00R\x13processStatusUpdate\x12`\n" +
@@ -6276,7 +6276,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x17wireguard_status_update\x18\t \x01(\v2\x1c.felix.WireguardStatusUpdateH\x00R\x15wireguardStatusUpdate\x12D\n" +
 	"\x11dataplane_in_sync\x18\n" +
 	" \x01(\v2\x16.felix.DataplaneInSyncH\x00R\x0fdataplaneInSyncB\t\n" +
-	"\apayload\"\xd1\x02\n" +
+	"\apayloadJ\x04\b\x0e\x10\x0fJ\x04\b\x12\x10\x13J\x04\b#\x10$J\x04\b$\x10%R\x12HostMetadataUpdateR\x12HostMetadataRemoveR\x14HostMetadataV6UpdateR\x14HostMetadataV6Remove\"\xd1\x02\n" +
 	"\fConfigUpdate\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x127\n" +
 	"\x06config\x18\x01 \x03(\v2\x1f.felix.ConfigUpdate.ConfigEntryR\x06config\x12[\n" +

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -84,16 +84,10 @@ message ToDataplane {
     // ConfigUpdate is sent at start of day or when the config changes.
     ConfigUpdate config_update = 13;
 
-    // HostMetadataUpdate is sent when a host IP is added or updated.  I.e. the
-    // IP used for BGP peering/IPIP.
-    HostMetadataUpdate host_metadata_update = 14;
-    // HostIPRemove is sent when a host IP is removed.
-    HostMetadataRemove host_metadata_remove = 18;
-
     // HostMetadataV4V6Update is sent when a host is added or updated.
-    HostMetadataV4V6Update host_metadata_v4v6_update = 37;
+    HostMetadataV4V6Update host_metadata_v4v6_update = 14;
     // HostIPRemove is sent when a host is removed.
-    HostMetadataV4V6Remove host_metadata_v4v6_remove = 38;
+    HostMetadataV4V6Remove host_metadata_v4v6_remove = 18;
 
     // IPAMPoolUpdate is sent when an IPAM pool is added/updated.
     IPAMPoolUpdate ipam_pool_update = 16;
@@ -137,11 +131,6 @@ message ToDataplane {
     WireguardEndpointV6Update wireguard_endpoint_v6_update = 33;
     // WireguardEndpointV6Remove is sent to undo IPv6 wireguard on the host.
     WireguardEndpointV6Remove wireguard_endpoint_v6_remove = 34;
-
-    // HostMetadataV6Update is sent when a host IPv6 address is added or updated.
-    HostMetadataV6Update host_metadata_v6_update = 35;
-    // HostMetadataV6Remove is sent when a host IPv6 address is removed.
-    HostMetadataV6Remove host_metadata_v6_remove = 36;
   }
 }
 
@@ -552,26 +541,6 @@ message HostMetadataV4V6Update {
 message HostMetadataV4V6Remove {
   string hostname = 1;
   string ipv4_addr = 2;
-}
-
-message HostMetadataUpdate {
-  string hostname = 1;
-  string ipv4_addr = 2;
-}
-
-message HostMetadataRemove {
-  string hostname = 1;
-  string ipv4_addr = 2;
-}
-
-message HostMetadataV6Update {
-  string hostname = 1;
-  string ipv6_addr = 2;
-}
-
-message HostMetadataV6Remove {
-  string hostname = 1;
-  string ipv6_addr = 2;
 }
 
 message IPAMPoolUpdate {

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -85,9 +85,9 @@ message ToDataplane {
     ConfigUpdate config_update = 13;
 
     // HostMetadataV4V6Update is sent when a host is added or updated.
-    HostMetadataV4V6Update host_metadata_v4v6_update = 14;
+    HostMetadataV4V6Update host_metadata_v4v6_update = 37;
     // HostIPRemove is sent when a host is removed.
-    HostMetadataV4V6Remove host_metadata_v4v6_remove = 18;
+    HostMetadataV4V6Remove host_metadata_v4v6_remove = 38;
 
     // IPAMPoolUpdate is sent when an IPAM pool is added/updated.
     IPAMPoolUpdate ipam_pool_update = 16;
@@ -160,6 +160,10 @@ message FromDataplane {
 
     DataplaneInSync dataplane_in_sync = 10;
   }
+
+  // Deprecated fields related to host information. Removed in favor of HostMetadataV4V6* messages.
+  reserved "HostMetadataUpdate", "HostMetadataRemove", "HostMetadataV6Update", "HostMetadataV6Remove";
+  reserved 14, 18, 35, 36;
 }
 
 message ConfigUpdate {

--- a/libcalico-go/lib/resources/node.go
+++ b/libcalico-go/lib/resources/node.go
@@ -21,7 +21,6 @@ import (
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
-// TODO: Upadate this
 // FindNodeAddress returns node address of the specified type. Type can be one of
 // CalicoNodeIP, InternalIP or ExternalIP
 func FindNodeAddress(node *internalapi.Node, ipType string, ipVersion int) (*cnet.IP, *cnet.IPNet) {

--- a/libcalico-go/lib/resources/node.go
+++ b/libcalico-go/lib/resources/node.go
@@ -21,6 +21,7 @@ import (
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
+// TODO: Upadate this
 // FindNodeAddress returns node address of the specified type. Type can be one of
 // CalicoNodeIP, InternalIP or ExternalIP
 func FindNodeAddress(node *internalapi.Node, ipType string, ipVersion int) (*cnet.IP, *cnet.IPNet) {


### PR DESCRIPTION
## Description

Remove redundant `HostMetadata*` messages. Atm, there are 3 variants of this message, named `HostMetadataUpdate`, `HostMetadataV6Update` and `HostMetadataV4V6Update`. This PR removes the first two, and uses the last one in all places.

There will be follow up changes:
- Rename `HostMetadatV4V6*` messages to just `HostMetadata*` (basically removing V4V6 part) for sake of simplicity.
- Moving Host and Node updates to a separate component out of data plane passthru component in calc graph.  

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Deprecating HostMetadataUpdate, HostMetadataRemove, HostMetadataV6Update, and HostMetadataV6Remove internal protobuf messages in favor of HostMetadataV4V6Update and HostMetadataV4V6 messages.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
