### PR TITLE
fix: automatically roll tigera-operator deployment when managed kubernetes-services-endpoint ConfigMap is changed

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -18,8 +18,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- if .Values.kubernetesServiceEndpoint.host }}
+        checksum/endpoints-config: {{ include (print $.Template.BasePath "/tigera-operator/01-kubernetes-services-endpoint.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:


### PR DESCRIPTION
## Description

When kubernetes-services-endpoint ConfigMap is managed by helm release (`kubernetesServiceEndpoint.host` property is specified), any change to the host/port property will not trigger the rollout of tigera-operator deployment. In this case, environment variables in the process of the operator are not updated and it requires manual restart of the deployment.
This change adds the checksum annotation to pod annotations and in case if the ConfigMap is managed by helm release and if it's changed, the checksum will be changed as well and it will trigger an automatic rollout.

## Related issues/PRs

Based on answer in QA: https://github.com/orgs/projectcalico/discussions/11332

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Any changes to the kubernetes-services-endpoint ConfigMap managed by Helm Release automatically trigger a tigera-operator Deployment rollout.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
