### PR TITLE
Fix persistent connection teardown race in BPF spoof test

### DIFF
--- a/felix/fv/test-connection/test-connection.go
+++ b/felix/fv/test-connection/test-connection.go
@@ -488,9 +488,12 @@ func (tc *testConn) tryLoopFile(loopFile string, logPongs bool, timeout, sleep t
 			continue
 		} else {
 			fmt.Printf("err = %+v\n", err)
-			// If the loop file exists, we were asked to stop. The connection
-			// error is expected during shutdown, so exit cleanly.
-			if ls.loopFile != "" {
+			// If the initial exchange has completed and the loop file exists,
+			// we were asked to stop. The connection error is expected during
+			// shutdown, so exit cleanly. We only check after sentInitial so
+			// that startup failures still fail loudly (the loop file is
+			// expected to exist before the first successful exchange).
+			if ls.sentInitial && ls.loopFile != "" {
 				if _, statErr := os.Stat(ls.loopFile); statErr == nil {
 					log.WithError(err).Info("Connection error during shutdown, exiting cleanly")
 					if rmErr := os.Remove(ls.loopFile); rmErr != nil {


### PR DESCRIPTION
When Stop() is called on a PersistentConnection, it creates a loop file to signal test-connection to exit, then waits for the process. However, the tryLoopFile loop checks the loop file only in ls.Next(), which comes AFTER the Receive() call. If the TCP connection gets reset (e.g. due to Felix reprogramming BPF state after a WEP reconfiguration), Receive() returns a non-timeout error and hits log.Fatal before ever checking the loop file. This causes test-connection to exit with code 1, which makes Stop() fail the test even though all assertions passed.

Fix: in the Receive() error handler, check if the loop file exists (meaning we were asked to stop). If so, exit cleanly instead of fatally.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
