### PR TITLE
Remove Felix FV flakes in no-encap tests

### DIFF
--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -91,20 +91,25 @@ func newNoEncapManagerWithSims(
 
 func (m *noEncapManager) OnUpdate(protoBufMsg interface{}) {
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataV4V6Update:
-		if (m.ipVersion == 4 && msg.Ipv4Addr == "") || (m.ipVersion == 6 && msg.Ipv6Addr == "") {
-			// Skip since the update is for a mismatched IP version
-			m.logCtx.WithField("msg", msg).Debug("Skipping mismatched IP version update")
-			return
-		}
-
+	case *proto.HostMetadataUpdate:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
-		if msg.Hostname == m.hostname {
-			if m.ipVersion == 6 {
-				m.routesNeedUpdate(msg.Ipv6Addr)
-			} else {
-				m.routesNeedUpdate(msg.Ipv4Addr)
-			}
+		if msg.Hostname == m.hostname && m.ipVersion == 4 {
+			m.routesNeedUpdate(msg.Ipv4Addr)
+		}
+	case *proto.HostMetadataRemove:
+		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
+		if msg.Hostname == m.hostname && m.ipVersion == 4 {
+			m.routesNeedUpdate("")
+		}
+	case *proto.HostMetadataV6Update:
+		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
+		if msg.Hostname == m.hostname && m.ipVersion == 6 {
+			m.routesNeedUpdate(msg.Ipv6Addr)
+		}
+	case *proto.HostMetadataV6Remove:
+		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
+		if msg.Hostname == m.hostname && m.ipVersion == 6 {
+			m.routesNeedUpdate("")
 		}
 	case *proto.HostMetadataV4V6Remove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -76,11 +76,11 @@ var _ = Describe("NoEncap Manager", func() {
 	})
 
 	It("successfully adds a route to the noEncap interface", func() {
-		noencapMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		noencapMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -158,11 +158,11 @@ var _ = Describe("NoEncap Manager", func() {
 	})
 
 	It("successfully adds a IPv6 route to the noEncap interface", func() {
-		noencapMgrV6.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgrV6.OnUpdate(&proto.HostMetadataV6Update{
 			Hostname: "node1",
 			Ipv6Addr: "fc00:10:96::2",
 		})
-		noencapMgrV6.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgrV6.OnUpdate(&proto.HostMetadataV6Update{
 			Hostname: "node2",
 			Ipv6Addr: "fc00:10:10::1",
 		})


### PR DESCRIPTION
## Description

Process `HostMetadataUpdate` and `HostMetadataV6Update` messages in no-encap manager instead of `HostMetadataV4V6Update` since it's seems to be causing flakes in FV tests (both in master and also in the [PR](https://github.com/projectcalico/calico/pull/10815) enabling Felix programming cluster routes by default).

By making this change in the above PR the last 3 CI runs were successful:
https://tigera.semaphoreci.com/workflows/5a1e0ce0-472e-4cea-b7c0-ac700f2d8fc3?pipeline_id=3c3460e1-1766-4f18-8251-547ac07a138e
https://tigera.semaphoreci.com/workflows/ae1cb563-4caa-40d9-b54e-34818749a749?pipeline_id=1b6a078e-1ad9-40b2-aae5-5202f5d3242f
https://tigera.semaphoreci.com/workflows/3722486e-622d-49ca-b90e-43e8b670a106?pipeline_id=b55e47e3-ca8e-487c-9ccb-64cfecb70be8

The difference between those messages is still unclear (In theory there should be no difference). I'm working on this [PR](https://github.com/projectcalico/calico/pull/11284) to get rid of the difference and use one message instead of all 3.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
