### PR TITLE
Fix nil pointer panic in AutoHEP e2e tests

### DIFF
--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -332,8 +332,8 @@ func updateHostEndpointConfig(client ctrlclient.Client, desiredKCC v3.KubeContro
 }
 
 // getHostEndpointConfig returns the HostEndpoint config from a KCC, or nil if
-// the Node controller config is not set. This is nil-safe unlike direct field
-// access through the pointer chain.
+// either the Node controller config or the HostEndpoint config is not set.
+// This is nil-safe unlike direct field access through the pointer chain.
 func getHostEndpointConfig(kcc v3.KubeControllersConfiguration) *v3.AutoHostEndpointConfig {
 	if kcc.Spec.Controllers.Node == nil {
 		return nil


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference panic in `auto_hostendpoints.go` BeforeEach when `KubeControllersConfiguration.Spec.Controllers.Node` or `.Node.HostEndpoint` is nil
- `GetAutoHEPsEnabled()` correctly nil-checks these pointer fields and returns `false`, but the code that runs when auto HEPs are disabled then directly dereferences the same nil pointers to enable them — causing a panic
- Also fixes the same class of nil dereference in `AfterEach` (via `reflect.DeepEqual`) and `UpdateHostEndpointConfig()`

## Failing jobs

All from pipeline [`6c982984-9db7-492d-9317-991bf2bbb207`](https://tigera-delivery.semaphoreci.com/workflows/58c55881-1a96-4602-b131-220bc39b6816?pipeline_id=6c982984-9db7-492d-9317-991bf2bbb207):

| Job ID | Platform | Panic location |
|--------|----------|----------------|
| [`cf86de83-4283-4f9e-bac3-6a35532ca58c`](https://tigera-delivery.semaphoreci.com/jobs/cf86de83-4283-4f9e-bac3-6a35532ca58c) | BPF kubeadm | `auto_hostendpoints.go:111` |
| [`dd2d8c33-b7fe-4e8e-bfef-afb9206222df`](https://tigera-delivery.semaphoreci.com/jobs/dd2d8c33-b7fe-4e8e-bfef-afb9206222df) | iptables kubeadm | `auto_hostendpoints.go:111` |
| [`00c2f73b-ce45-4fad-8334-52e1345e32f8`](https://tigera-delivery.semaphoreci.com/jobs/00c2f73b-ce45-4fad-8334-52e1345e32f8) | RKE2 | `auto_hostendpoints.go:111` |
| [`82960c58-4180-4031-98ad-1340ffacb4a3`](https://tigera-delivery.semaphoreci.com/jobs/82960c58-4180-4031-98ad-1340ffacb4a3) | AKS | `auto_hostendpoints.go:111` |
| [`160ece21-97c5-4d63-ba72-9c6d954383e8`](https://tigera-delivery.semaphoreci.com/jobs/160ece21-97c5-4d63-ba72-9c6d954383e8) | EKS | `auto_hostendpoints.go:111` |

## Root cause

`Controllers.Node` is `*NodeControllerConfig` and `Node.HostEndpoint` is `*AutoHostEndpointConfig` — both pointer types that are nil when auto HEPs are not configured. `GetAutoHEPsEnabled()` checks for nil correctly, but when it returns `false` the BeforeEach enters the enable path and immediately dereferences the nil pointers:

```go
if !GetAutoHEPsEnabled(originalKCC) {
    // PANIC: Node and/or HostEndpoint is nil
    testKCC.Spec.Controllers.Node.HostEndpoint.AutoCreate = "Enabled"
}
```

## Test plan
- [ ] Run AutoHEP e2e tests on a cluster where `KubeControllersConfiguration` has no explicit Node controller config (the common case that triggers the panic)
- [ ] Verify the AfterEach correctly restores the original config without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)