### PR TITLE
[CORE-12061][Cherry-pick script] Set `gh` --repo flag before creating the PR.

### DIFF
--- a/hack/cherry-pick-pull
+++ b/hack/cherry-pick-pull
@@ -255,23 +255,11 @@ EOF
     echo
     cat "${pr_body_file}"
   else
-    # Temporarily set the gh default repo to the one derived from DST_UPSTREAM_REMOTE.
-    gh_default_remote=$(gh repo set-default --view 2>&1)
-    if [[ "$gh_default_remote" != "${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}" ]]; then
-      echo "+++ Using ${DST_UPSTREAM_REMOTE} remote to set gh default repo to: ${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}"
-      gh repo set-default "${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}"
-
-      trap 'echo "+++ Restoring gh default repo";
-      if echo "$gh_default_remote" | grep -q "No default remote"; then
-          gh repo set-default -u
-      else
-          gh repo set-default "$gh_default_remote"
-      fi' EXIT
-    fi
-    echo "+++ Creating PR into ${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}. Running: gh pr create -t \"[${relshort}] ${new_title}\" -F \"${pr_body_file}\" -H \"${GITHUB_USER}:${NEWBRANCH}\" -B \"${rel}\" -l \"${new_labels}\""
+    echo "+++ Creating PR into ${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}. Running: gh pr create -t \"[${relshort}] ${new_title}\" -F \"${pr_body_file}\" --repo \"${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}\" -H \"${GITHUB_USER}:${NEWBRANCH}\" -B \"${rel}\" -l \"${new_labels}\""
     gh pr create \
       -t "[${relshort}] ${new_title}" \
       -F "${pr_body_file}" \
+      --repo "${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}" \
       -H "${GITHUB_USER}:${NEWBRANCH}" \
       -B "${rel}" \
       -l "${new_labels}"


### PR DESCRIPTION
## Description

This change ensures that the GitHub CLI (gh) has an expected repository when creating PR.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
