### PR TITLE
[v3.31] Revert "fix: DNS resolution in envoy by replacing UBI nsswitch.conf"

### DIFF
--- a/third_party/envoy-proxy/Dockerfile
+++ b/third_party/envoy-proxy/Dockerfile
@@ -35,10 +35,8 @@ COPY --from=ubi /lib64/libsemanage.so.2 /lib64/libsemanage.so.2
 COPY --from=ubi /lib64/libsepol.so.2 /lib64/libsepol.so.2
 COPY --from=ubi /lib64/libtinfo.so.6 /lib64/libtinfo.so.6
 
-COPY --from=envoybinary --chown=0:0 --chmod=644 \
-    /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
-COPY --from=envoybinary --chown=0:0 --chmod=755 \
-    /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=envoybinary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY --from=envoybinary --chmod=755 /usr/local/bin/envoy /usr/local/bin/envoy
 
 FROM ${CALICO_BASE}
 


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11240
The PR this is reverting is unnecessary because /etc/nsswitch.conf is carried over to the final image by calico/base

Reverts projectcalico/calico#11231

