### PR TITLE
CORE-12209: kubevirt changes for calicoctl

### DIFF
--- a/calicoctl/calicoctl/commands/datastore/migrate/migrateipam.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/migrateipam.go
@@ -132,9 +132,16 @@ func (m *migrateIPAM) PullFromDatastore() error {
 		// Update node names in the block to match the Kubernetes node
 		if m.nodeMap != nil {
 			for i, allocationAttribute := range block.Attributes {
-				// Update the node name if it has a corresponding Kubernetes node name
+				// Update the node name in ActiveOwnerAttrs if it has a corresponding Kubernetes node name
 				if nodeName, ok := m.nodeMap[allocationAttribute.ActiveOwnerAttrs["node"]]; ok {
 					block.Attributes[i].ActiveOwnerAttrs["node"] = nodeName
+				}
+
+				// Update the node name in AlternateOwnerAttrs if present
+				if allocationAttribute.AlternateOwnerAttrs != nil {
+					if nodeName, ok := m.nodeMap[allocationAttribute.AlternateOwnerAttrs["node"]]; ok {
+						block.Attributes[i].AlternateOwnerAttrs["node"] = nodeName
+					}
 				}
 
 				// Update the handle ID for any tunnel addresses

--- a/calicoctl/calicoctl/commands/datastore/migrate/migrateipam_test.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/migrateipam_test.go
@@ -56,6 +56,10 @@ var _ = Describe("IPAM migration handling", func() {
 							"node": nodeName,
 							"type": "ipipTunnelAddress",
 						},
+						AlternateOwnerAttrs: map[string]string{
+							"node": nodeName,
+							"type": "ipipTunnelAddress",
+						},
 					},
 				},
 			},
@@ -110,6 +114,7 @@ var _ = Describe("IPAM migration handling", func() {
 		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes).To(HaveLen(1))
 		Expect(*migrateIPAM.IPAMBlocks[0].Value.Attributes[0].HandleID).To(Equal(fmt.Sprintf("ipip-tunnel-addr-%s", newNodeName)))
 		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].ActiveOwnerAttrs["node"]).To(Equal(newNodeName))
+		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AlternateOwnerAttrs["node"]).To(Equal(newNodeName))
 
 		// Check that the block affinity attributes were changed correctly
 		newAffinityKey := model.BlockAffinityKey{
@@ -156,6 +161,7 @@ var _ = Describe("IPAM migration handling", func() {
 		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes).To(HaveLen(1))
 		Expect(*migrateIPAM.IPAMBlocks[0].Value.Attributes[0].HandleID).To(Equal(fmt.Sprintf("ipip-tunnel-addr-%s", nodeName)))
 		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].ActiveOwnerAttrs["node"]).To(Equal(nodeName))
+		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AlternateOwnerAttrs["node"]).To(Equal(nodeName))
 
 		// Check that the block affinity attributes were not changed
 		newAffinityKeyPath, err := model.KeyToDefaultPath(affinity1.Key)

