### PR TITLE
Fix IPv6 DNAT/SNAT rule formatting in iptables and nftables backends

### DIFF
--- a/felix/iptables/actions.go
+++ b/felix/iptables/actions.go
@@ -17,6 +17,8 @@ package iptables
 import (
 	"fmt"
 	"math"
+	"net"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 
@@ -274,7 +276,7 @@ func (g DNATAction) ToFragment(features *environment.Features) string {
 	if g.DestPort == 0 {
 		return fmt.Sprintf("--jump DNAT --to-destination %s", g.DestAddr)
 	} else {
-		return fmt.Sprintf("--jump DNAT --to-destination %s:%d", g.DestAddr, g.DestPort)
+		return fmt.Sprintf("--jump DNAT --to-destination %s", net.JoinHostPort(g.DestAddr, strconv.Itoa(int(g.DestPort))))
 	}
 }
 

--- a/felix/nftables/actions.go
+++ b/felix/nftables/actions.go
@@ -17,6 +17,8 @@ package nftables
 import (
 	"fmt"
 	"math"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -292,7 +294,7 @@ func (g DNATAction) ToFragment(features *environment.Features) string {
 	if g.DestPort == 0 {
 		return fmt.Sprintf("dnat to %s", g.DestAddr)
 	} else {
-		return fmt.Sprintf("dnat to %s:%d", g.DestAddr, g.DestPort)
+		return fmt.Sprintf("dnat to %s", net.JoinHostPort(g.DestAddr, strconv.Itoa(int(g.DestPort))))
 	}
 }
 

--- a/felix/rules/nat.go
+++ b/felix/rules/nat.go
@@ -16,6 +16,7 @@ package rules
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -92,7 +93,7 @@ func (r *DefaultRuleRenderer) NATOutgoingChain(natOutgoingActive bool, ipVersion
 			toPorts := fmt.Sprintf("%d-%d", r.NATPortRange.MinPort, r.NATPortRange.MaxPort)
 			portRangeSnatRule := r.Masq(toPorts)
 			if r.NATOutgoingAddress != nil {
-				toAddress := fmt.Sprintf("%s:%s", r.NATOutgoingAddress.String(), toPorts)
+				toAddress := net.JoinHostPort(r.NATOutgoingAddress.String(), toPorts)
 				portRangeSnatRule = r.SNAT(toAddress)
 			}
 			rules = []generictables.Rule{


### PR DESCRIPTION
Both ip6tables and nftables require bracketed IPv6 addresses when a port is present (e.g., [2001:db8::1]:80). The DNAT and SNAT actions were using plain string formatting which produces invalid rules for IPv6. Use net.JoinHostPort() which correctly brackets IPv6 addresses.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
