### PR TITLE
Add isolated customer environments calc graph benchmark

### DIFF
--- a/felix/calc/calc_graph_bench_test.go
+++ b/felix/calc/calc_graph_bench_test.go
@@ -413,15 +413,15 @@ func generateLabels() uniquelabels.Map {
 //   - production: boolean "true"/"false"
 
 func BenchmarkIsolatedCustomers1k(b *testing.B) {
-	benchIsolatedCustomers(b, 1_000, 10, 100)
+	benchIsolatedCustomers(b, 1_000, 1, 100)
 }
 
 func BenchmarkIsolatedCustomers10k(b *testing.B) {
-	benchIsolatedCustomers(b, 10_000, 10, 100)
+	benchIsolatedCustomers(b, 10_000, 1, 100)
 }
 
 func BenchmarkIsolatedCustomers100k(b *testing.B) {
-	benchIsolatedCustomers(b, 100_000, 10, 100)
+	benchIsolatedCustomers(b, 100_000, 1, 100)
 }
 
 const (


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Simulates a multi-tenant SaaS cluster with 1k/10k/100k identical namespaces.

```
goos: linux
goarch: amd64
pkg: github.com/projectcalico/calico/felix/calc
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkIsolatedCustomers1k-12      	      25	  45382677 ns/op	        10.13 HeapAllocMB	       100.0 IPSets	       100.0 LocalEps	      1403 Msgs	       100.0 Policies	         0.04368 s	16544401 B/op	  191707 allocs/op
BenchmarkIsolatedCustomers10k-12     	       3	 388005473 ns/op	        47.56 HeapAllocMB	       100.0 IPSets	       100.0 LocalEps	     10403 Msgs	       100.0 Policies	         0.3810 s	127345704 B/op	 1471678 allocs/op
BenchmarkIsolatedCustomers100k-12    	       1	6898444469 ns/op	       401.7 HeapAllocMB	       100.0 IPSets	       100.0 LocalEps	    100403 Msgs	       100.0 Policies	         6.898 s	1213249056 B/op	14929873 allocs/op
PASS
ok  	github.com/projectcalico/calico/felix/calc	19.689s
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
