### PR TITLE
Allow shimming of default location time for tests

### DIFF
--- a/lib/std/time/controlled.go
+++ b/lib/std/time/controlled.go
@@ -100,6 +100,9 @@ func (clock *controlledClock) Now() Time {
 	clock.Lock()
 	defer clock.Unlock()
 
+	if localOverride != nil {
+		return clock.Unix(clock.now, 0).In(localOverride)
+	}
 	return clock.Unix(clock.now, 0)
 }
 

--- a/lib/std/time/standard.go
+++ b/lib/std/time/standard.go
@@ -9,6 +9,9 @@ func newStdClock() Clock {
 }
 
 func (std *stdClock) Now() Time {
+	if localOverride != nil {
+		return time.Now().In(localOverride)
+	}
 	return time.Now()
 }
 

--- a/lib/std/time/time.go
+++ b/lib/std/time/time.go
@@ -1,6 +1,9 @@
 package time
 
-import "time"
+import (
+	"testing"
+	"time"
+)
 
 func init() {
 	activeClock = newStdClock()
@@ -69,6 +72,8 @@ const (
 var (
 	UTC   = time.UTC
 	Local = time.Local
+
+	localOverride *time.Location
 )
 
 // DoWithClock temporarily sets the shim as the time and runs the given function. After the function is run, the time
@@ -81,6 +86,13 @@ func DoWithClock(shim Clock, fn func() error) error {
 
 type CleanUpRegisterable interface {
 	Cleanup(func())
+}
+
+// ShimLocalForTesting temporarily sets the local used by the time package to the given location. This helps with time
+// comparisons where two equal times with different locations are considered unequal.
+func ShimLocalForTesting(t *testing.T, local *time.Location) {
+	localOverride = local
+	t.Cleanup(func() { localOverride = nil })
 }
 
 // ShimClockForTestingT temporarily sets the shim as the time and runs the given function for a test and when the test


### PR DESCRIPTION
This allows for easier comprisons of times for tests as two equal times with different locals aren't considered equal.

Note that there is an ENV variable TZ that can be used to update the local for the underlying time system. This proved unhelpful when comparing unset Time values (that don't have a local) with third party libraries that "parsed" empty time value strings (that would have a local).

So just allowing overriding the local for our package to match what we want from third party parsing proves much better.

Note that this is only for testing, and it's required to have a testing.T to set the default local.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
