### PR TITLE
CI: Improve robustness of ssh in remote VM setup

### DIFF
--- a/.semaphore/vms/configure-test-vm
+++ b/.semaphore/vms/configure-test-vm
@@ -17,6 +17,7 @@
 set -e
 set -x
 
+my_dir="$(dirname "$0")"
 vm_name=$1
 zone=${ZONE:-europe-west3-c}
 project=${GCP_PROJECT:-unique-caldron-775}
@@ -45,14 +46,19 @@ if [[ -z "$vm_pub_key" ]]; then
 fi
 
 vm_ip=$(gcloud compute instances describe "${vm_name}" --zone="${zone}" --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
+
+# Prime on-test-vm's cache.
+ip_cache_file="/tmp/vm_ip_${vm_name}_${zone}"
+echo "$vm_ip" > "$ip_cache_file"
+
 echo "$vm_ip ssh-ed25519 $vm_pub_key" >> ~/.ssh/known_hosts
 
-ssh_cmd="ssh ubuntu@${vm_ip}"
+ssh_cmd=( env "VM_NAME=$vm_name" "ZONE=$zone" "$my_dir/on-test-vm" )
 
 startup_success=false
 for ssh_try in $(seq 1 100); do
   echo "Checking startup script completion: $ssh_try"
-  if ${ssh_cmd} test -e /var/run/startup-script-complete; then
+  if "${ssh_cmd[@]}" test -e /var/run/startup-script-complete; then
     echo "Startup script completed"
     startup_success=true
     break
@@ -78,7 +84,7 @@ set +x
 echo "$DOCKERHUB_PASSWORD" | ssh "ubuntu@${vm_ip}" -- docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 scp -r -C "$HOME/secrets" "ubuntu@${vm_ip}:/home/ubuntu/secrets"
 set -x
-${ssh_cmd} "gcloud auth activate-service-account --key-file=/home/ubuntu/secrets/secret.google-service-account-key.json && \
+"${ssh_cmd[@]}" "gcloud auth activate-service-account --key-file=/home/ubuntu/secrets/secret.google-service-account-key.json && \
   gcloud config set project unique-caldron-775 && \
   gcloud storage cp '${GCS_WORKFLOW_DIR}/${COMPONENT}/fv-artifacts/*' /tmp && \
   tar -xzf /tmp/working-copy.tgz && \

--- a/.semaphore/vms/on-test-vm
+++ b/.semaphore/vms/on-test-vm
@@ -12,9 +12,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-vm_ip=$(gcloud compute instances describe ${VM_NAME} --zone=${ZONE} --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
+set -e
+
+if [ -z "${VM_NAME}" ]; then
+  echo "VM_NAME is not set' it should be set to the name of the test VM"
+  exit 1
+fi
+if [ -z "${ZONE}" ]; then
+  echo "ZONE is not set; it should be set to the GCP zone of the test VM"
+  exit 1
+fi
+
+# Note: configure-test-vm also writes this cache file, which helps to improve
+# speed and reduce calls to the gcloud API.
+ip_cache_file="/tmp/vm_ip_${VM_NAME}_${ZONE}"
+if [ -e "$ip_cache_file" ]; then
+  vm_ip=$(cat "$ip_cache_file")
+else
+  vm_ip=$(gcloud compute instances describe "${VM_NAME}" --zone="${ZONE}" --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
+  echo "$vm_ip" > "$ip_cache_file"
+fi
+
 exec ssh "ubuntu@${vm_ip}" -n -A \
   -o ServerAliveInterval=10 \
   -o StrictHostKeyChecking=yes \


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Always go through on-test-vm.
- But cache the VM's IP to reduce gcloud API traffic.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-12172
Follow-on from #11536, which added robustness improvements to `on-test-vm`. 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
