### PR TITLE
Add env vars to support auto PR creation by the Merge Cat bot.

### DIFF
--- a/hack/cherry-pick-pull
+++ b/hack/cherry-pick-pull
@@ -87,6 +87,9 @@ function init-vars() {
   CHERRY_PICK=${CHERRY_PICK:-""}
   SQUASH_COMMITS=${SQUASH_COMMITS:-""}
 
+  FAIL_ON_CONFLICT=${FAIL_ON_CONFLICT:-""}
+  AUTO_CREATE_PR=${AUTO_CREATE_PR:-""}
+
   if [[ -z ${GITHUB_USER:-} ]]; then
     echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
     exit 1
@@ -255,12 +258,19 @@ EOF
     echo
     cat "${pr_body_file}"
   else
-    echo "+++ Creating PR into ${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}. Running: gh pr create -t \"[${relshort}] ${new_title}\" -F \"${pr_body_file}\" --repo \"${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}\" -H \"${GITHUB_USER}:${NEWBRANCH}\" -B \"${rel}\" -l \"${new_labels}\""
+    head_ref="${GITHUB_USER}:${NEWBRANCH}"
+
+    # If AUTO_CREATE_PR is set and true, there is no fork involved.
+    if [[ -n "${AUTO_CREATE_PR}" ]]; then
+      head_ref="${NEWBRANCH}"
+    fi
+
+    echo "+++ Creating PR into ${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}. Running: gh pr create -t \"[${relshort}] ${new_title}\" -F \"${pr_body_file}\" --repo \"${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}\" -H \"${head_ref}\" -B \"${rel}\" -l \"${new_labels}\""
     gh pr create \
       -t "[${relshort}] ${new_title}" \
       -F "${pr_body_file}" \
       --repo "${DST_MAIN_REPO_ORG}/${DST_MAIN_REPO_NAME}" \
-      -H "${GITHUB_USER}:${NEWBRANCH}" \
+      -H "${head_ref}" \
       -B "${rel}" \
       -l "${new_labels}"
   fi
@@ -307,6 +317,11 @@ function create-branch-and-pr() {
       # If patch is applied cleanly, add files, they will be committed later
       eval "$add_cmd"
     else
+      if [[ -n "${FAIL_ON_CONFLICT}" ]]; then
+        echo "Conflicts detected and FAIL_ON_CONFLICT is set, aborting."
+        exit 1
+      fi
+
       # If there are conflicts, prompt user to resolve them in another window and continue
       conflicts=false
       while unmerged=$(git status --porcelain | grep ^U) && [[ -n ${unmerged} ]] \
@@ -395,10 +410,14 @@ function create-branch-and-pr() {
   echo
   echo "  git push ${FORK_REMOTE} ${NEWBRANCHUNIQ}:${NEWBRANCH}"
   echo
-  read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
-  if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
-    echo "Aborting." >&2
-    exit 1
+  if [[ -n "${AUTO_CREATE_PR}" ]]; then
+    echo "AUTO_CREATE_PR is set, proceeding without prompt."
+  else
+    read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
+    if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
+      echo "Aborting." >&2
+      exit 1
+    fi
   fi
   
   git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"


### PR DESCRIPTION
## Description

This PR introduces two environment variables in the `hack/cherry-pick-pull` script to enable `Merge Cat Bot` creating cherry-pick PRs automatically.

**FAIL_ON_CONFLICT**
Causes the script to fail fast as soon as a conflict is detected, instead of entering an interactive resolution flow.

**AUTO_CREATE_PR**
Skips the final confirmation prompt and allows the script to automatically create the PR without requiring human confirmation.

The choice to use two environment variables instead of having the bot programmatically answer prompts was made to provide a safer, more robust solution. This avoids relying on string parsing to determine which prompt to answer and helps keep the bot logic simple.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
