### PR TITLE
Pull in operator CRD update with windows name updates

### DIFF
--- a/charts/tigera-operator/crds/operator.tigera.io_installations.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_installations.yaml
@@ -3932,15 +3932,19 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-                                          Supported values are: calico-node-windows
+                                          Supported values are: node, felix, confd
+                                          calico-node-windows is allowed because it was previously allowed.
                                         enum:
                                           - calico-node-windows
+                                          - node
+                                          - felix
+                                          - confd
                                         type: string
                                       resources:
                                         description: |-
                                           Resources allows customization of limits and requests for compute resources such as cpu and memory.
-                                          If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-                                          If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+                                          If specified, this overrides the named DaemonSet container's resources.
+                                          If omitted, the DaemonSet will use its default value for this container's resources.
                                           If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
                                         properties:
                                           claims:
@@ -5472,6 +5476,9 @@ spec:
                           - Node
                           - Typha
                           - KubeControllers
+                          - NodeWindows
+                          - FelixWindows
+                          - ConfdWindows
                         type: string
                       resourceRequirements:
                         description:
@@ -12787,15 +12794,19 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-                                              Supported values are: calico-node-windows
+                                              Supported values are: node, felix, confd
+                                              calico-node-windows is allowed because it was previously allowed.
                                             enum:
                                               - calico-node-windows
+                                              - node
+                                              - felix
+                                              - confd
                                             type: string
                                           resources:
                                             description: |-
                                               Resources allows customization of limits and requests for compute resources such as cpu and memory.
-                                              If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-                                              If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+                                              If specified, this overrides the named DaemonSet container's resources.
+                                              If omitted, the DaemonSet will use its default value for this container's resources.
                                               If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
                                             properties:
                                               claims:
@@ -14352,6 +14363,9 @@ spec:
                               - Node
                               - Typha
                               - KubeControllers
+                              - NodeWindows
+                              - FelixWindows
+                              - ConfdWindows
                             type: string
                           resourceRequirements:
                             description:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -12642,15 +12642,19 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-                                          Supported values are: calico-node-windows
+                                          Supported values are: node, felix, confd
+                                          calico-node-windows is allowed because it was previously allowed.
                                         enum:
                                           - calico-node-windows
+                                          - node
+                                          - felix
+                                          - confd
                                         type: string
                                       resources:
                                         description: |-
                                           Resources allows customization of limits and requests for compute resources such as cpu and memory.
-                                          If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-                                          If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+                                          If specified, this overrides the named DaemonSet container's resources.
+                                          If omitted, the DaemonSet will use its default value for this container's resources.
                                           If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
                                         properties:
                                           claims:
@@ -14182,6 +14186,9 @@ spec:
                           - Node
                           - Typha
                           - KubeControllers
+                          - NodeWindows
+                          - FelixWindows
+                          - ConfdWindows
                         type: string
                       resourceRequirements:
                         description:
@@ -21497,15 +21504,19 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-                                              Supported values are: calico-node-windows
+                                              Supported values are: node, felix, confd
+                                              calico-node-windows is allowed because it was previously allowed.
                                             enum:
                                               - calico-node-windows
+                                              - node
+                                              - felix
+                                              - confd
                                             type: string
                                           resources:
                                             description: |-
                                               Resources allows customization of limits and requests for compute resources such as cpu and memory.
-                                              If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-                                              If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+                                              If specified, this overrides the named DaemonSet container's resources.
+                                              If omitted, the DaemonSet will use its default value for this container's resources.
                                               If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
                                             properties:
                                               claims:
@@ -23062,6 +23073,9 @@ spec:
                               - Node
                               - Typha
                               - KubeControllers
+                              - NodeWindows
+                              - FelixWindows
+                              - ConfdWindows
                             type: string
                           resourceRequirements:
                             description:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

https://github.com/tigera/operator/issues/4362


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The tigera-operator `Installation` CRD now accepts `node`, `felix`, and `confd` as Windows container names (in addition to the legacy `calico-node-windows`), and adds `NodeWindows`, `FelixWindows`, and `ConfdWindows` as `componentResources` keys, allowing per-container resource overrides on Windows nodes.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
