### PR TITLE
fix url parse

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"runtime"
 	"strconv"
@@ -478,7 +479,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: __KUBERNETES_SERVICE_PROTOCOL__://[__KUBERNETES_SERVICE_HOST__]:__KUBERNETES_SERVICE_PORT__
+    server: __KUBERNETES_SERVICE_PROTOCOL__://__KUBERNETES_HOST_PORT__
     __TLS_CFG__
 users:
 - name: calico
@@ -502,8 +503,7 @@ current-context: calico-context`
 	}
 	data = strings.Replace(data, "TOKEN", tu.Token, 1)
 	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_PROTOCOL__", getEnv("KUBERNETES_SERVICE_PROTOCOL", "https"))
-	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_HOST__", getEnv("KUBERNETES_SERVICE_HOST", ""))
-	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_PORT__", getEnv("KUBERNETES_SERVICE_PORT", ""))
+	data = strings.ReplaceAll(data, "__KUBERNETES_HOST_PORT__", net.JoinHostPort(getEnv("KUBERNETES_SERVICE_HOST", ""), getEnv("KUBERNETES_SERVICE_PORT", "")))
 
 	skipTLSVerify := os.Getenv("SKIP_TLS_VERIFY")
 	if skipTLSVerify == "true" {


### PR DESCRIPTION
## Description
after go 1.24.8. `url.Parse` enforce stricter parsing of bracketed IPv6 hostnames, When the URL like https://[10.250.0.1]:443, the operation fails. Therefore, in the kubeconfig file generated by install-cni, the square brackets around KUBERNETES_SERVICE_HOST should be removed.

> 2025-12-02 17:43:33.194 [ERROR][279844] cni-plugin/plugin.go 593: Final result of CNI DEL was an
error. error=host must be a URL or a host:port pair: "https://[10.250.0.1]:443"

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix parsing of URLs in CNI configuration. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
