### PR TITLE
e2e: Add auto-cleanup client wrapper for test resources

### DIFF
--- a/e2e/pkg/tests/bgp/bgp_password.go
+++ b/e2e/pkg/tests/bgp/bgp_password.go
@@ -126,11 +126,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err := cli.Create(ctx, peer)
 			Expect(err).NotTo(HaveOccurred(), "failed to create password-protected BGPPeer")
-			ginkgo.DeferCleanup(func() {
-				if err := cli.Delete(context.Background(), peer); err != nil && !errors.IsNotFound(err) {
-					framework.Logf("WARNING: failed to delete BGPPeer %s: %v", peer.Name, err)
-				}
-			})
 
 			// Disable full mesh so only the password-protected peers are active.
 			disableFullMesh(cli)
@@ -275,11 +270,6 @@ func createBGPPeerWithPassword(cli ctrlclient.Client, name, node, peerIP, secret
 	}
 	err := cli.Create(context.Background(), peer)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create BGPPeer %s", name)
-	ginkgo.DeferCleanup(func() {
-		if err := cli.Delete(context.Background(), peer); err != nil && !errors.IsNotFound(err) {
-			framework.Logf("WARNING: failed to delete BGPPeer %s: %v", name, err)
-		}
-	})
 }
 
 // expectBGPPeerNotEstablished verifies via CalicoNodeStatus that the BGP session
@@ -295,12 +285,6 @@ func expectBGPPeerNotEstablished(cli ctrlclient.Client, nodeName, peerIP string)
 	}
 	err := cli.Create(context.Background(), status)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create CalicoNodeStatus for node %s", nodeName)
