### PR TITLE
[CORE-12133-2] ASO: fix apt-get install race condition in setup scripts

### DIFF
--- a/process/testing/aso/Makefile
+++ b/process/testing/aso/Makefile
@@ -84,20 +84,20 @@ $(BINDIR)/kubectl:
 
 $(BINDIR)/cmctl:
 	mkdir -p $(@D)
-	curl -sSf -L --retry 5 https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_linux_amd64 -o $@
+	curl -sSf -L --retry 5 https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_linux_$(ARCH) -o $@
 	chmod +x $@
 	touch $@
 
 $(BINDIR)/asoctl:
 	mkdir -p $(@D)
-	curl -sSf -L --retry 5 https://github.com/Azure/azure-service-operator/releases/latest/download/asoctl-linux-amd64.gz -o $(BINDIR)/asoctl.gz
+	curl -sSf -L --retry 5 https://github.com/Azure/azure-service-operator/releases/latest/download/asoctl-linux-$(ARCH).gz -o $(BINDIR)/asoctl.gz
 	gunzip $(BINDIR)/asoctl.gz
 	chmod +x $@
 	touch $@
 
 $(BINDIR)/gomplate:
 	mkdir -p $(@D)
-	curl -sSf -L --retry 5 https://github.com/hairyhenderson/gomplate/releases/download/$(GOMPLATE_VERSION)/gomplate_linux-amd64 -o $@
+	curl -sSf -L --retry 5 https://github.com/hairyhenderson/gomplate/releases/download/$(GOMPLATE_VERSION)/gomplate_linux-$(ARCH) -o $@
 	chmod +x $@
 	touch $@
 

--- a/process/testing/aso/install-kubeadm.sh
+++ b/process/testing/aso/install-kubeadm.sh
@@ -19,8 +19,8 @@ set -e
 
 . ./vmss.sh node-ips
 
-: ${KUBECTL:=./bin/kubectl}
-: ${GOMPLATE:=./bin/gomplate}
+: "${KUBECTL:=./bin/kubectl}"
+: "${GOMPLATE:=./bin/gomplate}"
 
 # Reconstruct arrays from exported string variables
 # Bash arrays cannot be exported across shells, so we export them as space-separated strings
@@ -34,13 +34,12 @@ echo "========================================"
 echo "Node configuration loaded:"
 echo "  LINUX_NODE_COUNT: ${LINUX_NODE_COUNT}"
 echo "  WINDOWS_NODE_COUNT: ${WINDOWS_NODE_COUNT}"
-echo "  LINUX_EIPS (count: ${#LINUX_EIPS[@]}): ${LINUX_EIPS[@]}"
-echo "  LINUX_PIPS (count: ${#LINUX_PIPS[@]}): ${LINUX_PIPS[@]}"
-echo "  WINDOWS_EIPS (count: ${#WINDOWS_EIPS[@]}): ${WINDOWS_EIPS[@]}"
-echo "  WINDOWS_PIPS (count: ${#WINDOWS_PIPS[@]}): ${WINDOWS_PIPS[@]}"
+echo "  LINUX_EIPS (count: ${#LINUX_EIPS[@]}): ${LINUX_EIPS[*]}"
+echo "  LINUX_PIPS (count: ${#LINUX_PIPS[@]}): ${LINUX_PIPS[*]}"
+echo "  WINDOWS_EIPS (count: ${#WINDOWS_EIPS[@]}): ${WINDOWS_EIPS[*]}"
+echo "  WINDOWS_PIPS (count: ${#WINDOWS_PIPS[@]}): ${WINDOWS_PIPS[*]}"
 echo "========================================"
 echo
