### PR TITLE
Fix flaky BPF Proxy healthCheckNodeport test

### DIFF
--- a/felix/bpf/proxy/health_check_nodeport_test.go
+++ b/felix/bpf/proxy/health_check_nodeport_test.go
@@ -35,14 +35,64 @@ import (
 
 var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 	var p proxy.ProxyFrontend
-	k8s := fake.NewClientset()
+	var k8s *fake.Clientset
 
+	healthCheckNodePort := 1212
 	testNodeName := "testnode"
 	testNodeNameOther := "anothertestnode"
+
+	lbSvc := &v1.Service{
+		TypeMeta:   typeMetaV1("Service"),
+		ObjectMeta: objectMetaV1("LB"),
+		Spec: v1.ServiceSpec{
+			ClusterIP: "10.1.0.1",
+			Type:      v1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{
+				"app": "test",
+			},
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			HealthCheckNodePort:   int32(healthCheckNodePort),
+			Ports: []v1.ServicePort{
+				{
+					Protocol:   v1.ProtocolTCP,
+					Port:       4321,
+					TargetPort: intstr.FromInt(32678),
+				},
+			},
+		},
+	}
+
+	lbEps := &discovery.EndpointSlice{
+		TypeMeta:    typeMetaV1("EndpointSlice"),
+		ObjectMeta:  objectMetaV1("LB"),
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses: []string{"10.1.2.1"},
+				Conditions: discovery.EndpointConditions{
+					Ready: ptr.To(true),
+				},
+			},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Port:     ptr.To(int32(1234)),
+				Name:     ptr.To("LBPort"),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			},
+		},
+	}
 
 	BeforeEach(func() {
 		By("creating proxy with fake client and mock syncer", func() {
 			var err error
+
+			// Pre-populate the fake clientset with the service and endpoint
+			// slice so they are picked up during the informer's initial List.
+			// Adding objects via Tracker().Add() after the proxy starts is
+			// racy: the informer may complete its List before the watch is
+			// set up, causing the add event to be lost.
+			k8s = fake.NewClientset(lbSvc, lbEps)
 
 			p, err = proxy.New(k8s, &mockDummySyncer{}, testNodeName,
 				proxy.WithMinSyncPeriod(200*time.Millisecond), proxy.WithMaxSyncPeriod(1*time.Second))
@@ -58,58 +108,6 @@ var _ = Describe("BPF Proxy healthCheckNodeport", func() {
 	})
 
 	It("should expose health check endpoint", func() {
-		healthCheckNodePort := 1212
-
-		By("adding a LoadBalancer", func() {
-			err := k8s.Tracker().Add(&v1.Service{
-				TypeMeta:   typeMetaV1("Service"),
-				ObjectMeta: objectMetaV1("LB"),
-				Spec: v1.ServiceSpec{
-					ClusterIP: "10.1.0.1",
-					Type:      v1.ServiceTypeLoadBalancer,
-					Selector: map[string]string{
-						"app": "test",
-					},
-					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
-					HealthCheckNodePort:   int32(healthCheckNodePort),
-					Ports: []v1.ServicePort{
-						{
-							Protocol:   v1.ProtocolTCP,
-							Port:       4321,
-							TargetPort: intstr.FromInt(32678),
-						},
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		By("adding its endpointSlice", func() {
-			ep := &discovery.EndpointSlice{
-				TypeMeta:    typeMetaV1("EndpointSlice"),
-				ObjectMeta:  objectMetaV1("LB"),
-				AddressType: discovery.AddressTypeIPv4,
-				Endpoints: []discovery.Endpoint{
-					{
-						Addresses: []string{"10.1.2.1"},
-						Conditions: discovery.EndpointConditions{
-							Ready: ptr.To(true),
-						},
-					},
-				},
-				Ports: []discovery.EndpointPort{
-					{
-						Port:     ptr.To(int32(1234)),
-						Name:     ptr.To("LBPort"),
-						Protocol: ptr.To(v1.ProtocolTCP),
-					},
-				},
-			}
-
-			err := k8s.Tracker().Add(ep)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		By("checking that the healthCheckNodePort is accessible", func() {
 			Eventually(func() error {
 				result, err := http.Get(fmt.Sprintf("http://localhost:%d", healthCheckNodePort))


### PR DESCRIPTION
## Summary
- Pre-populate the fake K8s clientset with the Service and EndpointSlice at construction time instead of adding them via `Tracker().Add()` after the proxy starts
- This eliminates a race condition where the informer's initial `List` could complete before the `Watch` was set up, causing service add events to be silently lost
- Matches the pattern used by the other (non-flaky) proxy tests in `proxy_test.go`

## Test plan
- [x] `go test ./felix/bpf/proxy/...` passes (all 19 specs)
- [x] Targeted test passes 5/5 runs locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)