-	defer func() {
-		err := cli.Delete(context.Background(), status)
-		if err != nil && !errors.IsNotFound(err) {
-			framework.Logf("WARNING: failed to delete CalicoNodeStatus for node %s: %v", nodeName, err)
-		}
-	}()
 
 	// Wait for the specific peer to appear in the status report as non-established.
 	EventuallyWithOffset(1, func() error {

--- a/e2e/pkg/tests/bgp/export.go
+++ b/e2e/pkg/tests/bgp/export.go
@@ -82,10 +82,6 @@ var _ = describe.CalicoDescribe(
 			pool.Spec.DisableBGPExport = false
 			err = cli.Create(context.Background(), pool)
 			Expect(err).NotTo(HaveOccurred(), "Error creating IP pool")
-			ginkgo.DeferCleanup(func() {
-				err = cli.Delete(context.Background(), pool)
-				Expect(err).NotTo(HaveOccurred(), "Error deleting IP pool")
-			})
 
 			// Before each test, perform the following steps:
 			// - Create a server pod and corresponding service in the main namespace for the test.
@@ -136,10 +132,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err = cli.Create(context.Background(), peer)
 			Expect(err).NotTo(HaveOccurred(), "Error creating BGPPeer resource")
-			ginkgo.DeferCleanup(func() {
-				err := cli.Delete(context.Background(), peer)
-				Expect(err).NotTo(HaveOccurred(), "Error deleting BGPPeer resource during cleanup")
-			})
 
 			// Disable BGP export on the pool.
 			pool := &v3.IPPool{}

--- a/e2e/pkg/tests/bgp/peers.go
+++ b/e2e/pkg/tests/bgp/peers.go
@@ -25,7 +25,6 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	v1 "github.com/tigera/operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -125,12 +124,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err = cli.Create(context.Background(), peer)
 			Expect(err).NotTo(HaveOccurred(), "Error creating BGPPeer resource")
-			ginkgo.DeferCleanup(func() {
-				err := cli.Delete(context.Background(), peer)
-				if !errors.IsNotFound(err) {
-					Expect(err).NotTo(HaveOccurred(), "Error deleting BGPPeer resource during cleanup")
-				}
-			})
 
 			// Verify connectivity is restored.
 			checker.ResetExpectations()
@@ -166,12 +159,6 @@ var _ = describe.CalicoDescribe(
 					}
 					err = cli.Create(context.Background(), peer)
 					Expect(err).NotTo(HaveOccurred(), "Error creating per-node BGPPeer resource")
-					ginkgo.DeferCleanup(func() {
-						err := cli.Delete(context.Background(), peer)
-						if !errors.IsNotFound(err) {
-							Expect(err).NotTo(HaveOccurred(), "Error deleting per-node BGPPeer resource during cleanup")
-						}
-					})
 				}
 			}
 

--- a/e2e/pkg/tests/bgp/route_reflector.go
+++ b/e2e/pkg/tests/bgp/route_reflector.go
@@ -151,10 +151,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err = cli.Create(context.Background(), peer)
 			Expect(err).NotTo(HaveOccurred(), "Error creating BGPPeer resource")
-			ginkgo.DeferCleanup(func() {
-				err := cli.Delete(context.Background(), peer)
-				Expect(err).NotTo(HaveOccurred(), "Error deleting BGPPeer resource during cleanup")
-			})
 
 			// Verify connectivity is restored.
 			checker.ResetExpectations()
@@ -196,10 +192,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err = cli.Create(context.Background(), peer)
 			Expect(err).NotTo(HaveOccurred(), "Error creating BGPPeer resource")
-			ginkgo.DeferCleanup(func() {
-				err := cli.Delete(context.Background(), peer)
-				Expect(err).NotTo(HaveOccurred(), "Error deleting BGPPeer resource during cleanup")
-			})
 
 			// Wait for BGP to converge.
 			waitForBGPEstablished(cli, nodes.Items...)
@@ -272,10 +264,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err = cli.Create(context.Background(), peer)
 			Expect(err).NotTo(HaveOccurred(), "Error creating BGPPeer resource")
-			ginkgo.DeferCleanup(func() {
-				err := cli.Delete(context.Background(), peer)
-				Expect(err).NotTo(HaveOccurred(), "Error deleting BGPPeer resource during cleanup")
-			})
 
 			// Wait until BGP has converged.
 			waitForBGPEstablished(cli, nodes.Items...)

--- a/e2e/pkg/tests/bgp/utils.go
+++ b/e2e/pkg/tests/bgp/utils.go
@@ -147,12 +147,6 @@ func waitForBGPEstablishedForNode(cli ctrlclient.Client, node string) {
 	err := cli.Create(context.Background(), status)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Error creating CalicoNodeStatus resource")
 
-	// Make sure we clean up the CalicoNodeStatus resource after we're done.
-	defer func() {
-		err := cli.Delete(context.Background(), status)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Error deleting CalicoNodeStatus resource")
-	}()
-
 	// Expect the CalicoNodeStatus to report all BGPPeers as established.
 	EventuallyWithOffset(1, func() error {
 		err := cli.Get(context.Background(), ctrlclient.ObjectKey{Name: node}, status)

--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -218,11 +218,6 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 					}
 				})
 
-				ginkgo.AfterEach(func() {
-					err := cli.Delete(context.Background(), denyIngressPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
 				ginkgo.It("should block one node 1 from entering node 0 on port 9090 with ingress policy", func() {
 					// Without any policy, the test pod should be able to hit the service on both ports.
 					checker.ExpectSuccess(cliHostNet, server.ClusterIP().Port(port9090))
@@ -252,11 +247,6 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 					clientPod = conncheck.NewClient("client", f.Namespace, conncheck.WithClientCustomizer(clientPodOnNodeOne))
 					checker.AddClient(clientPod)
 					checker.Deploy()
-				})
-
-				ginkgo.AfterEach(func() {
-					err := cli.Delete(context.Background(), denyEgressPolicy)
-					Expect(err).NotTo(HaveOccurred())
 				})
 
 				ginkgo.It("should block one node 1 from reaching node 0 on port 9091 with egress policy", func() {

--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -28,7 +28,6 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 	v1 "k8s.io/api/core/v1"
-	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -109,8 +108,6 @@ var _ = describe.CalicoDescribe(
 		var checker conncheck.ConnectionTester
 		var hepServer1 *conncheck.Server
 		var client1 *conncheck.Client
-		var hep *v3.HostEndpoint
-
 		BeforeEach(func() {
 			var err error
 			cli, err = client.New(f.ClientConfig())
@@ -185,25 +182,11 @@ var _ = describe.CalicoDescribe(
 			Expect(err).NotTo(HaveOccurred())
 
 			// Create our hostEndpoint - it is created with the same name as the GNP.
-			hep = createHostEndpoint(cli, hepPolicyName, hepNodeName, hepPort1, pod.Status.HostIP)
+			createHostEndpoint(cli, hepPolicyName, hepNodeName, hepPort1, pod.Status.HostIP)
 		})
 
 		AfterEach(func() {
 			checker.Stop()
-
-			// Clean up any policies / heps we created.
-			err := cli.Delete(context.Background(), defaultAllow)
-			if err != nil && !errors.IsNotFound(err) {
-				Expect(err).NotTo(HaveOccurred())
-			}
-			err = cli.Delete(context.Background(), allowLogCollection)
-			if err != nil && !errors.IsNotFound(err) {
-				Expect(err).NotTo(HaveOccurred())
-			}
-			err = cli.Delete(context.Background(), hep)
-			if err != nil && !errors.IsNotFound(err) {
-				Expect(err).NotTo(HaveOccurred())
-			}
 		})
 
 		It("should block all inbound connections by default", func() {
@@ -230,10 +213,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err := cli.Create(context.Background(), policy)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(context.Background(), policy)
-				Expect(err).NotTo(HaveOccurred())
-			}()
 
 			checker.ExpectSuccess(client1, hepServer1.ServiceDomain().Port(hepPort1))
 			checker.ExpectSuccess(client1, hepServer1.ServiceDomain().Port(hepPort2))
@@ -270,10 +249,6 @@ var _ = describe.CalicoDescribe(
 
 			err := cli.Create(context.Background(), policy)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(context.Background(), policy)
-				Expect(err).NotTo(HaveOccurred())
-			}()
 
 			// The named port should be accessible, the other port should not.
 			checker.ExpectSuccess(client1, hepServer1.ServiceDomain().Port(hepPort1))
@@ -310,10 +285,6 @@ var _ = describe.CalicoDescribe(
 					err := cli.Create(context.Background(), allowIngressPolicy)
 					Expect(err).NotTo(HaveOccurred())
 				})
-				defer func() {
-					err := cli.Delete(context.Background(), allowIngressPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("asserting connections work now prior to creating the doNotTrack GNP", func() {
 					checker.ExpectSuccess(client1, hepServer1.ServiceDomain().Port(hepPort1))
@@ -348,10 +319,6 @@ var _ = describe.CalicoDescribe(
 					err := cli.Create(context.Background(), doNotTrackPolicy)
 					Expect(err).NotTo(HaveOccurred())
 				})
-				defer func() {
-					err := cli.Delete(context.Background(), doNotTrackPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				// Named port is not accessible, the other port should be.
 				checker.ExpectFailure(client1, hepServer1.ServiceDomain().Port(hepPort1))
@@ -389,10 +356,6 @@ var _ = describe.CalicoDescribe(
 					err := cli.Create(context.Background(), allowIngressPolicy)
 					Expect(err).NotTo(HaveOccurred())
 				})
-				defer func() {
-					err := cli.Delete(context.Background(), allowIngressPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("asserting connections work now from an external node", func() {
 					checker.ResetExpectations()
@@ -467,12 +430,6 @@ var _ = describe.CalicoDescribe(
 					err = cli.Create(context.Background(), doNotTrackExactPolicy)
 					Expect(err).NotTo(HaveOccurred())
 				})
-				defer func() {
-					err := cli.Delete(context.Background(), doNotTrackExactPolicy)
-					Expect(err).NotTo(HaveOccurred())
-					err = cli.Delete(context.Background(), globalNetworkSetDOS)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By(fmt.Sprintf("asserting that none of the ports (tcp %d, %d) are accessible from the external node", hepPort1, hepPort2), func() {
 					checker.ResetExpectations()

--- a/e2e/pkg/tests/networking/ipip.go
+++ b/e2e/pkg/tests/networking/ipip.go
@@ -92,10 +92,6 @@ var _ = describe.CalicoDescribe(
 			pool.Spec.IPIPMode = v3.IPIPModeAlways
 			err = cli.Create(context.Background(), pool)
 			Expect(err).NotTo(HaveOccurred(), "Error creating IP pool")
-			ginkgo.DeferCleanup(func() {
-				err = cli.Delete(context.Background(), pool)
-				Expect(err).NotTo(HaveOccurred(), "Error deleting IP pool")
-			})
 
 			// Before each test, perform the following steps:
 			// - Create a server pod and corresponding service in the main namespace for the test.

--- a/e2e/pkg/tests/policy/policy.go
+++ b/e2e/pkg/tests/policy/policy.go
@@ -129,12 +129,6 @@ var _ = describe.CalicoDescribe(
 			defaultDenyGNP.Spec.NamespaceSelector = testNamespacesOnly
 			err = cli.Create(ctx, defaultDenyGNP)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, defaultDenyGNP)
-				if err != nil {
-					framework.Failf("failed to delete resource: %s", err)
-				}
-			}()
 
 			// Create a GlobalNetworkPolicy that allows any pods access to DNS. This is needed so
 			// that pods can lookup service IPs by service name in subsequent steps.
@@ -165,12 +159,6 @@ var _ = describe.CalicoDescribe(
 			}
 			err = cli.Create(ctx, allowEgressToDNS)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, allowEgressToDNS)
-				if err != nil {
-					framework.Failf("failed to delete resource: %s", err)
-				}
-			}()
 
 			By("Checking the default deny is functioning")
 			checker.ResetExpectations()
@@ -186,12 +174,6 @@ var _ = describe.CalicoDescribe(
 			isolateNamespaceA := newNamespaceIsolationPolicy(policyName, nsA.Name, namespaceASelector, namespaceASelector)
 			err = cli.Create(ctx, isolateNamespaceA)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, isolateNamespaceA)
-				if err != nil {
-					framework.Failf("failed to delete resource: %s", err)
-				}
-			}()
 
 			// Create a policy which prevents ingress and egress traffic to / from pods in
 			// namespace B, unless the traffic is from / to another pod in namespace B.
@@ -201,12 +183,6 @@ var _ = describe.CalicoDescribe(
 			isolateNamespaceB := newNamespaceIsolationPolicy(policyNameB, nsB.Name, namespaceBSelector, namespaceBSelector)
 			err = cli.Create(ctx, isolateNamespaceB)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, isolateNamespaceB)
-				if err != nil {
-					framework.Failf("failed to delete resource: %s", err)
-				}
-			}()
 
 			By("Checking clients can only communicate within their own Namespace")
 			checker.ResetExpectations()
@@ -226,10 +202,6 @@ var _ = describe.CalicoDescribe(
 			defaultDeny := newDefaultDenyIngressPolicy(ns.Name)
 			err = cli.Create(ctx, defaultDeny)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, defaultDeny)
-				Expect(err).NotTo(HaveOccurred())
-			}()
 
 			// Verify the default deny.
 			checker.ExpectFailure(client1, server1.ClusterIP())
@@ -269,12 +241,6 @@ var _ = describe.CalicoDescribe(
 
 			err = cli.Create(ctx, np)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, np)
-				if err != nil {
-					framework.Failf("failed to delete resource: %s", err)
-				}
-			}()
 
 			// Verify the policy allows traffic.
 			checker.ResetExpectations()
@@ -291,10 +257,6 @@ var _ = describe.CalicoDescribe(
 			defaultDeny := newDefaultDenyIngressPolicy(ns.Name)
 			err := cli.Create(ctx, defaultDeny)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, defaultDeny)
-				Expect(err).NotTo(HaveOccurred())
-			}()
 			logrus.Info("Applied default-deny policy.")
 
 			// Verify the default deny.
@@ -331,12 +293,6 @@ var _ = describe.CalicoDescribe(
 
 			err = cli.Create(ctx, np)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := cli.Delete(ctx, np)
-				if err != nil {
-					framework.Failf("failed to delete resource: %s", err)
-				}
-			}()
 
 			// Verify the policy allows traffic.
 			checker.ResetExpectations()
@@ -368,9 +324,6 @@ var _ = describe.CalicoDescribe(
 
 			err := cli.Create(context.Background(), defaultDeny)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				Expect(cli.Delete(context.Background(), defaultDeny)).NotTo(HaveOccurred())
-			}()
 
 			By("checking client not able to contact the server since deny egress rule created.")
 			checker.ExpectFailure(client1, server1.ClusterIP())

--- a/e2e/pkg/tests/policy/service_policy.go
+++ b/e2e/pkg/tests/policy/service_policy.go
@@ -194,10 +194,6 @@ var _ = describe.CalicoDescribe(
 					defaultDeny := newDefaultDenyIngressPolicy(f.Namespace.Name)
 					err := cli.Create(context.Background(), defaultDeny)
 					Expect(err).NotTo(HaveOccurred())
-					defer func() {
-						err := cli.Delete(context.Background(), defaultDeny)
-						Expect(err).NotTo(HaveOccurred())
-					}()
 
 					By("Creating allow-kube-dns policy, so that services can be contacted by name.")
 
@@ -233,10 +229,6 @@ var _ = describe.CalicoDescribe(
 					}
 					err = cli.Create(context.Background(), allowDNSPolicy)
 					Expect(err).NotTo(HaveOccurred())
-					defer func() {
-						err := cli.Delete(context.Background(), allowDNSPolicy)
-						Expect(err).NotTo(HaveOccurred())
-					}()
 
 					By("Expecting the client will not be able to contact the server.")
 					checker.ExpectFailure(client1, server.ClusterIP().Port(80))
@@ -247,19 +239,11 @@ var _ = describe.CalicoDescribe(
 					allowClientPolicy := getAllowClientPolicy()
 					err = cli.Create(context.Background(), allowClientPolicy)
 					Expect(err).NotTo(HaveOccurred())
-					defer func() {
-						err := cli.Delete(context.Background(), allowClientPolicy)
-						Expect(err).NotTo(HaveOccurred())
-					}()
 
 					By("Creating allow-server-ingress policy.")
 					allowServerPolicy := getAllowServerPolicy()
 					err = cli.Create(context.Background(), allowServerPolicy)
 					Expect(err).NotTo(HaveOccurred())
-					defer func() {
-						err := cli.Delete(context.Background(), allowServerPolicy)
-						Expect(err).NotTo(HaveOccurred())
-					}()
 
 					if createClientService {
 						By("Creating service for client so that a ServiceMatch policy can be used to allow ingress traffic from the client.")

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -103,8 +103,6 @@ var _ = describe.CalicoDescribe(
 			})
 
 			AfterEach(func() {
-				Expect(cli.Delete(context.TODO(), tierObj)).ShouldNot(HaveOccurred())
-
 				checker.Stop()
 
 				// Stop the kubectl port forward
@@ -135,10 +133,6 @@ var _ = describe.CalicoDescribe(
 						whiskerv1.PolicyKindStagedKubernetesNetworkPolicy,
 						whiskerv1.Action(0), // Action is empty for StagedKubernetesNetworkPolicy
 					)
-				})
-
-				AfterEach(func() {
-					Expect(cli.Delete(context.TODO(), stagedKubernetesNetworkPolicy)).ShouldNot(HaveOccurred())
 				})
 			})
 
@@ -173,11 +167,6 @@ var _ = describe.CalicoDescribe(
 						whiskerv1.ActionDeny,
 					)
 				})
-
-				AfterEach(func() {
-					// clean-up policy
-					Expect(cli.Delete(context.TODO(), stagedPolicy)).ShouldNot(HaveOccurred())
-				})
 			})
 
 			Context("StagedGlobalNetworkPolicy", func() {
@@ -209,10 +198,6 @@ var _ = describe.CalicoDescribe(
 						whiskerv1.ActionDeny,
 					)
 				})
-
-				AfterEach(func() {
-					Expect(cli.Delete(context.TODO(), stagedGlobalNetworkPolicy)).ShouldNot(HaveOccurred())
-				})
 			})
 		})
 
@@ -242,7 +227,6 @@ var _ = describe.CalicoDescribe(
 			})
 
 			AfterEach(func() {
-				Expect(cli.Delete(context.TODO(), tierObj)).ShouldNot(HaveOccurred())
 				checker.Stop()
 			})
 
@@ -256,16 +240,10 @@ var _ = describe.CalicoDescribe(
 					podSelector := metav1.LabelSelector{MatchLabels: server.Pod().Labels}
 					policy := CreateStagedKubernetesNetworkPolicyIngressDeny("service-deny-in", server.Pod().Namespace, podSelector)
 					Expect(cli.Create(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					})
 
 					// enforce the policy
 					_, enforced := ConvertStagedKubernetesPolicyToK8SEnforced(policy)
 					Expect(cli.Create(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					})
 
 					// test connection from client to server - it should fail
 					checker.ResetExpectations()

--- a/e2e/pkg/tests/policy/tiered_rbac.go
+++ b/e2e/pkg/tests/policy/tiered_rbac.go
@@ -139,16 +139,6 @@ var _ = describe.CalicoDescribe(
 				}
 			}
 
-			By("Cleaning up test tiers")
-			for _, name := range []string{rbacTestTier, rbacOtherTier} {
-				tier := v3.NewTier()
-				tier.Name = name
-				if err := adminCli.Delete(ctx, tier); err != nil {
-					logrus.WithError(err).WithField("name", name).Error("Failed to delete Tier")
-					errOccurred = true
-				}
-			}
-
 			Expect(errOccurred).To(BeFalse(), "errors occurred during teardown")
 		})
 
