### PR TITLE
Optimize DedupeBuffer to avoid string keys for comparable key types

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer.go
@@ -17,6 +17,7 @@ package dedupebuffer
 import (
 	"container/list"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
-	"github.com/projectcalico/calico/typha/pkg/syncclient"
 )
 
 // DedupeBuffer buffer implements the syncer callbacks API on its
@@ -45,20 +45,21 @@ type DedupeBuffer struct {
 	lock sync.Mutex
 	cond *sync.Cond
 
-	// keyToPendingUpdate holds an entry for each updateWithStringKey in the
-	// pendingUpdates queue
-	keyToPendingUpdate    map[string]*list.Element
+	// keyToPendingUpdate holds an entry for each updateWithKey in the
+	// pendingUpdates queue.  Keys are either comparable model.Key structs
+	// (zero allocation) or string-encoded paths for non-comparable key types.
+	keyToPendingUpdate    map[any]*list.Element
 	peakPendingUpdatesLen int
 
 	// liveResourceKeys Contains an entry for every key that we have sent to
 	// the consumer and that we have not subsequently sent a deletion for.
-	liveResourceKeys              set.Set[string]
-	liveKeysNotSeenSinceReconnect set.Set[string]
+	liveResourceKeys              set.Set[any]
+	liveKeysNotSeenSinceReconnect set.Set[any]
 	resyncStart                   time.Time
 	// pendingUpdates is the queue of updates that we want to send to the
 	// consumer.  We use a linked list so that we can remove items from
 	// the middle if they are deleted before making it off the queue.
-	pendingUpdates list.List // Mix of api.SyncStatus and updateWithStringKey.
+	pendingUpdates list.List // Mix of api.SyncStatus and updateWithKey.
 
 	mostRecentStatusReceived api.SyncStatus
 	stopped                  bool
@@ -66,8 +67,8 @@ type DedupeBuffer struct {
 
 func New() *DedupeBuffer {
 	d := &DedupeBuffer{
-		keyToPendingUpdate: map[string]*list.Element{},
-		liveResourceKeys:   set.New[string](),
+		keyToPendingUpdate: map[any]*list.Element{},
+		liveResourceKeys:   set.New[any](),
 	}
 	d.cond = sync.NewCond(&d.lock)
 	return d
@@ -137,15 +138,6 @@ func (d *DedupeBuffer) OnStatusUpdated(status api.SyncStatus) {
 // deduplicate in-flight updates to the same keys.  It should only block for
 // short periods even if the downstream sink blocks for a long time.
 func (d *DedupeBuffer) OnUpdates(updates []api.Update) {
-	d.OnUpdatesKeysKnown(updates, nil)
-}
-
-// OnUpdatesKeysKnown is like OnUpdates, but it allows for the pre-serialised
-// keys of the KV pairs to be passed in.  If an entry in keys is "" or if keys
-// is shorter than updates the key will be computed.
-//
-// The updates and keys slices are not retained.
-func (d *DedupeBuffer) OnUpdatesKeysKnown(updates []api.Update, keys []string) {
 	debug := log.IsLevelEnabled(log.DebugLevel)
 	if debug {
 		log.WithField("numUpdates", len(updates)).Debug("Updates received")
@@ -159,24 +151,8 @@ func (d *DedupeBuffer) OnUpdatesKeysKnown(updates []api.Update, keys []string) {
 	}
 
 	queueWasEmpty := d.pendingUpdates.Len() == 0
-	for i, u := range updates {
-		var key string
-		if i < len(keys) {
-			// Have a cached key.
-			key = keys[i]
-		}
-		if key == "" {
-			// No key provided, calculate it.
-			var err error
-			key, err = model.KeyToDefaultPath(u.Key)
-			if err != nil {
-				// Shouldn't happen, we get our keys from Typha which has already
-				// encoded them once!
-				log.WithError(err).WithField("key", u.Key).Error(
-					"Failed to generate default path for key.  Will skip this update.")
-				continue
-			}
-		}
+	for _, u := range updates {
+		key := dedupeKey(u.Key)
 		if d.liveKeysNotSeenSinceReconnect != nil {
 			d.liveKeysNotSeenSinceReconnect.Discard(key)
 		}
@@ -193,7 +169,7 @@ func (d *DedupeBuffer) OnUpdatesKeysKnown(updates []api.Update, keys []string) {
 	}
 }
 
-func (d *DedupeBuffer) queueUpdate(key string, u api.Update) {
+func (d *DedupeBuffer) queueUpdate(key any, u api.Update) {
 	debug := log.IsLevelEnabled(log.DebugLevel)
 
 	if u.Value != nil {
@@ -225,9 +201,9 @@ func (d *DedupeBuffer) queueUpdate(key string, u api.Update) {
 				log.WithField("key", key).Debug("Key updated before being sent.")
 			}
 
-			usk := element.Value.(updateWithStringKey)
-			usk.update = u
-			element.Value = usk
+			uwk := element.Value.(updateWithKey)
+			uwk.update = u
+			element.Value = uwk
 		}
 	} else {
 		// No in-flight entry for this key.  Add to queue and record that
@@ -235,7 +211,7 @@ func (d *DedupeBuffer) queueUpdate(key string, u api.Update) {
 		if debug {
 			log.WithField("key", key).Debug("No in flight value for key, adding to queue.")
 		}
-		element = d.pendingUpdates.PushBack(updateWithStringKey{
+		element = d.pendingUpdates.PushBack(updateWithKey{
 			key:    key,
 			update: u,
 		})
@@ -259,8 +235,8 @@ func (d *DedupeBuffer) Stop() {
 	d.cond.Signal()
 }
 
-type updateWithStringKey struct {
-	key    string
+type updateWithKey struct {
+	key    any
 	update api.Update
 }
 
@@ -305,7 +281,7 @@ func (d *DedupeBuffer) pullNextBatch(buf []any, batchSize int) []any {
 		first := d.pendingUpdates.Front()
 		buf = append(buf, first.Value)
 		d.pendingUpdates.Remove(first)
-		if u, ok := first.Value.(updateWithStringKey); ok {
+		if u, ok := first.Value.(updateWithKey); ok {
 			key := u.key
 			delete(d.keyToPendingUpdate, key)
 			if len(d.keyToPendingUpdate) == 0 && d.peakPendingUpdatesLen > 100 {
@@ -313,7 +289,7 @@ func (d *DedupeBuffer) pullNextBatch(buf []any, batchSize int) []any {
 				// https://github.com/golang/go/issues/20135
 				// Opportunistically free the map when it's empty. This can
 				// free a good amount of RAM after loading a large snapshot.
-				d.keyToPendingUpdate = map[string]*list.Element{}
+				d.keyToPendingUpdate = map[any]*list.Element{}
 				d.peakPendingUpdatesLen = 0
 			}
 			// Update liveResourceKeys now, before we drop the lock.  Once we drop
@@ -340,7 +316,7 @@ func (d *DedupeBuffer) dropLockAndSendBatch(sink api.SyncerCallbacks, buf []any)
 	updates := make([]api.Update, 0, len(buf))
 	for _, msg := range buf {
 		switch msg := msg.(type) {
-		case updateWithStringKey:
+		case updateWithKey:
 			updates = append(updates, msg.update)
 		case api.SyncStatus:
 			if len(updates) > 0 {
@@ -382,11 +358,21 @@ func (d *DedupeBuffer) onInSyncAfterReconnection() {
 		"resources not seen during the resync.",
 		d.liveKeysNotSeenSinceReconnect.Len())
 	for key := range d.liveKeysNotSeenSinceReconnect.All() {
-		parsedKey := model.KeyFromDefaultPath(key)
-		if parsedKey == nil {
-			// Not clear how this could happen since these keys came from the
-			// set that we'd already parsed and passed downstream!
-			log.WithField("key", key).Panic("Failed to parse key during reconnection to Typha.")
+		var parsedKey model.Key
+		switch k := key.(type) {
+		case model.Key:
+			// Comparable key type stored directly; use as-is.
+			parsedKey = k
+		case string:
+			// Non-comparable key type was stored as a string; parse it back.
+			parsedKey = model.KeyFromDefaultPath(k)
+			if parsedKey == nil {
+				// Not clear how this could happen since these keys came from the
+				// set that we'd already parsed and passed downstream!
+				log.WithField("key", key).Panic("Failed to parse key during reconnection to Typha.")
+			}
+		default:
+			log.WithField("key", key).Panicf("Unexpected key type in liveKeysNotSeenSinceReconnect: %T", key)
 		}
 		d.queueUpdate(key, api.Update{
 			KVPair: model.KVPair{
@@ -399,4 +385,18 @@ func (d *DedupeBuffer) onInSyncAfterReconnection() {
 }
 
 var _ api.SyncerCallbacks = (*DedupeBuffer)(nil)
-var _ syncclient.RestartAwareCallbacks = (*DedupeBuffer)(nil)
+
+// dedupeKey returns a map-safe key for deduplication. For comparable model.Key
+// types (the vast majority), the key struct itself is returned — this avoids
+// allocating a string encoding. For non-comparable types (e.g. those embedding
+// net.IP / net.IPNet slices), we fall back to the string-encoded path.
+func dedupeKey(k model.Key) any {
+	if reflect.TypeOf(k).Comparable() {
+		return k
+	}
+	s, err := model.KeyToDefaultPath(k)
+	if err != nil {
+		log.WithError(err).WithField("key", k).Panic("Failed to serialize non-comparable key")
+	}
+	return s
+}

--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer.go
@@ -17,7 +17,6 @@ package dedupebuffer
 import (
 	"container/list"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -46,15 +45,15 @@ type DedupeBuffer struct {
 	cond *sync.Cond
 
 	// keyToPendingUpdate holds an entry for each updateWithKey in the
-	// pendingUpdates queue.  Keys are either comparable model.Key structs
-	// (zero allocation) or string-encoded paths for non-comparable key types.
-	keyToPendingUpdate    map[any]*list.Element
+	// pendingUpdates queue.  model.Key is an interface, but all concrete
+	// key types are Go-comparable so they are safe to use as map keys.
+	keyToPendingUpdate    map[model.Key]*list.Element
 	peakPendingUpdatesLen int
 
 	// liveResourceKeys Contains an entry for every key that we have sent to
 	// the consumer and that we have not subsequently sent a deletion for.
-	liveResourceKeys              set.Set[any]
-	liveKeysNotSeenSinceReconnect set.Set[any]
+	liveResourceKeys              set.Set[model.Key]
+	liveKeysNotSeenSinceReconnect set.Set[model.Key]
 	resyncStart                   time.Time
 	// pendingUpdates is the queue of updates that we want to send to the
 	// consumer.  We use a linked list so that we can remove items from
@@ -67,8 +66,8 @@ type DedupeBuffer struct {
 
 func New() *DedupeBuffer {
 	d := &DedupeBuffer{
-		keyToPendingUpdate: map[any]*list.Element{},
-		liveResourceKeys:   set.New[any](),
+		keyToPendingUpdate: map[model.Key]*list.Element{},
+		liveResourceKeys:   set.New[model.Key](),
 	}
 	d.cond = sync.NewCond(&d.lock)
 	return d
@@ -152,12 +151,11 @@ func (d *DedupeBuffer) OnUpdates(updates []api.Update) {
 
 	queueWasEmpty := d.pendingUpdates.Len() == 0
 	for _, u := range updates {
-		key := dedupeKey(u.Key)
 		if d.liveKeysNotSeenSinceReconnect != nil {
-			d.liveKeysNotSeenSinceReconnect.Discard(key)
+			d.liveKeysNotSeenSinceReconnect.Discard(u.Key)
 		}
 
-		d.queueUpdate(key, u)
+		d.queueUpdate(u.Key, u)
 	}
 	queueNowEmpty := d.pendingUpdates.Len() == 0
 	if queueWasEmpty && !queueNowEmpty {
@@ -169,7 +167,7 @@ func (d *DedupeBuffer) OnUpdates(updates []api.Update) {
 	}
 }
 
-func (d *DedupeBuffer) queueUpdate(key any, u api.Update) {
+func (d *DedupeBuffer) queueUpdate(key model.Key, u api.Update) {
 	debug := log.IsLevelEnabled(log.DebugLevel)
 
 	if u.Value != nil {
@@ -236,7 +234,7 @@ func (d *DedupeBuffer) Stop() {
 }
 
 type updateWithKey struct {
-	key    any
+	key    model.Key
 	update api.Update
 }
 
@@ -289,7 +287,7 @@ func (d *DedupeBuffer) pullNextBatch(buf []any, batchSize int) []any {
 				// https://github.com/golang/go/issues/20135
 				// Opportunistically free the map when it's empty. This can
 				// free a good amount of RAM after loading a large snapshot.
-				d.keyToPendingUpdate = map[any]*list.Element{}
+				d.keyToPendingUpdate = map[model.Key]*list.Element{}
 				d.peakPendingUpdatesLen = 0
 			}
 			// Update liveResourceKeys now, before we drop the lock.  Once we drop
@@ -358,25 +356,9 @@ func (d *DedupeBuffer) onInSyncAfterReconnection() {
 		"resources not seen during the resync.",
 		d.liveKeysNotSeenSinceReconnect.Len())
 	for key := range d.liveKeysNotSeenSinceReconnect.All() {
-		var parsedKey model.Key
-		switch k := key.(type) {
-		case model.Key:
-			// Comparable key type stored directly; use as-is.
-			parsedKey = k
-		case string:
-			// Non-comparable key type was stored as a string; parse it back.
-			parsedKey = model.KeyFromDefaultPath(k)
-			if parsedKey == nil {
-				// Not clear how this could happen since these keys came from the
-				// set that we'd already parsed and passed downstream!
-				log.WithField("key", key).Panic("Failed to parse key during reconnection to Typha.")
-			}
-		default:
-			log.WithField("key", key).Panicf("Unexpected key type in liveKeysNotSeenSinceReconnect: %T", key)
-		}
 		d.queueUpdate(key, api.Update{
 			KVPair: model.KVPair{
-				Key:   parsedKey,
+				Key:   key,
 				Value: nil,
 			},
 			UpdateType: api.UpdateTypeKVDeleted,
@@ -385,18 +367,3 @@ func (d *DedupeBuffer) onInSyncAfterReconnection() {
 }
 
 var _ api.SyncerCallbacks = (*DedupeBuffer)(nil)
-
-// dedupeKey returns a map-safe key for deduplication. For comparable model.Key
-// types (the vast majority), the key struct itself is returned — this avoids
-// allocating a string encoding. For non-comparable types (e.g. those embedding
-// net.IP / net.IPNet slices), we fall back to the string-encoded path.
-func dedupeKey(k model.Key) any {
-	if reflect.TypeOf(k).Comparable() {
-		return k
-	}
-	s, err := model.KeyToDefaultPath(k)
-	if err != nil {
-		log.WithError(err).WithField("key", k).Panic("Failed to serialize non-comparable key")
-	}
-	return s
-}

--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+	calinet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 func init() {
@@ -391,6 +392,84 @@ func TestDedupeBuffer_TyphaResyncNothingToDelete(t *testing.T) {
 	}))
 }
 
+// TestDedupeBuffer_NonComparableKeys tests dedupe and reconnection deletion
+// synthesis for key types that are not Go-comparable (e.g. BlockKey which
+// embeds net.IPNet containing a slice). These fall back to string-encoded
+// paths in the tracking maps.
+func TestDedupeBuffer_NonComparableKeys(t *testing.T) {
+	RegisterTestingT(t)
+	d := New()
+	rec := newGenericReceiver()
+
+	_, cidr1, _ := calinet.ParseCIDR("10.0.0.0/24")
+	_, cidr2, _ := calinet.ParseCIDR("10.0.1.0/24")
+	_, cidr3, _ := calinet.ParseCIDR("10.0.2.0/24")
+
+	blockUpdate := func(cidr calinet.IPNet, value string) api.Update {
+		u := api.Update{
+			KVPair: model.KVPair{
+				Key: model.BlockKey{CIDR: cidr},
+			},
+		}
+		if value != "" {
+			u.KVPair.Value = value
+		} else {
+			u.UpdateType = api.UpdateTypeKVDeleted
+		}
+		return u
+	}
+
+	// Initial state with three blocks.
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1")})
+	d.OnUpdates([]api.Update{blockUpdate(*cidr2, "block2")})
+	d.OnUpdates([]api.Update{blockUpdate(*cidr3, "block3")})
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchToGeneric(d, rec)
+
+	Expect(rec.liveKeys()).To(HaveLen(3))
+	Expect(rec.syncState()).To(Equal(api.InSync))
+
+	cidr1Path, _ := model.KeyToDefaultPath(model.BlockKey{CIDR: *cidr1})
+	cidr3Path, _ := model.KeyToDefaultPath(model.BlockKey{CIDR: *cidr3})
+
+	// Dedupe: update cidr1 twice before flush — only second value should appear.
+	rec.resetUpdatesSeen()
+	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1b")})
+	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1c")})
+	sendNextBatchToGeneric(d, rec)
+
+	Expect(rec.liveKeys()).To(HaveKey(cidr1Path))
+	updates := rec.updatesSeen()
+	// Should only have one update for cidr1, with the final value.
+	Expect(updates).To(HaveLen(1))
+	Expect(updates[0].Value).To(Equal("block1c"))
+
+	// Reconnection: cidr3 disappears during resync.
+	rec.resetUpdatesSeen()
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1c")})
+	d.OnUpdates([]api.Update{blockUpdate(*cidr2, "block2")})
+	// cidr3 not sent — should be synthesized as deletion.
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchToGeneric(d, rec)
+
+	Expect(rec.liveKeys()).To(HaveLen(2))
+	Expect(rec.liveKeys()).NotTo(HaveKey(cidr3Path))
+	Expect(rec.syncState()).To(Equal(api.InSync))
+
+	// Verify the deletion was synthesized for cidr3.
+	var deletionPaths []string
+	for _, u := range rec.updatesSeen() {
+		if u.Value == nil {
+			p, _ := model.KeyToDefaultPath(u.Key)
+			deletionPaths = append(deletionPaths, p)
+		}
+	}
+	Expect(deletionPaths).To(ConsistOf(cidr3Path))
+}
+
 func TestDedupeBuffer_Async(t *testing.T) {
 	RegisterTestingT(t)
 	d := New()
@@ -585,4 +664,74 @@ func (r *Receiver) Unblock() {
 	defer r.mutex.Unlock()
 	r.block = false
 	r.cond.Signal()
+}
+
+// genericReceiver is a test receiver that works with any model.Key type,
+// tracking updates by string-encoded path (since some key types are not
+// comparable and can't be used as Go map keys directly).
+type genericReceiver struct {
+	mutex          sync.Mutex
+	keys           map[string]any // path -> value
+	updates        []api.Update
+	finalSyncState api.SyncStatus
+}
+
+func newGenericReceiver() *genericReceiver {
+	return &genericReceiver{
+		keys: map[string]any{},
+	}
+}
+
+func (r *genericReceiver) OnStatusUpdated(status api.SyncStatus) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.finalSyncState = status
+}
+
+func (r *genericReceiver) OnUpdates(updates []api.Update) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for _, u := range updates {
+		r.updates = append(r.updates, u)
+		path, _ := model.KeyToDefaultPath(u.Key)
+		if u.Value == nil {
+			delete(r.keys, path)
+		} else {
+			r.keys[path] = u.Value
+		}
+	}
+}
+
+func (r *genericReceiver) liveKeys() map[string]any {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	cp := make(map[string]any, len(r.keys))
+	for k, v := range r.keys {
+		cp[k] = v
+	}
+	return cp
+}
+
+func (r *genericReceiver) updatesSeen() []api.Update {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	cp := make([]api.Update, len(r.updates))
+	copy(cp, r.updates)
+	return cp
+}
+
+func (r *genericReceiver) resetUpdatesSeen() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.updates = nil
+}
+
+func (r *genericReceiver) syncState() api.SyncStatus {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.finalSyncState
+}
+
+func sendNextBatchToGeneric(d *DedupeBuffer, r *genericReceiver) {
+	ExpectWithOffset(1, d.sendNextBatchToSinkNoBlock(r)).NotTo(HaveOccurred())
 }

--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
@@ -35,176 +35,161 @@ func init() {
 }
 
 func TestDedupeBuffer_SyncNoDupes(t *testing.T) {
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
 
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("foo", "bar")})
-			onUpdates([]api.Update{KVUpdate("foo2", "bar2")})
-			d.OnStatusUpdated(api.InSync)
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("foo", "bar")})
+	d.OnUpdates([]api.Update{KVUpdate("foo2", "bar2")})
+	d.OnStatusUpdated(api.InSync)
 
-			sendNextBatchSync(d, rec)
+	sendNextBatchSync(d, rec)
 
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore gets skipped since it's in the same batch.
-				api.ResyncInProgress.String(),
-				"foo=bar (new)",
-				"foo2=bar2 (new)",
-				api.InSync.String(),
-			}))
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"foo":  "bar",
+		"foo2": "bar2",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore gets skipped since it's in the same batch.
+		api.ResyncInProgress.String(),
+		"foo=bar (new)",
+		"foo2=bar2 (new)",
+		api.InSync.String(),
+	}))
 
-			// Now send in a deletion.
-			rec.ResetUpdatesSeen()
-			onUpdates([]api.Update{KVUpdate("foo", "")})
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"foo2": "bar2",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				"foo= (deleted)",
-			}))
+	// Now send in a deletion.
+	rec.ResetUpdatesSeen()
+	d.OnUpdates([]api.Update{KVUpdate("foo", "")})
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"foo2": "bar2",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		"foo= (deleted)",
+	}))
 
-			// Now send in a deletion, which is reverted before being sent.
-			rec.ResetUpdatesSeen()
-			onUpdates([]api.Update{KVUpdate("foo2", "")})
-			onUpdates([]api.Update{KVUpdate("foo2", "bar3")})
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"foo2": "bar3",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				"foo2=bar3 (updated)",
-			}))
+	// Now send in a deletion, which is reverted before being sent.
+	rec.ResetUpdatesSeen()
+	d.OnUpdates([]api.Update{KVUpdate("foo2", "")})
+	d.OnUpdates([]api.Update{KVUpdate("foo2", "bar3")})
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"foo2": "bar3",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		"foo2=bar3 (updated)",
+	}))
 
-			// Update both keys, should work as normal.
-			rec.ResetUpdatesSeen()
-			onUpdates([]api.Update{KVUpdate("foo", "bar")})
-			onUpdates([]api.Update{KVUpdate("foo2", "bar2")})
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"foo":  "bar",
-				"foo2": "bar2",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore gets skipped since it's in the same batch.
-				"foo=bar (new)",
-				"foo2=bar2 (updated)",
-			}))
-		})
-	}
+	// Update both keys, should work as normal.
+	rec.ResetUpdatesSeen()
+	d.OnUpdates([]api.Update{KVUpdate("foo", "bar")})
+	d.OnUpdates([]api.Update{KVUpdate("foo2", "bar2")})
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"foo":  "bar",
+		"foo2": "bar2",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore gets skipped since it's in the same batch.
+		"foo=bar (new)",
+		"foo2=bar2 (updated)",
+	}))
 }
 
 func TestDedupeBuffer_SyncWithDupes(t *testing.T) {
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
 
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("foo", "bar")})
-			onUpdates([]api.Update{KVUpdate("foo2", "bar2")})
-			onUpdates([]api.Update{KVUpdate("foo3", "bar3")})
-			onUpdates([]api.Update{KVUpdate("foo", "bar3")})
-			onUpdates([]api.Update{KVUpdate("foo2", "")})
-			d.OnStatusUpdated(api.InSync)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			d.OnStatusUpdated(api.InSync)
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("foo", "bar")})
+	d.OnUpdates([]api.Update{KVUpdate("foo2", "bar2")})
+	d.OnUpdates([]api.Update{KVUpdate("foo3", "bar3")})
+	d.OnUpdates([]api.Update{KVUpdate("foo", "bar3")})
+	d.OnUpdates([]api.Update{KVUpdate("foo2", "")})
+	d.OnStatusUpdated(api.InSync)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnStatusUpdated(api.InSync)
 
