### PR TITLE
Test k8s 1.35 compatibility with calico 3.31

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1367,7 +1367,7 @@ $(REPO_ROOT)/.$(KIND_NAME).created: $(KUBECTL) $(KIND)
 		--config $(KIND_CONFIG) \
 		--kubeconfig $(KIND_KUBECONFIG) \
 		--name $(KIND_NAME) \
-		--image kindest/node:$(KINDEST_NODE_VERSION)
+		--image ghcr.io/carvel-dev/kindest/node:$(KINDEST_NODE_VERSION)
 
 	# Wait for controller manager to be running and healthy, then create Calico CRDs.
 	while ! KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) get serviceaccount default; do echo "Waiting for default serviceaccount to be created..."; sleep 2; done

--- a/metadata.mk
+++ b/metadata.mk
@@ -20,7 +20,7 @@ GHR_VERSION=v0.17.0
 GITHUB_CLI_VERSION=2.76.2
 GOTESTSUM_VERSION=v1.12.3
 HELM_VERSION=v3.11.3
-KINDEST_NODE_VERSION=v1.33.1
+KINDEST_NODE_VERSION=v1.35.0-beta.0
 KIND_VERSION=v0.29.0
 
 # Configuration for Semaphore/Github integration.  This needs to be set

--- a/process/testing/winfv-cni-plugin/aso/install-aso.sh
+++ b/process/testing/winfv-cni-plugin/aso/install-aso.sh
@@ -35,7 +35,7 @@ SUFFIX=""
 : ${ASOCTL:=./bin/asoctl}
 
 # Create management cluster
-${KIND} create cluster --image kindest/node:${KUBE_VERSION} --name kind${SUFFIX}
+${KIND} create cluster --image ghcr.io/carvel-dev/kindest/node:${KUBE_VERSION} --name kind${SUFFIX}
 ${KUBECTL} wait node kind${SUFFIX}-control-plane --for=condition=ready --timeout=90s
 
 # Install cert-manager

--- a/process/testing/winfv-felix/capz/create-cluster.sh
+++ b/process/testing/winfv-felix/capz/create-cluster.sh
@@ -97,7 +97,7 @@ export EXP_MACHINE_POOL=true
 export EXP_AKS=true
 
 # Create management cluster
-${KIND} create cluster --image kindest/node:${KUBE_VERSION} --name kind${SUFFIX}
+${KIND} create cluster --image ghcr.io/carvel-dev/kindest/node:${KUBE_VERSION} --name kind${SUFFIX}
 ${KUBECTL} wait node kind${SUFFIX}-control-plane --for=condition=ready --timeout=90s
 
 sleep 30


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This is a test PR that is created to test the calico 3.31.2 version compatibility with k8s 1.35 beta. The kindest node image is built from the 1.35 beta branch of k8s repo. This PR will not be merged, just wanted to check if the semaphore tests are passing on this PR.

kindest:1.35-https://github.com/orgs/carvel-dev/packages/container/package/kindest%2Fnode

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
