### PR TITLE
Fix flaky tiered policy flow log test

### DIFF
--- a/felix/fv/tiered_policy_test.go
+++ b/felix/fv/tiered_policy_test.go
@@ -803,7 +803,7 @@ var _ = infrastructure.DatastoreDescribe("connectivity tests and flow logs with 
 			// Wait for the initial deny rules to be fully programmed before changing
 			// the tier default action, to avoid racing with the initial programming.
 			Eventually(rulesProgrammed, "15s", "200ms").Should(BeTrue())
-			Consistently(rulesProgrammed, "10s", "200ms").Should(BeTrue())
+			Consistently(rulesProgrammed, "2s", "200ms").Should(BeTrue())
 
 			tier, err := client.Tiers().Get(utils.Ctx, "tier1", options.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The flow log variant of the tiered policy test was changing tier1's DefaultAction
to Pass without first confirming the initial deny rules were fully programmed in
the dataplane. In BPF mode, this races with the initial policy compilation -
if the deny rules finish programming *after* Felix sees the Pass update, the
`rulesProgrammed` check stays true longer than the 30s timeout.

The connectivity test in the same file already follows the correct pattern: wait
for `rulesProgrammed` to be `BeTrue()` (and `Consistently` true) before changing
the tier. This PR adds the same synchronization to the flow log test.