### PR TITLE
Add job/workflow ID labels to test VMs.

### DIFF
--- a/.semaphore/vms/create-test-vms
+++ b/.semaphore/vms/create-test-vms
@@ -45,7 +45,7 @@ done
 # Sanitize the branch name to be compatible with GCP label requirements.
 branch_label="${SEMAPHORE_GIT_BRANCH:-unknown}"
 branch_label="$(echo "$branch_label" | tr '[:upper:]' '[:lower:]')"
-branch_label="$(echo "$branch_label" | sed 's/[^a-z0-9_-]/-/g')"
+branch_label="${branch_label//[^a-z0-9_-]/-}"
 labels="ci-runner=true"
 labels+=",ci-job-type=${CI_JOB_TYPE_LABEL:-${SEMAPHORE_GIT_REF_TYPE:-unknown}}"
 labels+=",ci-group=${CI_GROUP_LABEL:-unknown}"
@@ -55,6 +55,12 @@ labels+=",ci-branch=${branch_label}"
 labels+=",ci-project=${CALICO_DIR_NAME}"
 if [ -n "${SEMAPHORE_GIT_PR_NUMBER}" ]; then
   labels+=",ci-pr-number=${SEMAPHORE_GIT_PR_NUMBER}"
+fi
+if [ -n "${SEMAPHORE_WORKFLOW_ID}" ]; then
+  labels+=",ci-workflow-id=${SEMAPHORE_WORKFLOW_ID}"
+fi
+if [ -n "${SEMAPHORE_JOB_ID}" ]; then
+  labels+=",ci-job-id=${SEMAPHORE_JOB_ID}"
 fi
 if [ "${SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE}" = "true" ]; then
   labels+=",ci-scheduled=true"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Allows for full drill-down to an exact job in the analytics.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Builds on #11584

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
