### PR TITLE
OpenStack: make periodic compaction loop independent of resync

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -1132,8 +1132,8 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
     def periodic_compaction_thread(self, launch_epoch):
         """Periodic etcd compaction logic.
 
-        On a fixed interval, requests etcd compaction to prevent unbounded disk usage growth.
-        Only the master node performs compaction.
+        On a fixed interval, requests etcd compaction to prevent unbounded disk usage
+        growth.  Only the master node performs compaction.
         """
         TrackTask("COMPACTION")
         try:


### PR DESCRIPTION
We need to make the compaction and resync loops independent for two reasons.

1. If resync is enabled and takes a very long time (multiple hours), we don't want that to block us from regularly requesting compaction.

2. If resync is disabled, by resync_interval_secs being set to 0, we still want to request compaction periodically.

3. The help text for `etcd_compaction_period_mins` says "Interval in minutes between periodic etcd compactions."  So we should actually implement that!  Currently the actual interval is resync_interval_secs plus however long a resync cycle takes.

## Release Note

```release-note
OpenStack bugfix: request etcd compaction periodically regardless of how long resync takes, or if periodic resync is disabled.
```