### PR TITLE
[CORE-12132] Move windows e2es to azr provisioners

### DIFF
--- a/.semaphore/end-to-end/pipelines/windows.yml
+++ b/.semaphore/end-to-end/pipelines/windows.yml
@@ -4,7 +4,7 @@ name: banzai-calico Windows
 
 agent:
   machine:
-    type: c1-standard-1
+    type: f1-standard-2
     os_image: ubuntu2204
 
 execution_time_limit:
@@ -24,88 +24,89 @@ global_job_config:
     - name: CREATE_WINDOWS_NODES
       value: "true"
     - name: K8S_E2E_FLAGS
-      value: --ginkgo.focus=\[sig-calico\].*\[RunsOnWindows\]
+      value: --ginkgo.focus=(\[sig-calico\].*\[RunsOnWindows\]) --ginkgo.skip=(\[LinuxOnly\])
     - name: FUNCTIONAL_AREA
       value: "windows.yml"
     - name: USE_PRIVATE_REGISTRY
       value: "true"
     - name: PRIVATE_REGISTRY
       value: "quay.io/"
+    - name: INSTALLER
+      value: "operator"
+    - name: RUN_LOCAL_TESTS # run e2e tests from locally built binary
+      value: "true"
 
 # Dimensions
-# Provisioners: aws-kubeadm, gcp-kubeadm, rancher
+# Provisioners: azr-aso, azr-aks
 # Installer: operator
-# Windows OS: Windows Server 1809, Windows Server 2022
-# k8s Versions: stable-3, stable-1, stable
+# Windows OS: Windows Server 2022
+# k8s Versions: stable-1, stable
 # linux dataplane: bpf, iptables, nftables
-# encapsulation: vxlan, none
+# encapsulation: vxlan, no-encap
+# CNI: Calico, Azure CNI
 
 # Runs:
-# aws-kubeadm, 1809, stable-3, iptables, none
-# gcp-kubeadm, 2022, stable, bpf, vxlan
-# gcp-rancher, 2022, stable-1, nftables, none
+# azr-aso, 2022, stable, bpf, vxlan
+# azr-aso, 2022, stable-1, nftables, vxlan
+# azr-aks, 2022, stable-1, iptables, no-encap, azure CNI
 
 blocks:
   - name: Calico Windows
     dependencies: []
     task:
       jobs:
-        - name: aws-kubeadm, 1809, stable-3, iptables, none
+        - name: "azr-aso, 2022, stable, bpf, vxlan"
           execution_time_limit:
             hours: 5
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: PROVISIONER
-              value: aws-kubeadm
-            - name: WINDOWS_OS_VERSION
-              value: "1809"
+              value: azr-aso
             - name: K8S_VERSION
-              value: stable-3
-            - name: DATAPLANE
-              value: CalicoIptables
-            - name: ENCAPSULATION_TYPE
-              value: None
-            - name: VPC_SUBNETS
-              value: '["172.16.101.0/24"]' # single subnet because no encapsulation is being used
-
-        - name: gcp-kubeadm, 2022, stable, bpf, vxlan
-          execution_time_limit:
-            hours: 5
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          env_vars:
-            - name: PROVISIONER
-              value: gcp-kubeadm
-            - name: WINDOWS_OS_VERSION
-              value: "2022"
-            - name: K8S_VERSION
-              value: stable
+              value: stable-1
             - name: DATAPLANE
               value: CalicoBPF
             - name: ENCAPSULATION_TYPE
               value: VXLAN
+            - name: WINDOWS_OS
+              value: "2022"
 
-        - name: gcp-rancher, 2022, stable-1, nftables, vxlan
+        - name: "azr-aso, 2022, stable-1, nftables, vxlan"
           execution_time_limit:
             hours: 5
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: PROVISIONER
-              value: gcp-rancher
-            - name: WINDOWS_OS_VERSION
-              value: "2022"
+              value: azr-aso
             - name: K8S_VERSION
               value: stable-1
             - name: DATAPLANE
               value: CalicoNftables
             - name: ENCAPSULATION_TYPE
               value: VXLAN
