### PR TITLE
Stop consuming redundant HostMetadata message in no-encap manager

### DIFF
--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -111,11 +111,6 @@ func (m *noEncapManager) OnUpdate(protoBufMsg interface{}) {
 		if msg.Hostname == m.hostname && m.ipVersion == 6 {
 			m.routesNeedUpdate("")
 		}
-	case *proto.HostMetadataV4V6Remove:
-		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
-		if msg.Hostname == m.hostname {
-			m.routesNeedUpdate("")
-		}
 	default:
 		m.routeMgr.OnUpdate(msg)
 	}


### PR DESCRIPTION
## Description

No-encap manager already consumes `HostMetadataRemove` for IPv4:
https://github.com/projectcalico/calico/blob/e353d62804e462d8ce72ae5c46e7421dc4021b97/felix/dataplane/linux/noencap_mgr.go#L99

and also `HostMetadataV6Remove` for IPv6:
https://github.com/projectcalico/calico/blob/e353d62804e462d8ce72ae5c46e7421dc4021b97/felix/dataplane/linux/noencap_mgr.go#L109

So there is no need to consume `HostMetatadaV4V6Remove`.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
