### PR TITLE
calico-dhcp-agent: don't include mtu in router advertisements

### DIFF
--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -219,6 +219,8 @@ class DnsmasqRouted(dhcp.Dnsmasq):
 
         # Add '--enable-ra'.
         cmd.append("--enable-ra")
+        # Don't advertise the MTU, since we don't have the value here
+        cmd.append("--ra-param=ns-*,mtu:off,0")
 
         # Enumerate precisely the TAP interfaces to listen on.
         cmd.remove("--interface=tap*")

--- a/networking-calico/networking_calico/tests/test_dhcp_agent.py
+++ b/networking-calico/networking_calico/tests/test_dhcp_agent.py
@@ -485,6 +485,7 @@ class TestDnsmasqRouted(base.BaseTestCase):
                 "--dhcp-range=set:subnet-v6subnet-1,2001:db8:1::"
                 + ",static,off-link,80,86400s",
                 "--enable-ra",
+                "--ra-param=ns-*,mtu:off,0",
                 "--interface=tap1",
                 "--interface=tap2",
                 "--interface=tap3",
@@ -566,6 +567,7 @@ class TestDnsmasqRouted(base.BaseTestCase):
                 "--dhcp-range=set:subnet-v6subnet-1,2001:db8:1::"
                 + ",static,off-link,80,86400s",
                 "--enable-ra",
+                "--ra-param=ns-*,mtu:off,0",
                 "--interface=tap1",
                 "--interface=tap2",
                 "--interface=tap3",


### PR DESCRIPTION
## Description

The calico plugin does not have the network mtu in it's data model, so i think it's better to just leave it out, and then let the instance set it to the same value as the interface
```
$ cat /proc/sys/net/ipv6/conf/eth0/mtu 
1500
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The overall goal is to allow instances to use jumbo frames over ipv6, like they can for ipv4

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->


```release-note
OpenStack: don't force the MTU to 1500 in IPv6 router advertisements
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
