### PR TITLE
fix watcher cleanup in kube-controllers runconfig

### DIFF
--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -218,7 +218,6 @@ MAINLOOP:
 			time.Sleep(datastoreBackoff)
 			continue MAINLOOP
 		}
-		
 		for e := range w.ResultChan() {
 			switch e.Type {
 			case watch.Error:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In my Kubernetes environment (Kubernetes 1.28, Calico 3.27.4), I observed a slow, persistent increase in memory usage within the calico-kube-controllers. This appeared to indicate a potential memory leak. 
After investigation, I identified the cause of the memory leak: defer() inside a loop. Verification confirmed this effectively resolves the calico-kube-controllers memory leak (due to certain security considerations, I cannot include my environment's verification details in this PR, but the bug is quite obvious).

Therefore, the summary of this PR is as follows:
- fix kube-controllers runconfig watch loop so each recreated watcher is stopped immediately and the active watcher is cleaned up on shutdown
- prevents deferred Stop calls from piling up and leaking watcher resources when the config watch is recreated


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
This issue <https://github.com/projectcalico/calico/issues/10124> is most closely matching the observed problem. 
The heap data characteristics we obtained in our environment are highly similar to those described in this issue.

## Todos

- [ ] Tests  (please let me know if you want specific tests run)
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
Fix kube-controllers watch handling to avoid leaking watchers when the configuration watch is recreated.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
