### PR TITLE
Cherry pick #11743 for v3.31 branch

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -629,7 +629,7 @@ blocks:
           - export IMAGE=ubuntu-2404-noble-amd64-v20250502a
           - export UBUNTU_VERSION=noble
           - export DOCKER_VERSION=5:27.5.1-1~ubuntu.24.04~noble
-          - export BUILDX_VERSION=" "
+          - export BUILDX_VERSION=0.31.1-1~ubuntu.24.04~noble
           - mkdir artifacts
           - ./.semaphore/create-test-vms ${VM_PREFIX}
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -629,7 +629,7 @@ blocks:
           - export IMAGE=ubuntu-2404-noble-amd64-v20250502a
           - export UBUNTU_VERSION=noble
           - export DOCKER_VERSION=5:27.5.1-1~ubuntu.24.04~noble
-          - export BUILDX_VERSION=" "
+          - export BUILDX_VERSION=0.31.1-1~ubuntu.24.04~noble
           - mkdir artifacts
           - ./.semaphore/create-test-vms ${VM_PREFIX}
       jobs:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -210,7 +210,7 @@
         - export IMAGE=ubuntu-2404-noble-amd64-v20250502a
         - export UBUNTU_VERSION=noble
         - export DOCKER_VERSION=5:27.5.1-1~ubuntu.24.04~noble
-        - export BUILDX_VERSION=" "
+        - export BUILDX_VERSION=0.31.1-1~ubuntu.24.04~noble
         - mkdir artifacts
         - ./.semaphore/create-test-vms ${VM_PREFIX}
     jobs:

--- a/felix/.semaphore/create-test-vm
+++ b/felix/.semaphore/create-test-vm
@@ -23,7 +23,7 @@ zone=europe-west3-c
 
 : ${IMAGE:=ubuntu-2204-jammy-v20250312}
 : ${DOCKER_VERSION=5:20.10.14~3-0~ubuntu-jammy}
-: ${BUILDX_VERSION="=0.29.0-0~ubuntu.22.04~jammy"}
+: ${BUILDX_VERSION=0.29.0-0~ubuntu.22.04~jammy}
 : ${UBUNTU_VERSION=jammy}
 
 gcloud config set project $project
@@ -46,7 +46,7 @@ function create-vm() {
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg" && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu ${UBUNTU_VERSION} stable' | sudo tee /etc/apt/sources.list.d/docker.list" && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt update -y && \
-  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install -y --no-install-recommends git docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} docker-buildx-plugin${BUILDX_VERSION} containerd.io make iproute2 wireguard && \
+  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install -y --no-install-recommends git docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} docker-buildx-plugin=${BUILDX_VERSION} containerd.io make iproute2 wireguard && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo usermod -a -G docker ubuntu && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo modprobe ipip && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- 'if [ -s /etc/docker/daemon.json ] ; then cat /etc/docker/daemon.json | sed "\$d" | sed "\$s/\$/,/" > /tmp/daemon.json ; else echo -en {\\n > /tmp/daemon.json ; fi' && \


### PR DESCRIPTION
On the v3.31 branch, "UT/FV tests on new kernel" CI is failing and the artifacts show the same problem as in #11743, i.e.:
```
docker buildx build --load --platform=linux/amd64 --pull --build-arg UBI_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest --build-arg GIT_VERSION=v3.31.3-44-gd4da4610c064-dirty --build-arg CALICO_BASE=calico/base:ubi9-1764972441 --build-arg BPFTOOL_IMAGE=calico/bpftool:v7.5.0 -t typha:latest-amd64 -f docker-image/Dockerfile docker-image
ERROR: failed to build: Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.41: driver not connecting
make[2]: *** [Makefile:118: .calico_typha.created-amd64] Error 1
make[2]: Leaving directory '/home/ubuntu/calico/typha'
make[1]: *** [Makefile:302: build-typha] Error 2
make[1]: Leaving directory '/home/ubuntu/calico/felix'
make: Leaving directory '/home/ubuntu/calico/felix'
make: *** [Makefile:384: fv-bpf] Error 2
```

It's not identical to the master branch because v3.31 uses a separate copy of VM coding under `felix/.semaphore`.