-			sendNextBatchSync(d, rec)
+	sendNextBatchSync(d, rec)
 
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"foo":  "bar3",
-				"foo3": "bar3",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore skipped.
-				api.ResyncInProgress.String(),
-				"foo=bar3 (new)", // Update leap-frogs the original value.
-				"foo3=bar3 (new)",
-				api.InSync.String(),
-			}))
-		})
-	}
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"foo":  "bar3",
+		"foo3": "bar3",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore skipped.
+		api.ResyncInProgress.String(),
+		"foo=bar3 (new)", // Update leap-frogs the original value.
+		"foo3=bar3 (new)",
+		api.InSync.String(),
+	}))
 }
 
 // TestDedupeBuffer_TyphaResyncMainline tests resync with Typha where some keys
 // stay the same, some are modified and some deleted during the resync.
 func TestDedupeBuffer_TyphaResyncMainline(t *testing.T) {
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
 
-			// Send a simple initial state.
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})
-			onUpdates([]api.Update{KVUpdate("key2", "v2")})
-			onUpdates([]api.Update{KVUpdate("key3", "v3")})
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1",
-				"key2": "v2",
-				"key3": "v3",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore skipped.
-				api.ResyncInProgress.String(),
-				"key1=v1 (new)",
-				"key2=v2 (new)",
-				"key3=v3 (new)",
-				api.InSync.String(),
-			}))
-			rec.ResetUpdatesSeen()
+	// Send a simple initial state.
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2")})
+	d.OnUpdates([]api.Update{KVUpdate("key3", "v3")})
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1",
+		"key2": "v2",
+		"key3": "v3",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore skipped.
+		api.ResyncInProgress.String(),
+		"key1=v1 (new)",
+		"key2=v2 (new)",
+		"key3=v3 (new)",
+		api.InSync.String(),
+	}))
+	rec.ResetUpdatesSeen()
 
