### PR TITLE
fix: add nil check in AddressesAsCIDRs to prevent SIGSEGV

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -153,9 +153,9 @@ func (i l3rrNodeInfo) AddressesAsCIDRs() []ip.CIDR {
 		addrs[a] = struct{}{}
 	}
 
-	// Clean up empty (uninitialized) addresses
+	// Clean up empty (uninitialized) or nil addresses
 	for a := range addrs {
-		if a == emptyV4Addr || a == emptyV6Addr {
+		if a == nil || a == emptyV4Addr || a == emptyV6Addr {
 			delete(addrs, a)
 		}
 	}

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -154,6 +154,17 @@ var _ = Describe("L3RouteResolver", func() {
 			}
 			Expect(info.AddressesAsCIDRs()).To(Equal([]ip.CIDR{}))
 		})
+		It("should not panic on nil addresses in AddressesAsCIDRs()", func() {
+			// Test for issue #11384: SIGSEGV on null address
+			// When ExternalIP is empty, a nil ip.Addr can end up in the Addresses slice.
+			// The nil check should prevent a panic when AsCIDR() is called.
+			info := l3rrNodeInfo{
+				Addresses: []ip.Addr{nil, ip.FromString("192.168.0.1"), nil},
+			}
+			cidrs := info.AddressesAsCIDRs()
+			Expect(cidrs).To(HaveLen(1))
+			Expect(cidrs[0].String()).To(Equal("192.168.0.1/32"))
+		})
 		It("should consider VXLANV6Addr in Equal() method", func() {
 			info1 := l3rrNodeInfo{
 				VXLANV6Addr: ip.FromString("dead:beef::1"),


### PR DESCRIPTION
Fixes #11384

## Summary
- Add nil check in `AddressesAsCIDRs()` to prevent null pointer dereference
- Empty ExternalIP can result in nil `ip.Addr` in the Addresses slice, causing SIGSEGV when `AsCIDR()` is called

## Changes
- Added nil check at line 158 in `l3_route_resolver.go` before calling `AsCIDR()`
- Added test case to verify nil addresses are handled correctly

```release-note
Fix possible segmentation fault in IP address parsing code
```

## Test plan
- [x] Code compiles with `GOOS=linux go build ./felix/calc/`
- [x] Tests compile with `GOOS=linux go test -c ./felix/calc/`
- [x] Code formatted with `gofmt`