### PR TITLE
[v3.31] Use indexer for EndpointSlice lookups to avoid O(n) scans in confd

### DIFF
--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -147,7 +147,7 @@ var _ = Describe("RouteGenerator", func() {
 		rg = &routeGenerator{
 			nodeName:                   "foobar",
 			svcIndexer:                 cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			epIndexer:                  cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			epIndexer:                  cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{endpointSliceServiceIndex: endpointSliceServiceIndexFunc}),
 			svcRouteMap:                make(map[string]map[string]bool),
 			routeAdvertisementRefCount: make(map[string]int),
 			client: &client{


### PR DESCRIPTION

Cherry-pick of #11838 to release-v3.31.

Bug fix: Use a cache indexer for EndpointSlice lookups in confd's route generator to avoid O(n) full scans.

The k8s 1.33 bump (#10715, 0e18c27633) migrated confd from the deprecated `v1.Endpoints` API to `discovery/v1.EndpointSlice`. Since a single Service can have multiple EndpointSlices, `getEndpointsForService` was changed to iterate all EndpointSlices via `List()` and filter by label. This works correctly but is O(n) in the total number of EndpointSlices across all services.

This PR adds a `svcKey` indexer on EndpointSlices keyed by `namespace/serviceName` and uses `ByIndex` for O(1) lookups.

Changes:
- **`confd/pkg/backends/calico/routes.go`**: Add `endpointSliceServiceIndex` indexer function, register it in the EndpointSlice informer, and rewrite `getEndpointsForService` to use `ByIndex()`
- **`confd/pkg/backends/calico/routes_test.go`**: Register the indexer in test setup to match production initialization


<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Use indexer for EndpointSlice lookups to avoid O(n) scans in confd
```
