### PR TITLE
[v3.30] Set explicit priority 1024 for IPv6 routes to fix round-trip consistency

### DIFF
--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -1236,7 +1236,14 @@ func (r *RouteTable) refreshIfaceStateBestEffort(nl netlinkshim.Interface, iface
 }
 
 func (r *RouteTable) routeKeyForCIDR(cidr ip.CIDR) kernelRouteKey {
-	return kernelRouteKey{CIDR: cidr}
+	key := kernelRouteKey{CIDR: cidr}
+	// For IPv6, set priority to 1024. The kernel treats priority 0 as a sigil
+	// meaning "use the default value", which is 1024 for IPv6. We need to set
+	// an explicit priority so that routes round trip cleanly.
+	if r.ipVersion == 6 {
+		key.Priority = 1024
+	}
+	return key
 }
 
 func (r *RouteTable) routeIsOurs(route *netlink.Route) bool {

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -99,6 +99,7 @@ var _ = Describe("RouteTable v6", func() {
 				Protocol:  syscall.RTPROT_BOOT,
 				Scope:     netlink.SCOPE_UNIVERSE,
 				Table:     unix.RT_TABLE_MAIN,
+				Priority:  1024,
 			},
 		))
 	})

--- a/felix/wireguard/wireguard_test.go
+++ b/felix/wireguard/wireguard_test.go
@@ -1523,6 +1523,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_LINK,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 								Expect(rtDataplaneV6.RouteKeyToRoute[routekeyV6_2]).To(Equal(netlink.Route{
 									Family:    unix.AF_INET6,
@@ -1532,6 +1533,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_LINK,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 								Expect(rtDataplaneV6.RouteKeyToRoute[routekeyV6_3]).To(Equal(netlink.Route{
 									Family:    unix.AF_INET6,
@@ -1541,6 +1543,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_LINK,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 								Expect(rtDataplaneV6.RouteKeyToRoute[routekeyV6_4]).To(Equal(netlink.Route{
 									Family:    unix.AF_INET6,
@@ -1550,6 +1553,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_UNIVERSE,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 							}
 						})
@@ -1796,6 +1800,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_UNIVERSE,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 
 								// Remove the wireguard config for this peer. Should have no further impact.
@@ -2005,6 +2010,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_UNIVERSE,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 								Expect(linkV6.WireguardPeers).To(HaveLen(1))
 								Expect(linkV6.WireguardPeers).To(HaveKey(keyV6_peer1))
@@ -2118,6 +2124,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_UNIVERSE,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 
 								// Re-add the endpoint. Wireguard config will be added back in.
@@ -2143,6 +2150,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_LINK,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 							}
 						})
@@ -2301,6 +2309,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_UNIVERSE,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 
 								By("Deleting local route")
@@ -2328,6 +2337,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 									Protocol:  FelixRouteProtocol,
 									Scope:     netlink.SCOPE_LINK,
 									Table:     tableIndex,
+									Priority:  1024,
 								}))
 							}
 						})
@@ -2420,6 +2430,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 										Protocol:  FelixRouteProtocol,
 										Scope:     netlink.SCOPE_UNIVERSE,
 										Table:     tableIndex,
+										Priority:  1024,
 									}))
 								}
 							})
@@ -2534,6 +2545,7 @@ func describeEnableTests(enableV4, enableV6 bool) {
 										Protocol:  FelixRouteProtocol,
 										Scope:     netlink.SCOPE_LINK,
 										Table:     tableIndex,
+										Priority:  1024,
 									}))
 								}
 							})


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.30**: projectcalico/calico#11356
## Description

Bug fix. IPv6 routes were using priority 0, which the kernel treats as "use default" (1024 for IPv6). This caused inconsistency when reading routes back from the kernel, as they would return with priority 1024 rather than 0.

**Changes:**
- Modified `routeKeyForCIDR()` in `felix/routetable/route_table.go` to explicitly set `Priority: 1024` for IPv6 routes (`ipVersion == 6`)
- Updated IPv6 test cases in `felix/routetable/route_table_test.go` to expect `Priority: 1024` in route structures
- Updated IPv6 test cases in `felix/wireguard/wireguard_test.go` to expect `Priority: 1024` in route structures (12 test assertions)

**Affected components:** Felix route table management, Wireguard route management

**Testing:** 
- Updated 1 existing unit test in `felix/routetable/route_table_test.go` for IPv6 route creation
- Updated 12 existing unit tests in `felix/wireguard/wireguard_test.go` for IPv6 route validation

## Related issues/PRs

Fixes #11323

## Release Note

```release-note
Felix now explicitly sets priority 1024 for IPv6 routes instead of relying on kernel default, ensuring routes round-trip correctly when read from the kernel.
```

