### PR TITLE
Improve performance of CIDR IP autodetection when there are many addrs

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/addr_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/addr_linux.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autodetection
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Package-level variable for dependency injection (testing)
+var netlinkAddrList = netlink.AddrList
+
+// getAllInterfaceAddrs retrieves all addresses from all interfaces in one netlink call,
+// then groups them by interface index for O(1) lookup.
+// This avoids the O(N^2) behavior of calling i.Addrs() for each interface, which
+// internally performs a full RTM_GETADDR netlink dump of all addresses on the system
+// for each call, then filters to one interface.
+func getAllInterfaceAddrs() (map[int][]net.Addr, error) {
+	nlAddrs, err := netlinkAddrList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, err
+	}
+
+	addrsByIndex := make(map[int][]net.Addr)
+	for _, nlAddr := range nlAddrs {
+		linkIndex := nlAddr.LinkIndex
+		netAddr := &net.IPNet{
+			IP:   nlAddr.IP,
+			Mask: nlAddr.Mask,
+		}
+		addrsByIndex[linkIndex] = append(addrsByIndex[linkIndex], netAddr)
+	}
+
+	return addrsByIndex, nil
+}

--- a/node/pkg/lifecycle/startup/autodetection/addr_windows.go
+++ b/node/pkg/lifecycle/startup/autodetection/addr_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autodetection
+
+import (
+	"net"
+)
+
+// getAllInterfaceAddrs returns nil on Windows to signal fallback to i.Addrs().
+// netlink is Linux-only.
+func getAllInterfaceAddrs() (map[int][]net.Addr, error) {
+	return nil, nil
+}

--- a/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
@@ -14,10 +14,12 @@
 package autodetection
 
 import (
+	"errors"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
 )
 
 type getInterfacesTestCase struct {
@@ -96,3 +98,110 @@ var _ = DescribeTable("GetInterfaces",
 		},
 	}),
 )
+
+var _ = Describe("getAllInterfaceAddrs", func() {
+	It("should group addresses by interface index", func() {
+		originalAddrList := netlinkAddrList
+		defer func() { netlinkAddrList = originalAddrList }()
+
+		netlinkAddrList = func(link netlink.Link, family int) ([]netlink.Addr, error) {
+			return []netlink.Addr{
+				{LinkIndex: 1, IPNet: &net.IPNet{IP: net.ParseIP("192.168.1.10"), Mask: net.CIDRMask(24, 32)}},
+				{LinkIndex: 1, IPNet: &net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}},
+				{LinkIndex: 2, IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(8, 32)}},
+			}, nil
+		}
+
+		addrsByIndex, err := getAllInterfaceAddrs()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrsByIndex).To(HaveLen(2))
+		Expect(addrsByIndex[1]).To(HaveLen(2))
+		Expect(addrsByIndex[2]).To(HaveLen(1))
+
+		ipNet1 := addrsByIndex[1][0].(*net.IPNet)
+		Expect(ipNet1.IP.String()).To(Equal("192.168.1.10"))
+
+		ipNet2 := addrsByIndex[2][0].(*net.IPNet)
+		Expect(ipNet2.IP.String()).To(Equal("10.0.0.5"))
+	})
+
+	It("should handle netlink errors", func() {
+		originalAddrList := netlinkAddrList
+		defer func() { netlinkAddrList = originalAddrList }()
+
+		netlinkAddrList = func(link netlink.Link, family int) ([]netlink.Addr, error) {
+			return nil, errors.New("netlink error")
+		}
+
+		_, err := getAllInterfaceAddrs()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("netlink error"))
+	})
+
+	It("should handle empty address list", func() {
+		originalAddrList := netlinkAddrList
+		defer func() { netlinkAddrList = originalAddrList }()
+
+		netlinkAddrList = func(link netlink.Link, family int) ([]netlink.Addr, error) {
+			return []netlink.Addr{}, nil
+		}
+
+		addrsByIndex, err := getAllInterfaceAddrs()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrsByIndex).To(HaveLen(0))
+	})
+})
+
+var _ = Describe("GetInterfaces with netlink optimization", func() {
+	It("should fall back to i.Addrs() when bulk fetch fails", func() {
+		originalAddrList := netlinkAddrList
+		defer func() { netlinkAddrList = originalAddrList }()
+
+		// Force bulk fetch to fail
+		netlinkAddrList = func(link netlink.Link, family int) ([]netlink.Addr, error) {
+			return nil, errors.New("simulated netlink failure")
+		}
+
+		// Should still work via i.Addrs() fallback
+		getInterfaces := func() ([]net.Interface, error) {
+			return net.Interfaces()
+		}
+
+		_, err := GetInterfaces(getInterfaces, nil, DEFAULT_INTERFACES_TO_EXCLUDE, 4)
+		Expect(err).NotTo(HaveOccurred())
+		// Just verify no error occurs - the fallback worked
+	})
+
+	It("should use bulk-fetched addresses when available", func() {
+		originalAddrList := netlinkAddrList
+		defer func() { netlinkAddrList = originalAddrList }()
+
+		// Mock netlink to return specific addresses
+		netlinkAddrList = func(link netlink.Link, family int) ([]netlink.Addr, error) {
+			return []netlink.Addr{
+				{LinkIndex: 1, IPNet: &net.IPNet{IP: net.ParseIP("192.168.1.10"), Mask: net.CIDRMask(24, 32)}},
+				{LinkIndex: 2, IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(16, 32)}},
+			}, nil
+		}
+
+		getInterfaces := func() ([]net.Interface, error) {
+			return []net.Interface{
+				{Index: 1, Name: "eth0"},
+				{Index: 2, Name: "eth1"},
+			}, nil
+		}
+
+		ifaces, err := GetInterfaces(getInterfaces, nil, nil, 4)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ifaces).To(HaveLen(2))
+
+		// Verify addresses were attached correctly (reverse order due to loop)
+		Expect(ifaces[0].Name).To(Equal("eth1"))
+		Expect(ifaces[0].Cidrs).To(HaveLen(1))
+		Expect(ifaces[0].Cidrs[0].IP.String()).To(Equal("10.0.0.5"))
+
+		Expect(ifaces[1].Name).To(Equal("eth0"))
+		Expect(ifaces[1].Cidrs).To(HaveLen(1))
+		Expect(ifaces[1].Cidrs[0].IP.String()).To(Equal("192.168.1.10"))
+	})
+})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We recently started updating many of our nodes to use `IP_AUTODETECTION_METHOD=cidr`. We found a slight increase in CPU usage when doing so which is not an incredible change but is enough to cause us problems on some of our more tightly packed nodes. We looked into it and found a similar issue to one we reported in aws/amazon-ssm-agent#645 and have cooked up a patch to resolve this.

