### PR TITLE
[v3.30] fix: update images operations for hashrelease & release (#11253)

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -33,6 +33,29 @@ promotions:
   # Manual promotion for publishing a hashrelease.
   - name: Publish hashrelease
     pipeline_file: release/hashrelease.yml
+    parameters:
+      env_vars:
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "Build container images. If 'true', container images will be built as part of the hashrelease process."
+          name: BUILD_CONTAINER_IMAGES
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "create tarball of images. If 'true', a tarball of images will be added to the release.tgz. Requires BUILD_CONTAINER_IMAGES to also be 'true'."
+          name: ARCHIVE_IMAGES
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "publish images. If 'true', images will be pushed to the container registry/registries as part of the hashrelease process. Requires BUILD_CONTAINER_IMAGES to also be 'true'."
+          name: PUBLISH_IMAGES
   # Manual promotion for publishing a release.
   - name: Publish official release
     pipeline_file: release/release.yml

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,6 +33,29 @@ promotions:
   # Manual promotion for publishing a hashrelease.
   - name: Publish hashrelease
     pipeline_file: release/hashrelease.yml
+    parameters:
+      env_vars:
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "Build container images. If 'true', container images will be built as part of the hashrelease process."
+          name: BUILD_CONTAINER_IMAGES
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "create tarball of images. If 'true', a tarball of images will be added to the release.tgz. Requires BUILD_CONTAINER_IMAGES to also be 'true'."
+          name: ARCHIVE_IMAGES
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "publish images. If 'true', images will be pushed to the container registry/registries as part of the hashrelease process. Requires BUILD_CONTAINER_IMAGES to also be 'true'."
+          name: PUBLISH_IMAGES
   # Manual promotion for publishing a release.
   - name: Publish official release
     pipeline_file: release/release.yml

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -2,6 +2,29 @@ promotions:
   # Manual promotion for publishing a hashrelease.
   - name: Publish hashrelease
     pipeline_file: release/hashrelease.yml
+    parameters:
+      env_vars:
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "Build container images. If 'true', container images will be built as part of the hashrelease process."
+          name: BUILD_CONTAINER_IMAGES
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "create tarball of images. If 'true', a tarball of images will be added to the release.tgz. Requires BUILD_CONTAINER_IMAGES to also be 'true'."
+          name: ARCHIVE_IMAGES
+        - required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "false"
+          description: "publish images. If 'true', images will be pushed to the container registry/registries as part of the hashrelease process. Requires BUILD_CONTAINER_IMAGES to also be 'true'."
+          name: PUBLISH_IMAGES
   # Manual promotion for publishing a release.
   - name: Publish official release
     pipeline_file: release/release.yml

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -150,7 +150,7 @@ var (
 		Sources: cli.EnvVars("BUILD_CONTAINER_IMAGES"), // avoid BUILD_IMAGES as it is already used by the build system (lib.Makefile).
 		Value:   true,
 	}
-	buildHashreleaseImageFlag = &cli.BoolFlag{
+	buildHashreleaseImagesFlag = &cli.BoolFlag{
 		Name:    buildImagesFlag.Name,
 		Usage:   buildImagesFlag.Usage,
 		Sources: buildImagesFlag.Sources,
@@ -163,7 +163,7 @@ var (
 		Sources: cli.EnvVars("PUBLISH_IMAGES"),
 		Value:   true,
 	}
-	publishHashreleaseImageFlag = &cli.BoolFlag{
+	publishHashreleaseImagesFlag = &cli.BoolFlag{
 		Name:    publishImagesFlag.Name,
 		Usage:   publishImagesFlag.Usage,
 		Sources: publishImagesFlag.Sources,
@@ -175,6 +175,24 @@ var (
 		Usage:   "Archive images in the release tarball",
 		Sources: cli.EnvVars("ARCHIVE_IMAGES"),
 		Value:   true,
+		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			if b && !c.Bool(buildImagesFlag.Name) {
+				return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildImagesFlag.Name)
+			}
+			return nil
+		},
+	}
+	archiveHashreleaseImagesFlag = &cli.BoolFlag{
+		Name:    archiveImagesFlag.Name,
+		Usage:   archiveImagesFlag.Usage,
+		Sources: archiveImagesFlag.Sources,
+		Value:   false,
+		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			if b && !c.Bool(buildHashreleaseImagesFlag.Name) {
+				return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildHashreleaseImagesFlag.Name)
+			}
+			return nil
+		},
 	}
 )
 
