### PR TITLE
Wire up felix_collector_lookupcache_services prometheus gauge

### DIFF
--- a/felix/calc/services_addr_indexer.go
+++ b/felix/calc/services_addr_indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -309,6 +309,7 @@ func (slc *ServiceLookupsCache) onServiceUpdate(update api.Update, k model.Resou
 	} else {
 		slc.suh.AddOrUpdateService(k, update.Value.(*kapiv1.Service))
 	}
+	gaugeServicesCacheLength.Set(float64(len(slc.suh.services)))
 }
 
 func (slc *ServiceLookupsCache) GetServiceSpecFromResourceKey(key model.ResourceKey) (kapiv1.ServiceSpec, bool) {


### PR DESCRIPTION
The `felix_collector_lookupcache_services` gauge was registered in `init()` but never actually updated, so it always reported 0. This wires it up in `ServiceLookupsCache.onServiceUpdate()` so it reflects the actual number of services in the collector's lookup cache.

Needed this for FV tests that check service-correlated flow logs — without a way to confirm the service is in the cache before generating traffic, there's a race where the first flow log flush can force-report flows before service correlation completes, producing duplicate flows that differ only in `DstService`.