### PR TITLE
Use correct Kind when translating k8s policies

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/clusternetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/conversion/clusternetworkpolicy.go
@@ -115,7 +115,7 @@ func (c converter) K8sClusterNetworkPolicyToCalico(kcnp *clusternetpol.ClusterNe
 	kvp := &model.KVPair{
 		Key: model.ResourceKey{
 			Name: kcnp.Name,
-			Kind: apiv3.KindGlobalNetworkPolicy,
+			Kind: model.KindKubernetesClusterNetworkPolicy,
 		},
 		Value:    gnp,
 		Revision: kcnp.ResourceVersion,

--- a/libcalico-go/lib/backend/k8s/conversion/conversion.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion.go
@@ -370,7 +370,7 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		Key: model.ResourceKey{
 			Name:      np.Name,
 			Namespace: np.Namespace,
-			Kind:      apiv3.KindNetworkPolicy,
+			Kind:      model.KindKubernetesNetworkPolicy,
 		},
 		Value:    policy,
 		Revision: np.ResourceVersion,

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor.go
@@ -29,7 +29,7 @@ import (
 // consumption by Felix.
 func NewGlobalNetworkPolicyUpdateProcessor(keyKind string) watchersyncer.SyncerUpdateProcessor {
 	return NewSimpleUpdateProcessor(
-		apiv3.KindGlobalNetworkPolicy,
+		keyKind,
 		gnpKeyConverter(keyKind),
 		ConvertGlobalNetworkPolicyV3ToV1Value,
 	)

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
@@ -30,7 +30,7 @@ import (
 // consumption by Felix.
 func NewNetworkPolicyUpdateProcessor(keyKind string) watchersyncer.SyncerUpdateProcessor {
 	return NewSimpleUpdateProcessor(
-		apiv3.KindNetworkPolicy,
+		keyKind,
 		npKeyConverter(keyKind),
 		ConvertNetworkPolicyV3ToV1Value,
 	)

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -177,12 +177,12 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 
 // Define network policies and the corresponding expected v1 KVPairs.
 //
-// np1 is a NetworkPolicy with a single Egress rule, which contains ports only,
+// knp1 is a NetworkPolicy with a single Egress rule, which contains ports only,
 // and no selectors.
 var (
 	protocol = kapiv1.ProtocolTCP
 	port     = intstr.FromInt(80)
-	np1      = networkingv1.NetworkPolicy{
+	knp1     = networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test.policy",
 			Namespace: "default",
@@ -205,15 +205,15 @@ var (
 	}
 )
 
-// expected1 is the expected v1 KVPair representation of np1 from above.
+// expectedKNP1 is the expected v1 KVPair representation of np1 from above.
 var (
-	tcp       = numorstring.ProtocolFromStringV1("tcp")
-	expected1 = []*model.KVPair{
+	tcp          = numorstring.ProtocolFromStringV1("tcp")
+	expectedKNP1 = []*model.KVPair{
 		{
 			Key: model.PolicyKey{
 				Name:      "test.policy",
 				Namespace: "default",
-				Kind:      apiv3.KindNetworkPolicy,
+				Kind:      model.KindKubernetesNetworkPolicy,
 			},
 			Value: &model.Policy{
 				Tier:           "default",
@@ -236,8 +236,8 @@ var (
 	}
 )
 
-// np2 is a NetworkPolicy with a single Ingress rule which allows from all namespaces.
-var np2 = networkingv1.NetworkPolicy{
+// knp2 is a NetworkPolicy with a single Ingress rule which allows from all namespaces.
+var knp2 = networkingv1.NetworkPolicy{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "test.policy",
 		Namespace: "default",
@@ -258,12 +258,12 @@ var np2 = networkingv1.NetworkPolicy{
 	},
 }
 
-var expected2 = []*model.KVPair{
+var expectedKNP2 = []*model.KVPair{
 	{
 		Key: model.PolicyKey{
 			Name:      "test.policy",
 			Namespace: "default",
-			Kind:      apiv3.KindNetworkPolicy,
+			Kind:      model.KindKubernetesNetworkPolicy,
 		},
 		Value: &model.Policy{
 			Tier:           "default",
@@ -285,8 +285,8 @@ var expected2 = []*model.KVPair{
 	},
 }
 
-var _ = Describe("Test the NetworkPolicy update processor + conversion", func() {
-	up := updateprocessors.NewNetworkPolicyUpdateProcessor(apiv3.KindNetworkPolicy)
+var _ = Describe("Test KubernetesNetworkPolicy update processor + conversion", func() {
+	up := updateprocessors.NewNetworkPolicyUpdateProcessor(model.KindKubernetesNetworkPolicy)
 
 	DescribeTable("NetworkPolicy update processor + conversion tests",
 		func(np networkingv1.NetworkPolicy, expected []*model.KVPair) {
@@ -303,8 +303,8 @@ var _ = Describe("Test the NetworkPolicy update processor + conversion", func() 
 			Expect(out).To(Equal(expected))
 		},
 
-		Entry("should handle a NetworkPolicy with no rule selectors", np1, expected1),
-		Entry("should handle a NetworkPolicy with an empty ns selector", np2, expected2),
+		Entry("should handle a NetworkPolicy with no rule selectors", knp1, expectedKNP1),
+		Entry("should handle a NetworkPolicy with an empty ns selector", knp2, expectedKNP2),
 	)
 })
 

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/processor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/processor.go
@@ -61,7 +61,7 @@ func (sup *simpleUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, e
 	// Check the v3 resource is the correct type.
 	rk, ok := kvp.Key.(model.ResourceKey)
 	if !ok || rk.Kind != sup.v3Kind {
-		return nil, fmt.Errorf("Incorrect key type - expecting resource of kind %s", sup.v3Kind)
+		return nil, fmt.Errorf("Incorrect key type %s - expecting resource of kind %s", rk.Kind, sup.v3Kind)
 	}
 
 	// Convert the v3 resource to the equivalent v1 resource type, started with the Key.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Currently, we lose the originating "Kind" when converting k8s network policies to their Calico equivalents. This is OK since the updateprocessor in the watchercache key converter immediately swaps the kind back, but for Syncers that don't use the converter we lose this information, meaning downstream consumers cannot tell the diffrence between a k8s NetworkPolicy and a Calico NetworkPolicy.

This change ensures all syncer consumers can distinguish between the two by updating the conversion logic to set the kind correctly in the Key.

It shouldnt have any user-facing impacts, but fixes a bit of confusing logic.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.