@@ -338,14 +356,19 @@ var (
 		Sources: cli.EnvVars("IMAGE_SCANNER_SELECT"),
 		Value:   "all",
 	}
-	skipImageScanFlag = &cli.BoolFlag{
-		Name:    "skip-image-scan",
+	skipImageScanFlagName = "skip-image-scan"
+	skipImageScanFlag     = &cli.BoolFlag{
+		Name:    skipImageScanFlagName,
 		Usage:   "Skip sending the image to the image scan service",
 		Sources: cli.EnvVars("SKIP_IMAGE_SCAN"),
 		Value:   false,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if !b && (c.String(imageScannerAPIFlag.Name) == "" || c.String(imageScannerTokenFlag.Name) == "") {
-				return fmt.Errorf("Image scanner configuration is required, ensure %s and %s flags are set", imageScannerAPIFlag.Name, imageScannerTokenFlag.Name)
+			logrus.WithField(skipImageScanFlagName, b).Info("Image scanning configuration")
+			if !b && !imageScanningAPIConfig(c).Valid() {
+				if !c.Bool(ciFlag.Name) {
+					logrus.Warn("Image scanning configuration is incomplete")
+				}
+				return fmt.Errorf("invalid configuration for image scanning. Either set --%s and --%s or set --%s to 'true'", imageScannerAPIFlag.Name, imageScannerTokenFlag.Name, skipImageScanFlagName)
 			}
 			return nil
 		},

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -136,8 +136,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.IsHashRelease(),
 					calico.WithOutputDir(hashreleaseDir),
 					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithBuildImages(c.Bool(buildHashreleaseImageFlag.Name)),
-					calico.WithArchiveImages(c.Bool(archiveImagesFlag.Name)),
+					calico.WithBuildImages(c.Bool(buildHashreleaseImagesFlag.Name)),
+					calico.WithArchiveImages(c.Bool(archiveHashreleaseImagesFlag.Name)),
 					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
@@ -233,22 +233,23 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithHashrelease(*hashrel, *serverCfg),
-					calico.WithPublishImages(c.Bool(publishHashreleaseImageFlag.Name)),
+					calico.WithPublishImages(c.Bool(publishHashreleaseImagesFlag.Name)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
 					calico.WithImageScanning(!c.Bool(skipImageScanFlag.Name), *imageScanningAPIConfig(c)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
-					opts = append(opts, calico.WithImageRegistries(reg))
+					opts = append(opts,
+						calico.WithImageRegistries(reg),
+						calico.WithImageScanning(false, imagescanner.Config{}), // Disable image scanning if using custom registries.
+					)
+				} else {
+					opts = append(opts, calico.WithImageScanning(!c.Bool(skipImageScanFlag.Name), *imageScanningAPIConfig(c)))
 				}
-				// Note: We only need to check that the correct images exist if we haven't built them ourselves.
-				// So, skip this check if we're configured to build and publish images from the local codebase.
-				if !c.Bool(publishHashreleaseImageFlag.Name) {
-					components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir)
-					if err != nil {
-						return fmt.Errorf("failed to retrieve images for the hashrelease: %v", err)
-					}
-					opts = append(opts, calico.WithComponents(components))
+				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve images for the hashrelease: %v", err)
 				}
+				opts = append(opts, calico.WithComponents(components))
 				r := calico.NewManager(opts...)
 				if err := r.PublishRelease(); err != nil {
 					return err
@@ -280,13 +281,14 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 func hashreleaseBuildFlags() []cli.Flag {
 	f := append(productFlags,
 		registryFlag,
+		buildHashreleaseImagesFlag,
+		archiveHashreleaseImagesFlag,
 		archFlag)
 	f = append(f, operatorBuildFlags...)
 	f = append(f,
 		skipOperatorFlag,
 		skipBranchCheckFlag,
 		skipValidationFlag,
-		buildHashreleaseImageFlag,
 		githubTokenFlag)
 	return f
 }
@@ -298,7 +300,14 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		return fmt.Errorf("%s must be set if %s is set", operatorRegistryFlag, registryFlag)
 	}
 
-	// CI condtional checks.
+	if c.Bool(archiveHashreleaseImagesFlag.Name) && !c.Bool(buildHashreleaseImagesFlag.Name) {
+		return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildHashreleaseImagesFlag.Name)
+	}
+	if !c.Bool(archiveHashreleaseImagesFlag.Name) && c.Bool(buildHashreleaseImagesFlag.Name) {
+		logrus.Warnf("Images are built but not archived; to archive images set --%s to 'true'", archiveHashreleaseImagesFlag.Name)
+	}
+
+	// CI conditional checks.
 	if c.Bool(ciFlag.Name) {
 		if !hashreleaseServerConfig(c).Valid() {
 			return fmt.Errorf("missing hashrelease publishing configuration, ensure --%s is set",
@@ -306,7 +315,7 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		}
 	} else {
 		// If building images, log a warning if no registry is specified.
-		if c.Bool(buildHashreleaseImageFlag.Name) && len(c.StringSlice(registryFlag.Name)) == 0 {
+		if c.Bool(buildHashreleaseImagesFlag.Name) && len(c.StringSlice(registryFlag.Name)) == 0 {
 			logrus.Warn("Building images without specifying a registry will result in images being built with the default registries")
 		}
 
@@ -323,8 +332,8 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 func hashreleasePublishFlags() []cli.Flag {
 	f := append(gitFlags,
 		registryFlag,
+		publishHashreleaseImagesFlag,
 		archFlag,
-		publishHashreleaseImageFlag,
 		publishHashreleaseFlag,
 		latestFlag,
 		skipOperatorFlag,

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -157,6 +157,7 @@ func releaseBuildFlags() []cli.Flag {
 		archFlag,
 		registryFlag,
 		buildImagesFlag,
+		archiveImagesFlag,
 		githubTokenFlag,
 		skipValidationFlag)
 	return f

--- a/release/internal/imagescanner/scanner.go
+++ b/release/internal/imagescanner/scanner.go
@@ -67,8 +67,11 @@ func New(cfg Config) *Scanner {
 // Scan sends a request to the image scanner to scan the given images for the given product code and stream.
 func (i *Scanner) Scan(productCode string, images []string, stream string, release bool, outputDir string) error {
 	if !i.config.Valid() {
-		logrus.Error("Invalid image scanner configuration")
 		return fmt.Errorf("invalid image scanner configuration")
+	}
+	if len(images) == 0 {
+		logrus.Warn("No images to send to scanner, skipping...")
+		return nil
 	}
 	var bucketPath, scanType string
 	if release {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -576,9 +576,9 @@ func (r *CalicoManager) PublishRelease() error {
 			imageList = append(imageList, component.String())
 		}
 		imageScanner := imagescanner.New(r.imageScanningConfig)
-		err := imageScanner.Scan(r.productCode, imageList, r.hashrelease.Stream, false, r.tmpDir)
+		err := imageScanner.Scan(r.productCode, imageList, r.hashrelease.Stream, !r.isHashRelease, r.tmpDir)
 		if err != nil {
-			// Error is logged and ignored as this is not considered a fatal error
+			// Error is logged and ignored as a failure from ISS should not halt the release process.
 			logrus.WithError(err).Error("Failed to scan images")
 		}
 	}


### PR DESCRIPTION
## Description

cherry-pick #11253 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
fix (release-tool): include image tarballs in release archive file
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
