### PR TITLE
Sync comment for ProgramClusterRoutes in FelixConfig and BGPConfig

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -568,12 +568,9 @@ type FelixConfigurationSpec struct {
 	// use a distinct protocol (in addition to setting this field to false).
 	RemoveExternalRoutes *bool `json:"removeExternalRoutes,omitempty"`
 
-	// ProgramClusterRoutes specifies whether Felix should program all cluster routes instead of BIRD.
-	// Felix always programs VXLAN routes. [Default: Disabled]
-
 	// ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
 	// when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-	// confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+	// it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
 	// Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	ProgramClusterRoutes *string `json:"programClusterRoutes,omitempty"`

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -3165,7 +3165,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 					},
 					"programClusterRoutes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node, when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled, confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route. Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]",
+							Description: "ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node, when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled, it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route. Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/felix/docs/config-params.json
+++ b/felix/docs/config-params.json
@@ -1997,8 +1997,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Controls how a cluster node gets a route to a workload on another node,\nwhen that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,\nconfd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.\nFelix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet.",
-          "DescriptionHTML": "<p>Controls how a cluster node gets a route to a workload on another node,\nwhen that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,\nconfd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.\nFelix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet.</p>",
+          "Description": "Controls how a cluster node gets a route to a workload on another node,\nwhen that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,\nit is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.\nFelix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet.",
+          "DescriptionHTML": "<p>Controls how a cluster node gets a route to a workload on another node,\nwhen that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,\nit is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.\nFelix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet.</p>",
           "UserEditable": true,
           "GoType": "*string"
         },

--- a/felix/docs/config-params.md
+++ b/felix/docs/config-params.md
@@ -1070,7 +1070,7 @@ like Application layer policy.
 
 Controls how a cluster node gets a route to a workload on another node,
 when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
 Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet.
 
 | Detail |   |

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -1054,7 +1054,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1907,7 +1907,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -1917,7 +1917,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -1918,7 +1918,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -1902,7 +1902,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -1902,7 +1902,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -1919,7 +1919,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -1816,7 +1816,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -1902,7 +1902,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -35054,7 +35054,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -35054,7 +35054,7 @@ spec:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
                     when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Enabled, Felix will program that route.
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
                     Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
                   enum:
                     - Enabled


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Use the same doc comments used for `ProgramClusterRoutes` in BGPConfig that was added in the below PR for the same config option in FelixConfig 
https://github.com/projectcalico/calico/pull/11845



<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
