### PR TITLE
Bump Envoy Gateway to v1.5.6 (for master)

### DIFF
--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -7,7 +7,7 @@ BUILD_IMAGES ?= $(ENVOY_GATEWAY_IMAGE)
 
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
-ENVOY_GATEWAY_VERSION=v1.5.4
+ENVOY_GATEWAY_VERSION=v1.5.6
 
 ##############################################################################
 # Include lib.Makefile before anything else

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -7,7 +7,7 @@ BUILD_IMAGES ?= $(ENVOY_PROXY_IMAGE)
 
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
-ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.35.3-e1e533c6fb
+ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.35.8-6ddb700081
 
 EXCLUDEARCH ?= ppc64le s390x
 

--- a/third_party/envoy-ratelimit/Makefile
+++ b/third_party/envoy-ratelimit/Makefile
@@ -7,7 +7,7 @@ BUILD_IMAGES ?= $(ENVOY_RATELIMIT_IMAGE)
 
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
-ENVOY_RATELIMIT_VERSION=a90e0e5d
+ENVOY_RATELIMIT_VERSION=e74a664a
 
 ##############################################################################
 # Include lib.Makefile before anything else


### PR DESCRIPTION
## Release Note

```release-note
Bump bundled Envoy Gateway to v1.5.6
```