-			// Typha reconnection.
-			d.OnTyphaConnectionRestarted()
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
-			onUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
-			// onUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
-			onUpdates([]api.Update{KVUpdate("key4", "v4")})
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1",
-				"key2": "v2b",
-				"key4": "v4",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				api.ResyncInProgress.String(),
-				"key1=v1 (updated)",
-				"key2=v2b (updated)",
-				"key4=v4 (new)",
-				"key3= (deleted)",
-				api.InSync.String(),
-			}))
-		})
-	}
+	// Typha reconnection.
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
+	// d.OnUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
+	d.OnUpdates([]api.Update{KVUpdate("key4", "v4")})
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1",
+		"key2": "v2b",
+		"key4": "v4",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		api.ResyncInProgress.String(),
+		"key1=v1 (updated)",
+		"key2=v2b (updated)",
+		"key4=v4 (new)",
+		"key3= (deleted)",
+		api.InSync.String(),
+	}))
 }
 
 // TestDedupeBuffer_TyphaDoubleResyncNoFlush tests a back-to-back resync with
@@ -213,74 +198,68 @@ func TestDedupeBuffer_TyphaResyncMainline(t *testing.T) {
 // resync never started.
 func TestDedupeBuffer_TyphaDoubleResyncNoFlush(t *testing.T) {
 	// Tests a resync with Typha that itself gets interrupted by a new resync.
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
 
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
+	// Send a simple initial state.
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2")})
+	d.OnUpdates([]api.Update{KVUpdate("key3", "v3")})
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1",
+		"key2": "v2",
+		"key3": "v3",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore skipped.
+		api.ResyncInProgress.String(),
+		"key1=v1 (new)",
+		"key2=v2 (new)",
+		"key3=v3 (new)",
+		api.InSync.String(),
+	}))
+	rec.ResetUpdatesSeen()
 
