### PR TITLE
[WIP]Refactor BGPFilter generations for bird config

### DIFF
--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -79,9 +79,33 @@ template bgp bgp_template {
 }
 
 # -------------- BGP Filters ------------------
-{{- range $line := bgpFilterBIRDFuncs (gets "/resources/v3/projectcalico.org/bgpfilters/*") 4 }}
-{{ $line }}
-{{- end }}
+{{- range $config.FilterFuncs}}
+# v4 BGPFilter {{.Name}}
+{{- if .ImportFunc}}
+function {{.ImportFunc.FuncName}}() {
+{{- range .ImportFunc.Rules}}
+{{- $cond := conditionJoin .MatchCIDR .MatchSource .MatchInterface}}
+{{- if $cond}}
+  if ({{$cond}}) then { {{.Action}}; }
+{{- else}}
+  {{.Action}};
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- if .ExportFunc}}
+function {{.ExportFunc.FuncName}}() {
+{{- range .ExportFunc.Rules}}
+{{- $cond := conditionJoin .MatchCIDR .MatchSource .MatchInterface}}
+{{- if $cond}}
+  if ({{$cond}}) then { {{.Action}}; }
+{{- else}}
+  {{.Action}};
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- end}}
 
 {{- if $config.Peers}}
 # BGP Protocol Configurations

--- a/confd/etc/calico/confd/templates/bird6.cfg.template
+++ b/confd/etc/calico/confd/templates/bird6.cfg.template
@@ -78,9 +78,33 @@ template bgp bgp_template {
 }
 
 # -------------- BGP Filters ------------------
-{{- range $line := bgpFilterBIRDFuncs (gets "/resources/v3/projectcalico.org/bgpfilters/*") 6 }}
-{{ $line }}
-{{- end }}
+{{- range $config.FilterFuncs}}
+# v6 BGPFilter {{.Name}}
+{{- if .ImportFunc}}
+function {{.ImportFunc.FuncName}}() {
+{{- range .ImportFunc.Rules}}
+{{- $cond := conditionJoin .MatchCIDR .MatchSource .MatchInterface}}
+{{- if $cond}}
+  if ({{$cond}}) then { {{.Action}}; }
+{{- else}}
+  {{.Action}};
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- if .ExportFunc}}
+function {{.ExportFunc.FuncName}}() {
+{{- range .ExportFunc.Rules}}
+{{- $cond := conditionJoin .MatchCIDR .MatchSource .MatchInterface}}
+{{- if $cond}}
+  if ({{$cond}}) then { {{.Action}}; }
+{{- else}}
+  {{.Action}};
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- end}}
 
 {{- if $config.Peers}}
 # BGP Protocol Configurations

--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"slices"
 	"sort"
 	"strings"
@@ -109,6 +110,13 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 		"numOfRejectedFiltersForBGPExport": len(config.BGPExportFilterForDisabledIPPools),
 		"numOfAcceptedFiltersForBGPExport": len(config.BGPExportFilterForEnabledIPPools),
 	}).Debug("Processed ippools")
+
+	// Process BGP filter function definitions
+	if err := c.processFilterFuncs(config, ipVersion); err != nil {
+		logc.WithError(err).Warn("Failed to process BGP filter functions")
+		return nil, err
+	}
+	logc.Debugf("Processed BGP filter functions: found %d filter groups", len(config.FilterFuncs))
 
 	// Update cache with write lock
 	configCacheMutex.Lock()
@@ -789,6 +797,179 @@ func (c *client) processIPPools(config *types.BirdBGPConfig, ipVersion int) erro
 	slices.Sort(config.BGPExportFilterForEnabledIPPools)
 
 	return nil
