### PR TITLE
Fix error response status code in httpmachinery

### DIFF
--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -379,6 +379,10 @@ func verifyFlowCount(url string, count int) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		}
+
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err

--- a/lib/httpmachinery/pkg/apiutil/handler_test.go
+++ b/lib/httpmachinery/pkg/apiutil/handler_test.go
@@ -109,3 +109,69 @@ func TestJSONStreamResponse(t *testing.T) {
 	hdlr.ServeHTTP(apiutil.NewNOOPRouterConfig(), w, r)
 	Expect(w.Body.String()).To(Equal("data: {\"rspField\":\"foo\"}\n\ndata: {\"rspField\":\"bar\"}\n\n"))
 }
+
+func TestJSONErrorResponse(t *testing.T) {
+	setupTest(t)
+
+	type Request struct {
+		ReqField string `urlQuery:"reqField"`
+	}
+	type Response struct {
+		RespField string `json:"rspField"`
+	}
+
+	hdlr := apiutil.NewJSONListOrEventStreamHandler(func(ctx apicontext.Context, params Request) apiutil.ListOrStreamResponse[Response] {
+		return apiutil.NewListOrStreamResponse[Response]().
+			SetStatus(http.StatusInternalServerError).
+			SetError("Internal Server Error")
+	})
+
+	w := httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "foobar", nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	values := r.URL.Query()
+	values.Set("reqField", "value")
+	r.URL.RawQuery = values.Encode()
+
+	hdlr.ServeHTTP(apiutil.NewNOOPRouterConfig(), w, r)
+
+	Expect(w.Code).To(Equal(http.StatusInternalServerError))
+	Expect(testutil.MustUnmarshal[apiutil.ErrorResponse](t, w.Body.Bytes())).To(Equal(&apiutil.ErrorResponse{
+		Error: "Internal Server Error",
+	}))
+}
+
+func TestJSONListErrorResponse(t *testing.T) {
+	setupTest(t)
+
+	type Request struct {
+		ReqField string `urlQuery:"reqField"`
+	}
+	type Response struct {
+		RespField string `json:"rspField"`
+	}
+
+	hdlr := apiutil.NewJSONListHandler(func(ctx apicontext.Context, params Request) apiutil.ListResponse[Response] {
+		return apiutil.NewListResponse[Response]().
+			SetStatus(http.StatusInternalServerError).
+			SetError("Internal Server Error")
+	})
+
+	w := httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "foobar", nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	values := r.URL.Query()
+	values.Set("reqField", "value")
+	r.URL.RawQuery = values.Encode()
+
+	hdlr.ServeHTTP(apiutil.NewNOOPRouterConfig(), w, r)
+
+	Expect(w.Code).To(Equal(http.StatusInternalServerError))
+	Expect(testutil.MustUnmarshal[apiutil.ErrorResponse](t, w.Body.Bytes())).To(Equal(&apiutil.ErrorResponse{
+		Error: "Internal Server Error",
+	}))
+}

--- a/lib/httpmachinery/pkg/apiutil/response.go
+++ b/lib/httpmachinery/pkg/apiutil/response.go
@@ -187,6 +187,7 @@ type jsonErrorResponseWriter struct {
 }
 
 func (rs *jsonErrorResponseWriter) WriteResponse(ctx apicontext.Context, status int, w http.ResponseWriter) error {
+	w.WriteHeader(status)
 	writeJSONResponse(w, ErrorResponse{Error: rs.error})
 	return nil
 }


### PR DESCRIPTION
`jsonErrorResponseWriter.WriteResponse` was missing a `w.WriteHeader(status)` call before writing the response body. In Go, the first `Write` on an `http.ResponseWriter` implicitly calls `WriteHeader(200)`, so all error responses were being sent with HTTP 200 regardless of what was passed to `SetStatus()`.

This was causing a flake in the staged policy e2e flow log test. When whisker-backend couldn't reach goldmane it would return `SetStatus(500).SetError("Internal Server Error")`, but the response actually went out as HTTP 200 with body `{"error":"Internal Server Error"}`. Two things then went wrong:

- `verifyPortForward` saw a 200 and concluded the pipeline was healthy, even though goldmane was unreachable.
- `verifyFlowCount` parsed the error body as `apiutil.List[FlowResponse]` — Go's JSON decoder silently ignores the unknown `"error"` key, leaving `Items` as nil (len 0). So the test reported "expected 2 flows, got 0" instead of surfacing the actual error.

The fix is one line in `jsonErrorResponseWriter.WriteResponse` to call `w.WriteHeader(status)`, matching what `jsonListResponseWriter` already does. Also adds a status code check in `verifyFlowCount` as defense-in-depth, and test coverage for both `ListOrStreamResponse` and `ListResponse` error paths.