### PR TITLE
[release-v3.30] fix(dikastes): register ALPCheckProvider to restore L7 policy enforcement

### DIFF
--- a/app-policy/checker/alp_check_provider.go
+++ b/app-policy/checker/alp_check_provider.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/rules"
+)
+
+// ALPCheckProvider implements CheckProvider for application layer policy (ALP)
+// enforcement. It evaluates the request against the tiered network policies and
+// profiles configured for the local workload endpoint.
+type ALPCheckProvider struct{}
+
+// NewALPCheckProvider returns a new ALPCheckProvider.
+func NewALPCheckProvider() *ALPCheckProvider {
+	return &ALPCheckProvider{}
+}
+
+func (a *ALPCheckProvider) Name() string {
+	return "alp"
+}
+
+// EnabledForRequest returns true when the policy store has a local workload
+// endpoint configured, which is the case in per-pod (sidecar) mode.
+func (a *ALPCheckProvider) EnabledForRequest(ps *policystore.PolicyStore, _ *authz.CheckRequest) bool {
+	return ps.Endpoint != nil
+}
+
+// Check evaluates the request against the configured policies and profiles
+// for the local workload endpoint and returns the authorization decision.
+func (a *ALPCheckProvider) Check(ps *policystore.PolicyStore, req *authz.CheckRequest) (*authz.CheckResponse, error) {
+	flow := NewCheckRequestToFlowAdapter(req)
+	st := checkStore(ps, ps.Endpoint, rules.RuleDirIngress, flow)
+	return &authz.CheckResponse{Status: &st}, nil
+}

--- a/app-policy/checker/alp_check_provider_test.go
+++ b/app-policy/checker/alp_check_provider_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"testing"
+
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/felix/proto"
+	"github.com/projectcalico/calico/felix/types"
+)
+
+func TestALPCheckProviderName(t *testing.T) {
+	RegisterTestingT(t)
+	p := NewALPCheckProvider()
+	Expect(p.Name()).To(Equal("alp"))
+}
+
+func TestALPCheckProviderEnabledForRequest(t *testing.T) {
+	RegisterTestingT(t)
+	p := NewALPCheckProvider()
+
+	store := policystore.NewPolicyStore()
+	req := &authz.CheckRequest{}
+
+	// No endpoint set → disabled.
+	Expect(p.EnabledForRequest(store, req)).To(BeFalse())
+
+	// Endpoint set → enabled.
+	store.Endpoint = &proto.WorkloadEndpoint{}
+	Expect(p.EnabledForRequest(store, req)).To(BeTrue())
+}
+
+func TestALPCheckProviderCheckAllow(t *testing.T) {
+	RegisterTestingT(t)
+	p := NewALPCheckProvider()
+
+	store := policystore.NewPolicyStore()
+	store.Endpoint = &proto.WorkloadEndpoint{
+		ProfileIds: []string{"default"},
+	}
+	store.ProfileByID[types.ProfileID{Name: "default"}] = &proto.Profile{
+		InboundRules: []*proto.Rule{{Action: "Allow"}},
+	}
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/steve",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/sammy",
+		},
+	}}
+
+	resp, err := p.Check(store, req)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(resp.GetStatus().GetCode()).To(Equal(OK))
+}
+
+func TestALPCheckProviderCheckDeny(t *testing.T) {
+	RegisterTestingT(t)
+	p := NewALPCheckProvider()
+
+	store := policystore.NewPolicyStore()
+	store.Endpoint = &proto.WorkloadEndpoint{
+		ProfileIds: []string{"default"},
+	}
+	store.ProfileByID[types.ProfileID{Name: "default"}] = &proto.Profile{
+		InboundRules: []*proto.Rule{{Action: "Deny"}},
+	}
+
+	req := &authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/steve",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/sammy",
+		},
+	}}
+
+	resp, err := p.Check(store, req)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(resp.GetStatus().GetCode()).To(Equal(PERMISSION_DENIED))
+}