-            - name: RKE_VERSION # Don't just update these versions, need k8s and rke versions to match.
-              value: "v1.8.6" # https://github.com/rancher/rke/releases/tag/v1.8.6
+            - name: WINDOWS_OS
+              value: "2022"
+
+        - name: "azr-aks, 2022, stable-1, iptables, no encap, azure CNI"
+          execution_time_limit:
+            hours: 5
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: PROVISIONER
+              value: azr-aks
             - name: K8S_VERSION
-              value: "v1.32.7" # RKE 1.8.6 supports: v1.30.14-rancher1-1, v1.31.11-rancher1-1, v1.32.7-rancher1-1
+              value: stable-1
+            - name: DATAPLANE
+              value: CalicoIptables
+            - name: ENCAPSULATION_TYPE
+              value: "None"
+            - name: WINDOWS_OS
+              value: "2022"
+            - name: USE_VENDORED_CNI
+              value: "true"
 
 promotions:
   - name: Cleanup jobs

--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -122,6 +122,12 @@ gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIAL
 gcloud config set project ${GOOGLE_PROJECT}
 export GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --filter="region~'$GOOGLE_REGION'" --format="value(name)" | awk 'BEGIN {srand()} {a[NR]=$0} rand() * NR < 1 {zone=$0} END {print zone}')}
 
+dummy_needrestart_cmd="echo \"[INFO] creating dummy needrestart script in /usr/local/bin\""
+dummy_needrestart_cmd="$dummy_needrestart_cmd; echo \#\!/usr/bin/bash | sudo tee /usr/local/bin/needrestart"
+dummy_needrestart_cmd="$dummy_needrestart_cmd && echo 'echo [DEBUG] dummy needrestart invoked' | sudo tee -a /usr/local/bin/needrestart"
+dummy_needrestart_cmd="$dummy_needrestart_cmd && sudo chmod +x /usr/local/bin/needrestart"
+if ! command -v needrestart; then eval "$dummy_needrestart_cmd"; fi
+
 # Update package lists to ensure the latest versions are available.
 # Temporarily disable needrestart during installation to avoid interactive prompts.
 # Set needrestart to automatically restart all required services after installation.

--- a/e2e/pkg/tests/policy/policy.go
+++ b/e2e/pkg/tests/policy/policy.go
@@ -41,6 +41,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("NetworkPolicy"),
 	describe.WithCategory(describe.Policy),
