### PR TITLE
[v3.31] eBPF - Split program maps used for ctlb

### DIFF
--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -28,12 +28,6 @@ static CALI_BPF_INLINE bool is_ipv4_as_ipv6(__u32 *addr) {
 	return addr[0] == 0 && addr[1] == 0 && addr[2] == bpf_htonl(0x0000ffff);
 }
 
-enum cali_ctlb_prog_index {
-	PROG_INDEX_V6_CONNECT,
-	PROG_INDEX_V6_SENDMSG,
-	PROG_INDEX_V6_RECVMSG,
-};
-
 SEC("cgroup/connect6")
 int calico_connect_v46(struct bpf_sock_addr *ctx)
 {
@@ -55,7 +49,7 @@ int calico_connect_v46(struct bpf_sock_addr *ctx)
 		goto v4;
 	}
 
-	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_CONNECT);
+	bpf_tail_call(ctx, &cali_ctlb_conn, 0);
 	goto out;
 
 v4:
@@ -95,7 +89,7 @@ int calico_sendmsg_v46(struct bpf_sock_addr *ctx)
 		goto v4;
 	}
 
-	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_SENDMSG);
+	bpf_tail_call(ctx, &cali_ctlb_send, 0);
 	goto out;
 
 v4:
@@ -136,7 +130,7 @@ int calico_recvmsg_v46(struct bpf_sock_addr *ctx)
 		goto v4;
 	}
 
-	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_RECVMSG);
+	bpf_tail_call(ctx, &cali_ctlb_recv, 0);
 	goto out;
 
 

--- a/felix/bpf-gpl/ctlb_map.h
+++ b/felix/bpf-gpl/ctlb_map.h
@@ -2,6 +2,9 @@
 // Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
+#ifndef __CALI_CTLB_MAPS_H__
+#define __CALI_CTLB_MAPS_H__
+
 #include <linux/bpf.h>
 #include <stdbool.h>
 #include "bpf.h"
@@ -10,7 +13,24 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__type(key, __u32);
 	__type(value, __u32);
-	__uint(max_entries, 3);
+	__uint(max_entries, 1);
 	__uint(map_flags, 0);
-}cali_ctlb_progs SEC(".maps");
+}cali_ctlb_conn SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 1);
+	__uint(map_flags, 0);
+}cali_ctlb_send SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 1);
+	__uint(map_flags, 0);
+}cali_ctlb_recv SEC(".maps");
+
+#endif

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -60,7 +60,7 @@ type CommonMaps struct {
 	XDPProgramsMap  maps.Map
 	XDPJumpMap      maps.MapWithDeleteIfExists
 	ProfilingMap    maps.Map
-	CTLBProgramsMap maps.Map
+	CTLBProgramsMap []maps.Map
 	QoSMap          maps.MapWithUpdateWithFlags
 }
 
@@ -178,7 +178,9 @@ func (c *CommonMaps) slice() []maps.Map {
 		c.XDPProgramsMap,
 		c.XDPJumpMap,
 		c.ProfilingMap,
-		c.CTLBProgramsMap,
+		c.CTLBProgramsMap[0],
+		c.CTLBProgramsMap[1],
+		c.CTLBProgramsMap[2],
 		c.QoSMap,
 	}
 }

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -588,8 +588,9 @@ var (
 	natMapV6, natBEMapV6, ctMapV6, ctCleanupMapV6, rtMapV6, ipsMapV6, affinityMapV6, arpMapV6, fsafeMapV6         maps.Map
 	stateMap, countersMap, ifstateMap, progMap, progMapXDP, policyJumpMap, policyJumpMapXDP                       maps.Map
 	perfMap                                                                                                       maps.Map
-	profilingMap, ipfragsMapTmp, ctlbProgsMap                                                                     maps.Map
+	profilingMap, ipfragsMapTmp                                                                                   maps.Map
 	qosMap                                                                                                        maps.Map
+	ctlbProgsMap                                                                                                  []maps.Map
 	allMaps                                                                                                       []maps.Map
 )
 
@@ -630,7 +631,7 @@ func initMapsOnce() {
 		allMaps = []maps.Map{natMap, natBEMap, natMapV6, natBEMapV6, ctMap, ctMapV6, ctCleanupMap, ctCleanupMapV6, rtMap, rtMapV6, ipsMap, ipsMapV6,
 			stateMap, testStateMap, affinityMap, affinityMapV6, arpMap, arpMapV6, fsafeMap, fsafeMapV6,
 			countersMap, ipfragsMap, ipfragsMapTmp, ifstateMap, profilingMap,
-			policyJumpMap, policyJumpMapXDP, ctlbProgsMap, qosMap}
+			policyJumpMap, policyJumpMapXDP, ctlbProgsMap[0], ctlbProgsMap[1], ctlbProgsMap[2], qosMap}
 		for _, m := range allMaps {
 			err := m.EnsureExists()
 			if err != nil {


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11399
## Description

There was a change in 6.12 kernel which disallows jumping from programs of one type to the other. In our CTLB implementation we use a jump map to jump to connect, sendmsg or recvmsg v6 programs. Because of the kernel change, we cannot use the same jump map and results in `EINVAL` when loading the ctlb program.

Fix - Split the jump map into 3. one for connect, sendmsg and recvmsg respectively.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF - Fixed loading connecttime load balancer program in 6.12 kernel
```