@@ -240,8 +230,6 @@ var _ = describe.CalicoDescribe(
 				)
 				np.Spec.Order = ptr.To(200.0)
 				Expect(cli.Update(ctx, np)).To(Succeed(), "tier admin should be able to update policy")
-
-				Expect(adminCli.Delete(ctx, np)).To(Succeed())
 			})
 
 			// Verifies that update is denied when the user lacks tier GET access,
@@ -268,8 +256,6 @@ var _ = describe.CalicoDescribe(
 				err := cli.Update(ctx, np)
 				Expect(err).To(HaveOccurred(), "update should be denied without tier GET access")
 				Expect(apierrors.IsForbidden(err)).To(BeTrue(), "expected forbidden error, got: %v", err)
-
-				Expect(adminCli.Delete(ctx, np)).To(Succeed())
 			})
 		})
 
@@ -442,8 +428,6 @@ var _ = describe.CalicoDescribe(
 				err = cli.Delete(ctx, np)
 				Expect(err).To(HaveOccurred(), "read-only user should not be able to delete policy")
 				Expect(apierrors.IsForbidden(err)).To(BeTrue(), "expected forbidden error, got: %v", err)
-
-				Expect(adminCli.Delete(ctx, np)).To(Succeed())
 			})
 		})
 	},