-			// Send a simple initial state.
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})
-			onUpdates([]api.Update{KVUpdate("key2", "v2")})
-			onUpdates([]api.Update{KVUpdate("key3", "v3")})
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1",
-				"key2": "v2",
-				"key3": "v3",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore skipped.
-				api.ResyncInProgress.String(),
-				"key1=v1 (new)",
-				"key2=v2 (new)",
-				"key3=v3 (new)",
-				api.InSync.String(),
-			}))
-			rec.ResetUpdatesSeen()
+	// Typha reconnection.
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
+	// d.OnUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
+	d.OnUpdates([]api.Update{KVUpdate("key4", "v4")})
 
-			// Typha reconnection.
-			d.OnTyphaConnectionRestarted()
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
-			onUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
-			// onUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
-			onUpdates([]api.Update{KVUpdate("key4", "v4")})
+	// And another one before we flush the queue.
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1b")}) // Same
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2")})  // Changed
+	// d.OnUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
+	d.OnUpdates([]api.Update{KVUpdate("key4", "v4")})
 
-			// And another one before we flush the queue.
-			d.OnTyphaConnectionRestarted()
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1b")}) // Same
-			onUpdates([]api.Update{KVUpdate("key2", "v2")})  // Changed
-			// onUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
-			onUpdates([]api.Update{KVUpdate("key4", "v4")})
-
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1b",
-				"key2": "v2",
-				"key4": "v4",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				api.ResyncInProgress.String(),
-				"key1=v1b (updated)",
-				"key2=v2 (updated)",
-				"key4=v4 (new)",
-				"key3= (deleted)",
-				api.InSync.String(),
-			}))
-		})
-	}
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1b",
+		"key2": "v2",
+		"key4": "v4",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		api.ResyncInProgress.String(),
+		"key1=v1b (updated)",
+		"key2=v2 (updated)",
+		"key4=v4 (new)",
+		"key3= (deleted)",
+		api.InSync.String(),
+	}))
 }
 
 // TestDedupeBuffer_TyphaDoubleResyncAfterFlush tests a back-to-back Typha