+	describe.WithWindows(),
 	"Calico NetworkPolicy",
 	func() {
 		// Define variables common across all tests.
@@ -93,11 +94,11 @@ var _ = describe.CalicoDescribe(
 		// - Creating a default-deny policy applied to both namespaces using a GlobalNetworkPolicy.
 		// - Isolating both namespaces with ingress and egress policies
 		// - Asserting only same namespace connectivity exists.
-		framework.ConformanceIt("should correctly isolate namespaces [RunsOnWindows]", func() {
+		framework.ConformanceIt("should correctly isolate namespaces", func() {
 			nsA := f.Namespace
 
 			By("Creating a second namespace B")
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 			nsB, err := f.CreateNamespace(ctx, f.BaseName+"-b", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -221,7 +222,7 @@ var _ = describe.CalicoDescribe(
 
 		framework.ConformanceIt("should support service account selectors", func() {
 			ns := f.Namespace
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 
 			By(fmt.Sprintf("Applying a default-deny policy to namespace %s", ns.Name))
@@ -286,7 +287,8 @@ var _ = describe.CalicoDescribe(
 
 		framework.ConformanceIt("should support namespace selectors", func() {
 			ns := f.Namespace
-			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
 
 			By(fmt.Sprintf("Applying a default-deny policy to namespace %s", ns.Name))
 			defaultDeny := newDefaultDenyIngressPolicy(ns.Name)
@@ -345,7 +347,7 @@ var _ = describe.CalicoDescribe(
 			checker.Execute()
 		})
 
-		framework.ConformanceIt("should support a 'deny egress' policy [RunsOnWindows]", func() {
+		framework.ConformanceIt("should support a 'deny egress' policy", func() {
 			By("Creating calico egress policy which denies traffic within namespace.")
 			nsName := f.Namespace.Name
 			policyName := "deny-egress"

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -137,10 +137,16 @@ func (c *connectionTester) deploy() error {
 
 	// Wait for all pods to be running.
 	By("Waiting for all pods in the connection checker to be running")
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	timeout := 1 * time.Minute
+	if windows.ClusterIsWindows() {
+		// Windows images are very large (sometimes 2GB+), so this needs a considerably
+		// longer timeout in order to allow them to be pulled
+		timeout = 15 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	for _, client := range c.clients {
-		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, 1*time.Minute)
+		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, timeout)
 		if err != nil {
 			return err
 		}
@@ -152,7 +158,7 @@ func (c *connectionTester) deploy() error {
 		client.pod = p
 	}
 	for _, server := range c.servers {
-		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, server.pod.Name, server.pod.Namespace, 1*time.Minute)
+		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, server.pod.Name, server.pod.Namespace, timeout)
 		if err != nil {
 			return err
 		}
@@ -355,7 +361,7 @@ func (c *connectionTester) Execute() {
 	// Context to control overall timeout for all connections. After it times out, we'll forcefully
 	// terminate any remaining connections. This avoids deadlocking the test waiting for results if
 	// something goes wrong.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Launch all of the connections in parallel. We'll wait for them all to finish at the end and report on success / failure.
@@ -490,9 +496,7 @@ func (c *connectionTester) command(t Target) string {
 		// Windows.
 		switch t.GetProtocol() {
 		case TCP:
-			cmd = fmt.Sprintf("$sb={Invoke-WebRequest %s -UseBasicParsing -TimeoutSec 3 -DisableKeepAlive}; "+
-				"For ($i=0; $i -lt 5; $i++) { sleep 5; "+
-				"try {& $sb} catch { echo failed loop $i ; continue }; exit 0 ; }; exit 1", t.Destination())
+			cmd = fmt.Sprintf("Invoke-WebRequest %s -UseBasicParsing -TimeoutSec 5 -DisableKeepAlive -ErrorAction Stop | Out-Null", t.Destination())
 		case ICMP:
 			cmd = fmt.Sprintf("Test-Connection -Count 5 -ComputerName %s", t.Destination())
 		default:
@@ -592,7 +596,7 @@ func createClientPod(f *framework.Framework, namespace *v1.Namespace, baseName s
 	if windows.ClusterIsWindows() {
 		image = images.WindowsClientImage()
 		command = []string{"powershell.exe"}
-		args = []string{"Start-Sleep", "600"}
+		args = []string{"Start-Sleep", "3600"}
 		nodeselector["kubernetes.io/os"] = "windows"
 	} else {
 		image = images.Alpine
@@ -745,7 +749,7 @@ func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
 func ExecInPod(pod *v1.Pod, sh, opt, cmd string) (string, error) {
 	args := []string{"exec", pod.Name, "--", sh, opt, cmd}
 	return kubectl.NewKubectlCommand(pod.Namespace, args...).
-		WithTimeout(time.After(5 * time.Second)).
+		WithTimeout(time.After(10 * time.Second)).
 		Exec()
 }
 

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -50,7 +50,18 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 	}
 	for _, port := range ports {
 		args := []string{}
-		if !windows.ClusterIsWindows() {
+		env := []v1.EnvVar{}
+
+		if windows.ClusterIsWindows() {
+			env = []v1.EnvVar{
+				{
+					// porter (the windows server pod) uses the port value from the
+					// env var name, it doesn't care about the env var value here
+					Name:  fmt.Sprintf("SERVE_PORT_%d", port),
+					Value: "value-not-used",
+				},
+			}
+		} else {
 			args = []string{fmt.Sprintf("--port=%d", port)}
 		}
 
@@ -60,6 +71,7 @@ func CreateServerPodAndServiceX(f *framework.Framework, namespace *v1.Namespace,
 			Image:           image,
 			ImagePullPolicy: v1.PullIfNotPresent,
 			Args:            args,
+			Env:             env,
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: int32(port),


### PR DESCRIPTION
## Description

Move the windows e2e tests to Azure provisioners (azr-aso with Calico CNI and azr-aks with Azure CNI) and re-enable them:
- add an option to build and run the tests from the local e2e binary to body_standard.sh
- add a dummy `needrestart` script for VMs where it isn't present (so no other changes are needed to the scripts)
- use f1 semaphore machines for the windows e2es
- increase timeouts for windows e2es (especially policy tests)


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
