### PR TITLE
Update node image for s390x

### DIFF
--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -15,7 +15,6 @@ LIBBPF_CONTAINER_PATH = /go/src/github.com/projectcalico/calico/felix/bpf-gpl/li
 BPFGPL_CONTAINER_PATH = /go/src/github.com/projectcalico/calico/felix/bpf-gpl/
 LIBBPF_A = $(REPO_ROOT)/felix/bpf-gpl/libbpf/src/$(ARCH)/libbpf.a
 
-ifeq ($(ARCH), $(filter $(ARCH),amd64 arm64))
 # When cross-compiling, force lld as the linker — GNU ld is single-target,
 # while lld natively links the cross-arch ELF objects produced by clang.
 # (The cross sysroot itself is already supplied via CC's --sysroot flag.)
@@ -23,9 +22,17 @@ CROSS_CGO_LDFLAGS=
 ifneq ($(CROSS_SYSROOT),)
 	CROSS_CGO_LDFLAGS=$(CROSS_LDFLAGS)
 endif
-CGO_LDFLAGS = "-L$(LIBBPF_CONTAINER_PATH)/$(ARCH) $(CROSS_CGO_LDFLAGS) -lbpf -lelf -lz"
-CGO_CFLAGS = "-I$(LIBBPF_CONTAINER_PATH) -I$(BPFGPL_CONTAINER_PATH)"
+# Normalize userspace types to ensure consistency across architectures.
+# On ppc64le the kernel UAPI defines __u64 as `unsigned long` unless
+# __SANE_USERSPACE_TYPES__ is set, which makes cgo reject `C.ulonglong`
+# arguments to __u64 parameters (felix/bpf/maps/syscall.go). Matches the
+# same flag in felix/Makefile and node/Makefile.
+ARCH_CGO_CFLAGS=
+ifeq ($(ARCH),ppc64le)
+	ARCH_CGO_CFLAGS=-D__SANE_USERSPACE_TYPES__
 endif
+CGO_LDFLAGS = "-L$(LIBBPF_CONTAINER_PATH)/$(ARCH) $(CROSS_CGO_LDFLAGS) -lbpf -lelf -lz"
+CGO_CFLAGS = "-I$(LIBBPF_CONTAINER_PATH) -I$(BPFGPL_CONTAINER_PATH) $(ARCH_CGO_CFLAGS)"
 
 BINDIR = bin
 CONTAINER_MARKER = .image.created-$(ARCH)
@@ -49,11 +56,7 @@ $(BINDIR)/calico-$(ARCH): $(SRC_FILES)
 	$(call build_binary, ./, $@)
 
 $(BINDIR)/calico-cgo-$(ARCH): $(LIBBPF_A) $(SRC_FILES)
-ifeq ($(ARCH),$(filter $(ARCH),amd64 arm64))
 	$(call build_cgo_binary, ./, $@)
-else
-	$(call build_binary, ./, $@)
-endif
 
 # Race-enabled combined binary for Felix FV runs. The race detector requires
 # CGO so we always build with CGO_ENABLED=1 and pull in libbpf the same way

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -115,9 +115,6 @@ clean-generated:
 ###############################################################################
 BUILD_TARGETS:=bin/calico-felix
 
-ifeq ($(ARCH),$(filter $(ARCH),amd64 arm64 ppc64le))
-# Currently CGO can be enabled in ARM64 AMD64 and PPC64LE builds.
-CGO_ENABLED=1
 # Normalize userspace types to ensure consistency across architectures.
 ARCH_CGO_CFLAGS=
 ifeq ($(ARCH),ppc64le)
@@ -134,12 +131,6 @@ CGO_LDFLAGS="-L$(LIBBPF_CONTAINER_PATH)/$(ARCH) $(CROSS_CGO_LDFLAGS) -lbpf -lelf
 CGO_CFLAGS="-I$(LIBBPF_CONTAINER_PATH) -I$(BPFGPL_CONTAINER_PATH) $(ARCH_CGO_CFLAGS)"
 FV_RACE_DETECTOR_ENABLED?=true
 BUILD_TARGETS+=build-bpf
