### PR TITLE
Add native v3 CRDs e2e test blocks to dataplane pipelines

### DIFF
--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -100,6 +100,10 @@ blocks:
               value: "aws-kubeadm"
             - name: IPAM_TEST_POOL_SUBNET
               value: "10.0.0.0/29"
+            - name: USE_API_SERVER
+              value: "false"
+            - name: K8S_VERSION
+              value: "stable-3"
 
         - name: AWS single subnet
           execution_time_limit:
@@ -162,6 +166,8 @@ blocks:
               value: "Enabled"
             - name: KUBE_PROXY_MANAGEMENT
               value: "Enabled"
+            - name: USE_API_SERVER
+              value: "false"
 
         - name: GCP BPF DP encap w/ NodeLocal DNSCache
           execution_time_limit:
@@ -682,26 +688,6 @@ blocks:
               value: "US"
       secrets:
         - name: dynamo-read-creds
-
-  - name: Native v3 CRDs
-    dependencies: []
-    task:
-      jobs:
-        - name: Native v3 CRDs
-          execution_time_limit:
-            hours: 7
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          matrix:
-            - env_var: PROVISIONER
-              values: ["gcp-kubeadm", "aws-kubeadm"]
-          env_vars:
-            - name: USE_API_SERVER
-              value: "false"
-            - name: K8S_VERSION
-              value: "stable"
-            - name: INSTALLER
-              value: "operator"
 
 promotions:
   - name: Cleanup jobs

--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -279,6 +279,8 @@ blocks:
               value: gcp-kubeadm
             - name: KUBE_PROXY_MODE
               value: ipvs
+            - name: USE_API_SERVER
+              value: "false"
 
   - name: usage reporting
     dependencies: []
@@ -518,6 +520,8 @@ blocks:
               value: "10.0.0.0/29"
             - name: PROVISIONER
               value: "aws-kubeadm"
+            - name: USE_API_SERVER
+              value: "false"
 
         - name: AKS w AKS CNI + Overlay
           execution_time_limit:
@@ -765,26 +769,6 @@ blocks:
               value: --ginkgo.focus=(\[sig-calico\]|\[Conformance\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[DataPath\]|WireGuard)
             - name: USE_HASH_RELEASE
               value: "true"
-
-  - name: Native v3 CRDs
-    dependencies: []
-    task:
-      jobs:
-        - name: Native v3 CRDs
-          execution_time_limit:
-            hours: 7
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          matrix:
-            - env_var: PROVISIONER
-              values: ["gcp-kubeadm", "aws-kubeadm"]
-          env_vars:
-            - name: USE_API_SERVER
-              value: "false"
-            - name: K8S_VERSION
-              value: "stable"
-            - name: INSTALLER
-              value: "operator"
 
 promotions:
   - name: Cleanup jobs

--- a/.semaphore/end-to-end/pipelines/nftables.yml
+++ b/.semaphore/end-to-end/pipelines/nftables.yml
@@ -90,6 +90,32 @@ blocks:
             - name: ENCAPSULATION_TYPE
               value: "VXLAN"
 
+        - name: Native v3 CRDs (GCP)
+          execution_time_limit:
+            hours: 7
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: PROVISIONER
+              value: "gcp-kubeadm"
+            - name: K8S_VERSION
+              value: "stable"
+            - name: USE_API_SERVER
+              value: "false"
+
+        - name: Native v3 CRDs (AWS)
+          execution_time_limit:
+            hours: 7
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: PROVISIONER
+              value: "aws-kubeadm"
+            - name: K8S_VERSION
+              value: "stable-3"
+            - name: USE_API_SERVER
+              value: "false"
+
   - name: Nftables mode, EKS
     dependencies: []
     task:
@@ -173,26 +199,6 @@ blocks:
               value: ipv6
             - name: ENCAPSULATION_TYPE_V6
               value: "None"
-
-  - name: Native v3 CRDs
-    dependencies: []
-    task:
-      jobs:
-        - name: Native v3 CRDs
-          execution_time_limit:
-            hours: 7
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          matrix:
-            - env_var: PROVISIONER
-              values: ["gcp-kubeadm", "aws-kubeadm"]
-          env_vars:
-            - name: USE_API_SERVER
-              value: "false"
-            - name: K8S_VERSION
-              value: "stable"
-            - name: INSTALLER
-              value: "operator"
 
 promotions:
   - name: Cleanup jobs


### PR DESCRIPTION
Add a "Native v3 CRDs" block to each of the BPF, iptables, and nftables Banzai e2e pipelines. These cover the new deployment mode where the Calico API server is not used (`USE_API_SERVER=false`), relying on native v3 CRDs with MutatingAdmissionPolicy instead.

Each block runs on `gcp-kubeadm` and `aws-kubeadm` (the kubeadm provisioners that support the necessary K8s API features), targeting the latest K8s version only. All other config (dataplane, test flags, kube-proxy mode, etc.) is inherited from each pipeline's global settings, so the native v3 CRDs jobs run the exact same test suite as the default `USE_API_SERVER=true` runs.

6 new jobs total (2 per pipeline).