@@ -288,251 +267,219 @@ func TestDedupeBuffer_TyphaDoubleResyncNoFlush(t *testing.T) {
 // starts.
 func TestDedupeBuffer_TyphaDoubleResyncAfterFlush(t *testing.T) {
 	// Tests a resync with Typha that itself gets interrupted by a new resync.
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
 
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
+	// Send a simple initial state.
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2")})
+	d.OnUpdates([]api.Update{KVUpdate("key3", "v3")})
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1",
+		"key2": "v2",
+		"key3": "v3",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore skipped.
+		api.ResyncInProgress.String(),
+		"key1=v1 (new)",
+		"key2=v2 (new)",
+		"key3=v3 (new)",
+		api.InSync.String(),
+	}))
+	rec.ResetUpdatesSeen()
 
-			// Send a simple initial state.
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})
-			onUpdates([]api.Update{KVUpdate("key2", "v2")})
-			onUpdates([]api.Update{KVUpdate("key3", "v3")})
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1",
-				"key2": "v2",
-				"key3": "v3",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore skipped.
-				api.ResyncInProgress.String(),
-				"key1=v1 (new)",
-				"key2=v2 (new)",
-				"key3=v3 (new)",
-				api.InSync.String(),
-			}))
-			rec.ResetUpdatesSeen()
+	// Typha reconnection.
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
+	// d.OnUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
+	d.OnUpdates([]api.Update{KVUpdate("key4", "v4")})
 
-			// Typha reconnection.
-			d.OnTyphaConnectionRestarted()
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
-			onUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
-			// onUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
-			onUpdates([]api.Update{KVUpdate("key4", "v4")})
+	// Flush the queue before we send the in-sync.
+	sendNextBatchSync(d, rec)
 
-			// Flush the queue before we send the in-sync.
-			sendNextBatchSync(d, rec)
+	// This update will go onto the queue but then get thrown away
+	// by OnTyphaConnectionRestarted().
+	d.OnUpdates([]api.Update{KVUpdate("key5", "v5")})
 
-			// This update will go onto the queue but then get thrown away
-			// by OnTyphaConnectionRestarted().
-			onUpdates([]api.Update{KVUpdate("key5", "v5")})
+	// Then start a new resync.
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1b")}) // Same
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2")})  // Changed
+	// d.OnUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
+	d.OnUpdates([]api.Update{KVUpdate("key4", "v4")})
 
