### PR TITLE
Test disabling EndpointStatusPathPrefix for OpenStack

### DIFF
--- a/felix/config/config_params_test.go
+++ b/felix/config/config_params_test.go
@@ -197,6 +197,22 @@ var _ = Describe("Config override empty", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cp.IptablesBackend).To(Equal("auto"))
 	})
+
+	It("should have correct default EndpointStatusPathPrefix value", func() {
+		Expect(cp.EndpointStatusPathPrefix).To(Equal("/var/run/calico"))
+	})
+
+	Context("with EndpointStatusPathPrefix=none in config file", func() {
+		BeforeEach(func() {
+			changed, err := cp.UpdateFrom(map[string]string{"EndpointStatusPathPrefix": "none"}, config.ConfigFile)
+			Expect(changed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should have EndpointStatusPathPrefix empty", func() {
+			Expect(cp.EndpointStatusPathPrefix).To(Equal(""))
+		})
+	})
 })
 
 var (

--- a/felix/config/file_loader_test.go
+++ b/felix/config/file_loader_test.go
@@ -36,6 +36,10 @@ FelixHostname=hostname
 LogSeverityScreen=INFO
 LogSeveritySys=DEBUG`
 
+const confEmptyString = `[default]
+EndpointStatusPathPrefix=none
+`
+
 var _ = DescribeTable("File parameter parsing",
 	func(fileContent string, expected map[string]string) {
 		actual, err := config.LoadConfigFileData([]byte(fileContent))
@@ -53,6 +57,9 @@ var _ = DescribeTable("File parameter parsing",
 		"FelixHostname":     "hostname",
 		"LogSeverityScreen": "INFO",
 		"LogSeveritySys":    "DEBUG",
+	}),
+	Entry("Setting 'none' value", confEmptyString, map[string]string{
+		"EndpointStatusPathPrefix": "none",
 	}),
 )
 

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -50,6 +50,7 @@ if [ "${Q_AGENT}" = calico-felix ]; then
 [global]
 DatastoreType = etcdv3
 EtcdEndpoints = http://${SERVICE_HOST}:${ETCD_PORT}
+EndpointStatusPathPrefix = none
 EOF
                     if [ "${ENABLE_DEBUG_LOG_LEVEL}" = True ]; then
                         sudo sh -c "cat >> /etc/calico/felix.cfg" << EOF


### PR DESCRIPTION
EndpointStatusPathPrefix isn't needed for OpenStack, but has a default value that causes it to run. Test that it's possible to override that with a "none" setting in felix.cfg.