### PR TITLE
fix(windows): also print 'bin_dirs' value on uninstall-calico-hpc.ps1

### DIFF
--- a/node/windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1
+++ b/node/windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1
@@ -96,6 +96,7 @@ if ("$env:CNI_PLUGIN_TYPE" -eq "Calico") {
 
 Write-Host "Logging containerd CNI bin and conf dir paths:"
 Get-Content "$env:ProgramFiles/containerd/config.toml" | Select-String -Pattern "^(\s)*bin_dir = (.)*$"
+Get-Content "$env:ProgramFiles/containerd/config.toml" | Select-String -Pattern "^(\s)*bin_dirs = (.)*$"
 Get-Content "$env:ProgramFiles/containerd/config.toml" | Select-String -Pattern "^(\s)*conf_dir = (.)*$"
 
 Get-Module 'calico' | Remove-Module -Force


### PR DESCRIPTION
Print new 'bin_dirs' key used in containerd v2.1+

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
