### PR TITLE
Use common options in rule endpoint UT

### DIFF
--- a/felix/rules/endpoints_test.go
+++ b/felix/rules/endpoints_test.go
@@ -841,9 +841,7 @@ func endpointRulesTests(flowLogsEnabled bool, dropActionOverride string) func() 
 						epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.MarkEndpoint,
 							rrConfigNormalMangleReturn.MarkNonCaliEndpoint)
 
-						toWlRulesOpts := commonRuleBuilderOpts
-						toWlRules := newRuleBuilder(toWlRulesOpts...).build()
-
+						toWlRules := newRuleBuilder(commonRuleBuilderOpts...).build()
 						fromWlOpts := append(commonRuleBuilderOpts,
 							withEgress(),
 							withAllowVXLAN(),
@@ -889,9 +887,7 @@ func endpointRulesTests(flowLogsEnabled bool, dropActionOverride string) func() 
 							nil,
 						)
 
-						toWlRulesOpts := commonRuleBuilderOpts
-						toWlRules := newRuleBuilder(toWlRulesOpts...).build()
-
+						toWlRules := newRuleBuilder(commonRuleBuilderOpts...).build()
 						fromWlOpts := append(commonRuleBuilderOpts,
 							withEgress(),
 							withAllowIPIP(),
@@ -924,9 +920,7 @@ func endpointRulesTests(flowLogsEnabled bool, dropActionOverride string) func() 
 						epMarkMapper = NewEndpointMarkMapper(rrConfigNormalMangleReturn.MarkEndpoint,
 							rrConfigNormalMangleReturn.MarkNonCaliEndpoint)
 
-						toWlRulesOpts := commonRuleBuilderOpts
-						toWlRules := newRuleBuilder(toWlRulesOpts...).build()
-
+						toWlRules := newRuleBuilder(commonRuleBuilderOpts...).build()
 						fromWlOpts := append(commonRuleBuilderOpts,
 							withEgress(),
 							withAllowIPIP(),


### PR DESCRIPTION
## Description

This PR includes:
- Use a common option for options used in all tests.
- Changing `dropVXLAN` and `dropIPIP` options to `allowVXLAN` and `allowIPIP` since dropping those traffic is the default behavior.
- Setting host endpoint related behavior in `forHostendpoint`. For example, tunnels should be allowed for host endpoints.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
