### PR TITLE
CI: Robustness improvements

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -571,7 +571,7 @@ blocks:
           execution_time_limit:
             minutes: 20
           commands:
-            - make build image fv-prereqs
+            - make build image ut-bpf-prereqs fv-prereqs
             - ./.semaphore/cache-test-artifacts
         - name: "Felix: UT"
           priority:
@@ -1074,7 +1074,7 @@ blocks:
           commands:
             - ../.semaphore/vms/collect-artifacts-from-vms ${VM_PREFIX}
             - '../.semaphore/vms/publish-reports "Node: KinD STs"'
-            - ../.semaphore/vms/clean-up-vms ${ZONE} ${VM_PREFIX}
+            - ../.semaphore/vms/clean-up-vms ${VM_PREFIX}
       secrets:
         - name: google-service-account-for-gce
   - name: pod2daemon

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -571,7 +571,7 @@ blocks:
           execution_time_limit:
             minutes: 20
           commands:
-            - make build image fv-prereqs
+            - make build image ut-bpf-prereqs fv-prereqs
             - ./.semaphore/cache-test-artifacts
         - name: "Felix: UT"
           priority:
@@ -1074,7 +1074,7 @@ blocks:
           commands:
             - ../.semaphore/vms/collect-artifacts-from-vms ${VM_PREFIX}
             - '../.semaphore/vms/publish-reports "Node: KinD STs"'
-            - ../.semaphore/vms/clean-up-vms ${ZONE} ${VM_PREFIX}
+            - ../.semaphore/vms/clean-up-vms ${VM_PREFIX}
       secrets:
         - name: google-service-account-for-gce
   - name: pod2daemon

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -26,7 +26,7 @@
         execution_time_limit:
           minutes: 20
         commands:
-          - make build image fv-prereqs
+          - make build image ut-bpf-prereqs fv-prereqs
           - ./.semaphore/cache-test-artifacts
       - name: "Felix: UT"
         priority:

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -102,6 +102,6 @@
         commands:
           - ../.semaphore/vms/collect-artifacts-from-vms ${VM_PREFIX}
           - '../.semaphore/vms/publish-reports "Node: KinD STs"'
-          - ../.semaphore/vms/clean-up-vms ${ZONE} ${VM_PREFIX}
+          - ../.semaphore/vms/clean-up-vms ${VM_PREFIX}
     secrets:
       - name: google-service-account-for-gce

--- a/.semaphore/vms/on-test-vm
+++ b/.semaphore/vms/on-test-vm
@@ -15,4 +15,9 @@
 #
 
 vm_ip=$(gcloud compute instances describe ${VM_NAME} --zone=${ZONE} --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
-exec ssh "ubuntu@${vm_ip}" -n -A -o ServerAliveInterval=10 "$@"
+exec ssh "ubuntu@${vm_ip}" -n -A \
+  -o ServerAliveInterval=10 \
+  -o StrictHostKeyChecking=yes \
+  -o BatchMode=yes \
+  -o UpdateHostKeys=no \
+  "$@"

--- a/felix/.semaphore/wait-for-test-completion
+++ b/felix/.semaphore/wait-for-test-completion
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+while true; do
+  if [ -f test.rc ]; then
+    # Test finished, output its return code and exit.
+    cat test.rc
+    break
+  fi
+
+  # Avoid tight loop.
+  sleep 1
+
+  # Check if the process is still running.
+  if [ -e "/proc/$(cat test.pid)" ]; then
+    # It is, so keep waiting.
+    continue
+  fi
+  # Make sure we didn't race with it finishing...
+  sleep 1
+  if [ -f test.rc ]; then
+    continue
+  fi
+
+  # Not still running and no return code file, something went wrong.
+  echo "66"
+  break
+done

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -553,8 +553,14 @@ bin/bpf_ut.test: $(GENERATED_FILES) $(shell find bpf/ -name '*.go')
 bin/bpf_debug.test: $(GENERATED_FILES) $(shell find bpf/ -name '*.go')
 	$(DOCKER_GO_BUILD_CGO) go test ./bpf/ut -c -gcflags="-N -l" -o $@
 
+.PHONY: ut-bpf-prereqs
+ut-bpf-prereqs: $(LIBBPF_A) bin/bpf_ut.test bin/bpf.test build-bpf
+
 .PHONY: ut-bpf
-ut-bpf: $(LIBBPF_A) bin/bpf_ut.test bin/bpf.test build-bpf
+ut-bpf: ut-bpf-prereqs
+	$(MAKE) ut-bpf-no-prereqs
+
+ut-bpf-no-prereqs:
 	mkdir -p report
 	$(DOCKER_RUN) \
 		--privileged \


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Upstreaming some fixes from the enterprise codebase:

- Configure ssh for batch mode and disable editing of known_hosts to avoid races between concurrent tests.
- Detect VM reboot mid-test and dump serial console to diagnose panics.
- Fix that node didn't tear down its VMs.
- Run BPF UTs from the pre-built binaries instead of rebuilding on the test VM.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