-			// Then start a new resync.
-			d.OnTyphaConnectionRestarted()
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1b")}) // Same
-			onUpdates([]api.Update{KVUpdate("key2", "v2")})  // Changed
-			// onUpdates([]api.Update{KVUpdate("key3", "v3")}) // Deleted as part of resync.
-			onUpdates([]api.Update{KVUpdate("key4", "v4")})
-
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1b",
-				"key2": "v2",
-				"key4": "v4",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				api.ResyncInProgress.String(),
-				"key1=v1 (updated)",
-				"key2=v2b (updated)",
-				"key4=v4 (new)",
-				api.ResyncInProgress.String(),
-				"key1=v1b (updated)",
-				"key2=v2 (updated)",
-				"key4=v4 (updated)",
-				"key3= (deleted)", // Only deleted when we se in-sync.
-				api.InSync.String(),
-			}))
-		})
-	}
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1b",
+		"key2": "v2",
+		"key4": "v4",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		api.ResyncInProgress.String(),
+		"key1=v1 (updated)",
+		"key2=v2b (updated)",
+		"key4=v4 (new)",
+		api.ResyncInProgress.String(),
+		"key1=v1b (updated)",
+		"key2=v2 (updated)",
+		"key4=v4 (updated)",
+		"key3= (deleted)", // Only deleted when we se in-sync.
+		api.InSync.String(),
+	}))
 }
 
 // TestDedupeBuffer_TyphaResyncNothingToDelete covers the case where the
 // liveKeysNotSeenSinceReconnect set is empty at the end of the resync.
 func TestDedupeBuffer_TyphaResyncNothingToDelete(t *testing.T) {
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
 
-			// Send a simple initial state.
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})
-			onUpdates([]api.Update{KVUpdate("key2", "v2")})
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1",
-				"key2": "v2",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				// WaitForDatastore skipped.
-				api.ResyncInProgress.String(),
-				"key1=v1 (new)",
-				"key2=v2 (new)",
-				api.InSync.String(),
-			}))
-			rec.ResetUpdatesSeen()
+	// Send a simple initial state.
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2")})
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1",
+		"key2": "v2",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		// WaitForDatastore skipped.
+		api.ResyncInProgress.String(),
+		"key1=v1 (new)",
+		"key2=v2 (new)",
+		api.InSync.String(),
+	}))
+	rec.ResetUpdatesSeen()
 
-			// Typha reconnection.
-			d.OnTyphaConnectionRestarted()
-			d.OnStatusUpdated(api.WaitForDatastore)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
-			onUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
-			d.OnStatusUpdated(api.InSync)
-			sendNextBatchSync(d, rec)
-			Expect(rec.FinalValues()).To(Equal(map[string]string{
-				"key1": "v1",
-				"key2": "v2b",
-			}))
-			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				api.ResyncInProgress.String(),
-				"key1=v1 (updated)",
-				"key2=v2b (updated)",
-				api.InSync.String(),
-			}))
-		})
-	}
+	// Typha reconnection.
+	d.OnTyphaConnectionRestarted()
+	d.OnStatusUpdated(api.WaitForDatastore)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{KVUpdate("key1", "v1")})  // Same
+	d.OnUpdates([]api.Update{KVUpdate("key2", "v2b")}) // Changed
+	d.OnStatusUpdated(api.InSync)
+	sendNextBatchSync(d, rec)
+	Expect(rec.FinalValues()).To(Equal(map[string]string{
+		"key1": "v1",
+		"key2": "v2b",
+	}))
+	Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		api.ResyncInProgress.String(),
+		"key1=v1 (updated)",
+		"key2=v2b (updated)",
+		api.InSync.String(),
+	}))
 }
 
 func TestDedupeBuffer_Async(t *testing.T) {
-	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
-		t.Run(onUpdatesVersion, func(t *testing.T) {
-			RegisterTestingT(t)
-			d := New()
-			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
-			rec := NewReceiver()
-			go d.SendToSinkForever(rec)
-			defer d.Stop()
+	RegisterTestingT(t)
+	d := New()
+	rec := NewReceiver()
+	go d.SendToSinkForever(rec)
+	defer d.Stop()
 
-			rec.BlockAfterNextUpdate()
-			defer rec.Unblock()
+	rec.BlockAfterNextUpdate()
+	defer rec.Unblock()
 
-			// Send updates and wait for them to show up.
-			onUpdates([]api.Update{
-				KVUpdate("key1", "1a"),
-				KVUpdate("key2", "2a"),
-				KVUpdate("key3", "3a"),
-				KVUpdate("key4", "4a"),
-			})
-			Eventually(rec.FinalValues).Should(Equal(map[string]string{
-				"key1": "1a",
-				"key2": "2a",
-				"key3": "3a",
-				"key4": "4a",
-			}))
-			Expect(rec.UpdatesSeen()).To(ConsistOf(
-				"key1=1a (new)",
-				"key2=2a (new)",
-				"key3=3a (new)",
-				"key4=4a (new)",
-			))
-			rec.ResetUpdatesSeen()
+	// Send updates and wait for them to show up.
+	d.OnUpdates([]api.Update{
+		KVUpdate("key1", "1a"),
+		KVUpdate("key2", "2a"),
+		KVUpdate("key3", "3a"),
+		KVUpdate("key4", "4a"),
+	})
+	Eventually(rec.FinalValues).Should(Equal(map[string]string{
+		"key1": "1a",
+		"key2": "2a",
+		"key3": "3a",
+		"key4": "4a",
+	}))
+	Expect(rec.UpdatesSeen()).To(ConsistOf(
+		"key1=1a (new)",
+		"key2=2a (new)",
+		"key3=3a (new)",
+		"key4=4a (new)",
+	))
+	rec.ResetUpdatesSeen()
 
-			// Receiver should now be blocked.  Send in a series of updates,
-			// some of which replace earlier updates.
-			onUpdates([]api.Update{
-				KVUpdate("key1", "1a"), // No-op update
-				KVUpdate("key2", "2b"), // Genuine change
-				KVUpdate("key3", "3b"), // Genuine change x2
-				KVUpdate("key4", ""),   // delete
-				KVUpdate("key5", "5a"), // add
-				KVUpdate("key6", "6a"), // add
-				KVUpdate("key7", "7a"), // add
-			})
-			d.OnStatusUpdated(api.InSync)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			onUpdates([]api.Update{
-				KVUpdate("key1", "1a"), // No-op update
-				KVUpdate("key3", "3c"), // Genuine change; should replace earlier change
-				KVUpdate("key5", ""),   // Delete before ever being sent
-				KVUpdate("key7", "7b"), // Update before ever being sent
-				KVUpdate("key8", "8a"), // add
-			})
-			d.OnStatusUpdated(api.InSync)
-			d.OnStatusUpdated(api.ResyncInProgress)
-			d.OnStatusUpdated(api.InSync)
-			rec.Unblock()
+	// Receiver should now be blocked.  Send in a series of updates,
+	// some of which replace earlier updates.
+	d.OnUpdates([]api.Update{
+		KVUpdate("key1", "1a"), // No-op update
+		KVUpdate("key2", "2b"), // Genuine change
+		KVUpdate("key3", "3b"), // Genuine change x2
+		KVUpdate("key4", ""),   // delete
+		KVUpdate("key5", "5a"), // add
+		KVUpdate("key6", "6a"), // add
+		KVUpdate("key7", "7a"), // add
+	})
+	d.OnStatusUpdated(api.InSync)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnUpdates([]api.Update{
+		KVUpdate("key1", "1a"), // No-op update
+		KVUpdate("key3", "3c"), // Genuine change; should replace earlier change
+		KVUpdate("key5", ""),   // Delete before ever being sent
+		KVUpdate("key7", "7b"), // Update before ever being sent
+		KVUpdate("key8", "8a"), // add
+	})
+	d.OnStatusUpdated(api.InSync)
+	d.OnStatusUpdated(api.ResyncInProgress)
+	d.OnStatusUpdated(api.InSync)
+	rec.Unblock()
 
-			Eventually(rec.FinalValues).Should(Equal(
-				map[string]string{
-					"key1": "1a",
-					"key2": "2b",
-					"key3": "3c",
-					"key6": "6a",
-					"key7": "7b",
-					"key8": "8a",
-				}),
-				"After sending various updates should get correct final result.",
-			)
-			Eventually(rec.FinalSyncState).Should(Equal(api.InSync))
+	Eventually(rec.FinalValues).Should(Equal(
+		map[string]string{
+			"key1": "1a",
+			"key2": "2b",
+			"key3": "3c",
+			"key6": "6a",
+			"key7": "7b",
+			"key8": "8a",
+		}),
+		"After sending various updates should get correct final result.",
+	)
+	Eventually(rec.FinalSyncState).Should(Equal(api.InSync))
 
-			// The updates come out in the same order that we sent them
-			// but a key that gets updated twice between flushes of the queue
-			// is only sent once with its most recent value.
-			Expect(rec.UpdatesSeen()).To(Equal([]string{
-				"key1=1a (updated)", // Only dedupe things that are on the queue so this dupe does get sent.
-				"key2=2b (updated)",
-				"key3=3c (updated)", // The 3b update gets suppressed
-				"key4= (deleted)",   // key4 was sent before so the deletion is sent
-				// key5 should never be sent.
-				"key6=6a (new)",
-				"key7=7b (new)",
-				"resync",
-				"key8=8a (new)",
-				"in-sync",
-			}))
-		})
-	}
+	// The updates come out in the same order that we sent them
+	// but a key that gets updated twice between flushes of the queue
+	// is only sent once with its most recent value.
+	Expect(rec.UpdatesSeen()).To(Equal([]string{
+		"key1=1a (updated)", // Only dedupe things that are on the queue so this dupe does get sent.
+		"key2=2b (updated)",
+		"key3=3c (updated)", // The 3b update gets suppressed
+		"key4= (deleted)",   // key4 was sent before so the deletion is sent
+		// key5 should never be sent.
+		"key6=6a (new)",
+		"key7=7b (new)",
+		"resync",
+		"key8=8a (new)",
+		"in-sync",
+	}))
 }
 
 func sendNextBatchSync(d *DedupeBuffer, r *Receiver) {
 	ExpectWithOffset(1, d.sendNextBatchToSinkNoBlock(r)).NotTo(HaveOccurred())
-}
-
-func wrapOnUpdates(d *DedupeBuffer, onUpdatesVersion string) func(updates []api.Update) {
-	onUpdates := d.OnUpdates
-	if onUpdatesVersion == "KeysKnown" {
-		onUpdates = func(updates []api.Update) {
-			var keys []string
-			for _, upd := range updates {
-				key, err := model.KeyToDefaultPath(upd.Key)
-				Expect(err).NotTo(HaveOccurred())
-				keys = append(keys, key)
-			}
-			d.OnUpdatesKeysKnown(updates, keys)
-		}
-	}
-	return onUpdates
 }
 
 func KVUpdate(key, value string) api.Update {

--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
-	calinet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 func init() {
@@ -392,84 +391,6 @@ func TestDedupeBuffer_TyphaResyncNothingToDelete(t *testing.T) {
 	}))
 }
 
