### PR TITLE
Fix construction of chain names

### DIFF
--- a/felix/rules/dispatch_test.go
+++ b/felix/rules/dispatch_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Dispatch chains", func() {
 						},
 					},
 					{
-						Name: "cali-set-endpoint-mark-2",
+						Name: "cali-set-endpoint-mark-wep-2",
 						Rules: []generictables.Rule{
 							inboundGotoRule("cali2333", "cali-sm-cali2333"),
 							inboundGotoRule("cali2444", "cali-sm-cali2444"),
@@ -248,7 +248,7 @@ var _ = Describe("Dispatch chains", func() {
 						Name: "cali-set-endpoint-mark",
 						Rules: []generictables.Rule{
 							inboundGotoRule("cali1234", "cali-sm-cali1234"),
-							inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
+							inboundGotoRule("cali2+", "cali-set-endpoint-mark-wep-2"),
 							smUnknownEndpointDropRule("cali"),
 							smUnknownEndpointDropRule("tap"),
 							smNonCaliSetMarkRule,
@@ -354,7 +354,7 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-set-endpoint-mark-1",
+							Name: "cali-set-endpoint-mark-wep-1",
 							Rules: []generictables.Rule{
 								inboundGotoRule("cali11", "cali-sm-cali11"),
 								inboundGotoRule("cali12", "cali-sm-cali12"),
@@ -362,7 +362,7 @@ var _ = Describe("Dispatch chains", func() {
 							},
 						},
 						{
-							Name: "cali-set-endpoint-mark-2",
+							Name: "cali-set-endpoint-mark-wep-2",
 							Rules: []generictables.Rule{
 								inboundGotoRule("cali21", "cali-sm-cali21"),
 								inboundGotoRule("cali22", "cali-sm-cali22"),
@@ -371,8 +371,8 @@ var _ = Describe("Dispatch chains", func() {
 						{
 							Name: "cali-set-endpoint-mark",
 							Rules: []generictables.Rule{
-								inboundGotoRule("cali1+", "cali-set-endpoint-mark-1"),
-								inboundGotoRule("cali2+", "cali-set-endpoint-mark-2"),
+								inboundGotoRule("cali1+", "cali-set-endpoint-mark-wep-1"),
+								inboundGotoRule("cali2+", "cali-set-endpoint-mark-wep-2"),
 								smUnknownEndpointDropRule("cali"),
 								smUnknownEndpointDropRule("tap"),
 								smNonCaliSetMarkRule,


### PR DESCRIPTION
Add support to inject an infix into the constructed chain name in `buildSingleDispatchChainTree` when creating chains in multiple patches.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
There is an issue when running Calico in IPVS mode which can cause a harmful overlap with constructed chain names. This occurs when there are two or more interfaces starting with the prefix, say 'calia', and native interfaces starting with the letter 'a'.

The current implementation creates a chain called 'cali-set-endpoint-mark-a' for both groups of interfaces, which then leads to the situation that rules created for the latter group of interfaces will overwrite the rules created for the former group of interfaces. This is due to the fact that constructing chains is done in two passes.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes #10811

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix potential HEP / WEP chain name conflicts in IPVS mode.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
