### PR TITLE
BPF: Fix WEP policy program ingress/egress index confusion

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -494,9 +494,9 @@ func NewBPFEndpointManager(
 		// Note: the allocators only allocate a fraction of the map, the
 		// rest is reserved for sub-programs generated if a single program
 		// would be too large.
-		jumpMapAllocIngress: newJumpMapAlloc(jump.TCMaxEntryPoints),
-		jumpMapAllocEgress:  newJumpMapAlloc(jump.TCMaxEntryPoints),
-		xdpJumpMapAlloc:     newJumpMapAlloc(jump.XDPMaxEntryPoints),
+		jumpMapAllocIngress: newJumpMapAlloc("ingress", jump.TCMaxEntryPoints),
+		jumpMapAllocEgress:  newJumpMapAlloc("egress", jump.TCMaxEntryPoints),
+		xdpJumpMapAlloc:     newJumpMapAlloc("xdp", jump.XDPMaxEntryPoints),
 		ruleRenderer:        iptablesRuleRenderer,
 		onStillAlive:        livenessCallback,
 		lookupsCache:        lookupsCache,
@@ -1422,17 +1422,22 @@ func (m *bpfEndpointManager) markExistingWEPDirty(wlID types.WorkloadEndpointID,
 	}
 }
 
-func jumpMapDeleteEntry(m maps.Map, idx, stride int) error {
+func jumpMapDeleteSubProgs(m maps.Map, idx, stride int) error {
 	for subProg := 0; subProg < jump.MaxSubPrograms; subProg++ {
 		if err := m.Delete(jump.Key(polprog.SubProgramJumpIdx(idx, subProg, stride))); err != nil {
 			if maps.IsNotExists(err) {
-				logrus.WithError(err).WithField("idx", idx).Debug(
-					"Policy program already gone from map.")
+				if subProg == 0 {
+					logrus.WithField("idx", idx).Debug(
+						"First policy program already gone from map.")
+				} else {
+					logrus.WithField("idx", idx).Debug(
+						"Policy sub-program not present, stopping loop early.")
+				}
 				return nil
-			} else {
-				logrus.WithError(err).Warn("Failed to delete policy program from map; policy program may leak.")
-				return err
 			}
+
+			logrus.WithError(err).Warn("Failed to delete policy program from map; policy program may leak.")
+			return err
 		}
 	}
 
@@ -1464,7 +1469,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 					v.XDPPolicyV6,
 				} {
 					if idx := fn(); idx != -1 {
-						_ = jumpMapDeleteEntry(m.commonMaps.XDPJumpMap, idx, jump.XDPMaxEntryPoints)
+						_ = jumpMapDeleteSubProgs(m.commonMaps.XDPJumpMap, idx, jump.XDPMaxEntryPoints)
 					}
 				}
 				for _, fn := range []func() int{
@@ -1473,7 +1478,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 					v.TcIngressFilter,
 				} {
 					if idx := fn(); idx != -1 {
-						_ = jumpMapDeleteEntry(m.commonMaps.JumpMaps[hook.Ingress], idx, jump.TCMaxEntryPoints)
+						_ = jumpMapDeleteSubProgs(m.commonMaps.JumpMaps[hook.Ingress], idx, jump.TCMaxEntryPoints)
 					}
 				}
 				for _, fn := range []func() int{
@@ -1482,7 +1487,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 					v.TcEgressFilter,
 				} {
 					if idx := fn(); idx != -1 {
-						_ = jumpMapDeleteEntry(m.commonMaps.JumpMaps[hook.Egress], idx, jump.TCMaxEntryPoints)
+						_ = jumpMapDeleteSubProgs(m.commonMaps.JumpMaps[hook.Egress], idx, jump.TCMaxEntryPoints)
 					}
 				}
 			} else {
@@ -2721,7 +2726,7 @@ func (d *bpfEndpointManagerDataplane) wepApplyPolicyToDirection(readiness ifaceR
 	}
 
 	attachHook := hook.Ingress
-	if polDirection == PolDirnEgress {
+	if polDirection == PolDirnIngress {
 		attachHook = hook.Egress
 	}
 	policyIdx = indices.policyIdx[attachHook]
@@ -4276,6 +4281,7 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 	}
 	for i := len(progFDs); i < jump.MaxSubPrograms; i++ {
 		subProgIdx := polprog.SubProgramJumpIdx(polJumpMapIdx, i, stride)
+		logCtx.Debugf("Clearing sub-program %d at position %d in map %s", i, subProgIdx, polProgsMap.GetName())
 		if err := polProgsMap.Delete(jump.Key(subProgIdx)); err != nil {
 			if os.IsNotExist(err) {
 				break
@@ -4291,7 +4297,7 @@ func (m *bpfEndpointManager) jumpMapDelete(h hook.Hook, idx int) error {
 	if idx < 0 {
 		return nil
 	}
-
+	logrus.WithFields(logrus.Fields{"hook": h, "index": idx}).Debug("Deleting jump map entry")
 	jumpMap := m.commonMaps.XDPJumpMap
 	stride := jump.XDPMaxEntryPoints
 	if h != hook.XDP {
@@ -4299,7 +4305,7 @@ func (m *bpfEndpointManager) jumpMapDelete(h hook.Hook, idx int) error {
 		stride = jump.TCMaxEntryPoints
 	}
 
-	return jumpMapDeleteEntry(jumpMap, idx, stride)
+	return jumpMapDeleteSubProgs(jumpMap, idx, stride)
 }
 
 func (m *bpfEndpointManager) removePolicyProgram(ap attachPoint, ipFamily proto.IPVersion) error {
@@ -4318,7 +4324,7 @@ func (m *bpfEndpointManager) removePolicyProgram(ap attachPoint, ipFamily proto.
 		pm = m.commonMaps.JumpMaps[ap.HookName()]
 	}
 
-	if err := jumpMapDeleteEntry(pm, idx, stride); err != nil {
+	if err := jumpMapDeleteSubProgs(pm, idx, stride); err != nil {
 		return fmt.Errorf("removing policy iface %s hook %s: %w", ap.IfaceName(), ap.HookName(), err)
 	}
 
@@ -4916,8 +4922,10 @@ func getLeafNodes(intf *bpfIfaceNode) []string {
 	return leaves
 }
 
-func newJumpMapAlloc(entryPoints int) *jumpMapAlloc {
+func newJumpMapAlloc(name string, entryPoints int) *jumpMapAlloc {
 	a := &jumpMapAlloc{
+		name:      name,
+		logCtx:    logrus.WithField("jumpMapAllocName", name),
 		max:       entryPoints,
 		free:      set.New[int](),
 		freeStack: make([]int, entryPoints),
@@ -4931,9 +4939,11 @@ func newJumpMapAlloc(entryPoints int) *jumpMapAlloc {
 }
 
 type jumpMapAlloc struct {
-	lock sync.Mutex
-	max  int
+	name   string
+	logCtx *logrus.Entry
 
+	lock      sync.Mutex
+	max       int
 	free      set.Set[int]
 	freeStack []int
 	inUse     map[int]string
@@ -4951,7 +4961,7 @@ func (pa *jumpMapAlloc) Get(owner string) (int, error) {
 	pa.free.Discard(idx)
 	pa.inUse[idx] = owner
 
-	logrus.WithFields(logrus.Fields{"owner": owner, "index": idx}).Debug("jumpMapAlloc: Allocated policy map index")
+	pa.logCtx.WithFields(logrus.Fields{"owner": owner, "index": idx}).Debug("Allocated jump map index")
 	pa.checkFreeLockHeld(idx)
 	return idx, nil
 }
@@ -5001,7 +5011,7 @@ func (pa *jumpMapAlloc) Put(idx int, owner string) error {
 		err := fmt.Errorf("jumpMapAlloc: %q trying to free index %d but it is owned by %q", owner, idx, recordedOwner)
 		return err
 	}
-	logrus.WithFields(logrus.Fields{"owner": owner, "index": idx}).Debug("jumpMapAlloc: Released policy map index")
+	pa.logCtx.WithFields(logrus.Fields{"owner": owner, "index": idx}).Debug("Released policy map index")
 	delete(pa.inUse, idx)
 	pa.free.Add(idx)
 	pa.freeStack = append(pa.freeStack, idx)
@@ -5011,10 +5021,10 @@ func (pa *jumpMapAlloc) Put(idx int, owner string) error {
 
 func (pa *jumpMapAlloc) checkFreeLockHeld(idx int) {
 	if len(pa.freeStack) != pa.free.Len() {
-		logrus.WithFields(logrus.Fields{
+		pa.logCtx.WithFields(logrus.Fields{
 			"assigning": idx,
 			"set":       pa.free,
 			"stack":     pa.freeStack,
-		}).Panic("jumpMapAlloc: Free set and free stack got out of sync")
+		}).Panic("Free set and free stack got out of sync")
 	}
 }

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -2875,7 +2875,7 @@ var _ = Describe("jumpMapAlloc tests", func() {
 	var jma *jumpMapAlloc
 
 	BeforeEach(func() {
-		jma = newJumpMapAlloc(5)
+		jma = newJumpMapAlloc("test", 5)
 	})
 
 	It("should give initial values in order", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
WEP policy ingress maps to TC egress, code was mixing up the two resulting in crosstalk: when one jump map entry was cleaned up, it might clobber an entry in the other map.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-12170

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix bug where ingress and egress policy program indexes were confused, resulting in cleaning up the wrong policy program.
```


## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