+}
+
+// processFilterFuncs processes BGPFilter resources into structured BirdBGPFilterGroup entries
+// for template rendering.
+func (c *client) processFilterFuncs(config *types.BirdBGPConfig, ipVersion int) error {
+	logc := log.WithField("ipVersion", ipVersion)
+
+	filterPath := "/calico/resources/v3/projectcalico.org/bgpfilters"
+	kvPairs, err := c.GetValues([]string{filterPath})
+	if err != nil {
+		logc.WithError(err).Debug("No BGP filters found or error retrieving them")
+		return nil
+	}
+
+	versionStr := fmt.Sprintf("%d", ipVersion)
+
+	// Collect filter names for sorted iteration
+	var filterKeys []string
+	for key := range kvPairs {
+		filterKeys = append(filterKeys, key)
+	}
+	sort.Strings(filterKeys)
+
+	for _, key := range filterKeys {
+		value := kvPairs[key]
+		var filter v3.BGPFilter
+		if err := json.Unmarshal([]byte(value), &filter); err != nil {
+			logc.WithError(err).Warnf("Failed to unmarshal BGPFilter for key %s", key)
+			continue
+		}
+
+		filterName := path.Base(key)
+
+		var importRules []v3.BGPFilterRuleV4
+		var importRulesV6 []v3.BGPFilterRuleV6
+		var exportRules []v3.BGPFilterRuleV4
+		var exportRulesV6 []v3.BGPFilterRuleV6
+
+		if ipVersion == 4 {
+			importRules = filter.Spec.ImportV4
+			exportRules = filter.Spec.ExportV4
+		} else {
+			importRulesV6 = filter.Spec.ImportV6
+			exportRulesV6 = filter.Spec.ExportV6
+		}
+
+		hasImport := len(importRules) > 0 || len(importRulesV6) > 0
+		hasExport := len(exportRules) > 0 || len(exportRulesV6) > 0
+
+		if !hasImport && !hasExport {
+			continue
+		}
+
+		group := types.BirdBGPFilterGroup{
+			Name: filterName,
+		}
+
+		if hasImport {
+			funcName, err := template.BGPFilterFunctionName(filterName, "import", versionStr)
+			if err != nil {
+				return err
+			}
+			var rules []types.BirdBGPFilterRule
+			if ipVersion == 4 {
+				rules, err = buildFilterRulesV4(importRules)
+			} else {
+				rules, err = buildFilterRulesV6(importRulesV6)
+			}
+			if err != nil {
+				return err
+			}
+			group.ImportFunc = &types.BirdBGPFilterFunc{
+				FuncName: funcName,
+				Rules:    rules,
+			}
+		}
+
+		if hasExport {
+			funcName, err := template.BGPFilterFunctionName(filterName, "export", versionStr)
+			if err != nil {
+				return err
+			}
+			var rules []types.BirdBGPFilterRule
+			if ipVersion == 4 {
+				rules, err = buildFilterRulesV4(exportRules)
+			} else {
+				rules, err = buildFilterRulesV6(exportRulesV6)
+			}
+			if err != nil {
+				return err
+			}
+			group.ExportFunc = &types.BirdBGPFilterFunc{
+				FuncName: funcName,
+				Rules:    rules,
+			}
+		}
+
+		config.FilterFuncs = append(config.FilterFuncs, group)
+	}
+
+	return nil
+}
+
+// buildFilterRulesV4 converts v3 BGPFilterRuleV4 slices into BirdBGPFilterRule slices.
+func buildFilterRulesV4(rules []v3.BGPFilterRuleV4) ([]types.BirdBGPFilterRule, error) {
+	result := make([]types.BirdBGPFilterRule, 0, len(rules))
+	for _, r := range rules {
+		rule := types.BirdBGPFilterRule{
+			Action: strings.ToLower(string(r.Action)),
+		}
+		if r.CIDR != "" {
+			if r.MatchOperator == "" {
+				return nil, fmt.Errorf("operator not included in BGPFilter")
+			}
+			cidr, err := template.FilterMatchCIDR(r.CIDR, r.PrefixLength, nil, r.MatchOperator)
+			if err != nil {
+				return nil, err
+			}
+			rule.MatchCIDR = cidr
+		}
+		if r.Source != "" {
+			source, err := template.FilterMatchSource(r.Source)
+			if err != nil {
+				return nil, err
+			}
+			rule.MatchSource = source
+		}
+		if r.Interface != "" {
+			iface, err := template.FilterMatchInterface(r.Interface)
+			if err != nil {
+				return nil, err
+			}
+			rule.MatchInterface = iface
+		}
+		result = append(result, rule)
+	}
+	return result, nil
+}
+
+// buildFilterRulesV6 converts v3 BGPFilterRuleV6 slices into BirdBGPFilterRule slices.
+func buildFilterRulesV6(rules []v3.BGPFilterRuleV6) ([]types.BirdBGPFilterRule, error) {
+	result := make([]types.BirdBGPFilterRule, 0, len(rules))
+	for _, r := range rules {
+		rule := types.BirdBGPFilterRule{
+			Action: strings.ToLower(string(r.Action)),
+		}
+		if r.CIDR != "" {
+			if r.MatchOperator == "" {
+				return nil, fmt.Errorf("operator not included in BGPFilter")
+			}
+			cidr, err := template.FilterMatchCIDR(r.CIDR, nil, r.PrefixLength, r.MatchOperator)
+			if err != nil {
+				return nil, err
+			}
+			rule.MatchCIDR = cidr
+		}
+		if r.Source != "" {
+			source, err := template.FilterMatchSource(r.Source)
+			if err != nil {
+				return nil, err
+			}
+			rule.MatchSource = source
+		}
+		if r.Interface != "" {
+			iface, err := template.FilterMatchInterface(r.Interface)
+			if err != nil {
+				return nil, err
+			}
+			rule.MatchInterface = iface
+		}
+		result = append(result, rule)
+	}
+	return result, nil
 }
 
 // This function generates BIRD statements for an IPPool to be used as BIRD filters based on the following input:

--- a/confd/pkg/backends/calico/bgp_processor_test.go
+++ b/confd/pkg/backends/calico/bgp_processor_test.go
@@ -2318,3 +2318,223 @@ func TestConfigCache_ConcurrentReadWrite(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestProcessFilterFuncs_NoFilters(t *testing.T) {
+	c := newTestClient(map[string]string{}, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 4)
+	require.NoError(t, err)
+	assert.Empty(t, config.FilterFuncs)
+}
+
+func TestProcessFilterFuncs_ImportAndExport(t *testing.T) {
+	bgpFilter := map[string]any{
+		"spec": map[string]any{
+			"importV4": []any{
+				map[string]any{
+					"action":        "Accept",
+					"matchOperator": "In",
+					"cidr":          "10.0.0.0/8",
+				},
+			},
+			"exportV4": []any{
+				map[string]any{
+					"action":        "Reject",
+					"matchOperator": "In",
+					"cidr":          "77.0.0.0/16",
+				},
+			},
+		},
+	}
+	bgpFilterJSON, _ := json.Marshal(bgpFilter)
+
+	cache := map[string]string{
+		"/calico/resources/v3/projectcalico.org/bgpfilters/my-filter": string(bgpFilterJSON),
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 4)
+	require.NoError(t, err)
+	require.Len(t, config.FilterFuncs, 1)
+
+	group := config.FilterFuncs[0]
+	assert.Equal(t, "my-filter", group.Name)
+
+	require.NotNil(t, group.ImportFunc)
+	importFuncName, _ := template.BGPFilterFunctionName("my-filter", "import", "4")
+	assert.Equal(t, importFuncName, group.ImportFunc.FuncName)
+	require.Len(t, group.ImportFunc.Rules, 1)
+	assert.Equal(t, "accept", group.ImportFunc.Rules[0].Action)
+	assert.Equal(t, "(net ~ 10.0.0.0/8)", group.ImportFunc.Rules[0].MatchCIDR)
+
+	require.NotNil(t, group.ExportFunc)
+	exportFuncName, _ := template.BGPFilterFunctionName("my-filter", "export", "4")
+	assert.Equal(t, exportFuncName, group.ExportFunc.FuncName)
+	require.Len(t, group.ExportFunc.Rules, 1)
+	assert.Equal(t, "reject", group.ExportFunc.Rules[0].Action)
+	assert.Equal(t, "(net ~ 77.0.0.0/16)", group.ExportFunc.Rules[0].MatchCIDR)
+}
+
+func TestProcessFilterFuncs_AllMatchTypes(t *testing.T) {
+	bgpFilter := map[string]any{
+		"spec": map[string]any{
+			"importV4": []any{
+				map[string]any{
+					"action":        "Accept",
+					"matchOperator": "NotIn",
+					"cidr":          "55.4.0.0/16",
+					"source":        "RemotePeers",
+					"interface":     "vxlan.calico",
+				},
+			},
+		},
+	}
+	bgpFilterJSON, _ := json.Marshal(bgpFilter)
+
+	cache := map[string]string{
+		"/calico/resources/v3/projectcalico.org/bgpfilters/combo-filter": string(bgpFilterJSON),
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 4)
+	require.NoError(t, err)
+	require.Len(t, config.FilterFuncs, 1)
+
+	rule := config.FilterFuncs[0].ImportFunc.Rules[0]
+	assert.Equal(t, "accept", rule.Action)
+	assert.Equal(t, "(net !~ 55.4.0.0/16)", rule.MatchCIDR)
+	assert.Equal(t, "((defined(source))&&(source ~ [ RTS_BGP ]))", rule.MatchSource)
+	assert.Equal(t, `((defined(ifname))&&(ifname ~ "vxlan.calico"))`, rule.MatchInterface)
+}
+
+func TestProcessFilterFuncs_NoConditions(t *testing.T) {
+	bgpFilter := map[string]any{
+		"spec": map[string]any{
+			"exportV4": []any{
+				map[string]any{
+					"action": "Reject",
+				},
+			},
+		},
+	}
+	bgpFilterJSON, _ := json.Marshal(bgpFilter)
+
+	cache := map[string]string{
+		"/calico/resources/v3/projectcalico.org/bgpfilters/action-only": string(bgpFilterJSON),
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 4)
+	require.NoError(t, err)
+	require.Len(t, config.FilterFuncs, 1)
+
+	rule := config.FilterFuncs[0].ExportFunc.Rules[0]
+	assert.Equal(t, "reject", rule.Action)
+	assert.Empty(t, rule.MatchCIDR)
+	assert.Empty(t, rule.MatchSource)
+	assert.Empty(t, rule.MatchInterface)
+}
+
+func TestProcessFilterFuncs_MultipleFilters_Sorted(t *testing.T) {
+	filterA := map[string]any{
+		"spec": map[string]any{
+			"importV4": []any{
+				map[string]any{"action": "Accept", "matchOperator": "In", "cidr": "10.0.0.0/8"},
+			},
+		},
+	}
+	filterB := map[string]any{
+		"spec": map[string]any{
+			"importV4": []any{
+				map[string]any{"action": "Reject", "matchOperator": "In", "cidr": "20.0.0.0/8"},
+			},
+		},
+	}
+	filterAJSON, _ := json.Marshal(filterA)
+	filterBJSON, _ := json.Marshal(filterB)
+
+	cache := map[string]string{
+		"/calico/resources/v3/projectcalico.org/bgpfilters/z-filter": string(filterAJSON),
+		"/calico/resources/v3/projectcalico.org/bgpfilters/a-filter": string(filterBJSON),
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 4)
+	require.NoError(t, err)
+	require.Len(t, config.FilterFuncs, 2)
+
+	// Should be sorted by name
+	assert.Equal(t, "a-filter", config.FilterFuncs[0].Name)
+	assert.Equal(t, "z-filter", config.FilterFuncs[1].Name)
+}
+
+func TestProcessFilterFuncs_V6(t *testing.T) {
+	bgpFilter := map[string]any{
+		"spec": map[string]any{
+			"importV4": []any{
+				map[string]any{"action": "Accept", "matchOperator": "In", "cidr": "10.0.0.0/8"},
+			},
+			"importV6": []any{
+				map[string]any{"action": "Reject", "matchOperator": "In", "cidr": "5000::0/64"},
+			},
+		},
+	}
+	bgpFilterJSON, _ := json.Marshal(bgpFilter)
+
+	cache := map[string]string{
+		"/calico/resources/v3/projectcalico.org/bgpfilters/dual-filter": string(bgpFilterJSON),
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 6)
+	require.NoError(t, err)
+	require.Len(t, config.FilterFuncs, 1)
+
+	// Should only have V6 rules
+	group := config.FilterFuncs[0]
+	require.NotNil(t, group.ImportFunc)
+	assert.Contains(t, group.ImportFunc.FuncName, "importFilterV6")
+	require.Len(t, group.ImportFunc.Rules, 1)
+	assert.Equal(t, "(net ~ 5000::0/64)", group.ImportFunc.Rules[0].MatchCIDR)
+
+	// No export func since only importV6 has rules
+	assert.Nil(t, group.ExportFunc)
+}
+
+func TestProcessFilterFuncs_PrefixLength(t *testing.T) {
+	min := int32(16)
+	max := int32(24)
+	bgpFilter := map[string]any{
+		"spec": map[string]any{
+			"importV4": []any{
+				map[string]any{
+					"action":        "Reject",
+					"matchOperator": "NotIn",
+					"cidr":          "55.4.0.0/16",
+					"source":        "RemotePeers",
+					"prefixLength":  map[string]any{"min": min, "max": max},
+				},
+			},
+		},
+	}
+	bgpFilterJSON, _ := json.Marshal(bgpFilter)
+
+	cache := map[string]string{
+		"/calico/resources/v3/projectcalico.org/bgpfilters/prefix-filter": string(bgpFilterJSON),
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{}
+	err := c.processFilterFuncs(config, 4)
+	require.NoError(t, err)
+	require.Len(t, config.FilterFuncs, 1)
+
+	rule := config.FilterFuncs[0].ImportFunc.Rules[0]
+	assert.Equal(t, "(net !~ [ 55.4.0.0/16{16,24} ])", rule.MatchCIDR)
+	assert.Equal(t, "((defined(source))&&(source ~ [ RTS_BGP ]))", rule.MatchSource)
+}

--- a/confd/pkg/backends/types/bird_bgp_config.go
+++ b/confd/pkg/backends/types/bird_bgp_config.go
@@ -22,6 +22,7 @@ type BirdBGPConfig struct {
 	ASNumber         string
 	RouterID         string
 	Peers            []BirdBGPPeer
+	FilterFuncs      []BirdBGPFilterGroup
 	Filters          map[string]string
 	Communities      []CommunityRule
 	LogLevel         string
@@ -57,6 +58,29 @@ type BirdBGPPeer struct {
 	GracefulRestart string // restart time value
 	KeepaliveTime   string
 	NumAllowLocalAs string
+}
+
+// BirdBGPFilterGroup represents all BIRD filter functions from a single BGPFilter resource.
+type BirdBGPFilterGroup struct {
+	Name       string             // Filter resource name (used in comment)
+	ImportFunc *BirdBGPFilterFunc // nil if no import rules
+	ExportFunc *BirdBGPFilterFunc // nil if no export rules
+}
+
+// BirdBGPFilterFunc represents a single BIRD filter function definition,
+// e.g. function 'bgp_myfilter_importFilterV4'() { ... }
+type BirdBGPFilterFunc struct {
+	FuncName string              // Full BIRD function name, e.g. "'bgp_myfilter_importFilterV4'"
+	Rules    []BirdBGPFilterRule // Ordered list of filter rules
+}
+
+// BirdBGPFilterRule represents one rule within a BIRD filter function.
+// Match fields are pre-formatted BIRD condition strings; empty means no condition.
+type BirdBGPFilterRule struct {
+	Action         string // "accept" or "reject"
+	MatchCIDR      string // e.g. "(net ~ 10.0.0.0/8)"
+	MatchSource    string // e.g. "((defined(source))&&(source ~ [ RTS_BGP ]))"
+	MatchInterface string // e.g. "((defined(ifname))&&(ifname ~ \"eth0\"))"
 }
 
 // CommunityRule represents BGP community application rules

--- a/confd/pkg/resource/template/template_funcs.go
+++ b/confd/pkg/resource/template/template_funcs.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kelseyhightower/memkv"
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/confd/pkg/backends"
@@ -38,7 +37,7 @@ func newFuncMap() map[string]any {
 	m["fileExists"] = isFileExist
 	m["base64Encode"] = Base64Encode
 	m["base64Decode"] = Base64Decode
-	m["bgpFilterBIRDFuncs"] = BGPFilterBIRDFuncs
+	m["conditionJoin"] = ConditionJoin
 	return m
 }
 
@@ -62,57 +61,6 @@ func addCalicoFuncs(funcMap map[string]any) {
 	}
 }
 
-// filterStatement produces a single comparison expression to be used within a multi-statement BIRD filter
-// function.
-// e.g input of ("In", "77.0.0.1/16", "accept") produces output of "if ((net ~ 77.0.0.1/16)) then { accept; }"
-func filterStatement(fields filterArgs) (string, error) {
-	actionStatement, err := filterAction(fields.action)
-	if err != nil {
-		return "", err
-	}
-
-	var conditions []string
-	if fields.cidr != "" {
-		if fields.operator == "" {
-			return "", fmt.Errorf("operator not included in BGPFilter")
-		}
-		cidrCondition, err := filterMatchCIDR(fields.cidr, fields.prefixLengthV4, fields.prefixLengthV6, fields.operator)
-		if err != nil {
-			return "", err
-		}
-		conditions = append(conditions, cidrCondition)
-	}
-
-	if fields.source != "" {
-		sourceCondition, err := filterMatchSource(fields.source)
-		if err != nil {
-			return "", nil
-		}
-		conditions = append(conditions, sourceCondition)
-	}
-
-	if fields.iface != "" {
-		ifaceCondition, err := filterMatchInterface(fields.iface)
-		if err != nil {
-			return "", nil
-		}
-		conditions = append(conditions, ifaceCondition)
-	}
-
-	conditionExpr := strings.Join(conditions, "&&")
-	if conditionExpr != "" {
-		return fmt.Sprintf("if (%s) then { %s }", conditionExpr, actionStatement), nil
-	}
-	return actionStatement, nil
-}
-
-func filterAction(action v3.BGPFilterAction) (string, error) {
-	if action != v3.Accept && action != v3.Reject {
-		return "", fmt.Errorf("unexpected action found in BGPFilter: %s", action)
-	}
-	return fmt.Sprintf("%s;", strings.ToLower(string(action))), nil
-}
-
 var (
 	operatorLUT = map[v3.BGPFilterMatchOperator]string{
 		v3.Equal:    "=",
@@ -122,7 +70,7 @@ var (
 	}
 )
 
-func filterMatchPrefixLength(cidr string, prefixMin, prefixMax *int32) (string, error) {
+func FilterMatchPrefixLength(cidr string, prefixMin, prefixMax *int32) (string, error) {
 	cidrIP, cidrNet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return "", fmt.Errorf("unexpected error when parsing cidr %s: %s", cidr, err)
@@ -148,7 +96,7 @@ func filterMatchPrefixLength(cidr string, prefixMin, prefixMax *int32) (string, 
 	return fmt.Sprintf("[ %s{%d,%d} ]", cidr, minLength, maxLength), nil
 }
 
-func filterMatchCIDR(cidr string, prefixLengthV4 *v3.BGPFilterPrefixLengthV4, prefixLengthV6 *v3.BGPFilterPrefixLengthV6, operator v3.BGPFilterMatchOperator) (string, error) {
+func FilterMatchCIDR(cidr string, prefixLengthV4 *v3.BGPFilterPrefixLengthV4, prefixLengthV6 *v3.BGPFilterPrefixLengthV6, operator v3.BGPFilterMatchOperator) (string, error) {
 	op, ok := operatorLUT[operator]
 	if !ok {
 		return "", fmt.Errorf("unexpected operator found in BGPFilter: %s", operator)
@@ -156,9 +104,9 @@ func filterMatchCIDR(cidr string, prefixLengthV4 *v3.BGPFilterPrefixLengthV4, pr
 
 	var err error
 	if prefixLengthV4 != nil {
-		cidr, err = filterMatchPrefixLength(cidr, prefixLengthV4.Min, prefixLengthV4.Max)
+		cidr, err = FilterMatchPrefixLength(cidr, prefixLengthV4.Min, prefixLengthV4.Max)
 	} else if prefixLengthV6 != nil {
-		cidr, err = filterMatchPrefixLength(cidr, prefixLengthV6.Min, prefixLengthV6.Max)
+		cidr, err = FilterMatchPrefixLength(cidr, prefixLengthV6.Min, prefixLengthV6.Max)
 	}
 
 	if err != nil {
@@ -168,7 +116,7 @@ func filterMatchCIDR(cidr string, prefixLengthV4 *v3.BGPFilterPrefixLengthV4, pr
 	return fmt.Sprintf("(net %s %s)", op, cidr), nil
 }
 
-func filterMatchSource(source v3.BGPFilterMatchSource) (string, error) {
+func FilterMatchSource(source v3.BGPFilterMatchSource) (string, error) {
 	switch source {
 	case v3.BGPFilterSourceRemotePeers:
 		return "((defined(source))&&(source ~ [ RTS_BGP ]))", nil
@@ -177,11 +125,22 @@ func filterMatchSource(source v3.BGPFilterMatchSource) (string, error) {
 	}
 }
 
-func filterMatchInterface(iface string) (string, error) {
+func FilterMatchInterface(iface string) (string, error) {
 	if iface == "" {
 		return "", fmt.Errorf("empty interface found in BGPFilter")
 	}
 	return fmt.Sprintf("((defined(ifname))&&(ifname ~ \"%s\"))", iface), nil
+}
+
+// ConditionJoin joins non-empty condition strings with "&&" for use in BIRD filter expressions.
+func ConditionJoin(conditions ...string) string {
+	var nonEmpty []string
+	for _, c := range conditions {
+		if c != "" {
+			nonEmpty = append(nonEmpty, c)
+		}
+	}
+	return strings.Join(nonEmpty, "&&")
 }
 
 // BGPFilterFunctionName returns a formatted name for use as a BIRD function, truncating and hashing if the provided
@@ -201,203 +160,6 @@ func BGPFilterFunctionName(filterName, direction, version string) (string, error
 	pieces[1] = resizedName
 	fullName := strings.Join(pieces, "")
 	return fmt.Sprintf("'%s'", fullName), nil
-}
-
-type filterArgs struct {
-	operator       v3.BGPFilterMatchOperator
-	cidr           string
-	prefixLengthV4 *v3.BGPFilterPrefixLengthV4
-	prefixLengthV6 *v3.BGPFilterPrefixLengthV6
-	source         v3.BGPFilterMatchSource
-	iface          string
-	action         v3.BGPFilterAction
-}
-
-// BGPFilterBIRDFuncs generates a set of BIRD functions for BGPFilter resources that have been packaged into KVPairs.
-// By doing the formatting inside of this function we eliminate the need to copy and paste repeated blocks of golang
-// template code into our BIRD config templates that is both difficult to read and prone to errors
-//
-// e.g. for a BGPFilter resource specified as follows:
-//
-// kind: BGPFilter
-// apiVersion: projectcalico.org/v3
-// metadata:
-//
-//	name: test-bgpfilter
-//
-// spec:
-//
-//	exportV4:
-//	  - action: Accept
-//	    matchOperator: In
-//	    cidr: 77.0.0.0/16
-//	  - action: Reject
-//	    matchOperator: In
-//	    cidr: 77.1.0.0/16
-//	importV4:
-//	  - action: Accept
-//	    matchOperator: In
-//	    cidr: 44.0.0.0/16
-//	  - action: Reject
-//	    matchOperator: In
-//	    cidr: 44.1.0.0/16
-//
-// Would produce the following string array that can be easily output via BIRD config template:
-//
-//	[]string{
-//	  "# v4 BGPFilter test-bgpfilter",
-//	  "function 'bgp_test-bgpfilter_importFilterV4'() {",
-//	  "  if ((net ~ 44.0.0.0/16)) then { accept; }",
-//	  "  if ((net ~ 44.1.0.0/16)) then { reject; }",
-//	  "}",
-//	  "function 'bgp_test-bgpfilter_exportFilterV4'() {",
-//	  "  if ((net ~ 77.0.0.0/16)) then { accept; }",
-//	  "  if ((net ~ 77.1.0.0/16)) then { reject; }",
-//	  "}",
-//	 }
-func BGPFilterBIRDFuncs(pairs memkv.KVPairs, version int) ([]string, error) {
-	lines := []string{}
-	var line string
-	var versionStr string
-
-	if version == 4 || version == 6 {
-		versionStr = fmt.Sprintf("%d", version)
-	} else {
-		return []string{}, fmt.Errorf("version must be either 4 or 6")
-	}
-
-	for _, kvp := range pairs {
-		var filter v3.BGPFilter
-		err := json.Unmarshal([]byte(kvp.Value), &filter)
-		if err != nil {
-			return []string{}, fmt.Errorf("error unmarshalling JSON: %s", err)
-		}
-
-		importFiltersV4 := filter.Spec.ImportV4
-		exportFiltersV4 := filter.Spec.ExportV4
-		importFiltersV6 := filter.Spec.ImportV6
-		exportFiltersV6 := filter.Spec.ExportV6
-
-		var filterName string
-		var emitImports bool
-		var emitExports bool
-		v4Selected := version == 4
-
-		if v4Selected {
-			emitImports = len(importFiltersV4) > 0
-			emitExports = len(exportFiltersV4) > 0
-		} else {
-			emitImports = len(importFiltersV6) > 0
-			emitExports = len(exportFiltersV6) > 0
-		}
-
-		if emitImports || emitExports {
-			filterName = path.Base(kvp.Key)
-			line = fmt.Sprintf("# v%s BGPFilter %s", versionStr, filterName)
-			lines = append(lines, line)
-		}
-
-		var filterFuncName string
-		var filterRule string
-		if emitImports {
-			filterFuncName, err = BGPFilterFunctionName(filterName, "import", versionStr)
-			if err != nil {
-				return []string{}, err
-			}
-			line = fmt.Sprintf("function %s() {", filterFuncName)
-			lines = append(lines, line)
-
-			var ruleFields []filterArgs
-
-			if v4Selected {
-				for _, importV4 := range importFiltersV4 {
-					ruleFields = append(ruleFields, filterArgs{
-						operator:       importV4.MatchOperator,
-						cidr:           importV4.CIDR,
-						prefixLengthV4: importV4.PrefixLength,
-						source:         importV4.Source,
-						iface:          importV4.Interface,
-						action:         importV4.Action,
-					})
-				}
-			} else {
-				for _, importV6 := range importFiltersV6 {
-					ruleFields = append(ruleFields, filterArgs{
-						operator:       importV6.MatchOperator,
-						cidr:           importV6.CIDR,
-						prefixLengthV6: importV6.PrefixLength,
-						source:         importV6.Source,
-						iface:          importV6.Interface,
-						action:         importV6.Action,
-					})
-				}
-			}
-
-			for _, fields := range ruleFields {
-				filterRule, err = filterStatement(fields)
-				if err != nil {
-					return []string{}, err
-				}
-				line = fmt.Sprintf("  %s", filterRule)
-				lines = append(lines, line)
-			}
-
-			line = "}"
-			lines = append(lines, line)
-		}
-
-		if emitExports {
-			filterFuncName, err = BGPFilterFunctionName(filterName, "export", versionStr)
-			if err != nil {
-				return []string{}, err
-			}
-			line = fmt.Sprintf("function %s() {", filterFuncName)
-			lines = append(lines, line)
-
-			var ruleFields []filterArgs
-
-			if v4Selected {
-				for _, exportV4 := range exportFiltersV4 {
-					ruleFields = append(ruleFields, filterArgs{
-						operator:       exportV4.MatchOperator,
-						cidr:           exportV4.CIDR,
-						prefixLengthV4: exportV4.PrefixLength,
-						source:         exportV4.Source,
-						iface:          exportV4.Interface,
-						action:         exportV4.Action,
-					})
-				}
-			} else {
-				for _, exportV6 := range exportFiltersV6 {
-					ruleFields = append(ruleFields, filterArgs{
-						operator:       exportV6.MatchOperator,
-						cidr:           exportV6.CIDR,
-						prefixLengthV6: exportV6.PrefixLength,
-						source:         exportV6.Source,
-						iface:          exportV6.Interface,
-						action:         exportV6.Action,
-					})
-				}
-			}
-
-			for _, fields := range ruleFields {
-				filterRule, err = filterStatement(fields)
-				if err != nil {
-					return []string{}, err
-				}
-				line = fmt.Sprintf("  %s", filterRule)
-				lines = append(lines, line)
-			}
-
-			line = "}"
-			lines = append(lines, line)
-		}
-	}
-	if len(lines) == 0 {
-		line = fmt.Sprintf("# No v%s BGPFilters configured", versionStr)
-		lines = append(lines, line)
-	}
-	return lines, nil
 }
 
 // CreateMap creates a key-value map of string -> interface{}

--- a/confd/pkg/resource/template/template_funcs_test.go
+++ b/confd/pkg/resource/template/template_funcs_test.go
@@ -1,12 +1,7 @@
 package template
 
 import (
-	"encoding/json"
-	"reflect"
 	"testing"
-
-	"github.com/kelseyhightower/memkv"
-	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 )
 
 func Test_hashToIPv4_invalid_range(t *testing.T) {
@@ -58,139 +53,6 @@ func Test_bgpFilterFunctionName(t *testing.T) {
 	}
 }
 
-func Test_BGPFilterBIRDFuncs(t *testing.T) {
-	testFilter := v3.BGPFilter{}
-	testFilter.Name = "test-bgpfilter"
-	testFilter.Spec = v3.BGPFilterSpec{
-		ImportV4: []v3.BGPFilterRuleV4{
-			{Action: "Accept", Source: "RemotePeers", Interface: "vxlan.calico", MatchOperator: "NotIn", CIDR: "55.4.0.0/16"},
-			{Action: "Reject", Source: "RemotePeers", MatchOperator: "NotIn", CIDR: "55.4.0.0/16"},
-			{Action: "Reject", Source: "RemotePeers", MatchOperator: "NotIn", CIDR: "55.4.0.0/16", PrefixLength: &v3.BGPFilterPrefixLengthV4{Min: int32Helper(16), Max: int32Helper(24)}},
-			{Action: "Reject", Interface: "eth0", MatchOperator: "NotIn", CIDR: "55.4.0.0/16"},
-			{Action: "Accept", Interface: "eth0", Source: "RemotePeers"},
-			{Action: "Reject", Interface: "eth0", Source: "RemotePeers", PrefixLength: &v3.BGPFilterPrefixLengthV4{Min: int32Helper(16), Max: int32Helper(24)}},
-			{Action: "Reject", MatchOperator: "Equal", CIDR: "44.4.0.0/16"},
-			{Action: "Accept", Source: "RemotePeers"},
-			{Action: "Reject", Interface: "extraiface"},
-			{Action: "Reject"},
-		},
-		ExportV4: []v3.BGPFilterRuleV4{
-			{Action: "Reject", Source: "RemotePeers", Interface: "vxlan.calico", MatchOperator: "NotIn", CIDR: "55.4.0.0/16"},
-			{Action: "Reject", Source: "RemotePeers", MatchOperator: "NotIn", CIDR: "88.7.0.0/16"},
-			{Action: "Reject", Source: "RemotePeers", MatchOperator: "NotIn", CIDR: "88.7.0.0/16", PrefixLength: &v3.BGPFilterPrefixLengthV4{Max: int32Helper(24)}},
-			{Action: "Accept", Interface: "eth0", MatchOperator: "NotIn", CIDR: "55.4.0.0/16"},
-			{Action: "Reject", Interface: "eth0", Source: "RemotePeers"},
-			{Action: "Accept", MatchOperator: "In", CIDR: "77.7.0.0/16"},
-			{Action: "Accept", Source: "RemotePeers"},
-			{Action: "Accept", Interface: "extraiface"},
-			{Action: "Reject"},
-		},
-		ImportV6: []v3.BGPFilterRuleV6{
-			{Action: "Reject", Source: "RemotePeers", Interface: "vxlan.calico", MatchOperator: "NotIn", CIDR: "7000:1::0/64"},
-			{Action: "Reject", Source: "RemotePeers", MatchOperator: "NotEqual", CIDR: "8000:1::0/64"},
-			{Action: "Accept", Interface: "eth0", MatchOperator: "NotIn", CIDR: "6000:1::0/64"},
-			{Action: "Accept", Interface: "eth0", MatchOperator: "NotIn", CIDR: "6000:1::0/64", PrefixLength: &v3.BGPFilterPrefixLengthV6{Min: int32Helper(96)}},
-			{Action: "Reject", Interface: "eth0", Source: "RemotePeers"},
-			{Action: "Accept", MatchOperator: "NotEqual", CIDR: "7000:1::0/64"},
-			{Action: "Accept", MatchOperator: "NotEqual", CIDR: "7000:1::0/64", PrefixLength: &v3.BGPFilterPrefixLengthV6{Max: int32Helper(96)}},
-			{Action: "Accept", Source: "RemotePeers"},
-			{Action: "Accept", Interface: "extraiface"},
-			{Action: "Reject"},
-		},
-		ExportV6: []v3.BGPFilterRuleV6{
-			{Action: "Accept", Source: "RemotePeers", Interface: "vxlan.calico", MatchOperator: "NotIn", CIDR: "b000:1::0/64"},
-			{Action: "Reject", Source: "RemotePeers", MatchOperator: "NotIn", CIDR: "a000:1::0/64"},
-			{Action: "Reject", Interface: "eth0", MatchOperator: "NotIn", CIDR: "c000:1::0/64"},
-			{Action: "Reject", Interface: "eth0", MatchOperator: "NotIn", CIDR: "c000:1::0/64", PrefixLength: &v3.BGPFilterPrefixLengthV6{Min: int32Helper(120), Max: int32Helper(128)}},
-			{Action: "Accept", Interface: "eth0", Source: "RemotePeers"},
-			{Action: "Accept", MatchOperator: "NotIn", CIDR: "9000:1::0/64"},
-			{Action: "Accept", MatchOperator: "NotIn", CIDR: "9000:1::0/64", PrefixLength: &v3.BGPFilterPrefixLengthV6{Min: int32Helper(96), Max: int32Helper(120)}},
-			{Action: "Accept", Source: "RemotePeers"},
-			{Action: "Reject", Interface: "extraiface"},
-			{Action: "Reject"},
-		},
-	}
-	expectedBIRDCfgStrV4 := []string{
-		"# v4 BGPFilter test-bgpfilter",
-		"function 'bgp_test-bgpfilter_importFilterV4'() {",
-		"  if ((net !~ 55.4.0.0/16)&&((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"vxlan.calico\"))) then { accept; }",
-		"  if ((net !~ 55.4.0.0/16)&&((defined(source))&&(source ~ [ RTS_BGP ]))) then { reject; }",
-		"  if ((net !~ [ 55.4.0.0/16{16,24} ])&&((defined(source))&&(source ~ [ RTS_BGP ]))) then { reject; }",
-		"  if ((net !~ 55.4.0.0/16)&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { reject; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { accept; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { reject; }",
-		"  if ((net = 44.4.0.0/16)) then { reject; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))) then { accept; }",
-		"  if (((defined(ifname))&&(ifname ~ \"extraiface\"))) then { reject; }",
-		"  reject;",
-		"}",
-		"function 'bgp_test-bgpfilter_exportFilterV4'() {",
-		"  if ((net !~ 55.4.0.0/16)&&((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"vxlan.calico\"))) then { reject; }",
-		"  if ((net !~ 88.7.0.0/16)&&((defined(source))&&(source ~ [ RTS_BGP ]))) then { reject; }",
-		"  if ((net !~ [ 88.7.0.0/16{16,24} ])&&((defined(source))&&(source ~ [ RTS_BGP ]))) then { reject; }",
-		"  if ((net !~ 55.4.0.0/16)&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { accept; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { reject; }",
-		"  if ((net ~ 77.7.0.0/16)) then { accept; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))) then { accept; }",
-		"  if (((defined(ifname))&&(ifname ~ \"extraiface\"))) then { accept; }",
-		"  reject;",
-		"}",
-	}
-	expectedBIRDCfgStrV6 := []string{
-		"# v6 BGPFilter test-bgpfilter",
-		"function 'bgp_test-bgpfilter_importFilterV6'() {",
-		"  if ((net !~ 7000:1::0/64)&&((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"vxlan.calico\"))) then { reject; }",
-		"  if ((net != 8000:1::0/64)&&((defined(source))&&(source ~ [ RTS_BGP ]))) then { reject; }",
-		"  if ((net !~ 6000:1::0/64)&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { accept; }",
-		"  if ((net !~ [ 6000:1::0/64{96,128} ])&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { accept; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { reject; }",
-		"  if ((net != 7000:1::0/64)) then { accept; }",
-		"  if ((net != [ 7000:1::0/64{64,96} ])) then { accept; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))) then { accept; }",
-		"  if (((defined(ifname))&&(ifname ~ \"extraiface\"))) then { accept; }",
-		"  reject;",
-		"}",
-		"function 'bgp_test-bgpfilter_exportFilterV6'() {",
-		"  if ((net !~ b000:1::0/64)&&((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"vxlan.calico\"))) then { accept; }",
-		"  if ((net !~ a000:1::0/64)&&((defined(source))&&(source ~ [ RTS_BGP ]))) then { reject; }",
-		"  if ((net !~ c000:1::0/64)&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { reject; }",
-		"  if ((net !~ [ c000:1::0/64{120,128} ])&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { reject; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))&&((defined(ifname))&&(ifname ~ \"eth0\"))) then { accept; }",
-		"  if ((net !~ 9000:1::0/64)) then { accept; }",
-		"  if ((net !~ [ 9000:1::0/64{96,120} ])) then { accept; }",
-		"  if (((defined(source))&&(source ~ [ RTS_BGP ]))) then { accept; }",
-		"  if (((defined(ifname))&&(ifname ~ \"extraiface\"))) then { reject; }",
-		"  reject;",
-		"}",
-	}
-
-	jsonFilter, err := json.Marshal(testFilter)
-	if err != nil {
-		t.Errorf("Error formatting BGPFilter into JSON: %s", err)
-	}
-	kvps := []memkv.KVPair{
-		{Key: "test-bgpfilter", Value: string(jsonFilter)},
-	}
-
-	v4BIRDCfgResult, err := BGPFilterBIRDFuncs(kvps, 4)
-	if err != nil {
-		t.Errorf("Unexpected error while generating v4 BIRD BGPFilter functions: %s", err)
-	}
-	if !reflect.DeepEqual(v4BIRDCfgResult, expectedBIRDCfgStrV4) {
-		t.Errorf("Generated v4 BIRD config differs from expectation:\n Generated = %s,\n Expected = %s",
-			v4BIRDCfgResult, expectedBIRDCfgStrV4)
-	}
-
-	v6BIRDCfgResult, err := BGPFilterBIRDFuncs(kvps, 6)
-	if err != nil {
-		t.Errorf("Unexpected error while generating v6 BIRD BGPFilter functions: %s", err)
-	}
-	if !reflect.DeepEqual(v6BIRDCfgResult, expectedBIRDCfgStrV6) {
-		t.Errorf("Generated v6 BIRD config differs from expectation:\n Generated = %s,\n Expected = %s",
-			v6BIRDCfgResult, expectedBIRDCfgStrV6)
-	}
-}
-
 func Test_ValidateHashToIpv4Method(t *testing.T) {
 	expectedRouterId := "207.94.5.27"
 	nodeName := "Testrobin123"
@@ -211,8 +73,4 @@ func Test_ValidateHashToIpv4Method(t *testing.T) {
 	if expectedRouterId != actualRouterId {
 		t.Errorf("Expected %s to equal %s", expectedRouterId, actualRouterId)
 	}
-}
-
-func int32Helper(i int32) *int32 {
-	return &i
 }


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
                                                                                                                                                                                                                                                                                                                                                                         
  - Refactors BGPFilter BIRD config rendering from string-based generation in template functions to a structured data approach, consistent with how BGPPeer config is already rendered      
  - Moves BGPFilter processing from template_funcs.go (which generated raw BIRD syntax strings) into bgp_processor.go (which builds typed structs), so the Go template only handles layout
  - Prepares the codebase for adding new BGPFilter fields by making the rendering pipeline easier to extend

  Motivation

  BGPFilter and BGPPeer used two different patterns for rendering BIRD config:

  - BGPPeer (structured): Go builds a BirdBGPPeer struct, template iterates over fields to emit BIRD syntax
  - BGPFilter (string-based): Go function bgpFilterBIRDFuncs generated complete BIRD syntax strings, template just dumped them verbatim

  The string-based approach made it difficult to add new match criteria or operations, since BIRD syntax was deeply embedded in Go string formatting. This PR aligns BGPFilter with the BGPPeer pattern for better testability, separation of concerns, and extensibility.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
