### PR TITLE
Add SEMAPHORE_AGENT_UPLOAD_JOB_LOGS variable

### DIFF
--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -45,6 +45,9 @@ echo "[INFO] Installing jq..."
 sudo apt-get -o Acquire::Retries=5 update  -y
 sudo apt-get install -o Acquire::Retries=5 jq -y
 
+# If the job output is bigger than 16MB, this tells semaphore to save them as an artifact
+export SEMAPHORE_AGENT_UPLOAD_JOB_LOGS=when-trimmed
+
 echo "[INFO] exporting default env vars..."
 export SEMAPHORE_PIPELINE_STARTED_AT=$(date +%s)
 export PROVISIONER=${PROVISIONER:-"gcp-kubeadm"}


### PR DESCRIPTION
Set environment variable to save job logs as an artifact in the case that the logs are bigger than 16MB.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
