### PR TITLE
ci: Set priority of hashrelease builds to 90 (out of 100) [v3.30]

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -8,6 +8,9 @@ execution_time_limit:
   hours: 6
 
 global_job_config:
+  priority:
+    - value: 90
+      when: "branch =~ '.*'"
   secrets:
     - name: oss-release-secrets
     # Github SSH secret for pulling private repositories.


### PR DESCRIPTION
Cherry-pick of #11198.