-
 
 function copy_scripts_to_linux_nodes() {
   echo "Copying Linux setup scripts to all Linux nodes..."
@@ -56,8 +55,8 @@ function copy_scripts_to_linux_nodes() {
     fi
 
     echo "Copying scripts to Linux node ${node_num} (${linux_eip})..."
-    scp -i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-      ./linux/*.sh aso@${linux_eip}:~/ || {
+    scp -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+      ./linux/*.sh "aso@${linux_eip}:~/" || {
       echo "ERROR: Failed to copy scripts to Linux node ${node_num}"
       return 1
     }
@@ -83,8 +82,8 @@ function copy_scripts_to_windows_nodes() {
     fi
 
     echo "Copying scripts to Windows node ${node_num} (${windows_eip})..."
-    scp -i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-      ./windows/*.ps1 aso@${windows_eip}:c:\\k\\ || {
+    scp -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+      ./windows/*.ps1 "aso@${windows_eip}:c:\\k\\" || {
       echo "ERROR: Failed to copy scripts to Windows node ${node_num}"
       return 1
     }
@@ -146,8 +145,8 @@ function setup_kubeadm_cluster() {
 
   # Copy kubeconfig to local directory
   echo "Copying kubeconfig from master node..."
-  scp -i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-    aso@${LINUX_EIP}:/home/aso/.kube/config ./kubeconfig
+  scp -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+    "aso@${LINUX_EIP}:/home/aso/.kube/config" ./kubeconfig
 
   # Fix the API server address in kubeconfig - replace internal IP with external IP
   echo "Updating API server address in kubeconfig to use external IP ${LINUX_EIP}..."
@@ -155,7 +154,7 @@ function setup_kubeadm_cluster() {
   echo "  Original API server address: ${INTERNAL_API_SERVER}"
 
   # Extract port from the original server URL
-  API_PORT=$(echo ${INTERNAL_API_SERVER} | sed -n 's/.*:\([0-9]*\)$/\1/p')
+  API_PORT=$(echo "${INTERNAL_API_SERVER}" | sed -n 's/.*:\([0-9]*\)$/\1/p')
   if [[ -z "${API_PORT}" ]]; then
     API_PORT="6443"  # Default Kubernetes API port
   fi
@@ -264,11 +263,11 @@ function copy_files_from_linux() {
   mkdir -p ./windows/kubeadm
 
   # Copy kubeconfig
-  scp -i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no aso@${LINUX_EIP}:/home/aso/.kube/config ./windows/kubeadm/config
+  scp -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "aso@${LINUX_EIP}:/home/aso/.kube/config" ./windows/kubeadm/config
 
   # Copy Kubernetes PKI certificates (needed for authentication)
   ${MASTER_CONNECT_COMMAND} "sudo cp /etc/kubernetes/pki/ca.crt /tmp/ca.crt && sudo chmod 644 /tmp/ca.crt"
-  scp -i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no aso@${LINUX_EIP}:/tmp/ca.crt ./windows/kubeadm/
+  scp -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "aso@${LINUX_EIP}:/tmp/ca.crt" ./windows/kubeadm/
 
   echo "Kubernetes certificates copied successfully"
 }
@@ -309,7 +308,7 @@ function prepare_windows_node() {
 
   # Copy windows directory contents to c:\k\
   echo "Copying Windows files to node..."
-  scp -r -i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./windows/* aso@${windows_eip}:c:\\k\\
+  scp -r -i "${SSH_KEY_FILE}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./windows/* "aso@${windows_eip}:c:\\k\\"
 
   # Enable containers feature (requires reboot)
   echo "Enabling Windows Containers feature..."

--- a/process/testing/aso/linux/setup-node.sh
+++ b/process/testing/aso/linux/setup-node.sh
@@ -67,7 +67,7 @@ KUBE_MAJOR_MINOR=$(echo "${KUBE_VERSION}" | cut -d'.' -f1,2)
 echo "Installing kubeadm, kubelet, and kubectl ${KUBE_VERSION}..."
 echo "Using repository version: ${KUBE_MAJOR_MINOR}"
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl gpg
+sudo apt-get -o DPkg::Lock::Timeout=60 install -y apt-transport-https ca-certificates curl gpg
 
 # Create keyrings directory
 sudo mkdir -p /etc/apt/keyrings
@@ -78,7 +78,7 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 # Install Kubernetes components
 sudo apt-get update
-sudo apt-get install -y kubelet kubeadm kubectl
+sudo apt-get -o DPkg::Lock::Timeout=60 install -y kubelet kubeadm kubectl
 sudo apt-mark hold kubelet kubeadm kubectl
 
 # Enable kubelet


### PR DESCRIPTION
Add '-o DPkg::Lock::Timeout=60' to 'apt-get install' commands in the ASO setup scripts in order to wait for up to 60s when previous 'apt-get' operations still have the lock.

Other misc fixes: quotes for bash vars, '$(ARCH)' parameter in Makefile.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
