### PR TITLE
Fix flaky BPF spoof test: use new connection after WEP move

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1962,8 +1962,8 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						By("Starting permanent connection")
 						pc := w[0][0].StartPersistentConnection(w[1][0].IP, 8055, workload.PersistentConnectionOpts{
 							MonitorConnectivity: true,
+							Timeout:             60 * time.Second,
 						})
-						defer pc.Stop()
 
 						expectPongs := func() {
 							EventuallyWithOffset(1, pc.SinceLastPong, "5s").Should(
@@ -2000,12 +2000,26 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						By("Should no longer get pongs when using the spoof interface")
 						expectNoPongs()
 
-						// Move WEP to spoof interface
+						// Switch back to eth0 and stop the persistent connection
+						// cleanly before the WEP move.  RemoveFromInfra triggers
+						// WorkloadRemoveScannerTCP which marks the CT entry with
+						// FlagSendRST, causing BPF to RST the connection and the
+						// test-connection tool to exit with Fatal.
+						w[0][0].UseSpoofInterface(false)
+						expectPongs()
+						pc.Stop()
+
+						// Move WEP to spoof interface.  This simulates a pod being
+						// removed and a new pod being created on the spoof interface.
+						// Verify that new connections work on the new interface.
+						w[0][0].UseSpoofInterface(true)
 						w[0][0].RemoveFromInfra(infra)
 						w[0][0].RemoveSpoofWEPFromInfra(infra)
 						w[0][0].ConfigureInInfraAsSpoofInterface(infra)
-						By("Should get pongs again after switching WEP to spoof iface")
-						expectPongs()
+						By("Should have connectivity via new connections after WEP move to spoof iface")
+						cc.Expect(Some, w[0][0], w[1][0])
+						cc.CheckConnectivity()
+						cc.ResetExpectations()
 					})
 				}
 


### PR DESCRIPTION
## Summary

Fixes the flaky test `should not be able to spoof existing TCP connections` in the BPF FV suite.

## Issue Analysis

The final step of the test removed the WEP and recreated it on the spoof interface, then expected the **existing** TCP persistent connection to resume with pongs within 5 seconds.

**Root cause:** `WorkloadRemoveScannerTCP` marks conntrack entries with `FlagSendRST` (`0x20000`) when a workload IP is removed. The failure sequence:

1. `RemoveFromInfra(infra)` removes the WEP for w[0][0]
2. BPF endpoint manager sends w[0][0]'s IP to `workloadRemoveChan` (`bpf_ep_mgr.go:1309`)
3. Conntrack scanner sets `FlagSendRST` on the TCP CT entry (`cleanup.go:119`)
4. Next packet from w[0][0] → BPF sees `CALI_CT_FLAG_SEND_RESET` → sends TCP RST (`tc.c:453`)
5. `test-connection` receives RST → `Receive()` returns "connection reset" → `Fatal` exit (`test-connection.go:505`)
6. No more PONGs produced → `expectPongs()` times out regardless of timeout value
7. Additionally, `defer pc.Stop()` would fail the test during cleanup since `Stop()` uses `Expect(pc.stop()).NotTo(HaveOccurred())` and `Wait()` returns the non-zero exit code

This is **correct product behavior**: removing a pod kills its connections via RST. A new pod on a different interface would establish new connections, not reuse old ones.

## Fix

- **Stop the persistent connection cleanly before the WEP move.** Switch back to eth0 so pongs resume (unblocking the tool), then call `pc.Stop()`.
- **Add `Timeout: 60s`** to the persistent connection so the tool uses a 200ms read deadline instead of blocking forever on `Receive()`. This enables clean shutdown via `pc.Stop()` and keeps the tool sending during blocking phases so pongs resume quickly after unblocking.
- **After the WEP move, verify connectivity with fresh connections** via `cc.CheckConnectivity()` instead of expecting the old connection to survive the RST.

## Test plan

- [ ] Verify `should not be able to spoof existing TCP connections` passes: `make -C felix fv-bpf GINKGO_FOCUS="should not be able to spoof existing TCP connections"`
- [ ] Monitor CI for reduced flakiness of this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)