### PR TITLE
[v3.30] Fix AllowSpoofedSourcePrefixes dualstack

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr.go
+++ b/felix/dataplane/linux/endpoint_mgr.go
@@ -987,6 +987,14 @@ func (m *endpointManager) hasSourceSpoofingConfiguration(interfaceName string) b
 	return ok
 }
 
+func getAddrIpVersion(addr string) uint8 {
+	ip, _, _ := net.ParseCIDR(addr)
+	if ip.To4() == nil {
+		return 6
+	}
+	return 4
+}
+
 func (m *endpointManager) updateRPFSkipChain() {
 	log.Debug("Updating RPF skip chain")
 	chain := &generictables.Chain{
@@ -995,10 +1003,12 @@ func (m *endpointManager) updateRPFSkipChain() {
 	}
 	for interfaceName, addresses := range m.sourceSpoofingConfig {
 		for _, addr := range addresses {
-			chain.Rules = append(chain.Rules, generictables.Rule{
-				Match:  m.newMatch().InInterface(interfaceName).SourceNet(addr),
-				Action: m.actions.Allow(),
-			})
+			if m.ipVersion == getAddrIpVersion(addr) {
+				chain.Rules = append(chain.Rules, generictables.Rule{
+					Match:  m.newMatch().InInterface(interfaceName).SourceNet(addr),
+					Action: m.actions.Allow(),
+				})
+			}
 		}
 	}
 	m.rawTable.UpdateChain(chain)

--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -2109,7 +2109,7 @@ func endpointManagerTests(ipVersion uint8, flowlogs bool) func() {
 							Tiers:                      []*proto.TierInfo{},
 							Ipv4Nets:                   []string{"10.0.240.2/24"},
 							Ipv6Nets:                   []string{"2001:db8:2::2/128"},
-							AllowSpoofedSourcePrefixes: []string{"8.8.8.8/32"},
+							AllowSpoofedSourcePrefixes: []string{"8.8.8.8/32", "2001:feed::1/64"},
 						},
 					}
 					interfaceUp = &ifaceStateUpdate{
@@ -2128,15 +2128,24 @@ func endpointManagerTests(ipVersion uint8, flowlogs bool) func() {
 						mockProcSys.checkStateContains(map[string]string{
 							"/proc/sys/net/ipv4/conf/cali23456-cd/rp_filter": "0",
 						})
+						rawTable.checkChains([][]*generictables.Chain{hostDispatchEmptyNormal, {
+							&generictables.Chain{Name: rules.ChainRpfSkip, Rules: []generictables.Rule{
+								{
+									Match:  iptables.Match().InInterface("cali23456-cd").SourceNet("8.8.8.8/32"),
+									Action: iptables.AcceptAction{},
+								},
+							}},
+						}})
+					} else {
+						rawTable.checkChains([][]*generictables.Chain{hostDispatchEmptyNormal, {
+							&generictables.Chain{Name: rules.ChainRpfSkip, Rules: []generictables.Rule{
+								{
+									Match:  iptables.Match().InInterface("cali23456-cd").SourceNet("2001:feed::1/64"),
+									Action: iptables.AcceptAction{},
+								},
+							}},
+						}})
 					}
-					rawTable.checkChains([][]*generictables.Chain{hostDispatchEmptyNormal, {
-						&generictables.Chain{Name: rules.ChainRpfSkip, Rules: []generictables.Rule{
-							{
-								Match:  iptables.Match().InInterface("cali23456-cd").SourceNet("8.8.8.8/32"),
-								Action: iptables.AcceptAction{},
-							},
-						}},
-					}})
 
 					By("Re-enabling rpf check on an existing workload")
 					workloadUpdate.Endpoint.AllowSpoofedSourcePrefixes = []string{}
@@ -2152,7 +2161,7 @@ func endpointManagerTests(ipVersion uint8, flowlogs bool) func() {
 					}})
 
 					By("Enabling IP spoofing on an existing workload")
-					workloadUpdate.Endpoint.AllowSpoofedSourcePrefixes = []string{"8.8.8.8/32"}
+					workloadUpdate.Endpoint.AllowSpoofedSourcePrefixes = []string{"8.8.8.8/32", "2001:feed::1/64"}
 					epMgr.OnUpdate(workloadUpdate)
 					applyUpdates(epMgr)
 					if ipVersion == 4 {
@@ -2160,14 +2169,25 @@ func endpointManagerTests(ipVersion uint8, flowlogs bool) func() {
 							"/proc/sys/net/ipv4/conf/cali23456-cd/rp_filter": "0",
 						})
 					}
-					rawTable.checkChains([][]*generictables.Chain{hostDispatchEmptyNormal, {
-						&generictables.Chain{Name: rules.ChainRpfSkip, Rules: []generictables.Rule{
-							{
-								Match:  iptables.Match().InInterface("cali23456-cd").SourceNet("8.8.8.8/32"),
-								Action: iptables.AcceptAction{},
-							},
-						}},
-					}})
+					if ipVersion == 4 {
+						rawTable.checkChains([][]*generictables.Chain{hostDispatchEmptyNormal, {
+							&generictables.Chain{Name: rules.ChainRpfSkip, Rules: []generictables.Rule{
+								{
+									Match:  iptables.Match().InInterface("cali23456-cd").SourceNet("8.8.8.8/32"),
+									Action: iptables.AcceptAction{},
+								},
+							}},
+						}})
+					} else {
+						rawTable.checkChains([][]*generictables.Chain{hostDispatchEmptyNormal, {
+							&generictables.Chain{Name: rules.ChainRpfSkip, Rules: []generictables.Rule{
+								{
+									Match:  iptables.Match().InInterface("cali23456-cd").SourceNet("2001:feed::1/64"),
+									Action: iptables.AcceptAction{},
+								},
+							}},
+						}})
+					}
 
 					By("Removing a workload with IP spoofing configured")
 					epMgr.OnUpdate(&proto.WorkloadEndpointRemove{


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#11338
## Description

This patch fixes support of AllowSpoofedSourcePrefixes in dualstack mode. When running in dualstack mode and specifying the cni.projectcalico.org/allowedSourcePrefixes on a pod, we should be programming the raw chain rules in the table corresponding to the ipfamily of the address in question.

## Related issues/PRs

This was introduced by https://github.com/projectcalico/calico/pull/5742
This patch fixes [#11333](https://github.com/projectcalico/calico/issues/11333)

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix AllowSpoofedSourcePrefixes for dual stack clusters.
```


