### PR TITLE
Use indexer for EndpointSlice lookups to avoid O(n) scans in confd

### DIFF
--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -147,7 +147,7 @@ var _ = Describe("RouteGenerator", func() {
 		rg = &routeGenerator{
 			nodeName:                   "foobar",
 			svcIndexer:                 cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			epIndexer:                  cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			epIndexer:                  cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{endpointSliceServiceIndex: endpointSliceServiceIndexFunc}),
 			svcRouteMap:                make(map[string]map[string]bool),
 			routeAdvertisementRefCount: make(map[string]int),
 			client: &client{


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Bug fix: Use a cache indexer for EndpointSlice lookups in confd's route generator to avoid O(n) full scans.

The k8s 1.33 bump (#10715, 0e18c27633) migrated confd from the deprecated `v1.Endpoints` API to `discovery/v1.EndpointSlice`. Since a single Service can have multiple EndpointSlices, `getEndpointsForService` was changed to iterate all EndpointSlices via `List()` and filter by label. This works correctly but is O(n) in the total number of EndpointSlices across all services.

This PR adds a `svcKey` indexer on EndpointSlices keyed by `namespace/serviceName` and uses `ByIndex` for O(1) lookups.

Changes:
- **`confd/pkg/backends/calico/routes.go`**: Add `endpointSliceServiceIndex` indexer function, register it in the EndpointSlice informer, and rewrite `getEndpointsForService` to use `ByIndex()`
- **`confd/pkg/backends/calico/routes_test.go`**: Register the indexer in test setup to match production initialization

Testing:

Existing unit tests pass and cover the affected code paths.

We applied this change on top of `release-v3.31` and deployed to our cluster. The `calico-node` CPU usage dropped significantly, from ~2 cores (left, v3.31.3) to ~0.8 cores (right, with fix):

<img width="1660" height="363" alt="image" src="https://github.com/user-attachments/assets/73c559fe-319c-47a9-8fa1-74d8db14f85c" />


## Related issues/PRs
Fixes performance regression introduced by #10715. 





<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Use indexer for EndpointSlice lookups to avoid O(n) scans in confd
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
