### PR TITLE
[v3.30]  Fix CNI delete timer to start after acquiring IPAM lock

### DIFF
--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -434,9 +434,6 @@ func cmdDel(args *skel.CmdArgs) error {
 	})
 
 	logger.Info("Releasing address using handleID")
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
-	defer cancel()
 
 	// Acquire a best-effort host-wide lock to prevent multiple copies of the CNI plugin trying to assign/delete
 	// concurrently. ReleaseXXX is concurrency safe already but serialising the CNI plugins means that
@@ -444,6 +441,10 @@ func cmdDel(args *skel.CmdArgs) error {
 	// number of concurrent requests with essentially no downside.
 	unlock := acquireIPAMLockBestEffort(conf.IPAMLockFile)
 	defer unlock()
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
 
 	if err := calicoClient.IPAM().ReleaseByHandle(ctx, handleID); err != nil {
 		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.30**: projectcalico/calico#11824

 ## Description

  **Type:** Bug fix

  **Why this should be merged:**

  This PR fixes a critical bug in the CNI plugin's DELETE operation where the 90-second context timeout was incorrectly started *before* acquiring the IPAM lock, rather than after. This inconsistency
  with ADD operations (AssignIP and AutoAssign) caused DELETE operations to timeout when waiting for the lock during high pod churn.

  **Problem:**
  - During concurrent pod deletions, CNI processes queue for the host-wide IPAM lock
  - The DELETE operation started its 90-second timer before acquiring the lock
  - Lock wait time counted against the timeout budget
  - By the time a DELETE acquired the lock, the context was often already expired or near expiration
  - This resulted in "client rate limiter Wait returned an error: context deadline exceeded" errors

  **Solution:**
  In `cni-plugin/pkg/ipamplugin/ipam_plugin.go`. 
  - Lock is now acquired first, then the 90-second timer starts
  - This matches the pattern already used in ADD operations 
  - DELETE operations now get the full 90 seconds for API calls, regardless of lock wait time

  **Components affected:**
  - CNI plugin IPAM delete operations (`cmdDel` function)
  - Specifically the `ReleaseByHandle` flow

  **Impact:**
  - Low risk: Only reorders existing code, no logic changes
  - High benefit: Eliminates cascading DELETE failures during high pod churn
  - No API changes, backward compatible

  ## Related issues/PRs

https://github.com/projectcalico/calico/commit/8822f57fad8f9eebef57c0ad3cbdcac9eb0bf1ef


  ## Todos

  - [ ] Tests - Existing tests should pass; new tests for lock/timer ordering would be beneficial
  - [ ] Documentation - Code comment added explaining the timer ordering rationale
  - [ ] Release note - Included below

  ## Release Note

  ```release-note
 Fix CNI delete timeout to start after IPAM lock acquisition, preventing "context deadline exceeded" failures during high pod churn.
```

