### PR TITLE
Fix VXLAN device FlowBased mode detection in vxlanLinksIncompat

### DIFF
--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -352,6 +352,14 @@ func vxlanLinksIncompat(l1, l2 netlink.Link) string {
 	v1 := l1.(*netlink.Vxlan)
 	v2 := l2.(*netlink.Vxlan)
 
+	// FlowBased is the most fundamental mode difference — a flow-based device
+	// (used by the BPF dataplane with BTF) has no VNI, VtepDevIndex, or SrcAddr
+	// set on the device; the BPF program sets the tunnel key per-packet.
+	// Switching between iptables and eBPF dataplanes requires recreating the device.
+	if v1.FlowBased != v2.FlowBased {
+		return fmt.Sprintf("flow-based mode: %v vs %v", v1.FlowBased, v2.FlowBased)
+	}
+
 	if v1.VxlanId != v2.VxlanId {
 		return fmt.Sprintf("vni: %v vs %v", v1.VxlanId, v2.VxlanId)
 	}

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -47,6 +47,52 @@ func (t *mockVXLANFDB) SetVTEPs(targets []vxlanfdb.VTEP) {
 	t.setVTEPsCalls++
 }
 
+var _ = DescribeTable("vxlanLinksIncompat",
+	func(l1, l2 *netlink.Vxlan, expected string) {
+		Expect(vxlanLinksIncompat(l1, l2)).To(Equal(expected))
+	},
+	Entry("identical legacy devices", &netlink.Vxlan{
+		VxlanId: 4096, VtepDevIndex: 2, Port: 4789,
+	}, &netlink.Vxlan{
+		VxlanId: 4096, VtepDevIndex: 2, Port: 4789,
+	}, ""),
+	Entry("identical flow-based devices", &netlink.Vxlan{
+		FlowBased: true, Port: 4789,
+	}, &netlink.Vxlan{
+		FlowBased: true, Port: 4789,
+	}, ""),
+	Entry("legacy to flow-based (iptables to eBPF)", &netlink.Vxlan{
+		VxlanId: 4096, VtepDevIndex: 2, Port: 4789,
+	}, &netlink.Vxlan{
+		FlowBased: true, Port: 4789,
+	}, "flow-based mode: false vs true"),
+	Entry("flow-based to legacy (eBPF to iptables)", &netlink.Vxlan{
+		FlowBased: true, Port: 4789,
+	}, &netlink.Vxlan{
+		VxlanId: 4096, VtepDevIndex: 2, Port: 4789,
+	}, "flow-based mode: true vs false"),
+	Entry("VNI mismatch", &netlink.Vxlan{
+		VxlanId: 4096, Port: 4789,
+	}, &netlink.Vxlan{
+		VxlanId: 4097, Port: 4789,
+	}, "vni: 4096 vs 4097"),
+	Entry("port mismatch", &netlink.Vxlan{
+		VxlanId: 4096, Port: 4789,
+	}, &netlink.Vxlan{
+		VxlanId: 4096, Port: 4790,
+	}, "port: 4789 vs 4790"),
+	Entry("GBP mismatch", &netlink.Vxlan{
+		VxlanId: 4096, Port: 4789, GBP: true,
+	}, &netlink.Vxlan{
+		VxlanId: 4096, Port: 4789, GBP: false,
+	}, "gbp: true vs false"),
+	Entry("L2miss mismatch", &netlink.Vxlan{
+		VxlanId: 4096, Port: 4789, L2miss: true,
+	}, &netlink.Vxlan{
+		VxlanId: 4096, Port: 4789, L2miss: false,
+	}, "l2miss: true vs false"),
+)
+
 var _ = Describe("VXLANManager", func() {
 	var (
 		vxlanMgr, vxlanMgrV6 *vxlanManager


### PR DESCRIPTION
## Summary
- Add explicit `FlowBased` flag check as the first comparison in `vxlanLinksIncompat`, since it is the most fundamental mode difference between eBPF and iptables/nftables dataplanes.
- Without this, switching dataplanes produced a misleading "vni: 0 vs 4096" message instead of a clear "flow-based mode" incompatibility.
- Add `DescribeTable` test covering identical devices, flow-based vs legacy mismatches, and other field mismatches (VNI, port, GBP, L2miss).

## Test plan
- [x] New `vxlanLinksIncompat` table-driven unit tests pass (8/8)
- [ ] Existing VXLAN manager tests still pass
- [ ] Manual verification: switch Felix from iptables to BPF dataplane and confirm VXLAN device is properly recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)