### PR TITLE
[EV-6214] IterUnion prematurely stops when encountering duplicate items

### DIFF
--- a/libcalico-go/lib/set/union.go
+++ b/libcalico-go/lib/set/union.go
@@ -44,14 +44,14 @@ func IterUnion[T comparable](sets []Set[T], f func(item T) bool) {
 			return sets[j].Len() < sets[i].Len()
 		})
 		stop := false
-	setsLoop:
 		for i, s1 := range sets {
+		itemsLoop:
 			for item := range s1.All() {
 				// To check if we've seen this item before, look for it in
 				// the sets we've already scanned.
 				for j := 0; j < i; j++ {
 					if sets[j].Contains(item) {
-						continue setsLoop
+						continue itemsLoop
 					}
 				}
 				if !f(item) {

--- a/libcalico-go/lib/set/union_test.go
+++ b/libcalico-go/lib/set/union_test.go
@@ -40,23 +40,25 @@ func TestIterUnion(t *testing.T) {
 
 		// First sub-test verifies the actual union is correct.
 		t.Run(fmt.Sprint(testSets), func(t *testing.T) {
-			expected := New[int]()
-			var sets []Set[int]
-			for _, i := range testSets {
-				// We trust FromArray in this test; it is tested elsewhere...
-				sets = append(sets, FromArray(i))
-				// Trivial implementation of union for us to compare against.
-				for _, item := range i {
-					expected.Add(item)
+			for i := 0; i < 100; i++ {
+				expected := New[int]()
+				var sets []Set[int]
+				for _, i := range testSets {
+					// We trust FromArray in this test; it is tested elsewhere...
+					sets = append(sets, FromArray(i))
+					// Trivial implementation of union for us to compare against.
+					for _, item := range i {
+						expected.Add(item)
+					}
 				}
+				actual := New[int]()
+				IterUnion(sets, func(item int) bool {
+					Expect(actual.Contains(item)).To(BeFalse(), fmt.Sprintf("IterUnion produced duplicate value: %v", item))
+					actual.Add(item)
+					return true
+				})
+				Expect(actual).To(Equal(expected), fmt.Sprintf("Union of %v was incorrect", sets))
 			}
-			actual := New[int]()
-			IterUnion(sets, func(item int) bool {
-				Expect(actual.Contains(item)).To(BeFalse(), fmt.Sprintf("IterUnion produced duplicate value: %v", item))
-				actual.Add(item)
-				return true
-			})
-			Expect(actual).To(Equal(expected), fmt.Sprintf("Union of %v was incorrect", sets))
 		})
 
 		// Second sub-test verifies that we can stop by returning false.


### PR DESCRIPTION
## Description

Fixes IterUnion small size iteration bug, and adds multiple test runs for TestIterUnion.

See: https://tigera.atlassian.net/browse/EV-6214

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
