### PR TITLE
fix: check ifIndex when updating oldState (issue 11016)

### DIFF
--- a/felix/ifacemonitor/iface_monitor.go
+++ b/felix/ifacemonitor/iface_monitor.go
@@ -318,7 +318,7 @@ func (m *InterfaceMonitor) storeAndNotifyLinkInner(ifaceExists bool, ifaceName s
 
 	// Calculate the old and new states of the interface.
 	oldState := StateNotPresent
-	if info := m.ifaceIdxToInfo[ifIndex]; info != nil {
+	if info := m.ifaceIdxToInfo[ifIndex]; info != nil && m.ifaceNameToIdx[ifaceName] == ifIndex {
 		oldState = info.State
 	}
 	newState := StateNotPresent


### PR DESCRIPTION
## Description

An attempt to fix issue #11016 , as suggested by the issue author.

I didn't find any consistent way to reproduce the issue, but it manifests once in 10-15 reboots on my setup with ~80 calico interfaces. With this fix couldn't reproduce in ~35 reboots.

Below are some fragments of the debug log.

```
iface name calibb9f92fb94d
Old:
  - ID 170
  - IP 10.1.154.7
New:
  - ID 219
  - IP 10.1.153.243
```

```
2025-11-24 08:26:10.740 [INFO][84] felix/endpoint_mgr.go 761: Updating per-endpoint chains. id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:26:10.740 [DEBUG][84] felix/endpoint_mgr.go 1656: Updating policy groups for iface groups=<nil> ifaceName="calibb9f92fb94d"
2025-11-24 08:26:10.740 [INFO][84] felix/endpoint_mgr.go 794: Updating endpoint routes. id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:26:10.740 [DEBUG][84] felix/endpoint_mgr.go 831: Endpoint up, adding routes id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:26:10.740 [DEBUG][84] felix/route_table.go 458: SetRoutes called. ifaceName="calibb9f92fb94d" routeClass=RouteClassLocalWorkload table="IPv4:254" targets=[]routetable.Target{routetable.Target{Type:"", CIDR:ip.V4CIDR{addr:ip.V4Addr{0xa, 0x2, 0xb8, 0x7}, prefix:0x20}, 
2025-11-24 08:26:10.740 [DEBUG][84] felix/route_table.go 652: Skipping route for missing interface. ifaceName="calibb9f92fb94d" table="IPv4:254"
2025-11-24 08:26:10.740 [DEBUG][84] felix/route_table.go 714: No valid route for this CIDR (all candidate routes missing iface index). candidates=[]string{"calibb9f92fb94d"} cidr=10.1.154.7/32 table="IPv4:254"
2025-11-24 08:26:10.740 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.154.7/32(tos=0 metric=0)
2025-11-24 08:26:10.740 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.154.7


2025-11-24 08:26:16.204 [DEBUG][84] felix/status_file_reporter.go 172: Handling endpoint update endpoint=id:{orchestrator_id:"k8s"  workload_id:"my-ns/my-pod-5bd549cc47-srn9f"  endpoint_id:"eth0"}  status:{status:"down"}  endpoint:{state:"active"  name:"calibb9f92fb94d"  profile_ids:"kns.my-ns"  profile_ids:"ksa.my-ns.foss-mac"  ipv4_nets:"10.1.154.7/32"}
2025-11-24 08:26:16.204 [DEBUG][84] felix/proto_utils.go 39: Generating WorkloadEndpointKey from WorkloadEndpointID key=WorkloadEndpoint(node=xx-mynode-n-1, orchestrator=k8s, workload=my-ns/my-pod-5bd549cc47-srn9f, name=eth0)
2025-11-24 08:26:16.204 [DEBUG][84] felix/workloadendpointstatus.go 60: Generating filename from WorkloadEndpointKey parts=[]string{"k8s", "my-ns%2Fmy-pod-5bd549cc47-srn9f", "eth0"}
2025-11-24 08:26:16.204 [DEBUG][84] felix/status_file_reporter.go 267: Skipping WorkloadEndpointStatusUpdate with down status update=id:{orchestrator_id:"k8s"  workload_id:"my-ns/my-pod-5bd549cc47-srn9f"  endpoint_id:"eth0"}  status:{status:"down"}  endpoint:{state:"active"  name:"calibb9f92fb94d"  profile_ids:"kns.my-ns"  profile_ids:"ksa.my-ns.foss-mac"  ipv4_nets:"10.1.154.7/32"}
2025-11-24 08:26:16.204 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k="k8s my-ns%2Fmy-pod-5bd549cc47-srn9f eth0"
2025-11-24 08:26:16.208 [INFO][84] felix/int_dataplane.go 2357: Received *proto.IPSetDeltaUpdate update from calculation graph. msg=id:"s:Vbl4aLpsO8Ss0UCzvsdmKAp4rZRC-V4hJGyiGg"  removed_members:"10.1.154.7/32"
2025-11-24 08:26:16.208 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.154.7/32
2025-11-24 08:26:16.208 [DEBUG][84] felix/endpoint_mgr.go 385: Received message msg=id:"s:Vbl4aLpsO8Ss0UCzvsdmKAp4rZRC-V4hJGyiGg"  removed_members:"10.1.154.7/32"
2025-11-24 08:26:16.208 [DEBUG][84] felix/wireguard_mgr.go 64: Received message ipVersion=0x4 msg=id:"s:Vbl4aLpsO8Ss0UCzvsdmKAp4rZRC-V4hJGyiGg"  removed_members:"10.1.154.7/32"


2025-11-24 08:26:29.140 [INFO][84] felix/endpoint_mgr.go 857: Workload removed, deleting its chains. id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:26:29.140 [INFO][84] felix/endpoint_mgr.go 700: Deleting QoS bandwidth state if present id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:26:29.483 [INFO][84] felix/endpoint_mgr.go 714: Workload removed, deleting old state. id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:26:29.484 [DEBUG][84] felix/route_table.go 458: SetRoutes called. ifaceName="calibb9f92fb94d" routeClass=RouteClassLocalWorkload table="IPv4:254" targets=[]routetable.Target(nil)
2025-11-24 08:26:29.484 [DEBUG][84] felix/route_table.go 483: Cleaning up old route. cidr=10.1.154.7/32 table="IPv4:254"
2025-11-24 08:26:29.484 [DEBUG][84] felix/route_table.go 709: CIDR no longer has any associated routes. cidr=10.1.154.7/32 table="IPv4:254"
2025-11-24 08:26:29.484 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.154.7/32(tos=0 metric=0)
2025-11-24 08:26:29.484 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.154.7
2025-11-24 08:26:29.484 [DEBUG][84] felix/link_addrs.go 157: remove link local address iface="calibb9f92fb94d" ipVersion=4
2025-11-24 08:26:29.484 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k="calibb9f92fb94d"

2025-11-24 08:27:06.006 [DEBUG][84] felix/route_table.go 382: Interface state update. ifIndex=219 ifaceName="calibb9f92fb94d" name="calibb9f92fb94d" state="up" table="IPv4:254"
2025-11-24 08:27:06.006 [DEBUG][84] felix/route_table.go 408: Interface up, marking for route sync ifaceName="calibb9f92fb94d" table="IPv4:254"
2025-11-24 08:27:06.006 [DEBUG][84] felix/route_table.go 1323: Loaded route from kernel. kernKey=10.1.153.243/32(tos=0 metric=0) kernRoute=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219} table="IPv4:254"

2025-11-24 08:27:06.293 [DEBUG][84] felix/iface_monitor.go 283: storeAndNotifyLink called ifIndex=219 ifaceExists=true name="calibb9f92fb94d"
2025-11-24 08:27:06.293 [DEBUG][84] felix/iface_monitor.go 317: storeAndNotifyLinkInner called ifIndex=219 ifaceExists=true ifaceName="calibb9f92fb94d" link=&netlink.Veth{LinkAttrs:netlink.LinkAttrs{Index:219, MTU:1450, TxQLen:0, Name:"calibb9f92fb94d", 
2025-11-24 08:27:06.293 [DEBUG][84] felix/iface_monitor.go 358: Interface changed state ifIndex=219 ifaceName="calibb9f92fb94d" newState="up" oldState=""
2025-11-24 08:27:06.293 [INFO][84] felix/int_dataplane.go 1737: Linux interface state changed. ifIndex=219 ifaceName="calibb9f92fb94d" state="up"
2025-11-24 08:27:06.293 [DEBUG][84] felix/iface_monitor.go 271: Notifying addresses for interface ifIndex=219 name="calibb9f92fb94d"

2025-11-24 08:27:06.302 [DEBUG][84] felix/iface_monitor.go 283: storeAndNotifyLink called ifIndex=170 ifaceExists=true name="calibb9f92fb94d"
2025-11-24 08:27:06.302 [DEBUG][84] felix/iface_monitor.go 317: storeAndNotifyLinkInner called ifIndex=170 ifaceExists=true ifaceName="calibb9f92fb94d" link=&netlink.Veth{LinkAttrs:netlink.LinkAttrs{Index:170, MTU:1450, TxQLen:0, 
2025-11-24 08:27:06.302 [DEBUG][84] felix/iface_monitor.go 358: Interface changed state ifIndex=170 ifaceName="calibb9f92fb94d" newState="down" oldState="up"
2025-11-24 08:27:06.302 [INFO][84] felix/int_dataplane.go 1737: Linux interface state changed. ifIndex=170 ifaceName="calibb9f92fb94d" state="down"
2025-11-24 08:27:06.302 [DEBUG][84] felix/iface_monitor.go 283: storeAndNotifyLink called ifIndex=170 ifaceExists=false name="calibb9f92fb94d"
2025-11-24 08:27:06.302 [DEBUG][84] felix/iface_monitor.go 317: storeAndNotifyLinkInner called ifIndex=170 ifaceExists=false ifaceName="calibb9f92fb94d" link=&netlink.Veth{LinkAttrs:netlink.LinkAttrs{Index:170, MTU:1450, TxQLen:0, 
2025-11-24 08:27:06.302 [DEBUG][84] felix/iface_monitor.go 358: Interface changed state ifIndex=170 ifaceName="calibb9f92fb94d" newState="" oldState="down"
2025-11-24 08:27:06.302 [INFO][84] felix/int_dataplane.go 1737: Linux interface state changed. ifIndex=170 ifaceName="calibb9f92fb94d" state=""
2025-11-24 08:27:06.302 [INFO][84] felix/int_dataplane.go 1781: Linux interface addrs changed. addrs=<nil> ifaceName="calibb9f92fb94d"

2025-11-24 08:27:07.596 [DEBUG][84] felix/route_table.go 458: SetRoutes called. ifaceName="calibb9f92fb94d" routeClass=RouteClassLocalWorkload table="IPv4:254" targets=[]routetable.Target{routetable.Target{Type:"", CIDR:ip.V4CIDR{addr:ip.V4Addr{0xa, 0x2, 0xb7, 0xf3}, prefix:0x20}, GW:ip.Addr(nil), Src:ip.Addr(nil), DestMAC:net.HardwareAddr(nil), Protocol:0, MultiPath:[]routetable.NextHop(nil), MTU:0}}
2025-11-24 08:27:07.596 [DEBUG][84] felix/route_table.go 762: Preferred kernel route for this dest has changed. dst=10.1.153.243/32(tos=0 metric=0) iface="calibb9f92fb94d" newRoute=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219} oldRoute=<none> table="IPv4:254"
2025-11-24 08:27:07.596 [DEBUG][84] felix/delta_tracker.go 144: Set k=10.1.153.243/32(tos=0 metric=0) v=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219}
2025-11-24 08:27:07.596 [DEBUG][84] felix/delta_tracker.go 144: Set k=10.1.153.243 v=routetable.conntrackOwner{ifaceIdx:219, routeClass:0}

2025-11-24 08:27:07.633 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k="calibb9f92fb94d"

2025-11-24 08:27:09.201 [DEBUG][84] felix/endpoint_mgr.go 831: Endpoint up, adding routes id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:27:09.201 [DEBUG][84] felix/route_table.go 458: SetRoutes called. ifaceName="calibb9f92fb94d" routeClass=RouteClassLocalWorkload table="IPv4:254" targets=[]routetable.Target{routetable.Target{Type:"", CIDR:ip.V4CIDR{addr:ip.V4Addr{0xa, 0x2, 0xb7, 0xf3}, prefix:0x20}, GW:ip.Addr(nil), Src:ip.Addr(nil), DestMAC:net.HardwareAddr(nil), Protocol:0, MultiPath:[]routetable.NextHop(nil), MTU:0}}
2025-11-24 08:27:09.201 [DEBUG][84] felix/route_table.go 768: Preferred kernel route for this dest still the same. dst=10.1.153.243/32(tos=0 metric=0) iface="calibb9f92fb94d" route=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219} table="IPv4:254"
2025-11-24 08:27:09.201 [DEBUG][84] felix/delta_tracker.go 144: Set k=10.1.153.243/32(tos=0 metric=0) v=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219}
2025-11-24 08:27:09.201 [DEBUG][84] felix/delta_tracker.go 144: Set k=10.1.153.243 v=routetable.conntrackOwner{ifaceIdx:219, routeClass:0}

2025-11-24 08:27:09.860 [DEBUG][84] felix/wireguard_mgr.go 64: Received message ipVersion=0x4 msg=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"up", Index:219}
2025-11-24 08:27:09.860 [DEBUG][84] felix/route_table.go 382: Interface state update. ifIndex=219 ifaceName="calibb9f92fb94d" name="calibb9f92fb94d" state="up" table="IPv4:254"
2025-11-24 08:27:09.860 [DEBUG][84] felix/route_table.go 408: Interface up, marking for route sync ifaceName="calibb9f92fb94d" table="IPv4:254"
2025-11-24 08:27:09.860 [DEBUG][84] felix/route_table.go 768: Preferred kernel route for this dest still the same. dst=10.1.153.243/32(tos=0 metric=0) iface="calibb9f92fb94d" route=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219} table="IPv4:254"
2025-11-24 08:27:09.860 [DEBUG][84] felix/delta_tracker.go 144: Set k=10.1.153.243/32(tos=0 metric=0) v=kernelRoute{Type=1, Scope=253, Src=<nil>, Protocol=boot, OnLink=false, GW=<nil>, Ifindex=219}
2025-11-24 08:27:09.860 [DEBUG][84] felix/delta_tracker.go 144: Set k=10.1.153.243 v=routetable.conntrackOwner{ifaceIdx:219, routeClass:0}

2025-11-24 08:27:09.864 [DEBUG][84] felix/endpoint_mgr.go 408: Interface state changed. update=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"down", Index:170}
2025-11-24 08:27:09.864 [DEBUG][84] felix/wireguard_mgr.go 64: Received message ipVersion=0x4 msg=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"down", Index:170}
2025-11-24 08:27:09.864 [DEBUG][84] felix/route_table.go 382: Interface state update. ifIndex=170 ifaceName="calibb9f92fb94d" name="calibb9f92fb94d" state="down" table="IPv4:254"
2025-11-24 08:27:09.864 [DEBUG][84] felix/route_table.go 684: Skipping route for down interface. ifaceName="calibb9f92fb94d" table="IPv4:254"
2025-11-24 08:27:09.864 [DEBUG][84] felix/route_table.go 714: No valid route for this CIDR (all candidate routes missing iface index). candidates=[]string{"calibb9f92fb94d"} cidr=10.1.153.243/32 table="IPv4:254"
2025-11-24 08:27:09.864 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.153.243/32(tos=0 metric=0)
2025-11-24 08:27:09.864 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.153.243

2025-11-24 08:27:09.864 [INFO][84] felix/int_dataplane.go 2415: Received interface update msg=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"", Index:170}
2025-11-24 08:27:09.865 [DEBUG][84] felix/endpoint_mgr.go 385: Received message msg=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"", Index:170}
2025-11-24 08:27:09.865 [DEBUG][84] felix/endpoint_mgr.go 408: Interface state changed. update=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"", Index:170}
2025-11-24 08:27:09.865 [DEBUG][84] felix/wireguard_mgr.go 64: Received message ipVersion=0x4 msg=&intdataplane.ifaceStateUpdate{Name:"calibb9f92fb94d", State:"", Index:170}
2025-11-24 08:27:09.865 [DEBUG][84] felix/route_table.go 382: Interface state update. ifIndex=170 ifaceName="calibb9f92fb94d" name="calibb9f92fb94d" state="" table="IPv4:254"
2025-11-24 08:27:09.865 [DEBUG][84] felix/route_table.go 652: Skipping route for missing interface. ifaceName="calibb9f92fb94d" table="IPv4:254"
2025-11-24 08:27:09.865 [DEBUG][84] felix/route_table.go 714: No valid route for this CIDR (all candidate routes missing iface index). candidates=[]string{"calibb9f92fb94d"} cidr=10.1.153.243/32 table="IPv4:254"
2025-11-24 08:27:09.865 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.153.243/32(tos=0 metric=0)
2025-11-24 08:27:09.865 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.153.243

2025-11-24 08:27:10.275 [DEBUG][84] felix/iface_monitor.go 283: storeAndNotifyLink called ifIndex=219 ifaceExists=true name="calibb9f92fb94d"
2025-11-24 08:27:10.276 [DEBUG][84] felix/iface_monitor.go 317: storeAndNotifyLinkInner called ifIndex=219 ifaceExists=true ifaceName="calibb9f92fb94d" link=&netlink.Veth{LinkAttrs:netlink.LinkAttrs{Index:219, MTU:1450, TxQLen:0, Name:"calibb9f92fb94d", HardwareAddr:net.HardwareAddr{0xee, 0xee, 0xee, 0xee, 0xee, 0xee}, Flags:0x33, RawFlags:0x11043, ParentIndex:8, MasterIndex:0, Namespace:interface {}(nil), Alias:"", AltNames:[]string(nil), Statistics:(*netlink.LinkStatistics)(0xc001512600), Promisc:0, Allmulti:0, Multi:1, Xdp:(*netlink.LinkXdp)(0xc001f10240), EncapType:"ether", Protinfo:(*netlink.Protinfo)(nil), OperState:0x6, PhysSwitchID:0, NetNsID:52, NumTxQueues:1, NumRxQueues:1, TSOMaxSegs:0xffff, TSOMaxSize:0x7fff8, GSOMaxSegs:0xffff, GSOMaxSize:0x10000, GROMaxSize:0x10000, GSOIPv4MaxSize:0x10000, GROIPv4MaxSize:0x10000, Vfs:[]netlink.VfInfo(nil), Group:0x0, PermHWAddr:net.HardwareAddr(nil), ParentDev:"", ParentDevBus:"", Slave:netlink.LinkSlave(nil)}, PeerName:"", PeerHardwareAddr:net.HardwareAddr(nil), PeerNamespace:interface {}(nil), PeerTxQLen:0, PeerNumTxQueues:0x0, PeerNumRxQueues:0x0, PeerMTU:0x0}
2025-11-24 08:27:10.276 [DEBUG][84] felix/iface_monitor.go 361: Interface state hasn't changed, nothing to notify. ifIndex=219 ifaceName="calibb9f92fb94d" newState="up" oldState="up"

2025-11-24 08:27:24.725 [DEBUG][84] felix/route_table.go 1189: Checking interface state. idx=219 ifaceName="calibb9f92fb94d" newState="up" oldState="up"

2025-11-24 08:27:29.680 [DEBUG][84] felix/route_table.go 1189: Checking interface state. idx=219 ifaceName="calibb9f92fb94d" newState="up" oldState=""
2025-11-24 08:27:29.680 [DEBUG][84] felix/route_table.go 1199: Spotted interface had changed state during resync. ifaceName="calibb9f92fb94d" newState="up" oldState="" table="IPv4:1"

2025-11-24 08:27:29.932 [INFO][84] felix/endpoint_mgr.go 761: Updating per-endpoint chains. id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:27:29.932 [DEBUG][84] felix/endpoint_mgr.go 1656: Updating policy groups for iface groups=<nil> ifaceName="calibb9f92fb94d"
2025-11-24 08:27:29.932 [INFO][84] felix/endpoint_mgr.go 794: Updating endpoint routes. id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:27:29.932 [DEBUG][84] felix/endpoint_mgr.go 831: Endpoint up, adding routes id=types.WorkloadEndpointID{OrchestratorId:"k8s", WorkloadId:"my-ns/my-pod-5bd549cc47-srn9f", EndpointId:"eth0"}
2025-11-24 08:27:29.932 [DEBUG][84] felix/route_table.go 458: SetRoutes called. ifaceName="calibb9f92fb94d" routeClass=RouteClassLocalWorkload table="IPv4:254" targets=[]routetable.Target{routetable.Target{Type:"", CIDR:ip.V4CIDR{addr:ip.V4Addr{0xa, 0x2, 0xb7, 0xf3}, prefix:0x20}, GW:ip.Addr(nil), Src:ip.Addr(nil), DestMAC:net.HardwareAddr(nil), Protocol:0, MultiPath:[]routetable.NextHop(nil), MTU:0}}
2025-11-24 08:27:29.932 [DEBUG][84] felix/route_table.go 652: Skipping route for missing interface. ifaceName="calibb9f92fb94d" table="IPv4:254"
2025-11-24 08:27:29.932 [DEBUG][84] felix/route_table.go 714: No valid route for this CIDR (all candidate routes missing iface index). candidates=[]string{"calibb9f92fb94d"} cidr=10.1.153.243/32 table="IPv4:254"
2025-11-24 08:27:29.933 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.153.243/32(tos=0 metric=0)
2025-11-24 08:27:29.933 [DEBUG][84] felix/delta_tracker.go 190: Delete (desired) k=10.1.153.243

2025-11-24 08:27:29.959 [INFO][84] felix/endpoint_mgr.go 1511: Skipping configuration of interface because it is oper down. ifaceName="calibb9f92fb94d"

2025-11-24 08:27:35.327 [DEBUG][84] felix/int_dataplane.go 1440: Skipping interface for MTU detection mtu=1450 name="calibb9f92fb94d"
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/11016)

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
