### PR TITLE
Fix Go files check and some bad change_in clauses.

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -250,7 +250,7 @@ blocks:
     run:
       when: >-
         true or
-        change_in(['go.mod', 'go.sum', '/**/*.go', '**/deps.txt', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/go.mod', '/go.sum', '/**/*.go', '/**/deps.txt', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       env_vars:
@@ -281,7 +281,7 @@ blocks:
     run:
       when: >-
         true or
-        change_in(['networking-calico', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/networking-calico', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       jobs:
@@ -294,7 +294,7 @@ blocks:
     run:
       when: >-
         true or
-        change_in(['**/*'], {pipeline_file: 'track', exclude: ['libbpf', '.[a-z]*']})
+        change_in(['/**/*'], {pipeline_file: 'track', exclude: ['libbpf', '.[a-z]*']})
     dependencies: []
     task:
       jobs:
@@ -307,7 +307,7 @@ blocks:
     run:
       when: >-
         true or
-        change_in(['**/*.pb.go', '**/*.proto', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/**/*.pb.go', '/**/*.proto', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -250,7 +250,7 @@ blocks:
     run:
       when: >-
         false or
-        change_in(['go.mod', 'go.sum', '/**/*.go', '**/deps.txt', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/go.mod', '/go.sum', '/**/*.go', '/**/deps.txt', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       env_vars:
@@ -281,7 +281,7 @@ blocks:
     run:
       when: >-
         false or
-        change_in(['networking-calico', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/networking-calico', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       jobs:
@@ -294,7 +294,7 @@ blocks:
     run:
       when: >-
         false or
-        change_in(['**/*'], {pipeline_file: 'track', exclude: ['libbpf', '.[a-z]*']})
+        change_in(['/**/*'], {pipeline_file: 'track', exclude: ['libbpf', '.[a-z]*']})
     dependencies: []
     task:
       jobs:
@@ -307,7 +307,7 @@ blocks:
     run:
       when: >-
         false or
-        change_in(['**/*.pb.go', '**/*.proto', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+        change_in(['/**/*.pb.go', '/**/*.proto', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
     dependencies: []
     task:
       jobs:

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -25,7 +25,7 @@
   run:
     when: >-
       ${FORCE_RUN} or
-      change_in(['go.mod', 'go.sum', '/**/*.go', '**/deps.txt', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+      change_in(['/go.mod', '/go.sum', '/**/*.go', '/**/deps.txt', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
   dependencies: []
   task:
     env_vars:
@@ -56,7 +56,7 @@
   run:
     when: >-
       ${FORCE_RUN} or
-      change_in(['networking-calico', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+      change_in(['/networking-calico', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
   dependencies: []
   task:
     jobs:
@@ -69,7 +69,7 @@
   run:
     when: >-
       ${FORCE_RUN} or
-      change_in(['**/*'], {pipeline_file: 'track', exclude: ['libbpf', '.[a-z]*']})
+      change_in(['/**/*'], {pipeline_file: 'track', exclude: ['libbpf', '.[a-z]*']})
   dependencies: []
   task:
     jobs:
@@ -82,7 +82,7 @@
   run:
     when: >-
       ${FORCE_RUN} or
-      change_in(['**/*.pb.go', '**/*.proto', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
+      change_in(['/**/*.pb.go', '/**/*.proto', '/Makefile', '/lib.Makefile', '/metadata.mk'], {pipeline_file: 'ignore'})
   dependencies: []
   task:
     jobs:

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -25,7 +25,7 @@ github.com/blang/semver/v4 v4.0.0
 github.com/cespare/xxhash/v2 v2.3.0
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443
 github.com/containernetworking/cni v1.3.0
-github.com/containernetworking/plugins v1.8.0
+github.com/containernetworking/plugins v1.9.0
 github.com/coreos/go-iptables v0.8.0
 github.com/coreos/go-semver v0.3.1
 github.com/coreos/go-systemd/v22 v22.6.0


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Check go files CI Job wasn't running if only go.mod was changed due to using a relative path.  Relative paths are relative to the semaphore yaml file.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
