### PR TITLE
prevent nil pointer dereference in handleBlockUpdate

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -281,17 +281,22 @@ func (c *loadBalancerController) handleUpdate(update interface{}) {
 }
 
 func (c *loadBalancerController) handleBlockUpdate(kvp model.KVPair) {
-	if kvp.Value == nil {
+	block, ok := kvp.Value.(*model.AllocationBlock)
+	if !ok {
+		log.WithField("key", kvp.Key.String()).Errorf("unexpected type for AllocationBlock value: %T", kvp.Value)
+		c.allocationTracker.deleteBlock(kvp.Key.String())
+		return
+	}
+	if block == nil {
 		c.allocationTracker.deleteBlock(kvp.Key.String())
 		return
 	}
 
-	affinity := kvp.Value.(*model.AllocationBlock).Affinity
-	block := kvp.Value.(*model.AllocationBlock)
+	affinity := block.Affinity
 	key := kvp.Key.String()
 
-	if affinity != nil && *affinity != fmt.Sprintf("%s:%s", ipam.AffinityTypeVirtual, api.VirtualLoadBalancer) {
-		c.allocationTracker.deleteBlock(kvp.Key.String())
+	if affinity == nil || *affinity != fmt.Sprintf("%s:%s", ipam.AffinityTypeVirtual, api.VirtualLoadBalancer) {
+		c.allocationTracker.deleteBlock(key)
 		return
 	}
 

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -277,6 +277,27 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		Expect(c.allocationTracker.servicesByIP).To(BeEmpty())
 	})
 
+	It("should not panic on handleBlockUpdate with nil *AllocationBlock", func() {
+		cidr := cnet.MustParseCIDR("10.0.0.4/30")
+		key := model.BlockKey{CIDR: cidr}
+
+		// A nil *AllocationBlock wrapped in a non-nil interface passes the
+		// "kvp.Value == nil" check but causes a nil-pointer dereference on
+		// field access.
+		var nilBlock *model.AllocationBlock
+		kvp := model.KVPair{
+			Key:   key,
+			Value: nilBlock, // non-nil interface, nil underlying pointer
+		}
+
+		Expect(func() {
+			c.handleBlockUpdate(kvp)
+		}).ToNot(Panic())
+
+		// The block should have been cleaned up from the tracker.
+		Expect(c.allocationTracker.ipsByBlock).To(BeEmpty())
+	})
+
 	It("should parse calico annotations", func() {
 		ipv4poolName := "ipv4pool"
 		ipv6poolName := "ipv6pool"


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Blocks with leaked IPs can have nil affinity while still containing allocations. The previous condition allowed these blocks to fall through into processing logic that assumes load balancer attributes (HandleID, namespace, service) are present.. Only process blocks explicitly affine to "virtual:LoadBalancer".
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Prevent nil pointer dereference in LoadBalancer controller `handleBlockUpdate`
```
Fixes: https://github.com/projectcalico/calico/issues/11856
Cherry-pick of https://github.com/projectcalico/calico/pull/11913