### PR TITLE
support custom qps&brust for calico binaries

### DIFF
--- a/cni-plugin/internal/pkg/utils/utils.go
+++ b/cni-plugin/internal/pkg/utils/utils.go
@@ -703,6 +703,18 @@ func CreateClient(conf types.NetConf) (client.Interface, error) {
 		}
 	}
 
+	if conf.QPS != 0 {
+		if err := os.Setenv("K8S_CLIENT_QPS", fmt.Sprintf("%d", conf.QPS)); err != nil {
+			return nil, err
+		}
+	}
+
+	if conf.Burst != 0 {
+		if err := os.Setenv("K8S_CLIENT_BURST", fmt.Sprintf("%d", conf.Burst)); err != nil {
+			return nil, err
+		}
+	}
+
 	// Load the client config from the current environment.
 	clientConfig, err := apiconfig.LoadClientConfig("")
 	if err != nil {

--- a/cni-plugin/pkg/types/types.go
+++ b/cni-plugin/pkg/types/types.go
@@ -78,6 +78,8 @@ type NetConf struct {
 		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
 		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
 	} `json:"ipam,omitempty"`
+	QPS                  int                    `json:"qps,omitempty"`
+	Burst                int                    `json:"burst,omitempty"`
 	Args                 Args                   `json:"args"`
 	MTU                  int                    `json:"mtu"`
 	NumQueues            int                    `json:"num_queues"`

--- a/libcalico-go/lib/apiconfig/apiconfig.go
+++ b/libcalico-go/lib/apiconfig/apiconfig.go
@@ -80,7 +80,8 @@ type KubeConfig struct {
 	// This contains the contents that would normally be in the file pointed at by Kubeconfig.
 	KubeconfigInline string `json:"kubeconfigInline" ignored:"true"`
 	// K8sClientQPS overrides the QPS for the Kube client.
-	K8sClientQPS float32 `json:"k8sClientQPS"`
+	K8sClientQPS   float32 `json:"k8sClientQPS" envconfig:"K8S_CLIENT_QPS" default:""`
+	K8sClientBurst int     `json:"k8sClientBurst" envconfig:"K8S_CLIENT_BURST" default:""`
 	// K8sCurrentContext provides a context override for kubeconfig.
 	K8sCurrentContext string `json:"k8sCurrentContext" envconfig:"K8S_CURRENT_CONTEXT" default:""`
 }

--- a/libcalico-go/lib/backend/k8s/k8s.go
+++ b/libcalico-go/lib/backend/k8s/k8s.go
@@ -405,6 +405,11 @@ func CreateKubernetesClientset(ca *apiconfig.CalicoAPIConfigSpec) (*rest.Config,
 	// efficiently. The IPAM code can create bursts of requests to the API, so
 	// in order to keep pod creation times sensible we allow a higher request rate.
 	config.Burst = 100
+	if ca.K8sClientBurst != 0 {
+		config.Burst = ca.K8sClientBurst
+	}
+	log.Debugf("Kubernetes client QPS set to %v, burst set to %v", config.QPS, config.Burst)
+
 	cs, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, nil, resources.K8sErrorToCalico(err, nil)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Calico IPAM currently lacks explicit configuration for Kubernetes client QPS (queries per second) and burst limits. This forces operators to accept hard-coded defaults that may not align with their cluster’s scale or workload patterns.

Implement QPS/burst configurability for Calico IPAM’s Kubernetes client:

```yaml
{
  "name": "k8s-pod-network",
  "cniVersion": "0.3.1",
  "plugins": [
    {
      "type": "calico",
      "log_level": "info",
      "log_file_path": "/var/log/calico/cni/cni.log",
      "datastore_type": "kubernetes",
      "nodename": "develop",
      "mtu": 0,
      "qps": 5,
      "burst": 100,
      "ipam": {
          "type": "calico-ipam"
      },
      "policy": {
          "type": "k8s"
      },
      "kubernetes": {
          "kubeconfig": "/etc/cni/net.d/calico-kubeconfig"
      }
    },
    {
      "type": "portmap",
      "snat": true,
      "capabilities": {"portMappings": true}
    },
    {
      "type": "bandwidth",
      "capabilities": {"bandwidth": true}
    }
  ]
}
```


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Support custom qps and burst for Kubernetes client in calico and calico-ipam CNI plugins.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