--- a/app-policy/checker/server_test.go
+++ b/app-policy/checker/server_test.go
@@ -20,7 +20,6 @@ import (
 
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
-	"google.golang.org/genproto/googleapis/rpc/status"
 
 	"github.com/projectcalico/calico/app-policy/policystore"
 	"github.com/projectcalico/calico/felix/proto"
@@ -33,13 +32,15 @@ func TestCheckNoStore(t *testing.T) {
 	defer cancel()
 
 	stores := policystore.NewPolicyStoreManager()
-	uut := NewServer(ctx, stores)
+	uut := NewServer(ctx, stores,
+		WithRegisteredCheckProvider(NewALPCheckProvider()),
+	)
 
 	req := &authz.CheckRequest{}
 	resp, err := uut.Check(ctx, req)
 	Expect(err).To(BeNil())
-	// No provider is registerted, as such the status code is UNKNOWN
-	Expect(resp.GetStatus().GetCode()).To(Equal(UNKNOWN))
+	// Endpoint is nil so the ALP provider is not enabled; response stays at initial INTERNAL.
+	Expect(resp.GetStatus().GetCode()).To(Equal(INTERNAL))
 }
 
 func TestCheckStore(t *testing.T) {
@@ -48,10 +49,13 @@ func TestCheckStore(t *testing.T) {
 	defer cancel()
 
 	stores := policystore.NewPolicyStoreManager()
-	uut := NewServer(ctx, stores)
+	uut := NewServer(ctx, stores,
+		WithRegisteredCheckProvider(NewALPCheckProvider()),
+	)
 
-	store := policystore.NewPolicyStoreManager()
-	store.DoWithLock(func(s *policystore.PolicyStore) {
+	// Mark in-sync so writes go to the active store, then populate it.
+	stores.OnInSync()
+	stores.DoWithLock(func(s *policystore.PolicyStore) {
 		s.Endpoint = &proto.WorkloadEndpoint{
 			ProfileIds: []string{"default"},
 		}
@@ -69,11 +73,7 @@ func TestCheckStore(t *testing.T) {
 		},
 	}}
 
-	chk := func() *authz.CheckResponse {
-		rsp, err := uut.Check(ctx, req)
-		Expect(err).ToNot(HaveOccurred())
-		return rsp
-	}
-	// No provider is registerted, as such the status code is UNKNOWN
-	Eventually(chk).Should(Equal(&authz.CheckResponse{Status: &status.Status{Code: UNKNOWN}}))
+	resp, err := uut.Check(ctx, req)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(resp.GetStatus().GetCode()).To(Equal(OK))
 }

--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -107,7 +107,9 @@ func runServer(arguments map[string]interface{}) {
 	// Check server
 	gs := grpc.NewServer()
 	storeManager := policystore.NewPolicyStoreManager()
-	checkServer := checker.NewServer(ctx, storeManager)
+	checkServer := checker.NewServer(ctx, storeManager,
+		checker.WithRegisteredCheckProvider(checker.NewALPCheckProvider()),
+	)
 	authz.RegisterAuthorizationServer(gs, checkServer)
 	checkServerV2 := checkServer.V2Compat()
 	authz_v2alpha.RegisterAuthorizationServer(gs, checkServerV2)

--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -28,8 +28,6 @@ import (
 	"time"
 
 	"github.com/docopt/docopt-go"
-	authz_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
-	authz_v2alpha "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2alpha"
 	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -107,13 +105,7 @@ func runServer(arguments map[string]interface{}) {
 	// Check server
 	gs := grpc.NewServer()
 	storeManager := policystore.NewPolicyStoreManager()
-	checkServer := checker.NewServer(ctx, storeManager,
-		checker.WithRegisteredCheckProvider(checker.NewALPCheckProvider()),
-	)
-	authz.RegisterAuthorizationServer(gs, checkServer)
-	checkServerV2 := checkServer.V2Compat()
-	authz_v2alpha.RegisterAuthorizationServer(gs, checkServerV2)
-	authz_v2.RegisterAuthorizationServer(gs, checkServerV2)
+	newCheckServer(ctx, gs, storeManager)
 
 	// Synchronize the policy store
 	opts := uds.GetDialOptions()
@@ -241,4 +233,15 @@ func (h *httpTerminationHandler) RunHTTPServer(addr string, port string) (*http.
 		}
 	}()
 	return httpServer, httpServerWg, nil
+}
+
+// newCheckServer creates the ext_authz check server with the default set of
+// check providers and registers it on the given gRPC server. This is the single
+// source of truth for provider registration and is used by both runServer and
+// tests.
+func newCheckServer(ctx context.Context, gs *grpc.Server, storeManager policystore.PolicyStoreManager) {
+	checkServer := checker.NewServer(ctx, storeManager,
+		checker.WithRegisteredCheckProvider(checker.NewALPCheckProvider()),
+	)
+	checkServer.RegisterGRPCServices(gs)
 }

--- a/app-policy/cmd/dikastes/dikastes_fv_test.go
+++ b/app-policy/cmd/dikastes/dikastes_fv_test.go
@@ -102,16 +102,15 @@ func TestDikastesCheckDenyPolicy(t *testing.T) {
 				Tiers: []*proto.TierInfo{{
 					Name:            "default",
 					DefaultAction:   "Deny",
-					IngressPolicies: []*proto.PolicyID{{Name: "deny-all"}},
+					IngressPolicies: []string{"deny-all"},
 				}},
 			},
 		},
 	}})
 	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
 		ActivePolicyUpdate: &proto.ActivePolicyUpdate{
-			Id: &proto.PolicyID{Name: "deny-all"},
+			Id: &proto.PolicyID{Tier: "default", Name: "deny-all"},
 			Policy: &proto.Policy{
-				Tier:         "default",
 				InboundRules: []*proto.Rule{{Action: "Deny"}},
 			},
 		},
@@ -153,16 +152,15 @@ func TestDikastesCheckHTTPMethodMatch(t *testing.T) {
 				Tiers: []*proto.TierInfo{{
 					Name:            "default",
 					DefaultAction:   "Deny",
-					IngressPolicies: []*proto.PolicyID{{Name: "allow-get"}},
+					IngressPolicies: []string{"allow-get"},
 				}},
 			},
 		},
 	}})
 	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
 		ActivePolicyUpdate: &proto.ActivePolicyUpdate{
-			Id: &proto.PolicyID{Name: "allow-get"},
+			Id: &proto.PolicyID{Tier: "default", Name: "allow-get"},
 			Policy: &proto.Policy{
-				Tier: "default",
 				InboundRules: []*proto.Rule{{
 					Action:    "Allow",
 					HttpMatch: &proto.HTTPMatch{Methods: []string{"GET"}},

--- a/app-policy/cmd/dikastes/dikastes_fv_test.go
+++ b/app-policy/cmd/dikastes/dikastes_fv_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"path"
+	"sync"
+	"testing"
+
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+
+	"github.com/projectcalico/calico/app-policy/checker"
+	"github.com/projectcalico/calico/app-policy/policystore"
+	"github.com/projectcalico/calico/app-policy/syncher"
+	"github.com/projectcalico/calico/app-policy/uds"
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+// TestDikastesCheckAllowProfile verifies the full ext_authz flow: sync server
+// pushes an endpoint with an allow-all profile, then an authz Check request
+// through the dikastes gRPC server returns OK.
+func TestDikastesCheckAllowProfile(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := newDikastesTestEnv(t, ctx)
+	defer env.cleanup()
+
+	// Push an endpoint with an allow-all profile.
+	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointUpdate{
+		WorkloadEndpointUpdate: &proto.WorkloadEndpointUpdate{
+			Id: &proto.WorkloadEndpointID{
+				OrchestratorId: "k8s",
+				WorkloadId:     "default/test-pod",
+				EndpointId:     "eth0",
+			},
+			Endpoint: &proto.WorkloadEndpoint{
+				ProfileIds: []string{"kns.default"},
+			},
+		},
+	}})
+	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_ActiveProfileUpdate{
+		ActiveProfileUpdate: &proto.ActiveProfileUpdate{
+			Id: &proto.ProfileID{Name: "kns.default"},
+			Profile: &proto.Profile{
+				InboundRules: []*proto.Rule{{Action: "Allow"}},
+			},
+		},
+	}})
+	env.sendInSync()
+	env.waitReady()
+
+	resp := env.check(&authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/client",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/server",
+		},
+	}})
+	Expect(resp.GetStatus().GetCode()).To(Equal(checker.OK))
+}
+
+// TestDikastesCheckDenyPolicy verifies that a deny policy correctly results in
+// PERMISSION_DENIED through the full ext_authz gRPC flow.
+func TestDikastesCheckDenyPolicy(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := newDikastesTestEnv(t, ctx)
+	defer env.cleanup()
+
+	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointUpdate{
+		WorkloadEndpointUpdate: &proto.WorkloadEndpointUpdate{
+			Id: &proto.WorkloadEndpointID{
+				OrchestratorId: "k8s",
+				WorkloadId:     "default/test-pod",
+				EndpointId:     "eth0",
+			},
+			Endpoint: &proto.WorkloadEndpoint{
+				Tiers: []*proto.TierInfo{{
+					Name:            "default",
+					DefaultAction:   "Deny",
+					IngressPolicies: []*proto.PolicyID{{Name: "deny-all"}},
+				}},
+			},
+		},
+	}})
+	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
+		ActivePolicyUpdate: &proto.ActivePolicyUpdate{
+			Id: &proto.PolicyID{Name: "deny-all"},
+			Policy: &proto.Policy{
+				Tier:         "default",
+				InboundRules: []*proto.Rule{{Action: "Deny"}},
+			},
+		},
+	}})
+	env.sendInSync()
+	env.waitReady()
+
+	resp := env.check(&authz.CheckRequest{Attributes: &authz.AttributeContext{
+		Source: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/client",
+		},
+		Destination: &authz.AttributeContext_Peer{
+			Principal: "spiffe://cluster.local/ns/default/sa/server",
+		},
+	}})
+	Expect(resp.GetStatus().GetCode()).To(Equal(checker.PERMISSION_DENIED))
+}
+
+// TestDikastesCheckHTTPMethodMatch verifies L7 policy matching on HTTP method
+// through the full ext_authz gRPC flow.
+func TestDikastesCheckHTTPMethodMatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := newDikastesTestEnv(t, ctx)
+	defer env.cleanup()
+
+	// Policy allows only GET requests.
+	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_WorkloadEndpointUpdate{
+		WorkloadEndpointUpdate: &proto.WorkloadEndpointUpdate{
+			Id: &proto.WorkloadEndpointID{
+				OrchestratorId: "k8s",
+				WorkloadId:     "default/test-pod",
+				EndpointId:     "eth0",
+			},
+			Endpoint: &proto.WorkloadEndpoint{
+				Tiers: []*proto.TierInfo{{
+					Name:            "default",
+					DefaultAction:   "Deny",
+					IngressPolicies: []*proto.PolicyID{{Name: "allow-get"}},
+				}},
+			},
+		},
+	}})
+	env.sendUpdate(&proto.ToDataplane{Payload: &proto.ToDataplane_ActivePolicyUpdate{
+		ActivePolicyUpdate: &proto.ActivePolicyUpdate{
+			Id: &proto.PolicyID{Name: "allow-get"},
+			Policy: &proto.Policy{
+				Tier: "default",
+				InboundRules: []*proto.Rule{{
+					Action:    "Allow",
+					HttpMatch: &proto.HTTPMatch{Methods: []string{"GET"}},
+				}},
+			},
+		},
+	}})
+	env.sendInSync()
+	env.waitReady()
+
+	makeReq := func(method string) *authz.CheckRequest {
+		return &authz.CheckRequest{Attributes: &authz.AttributeContext{
+			Source: &authz.AttributeContext_Peer{
+				Principal: "spiffe://cluster.local/ns/default/sa/client",
+			},
+			Destination: &authz.AttributeContext_Peer{
+				Principal: "spiffe://cluster.local/ns/default/sa/server",
+			},
+			Request: &authz.AttributeContext_Request{
+				Http: &authz.AttributeContext_HttpRequest{Method: method},
+			},
+		}}
+	}
+
+	// GET should be allowed by the policy rule.
+	resp := env.check(makeReq("GET"))
+	Expect(resp.GetStatus().GetCode()).To(Equal(checker.OK))
+
+	// POST does not match the allow rule → falls through to tier default deny.
+	resp = env.check(makeReq("POST"))
+	Expect(resp.GetStatus().GetCode()).To(Equal(checker.PERMISSION_DENIED))
+}
+
+// dikastesTestEnv encapsulates the full dikastes test stack: a fake Felix sync
+// server, the dikastes authz gRPC server with ALPCheckProvider, and an authz
+// client — all connected over Unix domain sockets.
+type dikastesTestEnv struct {
+	t            *testing.T
+	syncServer   *testSyncServer
+	syncClient   *syncher.SyncClient
+	dikastesGRPC *grpc.Server
+	authzClient  authz.AuthorizationClient
+	authzConn    *grpc.ClientConn
+	socketDir    string
+	ctx          context.Context
+}
+
+func newDikastesTestEnv(t *testing.T, ctx context.Context) *dikastesTestEnv {
+	t.Helper()
+	RegisterTestingT(t)
+
+	socketDir, err := os.MkdirTemp("/tmp", "dikastes-fv-")
+	Expect(err).ToNot(HaveOccurred())
+
+	// Start fake Felix sync server.
+	syncSocketPath := path.Join(socketDir, "policysync.sock")
+	ss := newTestSyncServer(ctx, syncSocketPath)
+
+	// Create the dikastes authz server using the same newCheckServer as runServer().
+	storeManager := policystore.NewPolicyStoreManager()
+	gs := grpc.NewServer()
+	newCheckServer(ctx, gs, storeManager)
+
+	dikastesSocketPath := path.Join(socketDir, "dikastes.sock")
+	lis, err := net.Listen("unix", dikastesSocketPath)
+	Expect(err).ToNot(HaveOccurred())
+	go func() { _ = gs.Serve(lis) }()
+
+	// Connect sync client to populate the store.
+	sc := syncher.NewClient(syncSocketPath, storeManager, uds.GetDialOptions())
+	go sc.Sync(ctx)
+
+	// Connect authz client.
+	conn, err := grpc.NewClient(dikastesSocketPath, uds.GetDialOptions()...)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &dikastesTestEnv{
+		t:            t,
+		syncServer:   ss,
+		syncClient:   sc,
+		dikastesGRPC: gs,
+		authzClient:  authz.NewAuthorizationClient(conn),
+		authzConn:    conn,
+		socketDir:    socketDir,
+		ctx:          ctx,
+	}
+}
+
+func (e *dikastesTestEnv) sendUpdate(update *proto.ToDataplane) {
+	e.syncServer.updates <- update
+}
+
+func (e *dikastesTestEnv) sendInSync() {
+	e.syncServer.updates <- &proto.ToDataplane{
+		Payload: &proto.ToDataplane_InSync{InSync: &proto.InSync{}},
+	}
+}
+
+func (e *dikastesTestEnv) waitReady() {
+	Eventually(e.syncClient.Readiness, "5s", "100ms").Should(BeTrue())
+}
+
+func (e *dikastesTestEnv) check(req *authz.CheckRequest) *authz.CheckResponse {
+	resp, err := e.authzClient.Check(e.ctx, req)
+	Expect(err).ToNot(HaveOccurred())
+	return resp
+}
+
+func (e *dikastesTestEnv) cleanup() {
+	_ = e.authzConn.Close()
+	e.dikastesGRPC.GracefulStop()
+	_ = os.RemoveAll(e.socketDir)
+}
+
+// testSyncServer is a minimal fake Felix PolicySync gRPC server that sends
+// policy updates over a channel. Adapted from syncher/syncserver_test.go.
+type testSyncServer struct {
+	proto.UnimplementedPolicySyncServer
+	ctx        context.Context
+	updates    chan *proto.ToDataplane
+	grpcServer *grpc.Server
+	listener   net.Listener
+	cLock      sync.Mutex
+	cancelFns  []func()
+}
+
+func newTestSyncServer(ctx context.Context, socketPath string) *testSyncServer {
+	ss := &testSyncServer{
+		ctx:        ctx,
+		updates:    make(chan *proto.ToDataplane),
+		grpcServer: grpc.NewServer(),
+	}
+	proto.RegisterPolicySyncServer(ss.grpcServer, ss)
+	lis, err := net.Listen("unix", socketPath)
+	Expect(err).ToNot(HaveOccurred())
+	ss.listener = lis
+	go func() { _ = ss.grpcServer.Serve(lis) }()
+	return ss
+}
+
+func (s *testSyncServer) Sync(_ *proto.SyncRequest, stream proto.PolicySync_SyncServer) error {
+	ctx, cancel := context.WithCancel(s.ctx)
+	s.cLock.Lock()
+	s.cancelFns = append(s.cancelFns, cancel)
+	s.cLock.Unlock()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case update := <-s.updates:
+			if err := stream.Send(update); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *testSyncServer) Report(_ context.Context, _ *proto.DataplaneStats) (*proto.ReportResult, error) {
+	return &proto.ReportResult{}, nil
+}


### PR DESCRIPTION
Cherry-pick of #11986 to `release-v3.30`.

The staged policies refactoring (931244d78c, #9804) introduced a `CheckProvider` plugin interface in dikastes but never registered a provider in OSS. This caused all ext_authz Check requests to return UNKNOWN, which Envoy treats as a denial — breaking L7 application layer policy for all OSS users since v3.30.0.

This PR adds an `ALPCheckProvider` that wraps the existing `checkStore` logic and registers it in dikastes, restoring policy evaluation for the ext_authz Check RPC.

Fixes #11857

**Release note:**
```release-note
Fix Dikastes (L7 application layer policy) returning UNKNOWN for all ext_authz Check requests, which Envoy treats as 403. Register ALPCheckProvider to restore L7 policy enforcement.
```