### PR TITLE
[v3.29] eBPF - Split program maps used for ctlb

### DIFF
--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -28,15 +28,25 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__type(key, __u32);
 	__type(value, __u32);
-	__uint(max_entries, 3);
+	__uint(max_entries, 1);
 	__uint(map_flags, 0);
-}cali_ctlb_progs SEC(".maps");
+}cali_ctlb_conn SEC(".maps");
 
-enum cali_ctlb_prog_index {
-	PROG_INDEX_V6_CONNECT,
-	PROG_INDEX_V6_SENDMSG,
-	PROG_INDEX_V6_RECVMSG,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 1);
+	__uint(map_flags, 0);
+}cali_ctlb_send SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 1);
+	__uint(map_flags, 0);
+}cali_ctlb_recv SEC(".maps");
 
 SEC("cgroup/connect6")
 int calico_connect_v46(struct bpf_sock_addr *ctx)
@@ -59,7 +69,7 @@ int calico_connect_v46(struct bpf_sock_addr *ctx)
 		goto v4;
 	}
 
-	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_CONNECT);
+	bpf_tail_call(ctx, &cali_ctlb_conn, 0);
 	goto out;
 
 v4:
@@ -99,7 +109,7 @@ int calico_sendmsg_v46(struct bpf_sock_addr *ctx)
 		goto v4;
 	}
 
-	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_SENDMSG);
+	bpf_tail_call(ctx, &cali_ctlb_send, 0);
 	goto out;
 
 v4:
@@ -140,7 +150,7 @@ int calico_recvmsg_v46(struct bpf_sock_addr *ctx)
 		goto v4;
 	}
 
-	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_RECVMSG);
+	bpf_tail_call(ctx, &cali_ctlb_recv, 0);
 	goto out;
 
 

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -56,6 +56,7 @@ type CommonMaps struct {
 	JumpMap         maps.MapWithDeleteIfExists
 	XDPProgramsMap  maps.Map
 	XDPJumpMap      maps.MapWithDeleteIfExists
+	CTLBProgramsMap []maps.Map
 }
 
 type Maps struct {
@@ -87,6 +88,7 @@ func getCommonMaps() *CommonMaps {
 		JumpMap:         jump.Map().(maps.MapWithDeleteIfExists),
 		XDPProgramsMap:  hook.NewXDPProgramsMap(),
 		XDPJumpMap:      jump.XDPMap().(maps.MapWithDeleteIfExists),
+		CTLBProgramsMap: nat.ProgramsMap(),
 	}
 }
 
@@ -168,6 +170,9 @@ func (c *CommonMaps) slice() []maps.Map {
 		c.JumpMap,
 		c.XDPProgramsMap,
 		c.XDPJumpMap,
+		c.CTLBProgramsMap[0],
+		c.CTLBProgramsMap[1],
+		c.CTLBProgramsMap[2],
 	}
 }
 

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -34,27 +34,47 @@ import (
 )
 
 const (
-	ProgIndexCTLBConnectV6 = iota
-	ProgIndexCTLBSendV6
-	ProgIndexCTLBRecvV6
+	MapIndexCTLBConnectV6 = iota
+	MapIndexCTLBSendV6
+	MapIndexCTLBRecvV6
 )
 
 var ctlbProgToIndex = map[string]int{
-	"calico_connect_v6": ProgIndexCTLBConnectV6,
-	"calico_sendmsg_v6": ProgIndexCTLBSendV6,
-	"calico_recvmsg_v6": ProgIndexCTLBRecvV6,
+	"calico_connect_v6": MapIndexCTLBConnectV6,
+	"calico_sendmsg_v6": MapIndexCTLBSendV6,
+	"calico_recvmsg_v6": MapIndexCTLBRecvV6,
 }
 
