### PR TITLE
Correct OpenStack build dependencies

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1085,7 +1085,7 @@ blocks:
             - ../.semaphore/run-and-monitor ci.log make ci
   - name: "OpenStack integration (Yoga)"
     run:
-      when: "true or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/'], {pipeline_file: 'ignore'})"
+      when: "true or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/', '/.semaphore/semaphore.yml.d/blocks/40-openstack.yml'], {pipeline_file: 'ignore'})"
     dependencies:
       - Prerequisites
     task:
@@ -1132,7 +1132,7 @@ blocks:
             - artifact push job logs
   - name: "OpenStack integration (Caracal)"
     run:
-      when: "true or change_in(['/networking-calico/'], {pipeline_file: 'ignore'})"
+      when: "true or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/', '/.semaphore/semaphore.yml.d/blocks/40-openstack.yml'], {pipeline_file: 'ignore'})"
     dependencies:
       - Prerequisites
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1085,7 +1085,7 @@ blocks:
             - ../.semaphore/run-and-monitor ci.log make ci
   - name: "OpenStack integration (Yoga)"
     run:
-      when: "false or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/'], {pipeline_file: 'ignore'})"
+      when: "false or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/', '/.semaphore/semaphore.yml.d/blocks/40-openstack.yml'], {pipeline_file: 'ignore'})"
     dependencies:
       - Prerequisites
     task:
@@ -1132,7 +1132,7 @@ blocks:
             - artifact push job logs
   - name: "OpenStack integration (Caracal)"
     run:
-      when: "false or change_in(['/networking-calico/'], {pipeline_file: 'ignore'})"
+      when: "false or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/', '/.semaphore/semaphore.yml.d/blocks/40-openstack.yml'], {pipeline_file: 'ignore'})"
     dependencies:
       - Prerequisites
     task:

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -1,6 +1,6 @@
 - name: "OpenStack integration (Yoga)"
   run:
-    when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/'], {pipeline_file: 'ignore'})"
+    when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/', '/.semaphore/semaphore.yml.d/blocks/40-openstack.yml'], {pipeline_file: 'ignore'})"
   dependencies:
     - Prerequisites
   task:
@@ -48,7 +48,7 @@
 
 - name: "OpenStack integration (Caracal)"
   run:
-    when: "${FORCE_RUN} or change_in(['/networking-calico/'], {pipeline_file: 'ignore'})"
+    when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/networking-calico/', '/.semaphore/semaphore.yml.d/blocks/40-openstack.yml'], {pipeline_file: 'ignore'})"
   dependencies:
     - Prerequisites
   task:


### PR DESCRIPTION
The `change_in` expressions for OpenStack were missing a few things, and were wrongly different for the different OpenStack versions that we test against.