### PR TITLE
Fix nil pointer panic in BPF UT TestAttach

### DIFF
--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -45,6 +45,7 @@ import (
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	"github.com/projectcalico/calico/felix/calc"
 	linux "github.com/projectcalico/calico/felix/dataplane/linux"
+	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/generictables"
 	"github.com/projectcalico/calico/felix/idalloc"
 	"github.com/projectcalico/calico/felix/ifacemonitor"
@@ -88,7 +89,7 @@ func newBPFTestEpMgr(
 		&routetable.DummyTable{},
 		calc.NewLookupsCache(),
 		nil,
-		nil,
+		&environment.Features{},
 		1500,
 		nil,
 		nil,


### PR DESCRIPTION
## Summary

- `NewBPFEndpointManager` now dereferences `dataplanefeatures` directly (for `KernelHasUDPGSOFix`), but `newBPFTestEpMgr` in `attach_test.go` was passing `nil`, causing a nil pointer panic that crashes the test binary.
- Pass `&environment.Features{}` instead of `nil` to fix the panic.

This bug was masked in CI because the panic caused the test binary to exit while `bpftool prog tracelog` (started by `startBPFLogging()`) kept the pipeline pipe open, making it appear as a hang rather than a test failure.

## Test plan

- [x] `go vet ./felix/bpf/ut/` passes
- [ ] CI BPF UT batch completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)