### PR TITLE
Added cali bot trigger

### DIFF
--- a/.github/workflows/calico-github-issues-bot-trigger.yml
+++ b/.github/workflows/calico-github-issues-bot-trigger.yml
@@ -1,4 +1,4 @@
-name: Trigger Cali Bot
+name: Trigger Calico Github Issues Bot
 
 on:
   issues:
@@ -11,7 +11,7 @@ permissions:
   issues: read
 
 jobs:
-  trigger-cali-bot:
+  trigger-calico-github-issues-bot:
     runs-on: ubuntu-latest
 
     # Ignore PR comments and bot comments
@@ -31,7 +31,7 @@ jobs:
           echo "Comment ID:   ${{ github.event.comment.id }}"
           echo "Author:       ${{ github.event.comment.user.login }}"
 
-      - name: Trigger Cali Bot
+      - name: Trigger Calico Github Issues Bot
         env:
           CALI_BOT_PAT: ${{ secrets.CALI_BOT_PAT }}
         run: |
@@ -54,7 +54,7 @@ jobs:
             COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
           fi
 
-          echo "Dispatching Cali Bot with event: $EVENT_TYPE"
+          echo "Dispatching Calico Github Issues Bot with event: $EVENT_TYPE"
 
           curl --fail --show-error --silent -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -73,4 +73,4 @@ jobs:
           }
           EOF
 
-          echo "Cali Bot dispatch successful"
+          echo "Calico Github Issues Bot dispatch successful"


### PR DESCRIPTION
## Description

This PR adds a trigger for `cali-bot`.

The workflow runs when:

A new **GitHub** issue is **opened**

A **new comment** is **added** to an existing issue

When triggered, it dispatches an event to the cali-bot repository. The bot processes the issue or comment and posts an issue summary along with a suggested response to a designated Slack channel.

**The bot does not modify GitHub issues.** It only reads issue data and produces Slack notifications.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
