### PR TITLE
Fix Windows PolicyID string formulation

### DIFF
--- a/felix/dataplane/windows/endpoint_mgr.go
+++ b/felix/dataplane/windows/endpoint_mgr.go
@@ -593,22 +593,29 @@ func (m *endpointManager) getHnsEndpointId(ip string) (string, error) {
 // profileIDsToStrings converts a list of profile names to their string representation with prefix.
 func profileIDsToStrings(prefix string, in []string) (out []string) {
 	for _, s := range in {
-		out = append(out, prefix+s)
+		out = append(out, profileIDToString(prefix, s))
 	}
 	return
+}
+
+func profileIDToString(prefix string, name string) string {
+	return fmt.Sprintf("%s%s", prefix, name)
 }
 
 // policyIDsToStrings converts a list of PolicyID to their string representation with prefix.
 func policyIDsToStrings(prefix string, in []*proto.PolicyID) []string {
 	var out []string
 	for _, id := range in {
-		if id.Namespace != "" {
-			out = append(out, fmt.Sprintf("%s%s/%s/%s", prefix, id.Kind, id.Namespace, id.Name))
-		} else {
-			out = append(out, fmt.Sprintf("%s%s/%s", prefix, id.Kind, id.Name))
-		}
+		out = append(out, policyIDToString(prefix, id))
 	}
 	return out
+}
+
+func policyIDToString(prefix string, id *proto.PolicyID) string {
+	if id.Namespace != "" {
+		return fmt.Sprintf("%s%s/%s/%s", prefix, id.Kind, id.Namespace, id.Name)
+	}
+	return fmt.Sprintf("%s%s/%s", prefix, id.Kind, id.Name)
 }
 
 // loopPollingForInterfaceAddrs periodically checks the IP addresses on the host and sends updates on the channel

--- a/felix/dataplane/windows/policy_mgr.go
+++ b/felix/dataplane/windows/policy_mgr.go
@@ -44,20 +44,20 @@ func (m *policyManager) OnUpdate(msg interface{}) {
 			return
 		}
 		log.WithField("policyID", msg.Id).Info("Processing ActivePolicyUpdate")
-		m.policysetsDataplane.AddOrReplacePolicySet(policysets.PolicyNamePrefix+msg.Id.Name, msg.Policy)
+		m.policysetsDataplane.AddOrReplacePolicySet(policyIDToString(policysets.PolicyNamePrefix, msg.Id), msg.Policy)
 	case *proto.ActivePolicyRemove:
 		if model.KindIsStaged(msg.Id.Kind) {
 			log.WithField("policyID", msg.Id).Debug("Skipping ActivePolicyRemove with staged policy")
 			return
 		}
 		log.WithField("policyID", msg.Id).Info("Processing ActivePolicyRemove")
-		m.policysetsDataplane.RemovePolicySet(policysets.PolicyNamePrefix + msg.Id.Name)
+		m.policysetsDataplane.RemovePolicySet(policyIDToString(policysets.PolicyNamePrefix, msg.Id))
 	case *proto.ActiveProfileUpdate:
 		log.WithField("profileId", msg.Id).Info("Processing ActiveProfileUpdate")
-		m.policysetsDataplane.AddOrReplacePolicySet(policysets.ProfileNamePrefix+msg.Id.Name, msg.Profile)
+		m.policysetsDataplane.AddOrReplacePolicySet(profileIDToString(policysets.ProfileNamePrefix, msg.Id.Name), msg.Profile)
 	case *proto.ActiveProfileRemove:
 		log.WithField("profileId", msg.Id).Info("Processing ActiveProfileRemove")
-		m.policysetsDataplane.RemovePolicySet(policysets.ProfileNamePrefix + msg.Id.Name)
+		m.policysetsDataplane.RemovePolicySet(profileIDToString(policysets.ProfileNamePrefix, msg.Id.Name))
 	}
 }
 

