### PR TITLE
[v3.30] fix: advertise /32 LB IPs assigned from IPPool via BGP (CI-1944)

### DIFF
--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -364,6 +364,23 @@ func (rg *routeGenerator) isAllowedLoadBalancerIP(loadBalancerIP string) bool {
 	return false
 }
 
+// hasAnySingleLoadBalancerIP checks whether the service has any LoadBalancer IP
+// that matches a single-IP (/32 or /128) entry in serviceLoadBalancerIPs.
+// It checks both svc.Spec.LoadBalancerIP (deprecated but still used) and the
+// actual assigned IPs from svc.Status.LoadBalancer.Ingress, since IPs assigned
+// from a Calico IPPool only appear in status, not spec.
+func (rg *routeGenerator) hasAnySingleLoadBalancerIP(svc *v1.Service) bool {
+	if rg.isSingleLoadBalancerIP(svc.Spec.LoadBalancerIP) {
+		return true
+	}
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if rg.isSingleLoadBalancerIP(ingress.IP) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSingleLoadBalancerIP determines if the given IP is in the list of
 // allowed LoadBalancer CIDRs given in the default bgpconfiguration
 // and is a single IP entry (/32 for IPV4 or /128 for IPV6)
@@ -467,7 +484,7 @@ func (rg *routeGenerator) advertiseThisService(svc *v1.Service, ep *v1.Endpoints
 	// - LoadBalancer with a single IP.
 	// - Any one of the externalIPs are a single IP.
 	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
-		if svc.Spec.Type == v1.ServiceTypeLoadBalancer && rg.isSingleLoadBalancerIP(svc.Spec.LoadBalancerIP) {
+		if svc.Spec.Type == v1.ServiceTypeLoadBalancer && rg.hasAnySingleLoadBalancerIP(svc) {
 			logc.Debug("Advertising load balancer of type cluster because of single IP definition")
 			return true
 		}

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -650,6 +650,67 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey(key))
 			})
 
+
+			// This test reproduces the CI-1944 bug: when serviceLoadBalancerIPs has a /32 entry
+			// and the LB IP is assigned from an IPPool (so spec.loadBalancerIP is empty, IP only in
+			// status.loadBalancer.ingress), services with externalTrafficPolicy=Cluster should still
+			// be advertised per-service, since /32s are excluded from global aggregation.
+			It("should handle /32 routes for LoadBalancerIPs assigned from IPPool (status only, no spec.loadBalancerIP)", func() {
+				// Use a fresh LB IP that is not used by any other test service.
+				lbIP := "192.168.1.50"
+				key := "/calico/staticroutes/" + lbIP + "-32"
+
+				// Build a LoadBalancer service with Cluster traffic policy and NO spec.loadBalancerIP.
+				// The IP appears only in status.loadBalancer.ingress, as is typical for IPPool allocation.
+				lbSvcMeta := metav1.ObjectMeta{Namespace: "foo", Name: "lb-cluster"}
+				lbSvc := &v1.Service{
+					ObjectMeta: lbSvcMeta,
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ClusterIP:             "127.0.0.20",
+						ClusterIPs:            []string{"127.0.0.20"},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+						// LoadBalancerIP intentionally NOT set.
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{IP: lbIP}},
+						},
+					},
+				}
+				lbEp := &v1.Endpoints{
+					ObjectMeta: lbSvcMeta,
+				}
+				addEndpointSubset(lbEp, rg.nodeName)
+
+				// Configure a /32 serviceLoadBalancerIPs entry matching the service's LB IP.
+				lbIPRange := fmt.Sprintf("%s/32", lbIP)
+				By("onLoadBalancerIPsUpdate to include /32 route")
+				rg.client.onLoadBalancerIPsUpdate([]string{lbIPRange})
+
+				// No routes should be advertised yet (no service registered).
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache[key]).To(Equal(""))
+
+				// Add the service and endpoint.
+				err := rg.epIndexer.Add(lbEp)
+				Expect(err).NotTo(HaveOccurred())
+				err = rg.svcIndexer.Add(lbSvc)
+				Expect(err).NotTo(HaveOccurred())
+
+				// The /32 route should now be advertised from the per-service path.
+				By("Resyncing routes after adding service")
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache[key]).To(Equal(lbIP + "/32"))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
+
+				// Remove BGPConfiguration and verify route is withdrawn.
+				rg.client.onLoadBalancerIPsUpdate([]string{})
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache).NotTo(HaveKey(key))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey(key))
+			})
+
 			// This test simulates a situation where BGPConfiguration has a /32 route that exactly matches
 			// externalIP of a LoadBalancer service with ExternalTrafficPolicy set to Local. The route should only be advertised
 			// when the Service is created, and not when the BGPConfiguration is created.


### PR DESCRIPTION
Cherry-pick of #11917 to release-v3.30.

When serviceLoadBalancerIPs contains a /32 entry and the LB IP is assigned from a
Calico IPPool, the IP only appears in `svc.Status.LoadBalancer.Ingress` -- not in
`svc.Spec.LoadBalancerIP`. The old code only checked the spec field, so these services
were never advertised via BGP.

Adds `hasAnySingleLoadBalancerIP()` which checks both spec and status ingress IPs
against the configured /32 and /128 entries.

Tests adapted for v3.30's `v1.Endpoints` API (no EndpointSlice on this branch).