-else
-CGO_ENABLED=0
-CGO_LDFLAGS=""
-# Race detection requires CGO enabled.
-FV_RACE_DETECTOR_ENABLED?=false
-endif
 
 ifeq ($(ARCH),amd64)
 BUILD_TARGETS+=bin/calico-felix.exe
@@ -169,16 +160,11 @@ $(LIBBPF_A): $(LIBBPF_FILE_CREATED) $(shell find bpf-gpl/libbpf -type f -not -pa
 	# rejects libbpf's non-PIC references to glibc symbols like stderr.
 	$(DOCKER_RUN) $(if $(CROSS_CC),-e CC="$(CROSS_CC)") $(CALICO_BUILD) sh -c "make -j$$(nproc) -C bpf-gpl/libbpf/src BUILD_STATIC_ONLY=1 OBJDIR=$(ARCH) EXTRA_CFLAGS=-fPIC"
 
-DOCKER_GO_BUILD_CGO=$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(if $(CROSS_CC),-e CC="$(CROSS_CC)") -e CGO_LDFLAGS=$(CGO_LDFLAGS) -e CGO_CFLAGS=$(CGO_CFLAGS) $(CALICO_BUILD)
+DOCKER_GO_BUILD_CGO=$(DOCKER_RUN) -e CGO_ENABLED=1 $(if $(CROSS_CC),-e CC="$(CROSS_CC)") -e CGO_LDFLAGS=$(CGO_LDFLAGS) -e CGO_CFLAGS=$(CGO_CFLAGS) $(CALICO_BUILD)
 
-LIBBPF_DEP=$(if $(filter 1,$(CGO_ENABLED)),$(LIBBPF_A))
-bin/calico-felix-$(ARCH): $(LIBBPF_DEP) $(SRC_FILES)
+bin/calico-felix-$(ARCH): $(LIBBPF_A) $(SRC_FILES)
 	@echo Building felix for $(ARCH) on $(BUILDARCH)
-ifeq ($(ARCH),$(filter $(ARCH),amd64 arm64 ppc64le ))
 	$(call build_cgo_binary, $(PACKAGE_NAME)/cmd/calico-felix, $@)
-else
-	$(call build_binary, $(PACKAGE_NAME)/cmd/calico-felix, $@)
-endif
 
 bin/calico-felix-race-$(ARCH):  $(LIBBPF_A) $(SRC_FILES) ../go.mod
 	@echo Building felix with race detector enabled for $(ARCH) on $(BUILDARCH)
@@ -223,7 +209,7 @@ $(PROD_BPF_PROGS) &: $(BPF_APACHE_O_FILES) $(BPF_GPL_O_FILES)
 	cp $(BPF_GPL_O_FILES) $(BPF_APACHE_O_FILES) bin/bpf
 
 $(BPF_APACHE_O_FILES) &: $(shell find bpf-apache -name '*.[ch]') bpf-apache/Makefile
-	$(DOCKER_GO_BUILD) make -j$$(nproc) -C bpf-apache all
+	$(DOCKER_GO_BUILD) make -j$$(nproc) -C bpf-apache ARCH=$(ARCH) all
 	touch -c $@
 
 $(BPF_GPL_O_FILES) $(BPF_GPL_UT_O_FILES) &: $(shell find bpf-gpl -name '*.[ch]') bpf-gpl/Makefile

--- a/felix/bpf-apache/Makefile
+++ b/felix/bpf-apache/Makefile
@@ -24,9 +24,14 @@ CFLAGS +=  \
 	-Werror \
 	-fno-stack-protector \
 	-O2 \
-	-target bpf \
 	-emit-llvm \
 	-g
+
+BPF_TARGET := bpf
+ifeq ($(ARCH),s390x)
+BPF_TARGET := bpfeb
+endif
+CFLAGS += -target $(BPF_TARGET)
 
 # Host architecture define — BPF compilation uses "-target bpf" which
 # doesn't define the host arch, but glibc's gnu/stubs.h needs it to
@@ -49,7 +54,7 @@ all: $(OBJS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 bin/%.o: %.ll | bin
-	$(LD) -march=bpf -filetype=obj -o $@ $<
+	$(LD) -march=$(BPF_TARGET) -filetype=obj -o $@ $<
 
 bin:
 	mkdir -p bin

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -16,9 +16,14 @@ CFLAGS +=  \
 	-fno-stack-protector \
 	-Wno-address-of-packed-member \
 	-O2 \
-	-target bpf \
 	-emit-llvm \
 	-g
+
+BPF_TARGET := bpf
+ifeq ($(ARCH),s390x)
+BPF_TARGET := bpfeb
+endif
+CFLAGS += -target $(BPF_TARGET)
 
 # Build against libbpf and its recent copy of the kernel headers.
 # We link against the user API version of the headers because they contain
@@ -48,6 +53,8 @@ CFLAGS +=  \
 HOST_ARCH := $(shell uname -m)
 ifeq ($(HOST_ARCH),x86_64)
 CFLAGS += -D__x86_64__
+else ifeq ($(HOST_ARCH),s390x)
+CFLAGS += -D__s390x__
 endif
 
 # Set target-arch defines for BPF compilation.  ARCH is passed from
@@ -58,6 +65,8 @@ else ifeq ($(ARCH),arm64)
 CFLAGS += -D__TARGET_ARCH_arm64
 else ifeq ($(ARCH),ppc64le)
 CFLAGS += -D__TARGET_ARCH_powerpc -D__SANE_USERSPACE_TYPES__
+else ifeq ($(ARCH),s390x)
+CFLAGS += -D__TARGET_ARCH_s390
 endif
 CC := clang
 LD := llc
@@ -241,7 +250,7 @@ conntrack_cleanup_v6.d: conntrack_cleanup.c
 #     llvm/llvm-project#174894, not yet merged as of LLVM 22).
 #   - Restructuring bpf_exit() to avoid inline asm "exit" + __builtin_unreachable().
 #   - Requiring kernel 6.16+ and accepting the __bpf_trap kfunc calls.
-LINK=$(LD) -march=bpf -filetype=obj -bpf-disable-trap-unreachable -o $@ $<
+LINK=$(LD) -march=$(BPF_TARGET) -filetype=obj -bpf-disable-trap-unreachable -o $@ $<
 bin/tc_preamble_ingress.o: tc_preamble_ingress.ll | bin
 	$(LINK)
 bin/tc_preamble_egress.o: tc_preamble_egress.ll | bin

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -30,6 +30,7 @@ import (
 // #cgo amd64 LDFLAGS: -L${SRCDIR}/../../bpf-gpl/libbpf/src/amd64 -lbpf -lelf -lz
 // #cgo arm64 LDFLAGS: -L${SRCDIR}/../../bpf-gpl/libbpf/src/arm64 -lbpf -lelf -lz
 // #cgo ppc64le LDFLAGS: -L${SRCDIR}/../../bpf-gpl/libbpf/src/ppc64le -lbpf -lelf -lz
+// #cgo s390x LDFLAGS: -L${SRCDIR}/../../bpf-gpl/libbpf/src/s390x -lbpf -lelf -lz
 // #include "libbpf_api.h"
 import "C"
 

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -166,9 +166,9 @@ endif
 # slow QEMU emulation for CGO builds.
 #
 # Map Go ARCH names to clang target triples.
-# Only arm64 and ppc64le need cross-compilation support (CGO is not enabled for s390x).
 CLANG_CROSS_TRIPLE_arm64   := aarch64-linux-gnu
 CLANG_CROSS_TRIPLE_ppc64le := powerpc64le-linux-gnu
+CLANG_CROSS_TRIPLE_s390x   := s390x-linux-gnu
 
 # Rust target triple (long form). Injected as CARGO_BUILD_TARGET so cargo
 # cross-compiles transparently. Linker/sysroot side uses CROSS_TRIPLE below.

--- a/node/Makefile
+++ b/node/Makefile
@@ -191,10 +191,6 @@ filesystem/usr/lib/calico/bpf: $(shell find ../felix/bpf-gpl -type f) $(shell fi
 	cp -r ../felix/bpf-gpl/bin/* $@
 	cp -r ../felix/bpf-apache/bin/* $@
 
-# We need CGO when compiling in Felix for BPF support.
-# Currently CGO can be enabled in ARM64 AMD64 and PPC64LE builds.
-ifeq ($(ARCH), $(filter $(ARCH),amd64 arm64 ppc64le))
-CGO_ENABLED=1
 # Normalize userspace types to ensure consistency across architectures.
 ARCH_CGO_CFLAGS=
 ifeq ($(ARCH),ppc64le)
@@ -209,11 +205,6 @@ ifneq ($(CROSS_SYSROOT),)
 endif
 CGO_LDFLAGS="-L$(LIBBPF_CONTAINER_PATH)/$(ARCH) $(CROSS_CGO_LDFLAGS) -lbpf -lelf -lz"
 CGO_CFLAGS="-I$(LIBBPF_CONTAINER_PATH) -I$(BPFGPL_CONTAINER_PATH) $(ARCH_CGO_CFLAGS)"
-else
-CGO_ENABLED=0
-CGO_LDFLAGS=""
-CGO_CFLAGS=""
-endif
 
 # The node image uses the combined calico binary built with CGO for BPF support.
 CMD_CALICO_BINDIR = ../cmd/calico/bin
@@ -233,12 +224,7 @@ $(WINDOWS_ARCHIVE_ROOT)/cni/calico.exe: $(WINDOWS_BINARY)
 	cp $(WINDOWS_BINARY) $@
 
 $(TOOLS_MOUNTNS_BINARY):
-ifeq ($(CGO_ENABLED),1)
 	$(call build_cgo_binary, ./cmd/mountns, $@)
-else
-	$(call build_binary, ./cmd/mountns, $@)
-endif
-
 
 ###############################################################################
 # Building the image


### PR DESCRIPTION
## Description
The calico-node pod failed to run on s390x with this error:
```
goroutine 1 [running]:
github.com/projectcalico/calico/felix/bpf/maps.GetMapFDByPin(...)
        /go/src/github.com/projectcalico/calico/felix/bpf/maps/syscall_stub.go:24
github.com/projectcalico/calico/felix/bpf/maps.(*PinnedMap).Open(0xc000c0c630)
        /go/src/github.com/projectcalico/calico/felix/bpf/maps/maps.go:568 +0x696
github.com/projectcalico/calico/felix/bpf/maps.(*PinnedMap).EnsureExists(0xc000c0c630)
        /go/src/github.com/projectcalico/calico/felix/bpf/maps/maps.go:636 +0xc4
github.com/projectcalico/calico/felix/bpf/nat.RemoveConnectTimeLoadBalancer(0x1, {0x0, 0x0})
        /go/src/github.com/projectcalico/calico/felix/bpf/nat/connecttime.go:74 +0x214
github.com/projectcalico/calico/felix/dataplane/linux.NewIntDataplaneDriver({{0xc000076014, 0x21}, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0, ...})
        /go/src/github.com/projectcalico/calico/felix/dataplane/linux/int_dataplane.go:787 +0x38a6
github.com/projectcalico/calico/felix/dataplane.StartDataplaneDriver(0xc0008c9508, 0xc000ac5bf0, {0x515f908, 0xc0006900b0}, 0xc000bde2b0, 0xc000bde2c0, 0xc000a03a40, 0xc000634a60)
        /go/src/github.com/projectcalico/calico/felix/dataplane/driver.go:422 +0x2a60
github.com/projectcalico/calico/felix/daemon.Run({0x4a0fdd4, 0x15}, {0x50e8098, 0xd}, {0x50fb6d0, 0x18}, {0x513f240, 0x28})
        /go/src/github.com/projectcalico/calico/felix/daemon/daemon.go:441 +0x2992
main.main()
        /go/src/github.com/projectcalico/calico/node/cmd/calico-node/main.go:129 +0x964
```
This PR updates the s390x node image to align with amd64 and arm64.  With these changes the calico-node pod can be run and works as expected.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Depends on https://github.com/projectcalico/toolchain/pull/837

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix panic in calico/node on s390x architecture. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
