### PR TITLE
Collect more diags when the kind k8st cluster setup fails

### DIFF
--- a/node/tests/k8st/deploy_resources_on_kind_cluster.sh
+++ b/node/tests/k8st/deploy_resources_on_kind_cluster.sh
@@ -1,13 +1,75 @@
 #!/bin/bash -e
 
-# Clean up background jobs on exit.
+# Clean up background jobs on exit, and collect diagnostics on failure.
 set -m
 function cleanup() {
   rc=$?
+  if [ $rc -ne 0 ]; then
+    collect_diags
+  fi
   jobs -p | xargs --no-run-if-empty kill
   exit $rc
 }
 trap 'cleanup' SIGINT SIGHUP SIGTERM EXIT
+
+# collect_diags prints detailed cluster diagnostics on failure.
+# It collects tigerastatus, tigera-operator logs, and logs from failing pods.
+function collect_diags() {
+  # Guard against kubectl not being set yet (failure during variable init).
+  local kctl="${kubectl:-../hack/test/kind/kubectl}"
+
+  echo ""
+  echo "========================================================================"
+  echo "  DIAGNOSTICS: Collecting cluster state after failure"
+  echo "========================================================================"
+
+  echo ""
+  echo "-------- TigeraStatus Resources (YAML) --------"
+  ${kctl} get tigerastatus -o yaml 2>&1 || true
+
+  echo ""
+  echo "-------- Tigera Operator Logs --------"
+  ${kctl} logs -n tigera-operator -l k8s-app=tigera-operator --tail=200 2>&1 || true
+
+  echo ""
+  echo "-------- All Pod Status --------"
+  ${kctl} get po -A -o wide 2>&1 || true
+
+  echo ""
+  echo "-------- Logs from Non-Running / Non-Ready Pods --------"
+  ${kctl} get po -A --no-headers 2>/dev/null | while read -r ns name ready status rest; do
+    if [ "$status" != "Running" ] && [ "$status" != "Completed" ] && [ "$status" != "Succeeded" ]; then
+      echo ""
+      echo "---- Pod ${ns}/${name} (Status: ${status}) ----"
+      echo "  -- Description --"
+      ${kctl} describe pod -n "${ns}" "${name}" 2>&1 || true
+      echo "  -- Logs --"
+      ${kctl} logs -n "${ns}" "${name}" --all-containers --tail=100 2>&1 || true
+    fi
+  done
+
+  # Also check for Running pods that aren't fully ready (e.g., 0/1, 1/2).
+  ${kctl} get po -A --no-headers 2>/dev/null | while read -r ns name ready status rest; do
+    if [ "$status" = "Running" ]; then
+      ready_count="${ready%%/*}"
+      total_count="${ready##*/}"
+      if [ "$ready_count" != "$total_count" ]; then
+        echo ""
+        echo "---- Pod ${ns}/${name} (Running but not Ready: ${ready}) ----"
+        echo "  -- Description --"
+        ${kctl} describe pod -n "${ns}" "${name}" 2>&1 || true
+        echo "  -- Logs --"
+        ${kctl} logs -n "${ns}" "${name}" --all-containers --tail=100 2>&1 || true
+      fi
+    fi
+  done
+
+  echo ""
+  echo "========================================================================"
+  echo "  END OF DIAGNOSTICS"
+  echo "========================================================================"
+  echo ""
+}
 
 function wait_pod_ready() {
   args="$@"
@@ -33,11 +95,6 @@ function wait_pod_ready() {
 
   if [ $rc -ne 0 ]; then
     echo "Pod $args failed to become ready within 300s"
-    echo "collecting diags..."
-    ${kubectl} get po -A -o wide
-    ${kubectl} describe po $args
-    ${kubectl} logs $args
-    echo "Pod $args failed to become ready within 300s; diags above ^^"
   fi
 
   set -e
@@ -87,13 +144,7 @@ echo
 echo "Wait for tigera status to be ready"
 if ! ( ${kubectl} wait --for=create --timeout=60s tigerastatus/calico &&
        ${kubectl} wait --for=condition=Available --timeout=300s tigerastatus/calico ); then
-  echo "TigeraStatus for Calico is down, collecting diags..."
-  ${kubectl} get -o yaml tigerastatus/calico
-  echo "Logs for tigera-operator:"
-  ${kubectl} logs -n tigera-operator -l k8s-app=tigera-operator
-  echo "Status of pods:"
-  ${kubectl} get po -A -o wide
-  ${kubectl} describe po -n calico-system
+  echo "TigeraStatus for Calico failed to become Available"
   exit 1
 fi
 
@@ -102,7 +153,7 @@ fi
 if [ "$CALICO_API_GROUP" != "projectcalico.org/v3" ]; then
   echo "Wait for the Calico API server to be ready"
   if ! ${kubectl} wait --for=condition=Available --timeout=300s tigerastatus/apiserver; then
-    ${kubectl} get -o yaml tigerastatus/apiserver
+    echo "TigeraStatus for API server failed to become Available"
     exit 1
   fi
 fi


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Have found it a bit annoying recently when this target fails in CI and there isn't enough information to see what is going on!

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.