### PR TITLE
Adding KubeVirt permissions for calico-node ClusterRole

### DIFF
--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -6414,6 +6414,16 @@ rules:
       - daemonsets
     verbs:
       - get
+  # Felix (inside calico-node) is watching KubeVirt live-migration objects to 
+  # determine when to drain nodes. 
+  # These permissions can be removed if not using KubeVirt or not using live migration.
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - virtualmachineinstancemigrations
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # CNI cluster role


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

- Kubernetes version (all nodes): v1.32.0 
- Calico version: v3.31.4
- Calico manifest used: [manifests/calico.yaml](./manifests/calico.yaml)

Issue: Freshly installed kubernetes cluster with one controller and one worker fails to fully deploy `calico-node`.

<img width="558" height="219" alt="image" src="https://github.com/user-attachments/assets/dbca7799-51c3-434a-8e68-a6c4f705e2db" />

The logs shows:
```
2026-02-28 11:25:02.392 [INFO][55] felix/health.go 291: Reporter is not ready: reporting non-ready. name="InternalDataplaneMainLoop" 
2026-02-28 11:25:02.392 [INFO][55] felix/health.go 291: Reporter is not ready: reporting non-ready. name="CalculationGraph" 
2026-02-28 11:25:02.509 [INFO][55] felix/watchercache.go 243: Full resync is required ListRoot=".../v3/pc.org/livemigrations" 
2026-02-28 11:25:02.511 [INFO][55] felix/watchercache.go 274: Failed to perform list of current data during resync ListRoot=".../v3/pc.org/livemigrations" error=connection is unauthorized: virtualmachineinstancemigrations.kubevirt.io is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot list resource "virtualmachineinstancemigrations" in API group "kubevirt.io" at the cluster scope 
2026-02-28 11:25:02.511 [WARNING][55] felix/watchercache.go 284: Connection to datastore has failed - signaling error to client. ListRoot=".../v3/pc.org/livemigrations"
```

Fix:
```yaml
# Giving calico-node the permissions
  - apiGroups: ["kubevirt.io"]
    resources:
      - virtualmachineinstancemigrations
    verbs:
      - get
      - list
      - watch
```

<img width="556" height="221" alt="image" src="https://github.com/user-attachments/assets/d70beb42-478a-4f30-8484-dd028d3c82a4" />


<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Adding KubeVirt permissions for calico-node ClusterRole
```
