### PR TITLE
[BPF] fix, test and simplify BPFExtToServiceConnmark

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -154,7 +154,7 @@ $(LIBBPF_FILE_CREATED):
 	@echo Cloning libbpf
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c "make -j 16 -C bpf-gpl libbpf LIBBPF_VERSION=$(LIBBPF_VERSION)"
 
-$(LIBBPF_A): $(LIBBPF_FILE_CREATED) $(shell find bpf-gpl/libbpf -type f -not -path 'bpf-gpl/libbpf/src/$(ARCH)*' )
+$(LIBBPF_A): $(LIBBPF_FILE_CREATED) $(shell find bpf-gpl/libbpf -type f -not -path 'bpf-gpl/libbpf/src/$(ARCH)*' -not -path 'bpf-gpl/libbpf/.git*')
 	mkdir -p bpf-gpl/libbpf/src/$(ARCH)
 	mkdir -p bpf-gpl/include/src/$(ARCH)
 	$(MAKE) register ARCH=$(ARCH)

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -69,16 +69,21 @@ static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 {
 	int rc = ctx->fwd.res;
 	struct cali_tc_state *state = ctx->state;
+	__u32 fib_flags = 0;
 
 	if (rc == TC_ACT_SHOT) {
 		goto deny;
 	}
 
-	if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK && ctx->state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL) {
-		/* needs to go viaer routing in netfilter unless we have access
-		 * to BPF_FIB_LOOKUP_MARK in kernel 6.10+
-		 */
-		goto skip_fib;
+	if (!bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
+		if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK && ctx->state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL) {
+			/* needs to go via routing in netfilter unless we have access
+			 * to BPF_FIB_LOOKUP_MARK in kernel 6.10+
+			 */
+			goto skip_fib;
+		}
+	} else {
+		fib_flags = BPF_FIB_LOOKUP_MARK;
 	}
 
 #ifndef IPVER6
@@ -197,6 +202,11 @@ skip_redir_ifindex:
 				.ifindex = ctx->skb->ifindex,
 				.l4_protocol = state->ip_proto,
 			};
+
+			if (bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
+				fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+			}
+
 #ifdef IPVER6
 			ipv6_addr_t_to_be32_4_ip(fib_params(ctx)->ipv6_src, &state->ip_src);
 			ipv6_addr_t_to_be32_4_ip(fib_params(ctx)->ipv6_dst, &state->ip_dst);
@@ -205,7 +215,7 @@ skip_redir_ifindex:
 			fib_params(ctx)->ipv4_dst = state->ip_dst;
 #endif
 
-			rc = bpf_fib_lookup(ctx->skb, fib_params(ctx), sizeof(struct bpf_fib_lookup), 0);
+			rc = bpf_fib_lookup(ctx->skb, fib_params(ctx), sizeof(struct bpf_fib_lookup), fib_flags);
 			state->ct_result.ifindex_fwd = fib_params(ctx)->ifindex;
 		}
 
@@ -263,7 +273,7 @@ skip_redir_ifindex:
 			struct bpf_tunnel_key key = {
 				.tunnel_id = OVERLAY_TUNNEL_ID,
 			};
-	
+
 			__u64 flags = 0;
 			__u32 size = 0;
 #ifdef IPVER6
@@ -348,6 +358,11 @@ try_fib_external:
 			.l4_protocol = state->ip_proto,
 		};
 
+		if (bpf_core_field_exists(((struct bpf_fib_lookup *)0)->mark)) {
+			fib_params(ctx)->mark = EXT_TO_SVC_MARK;
+			CALI_DEBUG("FIB mark=0x%d", fib_params(ctx)->mark);
+		}
+
 		if (state->ip_proto != IPPROTO_ICMP_46) {
 			fib_params(ctx)->sport = bpf_htons(state->sport);
 			fib_params(ctx)->dport = bpf_htons(state->dport);
@@ -380,7 +395,7 @@ try_fib_external:
 
 		CALI_DEBUG("Traffic is towards the host namespace, doing Linux FIB lookup");
 		rc = bpf_fib_lookup(ctx->skb, fib_params(ctx), sizeof(struct bpf_fib_lookup),
-				ctx->fwd.fib_flags | BPF_FIB_LOOKUP_SKIP_NEIGH);
+				ctx->fwd.fib_flags | BPF_FIB_LOOKUP_SKIP_NEIGH | fib_flags);
 		switch (rc) {
 		case BPF_FIB_LKUP_RET_FRAG_NEEDED:
 			/* We are not asking for an MTU check, but we may still get

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -74,6 +74,13 @@ static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 		goto deny;
 	}
 
+	if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK && ctx->state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL) {
+		/* needs to go viaer routing in netfilter unless we have access
+		 * to BPF_FIB_LOOKUP_MARK in kernel 6.10+
+		 */
+		goto skip_fib;
+	}
+
 #ifndef IPVER6
         if ((CALI_F_FROM_HOST || CALI_F_FROM_WEP) && (ctx->state->flags & CALI_ST_FIRST_FRAG)) {
 		/* Revalidate the access to the packet */
@@ -512,12 +519,6 @@ skip_fib:
 		if (ctx->state->ct_result.flags & CALI_CT_FLAG_EXT_LOCAL) {
 			CALI_DEBUG("To host marked with FLAG_EXT_LOCAL");
 			ctx->fwd.mark |= EXT_TO_SVC_MARK;
-			if (CALI_F_FROM_WEP && EXT_TO_SVC_MARK) {
-				/* needs to go via normal routing unless we have access
-				 * to BPF_FIB_LOOKUP_MARK in kernel 6.10+
-				 */
-				rc = TC_ACT_UNSPEC;
-			}
 		}
 
 		if (CALI_F_NAT_IF) {

--- a/felix/routetable/routeclass_string.go
+++ b/felix/routetable/routeclass_string.go
@@ -25,8 +25,9 @@ const _RouteClass_name = "RouteClassLocalWorkloadRouteClassBPFSpecialRouteClassW
 var _RouteClass_index = [...]uint8{0, 23, 43, 62, 87, 108, 132, 152, 169, 192, 205}
 
 func (i RouteClass) String() string {
-	if i < 0 || i >= RouteClass(len(_RouteClass_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_RouteClass_index)-1 {
 		return "RouteClass(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _RouteClass_name[_RouteClass_index[i]:_RouteClass_index[i+1]]
+	return _RouteClass_name[_RouteClass_index[idx]:_RouteClass_index[idx+1]]
 }

--- a/metadata.mk
+++ b/metadata.mk
@@ -61,7 +61,7 @@ CNI_VERSION=master
 FLANNEL_VERSION=main
 
 # The libbpf version to use
-LIBBPF_VERSION=v1.4.6
+LIBBPF_VERSION=v1.6.2
 
 # The bpftool image to use; this is the output of the https://github.com/projectcalico/bpftool repo.
 BPFTOOL_IMAGE=calico/bpftool:v7.5.0


### PR DESCRIPTION
## Description

Make sure that the mark works as expected. Since kernel 6.10 we can use the mark with fib lookup.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: update BPFExtToServiceConnmark to work with fib lookup with kernel 6.10+ The mark allows steering response packet via different route than ingress traffic.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
