### PR TITLE
[v3.31] Fix square brackets on non-IPv6 addresses in CNI install

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -472,13 +472,31 @@ func copyFileAndPermissions(src, dst string) (err error) {
 }
 
 func writeKubeconfig(kubecfg *rest.Config) {
+	clientset, err := cni.BuildClientSet()
+	if err != nil {
+		logrus.WithError(err).Fatal("Unable to create client for generating CNI token")
+	}
+	tr := cni.NewTokenRefresher(clientset, cni.NamespaceOfUsedServiceAccount(), cni.CNIServiceAccountName())
+	tu, err := tr.UpdateToken()
+	if err != nil {
+		logrus.WithError(err).Fatal("Unable to create token for CNI kubeconfig")
+	}
+
+	data := calculateKubeconfig(kubecfg, tu.Token)
+
+	if err := os.WriteFile(winutils.GetHostPath("/host/etc/cni/net.d/calico-kubeconfig"), []byte(data), 0o600); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func calculateKubeconfig(kubecfg *rest.Config, token string) string {
 	data := `# Kubeconfig file for Calico CNI plugin.
 apiVersion: v1
 kind: Config
 clusters:
 - name: local
   cluster:
-    server: __KUBERNETES_SERVICE_PROTOCOL__://[__KUBERNETES_SERVICE_HOST__]:__KUBERNETES_SERVICE_PORT__
+    server: __KUBERNETES_SERVICE_PROTOCOL__://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__
     __TLS_CFG__
 users:
 - name: calico
@@ -490,19 +508,14 @@ contexts:
     cluster: local
     user: calico
 current-context: calico-context`
-
-	clientset, err := cni.BuildClientSet()
-	if err != nil {
-		logrus.WithError(err).Fatal("Unable to create client for generating CNI token")
-	}
-	tr := cni.NewTokenRefresher(clientset, cni.NamespaceOfUsedServiceAccount(), cni.CNIServiceAccountName())
-	tu, err := tr.UpdateToken()
-	if err != nil {
-		logrus.WithError(err).Fatal("Unable to create token for CNI kubeconfig")
-	}
-	data = strings.Replace(data, "TOKEN", tu.Token, 1)
+	data = strings.Replace(data, "TOKEN", token, 1)
 	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_PROTOCOL__", getEnv("KUBERNETES_SERVICE_PROTOCOL", "https"))
-	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_HOST__", getEnv("KUBERNETES_SERVICE_HOST", ""))
+	k8sHost := getEnv("KUBERNETES_SERVICE_HOST", "")
+	if strings.Contains(k8sHost, ":") && !strings.HasPrefix(k8sHost, "[") {
+		// IPv6 address needs to be enclosed in brackets.
+		k8sHost = "[" + k8sHost + "]"
+	}
+	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_HOST__", k8sHost)
 	data = strings.ReplaceAll(data, "__KUBERNETES_SERVICE_PORT__", getEnv("KUBERNETES_SERVICE_PORT", ""))
 
 	skipTLSVerify := os.Getenv("SKIP_TLS_VERIFY")
@@ -512,10 +525,7 @@ current-context: calico-context`
 		ca := "certificate-authority-data: " + base64.StdEncoding.EncodeToString(kubecfg.CAData)
 		data = strings.ReplaceAll(data, "__TLS_CFG__", ca)
 	}
-
-	if err := os.WriteFile(winutils.GetHostPath("/host/etc/cni/net.d/calico-kubeconfig"), []byte(data), 0o600); err != nil {
-		logrus.Fatal(err)
-	}
+	return data
 }
 
 // destinationUptoDate compares the given files and returns


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#11713
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This is not valid and Go's parser has been fixed to reject it. https://github.com/golang/go/issues/75678

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Fixes https://github.com/projectcalico/calico/issues/11711
CORE-12259

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that the CNI plugin installer generated a malformed URL for IPv4 addresses.  This bug was exposed by a fix to the golang URL parser.
```


