### PR TITLE
Fix flaky status package test race condition

### DIFF
--- a/kube-controllers/pkg/status/status_test.go
+++ b/kube-controllers/pkg/status/status_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,8 +127,11 @@ var _ = Describe("Status pkg UTs", func() {
 
 		By("status file should handle a lot of concurrent ready updates for all of the keys (plus more)", func() {
 			wg := sync.WaitGroup{}
-			wg.Add(200)
-			go st.SetReady("anykey", true, "reason")
+			wg.Add(201)
+			go func() {
+				st.SetReady("anykey", true, "reason")
+				wg.Done()
+			}()
 			for i := range 200 {
 				go func(j int) {
 					st.SetReady("anykey"+strconv.Itoa(j), true, "reason"+strconv.Itoa(j))


### PR DESCRIPTION
The concurrent readiness test was firing off `go st.SetReady("anykey", true, "reason")` without adding it to the WaitGroup. When `wg.Wait()` returned, that goroutine could still be in-flight, so "anykey" might still have its previous `false` value when `GetReadiness()` was asserted — causing a flaky failure.

Fix is just to track it in the WaitGroup like all the other goroutines.