### PR TITLE
CORE-11900: Added Merge Cat trigger on PR merge GH action

### DIFF
--- a/.github/workflows/trigger-merge-queue.yml
+++ b/.github/workflows/trigger-merge-queue.yml
@@ -1,0 +1,28 @@
+name: Trigger Merge Cat
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  trigger-merge-queue-bot:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Merge Cat
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.TIGERA_BOT_PAT }}" \
+            https://api.github.com/repos/tigera/merge-queue-bot/actions/workflows/merge-queue-bot-oss-gh-action.yml/dispatches \
+            -d @- <<'EOF'
+          {
+            "ref": "master",
+            "inputs": {
+              "trigger_pr_number": "${{ github.event.pull_request.number }}",
+              "trigger_merge_sha": "${{ github.event.pull_request.merge_commit_sha }}",
+              "triggered_by_action: "OSS_MERGE"
+            }
+          }
+          EOF


### PR DESCRIPTION
## Description

This PR adds a **GitHub Action** that runs on **PR merges to master**.
When an OSS PR is merged, this Action triggers the `Merge Cat workflow` to process the merged PR and immediately send a reminder to the author to create a corresponding cherry-pick in the `Enterprise` repository.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
