### PR TITLE
fix(release): update variables for operator release

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -230,6 +230,10 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				o := operator.NewManager(
 					operator.WithOperatorDirectory(filepath.Join(cfg.TmpDir, operator.DefaultRepoName)),
 					operator.IsHashRelease(),
+					operator.WithImage(hashrel.Operator.Image),
+					operator.WithRegistry(hashrel.Operator.Registry),
+					operator.WithVersion(hashrel.Operator.Version),
+					operator.WithCalicoVersion(hashrel.ProductVersion),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
 					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
 				)
@@ -243,7 +247,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.IsHashRelease(),
 					calico.WithVersion(hashrel.ProductVersion),
-					calico.WithOperatorVersion(hashrel.OperatorVersion),
+					calico.WithOperatorVersion(hashrel.Operator.Version),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),

--- a/release/internal/hashreleaseserver/server.go
+++ b/release/internal/hashreleaseserver/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/registry"
 )
 
 const (
@@ -56,8 +57,8 @@ type Hashrelease struct {
 	// ProductVersion is the product version in the hashrelease
 	ProductVersion string `yaml:"version"`
 
-	// OperatorVersion is the operator version for the hashrelease
-	OperatorVersion string `yaml:"operator"`
+	// Operator is the operator for the hashrelease
+	Operator registry.Component `yaml:"operator"`
 
 	// Source is the source of hashrelease content on the local filesystem
 	Source string `yaml:"source,omitempty"`

--- a/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.no_slack_response.approved.txt
+++ b/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.no_slack_response.approved.txt
@@ -2,5 +2,8 @@ name: 2026-01-06-v3-32-vertigo
 hash: v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f
 stream: master
 version: v3.32.0-0.dev-527-g92e0cd84e375
-operator: v1.42.0-0.dev-16-g3a924017cc9f
+operator:
+  version: v1.42.0-0.dev-16-g3a924017cc9f
+  image: tigera/operator
+  registry: quay.io
 url: https://2026-01-06-v3-32-vertigo.docs.eng.tigera.net

--- a/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.with_slack_response.approved.txt
+++ b/release/internal/outputs/hashrelease_test.TestPublishedHashrelease.with_slack_response.approved.txt
@@ -2,7 +2,10 @@ name: 2026-01-06-v3-32-vertigo
 hash: v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f
 stream: master
 version: v3.32.0-0.dev-527-g92e0cd84e375
-operator: v1.42.0-0.dev-16-g3a924017cc9f
+operator:
+  version: v1.42.0-0.dev-16-g3a924017cc9f
+  image: tigera/operator
+  registry: quay.io
 url: https://2026-01-06-v3-32-vertigo.docs.eng.tigera.net
 slack:
   channel: C123ABC456

--- a/release/internal/outputs/hashrelease_test.go
+++ b/release/internal/outputs/hashrelease_test.go
@@ -22,6 +22,7 @@ import (
 	approvals "github.com/approvals/go-approval-tests"
 
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
+	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/slack"
 )
 
@@ -32,11 +33,15 @@ func TestPublishedHashrelease(t *testing.T) {
 		t.Parallel()
 		td := t.TempDir()
 		h := &PublishedHashrelease{Hashrelease: &hashreleaseserver.Hashrelease{
-			Name:            "2026-01-06-v3-32-vertigo",
-			Hash:            "v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f",
-			Stream:          "master",
-			ProductVersion:  "v3.32.0-0.dev-527-g92e0cd84e375",
-			OperatorVersion: "v1.42.0-0.dev-16-g3a924017cc9f",
+			Name:           "2026-01-06-v3-32-vertigo",
+			Hash:           "v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f",
+			Stream:         "master",
+			ProductVersion: "v3.32.0-0.dev-527-g92e0cd84e375",
+			Operator: registry.Component{
+				Registry: "quay.io",
+				Image:    "tigera/operator",
+				Version:  "v1.42.0-0.dev-16-g3a924017cc9f",
+			},
 		}}
 
 		gotPath, err := h.Write(td)
@@ -60,11 +65,15 @@ func TestPublishedHashrelease(t *testing.T) {
 		td := t.TempDir()
 		h := &PublishedHashrelease{
 			Hashrelease: &hashreleaseserver.Hashrelease{
-				Name:            "2026-01-06-v3-32-vertigo",
-				Hash:            "v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f",
-				Stream:          "master",
-				ProductVersion:  "v3.32.0-0.dev-527-g92e0cd84e375",
-				OperatorVersion: "v1.42.0-0.dev-16-g3a924017cc9f",
+				Name:           "2026-01-06-v3-32-vertigo",
+				Hash:           "v3.32.0-0.dev-527-g92e0cd84e375-v1.42.0-0.dev-16-g3a924017cc9f",
+				Stream:         "master",
+				ProductVersion: "v3.32.0-0.dev-527-g92e0cd84e375",
+				Operator: registry.Component{
+					Registry: "quay.io",
+					Image:    "tigera/operator",
+					Version:  "v1.42.0-0.dev-16-g3a924017cc9f",
+				},
 			},
 			SlackResponse: &slack.MessageResponse{
 				Channel:   "C123ABC456",

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -307,14 +307,14 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 		logrus.WithError(err).Fatal("Failed to get pinned version")
 	}
 	return &hashreleaseserver.Hashrelease{
-		Name:            pinnedVersion.ReleaseName,
-		Hash:            pinnedVersion.Hash,
-		Note:            pinnedVersion.Note,
-		Stream:          version.DeterminePublishStream(productBranch, pinnedVersion.Title),
-		ProductVersion:  pinnedVersion.Title,
-		OperatorVersion: pinnedVersion.TigeraOperator.Version,
-		Source:          filepath.Join(hashreleaseSrcBaseDir, pinnedVersion.Hash),
-		Latest:          latest,
+		Name:           pinnedVersion.ReleaseName,
+		Hash:           pinnedVersion.Hash,
+		Note:           pinnedVersion.Note,
+		Stream:         version.DeterminePublishStream(productBranch, pinnedVersion.Title),
+		ProductVersion: pinnedVersion.Title,
+		Operator:       pinnedVersion.TigeraOperator,
+		Source:         filepath.Join(hashreleaseSrcBaseDir, pinnedVersion.Hash),
+		Latest:         latest,
 	}, nil
 }
 

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -57,9 +57,6 @@ type OperatorManager struct {
 
 	calicoVersion string
 
-	// outputDir is the absolute path to the output directory.
-	outputDir string
-
 	// image is the name of the operator image (e.g. tigera/operator)
 	image string
 
@@ -112,9 +109,18 @@ func (o *OperatorManager) Build() error {
 	if err := o.PreBuildValidation(); err != nil {
 		return err
 	}
-	env, logFields, err := o.buildEnv()
-	if err != nil {
-		return fmt.Errorf("env vars for building operator: %w", err)
+	env, logFields := o.env()
+	logFields["calico_registry"] = o.productRegistry
+	env = append(env, fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, o.productRegistry))
+	if o.isHashRelease {
+		if o.calicoVersion != "" {
+			env = append(env, fmt.Sprintf("%s_VERSION=%s", defaultProductEnvPrefix, o.calicoVersion))
+			logFields["calico_version"] = o.calicoVersion
+		}
+		if o.calicoDir != "" {
+			env = append(env, fmt.Sprintf("%s_DIR=%s", defaultProductEnvPrefix, o.calicoDir))
+			logFields["calico_dir"] = o.calicoDir
+		}
 	}
 	logrus.WithFields(logFields).Info("Building operator")
 	out, err := o.make("release", env)
@@ -126,34 +132,20 @@ func (o *OperatorManager) Build() error {
 	return nil
 }
 
-func (o *OperatorManager) buildEnv() ([]string, logrus.Fields, error) {
+func (o *OperatorManager) env() ([]string, logrus.Fields) {
 	logFields := logrus.Fields{
-		"registry":        o.registry,
-		"calico_registry": o.productRegistry,
-		"image":           o.image,
-		"version":         o.version,
+		"registry": o.registry,
+		"image":    o.image,
+		"version":  o.version,
 	}
 	env := append(os.Environ(),
 		fmt.Sprintf("REGISTRY=%s", o.registry),
-		fmt.Sprintf("IMAGE=%s", o.image),
+		fmt.Sprintf("IMAGE_NAME=%s", o.image),
 		fmt.Sprintf("VERSION=%s", o.version),
-		fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, o.productRegistry),
 	)
 	if o.isHashRelease {
 		logFields["hashrelease"] = "true"
 		env = append(env, "HASHRELEASE=true")
-		if o.calicoVersion != "" {
-			env = append(env, fmt.Sprintf("%s_VERSION=%s", defaultProductEnvPrefix, o.calicoVersion))
-			logFields["calico_version"] = o.calicoVersion
-		}
-		if o.calicoDir != "" {
-			env = append(env, fmt.Sprintf("%s_DIR=%s", defaultProductEnvPrefix, o.calicoDir))
-			logFields["calico_dir"] = o.calicoDir
-		}
-		if o.outputDir != "" {
-			env = append(env, fmt.Sprintf("OUTPUT_DIR=%s", o.outputDir))
-			logFields["output_dir"] = o.outputDir
-		}
 	}
 	if len(o.architectures) > 0 {
 		archs := strings.Join(o.architectures, ",")
@@ -163,17 +155,17 @@ func (o *OperatorManager) buildEnv() ([]string, logrus.Fields, error) {
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		env = append(env, "DEBUG=true")
 	}
-	return env, logFields, nil
+	return env, logFields
 }
 
 func (o *OperatorManager) PreBuildValidation() error {
 	if !o.validate {
 		return nil
 	}
-	var errStack error
 	if o.dir == "" {
-		errStack = errors.Join(errStack, fmt.Errorf("no repository root specified"))
+		return fmt.Errorf("no repository root specified")
 	}
+	var errStack error
 	dirty, err := utils.GitIsDirty(o.dir)
 	if err != nil {
 		return fmt.Errorf("failed to check if git is dirty: %w", err)
@@ -199,16 +191,33 @@ func (o *OperatorManager) PreBuildValidation() error {
 	return errStack
 }
 
+func (o *OperatorManager) PrePublishValidation() error {
+	if !o.publish {
+		return nil
+	}
+	if o.dir == "" {
+		return fmt.Errorf("no repository root specified")
+	}
+	var errStack error
+	if o.image == "" {
+		errStack = errors.Join(errStack, fmt.Errorf("no operator image specified"))
+	}
+	if o.registry == "" {
+		errStack = errors.Join(errStack, fmt.Errorf("no operator registry specified"))
+	}
+	if o.version == "" {
+		errStack = errors.Join(errStack, fmt.Errorf("no version specified"))
+	}
+	return errStack
+}
+
 func (o *OperatorManager) Publish() error {
 	if !o.publish {
 		logrus.Warn("Skipping publishing operator")
 		return nil
 	}
 
-	env, logFields, err := o.buildEnv()
-	if err != nil {
-		return fmt.Errorf("env vars for publishing operator: %w", err)
-	}
+	env, logFields := o.env()
 	logrus.WithFields(logFields).Info("Publishing operator")
 	out, err := o.make("release-publish", env)
 	if err != nil {

--- a/release/pkg/manager/operator/options.go
+++ b/release/pkg/manager/operator/options.go
@@ -37,13 +37,6 @@ func WithCalicoVersion(version string) Option {
 	}
 }
 
-func WithOutputDirectory(dir string) Option {
-	return func(o *OperatorManager) error {
-		o.outputDir = dir
-		return nil
-	}
-}
-
 func WithReleaseBranchPrefix(prefix string) Option {
 	return func(o *OperatorManager) error {
 		o.releaseBranchPrefix = prefix

--- a/release/pkg/tasks/notification.go
+++ b/release/pkg/tasks/notification.go
@@ -32,7 +32,7 @@ func AnnounceHashrelease(cfg *slack.Config, hashrel *hashreleaseserver.Hashrelea
 		Product:            product,
 		Stream:             hashrel.Stream,
 		ProductVersion:     hashrel.ProductVersion,
-		OperatorVersion:    hashrel.OperatorVersion,
+		OperatorVersion:    hashrel.Operator.Version,
 		ReleaseType:        "hashrelease",
 		CIURL:              ciURL,
 		DocsURL:            hashrel.URL(),


### PR DESCRIPTION
This fixes publishing operator hashrelease images based on changes introduced in #11996 

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
