### PR TITLE
Cache most recently created uniquelabels.Map and re-use

### DIFF
--- a/felix/calc/active_bpgpeer_calculator.go
+++ b/felix/calc/active_bpgpeer_calculator.go
@@ -71,7 +71,7 @@ func NewActiveBGPPeerCalculator(hostname string) *ActiveBGPPeerCalculator {
 		allBGPPeersByName: map[string]*v3.BGPPeer{},
 		peersByWorkloadID: map[model.WorkloadEndpointKey][]string{},
 	}
-	abp.labelIndex = labelindex.NewInheritIndex(abp.onPeerEndpointMatchStarted, abp.onPeerEndpointMatchStopped)
+	abp.labelIndex = labelindex.NewInheritIndex(abp.onPeerEndpointMatchStarted, abp.onPeerEndpointMatchStopped, labelindex.WithInheritIndexUniqueLabelMaker(makeUniqueLabelCached))
 	return abp
 }
 

--- a/felix/calc/active_rules_calculator.go
+++ b/felix/calc/active_rules_calculator.go
@@ -113,7 +113,7 @@ func NewActiveRulesCalculator() *ActiveRulesCalculator {
 		// Cache of profile IDs by local endpoint.
 		endpointKeyToProfileIDs: NewEndpointKeyToProfileIDMap(),
 	}
-	arc.labelIndex = labelindex.NewInheritIndex(arc.onMatchStarted, arc.onMatchStopped)
+	arc.labelIndex = labelindex.NewInheritIndex(arc.onMatchStarted, arc.onMatchStopped, labelindex.WithInheritIndexUniqueLabelMaker(makeUniqueLabelCached))
 	return arc
 }
 

--- a/felix/labelindex/named_port_bench_test.go
+++ b/felix/labelindex/named_port_bench_test.go
@@ -56,7 +56,7 @@ func benchmarkWorkloadUpdates(b *testing.B, numSels int) {
 	logrus.SetLevel(logrus.InfoLevel)
 	defer logrus.SetLevel(logLevel)
 
-	idx := NewSelectorAndNamedPortIndex(false)
+	idx := NewSelectorAndNamedPortIndex()
 	idx.OnMemberAdded = func(ipSetID string, member IPSetMember) {
 		lastID = ipSetID
 		lastMember = member
@@ -140,7 +140,7 @@ func benchmarkParentUpdates(b *testing.B, numSels, numEndpoints int) {
 	logrus.SetLevel(logrus.InfoLevel)
 	defer logrus.SetLevel(logLevel)
 
-	idx := NewSelectorAndNamedPortIndex(false)
+	idx := NewSelectorAndNamedPortIndex()
 	idx.OnMemberAdded = func(ipSetID string, member IPSetMember) {
 		lastID = ipSetID
 		lastMember = member
@@ -217,7 +217,7 @@ func benchmarkSelectorUpdates(b *testing.B, numEndpoints int) {
 	logrus.SetLevel(logrus.InfoLevel)
 	defer logrus.SetLevel(logLevel)
 
-	idx := NewSelectorAndNamedPortIndex(false)
+	idx := NewSelectorAndNamedPortIndex()
 	idx.OnMemberAdded = func(ipSetID string, member IPSetMember) {
 		lastID = ipSetID
 		lastMember = member

--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -921,7 +921,7 @@ func TestNamedPortIndex(t *testing.T) {
 		// First run each base test as-is: just apply its inputs and
 		// check that we get the right output.
 		t.Run("Base "+state.Name, func(t *testing.T) {
-			idx := NewSelectorAndNamedPortIndex(false)
+			idx := NewSelectorAndNamedPortIndex()
 			RegisterTestingT(t)
 			rec := newRecorder()
 			idx.OnMemberAdded = rec.OnMemberAdded
@@ -952,7 +952,7 @@ func TestNamedPortIndex(t *testing.T) {
 					func(t *testing.T) {
 						logutils.ConfigureLoggingForTestingT(t)
 						RegisterTestingT(t)
-						idx := NewSelectorAndNamedPortIndex(false)
+						idx := NewSelectorAndNamedPortIndex()
 						rec := newRecorder()
 						idx.OnMemberAdded = rec.OnMemberAdded
 						idx.OnMemberRemoved = rec.OnMemberRemoved
@@ -1308,7 +1308,7 @@ var _ = Describe("SelectorAndNamedPortIndex", func() {
 	var recorder *testRecorder
 
 	BeforeEach(func() {
-		uut = NewSelectorAndNamedPortIndex(false)
+		uut = NewSelectorAndNamedPortIndex()
 		recorder = newRecorder()
 		uut.OnMemberAdded = recorder.OnMemberAdded
 		uut.OnMemberRemoved = recorder.OnMemberRemoved


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
In the calculation graph profiles (aka "parent labels") reach several label indexes and each one calls `uniquelabels.Make` independently.  Since the calculation graph runs on a single thread, when processing a profile we call `uniquelabels.Make` 3 times in a row in this case and it returns a new but identical `uniquelabels.Map` each time.  Although the keys and values get deduped, the map itself has quite high overhead; it'd be better to only have one copy of the map...

Since profile is a v3 object, we can't just change the type of the field to a `uniquelabels.Map` (so that the map one be calculated once when parsing the JSON) and it feels a bit awkward to convert the v3 resource into a felix-specific resource at the top of the calc graph in order to make that work.

Instead, this PR adds a simple one-element cache in a wrapper around `uniquelabels.Make` when used in these indexes; this should give a 100% hit rate for this use case.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now avoids storing namespace labels multiple times in different caches, reduces memory usage.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