-// TestDedupeBuffer_NonComparableKeys tests dedupe and reconnection deletion
-// synthesis for key types that are not Go-comparable (e.g. BlockKey which
-// embeds net.IPNet containing a slice). These fall back to string-encoded
-// paths in the tracking maps.
-func TestDedupeBuffer_NonComparableKeys(t *testing.T) {
-	RegisterTestingT(t)
-	d := New()
-	rec := newGenericReceiver()
-
-	_, cidr1, _ := calinet.ParseCIDR("10.0.0.0/24")
-	_, cidr2, _ := calinet.ParseCIDR("10.0.1.0/24")
-	_, cidr3, _ := calinet.ParseCIDR("10.0.2.0/24")
-
-	blockUpdate := func(cidr calinet.IPNet, value string) api.Update {
-		u := api.Update{
-			KVPair: model.KVPair{
-				Key: model.BlockKey{CIDR: cidr},
-			},
-		}
-		if value != "" {
-			u.KVPair.Value = value
-		} else {
-			u.UpdateType = api.UpdateTypeKVDeleted
-		}
-		return u
-	}
-
-	// Initial state with three blocks.
-	d.OnStatusUpdated(api.ResyncInProgress)
-	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1")})
-	d.OnUpdates([]api.Update{blockUpdate(*cidr2, "block2")})
-	d.OnUpdates([]api.Update{blockUpdate(*cidr3, "block3")})
-	d.OnStatusUpdated(api.InSync)
-	sendNextBatchToGeneric(d, rec)
-
-	Expect(rec.liveKeys()).To(HaveLen(3))
-	Expect(rec.syncState()).To(Equal(api.InSync))
-
-	cidr1Path, _ := model.KeyToDefaultPath(model.BlockKey{CIDR: *cidr1})
-	cidr3Path, _ := model.KeyToDefaultPath(model.BlockKey{CIDR: *cidr3})
-
-	// Dedupe: update cidr1 twice before flush — only second value should appear.
-	rec.resetUpdatesSeen()
-	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1b")})
-	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1c")})
-	sendNextBatchToGeneric(d, rec)
-
-	Expect(rec.liveKeys()).To(HaveKey(cidr1Path))
-	updates := rec.updatesSeen()
-	// Should only have one update for cidr1, with the final value.
-	Expect(updates).To(HaveLen(1))
-	Expect(updates[0].Value).To(Equal("block1c"))
-
-	// Reconnection: cidr3 disappears during resync.
-	rec.resetUpdatesSeen()
-	d.OnTyphaConnectionRestarted()
-	d.OnStatusUpdated(api.ResyncInProgress)
-	d.OnUpdates([]api.Update{blockUpdate(*cidr1, "block1c")})
-	d.OnUpdates([]api.Update{blockUpdate(*cidr2, "block2")})
-	// cidr3 not sent — should be synthesized as deletion.
-	d.OnStatusUpdated(api.InSync)
-	sendNextBatchToGeneric(d, rec)
-
-	Expect(rec.liveKeys()).To(HaveLen(2))
-	Expect(rec.liveKeys()).NotTo(HaveKey(cidr3Path))
-	Expect(rec.syncState()).To(Equal(api.InSync))
-
-	// Verify the deletion was synthesized for cidr3.
-	var deletionPaths []string
-	for _, u := range rec.updatesSeen() {
-		if u.Value == nil {
-			p, _ := model.KeyToDefaultPath(u.Key)
-			deletionPaths = append(deletionPaths, p)
-		}
-	}
-	Expect(deletionPaths).To(ConsistOf(cidr3Path))
-}
-
 func TestDedupeBuffer_Async(t *testing.T) {
 	RegisterTestingT(t)
 	d := New()
@@ -664,74 +585,4 @@ func (r *Receiver) Unblock() {
 	defer r.mutex.Unlock()
 	r.block = false
 	r.cond.Signal()
-}
-
-// genericReceiver is a test receiver that works with any model.Key type,
-// tracking updates by string-encoded path (since some key types are not
-// comparable and can't be used as Go map keys directly).
-type genericReceiver struct {
-	mutex          sync.Mutex
-	keys           map[string]any // path -> value
-	updates        []api.Update
-	finalSyncState api.SyncStatus
-}
-
-func newGenericReceiver() *genericReceiver {
-	return &genericReceiver{
-		keys: map[string]any{},
-	}
-}
-
-func (r *genericReceiver) OnStatusUpdated(status api.SyncStatus) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	r.finalSyncState = status
-}
-
-func (r *genericReceiver) OnUpdates(updates []api.Update) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	for _, u := range updates {
-		r.updates = append(r.updates, u)
-		path, _ := model.KeyToDefaultPath(u.Key)
-		if u.Value == nil {
-			delete(r.keys, path)
-		} else {
-			r.keys[path] = u.Value
-		}
-	}
-}
-
-func (r *genericReceiver) liveKeys() map[string]any {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	cp := make(map[string]any, len(r.keys))
-	for k, v := range r.keys {
-		cp[k] = v
-	}
-	return cp
-}
-
-func (r *genericReceiver) updatesSeen() []api.Update {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	cp := make([]api.Update, len(r.updates))
-	copy(cp, r.updates)
-	return cp
-}
-
-func (r *genericReceiver) resetUpdatesSeen() {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	r.updates = nil
-}
-
-func (r *genericReceiver) syncState() api.SyncStatus {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	return r.finalSyncState
-}
-
-func sendNextBatchToGeneric(d *DedupeBuffer, r *genericReceiver) {
-	ExpectWithOffset(1, d.sendNextBatchToSinkNoBlock(r)).NotTo(HaveOccurred())
 }

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -131,15 +131,11 @@ func New(
 	if options == nil {
 		options = &Options{}
 	}
-	cbskn, ok := cbs.(CallbacksWithKeysKnown)
-	if !ok {
-		cbskn = simpleCallbacksAdapter{cbs}
-	}
 	sc := &SyncerClient{
 		logCxt: log.WithFields(log.Fields{
 			"type": options.SyncerType,
 		}),
-		callbacks:          cbskn,
+		callbacks:          cbs,
 		discoverer:         discoverer,
 		connAttemptTracker: discovery.NewConnAttemptTracker(discoverer),
 
@@ -172,29 +168,14 @@ type SyncerClient struct {
 	encoder    *gob.Encoder
 	decoder    *gob.Decoder
 
-	callbacks CallbacksWithKeysKnown
+	callbacks api.SyncerCallbacks
 	Finished  sync.WaitGroup
 }
 
-type CallbacksWithKeysKnown interface {
-	api.SyncerCallbacks
-	OnUpdatesKeysKnown(updates []api.Update, keys []string)
-}
-
 type RestartAwareCallbacks interface {
-	CallbacksWithKeysKnown
+	api.SyncerCallbacks
 	OnTyphaConnectionRestarted()
 }
-
-type simpleCallbacksAdapter struct {
-	api.SyncerCallbacks
-}
-
-func (c simpleCallbacksAdapter) OnUpdatesKeysKnown(updates []api.Update, keys []string) {
-	c.OnUpdates(updates)
-}
-
-var _ CallbacksWithKeysKnown = simpleCallbacksAdapter{}
 
 func (s *SyncerClient) Start(cxt context.Context) error {
 	// Connect synchronously so that we can return an error early if we can't connect at all.
@@ -530,7 +511,6 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc, co
 			logCxt.Debug("Pong sent to Typha")
 		case syncproto.MsgKVs:
 			updates := make([]api.Update, 0, len(msg.KVs))
-			keys := make([]string, 0, len(msg.KVs))
 			if s.options.DebugDiscardKVUpdates {
 				// For simulating lots of clients in tests, just throw away the data.
 				continue
@@ -548,9 +528,8 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc, co
 					}).Debug("Decoded update from Typha")
 				}
 				updates = append(updates, update)
-				keys = append(keys, kv.Key)
 			}
-			s.callbacks.OnUpdatesKeysKnown(updates, keys)
+			s.callbacks.OnUpdates(updates)
 		case syncproto.MsgDecoderRestart:
 			if s.options.DisableDecoderRestart {
 				log.Error("Server sent MsgDecoderRestart but we signalled no support.")


### PR DESCRIPTION
DedupeBuffer's internal tracking maps used string-encoded paths as keys, which meant every incoming update allocated a string. Since #11958 made every `model.Key` concrete type Go-comparable, the key structs themselves can serve as map / set keys directly.

- `keyToPendingUpdate`, `liveResourceKeys`, `liveKeysNotSeenSinceReconnect`, and `updateWithKey.key` are now typed as `model.Key`; the per-update string encoding is gone.
- The Typha sync client's `OnUpdatesKeysKnown` / `CallbacksWithKeysKnown` / `simpleCallbacksAdapter` plumbing existed only to hand pre-encoded string keys to the dedupe buffer, and is removed.

CORE-12844

**Release note**
```release-note
Felix: reduce memory used for handling Typha reconnection.  Avoid converting all datastore keys to string, store the already-used key structs instead.
```