--- a/calicoctl/calicoctl/commands/ipam/check.go
+++ b/calicoctl/calicoctl/commands/ipam/check.go
@@ -693,16 +693,28 @@ func formatAttrs(attribute model.AllocationAttribute) string {
 	if attribute.HandleID != nil {
 		primary = *attribute.HandleID
 	}
+
+	result := fmt.Sprintf("Main:%s Extra:%s", primary, kvsFormat(attribute.ActiveOwnerAttrs))
+
+	if len(attribute.AlternateOwnerAttrs) > 0 {
+		result = fmt.Sprintf("%s Alternate:%s", result, kvsFormat(attribute.AlternateOwnerAttrs))
+	}
+
+	return result
+}
+
+// kvsFormat formats a map as a sorted, comma-separated list of key=value pairs.
+func kvsFormat(m map[string]string) string {
 	var keys []string
-	for k := range attribute.ActiveOwnerAttrs {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	var kvs []string
 	for _, k := range keys {
-		kvs = append(kvs, fmt.Sprintf("%s=%s", k, attribute.ActiveOwnerAttrs[k]))
+		kvs = append(kvs, fmt.Sprintf("%s=%s", k, m[k]))
 	}
-	return fmt.Sprintf("Main:%s Extra:%s", primary, strings.Join(kvs, ","))
+	return strings.Join(kvs, ",")
 }
 
 type ownerRecord struct {

--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -32,7 +32,7 @@ import (
 func updateIPAMConfig(
 	ctx context.Context,
 	ipamClient ipamlib.Interface,
-	enabled bool,
+	strictAffinity *bool,
 	maxBlocks *int,
 	persistence *ipamlib.VMAddressPersistence,
 ) error {
@@ -41,16 +41,17 @@ func updateIPAMConfig(
 		return fmt.Errorf("error: %v", err)
 	}
 
-	// If StrictAffinity == true => an address from a block can only be assigned by
-	// host with block affinity.
-	ipamConfig.StrictAffinity = enabled
+	// Update StrictAffinity if specified.
+	if strictAffinity != nil {
+		ipamConfig.StrictAffinity = *strictAffinity
+	}
 
-	// Set MaxBlocksPerHost if specified
+	// Set MaxBlocksPerHost if specified.
 	if maxBlocks != nil {
 		ipamConfig.MaxBlocksPerHost = *maxBlocks
 	}
 
-	// Update KubeVirtVMAddressPersistence if specified
+	// Update KubeVirtVMAddressPersistence if specified.
 	if persistence != nil {
 		ipamConfig.KubeVirtVMAddressPersistence = persistence
 	}
@@ -60,11 +61,12 @@ func updateIPAMConfig(
 		return fmt.Errorf("error: %v", err)
 	}
 
-	fmt.Println("Successfully set StrictAffinity to:", enabled)
+	if strictAffinity != nil {
+		fmt.Println("Successfully set StrictAffinity to:", *strictAffinity)
+	}
 	if maxBlocks != nil {
 		fmt.Println("Successfully set MaxBlocksPerHost to:", *maxBlocks)
 	}
-
 	if persistence != nil {
 		fmt.Println("Successfully set KubeVirtVMAddressPersistence to:", *persistence)
 	}
@@ -89,24 +91,24 @@ func parsePersistence(val string) (*ipamlib.VMAddressPersistence, error) {
 // Configure IPAM.
 func Configure(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  <BINARY_NAME> ipam configure --strictaffinity=<true/false> 
-                               [--max-blocks-per-host=<number>] 
+  <BINARY_NAME> ipam configure [--strictaffinity=<true/false>]
+                               [--max-blocks-per-host=<number>]
                                [--kubevirt-ip-persistence=<Enabled|Disabled>]
-                               [--config=<CONFIG>] 
+                               [--config=<CONFIG>]
                                [--allow-version-mismatch]
 
 Options:
   -h --help                        Show this screen.
-     --strictaffinity=<true/false> Set StrictAffinity to true/false. When StrictAffinity
-                                   is true, borrowing IP addresses is not allowed.
+     --strictaffinity=<true/false>  Set StrictAffinity to true/false. When StrictAffinity
+                                    is true, borrowing IP addresses is not allowed.
      --max-blocks-per-host=<number> Set the maximum number of blocks that can be affine to a host.
      --kubevirt-ip-persistence=<Enabled|Disabled>
-                                   Control whether KubeVirt VMs retain persistent IP addresses
-                                   across lifecycle events.
-  -c --config=<CONFIG>             Path to the file containing connection configuration in
-                                   YAML or JSON format.
-                                   [default: ` + constants.DefaultConfigPath + `]
-     --allow-version-mismatch      Allow client and cluster versions mismatch.
+                                    Control whether KubeVirt VMs retain persistent IP addresses
+                                    across lifecycle events.
+  -c --config=<CONFIG>              Path to the file containing connection configuration in
+                                    YAML or JSON format.
+                                    [default: ` + constants.DefaultConfigPath + `]
+     --allow-version-mismatch       Allow client and cluster versions mismatch.
 
 Description:
  Modify configuration for Calico IP address management.
@@ -138,12 +140,18 @@ Description:
 	}
 
 	ipamClient := client.IPAM()
-	passedValue := parsedArgs["--strictaffinity"].(string)
-	enabled, err := strconv.ParseBool(passedValue)
-	if err != nil {
-		return fmt.Errorf("invalid value. Use true or false to set strictaffinity")
+
+	// Parse StrictAffinity (optional).
+	var strictAffinity *bool
+	if passedValue, ok := parsedArgs["--strictaffinity"].(string); ok && passedValue != "" {
+		enabled, err := strconv.ParseBool(passedValue)
+		if err != nil {
+			return fmt.Errorf("invalid value. Use true or false to set strictaffinity")
+		}
+		strictAffinity = &enabled
 	}
 
+	// Parse MaxBlocksPerHost (optional).
 	var maxBlocks *int
 	if maxBlockStr, ok := parsedArgs["--max-blocks-per-host"].(string); ok && maxBlockStr != "" {
 		maxBlocksVal, err := strconv.Atoi(maxBlockStr)
@@ -153,7 +161,7 @@ Description:
 		maxBlocks = &maxBlocksVal
 	}
 
-	// Parse KubeVirtVMAddressPersistence
+	// Parse KubeVirtVMAddressPersistence (optional).
 	var persistence *ipamlib.VMAddressPersistence
 	if val, ok := parsedArgs["--kubevirt-ip-persistence"].(string); ok && val != "" {
 		persistence, err = parsePersistence(val)
@@ -162,5 +170,9 @@ Description:
 		}
 	}
 
-	return updateIPAMConfig(ctx, ipamClient, enabled, maxBlocks, persistence)
+	if strictAffinity == nil && maxBlocks == nil && persistence == nil {
+		return fmt.Errorf("at least one configuration option must be specified")
+	}
+
+	return updateIPAMConfig(ctx, ipamClient, strictAffinity, maxBlocks, persistence)
 }

--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -26,10 +26,16 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
-	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
+	ipamlib "github.com/projectcalico/calico/libcalico-go/lib/ipam"
 )
 
-func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, enabled bool, maxBlocks *int) error {
+func updateIPAMConfig(
+	ctx context.Context,
+	ipamClient ipamlib.Interface,
+	enabled bool,
+	maxBlocks *int,
+	persistence *ipamlib.VMAddressPersistence,
+) error {
 	ipamConfig, err := ipamClient.GetIPAMConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("error: %v", err)
@@ -44,6 +50,11 @@ func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, en
 		ipamConfig.MaxBlocksPerHost = *maxBlocks
 	}
 
+	// Update KubeVirtVMAddressPersistence if specified
+	if persistence != nil {
+		ipamConfig.KubeVirtVMAddressPersistence = persistence
+	}
+
 	err = ipamClient.SetIPAMConfig(ctx, *ipamConfig)
 	if err != nil {
 		return fmt.Errorf("error: %v", err)
@@ -54,19 +65,44 @@ func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, en
 		fmt.Println("Successfully set MaxBlocksPerHost to:", *maxBlocks)
 	}
 
+	if persistence != nil {
+		fmt.Println("Successfully set KubeVirtVMAddressPersistence to:", *persistence)
+	}
+
 	return nil
+}
+
+// parsePersistence validates and converts CLI value to typed enum.
+func parsePersistence(val string) (*ipamlib.VMAddressPersistence, error) {
+	switch val {
+	case string(ipamlib.VMAddressPersistenceEnabled):
+		p := ipamlib.VMAddressPersistenceEnabled
+		return &p, nil
+	case string(ipamlib.VMAddressPersistenceDisabled):
+		p := ipamlib.VMAddressPersistenceDisabled
+		return &p, nil
+	default:
+		return nil, fmt.Errorf("invalid value for --kubevirt-ip-persistence. Use Enabled or Disabled")
+	}
 }
 
 // Configure IPAM.
 func Configure(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  <BINARY_NAME> ipam configure --strictaffinity=<true/false> [--max-blocks-per-host=<number>] [--config=<CONFIG>] [--allow-version-mismatch]
+  <BINARY_NAME> ipam configure --strictaffinity=<true/false> 
+                               [--max-blocks-per-host=<number>] 
+                               [--kubevirt-ip-persistence=<Enabled|Disabled>]
+                               [--config=<CONFIG>] 
+                               [--allow-version-mismatch]
 
 Options:
   -h --help                        Show this screen.
      --strictaffinity=<true/false> Set StrictAffinity to true/false. When StrictAffinity
                                    is true, borrowing IP addresses is not allowed.
-     --max-blocks-per-host=<number>       Set the maximum number of blocks that can be affine to a host.
+     --max-blocks-per-host=<number> Set the maximum number of blocks that can be affine to a host.
+     --kubevirt-ip-persistence=<Enabled|Disabled>
+                                   Control whether KubeVirt VMs retain persistent IP addresses
+                                   across lifecycle events.
   -c --config=<CONFIG>             Path to the file containing connection configuration in
                                    YAML or JSON format.
                                    [default: ` + constants.DefaultConfigPath + `]
@@ -117,5 +153,14 @@ Description:
 		maxBlocks = &maxBlocksVal
 	}
 
-	return updateIPAMStrictAffinity(ctx, ipamClient, enabled, maxBlocks)
+	// Parse KubeVirtVMAddressPersistence
+	var persistence *ipamlib.VMAddressPersistence
+	if val, ok := parsedArgs["--kubevirt-ip-persistence"].(string); ok && val != "" {
+		persistence, err = parsePersistence(val)
+		if err != nil {
+			return err
+		}
+	}
+
+	return updateIPAMConfig(ctx, ipamClient, enabled, maxBlocks, persistence)
 }

--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -26,15 +26,15 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
-	ipamlib "github.com/projectcalico/calico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
 )
 
 func updateIPAMConfig(
 	ctx context.Context,
-	ipamClient ipamlib.Interface,
+	ipamClient ipam.Interface,
 	strictAffinity *bool,
 	maxBlocks *int,
-	persistence *ipamlib.VMAddressPersistence,
+	persistence *ipam.VMAddressPersistence,
 ) error {
 	ipamConfig, err := ipamClient.GetIPAMConfig(ctx)
 	if err != nil {
@@ -75,13 +75,13 @@ func updateIPAMConfig(
 }
 
 // parsePersistence validates and converts CLI value to typed enum.
-func parsePersistence(val string) (*ipamlib.VMAddressPersistence, error) {
+func parsePersistence(val string) (*ipam.VMAddressPersistence, error) {
 	switch val {
-	case string(ipamlib.VMAddressPersistenceEnabled):
-		p := ipamlib.VMAddressPersistenceEnabled
+	case string(ipam.VMAddressPersistenceEnabled):
+		p := ipam.VMAddressPersistenceEnabled
 		return &p, nil
-	case string(ipamlib.VMAddressPersistenceDisabled):
-		p := ipamlib.VMAddressPersistenceDisabled
+	case string(ipam.VMAddressPersistenceDisabled):
+		p := ipam.VMAddressPersistenceDisabled
 		return &p, nil
 	default:
 		return nil, fmt.Errorf("invalid value for --kubevirt-ip-persistence. Use Enabled or Disabled")
@@ -162,7 +162,7 @@ Description:
 	}
 
 	// Parse KubeVirtVMAddressPersistence (optional).
-	var persistence *ipamlib.VMAddressPersistence
+	var persistence *ipam.VMAddressPersistence
 	if val, ok := parsedArgs["--kubevirt-ip-persistence"].(string); ok && val != "" {
 		persistence, err = parsePersistence(val)
 		if err != nil {

--- a/calicoctl/calicoctl/commands/ipam/show.go
+++ b/calicoctl/calicoctl/commands/ipam/show.go
@@ -93,15 +93,14 @@ func getBorrowedIPs(ctx context.Context, ippoolClient clientv3.IPPoolInterface, 
 						bIP := borrowedIP{block: b.CIDR.IPNet.String(), blockOwner: blockOwner, borrowingNode: borrowingNode}
 						bIP.addr = b.OrdinalToIP(i).String()
 
-						if attributes.HandleID != nil {
-							bIP.allocatedTo = *attributes.HandleID
-						}
-
-						// Determine allocation type
-						if _, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeVMIName]; ok {
+						// Determine allocation type and human-readable allocatedTo.
+						ns := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeNamespace]
+						if vmiName, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeVMIName]; ok {
 							bIP.allocationType = "vmi"
-						} else if _, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributePod]; ok {
+							bIP.allocatedTo = fmt.Sprintf("%s/%s", ns, vmiName)
+						} else if podName, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributePod]; ok {
 							bIP.allocationType = model.IPAMBlockAttributePod
+							bIP.allocatedTo = fmt.Sprintf("%s/%s", ns, podName)
 						} else if t, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeType]; ok {
 							bIP.allocationType = t
 						}

--- a/calicoctl/calicoctl/commands/ipam/show.go
+++ b/calicoctl/calicoctl/commands/ipam/show.go
@@ -91,12 +91,18 @@ func getBorrowedIPs(ctx context.Context, ippoolClient clientv3.IPPoolInterface, 
 					if blockOwner != borrowingNode {
 						bIP := borrowedIP{block: b.CIDR.IPNet.String(), blockOwner: blockOwner, borrowingNode: borrowingNode}
 						bIP.addr = b.OrdinalToIP(i).String()
-						if _, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributePod]; ok {
-							bIP.allocatedTo = fmt.Sprintf("%s/%s", attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeNamespace],
-								attributes.ActiveOwnerAttrs[model.IPAMBlockAttributePod])
+
+						if attributes.HandleID != nil {
+							bIP.allocatedTo = *attributes.HandleID
+						}
+
+						// Determine allocation type
+						if _, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeVMIName]; ok {
+							bIP.allocationType = "vmi"
+						} else if _, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributePod]; ok {
 							bIP.allocationType = model.IPAMBlockAttributePod
-						} else if _, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeType]; ok {
-							bIP.allocationType = attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeType]
+						} else if t, ok := attributes.ActiveOwnerAttrs[model.IPAMBlockAttributeType]; ok {
+							bIP.allocationType = t
 						}
 						details = append(details, &bIP)
 					}
