### PR TITLE
Use net.JoinHostPort() for IPv6-safe host:port formatting

### DIFF
--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -223,7 +223,7 @@ func (h *httpTerminationHandler) RunHTTPServer(addr string, port string) (*http.
 		}
 	}
 
-	httpServerSockAddr := fmt.Sprintf("%s:%s", addr, port)
+	httpServerSockAddr := net.JoinHostPort(addr, port)
 	httpServerMux := http.NewServeMux()
 	httpServerMux.Handle("/terminate", h)
 	httpServer := &http.Server{Addr: httpServerSockAddr, Handler: httpServerMux}

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -420,7 +421,7 @@ func (f *Felix) Ready() (bool, error) {
 		healthAddr = f.TopologyOptions.ExtraEnvVars["FELIX_HEALTHHOST"]
 	}
 
-	url := "http://" + healthAddr + ":9099/readiness"
+	url := "http://" + net.JoinHostPort(healthAddr, "9099") + "/readiness"
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/felix/fv/metrics/metrics.go
+++ b/felix/fv/metrics/metrics.go
@@ -106,7 +106,7 @@ func GetRawMetrics(ip string, port int, caFile, certFile, keyFile string) (out s
 		httpClient.Transport = &http.Transport{}
 	}
 	var resp *http.Response
-	resp, err = httpClient.Get(fmt.Sprintf("%v://%v:%v/metrics", method, ip, port))
+	resp, err = httpClient.Get(fmt.Sprintf("%s://%s/metrics", method, net.JoinHostPort(ip, strconv.Itoa(port))))
 	if err != nil {
 		return
 	}

--- a/guardian/pkg/server/server.go
+++ b/guardian/pkg/server/server.go
@@ -132,7 +132,7 @@ func (srv *server) ListenAndServeCluster() error {
 		return fmt.Errorf("failed to connect to tunnel: %w", err)
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", srv.listenHost, srv.listenPort))
+	listener, err := net.Listen("tcp", net.JoinHostPort(srv.listenHost, srv.listenPort))
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s:%s: %w", srv.listenHost, srv.listenPort, err)
 	}

--- a/node/pkg/health/health.go
+++ b/node/pkg/health/health.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -50,8 +51,8 @@ func init() {
 		felixHost = "localhost"
 	}
 
-	felixReadinessEp = "http://" + felixHost + ":" + felixPort + "/readiness"
-	felixLivenessEp = "http://" + felixHost + ":" + felixPort + "/liveness"
+	felixReadinessEp = "http://" + net.JoinHostPort(felixHost, felixPort) + "/readiness"
+	felixLivenessEp = "http://" + net.JoinHostPort(felixHost, felixPort) + "/liveness"
 }
 
 func Run(bird, bird6, felixReady, felixLive, birdLive, bird6Live bool, thresholdTime time.Duration) {

--- a/whisker-backend/pkg/config/api.go
+++ b/whisker-backend/pkg/config/api.go
@@ -16,7 +16,7 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
+	"net"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
@@ -56,7 +56,7 @@ func (cfg *Config) String() string {
 }
 
 func (cfg *Config) HostAddr() string {
-	return fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
+	return net.JoinHostPort(cfg.Host, cfg.Port)
 }
 
 func (cfg *Config) ConfigureLogging() {


### PR DESCRIPTION
Go 1.26 tightened net/url parsing to reject bare IPv6 addresses in URLs (issue #75223). URLs like http://2001:db8::1:9099/path were silently accepted in Go 1.25 but now correctly return a parse error. This broke all IPv6 BPF FV tests which construct health check URLs with unbracketed IPv6 addresses.

Replace string concatenation with net.JoinHostPort() which correctly brackets IPv6 addresses ([::1]:9099) and leaves IPv4 unchanged.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
