### PR TITLE
fix: gracefully return error on WatchList feature request

### DIFF
--- a/apiserver/pkg/storage/calico/resource.go
+++ b/apiserver/pkg/storage/calico/resource.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/features"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -249,7 +248,7 @@ func (rs *resourceStore) Watch(ctx context.Context, key string, opts storage.Lis
 
 	// Return error to force k8s-client to fall back to LIST/WATCH as long as calico-apiserver does not support the WatchList feature gate
 	if !utilfeature.DefaultMutableFeatureGate.Enabled(features.WatchList) && opts.SendInitialEvents != nil && *opts.SendInitialEvents {
-		return nil, aapierrors.NewBadRequest("WatchList feature with sendInitialEvents=true is not supported, client should fallback to LIST/WATCH")
+		return nil, aapierrors.NewBadRequest("WatchList feature with sendInitialEvents=true is not supported, client should fall back to LIST/WATCH")
 	}
 
 	ns, name, err := NamespaceAndNameFromKey(key, rs.isNamespaced)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Return error upon receiving WATCH/WATCHLIST request with `sendInitialEvent` opt for WatchList feature
 
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes [<ISSUE LINK>](https://github.com/projectcalico/calico/issues/11114)

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
- calico-apiserver not support WatchList feature yet, it better to return error to let client fall back to LIST/WATCH. 
- The fallback logic is already implemented in k8s-client
- fixes https://github.com/projectcalico/calico/issues/11114
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
