### PR TITLE
For VM-based tests on Jammy pin docker-buildx-plugin

### DIFF
--- a/node/cmd/calico-node/main.go
+++ b/node/cmd/calico-node/main.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Spurious change to trigger node CI.
-
 package main
 
 import (


### PR DESCRIPTION
We need to pin because download.docker.com now has a newer buildx that tries to use an API version
that is too new for the Docker daemon, causing this error:
```
docker buildx build --load --platform=linux/amd64 --pull --build-arg UBI_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest --build-arg GIT_VERSION=v3.32.0-0.dev-643-g38568836d2ac --build-arg CALICO_BASE=calico/base:ubi9-1769122535 --build-arg BPFTOOL_IMAGE=calico/bpftool:v7.5.0 --network=host --build-arg BIN_DIR=dist/bin --build-arg BIRD_IMAGE=calico/bird:v0.3.3-211-g9111ec3c-amd64 --build-arg GIT_VERSION=v3.32.0-0.dev-643-g38568836d2ac -t node:latest-amd64 -f ./Dockerfile.amd64 .
ERROR: failed to build: Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.41: driver not connecting
make[1]: Leaving directory '/home/ubuntu/calico/node'
make[1]: *** [Makefile:268: .calico_node.created-amd64] Error 1
make: Leaving directory '/home/ubuntu/calico/node'
make: *** [Makefile:440: k8s-test] Error 2
```