### PR TITLE
feat(release): include slack response for announced hashrelease

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/cloud-provider v0.34.2 // indirect
 	k8s.io/component-helpers v0.34.2 // indirect
 	k8s.io/controller-manager v0.34.2 // indirect

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -290,7 +290,9 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 				// Send a slack message to notify that the hashrelease has been published.
 				if c.Bool(publishHashreleaseFlag.Name) && c.Bool(notifyFlag.Name) {
-					return tasks.AnnounceHashrelease(slackConfig(c), hashrel, ciJobURL(c))
+					if _, err := tasks.AnnounceHashrelease(slackConfig(c), hashrel, ciJobURL(c)); err != nil {
+						logrus.WithError(err).Warn("Failed to send hashrelease announcement to Slack")
+					}
 				}
 				return nil
 			},

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -92,3 +92,4 @@ google.golang.org/grpc v1.76.0
 google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
 google.golang.org/protobuf v1.36.10
 gopkg.in/natefinch/lumberjack.v2 v2.2.1
+gopkg.in/yaml.v3 v3.0.1

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -42,36 +42,30 @@ type Hashrelease struct {
 	// Name is the name of the hashrelease.
 	// When publishing a hashrelease, this is the name of the folder in the server.
 	// When getting a hashrelease, this is the full path of the hashrelease folder.
-	Name string
+	Name string `yaml:"name"`
 
 	// Hash is the hash of the hashrelease
-	Hash string
+	Hash string `yaml:"hash"`
 
 	// Note is the info about the hashrelease
-	Note string
+	Note string `yaml:"note,omitempty"`
 
 	// Stream is the version the hashrelease is for (e.g master, v3.19)
-	Stream string
+	Stream string `yaml:"stream"`
 
 	// ProductVersion is the product version in the hashrelease
-	ProductVersion string
+	ProductVersion string `yaml:"version"`
 
 	// OperatorVersion is the operator version for the hashrelease
-	OperatorVersion string
+	OperatorVersion string `yaml:"operator"`
 
 	// Source is the source of hashrelease content on the local filesystem
-	Source string
-
-	// Dest is the path to the hashrelease dir on the server
-	Dest string
-
-	// Time is the modified time of the hashrelease
-	Time time.Time
+	Source string `yaml:"source,omitempty"`
 
 	// Latest is if the hashrelease is the latest for the stream
-	Latest bool
+	Latest bool `yaml:"latest,omitempty"`
 
-	ImageScanResultURL string
+	ImageScanResultURL string `yaml:"iss_url,omitempty"`
 }
 
 func (h *Hashrelease) URL() string {

--- a/release/internal/outputs/hashrelease.go
+++ b/release/internal/outputs/hashrelease.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
+	"github.com/projectcalico/calico/release/internal/slack"
+)
+
+var hashreleaseOutputFileName = "hashrelease.yaml"
+
+// PublishedHashrelease represents the output of a hashrelease publication.
+type PublishedHashrelease struct {
+	Hashrelease    *hashreleaseserver.Hashrelease `yaml:"-,inline"`
+	HashreleaseURL string                         `yaml:"url"`
+	SlackResponse  *slack.MessageResponse         `yaml:"slack,omitempty"`
+}
+
+func (h *PublishedHashrelease) Write(outputDir string) (string, error) {
+	h.HashreleaseURL = h.Hashrelease.URL()
+	fqPath := filepath.Join(outputDir, hashreleaseOutputFileName)
+	f, err := os.Create(fqPath)
+	if err != nil {
+		return "", fmt.Errorf("creating hashrelease output file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	encoder := yaml.NewEncoder(f)
+	encoder.SetIndent(2)
+	defer func() { _ = encoder.Close() }()
+
+	if err := encoder.Encode(h); err != nil {
+		return "", fmt.Errorf("writing hashrelease output to %s: %w", fqPath, err)
+	}
+	return fqPath, nil
+}

--- a/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.no_slack_response.approved.txt
+++ b/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.no_slack_response.approved.txt
@@ -1,0 +1,6 @@
+name: 2026-01-06-v3-32-vertigo
+hash: v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f
+stream: master
+version: v3.32.0-0.dev-527-g92e0cd84e375
+operator: v1.42.0-0.dev-16-g3a924017cc9f
+url: https://2026-01-06-v3-32-vertigo.docs.eng.tigera.net

--- a/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.with_slack_response.approved.txt
+++ b/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.with_slack_response.approved.txt
@@ -1,0 +1,9 @@
+name: 2026-01-06-v3-32-vertigo
+hash: v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f
+stream: master
+version: v3.32.0-0.dev-527-g92e0cd84e375
+operator: v1.42.0-0.dev-16-g3a924017cc9f
+url: https://2026-01-06-v3-32-vertigo.docs.eng.tigera.net
+slack:
+  channel: C123ABC456
+  timestamp: "1503435956.000247"

--- a/release/internal/outputs/hashrelease_test.go
+++ b/release/internal/outputs/hashrelease_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	approvals "github.com/approvals/go-approval-tests"
+
+	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
+	"github.com/projectcalico/calico/release/internal/slack"
+)
+
+func TestPublishedHashrelease(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no slack response", func(t *testing.T) {
+		t.Parallel()
+		td := t.TempDir()
+		h := &PublishedHashrelease{Hashrelease: &hashreleaseserver.Hashrelease{
+			Name:            "2026-01-06-v3-32-vertigo",
+			Hash:            "v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f",
+			Stream:          "master",
+			ProductVersion:  "v3.32.0-0.dev-527-g92e0cd84e375",
+			OperatorVersion: "v1.42.0-0.dev-16-g3a924017cc9f",
+		}}
+
+		gotPath, err := h.Write(td)
+		if err != nil {
+			t.Fatalf("Write() returned error: %v", err)
+		}
+		expected := filepath.Join(td, hashreleaseOutputFileName)
+		if gotPath != expected {
+			t.Fatalf("unexpected path: got %q want %q", gotPath, expected)
+		}
+
+		content, err := os.ReadFile(gotPath)
+		if err != nil {
+			t.Fatalf("failed to read output file: %v", err)
+		}
+		approvals.VerifyString(t, string(content))
+	})
+
+	t.Run("with slack response", func(t *testing.T) {
+		t.Parallel()
+		td := t.TempDir()
+		h := &PublishedHashrelease{
+			Hashrelease: &hashreleaseserver.Hashrelease{
+				Name:            "2026-01-06-v3-32-vertigo",
+				Hash:            "v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f",
+				Stream:          "master",
+				ProductVersion:  "v3.32.0-0.dev-527-g92e0cd84e375",
+				OperatorVersion: "v1.42.0-0.dev-16-g3a924017cc9f",
+			},
+			SlackResponse: &slack.MessageResponse{
+				Channel:   "C123ABC456",
+				Timestamp: "1503435956.000247",
+			},
+		}
+
+		gotPath, err := h.Write(td)
+		if err != nil {
+			t.Fatalf("Write() returned error: %v", err)
+		}
+		expected := filepath.Join(td, hashreleaseOutputFileName)
+		if gotPath != expected {
+			t.Fatalf("unexpected path: got %q want %q", gotPath, expected)
+		}
+
+		content, err := os.ReadFile(gotPath)
+		if err != nil {
+			t.Fatalf("failed to read output file: %v", err)
+		}
+		approvals.VerifyString(t, string(content))
+	})
+}

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -367,7 +367,6 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 		ProductVersion:  pinnedVersion.Title,
 		OperatorVersion: pinnedVersion.TigeraOperator.Version,
 		Source:          filepath.Join(hashreleaseSrcBaseDir, pinnedVersion.Hash),
-		Time:            time.Now(),
 		Latest:          latest,
 	}, nil
 }

--- a/release/pkg/tasks/notification.go
+++ b/release/pkg/tasks/notification.go
@@ -25,7 +25,7 @@ import (
 var product = utils.ProductName
 
 // AnnounceHashrelease sends a slack notification for a new hashrelease.
-func AnnounceHashrelease(cfg *slack.Config, hashrel *hashreleaseserver.Hashrelease, ciURL string) error {
+func AnnounceHashrelease(cfg *slack.Config, hashrel *hashreleaseserver.Hashrelease, ciURL string) (*slack.MessageResponse, error) {
 	logrus.WithField("hashrelease", hashrel.Name).Info("Sending hashrelease announcement to Slack")
 	msgData := &slack.HashreleaseMessageData{
 		ReleaseName:        hashrel.Name,


### PR DESCRIPTION
## Description

This update announce hashrelease to return the slack message and also add the ability to output the published hashrelease details. This is the start of allowing running smoke tests on hashreleases and updating the slack message with the result which will be done in a future PR.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