--- a/e2e/pkg/tests/policy/tiers.go
+++ b/e2e/pkg/tests/policy/tiers.go
@@ -89,10 +89,6 @@ var _ = describe.CalicoDescribe(
 		AfterEach(func() {
 			defer cancel()
 			checker.Stop()
-
-			By("Deleting tier0")
-			err := cli.Delete(ctx, tier0)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("with a single tier taking precedence over the default tier", func() {
@@ -114,10 +110,6 @@ var _ = describe.CalicoDescribe(
 
 				err := cli.Create(ctx, passPolicy)
 				Expect(err).NotTo(HaveOccurred())
-				defer func() {
-					err := cli.Delete(ctx, passPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("Testing server pod should not be accessible with default deny.")
 				checker.ExpectFailure(client1, server.ClusterIPs()...)
@@ -139,10 +131,6 @@ var _ = describe.CalicoDescribe(
 				}
 				err = cli.Create(ctx, allowPolicy)
 				Expect(err).NotTo(HaveOccurred())
-				defer func() {
-					err := cli.Delete(ctx, allowPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("Testing server pod should be accessible.")
 				checker.ExpectSuccess(client1, server.ClusterIPs()...)
@@ -161,12 +149,6 @@ var _ = describe.CalicoDescribe(
 
 				By("Creating tier1 with higher order number than tier0")
 				err := cli.Create(ctx, tier1)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			AfterEach(func() {
-				By("Deleting tier1")
-				err := cli.Delete(ctx, tier1)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -189,10 +171,6 @@ var _ = describe.CalicoDescribe(
 				}
 				err := cli.Create(ctx, passPolicy)
 				Expect(err).NotTo(HaveOccurred())
-				defer func() {
-					err := cli.Delete(ctx, passPolicy)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("Testing server pod should not be accessible due to default deny.")
 				checker.ExpectFailure(client1, server.ClusterIP())
@@ -217,10 +195,6 @@ var _ = describe.CalicoDescribe(
 				}
 				err = cli.Create(ctx, t1Allow)
 				Expect(err).NotTo(HaveOccurred())
-				defer func() {
-					err := cli.Delete(ctx, t1Allow)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("Testing server pod should be accessible.")
 				checker.ExpectSuccess(client1, server.ClusterIP())
@@ -246,10 +220,6 @@ var _ = describe.CalicoDescribe(
 				}
 				err := cli.Create(ctx, np)
 				Expect(err).NotTo(HaveOccurred())
-				defer func() {
-					err := cli.Delete(ctx, np)
-					Expect(err).NotTo(HaveOccurred())
-				}()
 
 				By("Testing server pod should not be accessible.")
 				checker.ExpectFailure(client1, server.ClusterIP())

--- a/e2e/pkg/utils/client/auto_cleanup.go
+++ b/e2e/pkg/utils/client/auto_cleanup.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// autoCleanupClient wraps a controller-runtime client.Client and registers a
+// Ginkgo DeferCleanup for every successful Create call. This ensures that
+// test-created resources are always cleaned up, even if the test author forgets
+// to add explicit cleanup logic.
+type autoCleanupClient struct {
+	client.Client
+}
+
+// NewWithAutoCleanup wraps an existing client so that every successful Create
+// automatically registers a Ginkgo DeferCleanup to delete the object.
+func NewWithAutoCleanup(c client.Client) client.Client {
+	return &autoCleanupClient{Client: c}
+}
+
+func (c *autoCleanupClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+
+	// Capture the GVK and object key at creation time so the deferred delete
+	// doesn't depend on the original object pointer, which the test may mutate.
+	gvk, err := c.GroupVersionKindFor(obj)
+	if err != nil {
+		logrus.WithError(err).Warn("Auto-cleanup: unable to determine GVK, skipping cleanup registration")
+		return nil
+	}
+	key := client.ObjectKeyFromObject(obj)
+
+	DeferCleanup(func() {
+		stub := &unstructured.Unstructured{}
+		stub.SetGroupVersionKind(gvk)
+		stub.SetName(key.Name)
+		stub.SetNamespace(key.Namespace)
+		if err := c.Client.Delete(context.Background(), stub); err != nil {
+			if !apierrors.IsNotFound(err) {
+				logrus.WithError(err).WithFields(logrus.Fields{
+					"gvk":  gvk,
+					"name": key,
+				}).Warn("Auto-cleanup: failed to delete object")
+			}
+		}
+	})
+	return nil
+}

--- a/e2e/pkg/utils/client/client.go
+++ b/e2e/pkg/utils/client/client.go
@@ -28,7 +28,21 @@ import (
 )
 
 // New returns a new controller-runtime client configured to use the projectcalico.org/v3 API group.
+// The returned client automatically registers Ginkgo DeferCleanup for every successful Create call,
+// ensuring test-created resources are always cleaned up. Use NewWithoutAutoCleanup if you need to
+// opt out of this behavior.
 func New(cfg *rest.Config) (client.Client, error) {
+	c, err := NewWithoutAutoCleanup(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewWithAutoCleanup(c), nil
+}
+
+// NewWithoutAutoCleanup returns a new controller-runtime client without automatic cleanup behavior.
+// Use this when you need full control over resource lifecycle, e.g., for resources created in
+// BeforeSuite or tests that explicitly test deletion behavior.
+func NewWithoutAutoCleanup(cfg *rest.Config) (client.Client, error) {
 	// Use the API client if the Calico v3 API is available, otherwise fall back to the calicoctl exec client.
 	c, err := NewAPIClient(cfg)
 	if err != nil {


### PR DESCRIPTION
Wrap the e2e controller-runtime client with an `autoCleanupClient` that
registers a Ginkgo `DeferCleanup` for every successful `Create` call. This
makes resource cleanup automatic — test authors no longer need to remember
to add explicit defer/DeferCleanup/AfterEach blocks for every object they
create, which has been a common source of leaked resources in parallel runs.

`client.New()` returns the wrapped client by default, so all existing callers
get this for free. A new `NewWithoutAutoCleanup()` function is available for
cases that need full lifecycle control (BeforeSuite-level resources, tests
that explicitly verify deletion behavior, etc.).

The wrapper captures the GVK and object key at creation time (via
`unstructured.Unstructured`) so the deferred delete doesn't depend on the
original object pointer. It tolerates `NotFound` on delete, so tests that
already clean up explicitly won't break.

Also removes ~250 lines of now-redundant cleanup boilerplate across all
e2e test files. Cleanup blocks using `f.ClientSet` (k8s native clientset)
or performing state restoration (not simple deletes) are retained since
they aren't covered by the auto-cleanup wrapper.