### PR TITLE
[v3.31] kube-proxy binds service health probes to node IPs

### DIFF
--- a/felix/bpf/proxy/health_check_nodeport_test.go
+++ b/felix/bpf/proxy/health_check_nodeport_test.go
@@ -17,6 +17,7 @@ package proxy_test
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -33,7 +34,7 @@ import (
 )
 
 var _ = Describe("BPF Proxy healthCheckNodeport", func() {
-	var p proxy.Proxy
+	var p proxy.ProxyFrontend
 	k8s := fake.NewClientset()
 
 	testNodeName := "testnode"
@@ -46,6 +47,7 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 			p, err = proxy.New(k8s, &mockDummySyncer{},
 				testNodeName, proxy.WithMinSyncPeriod(200*time.Millisecond))
 			Expect(err).NotTo(HaveOccurred())
+			p.SetHostIPs([]net.IP{net.ParseIP("127.0.0.1")})
 		})
 	})
 

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -137,6 +137,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 		return errors.WithMessage(err, "new bpf syncer")
 	}
 
+	kp.proxy.SetHostIPs(hostIPs)
 	kp.proxy.SetSyncer(syncer)
 
 	log.Infof("kube-proxy v%d node info updated, hostname=%q hostIPs=%+v", kp.ipFamily, kp.hostname, hostIPs)

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -15,9 +15,7 @@
 package proxy_test
 
 import (
-	"fmt"
 	"net"
-	"net/http"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -110,21 +108,9 @@ var _ = Describe("BPF kube-proxy", func() {
 			}).Should(BeTrue())
 		})
 
