### PR TITLE
Prevent nil pointer dereference in handleBlockUpdate

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -290,17 +290,22 @@ func (c *loadBalancerController) handleUpdate(update interface{}) {
 }
 
 func (c *loadBalancerController) handleBlockUpdate(kvp model.KVPair) {
-	if kvp.Value == nil {
+	block, ok := kvp.Value.(*model.AllocationBlock)
+	if !ok {
+		log.WithField("key", kvp.Key.String()).Errorf("unexpected type for AllocationBlock value: %T", kvp.Value)
+		c.allocationTracker.deleteBlock(kvp.Key.String())
+		return
+	}
+	if block == nil {
 		c.allocationTracker.deleteBlock(kvp.Key.String())
 		return
 	}
 
-	affinity := kvp.Value.(*model.AllocationBlock).Affinity
-	block := kvp.Value.(*model.AllocationBlock)
+	affinity := block.Affinity
 	key := kvp.Key.String()
 
-	if affinity != nil && *affinity != fmt.Sprintf("%s:%s", ipam.AffinityTypeVirtual, api.VirtualLoadBalancer) {
-		c.allocationTracker.deleteBlock(kvp.Key.String())
+	if affinity == nil || *affinity != fmt.Sprintf("%s:%s", ipam.AffinityTypeVirtual, api.VirtualLoadBalancer) {
+		c.allocationTracker.deleteBlock(key)
 		return
 	}
 


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Blocks with leaked IPs can have nil affinity while still containing allocations. The previous condition allowed these blocks to fall through into processing logic that assumes load balancer attributes (HandleID, namespace, service) are present.. Only process blocks explicitly affine to "virtual:LoadBalancer".
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Prevent nil pointer dereference in handleBlockUpdate in LoadBalancer controller
```
Fixes: https://github.com/projectcalico/calico/issues/11856
Cherry-pick of https://github.com/projectcalico/calico/pull/11913