### PR TITLE
Add implement-calico-api-resource Claude Code skill

### DIFF
--- a/.claude/skills/implement-calico-api-resource/SKILL.md
+++ b/.claude/skills/implement-calico-api-resource/SKILL.md
@@ -59,15 +59,8 @@ const (
     KindMyResourceList = "MyResourceList"
 )
 
-// For cluster-scoped:
-// +genclient:nonNamespaced
+// +genclient:nonNamespaced  (cluster-scoped only)
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster
-
-// For namespaced:
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Namespaced
 
 // MyResourceList contains a list of MyResource resources.
 type MyResourceList struct {
@@ -117,7 +110,7 @@ func NewMyResource() *MyResource {
 - `+kubebuilder:resource:scope=Cluster|Namespaced` — CRD scope
 - `+kubebuilder:resource:shortName={...}` — kubectl short names
 
-**Gotcha:** The `List` type needs `+genclient:nonNamespaced` too (for cluster-scoped resources), and `+k8s:deepcopy-gen:interfaces=...` on both types.
+**Gotcha:** The `List` type needs `+genclient:nonNamespaced` too (for cluster-scoped resources), and `+k8s:deepcopy-gen:interfaces=...` on both types. Do NOT put `+kubebuilder:resource` on the List type — only on the main resource type.
 
 ### Step 2: Register in API Scheme
 
@@ -246,14 +239,7 @@ c.registerResourceClient(
 )
 ```
 
-Also add to the `knownV3Kinds` list (used for CRD cleanup):
-
-```go
-knownV3Kinds := []string{
-    // ... existing kinds ...
-    apiv3.KindMyResource,
-}
-```
+If there is any CRD cleanup or garbage-collection mechanism for v3 kinds in this client, ensure your new kind is included there as appropriate.
 
 ### Step 9: Namespace Helper (if namespaced)
 
@@ -276,7 +262,9 @@ func IsNamespaced(kind string) bool {
 
 **File:** `libcalico-go/lib/validator/v3/validator.go`
 
-If your resource has custom validation beyond kubebuilder annotations, register a struct validator:
+**Prefer kubebuilder annotations** for validation wherever possible (e.g., `+kubebuilder:validation:Enum`, `+kubebuilder:validation:Pattern`, `+kubebuilder:validation:Required`). Kubebuilder annotations generate CRD schema validation that is enforced by the Kubernetes API server. The Go struct validator in this file is only executed by the `crd.projectcalico.org/v1` code path — it is **not** executed for `projectcalico.org/v3` CRDs, so any validation that only lives here will be silently skipped on newer clusters.
+
+If your resource needs cross-field or complex validation that cannot be expressed with kubebuilder annotations, register a struct validator:
 
 ```go
 // In the init/registration function:


### PR DESCRIPTION
## Description

New feature: adds a Claude Code skill (`.claude/skills/implement-calico-api-resource/SKILL.md`) that guides through all the plumbing needed to add a new Calico API resource across every layer of the codebase.

This is a companion to the existing `design-kubernetes-api` skill — that one helps design the API types, this one handles the implementation plumbing afterward. The skill covers 20 steps:

1. API type definition in `api/pkg/apis/projectcalico/v3/`
2. Scheme registration
3. Quick API code generation (`cd api && make gen-files`)
4. CRD v1 operator types
5. CRD v1 scheme registration
6. Backend model registration
7. K8s backend resource client
8. K8s backend client registration
9. Namespace helper (if namespaced)
10. Validator
11. clientv3 typed client
12. Apiserver registry (storage + strategy)
13. Apiserver Calico storage adapter
14. Apiserver storage interface switch
15. Apiserver converter
16. Apiserver REST storage provider
17. Felix syncer (if needed)
18. calicoctl resource manager
19. RBAC
20. Full generation, formatting, and commit

Tested end-to-end by implementing a test Network resource — all 20 steps compiled and generated cleanly.

Components affected: `.claude/` (skill definition only, no runtime code changes).

## Related issues/PRs

N/A

## Todos

- [x] Tests (manually tested by implementing a Network resource end-to-end)
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
None — Claude Code skill only, no runtime changes.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.