As I understand it the issue is that Go's `net.Interface.Addrs()` does a full `RTM_GETADDR` netlink dump of ALL addresses on the system for each call, then filters to one interface. `GetInterfaces`  calls `convertInterface` → `i.Addrs()` for every interface that passes the name filter. On nodes with many addresses (e.g., thousands of IPVS service VIPs on kube-ipvs0), this is `O(N_interfaces * N_total_addresses)` per invocation. The monitor-addresses process repeats this every 60 seconds.

AWS' ssm-agent [fixed this](https://github.com/aws/amazon-ssm-agent/commit/4e026e0ad923c45a10d276badc6e3abf722fa752#diff-1331bd687c96036031bec147d1791cecef85560d6320bbc38f83d7e4fa0e5956R29-R36) by doing one single load of all addresses and then using it inside the loop. I believe that approach will work here as well.

I've added some unit tests and run this in a testing environment for a while (it appears to work correctly afaict). In terms of addressing the resource consumption, I've attached a chart of CPU usage for 3 calico-node pods. The first two are base v3.30.4 calico-nodes. The first one is with `IP_AUTODETECTION_METHOD=""`, the second and third ones have it set to `cidr`. The third one is a version of v3.30.4 with this patch backported to it. As you can see the total change is _maybe_ 1/4 a CPU but we find that this can be rather important on some of our more highly-loaded nodes and this behavior seems to get worse when calico and kube-proxy are both trying to talk to netlink a lot.

<img width="3158" height="806" alt="image" src="https://github.com/user-attachments/assets/a51533c4-1e1c-4d03-a422-69c8c540e01e" />

This does create a new/different race condition where if interfaces change addresses between the initial load and us acting on it, we may have the incorrect link index but I think this race already existed in the old way as well, just in a different form? Happy to be told this is actually a problem though, we will go back to the drawing board and come up with some other fix hopefully.

## Related issues/PRs

None that I know of. Happy to go make one if we'd like to discuss solutions instead of just accepting this.

## Todos

- [x] Tests
- [x] Documentation (unnecessary, internal only)
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve resource consumption when IP_AUTODETECTION_METHOD is set to cidr on Linux instances with many addresses.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
