### PR TITLE
Update pool sorting logic in pool controller

### DIFF
--- a/kube-controllers/pkg/controllers/ippool/pool_controller.go
+++ b/kube-controllers/pkg/controllers/ippool/pool_controller.go
@@ -309,7 +309,7 @@ func poolSortFunc(a, b any) int {
 }
 
 // poolSortCategory returns the sort priority for a pool:
-//   - 0: Active pools (explicitly Allocatable=True) — sorted first so we prefer to keep existing active pools active.
+//   - 0: Active pools (Allocatable=True, not being deleted) — sorted first so we prefer to keep existing active pools active.
 //   - 1: Terminating pools (DeletionTimestamp set) — sorted after active but before disabled pools, so they are
 //     inserted into the overlap trie before disabled pools are evaluated. This ensures terminating pools continue
 //     to mask overlapping disabled pools until fully deleted.

--- a/kube-controllers/pkg/controllers/ippool/pool_controller_unit_test.go
+++ b/kube-controllers/pkg/controllers/ippool/pool_controller_unit_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestPoolSortFunc(t *testing.T) {
-	now := time.Unix(1000000, 0)
+	now := time.Unix(0, 0)
 
 	makePool := func(name string, createdAt time.Time, condition *metav1.Condition, deleting bool) *v3.IPPool {
 		p := &v3.IPPool{
@@ -148,17 +148,13 @@ func TestPoolSortFunc(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Convert to []any for the sort function.
-			items := make([]any, len(tt.pools))
+			slices.SortFunc(tt.pools, func(a, b *v3.IPPool) int {
+				return poolSortFunc(a, b)
+			})
+
+			got := make([]string, len(tt.pools))
 			for i, p := range tt.pools {
-				items[i] = p
-			}
-
-			slices.SortFunc(items, poolSortFunc)
-
-			got := make([]string, len(items))
-			for i, item := range items {
-				got[i] = item.(*v3.IPPool).Name
+				got[i] = p.Name
 			}
 
 			if len(got) != len(tt.expected) {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This is a minor improvement to the pool sorting behavior in the new IP pool controller. It ensures the we also account for the deletion time stamp when sorting IP pools, which becomes relevant when making decisions about how to mask / unmask overlapping IP pools that become active or not when an IP pool is terminating, and ensures we do not consider the IP pool active until any masking IP pool is fully terminated.

It also adds some UT specifically targeted at the sorting logic. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.