### PR TITLE
[v3.31] eBPF: fix that local workload with borrowed IPs lose connectivity

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -807,8 +807,11 @@ func (c *L3RouteResolver) flush() {
 					rt.Borrowed = true
 				}
 				if ri.Refs[0].RefType == RefTypeWEP {
-					// This is not a tunnel ref, so must be a workload.
+					// This is explicitly a workload endpoint.
 					if ri.Refs[0].NodeName == c.myNodeName {
+						// Flag that there's a live WEP on this IP; this avoids
+						// confusion in the dataplane if we have borrowed IPs
+						// (which get flagged as both local and remote!).
 						rt.LocalWorkload = true
 						rt.Types |= proto.RouteType_LOCAL_WORKLOAD
 					} else {

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -335,11 +335,8 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.CIDR) routes.ValueInterface {
 		}
 		nodeIP := net.ParseIP(cgRoute.DstNodeIp)
 		route = m.bpfOps.NewValueWithNextHop(flags, ip.FromNetIP(nodeIP))
-	} else if rts&proto.RouteType_LOCAL_WORKLOAD == proto.RouteType_LOCAL_WORKLOAD && !cgRoute.Borrowed /* not ours */ {
-		if !cgRoute.LocalWorkload {
-			// Just the local IPAM block, not an actual workload.
-			return nil
-		}
+	} else if cgRoute.GetLocalWorkload() {
+		// Explicitly a local WorkloadEndpoint /32.
 		if wepIDs, ok := m.cidrToWEPIDs[cidr]; ok {
 			bestWepScore := -1
 			var bestWepID *proto.WorkloadEndpointID
@@ -389,6 +386,7 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.CIDR) routes.ValueInterface {
 		// hostname.
 		flags |= routes.FlagsLocalHost
 	} else if rts&proto.RouteType_REMOTE_WORKLOAD == proto.RouteType_REMOTE_WORKLOAD {
+		// Either a remote IPAM block or a remote workload with a borrowed IP.
 		flags |= routes.FlagsRemoteWorkload
 		if m.wgEnabled {
 			flags |= routes.FlagTunneled
@@ -406,6 +404,10 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.CIDR) routes.ValueInterface {
 		}
 		nodeIP := net.ParseIP(cgRoute.DstNodeIp)
 		route = m.bpfOps.NewValueWithNextHop(flags, ip.FromNetIP(nodeIP))
+	} else if rts&proto.RouteType_LOCAL_WORKLOAD == proto.RouteType_LOCAL_WORKLOAD {
+		// Local IPAM block. We don't need to have a map entry for that right
+		// now.
+		return nil
 	}
 
 	if route == nil && flags != 0 {

--- a/felix/fv/routing_test.go
+++ b/felix/fv/routing_test.go
@@ -69,8 +69,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 		routeSource := testConfig.RouteSource
 		brokenXSum := testConfig.BrokenXSum
 		enableIPv6 := testConfig.EnableIPv6
+		description := fmt.Sprintf("with topology set to IPIPMode %s, routeSource %s, brokenXSum: %v, enableIPv6: %v", ipipMode, routeSource, brokenXSum, enableIPv6)
 
-		Describe(fmt.Sprintf("with topology set to IPIPMode %s, routeSource %s, brokenXSum: %v, enableIPv6: %v", ipipMode, routeSource, brokenXSum, enableIPv6), func() {
+		Describe(description, func() {
 			var (
 				infra           infrastructure.DatastoreInfra
 				tc              infrastructure.TopologyContainers
@@ -893,7 +894,102 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 			})
 		})
 
-		Describe("with a borrowed tunnel IP on one host", func() {
+		Describe(description+" and borrowed workload IPs", func() {
+			var (
+				infra           infrastructure.DatastoreInfra
+				tc              infrastructure.TopologyContainers
+				felixes         []*infrastructure.Felix
+				client          client.Interface
+				w               [3]*workload.Workload
+				w6              [3]*workload.Workload
+				cc              *connectivity.Checker
+				topologyOptions infrastructure.TopologyOptions
+				timeout         = time.Second * 30
+			)
+
+			BeforeEach(func() {
+				if !(ipipMode != api.IPIPModeAlways || routeSource != "WorkloadIPs") {
+					Skip("Skipping due to known issue with tunnel IPs not being programmed in WEP mode")
+				}
+
+				infra = getInfra()
+
+				if (NFTMode() || BPFMode()) && getDataStoreType(infra) == "etcdv3" {
+					Skip("Skipping NFT / BPF tests for etcdv3 backend.")
+				}
+
+				topologyOptions = createIPIPBaseTopologyOptions(ipipMode, enableIPv6, routeSource, brokenXSum)
+
+				cc = &connectivity.Checker{}
+
+				// Deploy the topology.
+				tc, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
+
+				// Assign tunnel addresses in IPAM based on the topology.
+				// This will assign blocks to particular nodes so that the
+				// workload IP assignments below will borrow.
+				assignTunnelAddresses(infra, tc, client)
+
+				// Offset of +1 means that felix[0]'s workload borrows its IP from
+				// felix[1]'s block and so on.
+				w, w6, _, _ = setupWorkloadsWithOffset(infra, tc, topologyOptions, client, enableIPv6, 1)
+				felixes = tc.Felixes
+			})
+
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
+					for _, felix := range felixes {
+						if NFTMode() {
+							logNFTDiags(felix)
+						} else {
+							felix.Exec("iptables-save", "-c")
+							felix.Exec("ipset", "list")
+						}
+						felix.Exec("ipset", "list")
+						felix.Exec("ip", "r")
+						felix.Exec("ip", "a")
+						felix.Exec("calico-bpf", "routes", "dump")
+						if enableIPv6 {
+							felix.Exec("ip", "-6", "route")
+							felix.Exec("calico-bpf", "-6", "routes", "dump")
+						}
+					}
+				}
+
+				for _, wl := range w {
+					wl.Stop()
+				}
+				for _, wl := range w6 {
+					wl.Stop()
+				}
+				tc.Stop()
+
+				if CurrentGinkgoTestDescription().Failed {
+					infra.DumpErrorData()
+				}
+				infra.Stop()
+			})
+
+			It("should have connectivity", func() {
+				for i := 0; i < 3; i++ {
+					f := felixes[i]
+					cc.ExpectSome(f, w[i])          // Host to local workload.
+					cc.ExpectSome(f, w[(i+1)%3])    // Host to next node's workload
+					cc.ExpectSome(w[i], w[(i+1)%3]) // Local workload to next node's workload.
+
+					if enableIPv6 {
+						cc.ExpectSome(f, w6[i])
+						cc.ExpectSome(f, w6[(i+1)%3])
+						cc.ExpectSome(w6[i], w6[(i+1)%3])
+					}
+
+				}
+
+				cc.CheckConnectivityWithTimeout(timeout)
+			})
+		})
+
+		Describe(description+" and a borrowed tunnel IP on one host", func() {
 			var (
 				infra           infrastructure.DatastoreInfra
 				tc              infrastructure.TopologyContainers


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11640
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The old condition checked that the "borrowed" flag was false before checking if the route was a workload.  There's no reason that a local workload can't have a borrowed IP, so this was a bug.

We now have an explicit "really a local WEP" flag; use that explicitly to avoid confusion with the informational flags (where multiple flags can be set for borrowed IPs).
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-12198

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF: fix that local workload with borrowed IPs lose connectivity
```


