### PR TITLE
[v3.31] Fix PATH env var in calico-node Windows image

### DIFF
--- a/node/Dockerfile-windows
+++ b/node/Dockerfile-windows
@@ -42,7 +42,7 @@ COPY windows-packaging/CalicoWindows/libs/hns/hns.psm1 /CalicoWindows/libs/hns/h
 COPY windows-packaging/nssm.exe /nssm.exe
 COPY windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1 /uninstall-calico.ps1
 
-ENV PATH=$PATH;/CalicoWindows
+ENV PATH="$PATH;C:\CalicoWindows;C:\Windows\System32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Program Files\PowerShell"
 WORKDIR /CalicoWindows
 # The nanoserver image does not have powershell but this works because
 # this container will be running on the host.


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11489
The PATH env var in Windows images doesn't seem to be populated with sane values (powershell, system32, etc). Manually add those to the calico-node Windows image.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```


