### PR TITLE
Route manager: use link name in log

### DIFF
--- a/felix/dataplane/linux/route_mgr.go
+++ b/felix/dataplane/linux/route_mgr.go
@@ -454,7 +454,7 @@ func (m *routeManager) detectParentIface() (netlink.Link, error) {
 		for _, addr := range addrs {
 			// Match address with or without subnet mask
 			if addr.IP.String() == parentAddr || addr.IPNet.String() == parentAddr {
-				m.logCtx.Debugf("Found parent interface: %s", link.Attrs().Name)
+				m.logCtx.Debugf("Found parent interface: %+v", link)
 				return link, nil
 			}
 		}


### PR DESCRIPTION
## Description

Update log message from:

```
felix/route_mgr.go 457: Found parent interface: &{{%!s(int=3) %!s(int=1500) %!s(int=0) eth0 fa:2f:da:c8:48:93 up|broadcast|multicast|running %!s(uint32=69699) %!s(int=97) %!s(int=0) <nil>  [] %!s(*netlink.LinkStatistics=&{172 142 41241 31200 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0}) %!s(int=0) %!s(int=0) %!s(int=1) %!s(*netlink.LinkXdp=&{0 false 0 0 0}) ether <nil> up %!s(int=0) %!s(int=0) %!s(int=4) %!s(int=4) %!s(uint32=65535) %!s(uint32=524280) %!s(uint32=65535) %!s(uint32=65536) %!s(uint32=65536) %!s(uint32=65536) %!s(uint32=65536) [] %!s(uint32=0)    <nil>}   <nil> %!s(int=0) %!s(uint32=0) %!s(uint32=0) %!s(uint32=0)} ipVersion=0x4 tunnelDevice=""
```
to 

```
felix/route_mgr.go 457: Found parent interface: eth0
```




<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
