### PR TITLE
Support spec.loadBalancerIP in LoadBalancer controller

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -701,6 +701,15 @@ func (c *loadBalancerController) assignIP(svc *v1.Service) ([]string, error) {
 		return nil, err
 	}
 
+	// Fall back to spec.loadBalancerIP when no specific IP was requested via annotation.
+	if loadBalancerIPs == nil && svc.Spec.LoadBalancerIP != "" {
+		ip := cnet.ParseIP(svc.Spec.LoadBalancerIP)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IP in spec.loadBalancerIP: %s", svc.Spec.LoadBalancerIP)
+		}
+		loadBalancerIPs = []cnet.IP{*ip}
+	}
+
 	var assignedIPs []string
 
 	metadataAttrs := map[string]string{
@@ -912,10 +921,11 @@ func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool 
 
 		if svc.Annotations[annotationIPv4Pools] != "" ||
 			svc.Annotations[annotationIPv6Pools] != "" ||
-			svc.Annotations[annotationLoadBalancerIP] != "" {
+			svc.Annotations[annotationLoadBalancerIP] != "" ||
+			svc.Spec.LoadBalancerIP != "" {
 
 			if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != calicoLoadBalancerClass {
-				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer annotation set with spec.LoadBalancerClass != calico is not supported")
+				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer IP request set with spec.LoadBalancerClass != calico is not supported")
 				return false
 			}
 			return true

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -540,6 +540,21 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		Expect(cli.IPAMUpgradeCallCount()).To(Equal(2))
 	})
 
+	It("should recognize spec.loadBalancerIP as calico-managed in RequestedServicesOnly mode", func() {
+		// With no annotations and no spec.loadBalancerIP, not managed in RequestedServicesOnly mode.
+		managed := IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeFalse())
+
+		// Setting spec.loadBalancerIP should make it calico-managed (user is requesting a specific IP).
+		svc.Spec.LoadBalancerIP = "10.0.0.5"
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeTrue())
+
+		// Should still be managed in AllServices mode.
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)
+		Expect(managed).To(BeTrue())
+	})
+
 	It("should handle invalid IP addresses in allocation tracker without panicking", func() {
 		svcKey, err := serviceKeyFromService(&svc)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes #11815

Adds support for spec.loadBalancerIP as a fallback in the LoadBalancer controller when no Calico-specific annotation is set.                              
   
 **Changes:**
 - spec.loadBalancerIP is now recognized as an opt-in signal in RequestedServicesOnly mode via  IsCalicoManagedLoadBalancer
 - spec.loadBalancerIP is used as the requested IP in IPAM when no projectcalico.org/loadBalancerIPs annotation is  present

 **Testing:**                                                                                                                                
 Added a unit test that verifies the new behavior:
 - should recognize spec.loadBalancerIP as calico-managed in RequestedServicesOnly mode

  **Release note:**

  ```release-note
 LoadBalancer controller now supports spec.loadBalancerIP as a fallback when no Calico-specific annotation is set.
```
