### PR TITLE
CORE-11758: Added benchmark test for Goldmane.Receive function

### DIFF
--- a/goldmane/pkg/goldmane/goldmane_benchmark_test.go
+++ b/goldmane/pkg/goldmane/goldmane_benchmark_test.go
@@ -15,7 +15,6 @@
 package goldmane_test
 
 import (
-	"github.com/projectcalico/calico/goldmane/pkg/testutils"
 	"math/rand/v2"
 	"os"
 	"runtime"
@@ -25,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/goldmane/pkg/goldmane"
+	"github.com/projectcalico/calico/goldmane/pkg/testutils"
 	"github.com/projectcalico/calico/goldmane/pkg/types"
 	"github.com/projectcalico/calico/lib/std/time"
 )


### PR DESCRIPTION
## Description

**Add Benchmarks for Goldmane.Receive Performance**

This PR adds benchmark tests for the `Goldmane.Receive` ingestion path to track CPU and memory behavior in single-threaded and parallel execution.

**What’s included:**
- BenchmarkGoldmaneReceive — serial execution
- BenchmarkGoldmaneReceiveParallel — concurrent execution
- Heap usage reporting + custom metrics

| Metric            | Single | Parallel |
|-------------------|--------|---------|
| Max HeapAlloc MB  | 5.0    | 8.0     |
| Max ns/op (ref)   | 13,000 | 35,000  |

Tests fail if heap allocation exceeds limits to catch memory regressions early.

**How to run benchmarks**
-  `cd goldmane`
-  `make benchmark`

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
