### PR TITLE
Tag IPIP tests as needing no encap support

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -71,6 +71,14 @@ var features = map[string]bool{
 	"IPIP":            true,
 }
 
+// RequiresNoEncap marks tests that require unencapsulated traffic to function.
+// This is typically used for tests that verify BGP functionality without IPIP, or other similar tests.
+// Such tests must be run on clusters that support unencapsulated traffic, such as bare-metal clusters
+// or cloud clusters with appropriate configuration.
+func RequiresNoEncap() any {
+	return framework.WithLabel("NoEncap")
+}
+
 // WithFeature marks tests as verifying a specific feature.
 func WithFeature(feature string) any {
 	if !features[feature] {

--- a/e2e/pkg/tests/networking/ipip.go
+++ b/e2e/pkg/tests/networking/ipip.go
@@ -41,6 +41,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("IPIP"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresNoEncap(),
 	"IP-in-IP tests",
 	func() {
 		// Define variables common across all tests.
@@ -52,7 +53,7 @@ var _ = describe.CalicoDescribe(
 		var poolName string
 
 		// Create a new framework for the tests.
-		f := utils.NewDefaultFramework("bgp-export")
+		f := utils.NewDefaultFramework("ipip")
 
 		ginkgo.BeforeEach(func() {
 			if windows.ClusterIsWindows() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

tag IPIP tests as requiring support for unencap'd traffic

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.