### PR TITLE
Add All() iterator method to Set types

### DIFF
--- a/libcalico-go/lib/set/adaptive_test.go
+++ b/libcalico-go/lib/set/adaptive_test.go
@@ -47,6 +47,81 @@ var _ = Describe("Adaptive set", func() {
 			Fail("Sets are not equal")
 		}
 	})
+
+	Describe("Adaptive.All() iterator", func() {
+		It("should iterate over small array-backed set", func() {
+			s := set.AdaptiveFrom(1, 2, 3)
+			seen := make(map[int]bool)
+			for item := range s.All() {
+				seen[item] = true
+			}
+			if len(seen) != 3 {
+				Fail("Did not see all items")
+			}
+		})
+
+		It("should allow deletion during iteration of array-backed set", func() {
+			s := set.AdaptiveFrom(1, 2, 3, 4, 5)
+			for item := range s.All() {
+				if item%2 == 0 {
+					s.Discard(item)
+				}
+			}
+			if s.Len() != 3 {
+				Fail("Expected 3 items remaining")
+			}
+			if !s.Contains(1) || !s.Contains(3) || !s.Contains(5) {
+				Fail("Expected odd numbers to remain")
+			}
+		})
+
+		It("should iterate over large map-backed set", func() {
+			// Create a set large enough to trigger map backing (>16 items)
+			items := make([]int, 20)
+			for i := range items {
+				items[i] = i
+			}
+			s := set.AdaptiveFromArray(items)
+			seen := make(map[int]bool)
+			for item := range s.All() {
+				seen[item] = true
+			}
+			if len(seen) != 20 {
+				Fail("Did not see all items")
+			}
+		})
+
+		It("should allow deletion during iteration of map-backed set", func() {
+			// Create a set large enough to trigger map backing (>16 items)
+			items := make([]int, 20)
+			for i := range items {
+				items[i] = i
+			}
+			s := set.AdaptiveFromArray(items)
+			for item := range s.All() {
+				if item%2 == 0 {
+					s.Discard(item)
+				}
+			}
+			if s.Len() != 10 {
+				Fail("Expected 10 items remaining")
+			}
+		})
+
+		It("should support early termination", func() {
+			s := set.AdaptiveFrom(1, 2, 3, 4, 5)
+			count := 0
+			for range s.All() {
+				count++
+				if count >= 2 {
+					break
+				}
+			}
+			if count != 2 {
+				Fail("Expected to stop after 2 iterations")
+			}
+		})
+	})
 })
 
 func FuzzAdaptiveSet(f *testing.F) {

--- a/libcalico-go/lib/set/interface.go
+++ b/libcalico-go/lib/set/interface.go
@@ -14,6 +14,7 @@ package set
 import (
 	"errors"
 	"fmt"
+	"iter"
 )
 
 type Set[T any] interface {
@@ -25,6 +26,9 @@ type Set[T any] interface {
 	Clear()
 	Contains(T) bool
 	Iter(func(item T) error)
+	// All returns an iterator for use with Go's range-over-func feature.
+	// The iterator supports deletion from the set during iteration without panicking.
+	All() iter.Seq[T]
 	Copy() Set[T]
 	Equals(Set[T]) bool
 	ContainsAll(Set[T]) bool

--- a/libcalico-go/lib/set/set.go
+++ b/libcalico-go/lib/set/set.go
@@ -17,6 +17,7 @@ package set
 import (
 	"bytes"
 	"fmt"
+	"iter"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -117,6 +118,19 @@ loop:
 			break
 		default:
 			log.WithError(err).Panic("Unexpected iteration error")
+		}
+	}
+}
+
+// All returns an iterator for use with Go's range-over-func feature.
+// The iterator supports deletion from the set during iteration without panicking,
+// since the underlying map allows safe mutation during iteration.
+func (set Typed[T]) All() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for item := range set {
+			if !yield(item) {
+				return
+			}
 		}
 	}
 }

--- a/libcalico-go/lib/set/set_test.go
+++ b/libcalico-go/lib/set/set_test.go
@@ -296,4 +296,88 @@ var _ = Describe("EmptySet", func() {
 	It("should stringify", func() {
 		Expect(empty.String()).To(Equal("set.Set{}"))
 	})
+	It("should iterate 0 times with All()", func() {
+		for range empty.All() {
+			Fail("Iterated > 0 times")
+		}
+	})
+})
+
+var _ = Describe("Set.All() iterator", func() {
+	It("should iterate over empty set", func() {
+		s := set.New[int]()
+		count := 0
+		for range s.All() {
+			count++
+		}
+		Expect(count).To(Equal(0))
+	})
+
+	It("should iterate over all elements", func() {
+		s := set.From(1, 2, 3, 4, 5)
+		seen := make(map[int]bool)
+		for item := range s.All() {
+			seen[item] = true
+		}
+		Expect(seen).To(HaveLen(5))
+		Expect(seen[1]).To(BeTrue())
+		Expect(seen[2]).To(BeTrue())
+		Expect(seen[3]).To(BeTrue())
+		Expect(seen[4]).To(BeTrue())
+		Expect(seen[5]).To(BeTrue())
+	})
+
+	It("should support early termination", func() {
+		s := set.From(1, 2, 3, 4, 5)
+		count := 0
+		for range s.All() {
+			count++
+			if count >= 2 {
+				break
+			}
+		}
+		Expect(count).To(Equal(2))
+		Expect(s.Len()).To(Equal(5)) // Set should be unchanged
+	})
+
+	It("should allow deletion during iteration", func() {
+		s := set.From(1, 2, 3, 4, 5)
+		for item := range s.All() {
+			if item%2 == 0 {
+				s.Discard(item)
+			}
+		}
+		Expect(s.Len()).To(Equal(3))
+		Expect(s.Contains(1)).To(BeTrue())
+		Expect(s.Contains(2)).To(BeFalse())
+		Expect(s.Contains(3)).To(BeTrue())
+		Expect(s.Contains(4)).To(BeFalse())
+		Expect(s.Contains(5)).To(BeTrue())
+	})
+
+	It("should allow deletion of all items during iteration", func() {
+		s := set.From(1, 2, 3, 4, 5)
+		count := 0
+		for item := range s.All() {
+			s.Discard(item)
+			count++
+		}
+		Expect(count).To(Equal(5))
+		Expect(s.Len()).To(Equal(0))
+	})
+
+	It("should allow addition during iteration", func() {
+		s := set.From(1, 2, 3)
+		count := 0
+		for item := range s.All() {
+			count++
+			if item == 1 {
+				s.Add(100) // May or may not be visited depending on map iteration order
+			}
+		}
+		// Count will be at least 3 (original items), but may include 100 if it's visited
+		Expect(count).To(BeNumerically(">=", 3))
+		Expect(count).To(BeNumerically("<=", 4))
+		Expect(s.Contains(100)).To(BeTrue())
+	})
 })


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add support for Go 1.22+ range-over-func iteration to the Set types (Typed and Adaptive) in libcalico-go/lib/set alongside the existing Iter() method.

Changes:
- Add All() iter.Seq[T] method to Set[T] interface
- Implement All() for Typed[T] with direct map iteration
- Implement All() for Adaptive[T] with intelligent handling:
  - Map-backed sets (>16 items): direct iteration
  - Array-backed sets (≤16 items): snapshot for safe mutation
- Add tests for All() method

The new All() method provides modern Go iteration using iter.Seq while maintaining the same safe-mutation-during-iteration guarantees as the existing Iter() method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
