### PR TITLE
Add an AKS migration e2e run

### DIFF
--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -161,6 +161,22 @@ blocks:
               value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]|Feature:NetworkPolicy) --ginkgo.skip=(Slow|Disruptive|calient|allow.ingress.access.from.updated.pod|Dataplane:LB|outside.the.cluster|MTU|ExternalNode|external.to.nodeport|StrictAffinity|Feature:SCTP)
             - name: CLUSTER_MODE
               value: "private"
+
+        - name: AKS migrate from vendored Calico CNI to Calico CNI
+          execution_time_limit:
+            hours: 7
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: INSTALLER
+              value: operator
+            - name: USE_VENDORED_CNI  # This sets up the cluster with AKS vendored CNI
+              value: "true"
+            - name: CNI_PLUGIN
+              value: Calico    # This (together with USE_VENDORED_CNI) sets up the cluster with AKS vendored Calico
+            - name: DESIRED_POLICY
+              value: Calico   # This converts the cluster to unmanaged-Calico policy
+
       env_vars:
         - name: K8S_E2E_FLAGS
           value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])

--- a/.semaphore/end-to-end/scripts/body_standard.sh
+++ b/.semaphore/end-to-end/scripts/body_standard.sh
@@ -47,6 +47,13 @@ if [[ -n "$OPERATOR_MIGRATE" ]]; then
   ${HOME}/${SEMAPHORE_GIT_DIR}/.semaphore/end-to-end/scripts/test_scripts/operator_migrate.sh
 fi
 
+# Perform the AKS migration following the instructions here:
+# https://docs.tigera.io/calico/latest/getting-started/kubernetes/managed-public-cloud/aks-migrate
+if [[ -n "$DESIRED_POLICY" ]]; then
+  echo "[INFO] starting AKS migration..."
+  bz addons run aks-migrate:setup
+fi
+
 if [[ -n "$UPLEVEL_RELEASE_STREAM" ]]; then
   echo "[INFO] starting bz upgrade..."
   bz upgrade $VERBOSE | tee >(gzip --stdout > ${BZ_LOGS_DIR}/upgrade.log.gz)


### PR DESCRIPTION
## Description
Add an e2e test run to exercise the process in https://docs.tigera.io/calico/latest/getting-started/kubernetes/managed-public-cloud/aks-migrate

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