--- a/felix/dataplane/windows/policy_mgr_test.go
+++ b/felix/dataplane/windows/policy_mgr_test.go
@@ -52,36 +52,36 @@ func TestPolicyManager(t *testing.T) {
 	})
 
 	// assertion for ingress rules
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, true)).To(Equal([]*hns.ACLPolicy{
-		// policy-pol1 deny rule should be present
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, true, true)).To(Equal([]*hns.ACLPolicy{
+		// policy-GlobalNetworkPolicy/pol1 deny rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned for ingress rules update for policy-pol1")
+	}), "unexpected rules returned for ingress rules update for policy-GlobalNetworkPolicy/pol1")
 
 	// assertion for ingress rules with endOfTierDrop disabled
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, false)).To(Equal([]*hns.ACLPolicy{
-		// policy-pol1 deny rule should be present
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, true, false)).To(Equal([]*hns.ACLPolicy{
+		// policy-GlobalNetworkPolicy/pol1 deny rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned for ingress rules update for policy-pol1")
+	}), "unexpected rules returned for ingress rules update for policy-GlobalNetworkPolicy/pol1")
 
 	// assertion for egress rules
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, true)).To(Equal([]*hns.ACLPolicy{
-		// policy-pol1 allow rule should be present
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, false, true)).To(Equal([]*hns.ACLPolicy{
+		// policy-GlobalNetworkPolicy/pol1 allow rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned for egress rules update for policy-pol1")
+	}), "unexpected rules returned for egress rules update for policy-GlobalNetworkPolicy/pol1")
 
 	// assertion for egress rules with endOfTierDrop disabled
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, false)).To(Equal([]*hns.ACLPolicy{
-		// policy-pol1 allow rule should be present
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, false, false)).To(Equal([]*hns.ACLPolicy{
+		// policy-GlobalNetworkPolicy/pol1 allow rule should be present
 		{Type: hns.ACL, Protocol: 256, Action: hns.Allow, Direction: hns.Out, RuleType: hns.Switch, Priority: 1000},
 		// Default deny rule.
 		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned for egress rules update for policy-pol1")
+	}), "unexpected rules returned for egress rules update for policy-GlobalNetworkPolicy/pol1")
 
 	// remove policy here
 	policyMgr.OnUpdate(&proto.ActivePolicyRemove{
@@ -89,24 +89,24 @@ func TestPolicyManager(t *testing.T) {
 	})
 
 	// default ingress rule
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, true, true)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-GlobalNetworkPolicy/pol1")
 
 	// default ingress rule with endOfTierDrop disabled
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, true, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, true, false)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.In, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-GlobalNetworkPolicy/pol1")
 
 	// default egress rule
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, true)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, false, true)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: hns.Block, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-GlobalNetworkPolicy/pol1")
 
 	// default egress rule with endOfTierDrop disabled
-	Expect(ps.GetPolicySetRules([]string{"policy-pol1"}, false, false)).To(Equal([]*hns.ACLPolicy{
+	Expect(ps.GetPolicySetRules([]string{"policy-GlobalNetworkPolicy/pol1"}, false, false)).To(Equal([]*hns.ACLPolicy{
 		{Type: hns.ACL, Protocol: 256, Action: policysets.ActionPass, Direction: hns.Out, RuleType: hns.Switch, Priority: 1001},
-	}), "unexpected rules returned after ActivePolicyRemove event for policy-pol1")
+	}), "unexpected rules returned after ActivePolicyRemove event for policy-GlobalNetworkPolicy/pol1")
 
 	// Apply profile update
 	policyMgr.OnUpdate(&proto.ActiveProfileUpdate{

--- a/felix/dataplane/windows/policysets/policysets.go
+++ b/felix/dataplane/windows/policysets/policysets.go
@@ -593,7 +593,6 @@ func protoPortToHCSPort(port *proto.PortRange) string {
 
 // This function will create chunks of ports/ports range with chunksize
 func SplitPortList(ports []*proto.PortRange, chunkSize int) (splits [][]*proto.PortRange) {
-
 	if len(ports) == 0 {
 		splits = append(splits, []*proto.PortRange{})
 	}
@@ -611,7 +610,6 @@ func SplitPortList(ports []*proto.PortRange, chunkSize int) (splits [][]*proto.P
 
 // This function will create chunks of IP addresses/Cidr with chunksize
 func SplitIPList(ipAddrs []string, chunkSize int) (splits [][]string) {
-
 	if len(ipAddrs) == 0 {
 		splits = append(splits, []string{})
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We properly translate the PolicyID to strings elsewhere, but not here.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.