### PR TITLE
adds maglev with aws-kubeadm block to BPF end-to-ends

### DIFF
--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -621,6 +621,29 @@ blocks:
             - name: K8S_E2E_FLAGS
               value: --ginkgo.focus=(Dataplane:BPF.*ModeSwitch.*external-node-to-nodePort)
 
+  - name: Maglev
+    dependencies: []
+    task:
+      jobs:
+        - name: BPF + AWS-kubeadm w External Node
+          execution_time_limit:
+            hours: 1
+          commands:
+            ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: PROVISIONER
+              value: "aws-kubeadm"
+            - name: VPC_SUBNETS
+              value: '["172.16.101.0/24"]' # single subnet because no encapsulation is being used
+            - name: IPAM_TEST_POOL_SUBNET
+              value: "10.0.0.0/29"
+            - name: ENABLE_DSR
+              value: "true"
+            - name: ENCAPSULATION_TYPE
+              value: "None"
+            - name: BGP_STATUS
+              value: Enabled
+
   - name: Wireguard
     dependencies: []
     task:


### PR DESCRIPTION
## Description

Adds a Maglev E2E to the semaphore BPF blocks

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