@@ -160,16 +166,44 @@ func showIP(ctx context.Context, ipamClient ipam.Interface, passedIP any) error 
 
 	// IP address is assigned.
 	fmt.Printf("IP %s is in use\n", ip)
-	attr := allocAttr.ActiveOwnerAttrs
-	if len(attr) != 0 {
-		fmt.Println("Attributes:")
-		for k, v := range attr {
-			fmt.Printf("  %v: %v\n", k, v)
-		}
+
+	// Print HandleID
+	if allocAttr.HandleID != nil {
+		fmt.Printf("Handle ID: %s\n", *allocAttr.HandleID)
 	} else {
-		fmt.Println("No attributes defined")
+		fmt.Println("Handle ID: <none>")
 	}
+
+	// Active Owner Attributes
+	active := formatOwnerAttrs("Active Owner Attributes", allocAttr.ActiveOwnerAttrs)
+	if active != "" {
+		fmt.Print(active)
+	} else {
+		fmt.Println("No Active Owner attributes defined")
+	}
+
+	// Alternate Owner Attributes
+	alternate := formatOwnerAttrs("Alternate Owner Attributes", allocAttr.AlternateOwnerAttrs)
+	if alternate != "" {
+		fmt.Print(alternate)
+	}
+
 	return nil
+}
+
+// formatOwnerAttrs formats owner attributes into a printable string.
+// If attrs is empty, it returns an empty string.
+func formatOwnerAttrs(title string, attrs map[string]string) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s:\n", title))
+	for k, v := range attrs {
+		b.WriteString(fmt.Sprintf("  %v: %v\n", k, v))
+	}
+	return b.String()
 }
 
 func showBlockUtilization(ctx context.Context, ipamClient ipam.Interface, showBlocks bool) error {

--- a/calicoctl/calicoctl/commands/ipam/show.go
+++ b/calicoctl/calicoctl/commands/ipam/show.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
 	docopt "github.com/docopt/docopt-go"
@@ -198,10 +199,16 @@ func formatOwnerAttrs(title string, attrs map[string]string) string {
 		return ""
 	}
 
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("%s:\n", title))
-	for k, v := range attrs {
-		b.WriteString(fmt.Sprintf("  %v: %v\n", k, v))
+	for _, k := range keys {
+		b.WriteString(fmt.Sprintf("  %v: %v\n", k, attrs[k]))
 	}
 	return b.String()
 }

