### PR TITLE
CI: Tell Semaphore to upload logs as artifacts when truncating

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -25,6 +25,8 @@ global_job_config:
       value: calico-transient-build-artifacts-europe-west3
     - name: BUILDKIT_PROGRESS
       value: plain
+    - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+      value: when-trimmed
   prologue:
     commands:
       - export CALICO_DIR_NAME=${SEMAPHORE_GIT_DIR}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,6 +25,8 @@ global_job_config:
       value: calico-transient-build-artifacts-europe-west3
     - name: BUILDKIT_PROGRESS
       value: plain
+    - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+      value: when-trimmed
   prologue:
     commands:
       - export CALICO_DIR_NAME=${SEMAPHORE_GIT_DIR}

--- a/.semaphore/semaphore.yml.d/02-global_job_config.yml
+++ b/.semaphore/semaphore.yml.d/02-global_job_config.yml
@@ -9,6 +9,8 @@ global_job_config:
       value: calico-transient-build-artifacts-europe-west3
     - name: BUILDKIT_PROGRESS
       value: plain
+    - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+      value: when-trimmed
   prologue:
     commands:
       - export CALICO_DIR_NAME=${SEMAPHORE_GIT_DIR}


### PR DESCRIPTION
SemaphoreCI has a 16MB log limit.  Some of our jobs sometimes go over that limit; set a workaround flag that tells Semaphore to upload logs as artifacts in that case.