### PR TITLE
[v3.31] Address issues spotted by Copilot and CI on #11647

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -1075,7 +1075,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
     def resync_monitor_thread(self, launch_epoch):
         """Monitor the interval between completed resyncs.
 
-        Logs an error if the period resync duration surpasses
+        Logs an error if the periodic resync duration surpasses
         the configured maximum time in seconds.
         """
         try:
@@ -1088,7 +1088,10 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
                     curr_time = datetime.now()
                     time_delta = curr_time - self.last_resync_time
-                    if time_delta.seconds > cfg.CONF.calico.resync_max_interval_secs:
+                    if (
+                        time_delta.total_seconds()
+                        > cfg.CONF.calico.resync_max_interval_secs
+                    ):
                         LOG.error(
                             "The time since the last resync completion has surpassed"
                             f" {cfg.CONF.calico.resync_max_interval_secs} seconds"
@@ -1097,7 +1100,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                     deadline = self.last_resync_time + timedelta(
                         seconds=cfg.CONF.calico.resync_max_interval_secs
                     )
-                    time_left = (deadline - curr_time).seconds
+                    time_left = (deadline - curr_time).total_seconds()
                     polling_rate = cfg.CONF.calico.resync_max_interval_secs / 5
                     sleep_time = time_left if deadline > curr_time else polling_rate
                     eventlet.sleep(sleep_time)

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_mech_calico.py
@@ -61,9 +61,10 @@ class TestMechanismDriverVoting(lib.Lib, unittest.TestCase):
         super(TestMechanismDriverVoting, self).tearDown()
 
     def _disable_background_threads(self, driver):
-        """Disable background threads that would touch etcd."""
+        """Disable background threads that would touch etcd or do unrelated things."""
         driver.periodic_resync_thread = mock.Mock()
         driver._status_updating_thread = mock.Mock()
+        driver.resync_monitor_thread = mock.Mock()
 
     @mock.patch.object(mech_calico, "Elector")
     def test_parent_creates_elector(self, m_elector):

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_monitor_thread.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_monitor_thread.py
@@ -115,10 +115,8 @@ class TestResyncMonitorThread(lib.Lib, unittest.TestCase):
         """Test that resync resets current interval duration to below max."""
         lib.m_oslo_config.cfg.CONF.calico.resync_max_interval_secs = TEST_MAX_INTERVAL
         self.driver.elector.master.return_value = True
-        fake_resync_time_time = datetime.now() - timedelta(
-            seconds=TEST_MAX_INTERVAL + 1
-        )
-        self.driver.last_resync_time = fake_resync_time_time
+        fake_resync_time = datetime.now() - timedelta(seconds=TEST_MAX_INTERVAL + 1)
+        self.driver.last_resync_time = fake_resync_time
 
         self.mock_sleep.side_effect = self.simulate_epoch_progression()
         self.driver.resync_monitor_thread(INITIAL_EPOCH)
@@ -142,10 +140,8 @@ class TestResyncMonitorThread(lib.Lib, unittest.TestCase):
         """Test that errors continue logging if resync does not occur."""
         lib.m_oslo_config.cfg.CONF.calico.resync_max_interval_secs = TEST_MAX_INTERVAL
         self.driver.elector.master.return_value = True
-        fake_resync_time_time = datetime.now() - timedelta(
-            seconds=TEST_MAX_INTERVAL + 1
-        )
-        self.driver.last_resync_time = fake_resync_time_time
+        fake_resync_time = datetime.now() - timedelta(seconds=TEST_MAX_INTERVAL + 1)
+        self.driver.last_resync_time = fake_resync_time
 
         self.mock_sleep.side_effect = self.simulate_epoch_progression()
         self.driver.resync_monitor_thread(INITIAL_EPOCH)


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11651
Copilot didn't run on #11577 because that was contributed from outside Tigera; but it did run when I cherry-picked that PR to other branches, and spotted some minor issues that I'm fixing here.

I also noticed occurrences of the following TypeError in CI.  They don't cause any tests to fail, because they occur in a spawned thread, but they look wrong:
```
Traceback (most recent call last):
  File "/code/.tox/py38/lib/python3.8/site-packages/eventlet/hubs/hub.py", line 471, in fire_timers
    timer()
  File "/code/.tox/py38/lib/python3.8/site-packages/eventlet/hubs/timer.py", line 59, in __call__
    cb(*args, **kw)
  File "/code/.tox/py38/lib/python3.8/site-packages/eventlet/greenthread.py", line 264, in main
    result = function(*args, **kwargs)
  File "/code/networking_calico/plugins/ml2/drivers/calico/mech_calico.py", line 1118, in resync_monitor_thread
    if time_delta.total_seconds() > cfg.CONF.calico.resync_max_interval_secs:
TypeError: '>' not supported between instances of 'float' and 'MagicMock'
```
They occur because of the resync_monitor_thread being started in tests in test_mech_calico.py.  The resync_monitor_thread isn't wanted for those tests, so let's suppress it.

