### PR TITLE
[v3.31] Fix - the vxlan overlay VNI is always 0

### DIFF
--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -518,6 +518,8 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 	copy(in, ap.Iface)
 	globalData.IfaceName = string(in)
 
+	globalData.OverlayTunnelID = ap.OverlayTunnelID
+
 	return globalData
 }
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -54,6 +54,7 @@ import (
 	. "github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/tcpdump"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/felix/proto"
@@ -1692,10 +1693,24 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				})
 
 				It("connectivity from all workloads via workload 0's main IP", func() {
+					var tcpd *tcpdump.TCPDump
+
+					if testOpts.tunnel == "vxlan" {
+						tcpd = tc.Felixes[0].AttachTCPDump("eth0")
+						tcpd.SetLogEnabled(true)
+						tcpd.AddMatcher("eth0-vxlan", regexp.MustCompile("VXLAN,.* vni 4096"))
+						tcpd.Start("-vvv", "udp", "port", "4789")
+						defer tcpd.Stop()
+					}
+
 					cc.ExpectSome(w[0][1], w[0][0])
 					cc.ExpectSome(w[1][0], w[0][0])
 					cc.ExpectSome(w[1][1], w[0][0])
 					cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+
+					if testOpts.tunnel == "vxlan" {
+						Eventually(func() int { return tcpd.MatchCount("eth0-vxlan") }).Should(BeNumerically(">", 0))
+					}
 				})
 
 				_ = !testOpts.ipv6 && !testOpts.dsr && testOpts.protocol == "udp" && testOpts.udpUnConnected && !testOpts.connTimeEnabled &&


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11692
The eBPF dataplane regressed when switching to the flow based vxlan device and the VNI is always 0 regardless of the actual setting (4096 by default).

fixes https://github.com/projectcalico/calico/issues/11689

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix - The eBPF dataplane regressed when switching to the flow based vxlan device and the VNI is always 0 regardless of the actual setting 
```