### PR TITLE
Make all model.Key types comparable by using netip types

### DIFF
--- a/calicoctl/calicoctl/commands/datastore/migrate/migrateipam_test.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/migrateipam_test.go
@@ -17,6 +17,7 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,7 +45,7 @@ var _ = Describe("IPAM migration handling", func() {
 	BeforeEach(func() {
 		block1 = &model.KVPair{
 			Key: model.BlockKey{
-				CIDR: net.MustParseCIDR("192.168.201.0/26"),
+				CIDR: netip.MustParsePrefix("192.168.201.0/26"),
 			},
 			Value: &model.AllocationBlock{
 				CIDR:     net.MustParseCIDR("192.168.201.0/26"),
@@ -67,7 +68,7 @@ var _ = Describe("IPAM migration handling", func() {
 
 		affinity1 = &model.KVPair{
 			Key: model.BlockAffinityKey{
-				CIDR:         net.MustParseCIDR("192.168.201.0/26"),
+				CIDR:         netip.MustParsePrefix("192.168.201.0/26"),
 				Host:         nodeName,
 				AffinityType: string(ipam.AffinityTypeHost),
 			},
@@ -118,7 +119,7 @@ var _ = Describe("IPAM migration handling", func() {
 
 		// Check that the block affinity attributes were changed correctly
 		newAffinityKey := model.BlockAffinityKey{
-			CIDR:         net.MustParseCIDR("192.168.201.0/26"),
+			CIDR:         netip.MustParsePrefix("192.168.201.0/26"),
 			Host:         newNodeName,
 			AffinityType: string(ipam.AffinityTypeHost),
 		}

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -673,12 +673,12 @@ func (c *client) updatePeersV1() {
 			for _, peer := range peers {
 				log.Debugf("Peer: %#v", peer)
 				if globalPass {
-					key := model.GlobalBGPPeerKey{PeerIP: peer.PeerIP, Port: peer.Port}
+					key := model.GlobalBGPPeerKey{PeerIP: model.AddrFromIP(peer.PeerIP), Port: peer.Port}
 					emit(key, peer)
 				} else {
 					for _, localNodeName := range localNodeNames {
 						log.Debugf("Local node name: %#v", localNodeName)
-						key := model.NodeBGPPeerKey{Nodename: localNodeName, PeerIP: peer.PeerIP, Port: peer.Port}
+						key := model.NodeBGPPeerKey{Nodename: localNodeName, PeerIP: model.AddrFromIP(peer.PeerIP), Port: peer.Port}
 						emit(key, peer)
 					}
 				}
@@ -750,7 +750,7 @@ func (c *client) updatePeersV1() {
 
 		for _, peer := range peers {
 			for _, localNodeName := range localNodeNames {
-				key := model.NodeBGPPeerKey{Nodename: localNodeName, PeerIP: peer.PeerIP, Port: peer.Port}
+				key := model.NodeBGPPeerKey{Nodename: localNodeName, PeerIP: model.AddrFromIP(peer.PeerIP), Port: peer.Port}
 				emit(key, peer)
 			}
 		}

--- a/confd/tests/helpers_test.go
+++ b/confd/tests/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,7 +54,6 @@ import (
 	backendapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
-	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/typha/pkg/syncclientutils"
 )
@@ -665,7 +665,7 @@ func createBlockAffinities(t *testing.T, be *datastoreBackend) func() {
 		for _, a := range standardBlockAffinities {
 			_, err := bc.Apply(ctx, &model.KVPair{
 				Key: model.BlockAffinityKey{
-					CIDR: mustParseCIDR(a.cidr),
+					CIDR: netip.MustParsePrefix(a.cidr),
 					Host: a.host,
 				},
 				Value: &model.BlockAffinity{
@@ -677,7 +677,7 @@ func createBlockAffinities(t *testing.T, be *datastoreBackend) func() {
 		return func() {
 			for _, a := range standardBlockAffinities {
 				_, _ = bc.Delete(ctx, model.BlockAffinityKey{
-					CIDR: mustParseCIDR(a.cidr),
+					CIDR: netip.MustParsePrefix(a.cidr),
 					Host: a.host,
 				}, "")
 			}
@@ -716,14 +716,6 @@ func createBlockAffinities(t *testing.T, be *datastoreBackend) func() {
 			}
 		}
 	}
-}
-
-func mustParseCIDR(s string) cnet.IPNet {
-	_, cidr, err := cnet.ParseCIDR(s)
-	if err != nil {
-		panic(fmt.Sprintf("parsing CIDR %q: %v", s, err))
-	}
-	return *cidr
 }
 
 // oneshotTestCase defines a single oneshot confd template rendering test.

--- a/felix/calc/calc_graph_test.go
+++ b/felix/calc/calc_graph_test.go
@@ -118,7 +118,7 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 		Expect(err).To(BeNil())
 	},
 	Entry("IPPool",
-		model.IPPoolKey{CIDR: mustParseNet("10.0.0.0/16")},
+		model.IPPoolKey{CIDR: mustParsePrefix("10.0.0.0/16")},
 		&model.IPPool{
 			CIDR: mustParseNet("10.0.0.0/16"),
 		},
@@ -133,7 +133,7 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 			Id: "10.0.0.0-16",
 		}),
 	Entry("IPPool masquerade",
-		model.IPPoolKey{CIDR: mustParseNet("10.0.0.0/16")},
+		model.IPPoolKey{CIDR: mustParsePrefix("10.0.0.0/16")},
 		&model.IPPool{
 			CIDR:       mustParseNet("10.0.0.0/16"),
 			Masquerade: true,

--- a/felix/calc/encapsulation_resolver_test.go
+++ b/felix/calc/encapsulation_resolver_test.go
@@ -58,7 +58,7 @@ var _ = Describe("EncapsulationCalculator", func() {
 					Expect(err).To(Not(HaveOccurred()))
 					p := model.KVPair{
 						Key: model.IPPoolKey{
-							CIDR: *cidr,
+							CIDR: model.PrefixFromIPNet(*cidr),
 						},
 						Value: nil,
 					}
@@ -399,7 +399,7 @@ func addPoolUpdate(cidr net.IPNet, ipipMode, vxlanMode encap.Mode) api.Update {
 	return api.Update{
 		KVPair: model.KVPair{
 			Key: model.IPPoolKey{
-				CIDR: cidr,
+				CIDR: model.PrefixFromIPNet(cidr),
 			},
 			Value: &model.IPPool{
 				CIDR:      cidr,
@@ -415,7 +415,7 @@ func removePoolUpdate(cidr net.IPNet) api.Update {
 	return api.Update{
 		KVPair: model.KVPair{
 			Key: model.IPPoolKey{
-				CIDR: cidr,
+				CIDR: model.PrefixFromIPNet(cidr),
 			},
 			Value: nil,
 		},
@@ -442,7 +442,7 @@ func getModelPool(cidr string, ipipMode, vxlanMode encap.Mode) *model.KVPair {
 	}
 	return &model.KVPair{
 		Key: model.IPPoolKey{
-			CIDR: *parsedCidr,
+			CIDR: model.PrefixFromIPNet(*parsedCidr),
 		},
 		Value: &model.IPPool{
 			CIDR:      *parsedCidr,

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -657,7 +657,7 @@ func (buf *EventSequencer) OnIPPoolUpdate(key model.IPPoolKey, pool *model.IPPoo
 		"key":  key,
 		"pool": pool,
 	}).Debug("IPPool update")
-	cidr := ip.CIDRFromCalicoNet(key.CIDR)
+	cidr := ip.CIDRFromPrefix(key.CIDR)
 	buf.pendingIPPoolDeletes.Discard(cidr)
 	buf.pendingIPPoolUpdates[cidr] = pool
 }
@@ -729,7 +729,7 @@ func (buf *EventSequencer) flushHostWireguardUpdates() {
 
 func (buf *EventSequencer) OnIPPoolRemove(key model.IPPoolKey) {
 	log.WithField("key", key).Debug("IPPool removed")
-	cidr := ip.CIDRFromCalicoNet(key.CIDR)
+	cidr := ip.CIDRFromPrefix(key.CIDR)
 	delete(buf.pendingIPPoolUpdates, cidr)
 	if buf.sentIPPools.Contains(cidr) {
 		buf.pendingIPPoolDeletes.Add(cidr)

--- a/felix/calc/event_sequencer_test.go
+++ b/felix/calc/event_sequencer_test.go
@@ -493,11 +493,11 @@ var _ = Describe("IPPool update/remove", func() {
 	})
 
 	It("Create an IP Pool and delete it without flushing the event sequencer", func() {
-		uut.OnIPPoolUpdate(model.IPPoolKey{CIDR: mustParseNet("10.0.0.0/16")},
+		uut.OnIPPoolUpdate(model.IPPoolKey{CIDR: mustParsePrefix("10.0.0.0/16")},
 			&model.IPPool{
 				CIDR: mustParseNet("10.0.0.0/16"),
 			})
-		uut.OnIPPoolRemove(model.IPPoolKey{CIDR: mustParseNet("10.0.0.0/16")})
+		uut.OnIPPoolRemove(model.IPPoolKey{CIDR: mustParsePrefix("10.0.0.0/16")})
 		Expect(recorder.Messages).To(BeNil())
 	})
 })

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -72,7 +72,7 @@ var _ = Describe("L3RouteResolver", func() {
 
 			l3RR.OnPoolUpdate(api.Update{
 				KVPair: model.KVPair{
-					Key:   model.IPPoolKey{CIDR: v1Pool.CIDR},
+					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(v1Pool.CIDR)},
 					Value: &v1Pool,
 				},
 			})
@@ -188,7 +188,7 @@ var _ = Describe("L3RouteResolver", func() {
 			}
 			l3RR.OnPoolUpdate(api.Update{
 				KVPair: model.KVPair{
-					Key:   model.IPPoolKey{CIDR: pool.CIDR},
+					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(pool.CIDR)},
 					Value: &pool,
 				},
 			})
@@ -199,7 +199,7 @@ var _ = Describe("L3RouteResolver", func() {
 			blockCIDR := net.MustParseCIDR("10.0.1.0/29")
 			l3RR.OnBlockUpdate(api.Update{
 				KVPair: model.KVPair{
-					Key: model.BlockKey{CIDR: blockCIDR},
+					Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
 					Value: &model.AllocationBlock{
 						CIDR:        blockCIDR,
 						Affinity:    &remoteAffinity,
@@ -245,7 +245,7 @@ var _ = Describe("L3RouteResolver", func() {
 			}
 			l3RR.OnPoolUpdate(api.Update{
 				KVPair: model.KVPair{
-					Key:   model.IPPoolKey{CIDR: pool.CIDR},
+					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(pool.CIDR)},
 					Value: &pool,
 				},
 			})
@@ -256,7 +256,7 @@ var _ = Describe("L3RouteResolver", func() {
 			blockCIDR := net.MustParseCIDR("10.0.1.0/32")
 			l3RR.OnBlockUpdate(api.Update{
 				KVPair: model.KVPair{
-					Key: model.BlockKey{CIDR: blockCIDR},
+					Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
 					Value: &model.AllocationBlock{
 						CIDR:        blockCIDR,
 						Affinity:    &remoteAffinity,

--- a/felix/calc/resources_for_test.go
+++ b/felix/calc/resources_for_test.go
@@ -837,15 +837,15 @@ var remoteHostVXLANV6TunnelMACConfigKey = model.HostConfigKey{
 }
 
 var ipPoolKey = model.IPPoolKey{
-	CIDR: mustParseNet("10.0.0.0/16"),
+	CIDR: mustParsePrefix("10.0.0.0/16"),
 }
 
 var ipPoolKey2 = model.IPPoolKey{
-	CIDR: mustParseNet("11.0.0.0/16"),
+	CIDR: mustParsePrefix("11.0.0.0/16"),
 }
 
 var hostCoveringIPPoolKey = model.IPPoolKey{
-	CIDR: mustParseNet("192.168.0.0/24"),
+	CIDR: mustParsePrefix("192.168.0.0/24"),
 }
 
 var hostCoveringIPPool = model.IPPool{
@@ -860,7 +860,7 @@ var ipPoolWithIPIP = model.IPPool{
 }
 
 var v6IPPoolKey = model.IPPoolKey{
-	CIDR: mustParseNet("feed:beef::/64"),
+	CIDR: mustParsePrefix("feed:beef::/64"),
 }
 
 var v6IPPool = model.IPPool{
@@ -900,19 +900,19 @@ var ipPoolWithVXLANCrossSubnet = model.IPPool{
 }
 
 var remoteIPAMBlockKey = model.BlockKey{
-	CIDR: mustParseNet("10.0.1.0/29"),
+	CIDR: mustParsePrefix("10.0.1.0/29"),
 }
 
 var remoteIPAMSlash32BlockKey = model.BlockKey{
-	CIDR: mustParseNet("10.0.0.0/32"),
+	CIDR: mustParsePrefix("10.0.0.0/32"),
 }
 
 var remotev6IPAMBlockKey = model.BlockKey{
-	CIDR: mustParseNet("feed:beef:0:0:1::/96"),
+	CIDR: mustParsePrefix("feed:beef:0:0:1::/96"),
 }
 
 var localIPAMBlockKey = model.BlockKey{
-	CIDR: mustParseNet("10.0.0.0/29"),
+	CIDR: mustParsePrefix("10.0.0.0/29"),
 }
 
 var (

--- a/felix/calc/utils_net_test.go
+++ b/felix/calc/utils_net_test.go
@@ -16,6 +16,7 @@ package calc_test
 
 import (
 	net2 "net"
+	"net/netip"
 
 	log "github.com/sirupsen/logrus"
 
@@ -41,4 +42,8 @@ func mustParseNet(n string) net.IPNet {
 func mustParseIP(s string) net.IP {
 	ip := net2.ParseIP(s)
 	return net.IP{IP: ip}
+}
+
+func mustParsePrefix(s string) netip.Prefix {
+	return netip.MustParsePrefix(s)
 }

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -27,6 +27,7 @@ import (
 	"math/big"
 	"math/bits"
 	"net"
+	"net/netip"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -356,6 +357,24 @@ func CIDRFromString(cidrStr string) (CIDR, error) {
 
 func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 	return CIDRFromIPNet(&ipNet.IPNet)
+}
+
+// CIDRFromPrefix converts a netip.Prefix to a CIDR.
+func CIDRFromPrefix(p netip.Prefix) CIDR {
+	addr := p.Addr()
+	bits := p.Bits()
+	if addr.Is4() {
+		raw := addr.As4()
+		return V4CIDR{
+			addr:   V4Addr(raw),
+			prefix: uint8(bits),
+		}
+	}
+	raw := addr.As16()
+	return V6CIDR{
+		addr:   V6Addr(raw),
+		prefix: uint8(bits),
+	}
 }
 
 func CIDRsFromCalicoNets(ipNets []calinet.IPNet) []CIDR {

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -360,7 +360,9 @@ func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 }
 
 // CIDRFromPrefix converts a netip.Prefix to a CIDR.
+// The prefix is masked to ensure canonical representation.
 func CIDRFromPrefix(p netip.Prefix) CIDR {
+	p = p.Masked()
 	addr := p.Addr()
 	bits := p.Bits()
 	if addr.Is4() {

--- a/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
@@ -336,7 +336,8 @@ func validateCalicoIPAM(fc *testutils.FlannelCluster, client client.Interface, b
 		var blocks []*net.IPNet
 		for _, o := range datastoreObjs.KVPairs {
 			k := o.Key.(model.BlockAffinityKey)
-			cidr := net.IPNet{IP: k.CIDR.IP, Mask: k.CIDR.Mask}
+			kCIDR := model.IPNetFromPrefix(k.CIDR)
+			cidr := net.IPNet(kCIDR.IPNet)
 			blocks = append(blocks, &cidr)
 		}
 		Expect(len(blocks)).To(Equal(4))

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -213,7 +213,7 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		Expect(c.allocationTracker.ipsByService[*svcKey]).To(BeEmpty())
 
 		cidr := cnet.MustParseCIDR("10.0.0.4/30")
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		aff := "virtual:load-balancer"
 		idx0 := 0
 		idx1 := 1
@@ -294,7 +294,7 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 
 	It("should not panic on handleBlockUpdate with nil *AllocationBlock", func() {
 		cidr := cnet.MustParseCIDR("10.0.0.4/30")
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 
 		// A nil *AllocationBlock wrapped in a non-nil interface passes the
 		// "kvp.Value == nil" check but causes a nil-pointer dereference on

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -365,7 +365,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			idx := 0
 			cidr := net.MustParseCIDR("10.0.0.0/30")
 			aff := "host:cnode"
-			key := model.BlockKey{CIDR: cidr}
+			key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 			b := model.AllocationBlock{
 				CIDR:        cidr,
 				Affinity:    &aff,
@@ -584,7 +584,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		// Add a new block with no allocations.
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -729,7 +729,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		// Add first block with no pools established.
 		firstBlockCIDR := net.MustParseCIDR("192.168.0.0/30")
 		firstBlockAff := "host:cnode"
-		firstBlockKey := model.BlockKey{CIDR: firstBlockCIDR}
+		firstBlockKey := model.BlockKey{CIDR: model.PrefixFromIPNet(firstBlockCIDR)}
 		firstBlock := model.AllocationBlock{
 			CIDR:        firstBlockCIDR,
 			Affinity:    &firstBlockAff,
@@ -818,7 +818,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		secondBlockCIDR := net.MustParseCIDR("10.16.0.0/30")
 		secondBlockAff := "host:cnode"
-		secondBlockKey := model.BlockKey{CIDR: secondBlockCIDR}
+		secondBlockKey := model.BlockKey{CIDR: model.PrefixFromIPNet(secondBlockCIDR)}
 		secondBlock := model.AllocationBlock{
 			CIDR:        secondBlockCIDR,
 			Affinity:    &secondBlockAff,
@@ -915,7 +915,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1034,7 +1034,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1115,7 +1115,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1282,7 +1282,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1308,7 +1308,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Allocate an IPv6 address to the pod as well.
 		cidrv6 := net.MustParseCIDR("fe80::00/126")
-		key2 := model.BlockKey{CIDR: cidrv6}
+		key2 := model.BlockKey{CIDR: model.PrefixFromIPNet(cidrv6)}
 		b2 := model.AllocationBlock{
 			CIDR:        cidrv6,
 			Affinity:    &aff,
@@ -1448,7 +1448,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1529,7 +1529,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1573,7 +1573,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Add a new block with no allocations.
 		cidr2 := net.MustParseCIDR("10.0.0.4/30")
-		key2 := model.BlockKey{CIDR: cidr2}
+		key2 := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr2)}
 		b2 := model.AllocationBlock{
 			CIDR:        cidr2,
 			Affinity:    &aff,
@@ -1639,7 +1639,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		handle := "test-handle"
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -1683,7 +1683,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Add a new block with no allocations.
 		cidr2 := net.MustParseCIDR("10.0.0.4/30")
-		key2 := model.BlockKey{CIDR: cidr2}
+		key2 := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr2)}
 		b2 := model.AllocationBlock{
 			CIDR:        cidr2,
 			Affinity:    &aff,
@@ -1755,7 +1755,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			}
 			cidr := net.MustParseCIDR(fmt.Sprintf("10.0.%d.0/24", i))
 			aff := "host:cnode"
-			key := model.BlockKey{CIDR: cidr}
+			key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 			b := model.AllocationBlock{
 				CIDR:        cidr,
 				Affinity:    &aff,
@@ -1834,7 +1834,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			}
 			cidr := net.MustParseCIDR(fmt.Sprintf("10.0.%d.0/31", i))
 			aff := "host:cnode"
-			key := model.BlockKey{CIDR: cidr}
+			key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 			b := model.AllocationBlock{
 				CIDR:        cidr,
 				Affinity:    &aff,
@@ -2190,7 +2190,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:dead-node"
 		idx := 0
-		key := model.BlockKey{CIDR: cidr}
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
 		b := model.AllocationBlock{
 			CIDR:        cidr,
 			Affinity:    &aff,
@@ -2296,7 +2296,7 @@ var _ = Describe("IPAM controller UTs", func() {
 					},
 				},
 			}
-			kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &b}
+			kvp := model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}, Value: &b}
 			c.onUpdate(bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew})
 		}
 
@@ -2393,7 +2393,7 @@ var _ = Describe("IPAM controller UTs", func() {
 					},
 				},
 			}
-			kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &b}
+			kvp := model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}, Value: &b}
 			c.onUpdate(bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew})
 		}
 
@@ -2474,7 +2474,7 @@ func createBlock(pods []v1.Pod, host, cidrStr string) bapi.Update {
 		Unallocated: unalloc,
 		Attributes:  attrs,
 	}
-	kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &block}
+	kvp := model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}, Value: &block}
 	return bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
 }
 

--- a/libcalico-go/lib/backend/k8s/client_test.go
+++ b/libcalico-go/lib/backend/k8s/client_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"os"
 	"strings"
 	"sync"
@@ -2644,7 +2645,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			cidr := net.MustParseCIDR("10.0.0.0/26")
 			kvp := model.KVPair{
 				Key: model.BlockAffinityKey{
-					CIDR:         cidr,
+					CIDR:         model.PrefixFromIPNet(cidr),
 					Host:         nodename,
 					AffinityType: string(ipam.AffinityTypeHost),
 				},
@@ -2658,7 +2659,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			cidr := net.MustParseCIDR("10.0.1.0/26")
 			kvp := model.KVPair{
 				Key: model.BlockAffinityKey{
-					CIDR:         cidr,
+					CIDR:         model.PrefixFromIPNet(cidr),
 					Host:         "othernode",
 					AffinityType: string(ipam.AffinityTypeHost),
 				},
@@ -3819,7 +3820,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			// Create a block affinity.
 			_, err = c.Create(ctx, &model.KVPair{
 				Key: model.BlockAffinityKey{
-					CIDR:         net.MustParseCIDR("10.0.0.0/26"),
+					CIDR:         netip.MustParsePrefix("10.0.0.0/26"),
 					Host:         "test-hostname",
 					AffinityType: string(ipam.AffinityTypeHost),
 				},
@@ -3854,7 +3855,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			// Create a block.
 			_, err = c.Create(ctx, &model.KVPair{
 				Key: model.BlockKey{
-					CIDR: net.MustParseCIDR("10.0.0.0/26"),
+					CIDR: netip.MustParsePrefix("10.0.0.0/26"),
 				},
 				Value: &model.AllocationBlock{
 					Affinity:    nil,

--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +37,6 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
@@ -50,7 +50,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affinity k8s backend tests", testut
 		kvp := model.KVPair{
 			Key: model.BlockAffinityKey{
 				Host:         "my-host",
-				CIDR:         net.MustParseCIDR("192.168.1.0/24"),
+				CIDR:         netip.MustParsePrefix("192.168.1.0/24"),
 				AffinityType: string(ipam.AffinityTypeHost),
 			},
 			Value: &model.BlockAffinity{
@@ -224,7 +224,7 @@ var _ = Describe("BlockAffinityClient tests with fake REST client", func() {
 			kvp := &model.KVPair{
 				Key: model.BlockAffinityKey{
 					Host:         "my-host",
-					CIDR:         net.MustParseCIDR("192.168.1.0/24"),
+					CIDR:         netip.MustParsePrefix("192.168.1.0/24"),
 					AffinityType: string(ipam.AffinityTypeHost),
 				},
 				Value: &model.BlockAffinity{State: model.StateConfirmed},

--- a/libcalico-go/lib/backend/k8s/resources/ipam_affinity_v1.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_affinity_v1.go
@@ -92,7 +92,7 @@ func (c *blockAffinityClientV1) toModelV1(kvpv3 *model.KVPair) (*model.KVPair, e
 
 		return &model.KVPair{
 			Key: model.BlockAffinityKey{
-				CIDR:         *cidr,
+				CIDR:         model.PrefixFromIPNet(*cidr),
 				AffinityType: affinityType,
 				Host:         kvpv3.Value.(*v3.BlockAffinity).Spec.Node,
 			},
@@ -132,7 +132,7 @@ func (c *blockAffinityClientV1) toModelV1(kvpv3 *model.KVPair) (*model.KVPair, e
 
 		return &model.KVPair{
 			Key: model.BlockAffinityKey{
-				CIDR:         *cidr,
+				CIDR:         model.PrefixFromIPNet(*cidr),
 				AffinityType: affinityType,
 				Host:         kvpv3.Value.(*internalapi.BlockAffinity).Spec.Node,
 			},
@@ -152,7 +152,7 @@ func (c *blockAffinityClientV1) parseKey(k model.Key) (name, cidr, host, affinit
 	host = k.(model.BlockAffinityKey).Host
 	affinityType = k.(model.BlockAffinityKey).AffinityType
 	cidr = fmt.Sprintf("%s", k.(model.BlockAffinityKey).CIDR)
-	cidrname := names.CIDRToName(k.(model.BlockAffinityKey).CIDR)
+	cidrname := names.CIDRToName(model.IPNetFromPrefix(k.(model.BlockAffinityKey).CIDR))
 
 	// Include the hostname as well.
 	name = fmt.Sprintf("%s-%s", host, cidrname)
@@ -310,8 +310,11 @@ func (c *blockAffinityClientV1) List(ctx context.Context, li model.ListInterface
 		if (host == "" || v1kvp.Key.(model.BlockAffinityKey).Host == host) &&
 			(affinityType == "" || v1kvp.Key.(model.BlockAffinityKey).AffinityType == affinityType) {
 			cidr := v1kvp.Key.(model.BlockAffinityKey).CIDR
-			cidrPtr := &cidr
-			if (requestedIPVersion == 0 || requestedIPVersion == cidrPtr.Version()) && !v1kvp.Value.(*model.BlockAffinity).Deleted {
+			cidrVer := 4
+			if !cidr.Addr().Is4() {
+				cidrVer = 6
+			}
+			if (requestedIPVersion == 0 || requestedIPVersion == cidrVer) && !v1kvp.Value.(*model.BlockAffinity).Deleted {
 				// Matches the given host and IP version.
 				kvpl.KVPairs = append(kvpl.KVPairs, v1kvp)
 			}

--- a/libcalico-go/lib/backend/k8s/resources/ipam_block.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_block.go
@@ -221,7 +221,7 @@ func (c *ipamBlockClient) IPAMBlockV3toV1(kvpv3 *model.KVPair) (*model.KVPair, e
 
 		return &model.KVPair{
 			Key: model.BlockKey{
-				CIDR: *cidr,
+				CIDR: model.PrefixFromIPNet(*cidr),
 			},
 			Value: &model.AllocationBlock{
 				CIDR:                        *cidr,
@@ -258,7 +258,7 @@ func (c *ipamBlockClient) IPAMBlockV3toV1(kvpv3 *model.KVPair) (*model.KVPair, e
 
 		return &model.KVPair{
 			Key: model.BlockKey{
-				CIDR: *cidr,
+				CIDR: model.PrefixFromIPNet(*cidr),
 			},
 			Value: &model.AllocationBlock{
 				CIDR:                        *cidr,
@@ -374,6 +374,6 @@ func (c *ipamBlockClient) IPAMBlockV1toV3(kvpv1 *model.KVPair) *model.KVPair {
 
 func parseKey(k model.Key) (name, cidr string) {
 	cidr = fmt.Sprintf("%s", k.(model.BlockKey).CIDR)
-	name = names.CIDRToName(k.(model.BlockKey).CIDR)
+	name = names.CIDRToName(model.IPNetFromPrefix(k.(model.BlockKey).CIDR))
 	return
 }

--- a/libcalico-go/lib/backend/k8s/resources/ipam_block.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_block.go
@@ -373,7 +373,7 @@ func (c *ipamBlockClient) IPAMBlockV1toV3(kvpv1 *model.KVPair) *model.KVPair {
 }
 
 func parseKey(k model.Key) (name, cidr string) {
-	cidr = fmt.Sprintf("%s", k.(model.BlockKey).CIDR)
+	cidr = k.(model.BlockKey).CIDR.Masked().String()
 	name = names.CIDRToName(model.IPNetFromPrefix(k.(model.BlockKey).CIDR))
 	return
 }

--- a/libcalico-go/lib/backend/k8s/resources/ippool.go
+++ b/libcalico-go/lib/backend/k8s/resources/ippool.go
@@ -61,7 +61,7 @@ func IPPoolV3ToV1(kvp *model.KVPair) (*model.KVPair, error) {
 		return nil, err
 	}
 	v1key := model.IPPoolKey{
-		CIDR: *cidr,
+		CIDR: model.PrefixFromIPNet(*cidr),
 	}
 	var ipipInterface string
 	var ipipMode encap.Mode

--- a/libcalico-go/lib/backend/model/bgppeer.go
+++ b/libcalico-go/lib/backend/model/bgppeer.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"net/netip"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -37,20 +38,20 @@ var (
 )
 
 type NodeBGPPeerKey struct {
-	Nodename string `json:"-" validate:"omitempty"`
-	PeerIP   net.IP `json:"-" validate:"required"`
-	Port     uint16 `json:"-" validate:"omitempty"`
+	Nodename string     `json:"-" validate:"omitempty"`
+	PeerIP   netip.Addr `json:"-" validate:"required"`
+	Port     uint16     `json:"-" validate:"omitempty"`
 }
 
 func (key NodeBGPPeerKey) defaultPath() (string, error) {
-	if key.PeerIP.IP == nil {
+	if !key.PeerIP.IsValid() {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "peerIP"}
 	}
 	if key.Nodename == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "node"}
 	}
 	e := fmt.Sprintf("/calico/bgp/v1/host/%s/peer_v%d/%s",
-		key.Nodename, key.PeerIP.Version(), combineIPAndPort(key.PeerIP, key.Port))
+		key.Nodename, addrVersion(key.PeerIP), combineAddrAndPort(key.PeerIP, key.Port))
 	return e, nil
 }
 
@@ -76,19 +77,19 @@ func (key NodeBGPPeerKey) String() string {
 
 type NodeBGPPeerListOptions struct {
 	Nodename string
-	PeerIP   net.IP
+	PeerIP   netip.Addr
 	Port     uint16
 }
 
 func (options NodeBGPPeerListOptions) defaultPathRoot() string {
 	if options.Nodename == "" {
 		return "/calico/bgp/v1/host"
-	} else if options.PeerIP.IP == nil {
+	} else if !options.PeerIP.IsValid() {
 		return fmt.Sprintf("/calico/bgp/v1/host/%s",
 			options.Nodename)
 	} else {
 		return fmt.Sprintf("/calico/bgp/v1/host/%s/peer_v%d/%s",
-			options.Nodename, options.PeerIP.Version(), combineIPAndPort(options.PeerIP, options.Port))
+			options.Nodename, addrVersion(options.PeerIP), combineAddrAndPort(options.PeerIP, options.Port))
 	}
 }
 
@@ -96,47 +97,48 @@ func (options NodeBGPPeerListOptions) KeyFromDefaultPath(path string) Key {
 	log.Debugf("Get BGPPeer key from %s", path)
 	nodename := ""
 	var port uint16
-	peerIP := net.IP{}
 	ekeyb := []byte(path)
-	if r := matchHostBGPPeer.FindAllSubmatch(ekeyb, -1); len(r) == 1 {
+	if r := matchHostBGPPeer.FindAllSubmatch(ekeyb, -1); len(r) != 1 {
+		log.Debugf("%s didn't match regex", path)
+		return nil
+	} else {
 		var ipBytes []byte
 		ipBytes, port = extractIPAndPort(string(r[0][2]))
 		nodename = string(r[0][1])
-		if err := peerIP.UnmarshalText(ipBytes); err != nil {
-			log.WithError(err).WithField("PeerIP", r[0][2]).Error("Error unmarshalling GlobalBGPPeer IP address")
+		peerIP, err := netip.ParseAddr(string(ipBytes))
+		if err != nil {
+			log.WithError(err).WithField("PeerIP", r[0][2]).Error("Error unmarshalling NodeBGPPeer IP address")
 			return nil
 		}
-	} else {
-		log.Debugf("%s didn't match regex", path)
-		return nil
-	}
+		peerIP = peerIP.Unmap()
 
-	if options.PeerIP.IP != nil && !options.PeerIP.Equal(peerIP.IP) {
-		log.Debugf("Didn't match peerIP %s != %s", options.PeerIP.String(), peerIP.String())
-		return nil
-	}
-	if options.Nodename != "" && nodename != options.Nodename {
-		log.Debugf("Didn't match hostname %s != %s", options.Nodename, nodename)
-		return nil
-	}
+		if options.PeerIP.IsValid() && options.PeerIP != peerIP {
+			log.Debugf("Didn't match peerIP %s != %s", options.PeerIP.String(), peerIP.String())
+			return nil
+		}
+		if options.Nodename != "" && nodename != options.Nodename {
+			log.Debugf("Didn't match hostname %s != %s", options.Nodename, nodename)
+			return nil
+		}
 
-	if port == 0 {
-		return NodeBGPPeerKey{PeerIP: peerIP, Nodename: nodename}
+		if port == 0 {
+			return NodeBGPPeerKey{PeerIP: peerIP, Nodename: nodename}
+		}
+		return NodeBGPPeerKey{PeerIP: peerIP, Nodename: nodename, Port: port}
 	}
-	return NodeBGPPeerKey{PeerIP: peerIP, Nodename: nodename, Port: port}
 }
 
 type GlobalBGPPeerKey struct {
-	PeerIP net.IP `json:"-" validate:"required"`
-	Port   uint16 `json:"-" validate:"omitempty"`
+	PeerIP netip.Addr `json:"-" validate:"required"`
+	Port   uint16     `json:"-" validate:"omitempty"`
 }
 
 func (key GlobalBGPPeerKey) defaultPath() (string, error) {
-	if key.PeerIP.IP == nil {
+	if !key.PeerIP.IsValid() {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "peerIP"}
 	}
 	e := fmt.Sprintf("/calico/bgp/v1/global/peer_v%d/%s",
-		key.PeerIP.Version(), combineIPAndPort(key.PeerIP, key.Port))
+		addrVersion(key.PeerIP), combineAddrAndPort(key.PeerIP, key.Port))
 	return e, nil
 }
 
@@ -161,46 +163,44 @@ func (key GlobalBGPPeerKey) String() string {
 }
 
 type GlobalBGPPeerListOptions struct {
-	PeerIP net.IP
+	PeerIP netip.Addr
 	Port   uint16
 }
 
 func (options GlobalBGPPeerListOptions) defaultPathRoot() string {
-	if options.PeerIP.IP == nil {
+	if !options.PeerIP.IsValid() {
 		return "/calico/bgp/v1/global"
 	} else {
 		return fmt.Sprintf("/calico/bgp/v1/global/peer_v%d/%s",
-			options.PeerIP.Version(), combineIPAndPort(options.PeerIP, options.Port))
+			addrVersion(options.PeerIP), combineAddrAndPort(options.PeerIP, options.Port))
 	}
 }
 
 func (options GlobalBGPPeerListOptions) KeyFromDefaultPath(path string) Key {
 	log.Debugf("Get BGPPeer key from %s", path)
-	peerIP := net.IP{}
 	ekeyb := []byte(path)
 	var port uint16
 
-	if r := matchGlobalBGPPeer.FindAllSubmatch(ekeyb, -1); len(r) == 1 {
+	if r := matchGlobalBGPPeer.FindAllSubmatch(ekeyb, -1); len(r) != 1 {
+		log.Debugf("%s didn't match regex", path)
+		return nil
+	} else {
 		var ipBytes []byte
 		ipBytes, port = extractIPAndPort(string(r[0][1]))
-		if err := peerIP.UnmarshalText(ipBytes); err != nil {
+		peerIP, err := netip.ParseAddr(string(ipBytes))
+		if err != nil {
 			log.WithError(err).WithField("PeerIP", r[0][1]).Error("Error unmarshalling GlobalBGPPeer IP address")
 			return nil
 		}
-	} else {
-		log.Debugf("%s didn't match regex", path)
-		return nil
-	}
+		peerIP = peerIP.Unmap()
 
-	if options.PeerIP.IP != nil && !options.PeerIP.Equal(peerIP.IP) {
-		log.Debugf("Didn't match peerIP %s != %s", options.PeerIP.String(), peerIP.String())
-		return nil
-	}
+		if options.PeerIP.IsValid() && options.PeerIP != peerIP {
+			log.Debugf("Didn't match peerIP %s != %s", options.PeerIP.String(), peerIP.String())
+			return nil
+		}
 
-	if port == 0 {
 		return GlobalBGPPeerKey{PeerIP: peerIP, Port: port}
 	}
-	return GlobalBGPPeerKey{PeerIP: peerIP, Port: port}
 }
 
 type BGPPeer struct {
@@ -227,11 +227,11 @@ func extractIPAndPort(ipPort string) ([]byte, uint16) {
 	return []byte(ipPort), defaultPort
 }
 
-func combineIPAndPort(ip net.IP, port uint16) string {
+func combineAddrAndPort(addr netip.Addr, port uint16) string {
 	if port == 0 || port == defaultPort {
-		return ip.String()
+		return addr.String()
 	} else {
 		strPort := strconv.Itoa(int(port))
-		return ip.String() + ipPortSeparator + strPort
+		return addr.String() + ipPortSeparator + strPort
 	}
 }

--- a/libcalico-go/lib/backend/model/bgppeer_test.go
+++ b/libcalico-go/lib/backend/model/bgppeer_test.go
@@ -15,13 +15,12 @@
 package model_test
 
 import (
-	"net"
+	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	. "github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 var _ = DescribeTable(
@@ -42,31 +41,31 @@ var _ = DescribeTable(
 	Entry(
 		"global BGP peer without port",
 		"/calico/bgp/v1/global/peer_v4/10.0.0.5",
-		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 179},
+		GlobalBGPPeerKey{PeerIP: netip.MustParseAddr("10.0.0.5"), Port: 179},
 		true,
 	),
 	Entry(
 		"global BGP peer with port",
 		"/calico/bgp/v1/global/peer_v4/10.0.0.5-500",
-		GlobalBGPPeerKey{PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 500},
+		GlobalBGPPeerKey{PeerIP: netip.MustParseAddr("10.0.0.5"), Port: 500},
 		true,
 	),
 	Entry(
 		"node BGP peer without port",
 		"/calico/bgp/v1/host/random-node-1/peer_v4/10.0.0.5",
-		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 179},
+		NodeBGPPeerKey{Nodename: "random-node-1", PeerIP: netip.MustParseAddr("10.0.0.5"), Port: 179},
 		false,
 	),
 	Entry(
 		"node BGP peer with port",
 		"/calico/bgp/v1/host/random-node-2/peer_v4/10.0.0.5-500",
-		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("10.0.0.5")}, Port: 500},
+		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: netip.MustParseAddr("10.0.0.5"), Port: 500},
 		false,
 	),
 	Entry(
 		"node BGP IPv6 peer with port",
 		"/calico/bgp/v1/host/random-node-2/peer_v6/aabb:aabb::ffff-123",
-		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: cnet.IP{IP: net.ParseIP("aabb:aabb::ffff")}, Port: 123},
+		NodeBGPPeerKey{Nodename: "random-node-2", PeerIP: netip.MustParseAddr("aabb:aabb::ffff"), Port: 123},
 		false,
 	),
 )

--- a/libcalico-go/lib/backend/model/block.go
+++ b/libcalico-go/lib/backend/model/block.go
@@ -74,8 +74,9 @@ func (key BlockKey) defaultPath() (string, error) {
 	if !key.CIDR.IsValid() {
 		return "", errors.ErrorInsufficientIdentifiers{}
 	}
-	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
-	e := fmt.Sprintf("/calico/ipam/v2/assignment/ipv%d/block/%s", prefixVersion(key.CIDR), c)
+	cidr := key.CIDR.Masked()
+	c := strings.Replace(cidr.String(), "/", "-", 1)
+	e := fmt.Sprintf("/calico/ipam/v2/assignment/ipv%d/block/%s", prefixVersion(cidr), c)
 	return e, nil
 }
 

--- a/libcalico-go/lib/backend/model/block.go
+++ b/libcalico-go/lib/backend/model/block.go
@@ -17,6 +17,7 @@ package model
 import (
 	"fmt"
 	"math/big"
+	"net/netip"
 	"reflect"
 	"regexp"
 	"strings"
@@ -66,15 +67,15 @@ var (
 )
 
 type BlockKey struct {
-	CIDR net.IPNet `json:"-" validate:"required,name"`
+	CIDR netip.Prefix `json:"-" validate:"required,name"`
 }
 
 func (key BlockKey) defaultPath() (string, error) {
-	if key.CIDR.IP == nil {
+	if !key.CIDR.IsValid() {
 		return "", errors.ErrorInsufficientIdentifiers{}
 	}
 	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
-	e := fmt.Sprintf("/calico/ipam/v2/assignment/ipv%d/block/%s", key.CIDR.Version(), c)
+	e := fmt.Sprintf("/calico/ipam/v2/assignment/ipv%d/block/%s", prefixVersion(key.CIDR), c)
 	return e, nil
 }
 
@@ -118,12 +119,12 @@ func (options BlockListOptions) KeyFromDefaultPath(path string) Key {
 		return nil
 	}
 	cidrStr := strings.Replace(r[0][1], "-", "/", 1)
-	_, cidr, err := net.ParseCIDR(cidrStr)
+	prefix, err := netip.ParsePrefix(cidrStr)
 	if err != nil {
 		log.Debugf("find an invalid cidr %s for path=%v , info=%v ", r[0][1], path, err)
 		return nil
 	}
-	return BlockKey{CIDR: *cidr}
+	return BlockKey{CIDR: prefix.Masked()}
 }
 
 type AllocationBlock struct {

--- a/libcalico-go/lib/backend/model/block_affinity.go
+++ b/libcalico-go/lib/backend/model/block_affinity.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha3"
 	"encoding/base32"
 	"fmt"
+	"net/netip"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 var (
@@ -46,9 +46,9 @@ const (
 )
 
 type BlockAffinityKey struct {
-	CIDR         net.IPNet `json:"-" validate:"required,name"`
-	Host         string    `json:"-"`
-	AffinityType string    `json:"-"`
+	CIDR         netip.Prefix `json:"-" validate:"required,name"`
+	Host         string       `json:"-"`
+	AffinityType string       `json:"-"`
 }
 
 type BlockAffinity struct {
@@ -57,7 +57,7 @@ type BlockAffinity struct {
 }
 
 func (key BlockAffinityKey) defaultPath() (string, error) {
-	if key.CIDR.IP == nil || key.Host == "" {
+	if !key.CIDR.IsValid() || key.Host == "" {
 		return "", errors.ErrorInsufficientIdentifiers{}
 	}
 
@@ -67,7 +67,7 @@ func (key BlockAffinityKey) defaultPath() (string, error) {
 	}
 
 	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
-	e := fmt.Sprintf("/calico/ipam/v2/%s/%s/ipv%d/block/%s", affinityType, key.Host, key.CIDR.Version(), c)
+	e := fmt.Sprintf("/calico/ipam/v2/%s/%s/ipv%d/block/%s", affinityType, key.Host, prefixVersion(key.CIDR), c)
 	return e, nil
 }
 
@@ -129,11 +129,12 @@ func (options BlockAffinityListOptions) KeyFromDefaultPath(path string) Key {
 		return nil
 	}
 	cidrStr := strings.Replace(r[0][3], "-", "/", 1)
-	_, cidr, _ := net.ParseCIDR(cidrStr)
-	if cidr == nil {
+	prefix, err := netip.ParsePrefix(cidrStr)
+	if err != nil {
 		log.Debugf("Failed to parse CIDR in block affinity path: %q", path)
 		return nil
 	}
+	prefix = prefix.Masked()
 	host := r[0][2]
 	affinityType := r[0][1]
 
@@ -141,12 +142,12 @@ func (options BlockAffinityListOptions) KeyFromDefaultPath(path string) Key {
 		log.Debugf("Didn't match hostname: %s != %s", options.Host, host)
 		return nil
 	}
-	if options.IPVersion != 0 && options.IPVersion != cidr.Version() {
-		log.Debugf("Didn't match IP version. %d != %d", options.IPVersion, cidr.Version())
+	if options.IPVersion != 0 && options.IPVersion != prefixVersion(prefix) {
+		log.Debugf("Didn't match IP version. %d != %d", options.IPVersion, prefixVersion(prefix))
 		return nil
 	}
 	return BlockAffinityKey{
-		CIDR:         *cidr,
+		CIDR:         prefix,
 		Host:         host,
 		AffinityType: affinityType,
 	}

--- a/libcalico-go/lib/backend/model/block_affinity.go
+++ b/libcalico-go/lib/backend/model/block_affinity.go
@@ -66,8 +66,9 @@ func (key BlockAffinityKey) defaultPath() (string, error) {
 		affinityType = IPAMAffinityTypeHost
 	}
 
-	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
-	e := fmt.Sprintf("/calico/ipam/v2/%s/%s/ipv%d/block/%s", affinityType, key.Host, prefixVersion(key.CIDR), c)
+	cidr := key.CIDR.Masked()
+	c := strings.Replace(cidr.String(), "/", "-", 1)
+	e := fmt.Sprintf("/calico/ipam/v2/%s/%s/ipv%d/block/%s", affinityType, key.Host, prefixVersion(cidr), c)
 	return e, nil
 }
 

--- a/libcalico-go/lib/backend/model/ippool.go
+++ b/libcalico-go/lib/backend/model/ippool.go
@@ -42,8 +42,9 @@ func (key IPPoolKey) defaultPath() (string, error) {
 	if !key.CIDR.IsValid() {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "cidr"}
 	}
-	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
-	e := fmt.Sprintf("/calico/v1/ipam/v%d/pool/%s", prefixVersion(key.CIDR), c)
+	cidr := key.CIDR.Masked()
+	c := strings.Replace(cidr.String(), "/", "-", 1)
+	e := fmt.Sprintf("/calico/v1/ipam/v%d/pool/%s", prefixVersion(cidr), c)
 	return e, nil
 }
 
@@ -76,8 +77,9 @@ func (options IPPoolListOptions) defaultPathRoot() string {
 	if !options.CIDR.IsValid() {
 		return k
 	}
-	c := strings.Replace(options.CIDR.String(), "/", "-", 1)
-	k = k + fmt.Sprintf("v%d/pool/", prefixVersion(options.CIDR)) + c
+	cidr := options.CIDR.Masked()
+	c := strings.Replace(cidr.String(), "/", "-", 1)
+	k = k + fmt.Sprintf("v%d/pool/", prefixVersion(cidr)) + c
 	return k
 }
 

--- a/libcalico-go/lib/backend/model/ippool.go
+++ b/libcalico-go/lib/backend/model/ippool.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"net/netip"
 	"reflect"
 	"regexp"
 	"strings"
@@ -34,15 +35,15 @@ var (
 )
 
 type IPPoolKey struct {
-	CIDR net.IPNet `json:"-" validate:"required,name"`
+	CIDR netip.Prefix `json:"-" validate:"required,name"`
 }
 
 func (key IPPoolKey) defaultPath() (string, error) {
-	if key.CIDR.IP == nil {
+	if !key.CIDR.IsValid() {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "cidr"}
 	}
 	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
-	e := fmt.Sprintf("/calico/v1/ipam/v%d/pool/%s", key.CIDR.Version(), c)
+	e := fmt.Sprintf("/calico/v1/ipam/v%d/pool/%s", prefixVersion(key.CIDR), c)
 	return e, nil
 }
 
@@ -67,16 +68,16 @@ func (key IPPoolKey) String() string {
 }
 
 type IPPoolListOptions struct {
-	CIDR net.IPNet
+	CIDR netip.Prefix
 }
 
 func (options IPPoolListOptions) defaultPathRoot() string {
 	k := "/calico/v1/ipam/"
-	if options.CIDR.IP == nil {
+	if !options.CIDR.IsValid() {
 		return k
 	}
 	c := strings.Replace(options.CIDR.String(), "/", "-", 1)
-	k = k + fmt.Sprintf("v%d/pool/", options.CIDR.Version()) + fmt.Sprintf("%s", c)
+	k = k + fmt.Sprintf("v%d/pool/", prefixVersion(options.CIDR)) + c
 	return k
 }
 
@@ -88,16 +89,17 @@ func (options IPPoolListOptions) KeyFromDefaultPath(path string) Key {
 		return nil
 	}
 	cidrStr := strings.Replace(r[0][1], "-", "/", 1)
-	_, cidr, err := net.ParseCIDR(cidrStr)
+	prefix, err := netip.ParsePrefix(cidrStr)
 	if err != nil {
 		log.WithError(err).Warningf("Failed to parse CIDR %s", cidrStr)
 		return nil
 	}
-	if options.CIDR.IP != nil && !reflect.DeepEqual(*cidr, options.CIDR) {
-		log.Debugf("Didn't match cidr %s != %s", options.CIDR.String(), cidr.String())
+	prefix = prefix.Masked()
+	if options.CIDR.IsValid() && prefix != options.CIDR.Masked() {
+		log.Debugf("Didn't match cidr %s != %s", options.CIDR.String(), prefix.String())
 		return nil
 	}
-	return IPPoolKey{CIDR: *cidr}
+	return IPPoolKey{CIDR: prefix}
 }
 
 type IPPool struct {

--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -17,6 +17,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"reflect"
 	"strings"
 	"time"
@@ -27,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/namespace"
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 const (
@@ -79,6 +79,14 @@ type Key interface {
 	// String returns a unique string representation of this key.  The string
 	// returned by this method must uniquely identify this Key.
 	String() string
+}
+
+// ComparableKey is a Key that is also comparable, meaning it can be used as a
+// Go map key or compared with ==.  All Key implementations in this package
+// satisfy this constraint.
+type ComparableKey interface {
+	Key
+	comparable
 }
 
 // Interface used to perform datastore lookups.
@@ -133,7 +141,7 @@ type KVPairList struct {
 // order to support datastores that do not support storing data at non-leaf
 // nodes in the hierarchy (such as etcd v3), the path returned for a "parent"
 // key, is not a direct ancestor of its children.
-func KeyToDefaultPath(key Key) (string, error) {
+func KeyToDefaultPath[K ComparableKey](key K) (string, error) {
 	return key.defaultPath()
 }
 
@@ -161,7 +169,7 @@ func KeyToDefaultPath(key Key) (string, error) {
 // and KeyToDefaultPath(PolicyKey{Kind: "NetworkPolicy", Namespace: "default", Name: "b"}):
 //
 //	"/calico/v1/policy/NetworkPolicy/default/b"
-func KeyToDefaultDeletePath(key Key) (string, error) {
+func KeyToDefaultDeletePath[K ComparableKey](key K) (string, error) {
 	return key.defaultDeletePath()
 }
 
@@ -191,7 +199,7 @@ func KeyToDefaultDeletePath(key Key) (string, error) {
 // indicating that these paths should also be deleted when they are empty.
 // In this example it is equivalent to deleting the workload when there are
 // no more endpoints in the workload.
-func KeyToDefaultDeleteParentPaths(key Key) ([]string, error) {
+func KeyToDefaultDeleteParentPaths[K ComparableKey](key K) ([]string, error) {
 	return key.defaultDeleteParentPaths()
 }
 
@@ -562,11 +570,11 @@ func OldKeyFromDefaultPath(path string) Key {
 		log.Debugf("Path is a pool: %v", path)
 		mungedCIDR := m[1]
 		cidr := strings.Replace(mungedCIDR, "-", "/", 1)
-		_, c, err := net.ParseCIDR(cidr)
+		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to parse CIDR %s", cidr)
 		} else {
-			return IPPoolKey{CIDR: *c}
+			return IPPoolKey{CIDR: prefix.Masked()}
 		}
 	} else if m := matchGlobalConfig.FindStringSubmatch(path); m != nil {
 		log.Debugf("Path is a global felix config: %v", path)
@@ -639,7 +647,7 @@ func parseJSONPointer[V any](key Key, rawData []byte) (*V, error) {
 // our value structs, according to the type of key.  I.e. if passed a
 // PolicyKey as the first parameter, it will try to parse rawData into a
 // Policy struct.
-func ParseValue(key Key, rawData []byte) (any, error) {
+func ParseValue[K ComparableKey](key K, rawData []byte) (any, error) {
 	return key.parseValue(rawData)
 }
 

--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -81,14 +81,6 @@ type Key interface {
 	String() string
 }
 
-// ComparableKey is a Key that is also comparable, meaning it can be used as a
-// Go map key or compared with ==.  All Key implementations in this package
-// satisfy this constraint.
-type ComparableKey interface {
-	Key
-	comparable
-}
-
 // Interface used to perform datastore lookups.
 type ListInterface interface {
 	// defaultPathRoot() returns a default stringified root path, i.e. path
@@ -141,7 +133,7 @@ type KVPairList struct {
 // order to support datastores that do not support storing data at non-leaf
 // nodes in the hierarchy (such as etcd v3), the path returned for a "parent"
 // key, is not a direct ancestor of its children.
-func KeyToDefaultPath[K ComparableKey](key K) (string, error) {
+func KeyToDefaultPath(key Key) (string, error) {
 	return key.defaultPath()
 }
 
@@ -169,7 +161,7 @@ func KeyToDefaultPath[K ComparableKey](key K) (string, error) {
 // and KeyToDefaultPath(PolicyKey{Kind: "NetworkPolicy", Namespace: "default", Name: "b"}):
 //
 //	"/calico/v1/policy/NetworkPolicy/default/b"
-func KeyToDefaultDeletePath[K ComparableKey](key K) (string, error) {
+func KeyToDefaultDeletePath(key Key) (string, error) {
 	return key.defaultDeletePath()
 }
 
@@ -199,7 +191,7 @@ func KeyToDefaultDeletePath[K ComparableKey](key K) (string, error) {
 // indicating that these paths should also be deleted when they are empty.
 // In this example it is equivalent to deleting the workload when there are
 // no more endpoints in the workload.
-func KeyToDefaultDeleteParentPaths[K ComparableKey](key K) ([]string, error) {
+func KeyToDefaultDeleteParentPaths(key Key) ([]string, error) {
 	return key.defaultDeleteParentPaths()
 }
 
@@ -647,7 +639,7 @@ func parseJSONPointer[V any](key Key, rawData []byte) (*V, error) {
 // our value structs, according to the type of key.  I.e. if passed a
 // PolicyKey as the first parameter, it will try to parse rawData into a
 // Policy struct.
-func ParseValue[K ComparableKey](key K, rawData []byte) (any, error) {
+func ParseValue(key Key, rawData []byte) (any, error) {
 	return key.parseValue(rawData)
 }
 

--- a/libcalico-go/lib/backend/model/keys_test.go
+++ b/libcalico-go/lib/backend/model/keys_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"net/netip"
 	"reflect"
 	"testing"
 
@@ -22,8 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
-
-	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
 // interestingPaths contains seed data for the KeyFromDefaultPath fuzzer.
@@ -114,6 +113,13 @@ func FuzzKeyFromDefaultPath(f *testing.F) {
 			// and consistent in some areas of escaping.
 			return
 		}
+
+		// All Key implementations must be comparable so they can be used as
+		// Go map keys and compared with ==.
+		if !reflect.TypeOf(newKey).Comparable() {
+			t.Fatalf("Key type %T is not comparable", newKey)
+		}
+
 		// If the old can parse it the new should parse it too (and get the same Key).
 		if !safeKeysEqual(oldKey, newKey) {
 			t.Fatalf("%q -> (new output) %v != (old output) %v", path, newKey, oldKey)
@@ -150,10 +156,6 @@ func safeKeysEqual(a, b Key) bool {
 		return false
 	}
 
-	// Due to an unfortunate historical mistake some of our keys embed non-comparable types net.IP and friends.
-	if !reflect.ValueOf(a).Type().Comparable() || !reflect.ValueOf(b).Type().Comparable() {
-		return reflect.DeepEqual(a, b)
-	}
 	return a == b
 }
 
@@ -283,7 +285,7 @@ var _ = DescribeTable(
 	Entry(
 		"IP pool",
 		"/calico/v1/ipam/v4/pool/10.0.0.0-8",
-		IPPoolKey{CIDR: mustParseCIDR("10.0.0.0/8")},
+		IPPoolKey{CIDR: netip.MustParsePrefix("10.0.0.0/8")},
 		false,
 	),
 	Entry(
@@ -520,7 +522,7 @@ var _ = DescribeTable(
 	Entry(
 		"Block affinity claims with confirmed state",
 		BlockAffinityKey{
-			CIDR: mustParseCIDR("172.29.128.64/26"),
+			CIDR: netip.MustParsePrefix("172.29.128.64/26").Masked(),
 			Host: "happyhost.io",
 		},
 		`{"state":"confirmed"}`,
@@ -529,7 +531,7 @@ var _ = DescribeTable(
 	Entry(
 		"Block affinity claims with pending state",
 		BlockAffinityKey{
-			CIDR: mustParseCIDR("172.29.128.0/26"),
+			CIDR: netip.MustParsePrefix("172.29.128.0/26"),
 			Host: "slightlyhappyhost.io",
 		},
 		`{"state":"pending"}`,
@@ -538,7 +540,7 @@ var _ = DescribeTable(
 	Entry(
 		"Block affinity claims with pending-deletion state",
 		BlockAffinityKey{
-			CIDR: mustParseCIDR("172.29.128.192/26"),
+			CIDR: netip.MustParsePrefix("172.29.128.192/26").Masked(),
 			Host: "notsohappyhost.io",
 		},
 		`{"state":"pendingDeletion"}`,
@@ -547,7 +549,7 @@ var _ = DescribeTable(
 	Entry(
 		"Pre-3.0.7 style block affinity claims with no state i.e. empty string in value",
 		BlockAffinityKey{
-			CIDR: mustParseCIDR("172.29.128.128/26"),
+			CIDR: netip.MustParsePrefix("172.29.128.128/26").Masked(),
 			Host: "oldhost.io",
 		},
 		``,
@@ -556,7 +558,7 @@ var _ = DescribeTable(
 	Entry(
 		"Block affinity claims with empty state {} in value",
 		BlockAffinityKey{
-			CIDR: mustParseCIDR("172.29.128.128/26"),
+			CIDR: netip.MustParsePrefix("172.29.128.128/26").Masked(),
 			Host: "oldhost.io",
 		},
 		`{}`,
@@ -636,14 +638,6 @@ var _ = DescribeTable(
 		},
 	),
 )
-
-func mustParseCIDR(s string) net.IPNet {
-	_, ipNet, err := net.ParseCIDR(s)
-	if err != nil {
-		panic(err)
-	}
-	return *ipNet
-}
 
 var (
 	benchResult any

--- a/libcalico-go/lib/backend/model/netip_helpers.go
+++ b/libcalico-go/lib/backend/model/netip_helpers.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"net"
+	"net/netip"
+
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
+)
+
+// PrefixFromIPNet converts a calico net.IPNet to a netip.Prefix.
+// The result is always masked (host bits cleared) for consistency.
+func PrefixFromIPNet(n cnet.IPNet) netip.Prefix {
+	addr, ok := netip.AddrFromSlice(n.IP)
+	if !ok {
+		return netip.Prefix{}
+	}
+	addr = addr.Unmap()
+	ones, _ := n.Mask.Size()
+	p := netip.PrefixFrom(addr, ones)
+	return p.Masked()
+}
+
+// PrefixFromStdIPNet converts a stdlib net.IPNet to a netip.Prefix.
+func PrefixFromStdIPNet(n net.IPNet) netip.Prefix {
+	return PrefixFromIPNet(cnet.IPNet{IPNet: n})
+}
+
+// IPNetFromPrefix converts a netip.Prefix back to a calico net.IPNet.
+// The result is always masked (host bits cleared), symmetric with
+// PrefixFromIPNet.
+func IPNetFromPrefix(p netip.Prefix) cnet.IPNet {
+	p = p.Masked()
+	addr := p.Addr()
+	bits := p.Bits()
+	var ipLen int
+	if addr.Is4() {
+		ipLen = net.IPv4len * 8
+	} else {
+		ipLen = net.IPv6len * 8
+	}
+	return cnet.IPNet{
+		IPNet: net.IPNet{
+			IP:   addr.AsSlice(),
+			Mask: net.CIDRMask(bits, ipLen),
+		},
+	}
+}
+
+// AddrFromIP converts a calico net.IP to a netip.Addr.
+func AddrFromIP(ip cnet.IP) netip.Addr {
+	addr, ok := netip.AddrFromSlice(ip.IP)
+	if !ok {
+		return netip.Addr{}
+	}
+	return addr.Unmap()
+}
+
+// IPFromAddr converts a netip.Addr back to a calico net.IP.
+func IPFromAddr(a netip.Addr) cnet.IP {
+	return cnet.IP{IP: a.AsSlice()}
+}
+
+// prefixVersion returns the IP version (4 or 6) for a netip.Prefix.
+func prefixVersion(p netip.Prefix) int {
+	if p.Addr().Is4() {
+		return 4
+	}
+	return 6
+}
+
+// addrVersion returns the IP version (4 or 6) for a netip.Addr.
+func addrVersion(a netip.Addr) int {
+	if a.Is4() {
+		return 4
+	}
+	return 6
+}

--- a/libcalico-go/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -17,6 +17,7 @@ package bgpsyncer_test
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -175,7 +176,7 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 			)
 			Expect(err).NotTo(HaveOccurred())
 			// The pool will add as single entry ( +1 )
-			poolKeyV1 := model.IPPoolKey{CIDR: net.MustParseCIDR("192.124.0.0/21")}
+			poolKeyV1 := model.IPPoolKey{CIDR: netip.MustParsePrefix("192.124.0.0/21")}
 			expectedCacheSize += 1
 			syncTester.ExpectCacheSize(expectedCacheSize)
 			syncTester.ExpectData(model.KVPair{
@@ -281,7 +282,8 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 				current := syncTester.GetCacheEntries()
 				for _, kvp := range current {
 					if kab, ok := kvp.Key.(model.BlockAffinityKey); ok {
-						if kab.Host == "127.0.0.1" && poolCIDRNet.Contains(kab.CIDR.IP) && kab.AffinityType == string(ipam.AffinityTypeHost) {
+						kabCIDR := model.IPNetFromPrefix(kab.CIDR)
+						if kab.Host == "127.0.0.1" && poolCIDRNet.Contains(kabCIDR.IP) && kab.AffinityType == string(ipam.AffinityTypeHost) {
 							blockAffinityKeyV1 = kab
 							break
 						}

--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -16,6 +16,7 @@ package felixsyncer_test
 
 import (
 	"context"
+	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -450,7 +451,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			// The pool will add as single entry ( +1 )
 			expectedCacheSize += 1
 			syncTester.ExpectData(model.KVPair{
-				Key: model.IPPoolKey{CIDR: net.MustParseCIDR("192.124.0.0/21")},
+				Key: model.IPPoolKey{CIDR: netip.MustParsePrefix("192.124.0.0/21")},
 				Value: &model.IPPool{
 					CIDR:           poolCIDRNet,
 					IPIPInterface:  "tunl0",
@@ -606,7 +607,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 			affinity := "host:127.0.0.1"
 			zero := 0
 			syncTester.ExpectData(model.KVPair{
-				Key: model.BlockKey{CIDR: *cidr},
+				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(*cidr)},
 				Value: &model.AllocationBlock{
 					CIDR:        *cidr,
 					Affinity:    &affinity,

--- a/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/tunnelipsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/tunnelipsyncer_e2e_test.go
@@ -16,6 +16,7 @@ package tunnelipsyncer_test
 
 import (
 	"context"
+	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -94,7 +95,7 @@ var _ = testutils.E2eDatastoreDescribe("Tunnel IP allocation syncer tests", test
 			)
 			Expect(err).NotTo(HaveOccurred())
 			// The pool will add as single entry ( +1 )
-			poolKeyV1 := model.IPPoolKey{CIDR: net.MustParseCIDR("192.124.0.0/21")}
+			poolKeyV1 := model.IPPoolKey{CIDR: netip.MustParsePrefix("192.124.0.0/21")}
 			expectedCacheSize += 1
 			syncTester.ExpectCacheSize(expectedCacheSize)
 			syncTester.ExpectData(model.KVPair{

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
@@ -162,7 +162,7 @@ func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, er
 				continue
 			}
 			kvps = append(kvps, &model.KVPair{
-				Key:      model.BlockAffinityKey{Host: name, CIDR: *cidr},
+				Key:      model.BlockAffinityKey{Host: name, CIDR: model.PrefixFromIPNet(*cidr)},
 				Value:    nil,
 				Revision: kvp.Revision,
 			})
@@ -177,7 +177,7 @@ func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, er
 			}
 
 			kvps = append(kvps, &model.KVPair{
-				Key:      model.BlockAffinityKey{Host: name, CIDR: *cidr},
+				Key:      model.BlockAffinityKey{Host: name, CIDR: model.PrefixFromIPNet(*cidr)},
 				Value:    &model.BlockAffinity{State: model.StateConfirmed},
 				Revision: kvp.Revision,
 			})

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
@@ -308,10 +308,10 @@ var _ = Describe("Test the (BGP) Node update processor with USE_POD_CIDR=true", 
 		// Make sure we have the correct KVP updates - one for each CIDR.
 		c1 := net.MustParseCIDR("192.168.1.0/24")
 		v := model.BlockAffinity{State: model.StateConfirmed}
-		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: c1, Host: "mynode"}, Value: &v})
+		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: model.PrefixFromIPNet(c1), Host: "mynode"}, Value: &v})
 
 		c2 := net.MustParseCIDR("192.168.2.0/24")
-		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: c2, Host: "mynode"}, Value: &v})
+		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: model.PrefixFromIPNet(c2), Host: "mynode"}, Value: &v})
 
 		// Remove CIDR 2 and make sure we get a delete for it.
 		By("handling an update that removes a CIDR")
@@ -327,10 +327,10 @@ var _ = Describe("Test the (BGP) Node update processor with USE_POD_CIDR=true", 
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert we get block affinity 1
-		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: c1, Host: "mynode"}, Value: &v})
+		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: model.PrefixFromIPNet(c1), Host: "mynode"}, Value: &v})
 
 		// And a remove for block affinity 2.
-		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: c2, Host: "mynode"}, Value: nil})
+		assertBlockAffinityUpdate(kvps, &model.KVPair{Key: model.BlockAffinityKey{CIDR: model.PrefixFromIPNet(c2), Host: "mynode"}, Value: nil})
 	})
 })
 

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		By("Testing invalid Key on ProcessDeleted")
 		_, err := cc.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: net.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(net.MustParseIP("1.2.3.4")),
 			},
 		})
 		Expect(err).To(HaveOccurred())
@@ -158,7 +158,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		By("Testing invalid Key on Process")
 		_, err = cc.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: net.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(net.MustParseIP("1.2.3.4")),
 			},
 			Value: apiv3.NewFelixConfiguration(),
 		})

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/conflictresolvingcacheproc_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Test the conflict resolving cache", func() {
 		Revision: "12345",
 	}
 	v1Key1 := model.GlobalBGPPeerKey{
-		PeerIP: net.MustParseIP("1.2.3.4"),
+		PeerIP: model.AddrFromIP(net.MustParseIP("1.2.3.4")),
 	}
 
 	converter := &fakeconverter{}

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -269,7 +269,7 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 				continue
 			}
 			kvps = append(kvps, &model.KVPair{
-				Key:      model.BlockKey{CIDR: *cidr},
+				Key:      model.BlockKey{CIDR: model.PrefixFromIPNet(*cidr)},
 				Value:    nil,
 				Revision: kvp.Revision,
 			})
@@ -285,7 +285,7 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 
 			aff := fmt.Sprintf("host:%s", name)
 			kvps = append(kvps, &model.KVPair{
-				Key:      model.BlockKey{CIDR: *cidr},
+				Key:      model.BlockKey{CIDR: model.PrefixFromIPNet(*cidr)},
 				Value:    &model.AllocationBlock{CIDR: *cidr, Affinity: &aff},
 				Revision: kvp.Revision,
 			})

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor_test.go
@@ -543,11 +543,11 @@ var _ = Describe("Test the (Felix) Node update processor with USE_POD_CIDR=true"
 		c1 := net.MustParseCIDR("192.168.1.0/24")
 		aff := "host:mynode"
 		v1 := model.AllocationBlock{CIDR: c1, Affinity: &aff}
-		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: c1}, Value: &v1})
+		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(c1)}, Value: &v1})
 
 		c2 := net.MustParseCIDR("192.168.2.0/24")
 		v2 := model.AllocationBlock{CIDR: c2, Affinity: &aff}
-		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: c2}, Value: &v2})
+		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(c2)}, Value: &v2})
 
 		// Remove CIDR 2 and make sure we get a delete for it.
 		By("handling an update that removes a CIDR")
@@ -563,10 +563,10 @@ var _ = Describe("Test the (Felix) Node update processor with USE_POD_CIDR=true"
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert we get block 1
-		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: c1}, Value: &v1})
+		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(c1)}, Value: &v1})
 
 		// And a remove for block 2.
-		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: c2}, Value: nil})
+		assertBlockUpdate(kvps, &model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(c2)}, Value: nil})
 	})
 })
 

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/globalnetworkpolicyprocessor_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Test the GlobalNetworkPolicy update processor", func() {
 
 		It("should NOT accept a GlobalNetworkPolicy with the wrong Key type", func() {
 			_, err := up.Process(&model.KVPair{
-				Key:      model.GlobalBGPPeerKey{PeerIP: cnet.MustParseIP("1.2.3.4")},
+				Key:      model.GlobalBGPPeerKey{PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4"))},
 				Value:    emptyGNP,
 				Revision: "abcde",
 			})

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/hostendpointprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/hostendpointprocessor_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Test the HostEndpoint update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: net.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(net.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/ippoolprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/ippoolprocessor_test.go
@@ -15,6 +15,8 @@
 package updateprocessors_test
 
 import (
+	"net/netip"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -38,10 +40,10 @@ var _ = Describe("Test the IPPool update processor", func() {
 	cidr1str := "1.2.3.0/24"
 	cidr2str := "aa:bb:cc::/120"
 	v1PoolKeyCidr1 := model.IPPoolKey{
-		CIDR: net.MustParseCIDR(cidr1str),
+		CIDR: netip.MustParsePrefix(cidr1str),
 	}
 	v1PoolKeyCidr2 := model.IPPoolKey{
-		CIDR: net.MustParseCIDR(cidr2str),
+		CIDR: netip.MustParsePrefix(cidr2str),
 	}
 
 	It("should handle conversion of valid IPPools", func() {
@@ -62,7 +64,7 @@ var _ = Describe("Test the IPPool update processor", func() {
 		Expect(kvps[0]).To(Equal(&model.KVPair{
 			Key: v1PoolKeyCidr1,
 			Value: &model.IPPool{
-				CIDR:             v1PoolKeyCidr1.CIDR,
+				CIDR:             model.IPNetFromPrefix(v1PoolKeyCidr1.CIDR),
 				IPIPMode:         encap.Never,
 				Masquerade:       false,
 				IPAM:             true,
@@ -102,7 +104,7 @@ var _ = Describe("Test the IPPool update processor", func() {
 			{
 				Key: v1PoolKeyCidr1,
 				Value: &model.IPPool{
-					CIDR:             v1PoolKeyCidr1.CIDR,
+					CIDR:             model.IPNetFromPrefix(v1PoolKeyCidr1.CIDR),
 					IPIPInterface:    "tunl0",
 					IPIPMode:         encap.Always,
 					Masquerade:       true,
@@ -116,7 +118,7 @@ var _ = Describe("Test the IPPool update processor", func() {
 			{
 				Key: v1PoolKeyCidr2,
 				Value: &model.IPPool{
-					CIDR:             v1PoolKeyCidr2.CIDR,
+					CIDR:             model.IPNetFromPrefix(v1PoolKeyCidr2.CIDR),
 					IPIPInterface:    "",
 					IPIPMode:         encap.Never,
 					Masquerade:       false,
@@ -144,7 +146,7 @@ var _ = Describe("Test the IPPool update processor", func() {
 			{
 				Key: v1PoolKeyCidr2,
 				Value: &model.IPPool{
-					CIDR:             v1PoolKeyCidr2.CIDR,
+					CIDR:             model.IPNetFromPrefix(v1PoolKeyCidr2.CIDR),
 					IPIPInterface:    "",
 					IPIPMode:         encap.Never,
 					Masquerade:       false,
@@ -202,7 +204,7 @@ var _ = Describe("Test the IPPool update processor", func() {
 		Expect(kvps[0]).To(Equal(&model.KVPair{
 			Key: v1PoolKeyCidr1,
 			Value: &model.IPPool{
-				CIDR:             v1PoolKeyCidr1.CIDR,
+				CIDR:             model.IPNetFromPrefix(v1PoolKeyCidr1.CIDR),
 				IPIPMode:         encap.Never,
 				Masquerade:       false,
 				IPAM:             true,
@@ -224,7 +226,7 @@ var _ = Describe("Test the IPPool update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: net.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(net.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 
 		It("should NOT accept a NetworkPolicy with the wrong Key type", func() {
 			_, err := up.Process(&model.KVPair{
-				Key:      model.GlobalBGPPeerKey{PeerIP: cnet.MustParseIP("1.2.3.4")},
+				Key:      model.GlobalBGPPeerKey{PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4"))},
 				Value:    emptyNP,
 				Revision: "abcde",
 			})

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networksetprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networksetprocessor_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Test the NetworkSet update processor", func() {
 		}))
 		_, err = up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: net.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(net.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Test the Profile update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: cnet.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/stagedglobalnetworkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/stagedglobalnetworkpolicyprocessor_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Test the StagedGlobalNetworkPolicy update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: cnet.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/stagednetworkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/stagednetworkpolicyprocessor_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Test the StagedNetworkPolicy update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: cnet.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/tierprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/tierprocessor_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Test the Tier update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: cnet.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Test the WorkloadEndpoint update processor", func() {
 
 		_, err := up.Process(&model.KVPair{
 			Key: model.GlobalBGPPeerKey{
-				PeerIP: cnet.MustParseIP("1.2.3.4"),
+				PeerIP: model.AddrFromIP(cnet.MustParseIP("1.2.3.4")),
 			},
 			Value:    res,
 			Revision: "abcde",

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -17,6 +17,7 @@ package watchersyncer_test
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/watchersyncer"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
-	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
@@ -69,7 +69,7 @@ var (
 		Name: "ippool-2",
 	}
 	l3Key1 = model.BlockAffinityKey{
-		CIDR:         cnet.MustParseCIDR("1.2.3.0/24"),
+		CIDR:         netip.MustParsePrefix("1.2.3.0/24"),
 		Host:         "mynode",
 		AffinityType: string(ipam.AffinityTypeHost),
 	}

--- a/libcalico-go/lib/clientv3/ippool.go
+++ b/libcalico-go/lib/clientv3/ippool.go
@@ -93,9 +93,10 @@ func (r ipPools) Create(ctx context.Context, res *apiv3.IPPool, opts options.Set
 		// supported with host-local IPAM on KDD.
 		for _, b := range blocks.KVPairs {
 			k := b.Key.(model.BlockKey)
-			ones, _ := k.CIDR.Mask.Size()
+			kCIDR := model.IPNetFromPrefix(k.CIDR)
+			ones, _ := kCIDR.Mask.Size()
 			// Check if this block has a different size to the pool, and that it overlaps with the pool.
-			if ones != poolBlockSize && k.CIDR.IsNetOverlap(*poolCIDR) {
+			if ones != poolBlockSize && kCIDR.IsNetOverlap(*poolCIDR) {
 				return nil, cerrors.ErrorValidation{
 					ErroredFields: []cerrors.ErroredField{{
 						Name:   "IPPool.Spec.BlockSize",

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -157,7 +157,7 @@ func (c ipamClient) AutoAssign(ctx context.Context, args AutoAssignArgs) (*IPAMA
 // affinity of the block.
 func (c ipamClient) getBlockFromAffinity(ctx context.Context, aff *model.KVPair, rsvdAttr *HostReservedAttr, affinityCfg AffinityConfig) (*model.KVPair, error) {
 	// Parse out affinity data.
-	cidr := aff.Key.(model.BlockAffinityKey).CIDR
+	cidr := model.IPNetFromPrefix(aff.Key.(model.BlockAffinityKey).CIDR)
 	host := aff.Key.(model.BlockAffinityKey).Host
 	state := aff.Value.(*model.BlockAffinity).State
 	logCtx := log.WithFields(log.Fields{"host": host, "cidr": cidr})
@@ -815,7 +815,7 @@ func (c ipamClient) autoAssign(ctx context.Context, num int, handleID *string, a
 
 					// At this point, block b's Unallocated field has been reduced already.
 					// We should get the original block from datastore again.
-					blockCIDR := b.Key.(model.BlockKey).CIDR
+					blockCIDR := model.IPNetFromPrefix(b.Key.(model.BlockKey).CIDR)
 					b, err = c.blockReaderWriter.queryBlock(ctx, blockCIDR, "")
 					if err != nil {
 						logCtx.WithError(err).Warn("Failed to get block again after update conflict")
@@ -836,7 +836,7 @@ func (c ipamClient) autoAssign(ctx context.Context, num int, handleID *string, a
 						// so b has uncommitted allocations relative to the datastore.
 						// Re-query before retrying so the next attempt doesn't pile new
 						// allocations on top and persist the leaked ones via updateBlock.
-						blockCIDR := b.Key.(model.BlockKey).CIDR
+						blockCIDR := model.IPNetFromPrefix(b.Key.(model.BlockKey).CIDR)
 						b, err = c.blockReaderWriter.queryBlock(ctx, blockCIDR, "")
 						if err != nil {
 							logCtx.WithError(err).Warn("Failed to re-query block after ErrMaxAllocReached")
@@ -1393,7 +1393,7 @@ func (c ipamClient) releaseIPsFromBlock(ctx context.Context, handleMap map[strin
 }
 
 func (c ipamClient) assignFromExistingBlock(ctx context.Context, block *model.KVPair, num int, handleID *string, attrs map[string]string, affinityCfg AffinityConfig, affCheck bool, reservations addrFilter, maxAlloc int) ([]net.IPNet, error) {
-	blockCIDR := block.Key.(model.BlockKey).CIDR
+	blockCIDR := model.IPNetFromPrefix(block.Key.(model.BlockKey).CIDR)
 	logCtx := log.WithFields(log.Fields{string(affinityCfg.AffinityType): affinityCfg.Host, "block": blockCIDR})
 	if handleID != nil {
 		logCtx = logCtx.WithField("handle", *handleID)
@@ -1802,7 +1802,7 @@ func (c ipamClient) affinityConfigsByBlocks(ctx context.Context, pool net.IPNet)
 		k := o.Key.(model.BlockAffinityKey)
 
 		// Only add the pair to the map if the block belongs to the pool.
-		if pool.Contains(k.CIDR.IPNet.IP) {
+		if pool.Contains(k.CIDR.Addr().AsSlice()) {
 			pairs[k.CIDR.String()] = AffinityConfig{AffinityType: AffinityType(k.AffinityType), Host: k.Host}
 		}
 		log.Debugf("Block %s -> %s", k.CIDR.String(), k.Host)
@@ -2512,7 +2512,7 @@ func (c ipamClient) ensureBlock(ctx context.Context, rsvdAttr *HostReservedAttr,
 		return nil, err
 	}
 
-	blockCIDR := b.Key.(model.BlockKey).CIDR
+	blockCIDR := model.IPNetFromPrefix(b.Key.(model.BlockKey).CIDR)
 	logCtx.Infof("Host's block '%s' ", blockCIDR.String())
 	return &blockCIDR, nil
 }

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"math/rand"
 	"net"
+	"net/netip"
 	"time"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -71,7 +72,7 @@ func (rw blockReaderWriter) getAffineBlocks(
 	// Iterate through and extract the block CIDRs.
 	for _, o := range datastoreObjs.KVPairs {
 		k := o.Key.(model.BlockAffinityKey)
-		blocks = append(blocks, k.CIDR)
+		blocks = append(blocks, model.IPNetFromPrefix(k.CIDR))
 	}
 	return
 }
@@ -145,7 +146,7 @@ func (rw blockReaderWriter) findUsableBlock(
 	}
 
 	// Build a map for faster lookups.
-	exists := map[string]blockInfo{}
+	exists := map[netip.Prefix]blockInfo{}
 	for _, e := range existingBlocks.KVPairs {
 		allocBlock := e.Value.(*model.AllocationBlock)
 		host := allocBlock.Host()
@@ -156,10 +157,11 @@ func (rw blockReaderWriter) findUsableBlock(
 		}
 		block := allocationBlock{allocBlock}
 		numFree := block.NumFreeAddresses(reservations)
-		exists[e.Key.(model.BlockKey).CIDR.String()] = blockInfo{
+		cidr := e.Key.(model.BlockKey).CIDR
+		exists[cidr] = blockInfo{
 			numFree:     numFree,
 			affinityCfg: bAffinityCfg,
-			cidr:        e.Key.(model.BlockKey).CIDR,
+			cidr:        model.IPNetFromPrefix(cidr),
 			empty:       block.empty(),
 			claimTime:   block.affinityClaimTime(),
 			seqNo:       block.SequenceNumber,
@@ -182,7 +184,7 @@ func (rw blockReaderWriter) findUsableBlock(
 
 			// Check if a block already exists for this subnet.
 			log.Debugf("Getting block: %s", subnet.String())
-			if info, ok := exists[subnet.String()]; !ok {
+			if info, ok := exists[model.PrefixFromIPNet(*subnet)]; !ok {
 				log.Infof("Found free block: %+v", *subnet)
 				return subnet, nil
 			} else if info.affinityCfg == affinityCfg && info.numFree != 0 {
@@ -252,7 +254,7 @@ func (rw blockReaderWriter) getPendingAffinity(ctx context.Context, affinityCfg 
 	logCtx := log.WithFields(log.Fields{string(affinityCfg.AffinityType): affinityCfg.Host, "subnet": subnet})
 	logCtx.Info("Trying to create affinity in pending state")
 	obj := model.KVPair{
-		Key:   model.BlockAffinityKey{Host: affinityCfg.Host, AffinityType: string(affinityCfg.AffinityType), CIDR: subnet},
+		Key:   model.BlockAffinityKey{Host: affinityCfg.Host, AffinityType: string(affinityCfg.AffinityType), CIDR: model.PrefixFromIPNet(subnet)},
 		Value: &model.BlockAffinity{State: model.StatePending},
 	}
 	aff, err := rw.client.Create(ctx, &obj)
@@ -288,7 +290,7 @@ func (rw blockReaderWriter) getPendingAffinity(ctx context.Context, affinityCfg 
 // steals the block, claimAffineBlock will attempt to delete the provided pending affinity.
 func (rw blockReaderWriter) claimAffineBlock(ctx context.Context, aff *model.KVPair, config IPAMConfig, rsvdAttr *HostReservedAttr, affinityCfg AffinityConfig) (*model.KVPair, error) {
 	// Pull out relevant fields.
-	subnet := aff.Key.(model.BlockAffinityKey).CIDR
+	subnet := model.IPNetFromPrefix(aff.Key.(model.BlockAffinityKey).CIDR)
 	host := aff.Key.(model.BlockAffinityKey).Host
 	logCtx := log.WithFields(log.Fields{"affinityType": affinityCfg.AffinityType, "host": host, "subnet": subnet})
 
@@ -300,7 +302,7 @@ func (rw blockReaderWriter) claimAffineBlock(ctx context.Context, aff *model.KVP
 
 	// Create the new block in the datastore.
 	o := model.KVPair{
-		Key:   model.BlockKey{CIDR: block.CIDR},
+		Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(block.CIDR)},
 		Value: block.AllocationBlock,
 	}
 	logCtx.Info("Attempting to create a new block")
@@ -353,7 +355,7 @@ func (rw blockReaderWriter) claimAffineBlock(ctx context.Context, aff *model.KVP
 
 func (rw blockReaderWriter) confirmAffinity(ctx context.Context, aff *model.KVPair) (*model.KVPair, error) {
 	host := aff.Key.(model.BlockAffinityKey).Host
-	cidr := aff.Key.(model.BlockAffinityKey).CIDR
+	cidr := model.IPNetFromPrefix(aff.Key.(model.BlockAffinityKey).CIDR)
 	affinityType := aff.Key.(model.BlockAffinityKey).AffinityType
 	affinityCfg := AffinityConfig{
 		AffinityType: AffinityType(affinityType),
@@ -495,7 +497,7 @@ func (rw blockReaderWriter) releaseBlockAffinity(
 
 // queryAffinity gets an affinity for the given host + CIDR key.
 func (rw blockReaderWriter) queryAffinity(ctx context.Context, affinityCfg AffinityConfig, cidr cnet.IPNet, revision string) (*model.KVPair, error) {
-	return rw.client.Get(ctx, model.BlockAffinityKey{Host: affinityCfg.Host, AffinityType: string(affinityCfg.AffinityType), CIDR: cidr}, revision)
+	return rw.client.Get(ctx, model.BlockAffinityKey{Host: affinityCfg.Host, AffinityType: string(affinityCfg.AffinityType), CIDR: model.PrefixFromIPNet(cidr)}, revision)
 }
 
 // updateAffinity updates the given affinity.
@@ -511,7 +513,7 @@ func (rw blockReaderWriter) deleteAffinity(ctx context.Context, aff *model.KVPai
 
 // queryBlock gets a block for the given block CIDR key.
 func (rw blockReaderWriter) queryBlock(ctx context.Context, blockCIDR cnet.IPNet, revision string) (*model.KVPair, error) {
-	return rw.client.Get(ctx, model.BlockKey{CIDR: blockCIDR}, revision)
+	return rw.client.Get(ctx, model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)}, revision)
 }
 
 func (rw blockReaderWriter) listBlocks(ctx context.Context, revision string) (*model.KVPairList, error) {
@@ -721,9 +723,10 @@ func (rw blockReaderWriter) getBlockForIP(ctx context.Context, ip cnet.IP, cache
 	// Iterate through and extract the block CIDRs.
 	for _, o := range datastoreObjs.KVPairs {
 		k := o.Key.(model.BlockKey)
-		if k.CIDR.IPNet.Contains(ip.IP) {
+		kCIDR := model.IPNetFromPrefix(k.CIDR)
+		if kCIDR.IPNet.Contains(ip.IP) {
 			log.Debugf("Found IP %s in block %s", ip.String(), k.String())
-			return &k.CIDR, datastoreObjs, nil
+			return &kCIDR, datastoreObjs, nil
 		}
 	}
 

--- a/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_reader_writer_test.go
@@ -292,7 +292,8 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 						// Expect that the IP address is within the affine block.
 						cidr := affs.KVPairs[0].Key.(model.BlockAffinityKey).CIDR
 						ip := ips[0]
-						Expect(cidr.Contains(ip.IP)).To(BeTrue())
+						ipAddr := model.AddrFromIP(ip)
+						Expect(cidr.Contains(ipAddr)).To(BeTrue())
 					}
 				}
 			})
@@ -471,11 +472,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			// Expect that hostA proc 1 fails to confirm the affinity, leaving it in pending state.
 
 			blockKVP := model.KVPair{
-				Key:   model.BlockKey{CIDR: *net},
+				Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(*net)},
 				Value: &model.AllocationBlock{},
 			}
 			affinityKVP := model.KVPair{
-				Key:   model.BlockAffinityKey{Host: hostA, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost},
+				Key:   model.BlockAffinityKey{Host: hostA, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost},
 				Value: &model.BlockAffinity{},
 			}
 
@@ -553,11 +554,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			By("setting up the client for the test", func() {
 				b := newBlock(*net, nil)
 				blockKVP = model.KVPair{
-					Key:   model.BlockKey{CIDR: *net},
+					Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(*net)},
 					Value: b.AllocationBlock,
 				}
 				affinityKVP = model.KVPair{
-					Key:   model.BlockAffinityKey{Host: hostA, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost},
+					Key:   model.BlockAffinityKey{Host: hostA, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost},
 					Value: &model.BlockAffinity{},
 				}
 
@@ -639,11 +640,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 
 			// Creation function for a block affinity - actually create it.
 			affKVP := &model.KVPair{
-				Key:   model.BlockAffinityKey{Host: hostA, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost},
+				Key:   model.BlockAffinityKey{Host: hostA, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost},
 				Value: &model.BlockAffinity{},
 			}
 			affKVP2 := &model.KVPair{
-				Key:   model.BlockAffinityKey{Host: hostB, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost},
+				Key:   model.BlockAffinityKey{Host: hostB, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost},
 				Value: &model.BlockAffinity{State: model.StateConfirmed},
 			}
 
@@ -665,7 +666,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			now := metav1.NewTime(time.Now())
 			b.AffinityClaimTime = &now
 			blockKVP := &model.KVPair{
-				Key:   model.BlockKey{CIDR: *net},
+				Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(*net)},
 				Value: b.AllocationBlock,
 			}
 
@@ -673,7 +674,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			b2.Affinity = &affStrB
 			b2.AffinityClaimTime = &now
 			blockKVP2 := &model.KVPair{
-				Key:   model.BlockKey{CIDR: *net},
+				Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(*net)},
 				Value: b2.AllocationBlock,
 			}
 			fc.createFuncs[blockKVP.Key.String()] = func(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
@@ -794,7 +795,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 		})
 
 		ageTheBlock := func() {
-			block, err := bc.Get(ctx, model.BlockKey{CIDR: *net}, "")
+			block, err := bc.Get(ctx, model.BlockKey{CIDR: model.PrefixFromIPNet(*net)}, "")
 			Expect(err).NotTo(HaveOccurred())
 			overAMinuteAgo := metav1.NewTime(time.Now().Add(-61 * time.Second))
 			block.Value.(*model.AllocationBlock).AffinityClaimTime = &overAMinuteAgo
@@ -914,7 +915,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			By("trying to claim the reclaimable block, with a context error queued", func() {
 				subCtx, cancel := context.WithCancel(ctx)
 				defer cancel()
-				fc.getFuncs[model.BlockKey{CIDR: *net}.String()] = func(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+				fc.getFuncs[model.BlockKey{CIDR: model.PrefixFromIPNet(*net)}.String()] = func(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
 					cancel()
 					return nil, subCtx.Err()
 				}
@@ -936,12 +937,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			aff := "host:" + hostA
 			b.AllocationBlock.Affinity = &aff
 			blockKVP := model.KVPair{
-				Key:   model.BlockKey{CIDR: *net},
+				Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(*net)},
 				Value: b.AllocationBlock,
 			}
 
 			affinityKVP := model.KVPair{
-				Key: model.BlockAffinityKey{Host: hostA, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost},
+				Key: model.BlockAffinityKey{Host: hostA, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost},
 				Value: &model.BlockAffinity{
 					State: model.StateConfirmed,
 				},
@@ -1099,27 +1100,27 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			})
 
 			By("checking the affinity exists", func() {
-				k := model.BlockAffinityKey{Host: host, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost}
+				k := model.BlockAffinityKey{Host: host, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost}
 				aff, err := bc.Get(ctx, k, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(aff.Value.(*model.BlockAffinity).State).To(Equal(model.StateConfirmed))
 			})
 
 			By("checking the virtual affinity exists", func() {
-				k := model.BlockAffinityKey{Host: host, CIDR: *loadBalancerNet, AffinityType: model.IPAMAffinityTypeVirtual}
+				k := model.BlockAffinityKey{Host: host, CIDR: model.PrefixFromIPNet(*loadBalancerNet), AffinityType: model.IPAMAffinityTypeVirtual}
 				aff, err := bc.Get(ctx, k, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(aff.Value.(*model.BlockAffinity).State).To(Equal(model.StateConfirmed))
 			})
 
 			By("checking the block exists", func() {
-				k := model.BlockKey{CIDR: *net}
+				k := model.BlockKey{CIDR: model.PrefixFromIPNet(*net)}
 				_, err := bc.Get(ctx, k, "")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			By("checking the virtual block exists", func() {
-				k := model.BlockKey{CIDR: *loadBalancerNet}
+				k := model.BlockKey{CIDR: model.PrefixFromIPNet(*loadBalancerNet)}
 				_, err := bc.Get(ctx, k, "")
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1137,25 +1138,25 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests", tes
 			})
 
 			By("checking the affinity no longer exists", func() {
-				k := model.BlockAffinityKey{Host: host, CIDR: *net, AffinityType: model.IPAMAffinityTypeHost}
+				k := model.BlockAffinityKey{Host: host, CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost}
 				_, err := bc.Get(ctx, k, "")
 				Expect(err).To(HaveOccurred())
 			})
 
 			By("checking the virtual affinity no longer exists", func() {
-				k := model.BlockAffinityKey{Host: host, CIDR: *loadBalancerNet, AffinityType: model.IPAMAffinityTypeVirtual}
+				k := model.BlockAffinityKey{Host: host, CIDR: model.PrefixFromIPNet(*loadBalancerNet), AffinityType: model.IPAMAffinityTypeVirtual}
 				_, err := bc.Get(ctx, k, "")
 				Expect(err).To(HaveOccurred())
 			})
 
 			By("checking the block no longer exists", func() {
-				k := model.BlockKey{CIDR: *net}
+				k := model.BlockKey{CIDR: model.PrefixFromIPNet(*net)}
 				_, err := bc.Get(ctx, k, "")
 				Expect(err).To(HaveOccurred())
 			})
 
 			By("checking the virtual block no longer exists", func() {
-				k := model.BlockKey{CIDR: *loadBalancerNet}
+				k := model.BlockKey{CIDR: model.PrefixFromIPNet(*loadBalancerNet)}
 				_, err := bc.Get(ctx, k, "")
 				Expect(err).To(HaveOccurred())
 			})
@@ -1276,7 +1277,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests (kdd 
 	It("should respect Kubernetes UID for affinities", func() {
 		// Create a block affinity
 		initKVP := &model.KVPair{
-			Key:   model.BlockAffinityKey{Host: "somehost", CIDR: *net, AffinityType: model.IPAMAffinityTypeHost},
+			Key:   model.BlockAffinityKey{Host: "somehost", CIDR: model.PrefixFromIPNet(*net), AffinityType: model.IPAMAffinityTypeHost},
 			Value: &model.BlockAffinity{},
 		}
 		kvpa, err := bc.Create(ctx, initKVP)
@@ -1300,7 +1301,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM affine block allocation tests (kdd 
 	It("should respect Kubernetes UID for blocks", func() {
 		// Create a block
 		initKVP := &model.KVPair{
-			Key: model.BlockKey{CIDR: *net},
+			Key: model.BlockKey{CIDR: model.PrefixFromIPNet(*net)},
 			Value: &model.AllocationBlock{
 				CIDR:        cnet.MustParseCIDR("10.0.1.0/29"),
 				Allocations: []*int{nil, nil, nil},

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"runtime"
 	"strings"
 	"time"
@@ -899,12 +900,12 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			cidr := "10.0.0.0/24"
 			b := newBlock(cnet.MustParseCIDR(cidr), nil)
 			blockKVP := model.KVPair{
-				Key:   model.BlockKey{CIDR: cnet.MustParseCIDR(cidr)},
+				Key:   model.BlockKey{CIDR: netip.MustParsePrefix(cidr)},
 				Value: b.AllocationBlock,
 			}
 			affKVP := model.KVPair{
 				Key: model.BlockAffinityKey{
-					CIDR:         cnet.MustParseCIDR(cidr),
+					CIDR:         netip.MustParsePrefix(cidr),
 					Host:         hostname,
 					AffinityType: "",
 				},
@@ -4162,7 +4163,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 			b := newBlock(cnet.MustParseCIDR("192.168.0.0/26"), nil)
 			b.SequenceNumber = 0
 			kvp := &model.KVPair{
-				Key:   model.BlockKey{CIDR: b.CIDR},
+				Key:   model.BlockKey{CIDR: model.PrefixFromIPNet(b.CIDR)},
 				Value: b.AllocationBlock,
 			}
 			_, err := bc.Create(context.TODO(), kvp)
@@ -4541,7 +4542,7 @@ func getAffineBlocks(backend bapi.Client, host string) []cnet.IPNet {
 	var blocks []cnet.IPNet
 	for _, o := range datastoreObjs.KVPairs {
 		k := o.Key.(model.BlockAffinityKey)
-		blocks = append(blocks, k.CIDR)
+		blocks = append(blocks, model.IPNetFromPrefix(k.CIDR))
 	}
 	return blocks
 }

--- a/libcalico-go/lib/ipam/ipam_win_test.go
+++ b/libcalico-go/lib/ipam/ipam_win_test.go
@@ -669,7 +669,8 @@ func isValidWindowsHandle(backend bapi.Client, ipPoolsWindows *ipamtestutils.IPP
 	var block allocationBlock
 	for _, o := range datastoreObjs.KVPairs {
 		k := o.Key.(model.BlockKey)
-		if k.CIDR.IP.String() == blockCIDR.IP.String() && k.CIDR.Mask.String() == blockCIDR.Mask.String() {
+		kCIDR := model.IPNetFromPrefix(k.CIDR)
+		if kCIDR.IP.String() == blockCIDR.IP.String() && kCIDR.Mask.String() == blockCIDR.Mask.String() {
 			block = allocationBlock{o.Value.(*model.AllocationBlock)}
 		}
 

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -89,7 +89,7 @@ var (
 	ipPoolCIDR = calinet.MustParseCIDR("10.0.1.0/24")
 	ipPool1    = api.Update{
 		KVPair: model.KVPair{
-			Key: model.IPPoolKey{CIDR: ipPoolCIDR},
+			Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(ipPoolCIDR)},
 			Value: &model.IPPool{
 				CIDR:          ipPoolCIDR,
 				IPIPInterface: "tunl0",
@@ -145,7 +145,7 @@ var (
 	blockAffCIDR = calinet.MustParseCIDR("10.0.1.0/26")
 	blockAff1    = api.Update{
 		KVPair: model.KVPair{
-			Key:      model.BlockAffinityKey{CIDR: blockAffCIDR, AffinityType: model.IPAMAffinityTypeHost, Host: "node1"},
+			Key:      model.BlockAffinityKey{CIDR: model.PrefixFromIPNet(blockAffCIDR), AffinityType: model.IPAMAffinityTypeHost, Host: "node1"},
 			Value:    &model.BlockAffinity{State: model.StateConfirmed},
 			Revision: "1239",
 		},


### PR DESCRIPTION
Replace `net.IP`/`net.IPNet` with `netip.Addr`/`netip.Prefix` in the 5
non-comparable Key structs (`BlockKey`, `IPPoolKey`, `BlockAffinityKey`,
`NodeBGPPeerKey`, `GlobalBGPPeerKey`). This allows all Key types to be
used as Go map keys and compared with `==`, eliminating the need for
`reflect.DeepEqual` workarounds.

Key changes:
- Add conversion helpers in `model/netip_helpers.go` for bridging between old (`net.IP`/`net.IPNet`) and new (`netip.Addr`/`netip.Prefix`) types
- Add `ip.CIDRFromPrefix()` for felix calc graph usage
- Make `KeyToDefaultPath`/`ParseValue` generic with `ComparableKey` constraint for compile-time enforcement
- Add comparability assertion in `FuzzKeyFromDefaultPath`
- Update all callers to use conversion functions at type boundaries

Value types (`model.IPPool`, `model.AllocationBlock`, `model.BGPPeer`) are
unchanged — only Key structs are modified.

CORE-12843


**Release note:**
```release-note
Fix that certain internal API key types were non-comparable, requiring workarounds in various places.
```