### PR TITLE
[BPF] Maglev map: de-dupe backend maps

### DIFF
--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -7,7 +7,7 @@
 
 #include "types.h"
 
-CALI_MAP(cali_state, 4,
+CALI_MAP(cali_state, 5,
 		BPF_MAP_TYPE_PERCPU_ARRAY,
 		__u32, struct cali_tc_state,
 		2, 0)

--- a/felix/bpf-gpl/maglev.h
+++ b/felix/bpf-gpl/maglev.h
@@ -33,19 +33,14 @@ static CALI_BPF_INLINE struct calico_nat_dest* maglev_select_backend(struct cali
 	CALI_DEBUG("Maglev: hashed packet to %d", hash);
 	struct cali_maglev_key ch_key = {
 		.ordinal = (hash % lut_size),
-		.vip = *ip_dst,
-		.port = dport,
-		.proto = ip_proto,
+		.sid = ctx->state->nat_svc_id,
 	};
 	struct calico_nat_dest *ch_val;
 
 	ch_val = cali_maglev_lookup_elem(&ch_key);
 
 	if (!ch_val) {
-		__u32 proto_debug = ip_proto;
-		CALI_DEBUG("Maglev: no backend found for " IP_FMT ":%d", debug_ip(*ip_dst), dport);
-		CALI_DEBUG("Packet proto: %d, Ordinal: %d", proto_debug, ch_key.ordinal);
-
+		CALI_DEBUG("Maglev: no backend found for svc %d, idx %d", ctx->state->nat_svc_id, ch_key.ordinal);
 		return NULL;
 	}
 

--- a/felix/bpf-gpl/nat_types.h
+++ b/felix/bpf-gpl/nat_types.h
@@ -120,17 +120,14 @@ struct vxlanhdr {
 };
 
 struct cali_maglev_key {
-	ipv46_addr_t vip;
-	__u16 port;
-	__u8 proto;
-	__u8 pad;
+	__u32 sid;
 	__u32 ordinal; // should always be a value of [0..M-1], where M is a very large prime number. -Alex
 };
 
 #ifdef IPVER6
-CALI_MAP_NAMED(cali_v6_mglv, cali_maglev,,
+CALI_MAP_NAMED(cali_v6_mglv, cali_maglev,2,
 #else
-CALI_MAP_NAMED(cali_v4_mglv, cali_maglev,,
+CALI_MAP_NAMED(cali_v4_mglv, cali_maglev,2,
 #endif
 		BPF_MAP_TYPE_HASH,
 		struct cali_maglev_key, struct calico_nat_dest,

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -115,6 +115,9 @@ struct cali_tc_state {
 	 * appropriate conntrack entry.
 	 */
 	DECLARE_IP_ADDR(ip_src_masq);
+
+	__u32 nat_svc_id;
+	__u32 pad;
 #ifndef IPVER6
 	__u8 __pad_ipv4[44];
 #endif

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -121,10 +121,12 @@ type State struct {
 	SrcAddrMasq1        uint32
 	SrcAddrMasq2        uint32
 	SrcAddrMasq3        uint32
-	_                   [48]byte // ipv6 padding
+	NATSvcID            uint32
+	_                   uint32
+	_                   [44]byte // ipv6 padding
 }
 
-const expectedSize = 488
+const expectedSize = 496
 
 func (s *State) AsBytes() []byte {
 	bPtr := (*[expectedSize]byte)(unsafe.Pointer(s))
@@ -146,7 +148,7 @@ var MapParameters = maps.MapParameters{
 	ValueSize:  expectedSize,
 	MaxEntries: 2,
 	Name:       "cali_state",
-	Version:    4,
+	Version:    5,
 }
 
 func Map() maps.Map {

--- a/felix/bpf/ut/maglev_test.go
+++ b/felix/bpf/ut/maglev_test.go
@@ -45,7 +45,10 @@ import (
 // used by the BPF program, and would be an error to do so.
 // We would like such errors to be immediately apparent, hence the omission.
 
-var maglevTestM = 31
+var (
+	maglevSvcID = uint32(55555)
+	maglevTestM = testMaglevLUTSize
+)
 
 func TestMaglevNATServiceIPTCP(t *testing.T) {
 	RegisterTestingT(t)
@@ -114,12 +117,12 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	// Node 3: Flagging frontend map item with the consistent-hash flag.
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueWithFlags(0, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueWithFlags(maglevSvcID, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Node 3: Build a maglev LUT and program each item to the BPF map.
-	mglv := consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv := consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  podIP.String(),
 		Prt: podPort,
@@ -127,7 +130,7 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	lut := mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap.Update(
-			nat.NewMaglevBackendKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKey(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -252,12 +255,12 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	// Node 2: now we are at the node with local workload
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueWithFlags(0 /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueWithFlags(maglevSvcID /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Node 2: Build a maglev LUT and program each item to the BPF map.
-	mglv = consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv = consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  podIP.String(),
 		Prt: podPort,
@@ -265,7 +268,7 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	lut = mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap.Update(
-			nat.NewMaglevBackendKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKey(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -473,12 +476,12 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	// Node 1: Flagging frontend map item with the consistent-hash flag.
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueWithFlags(0, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueWithFlags(maglevSvcID, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Node 1: Build a maglev LUT and program each item to the BPF map.
-	mglv = consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv = consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  podIP.String(),
 		Prt: podPort,
@@ -486,7 +489,7 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	lut = mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap.Update(
-			nat.NewMaglevBackendKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKey(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -598,12 +601,12 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	// now we are at the node with local workload
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueWithFlags(0 /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueWithFlags(maglevSvcID /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Node 2: Build a maglev LUT and program each item to the BPF map.
-	mglv = consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv = consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  podIP.String(),
 		Prt: podPort,
@@ -611,7 +614,7 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	lut = mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap.Update(
-			nat.NewMaglevBackendKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKey(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -807,10 +810,10 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueWithFlags(0, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueWithFlags(maglevSvcID, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	mglv = consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv = consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  podIP.String(),
 		Prt: podPort,
@@ -818,7 +821,7 @@ func TestMaglevNATServiceIPTCP(t *testing.T) {
 	lut = mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap.Update(
-			nat.NewMaglevBackendKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKey(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -924,7 +927,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 
 	err = natMapV6.Update(
 		nat.NewNATKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueV6WithFlags(0, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueV6WithFlags(maglevSvcID, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -936,7 +939,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Build a maglev LUT and program each item to the BPF map.
-	mglv := consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv := consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  natIP.String(),
 		Prt: natPort,
@@ -944,7 +947,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 	lut := mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap6.Update(
-			nat.NewMaglevBackendKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKeyV6(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValueV6(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -1085,7 +1088,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 	// now we are at the node with local workload
 	err = natMapV6.Update(
 		nat.NewNATKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueV6WithFlags(0 /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueV6WithFlags(maglevSvcID /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1403,7 +1406,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 
 	err = natMapV6.Update(
 		nat.NewNATKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueV6WithFlags(0, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueV6WithFlags(maglevSvcID, 1, 0, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1412,7 +1415,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Build a maglev LUT and program each item to the BPF map.
-	mglv = consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv = consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  natIP.String(),
 		Prt: natPort,
@@ -1420,7 +1423,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 	lut = mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap6.Update(
-			nat.NewMaglevBackendKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKeyV6(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValueV6(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -1561,7 +1564,7 @@ func TestMaglevNATServiceIPTCPV6(t *testing.T) {
 	// now we are at the node with local workload
 	err = natMapV6.Update(
 		nat.NewNATKeyV6(ipv6.DstIP, uint16(tcp.DstPort), uint8(layers.IPProtocolTCP)).AsBytes(),
-		nat.NewNATValueV6WithFlags(0 /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueV6WithFlags(maglevSvcID /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1896,7 +1899,7 @@ func TestMaglevNATNodePortNoFWD(t *testing.T) {
 	// local workload
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
-		nat.NewNATValueWithFlags(0 /* count */, 1 /* local */, 1, 0, nat.NATFlgMaglev).AsBytes(),
+		nat.NewNATValueWithFlags(maglevSvcID /* id */, 1 /* count */, 1 /* local */, 0, nat.NATFlgMaglev).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1904,7 +1907,7 @@ func TestMaglevNATNodePortNoFWD(t *testing.T) {
 	natPort := uint16(666)
 
 	// Build a maglev LUT and program each item to the BPF map.
-	mglv := consistenthash.New(maglevTestM, fnv.New32(), fnv.New32())
+	mglv := consistenthash.New(int(maglevTestM), fnv.New32(), fnv.New32())
 	mglv.AddBackend(chtypes.MockEndpoint{
 		Ip:  natIP.String(),
 		Prt: natPort,
@@ -1912,7 +1915,7 @@ func TestMaglevNATNodePortNoFWD(t *testing.T) {
 	lut := mglv.Generate()
 	for ordinal, ep := range lut {
 		err = mgMap.Update(
-			nat.NewMaglevBackendKey(ipv4.DstIP, uint16(udp.DstPort), uint8(ipv4.Protocol), uint32(ordinal)).AsBytes(),
+			nat.NewMaglevBackendKey(maglevSvcID, uint32(ordinal)).AsBytes(),
 			nat.NewNATBackendValue(net.ParseIP(ep.IP()), uint16(ep.Port())).AsBytes(),
 		)
 		Expect(err).NotTo(HaveOccurred())

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1938,37 +1938,39 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 						return val, exists
 					}
-					maglevMapAnySearch := func(key nat.MaglevBackendKeyInterface, family string, felix *infrastructure.Felix) nat.BackendValueInterface {
+					maglevMapAnySearch := func(val nat.BackendValueInterface, family string, felix *infrastructure.Felix) nat.BackendValueInterface {
 						Expect(family).To(Or(Equal("ipv4"), Equal("ipv6")))
 
-						var v nat.BackendValueInterface
-						var ok bool
 						switch family {
 						case "ipv4":
-							mm := dumpMaglevMap(felix)
-							kp := nat.MaglevBackendKey{}
-							Expect(key).To(BeAssignableToTypeOf(kp))
-							kp, _ = key.(nat.MaglevBackendKey)
+							vType := nat.BackendValue{}
+							Expect(val).To(BeAssignableToTypeOf(vType))
+							kvs := dumpMaglevMap(felix)
+							valParsed, _ := val.(nat.BackendValue)
 
-							if v, ok = mm[kp]; !ok {
-								return nil
+							for _, v := range kvs {
+								if v.Addr().Equal(valParsed.Addr()) && v.Port() == valParsed.Port() {
+									return v
+								}
 							}
 
 						case "ipv6":
-							mm := dumpMaglevMapV6(felix)
-							kp := nat.MaglevBackendKeyV6{}
-							Expect(key).To(BeAssignableToTypeOf(kp))
-							kp, _ = key.(nat.MaglevBackendKeyV6)
+							vType := nat.BackendValueV6{}
+							Expect(val).To(BeAssignableToTypeOf(vType))
+							kvs := dumpMaglevMapV6(felix)
+							valParsed, _ := val.(nat.BackendValueV6)
 
-							if v, ok = mm[kp]; !ok {
-								return nil
+							for _, v := range kvs {
+								if v.Addr().Equal(valParsed.Addr()) && v.Port() == valParsed.Port() {
+									return v
+								}
 							}
 						}
-						return v
+						return nil
 					}
-					maglevMapAnySearchFunc := func(key nat.MaglevBackendKeyInterface, family string, felix *infrastructure.Felix) func() nat.BackendValueInterface {
+					maglevMapAnySearchFunc := func(val nat.BackendValueInterface, family string, felix *infrastructure.Felix) func() nat.BackendValueInterface {
 						return func() nat.BackendValueInterface {
-							return maglevMapAnySearch(key, family, felix)
+							return maglevMapAnySearch(val, family, felix)
 						}
 					}
 
@@ -2026,22 +2028,28 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 						conntrackFlushWorkloadEntries(tc.Felixes)
 
-						var testMaglevMapKey nat.MaglevBackendKeyInterface
+						eps := k8sGetEpsForService(k8sClient, testSvc)
+						Expect(eps).NotTo(HaveLen(0), "Expected endpoints for the service")
+						Expect(eps[0].Endpoints).NotTo(HaveLen(0), "Endpointslice had no endpoints")
+						Expect(eps[0].Endpoints[0].Addresses).NotTo(BeEmpty(), "No addresses in endpointslice item")
+						Expect(net.ParseIP(eps[0].Endpoints[0].Addresses[0])).NotTo(BeNil(), "Endpoint address was not parseable as an IP")
+
+						var testMaglevMapVal nat.BackendValueInterface
 						switch family {
 						case "ipv4":
-							testMaglevMapKey = nat.NewMaglevBackendKey(net.ParseIP(clusterIP), port, proto, 0)
+							testMaglevMapVal = nat.NewNATBackendValue(net.ParseIP(eps[0].Endpoints[0].Addresses[0]), uint16(tgtPort))
 						case "ipv6":
-							testMaglevMapKey = nat.NewMaglevBackendKeyV6(net.ParseIP(clusterIP), port, proto, 0)
+							testMaglevMapVal = nat.NewNATBackendValueV6(net.ParseIP(eps[0].Endpoints[0].Addresses[0]), uint16(tgtPort))
 						default:
 							log.Panicf("Unexpected IP family %s", family)
 						}
 
 						log.Info("Waiting for Maglev map to converge...")
-						Eventually(maglevMapAnySearchFunc(testMaglevMapKey, family, tc.Felixes[0]), "10s").ShouldNot(BeNil(), "A maglev map entry never showed up (Felix[0])")
-						Eventually(maglevMapAnySearchFunc(testMaglevMapKey, family, tc.Felixes[1]), "10s").ShouldNot(BeNil(), "A maglev map entry never showed up (Felix[1])")
-						Eventually(maglevMapAnySearchFunc(testMaglevMapKey, family, tc.Felixes[2]), "10s").ShouldNot(BeNil(), "A maglev map entry never showed up (Felix[2])")
+						Eventually(maglevMapAnySearchFunc(testMaglevMapVal, family, tc.Felixes[0]), "10s").ShouldNot(BeNil(), "A maglev map entry never showed up (Felix[0]). Looked for backend: %v", testMaglevMapVal)
+						Eventually(maglevMapAnySearchFunc(testMaglevMapVal, family, tc.Felixes[1]), "10s").ShouldNot(BeNil(), "A maglev map entry never showed up (Felix[1]). Looked for backend: %v", testMaglevMapVal)
+						Eventually(maglevMapAnySearchFunc(testMaglevMapVal, family, tc.Felixes[2]), "10s").ShouldNot(BeNil(), "A maglev map entry never showed up (Felix[2]). Looked for backend: %v", testMaglevMapVal)
 
-						Expect(maglevMapAnySearch(testMaglevMapKey, family, tc.Felixes[1]).Addr().String()).Should(Equal(w[0][0].IP))
+						Expect(maglevMapAnySearch(testMaglevMapVal, family, tc.Felixes[1]).Addr().String()).Should(Equal(w[0][0].IP))
 
 						// Configure routes on external client and Felix nodes.
 						// Use Felix[1] as a middlebox initially.


### PR DESCRIPTION
## Description

When a given maglev service has many frontends programmed (say, for different LoadBalancer VIPs), re-use the same backend map instead of programming one for each frontend.


## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
[BPF] Improve Maglev memory tenancy by re-using backend maps where possible.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