-var ProgramsMapParameters = maps.MapParameters{
+var ConnMapParameters = maps.MapParameters{
 	Type:       "prog_array",
 	KeySize:    4,
 	ValueSize:  4,
-	MaxEntries: 3,
-	Name:       "cali_ctlb_progs",
+	MaxEntries: 1,
+	Name:       "cali_ctlb_conn",
 }
 
-func newProgramsMap() maps.Map {
-	return maps.NewPinnedMap(ProgramsMapParameters)
+var SendMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: 1,
+	Name:       "cali_ctlb_send",
+}
+
+var RecvMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: 1,
+	Name:       "cali_ctlb_recv",
+}
+
+func ProgramsMap() []maps.Map {
+	return []maps.Map{
+		maps.NewPinnedMap(ConnMapParameters),
+		maps.NewPinnedMap(SendMapParameters),
+		maps.NewPinnedMap(RecvMapParameters),
+	}
 }
 
 func RemoveConnectTimeLoadBalancer(ipv4Enabled bool, cgroupv2 string) error {
@@ -70,18 +90,22 @@ func RemoveConnectTimeLoadBalancer(ipv4Enabled bool, cgroupv2 string) error {
 
 	pinDir := path.Join(bpfMount, bpfdefs.CtlbPinDir)
 	defer bpf.CleanUpCalicoPins(pinDir)
-	ctlbProgsMap := newProgramsMap()
-	if err := ctlbProgsMap.EnsureExists(); err != nil {
-		return fmt.Errorf("failed to create ctlb jump map: %w", err)
+	ctlbProgsMap := ProgramsMap()
+	for _, index := range ctlbProgToIndex {
+		if err := ctlbProgsMap[index].EnsureExists(); err != nil {
+			return fmt.Errorf("failed to create ctlb jump map: %w", err)
+		}
 	}
 	for _, index := range ctlbProgToIndex {
-		err := ctlbProgsMap.Delete(jump.Key(index))
+		err := ctlbProgsMap[index].Delete(jump.Key(0))
 		if err != nil && !os.IsNotExist(err) {
 			log.Errorf("failed to delete the ctlb jump map entry: %s", err)
 		}
 	}
-	ctlbProgsMap.Close()
-	os.Remove(ctlbProgsMap.Path())
+	for _, index := range ctlbProgToIndex {
+		ctlbProgsMap[index].Close()
+		os.Remove(ctlbProgsMap[index].Path())
+	}
 
 	if err := detachCtlbPrograms(ipv4Enabled, pinDir, cgroupv2); err != nil {
 		return err
@@ -216,23 +240,21 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 	return nil
 }
 
-func updateCTLBJumpMap(jumpMap maps.Map, obj *libbpf.Obj) error {
-	for prog, index := range ctlbProgToIndex {
-		fd, err := obj.ProgramFD(prog)
-		if err != nil {
-			return fmt.Errorf("failed to get prog FD. Program = %s: %w", prog, err)
-		}
+func updateCTLBJumpMap(jumpMap maps.Map, obj *libbpf.Obj, prog string) error {
+	fd, err := obj.ProgramFD(prog)
+	if err != nil {
+		return fmt.Errorf("failed to get prog FD. Program = %s: %w", prog, err)
+	}
 
-		err = maps.UpdateMapEntry(jumpMap.MapFD(), jump.Key(index), jump.Value(uint32(fd)))
-		if err != nil {
-			log.WithError(err).Errorf("Failed to update %s map at index %d", prog, index)
-			return err
-		}
+	err = maps.UpdateMapEntry(jumpMap.MapFD(), jump.Key(0), jump.Value(uint32(fd)))
+	if err != nil {
+		log.WithError(err).Errorf("Failed to update %s map at index 0", prog)
+		return err
 	}
 	return nil
 }
 
-func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP, legacy bool) error {
+func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool, ctlbProgsMap []maps.Map, legacy bool) error {
 	bpfMount, err := utils.MaybeMountBPFfs()
 	if err != nil {
 		log.WithError(err).Error("Failed to mount bpffs, unable to do connect-time load balancing")
@@ -250,8 +272,7 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 		return fmt.Errorf("failed to set-up cgroupv2: %w", err)
 	}
 
-	ctlbProgsMap := newProgramsMap()
-	var v4Obj, v46Obj, v6Obj *libbpf.Obj
+	var v4Obj, v6Obj *libbpf.Obj
 
 	// Load and attach v4, v46 CTLB program.
 	if ipv4Enabled {
@@ -261,7 +282,7 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 		}
 		defer v4Obj.Close()
 
-		v46Obj, err = loadProgram(logLevel, "46", udpNotSeen, excludeUDP)
+		v46Obj, err := loadProgram(logLevel, "46", udpNotSeen, excludeUDP)
 		if err != nil {
 			return err
 		}
@@ -296,10 +317,6 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 				return err
 			}
 		}
-		if !ipv6Enabled {
-			//delete the jump map
-			os.Remove(ctlbProgsMap.Path())
-		}
 	}
 	// Load the v6 CTLB program.
 	if ipv6Enabled {
@@ -310,13 +327,11 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 		defer v6Obj.Close()
 		// If dual-stack, populate the jump maps with v6 ctlb programs.
 		if ipv4Enabled {
-			if err := ctlbProgsMap.EnsureExists(); err != nil {
-				log.WithError(err).Error("Failed to create CTLB programs maps")
-				return err
-			}
-			err = updateCTLBJumpMap(ctlbProgsMap, v6Obj)
-			if err != nil {
-				return err
+			for prog, index := range ctlbProgToIndex {
+				err = updateCTLBJumpMap(ctlbProgsMap[index], v6Obj, prog)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			err = attachProgram("connect", "6", pinDir, cgroupPath, udpNotSeen, excludeUDP, v6Obj, legacy)
@@ -340,15 +355,15 @@ func installCTLB(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string
 	return nil
 }
 
-func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
-	return installCTLB(ipv4Enabled, ipv6Enabled, cgroupv2, logLevel, udpNotSeen, excludeUDP, false)
+func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool, ctlbProgramsMap []maps.Map) error {
+	return installCTLB(ipv4Enabled, ipv6Enabled, cgroupv2, logLevel, udpNotSeen, excludeUDP, ctlbProgramsMap, false)
 }
 
-func InstallConnectTimeLoadBalancerLegacy(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
-	return installCTLB(ipv4Enabled, ipv6Enabled, cgroupv2, logLevel, udpNotSeen, excludeUDP, true)
+func InstallConnectTimeLoadBalancerLegacy(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool, ctlbProgramsMap []maps.Map) error {
+	return installCTLB(ipv4Enabled, ipv6Enabled, cgroupv2, logLevel, udpNotSeen, excludeUDP, ctlbProgramsMap, true)
 }
 
-func ProgFileName(logLevel string, ipver string) string {
+func ProgFileName(logLevel, ipver string) string {
 	logLevel = strings.ToLower(logLevel)
 	if logLevel == "off" {
 		logLevel = "no_log"

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -850,7 +850,10 @@ func TestCTLBAttachLegacy(t *testing.T) {
 	RegisterTestingT(t)
 
 	testCtlbAttachLegacy := func(v4, v6 bool) {
-		err := nat.InstallConnectTimeLoadBalancerLegacy(v4, v6, "", "debug", 60*time.Second, false)
+		bpfmaps, err := bpfmap.CreateBPFMaps(false)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = nat.InstallConnectTimeLoadBalancerLegacy(v4, v6, "", "debug", 60*time.Second, false, bpfmaps.CommonMaps.CTLBProgramsMap)
 		Expect(err).NotTo(HaveOccurred())
 
 		checkPinPath := func(pinPath string, mustExist bool) {
@@ -920,7 +923,10 @@ func TestCTLBAttachLegacy(t *testing.T) {
 func TestCTLBAttach(t *testing.T) {
 	RegisterTestingT(t)
 	testCtlbAttach := func(v4, v6 bool) {
-		err := nat.InstallConnectTimeLoadBalancer(v4, v6, "", "debug", 60*time.Second, false)
+		bpfmaps, err := bpfmap.CreateBPFMaps(false)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = nat.InstallConnectTimeLoadBalancer(v4, v6, "", "debug", 60*time.Second, false, bpfmaps.CommonMaps.CTLBProgramsMap)
 		Expect(err).NotTo(HaveOccurred())
 
 		checkPinPath := func(pinPath string, mustExist bool) {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -576,6 +576,7 @@ var (
 	natMap, natBEMap, ctMap, rtMap, ipsMap, testStateMap, affinityMap, arpMap, fsafeMap     maps.Map
 	natMapV6, natBEMapV6, ctMapV6, rtMapV6, ipsMapV6, affinityMapV6, arpMapV6, fsafeMapV6   maps.Map
 	stateMap, countersMap, ifstateMap, progMap, progMapXDP, policyJumpMap, policyJumpMapXDP maps.Map
+	ctlbProgsMap                                                                            []maps.Map
 	allMaps                                                                                 []maps.Map
 )
 
@@ -603,11 +604,12 @@ func initMapsOnce() {
 		ifstateMap = ifstate.Map()
 		policyJumpMap = jump.Map()
 		policyJumpMapXDP = jump.XDPMap()
+		ctlbProgsMap = nat.ProgramsMap()
 
 		allMaps = []maps.Map{natMap, natBEMap, natMapV6, natBEMapV6, ctMap, ctMapV6, rtMap, rtMapV6, ipsMap, ipsMapV6,
 			stateMap, testStateMap, affinityMap, affinityMapV6, arpMap, arpMapV6, fsafeMap, fsafeMapV6,
 			countersMap, ifstateMap,
-			policyJumpMap, policyJumpMapXDP}
+			policyJumpMap, policyJumpMapXDP, ctlbProgsMap[0], ctlbProgsMap[1], ctlbProgsMap[2]}
 		for _, m := range allMaps {
 			err := m.EnsureExists()
 			if err != nil {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -882,7 +882,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 			// Activate the connect-time load balancer.
 			err = bpfnat.InstallConnectTimeLoadBalancer(true, config.BPFIpv6Enabled,
-				config.BPFCgroupV2, logLevel, config.BPFConntrackTimeouts.UDPLastSeen, excludeUDP)
+				config.BPFCgroupV2, logLevel, config.BPFConntrackTimeouts.UDPLastSeen, excludeUDP, bpfMaps.CommonMaps.CTLBProgramsMap)
 			if err != nil {
 				log.WithError(err).Panic("BPFConnTimeLBEnabled but failed to attach connect-time load balancer, bailing out.")
 			}


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.29**: projectcalico/calico#11399
## Description

There was a change in 6.12 kernel which disallows jumping from programs of one type to the other. In our CTLB implementation we use a jump map to jump to connect, sendmsg or recvmsg v6 programs. Because of the kernel change, we cannot use the same jump map and results in `EINVAL` when loading the ctlb program.

Fix - Split the jump map into 3. one for connect, sendmsg and recvmsg respectively.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF - Fixed loading connecttime load balancer program in 6.12 kernel
```


