### PR TITLE
Fix staged policy e2e flow log test flake

### DIFF
--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 package policy
 
 import (
@@ -393,24 +393,10 @@ func verifyFlowCount(url string, count int) {
 		}
 
 		if len(response.Items) != count {
-			var diag strings.Builder
-			diag.WriteString(fmt.Sprintf("expected %d flow items, got %d\n", count, len(response.Items)))
-			for i, item := range response.Items {
-				diag.WriteString(fmt.Sprintf("  flow[%d]: reporter=%s action=%s src=%s/%s dst=%s/%s proto=%s destPort=%d\n",
-					i, item.Reporter, item.Action,
-					item.SourceNamespace, item.SourceName,
-					item.DestNamespace, item.DestName,
-					item.Protocol, item.DestPort))
-				if len(item.Policies.Enforced) > 0 || len(item.Policies.Pending) > 0 {
-					for _, p := range item.Policies.Enforced {
-						diag.WriteString(fmt.Sprintf("    enforced: %s\n", policyHitString(p.Kind, p.Namespace, p.Name, p.Tier, p.Action)))
-					}
-					for _, p := range item.Policies.Pending {
-						diag.WriteString(fmt.Sprintf("    pending: %s\n", policyHitString(p.Kind, p.Namespace, p.Name, p.Tier, p.Action)))
-					}
-				}
-			}
-			return fmt.Errorf("%s", diag.String())
+			return fmt.Errorf(
+				"expected %d flow items, got %d\n%s",
+				count, len(response.Items), formatFlowDiagnostics(response.Items),
+			)
 		}
 
 		return nil
@@ -427,74 +413,77 @@ func verifyFlowContainsStagedPolicy(url, name, tier string, kind whiskerv1.Polic
 
 	body, err := io.ReadAll(resp.Body)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 	err = json.Unmarshal(body, &response)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 	ExpectWithOffset(1, kind).NotTo(Equal(""), "BUG: kind should not be empty")
 
-	// Build up an error message to help debug if the policy is not found
-	var msg strings.Builder
-	msg.WriteString(fmt.Sprintf("Could not find flow:\nKind:%s Name:%s Tier:%s Action:%s\n\n", kind, name, tier, action))
-	msg.WriteString(fmt.Sprintf("Found %d flow items:\n", len(response.Items)))
+	matchesPolicyHit := func(p *whiskerv1.PolicyHit) bool {
+		return p != nil && p.Name == name && p.Tier == tier && p.Kind == kind && p.Action == action
+	}
 
-responseLoop:
 	for _, item := range response.Items {
-		pendingPolicies := item.Policies.Pending
-		for _, pending := range pendingPolicies {
-			msg.WriteString(fmt.Sprintf(
-				"  - %s\n", policyHitString(
-					pending.Kind,
-					pending.Namespace,
-					pending.Name,
-					pending.Tier,
-					pending.Action,
-				)))
-
-			if pending.Name == name &&
-				pending.Tier == tier &&
-				pending.Kind == kind &&
-				pending.Action == action {
+		for _, pending := range item.Policies.Pending {
+			if matchesPolicyHit(pending) || matchesPolicyHit(pending.Trigger) {
 				containsStagedPolicy = true
-				break responseLoop
-			}
-
-			if pending.Trigger != nil {
-				msg.WriteString(fmt.Sprintf(
-					"    - TriggeredBy(%s)\n",
-					policyHitString(
-						pending.Trigger.Kind,
-						pending.Trigger.Namespace,
-						pending.Trigger.Name,
-						pending.Trigger.Tier,
-						pending.Trigger.Action,
-					)))
-				if pending.Trigger.Name == name &&
-					pending.Trigger.Tier == tier &&
-					pending.Trigger.Kind == kind &&
-					pending.Trigger.Action == action {
-					containsStagedPolicy = true
-					break responseLoop
-				}
+				break
 			}
 		}
 	}
 
-	Expect(containsStagedPolicy).Should(BeTrue(), msg.String())
+	Expect(containsStagedPolicy).Should(
+		BeTrue(),
+		fmt.Sprintf(
+			"Could not find staged policy: Kind:%s Name:%s Tier:%s Action:%s\n%s",
+			kind, name, tier, action, formatFlowDiagnostics(response.Items),
+		),
+	)
 }
 
-func policyHitString(kind whiskerv1.PolicyKind, namespace, name, tier string, action whiskerv1.Action) string {
-	msg := fmt.Sprintf("Kind:%s ", kind)
-	if namespace != "" {
-		msg += fmt.Sprintf("Namespace:%s ", namespace)
+func formatFlowDiagnostics(flows []whiskerv1.FlowResponse) string {
+	var diag strings.Builder
+	diag.WriteString(fmt.Sprintf("Found %d flow(s):\n", len(flows)))
+	for i, item := range flows {
+		diag.WriteString(fmt.Sprintf(
+			"  flow[%d]: reporter=%s action=%s src=%s/%s dst=%s/%s proto=%s destPort=%d\n",
+			i, item.Reporter, item.Action,
+			item.SourceNamespace, item.SourceName,
+			item.DestNamespace, item.DestName,
+			item.Protocol, item.DestPort,
+		))
+		if len(item.Policies.Enforced) > 0 {
+			diag.WriteString("      enforced:\n")
+			for _, p := range item.Policies.Enforced {
+				diag.WriteString(fmt.Sprintf("        - %s\n", formatPolicyHit(p)))
+			}
+		}
+		if len(item.Policies.Pending) > 0 {
+			diag.WriteString("      pending:\n")
+			for _, p := range item.Policies.Pending {
+				diag.WriteString(fmt.Sprintf("        - %s\n", formatPolicyHit(p)))
+				if p.Trigger != nil {
+					diag.WriteString(fmt.Sprintf("          triggered-by:\n            %s\n", formatPolicyHit(p.Trigger)))
+				}
+			}
+		}
 	}
-	if name != "" {
-		msg += fmt.Sprintf("Name:%s ", name)
+	return diag.String()
+}
+
+func formatPolicyHit(p *whiskerv1.PolicyHit) string {
+	if p == nil {
+		return "<nil>"
 	}
-	if tier != "" {
-		msg += fmt.Sprintf("Tier:%s ", tier)
+	msg := fmt.Sprintf("Kind:%s ", p.Kind)
+	if p.Namespace != "" {
+		msg += fmt.Sprintf("Namespace:%s ", p.Namespace)
 	}
-	msg += fmt.Sprintf("Action:%s ", action)
+	if p.Name != "" {
+		msg += fmt.Sprintf("Name:%s ", p.Name)
+	}
+	if p.Tier != "" {
+		msg += fmt.Sprintf("Tier:%s ", p.Tier)
+	}
+	msg += fmt.Sprintf("Action:%s", p.Action)
 	return msg
 }
 


### PR DESCRIPTION
The staged policy flow log e2e test was flaking in CI with "expected 2 flow items, got 1". The
flow log pipeline (15s Felix flush + goldmane aggregation + bucket boundaries) can take up to ~60s
worst-case to make both reporter flows visible, and the 90s timeout didn't leave enough margin on
slower Semaphore VMs.

- Bump the `verifyFlowCount` timeout from 90s to 150s
- On failure, dump the flows that _were_ returned (reporter, action, src/dst, policies) so we can
  immediately tell which reporter is missing next time this flakes