### PR TITLE
CORE-11900: Change Merge Cat GH event type to pull_request_target

### DIFF
--- a/.github/workflows/trigger-merge-queue.yml
+++ b/.github/workflows/trigger-merge-queue.yml
@@ -23,7 +23,7 @@ jobs:
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.TIGERA_BOT_PAT }}" \
-            https://api.github.com/repos/tigera/merge-queue-bot/actions/workflows/merge-queue-bot-oss-gh-action.yml/dispatches \
+            https://api.github.com/repos/tigera/merge-queue-bot/actions/workflows/221254945/dispatches \
             -d @- <<'EOF'
           {
             "ref": "master",


### PR DESCRIPTION
## Description

Changed `Merge Cat` **GH event type** to `pull_request_target` since for previous event type actions secrets are not available

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