-		By("checking that the healthCheckNodePort is accessible", func() {
-			Eventually(func() error {
-				result, err := http.Get(fmt.Sprintf("http://localhost:%d", healthCheckNodePort))
-				if err != nil {
-					return err
-				}
-				if result.StatusCode != 503 {
-					return fmt.Errorf("Unexpected status code %d; expected 503", result.StatusCode)
-				}
-				return nil
-			}, "5s", "200ms").Should(Succeed())
-		})
+		updatedIP := net.IPv4(2, 2, 2, 2)
 
 		By("checking nodeport has the updated IP and not the initial IP", func() {
-			updatedIP := net.IPv4(2, 2, 2, 2)
 			p.OnHostIPsUpdate([]net.IP{updatedIP})
 
 			Eventually(func() bool {
@@ -141,19 +127,6 @@ var _ = Describe("BPF kube-proxy", func() {
 				}
 				return false
 			}).Should(BeTrue())
-		})
-
-		By("checking that the healthCheckNodePort is still accessible", func() {
-			Eventually(func() error {
-				result, err := http.Get(fmt.Sprintf("http://localhost:%d", healthCheckNodePort))
-				if err != nil {
-					return err
-				}
-				if result.StatusCode != 503 {
-					return fmt.Errorf("Unexpected status code %d; expected 503", result.StatusCode)
-				}
-				return nil
-			}, "5s", "200ms").Should(Succeed())
 		})
 
 		By("checking nodeport has 2 updated IPs", func() {

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -57,6 +57,7 @@ type Proxy interface {
 type ProxyFrontend interface {
 	Proxy
 	SetSyncer(DPSyncer)
+	SetHostIPs([]net.IP)
 }
 
 // DPSyncerState groups the information passed to the DPSyncer's Apply
@@ -151,6 +152,8 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 
 		stopCh:        make(chan struct{}),
 		healthzServer: new(alwaysHealthy),
+		// N.B. we do not start healthzServer until we have at least some host
+		// IPs. Dataplane implementation of hostports assumes we have a host IP.
 	}
 
 	for _, o := range opts {
@@ -166,7 +169,6 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 	dp.SetTriggerFn(p.runner.Run)
 
 	ipVersion := p.v1IPFamily()
-	p.svcHealthServer = healthcheck.NewServiceHealthServer(p.hostname, p.recorder, util.NewNodePortAddresses(ipVersion, []string{"0.0.0.0/0"}), p.healthzServer)
 
 	p.epsChanges = k8sp.NewEndpointsChangeTracker(ipVersion, p.hostname, nil, nil)
 	p.svcChanges = k8sp.NewServiceChangeTracker(ipVersion, makeServiceInfo, nil)
@@ -227,8 +229,7 @@ func (p *proxy) Stop() {
 	p.stopOnce.Do(func() {
 		log.Info("Proxy stopping")
 		// Pass empty update to close all the health checks.
-		_ = p.svcHealthServer.SyncServices(map[types.NamespacedName]uint16{})
-		_ = p.svcHealthServer.SyncEndpoints(map[types.NamespacedName]int{})
+		p.stopSvcHealthServer()
 		p.dpSyncer.Stop()
 		close(p.stopCh)
 		p.stopWg.Wait()
@@ -263,11 +264,13 @@ func (p *proxy) invokeDPSyncer() {
 	_ = p.svcMap.Update(p.svcChanges)
 	_ = p.epsMap.Update(p.epsChanges)
 
-	if err := p.svcHealthServer.SyncServices(p.svcMap.HealthCheckNodePorts()); err != nil {
-		log.WithError(err).Error("Error syncing healthcheck services")
-	}
-	if err := p.svcHealthServer.SyncEndpoints(p.epsMap.LocalReadyEndpoints()); err != nil {
-		log.WithError(err).Error("Error syncing healthcheck endpoints")
+	if p.healthzServer != nil && p.svcHealthServer != nil {
+		if err := p.svcHealthServer.SyncServices(p.svcMap.HealthCheckNodePorts()); err != nil {
+			log.WithError(err).Error("Error syncing healthcheck services")
+		}
+		if err := p.svcHealthServer.SyncEndpoints(p.epsMap.LocalReadyEndpoints()); err != nil {
+			log.WithError(err).Error("Error syncing healthcheck endpoints")
+		}
 	}
 
 	if p.healthzServer != nil {
@@ -351,6 +354,34 @@ func (p *proxy) SetSyncer(s DPSyncer) {
 	p.syncerLck.Unlock()
 
 	p.forceSyncDP()
+}
+
+func (p *proxy) stopSvcHealthServer() {
+	if p.svcHealthServer != nil {
+		_ = p.svcHealthServer.SyncServices(map[types.NamespacedName]uint16{})
+		_ = p.svcHealthServer.SyncEndpoints(map[types.NamespacedName]int{})
+	}
+}
+
+func (p *proxy) SetHostIPs(hostIPs []net.IP) {
+	p.runnerLck.Lock()
+	defer p.runnerLck.Unlock()
+
+	p.stopSvcHealthServer()
+
+	ips := make([]string, 0, len(hostIPs))
+	for _, ip := range hostIPs {
+		if ip.To4() != nil && p.ipFamily == 4 {
+			ips = append(ips, ip.String()+"/32")
+		} else if ip.To4() == nil && p.ipFamily != 4 {
+			ips = append(ips, ip.String()+"/128")
+		}
+	}
+
+	npa := util.NewNodePortAddresses(p.v1IPFamily(), ips)
+	log.Infof("NodePortAddresses V%d for health checks: %s", p.ipFamily, npa.String())
+	p.svcHealthServer = healthcheck.NewServiceHealthServer(p.hostname, p.recorder,
+		npa, p.healthzServer)
 }
 
 func (p *proxy) IPFamily() discovery.AddressType {

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -530,8 +530,9 @@ func describeBPFDualStackProxyHealthTests() bool {
 	desc := "_BPF_ _BPF-SAFE_ BPF dual stack kube-proxy health checking tests"
 	return infrastructure.DatastoreDescribe(desc, []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 		var (
-			infra infrastructure.DatastoreInfra
-			tc    infrastructure.TopologyContainers
+			infra     infrastructure.DatastoreInfra
+			tc        infrastructure.TopologyContainers
+			k8sClient *kubernetes.Clientset
 		)
 
 		BeforeEach(func() {
@@ -547,7 +548,8 @@ func describeBPFDualStackProxyHealthTests() bool {
 			opts.BPFProxyHealthzPort = 10256
 			opts.IPIPMode = api.IPIPModeNever
 
-			tc, _ = infrastructure.StartNNodeTopology(1, opts, infra)
+			tc, _ = infrastructure.StartNNodeTopology(2, opts, infra)
+			k8sClient = infra.(*infrastructure.K8sDatastoreInfra).K8sClient
 		})
 
 		AfterEach(func() {
@@ -564,6 +566,58 @@ func describeBPFDualStackProxyHealthTests() bool {
 
 			Eventually(func() int { return felixReady(felix.IP) }, "10s", "330ms").Should(BeGood())
 			Eventually(func() int { return felixReady(felix.IPv6) }, "10s", "330ms").Should(BeGood())
+		})
+
+		It("should have nodeport health probe working over both IPv4 and IPv6", func() {
+			// Create a workload on node 0
+			w0 := workload.Run(
+				tc.Felixes[0],
+				"w0",
+				"default",
+				"10.65.0.2",
+				"8055",
+				"tcp",
+				workload.WithIPv6Address("dead:beef::0:2"),
+			)
+			w0.WorkloadEndpoint.Labels = map[string]string{"name": w0.Name, "app": "test"}
+			w0.ConfigureInInfra(infra)
+
+			// Create a NodePort service with ExternalTrafficPolicy=Local
+			// This will automatically get a HealthCheckNodePort allocated
+			clusterIPs := []string{"10.101.0.20", "dead:beef::abcd:0:0:20"}
+			testSvc := k8sServiceForDualStack("test-np-health", clusterIPs, w0, 80, 8055, 30080, "tcp")
+			testSvc.Spec.Type = v1.ServiceTypeLoadBalancer
+			testSvc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+			healthCheckNodePort := int32(30081)
+			testSvc.Spec.HealthCheckNodePort = healthCheckNodePort
+			_, err := k8sClient.CoreV1().Services("default").Create(context.Background(), testSvc, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(k8sGetEpsForServiceFunc(k8sClient, testSvc), "10s").Should(HaveLen(1),
+				"Service endpoints didn't get created? Is controller-manager happy?")
+
+			// Check health probe on node 0 (has local endpoint) - should return 200
+			Eventually(func() int {
+				return healthStatus(tc.Felixes[0].IP, strconv.Itoa(int(healthCheckNodePort)), "")
+			}, "10s", "330ms").Should(Equal(200))
+
+			Eventually(func() int {
+				return healthStatus("["+tc.Felixes[0].IPv6+"]", strconv.Itoa(int(healthCheckNodePort)), "")
+			}, "10s", "330ms").Should(Equal(200))
+
+			// Check health probe on node 1 (no local endpoint) - should return 503
+			Eventually(func() int {
+				return healthStatus(tc.Felixes[1].IP, strconv.Itoa(int(healthCheckNodePort)), "")
+			}, "10s", "330ms").Should(Equal(503))
+
+			Eventually(func() int {
+				return healthStatus("["+tc.Felixes[1].IPv6+"]", strconv.Itoa(int(healthCheckNodePort)), "")
+			}, "10s", "330ms").Should(Equal(503))
+
+			// Clean up
+			w0.Stop()
+			err = k8sClient.CoreV1().Services("default").Delete(context.Background(), "test-np-health", metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 }


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11280
We were listening to any IP, but that makes the servers collide in dual stack setup. Since we implement nodeports and loadbalancers only for a set of known host IPs, we can also limit the binding to these IPs only. v4 and v6 then do not collide.

We do not start the servers until kube-proxy lears about the host IPs, but it will eventually, soon after start.

fixes https://github.com/projectcalico/calico/issues/11264

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: kube-proxy binds service health probes to node IPs instead of "any"
```