--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -2203,10 +2203,16 @@ func (c ipamClient) SetIPAMConfig(ctx context.Context, cfg IPAMConfig) error {
 }
 
 func (c ipamClient) convertIPAMConfigToBackend(cfg *IPAMConfig) *model.IPAMConfig {
+	var persistence *string
+	if cfg.KubeVirtVMAddressPersistence != nil {
+		s := string(*cfg.KubeVirtVMAddressPersistence)
+		persistence = &s
+	}
 	return &model.IPAMConfig{
-		StrictAffinity:     cfg.StrictAffinity,
-		AutoAllocateBlocks: cfg.AutoAllocateBlocks,
-		MaxBlocksPerHost:   cfg.MaxBlocksPerHost,
+		StrictAffinity:               cfg.StrictAffinity,
+		AutoAllocateBlocks:           cfg.AutoAllocateBlocks,
+		MaxBlocksPerHost:             cfg.MaxBlocksPerHost,
+		KubeVirtVMAddressPersistence: persistence,
 	}
 }
 


### PR DESCRIPTION
  - Add `--kubevirt-ip-persistence=<Enabled|Disabled>` flag to calicoctl ipam configure for controlling KubeVirt VM IP persistence across lifecycle events
  - Make `--strictaffinity` optional so individual IPAM settings can be changed independently
  - Add `AlternateOwnerAttrs` support to IPAM migration, check, and show commands
  - Detect VMI allocation type in borrowed IP display (`calicoctl ipam show --show-borrowed`)
  - Show `HandleID`, `Active/Alternate Owner` Attributes separately in `calicoctl ipam show --ip`
  - Plumb `KubeVirtVMAddressPersistence` through IPAM config backend conversion


<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
`calicoctl ipam configure` now accepts `--kubevirt-ip-persistence=<Enabled|Disabled>` to toggle whether KubeVirt VMs retain a persistent IP across reboots, live migrations, and pod evictions. Pairs with the IPAM-side support added in #11865.
```
