### PR TITLE
fix(felix): use DROP instead of REJECT for raw table RPF check

### DIFF
--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1360,8 +1360,10 @@ func (r *DefaultRuleRenderer) StaticRawPreroutingChain(ipVersion uint8) *generic
 	// Apply strict RPF check to packets from workload interfaces.  This prevents
 	// workloads from spoofing their IPs.  Note: non-privileged containers can't
 	// usually spoof but privileged containers and VMs can.
+	// Note: we use Drop() instead of IptablesFilterDenyAction() because REJECT is
+	// not a valid target in the raw table.
 	rules = append(rules,
-		r.RPFilter(ipVersion, markFromWorkload, markFromWorkload, r.OpenStackSpecialCasesEnabled, r.IptablesFilterDenyAction())...)
+		r.RPFilter(ipVersion, markFromWorkload, markFromWorkload, r.OpenStackSpecialCasesEnabled, r.Drop())...)
 
 	rules = append(rules,
 		// Send non-workload traffic to the untracked policy chains.

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -91,11 +91,8 @@ var _ = Describe("Static", func() {
 	}
 
 	for _, trueOrFalse := range []bool{true, false} {
-		var denyAction generictables.Action
-		denyAction = iptables.DropAction{}
 		denyActionString := "DROP"
 		if trueOrFalse {
-			denyAction = iptables.RejectAction{}
 			denyActionString = "REJECT"
 		}
 
@@ -151,8 +148,10 @@ var _ = Describe("Static", func() {
 								Action: iptables.AcceptAction{},
 							},
 							{
+								// Note: raw table RPF check always uses DROP, not denyAction,
+								// because REJECT is not a valid target in the raw table.
 								Match:  iptables.Match().MarkSingleBitSet(0x40).RPFCheckFailed(),
-								Action: denyAction,
+								Action: iptables.DropAction{},
 							},
 							{
 								Match:  iptables.Match().MarkClear(0x40),
@@ -180,8 +179,10 @@ var _ = Describe("Static", func() {
 								Action: iptables.JumpAction{Target: ChainRpfSkip},
 							},
 							{
+								// Note: raw table RPF check always uses DROP, not denyAction,
+								// because REJECT is not a valid target in the raw table.
 								Match:  iptables.Match().MarkSingleBitSet(0x40).RPFCheckFailed(),
-								Action: denyAction,
+								Action: iptables.DropAction{},
 							},
 							{
 								Match:  iptables.Match().MarkClear(0x40),
@@ -550,8 +551,10 @@ var _ = Describe("Static", func() {
 							Action: iptables.JumpAction{Target: ChainRpfSkip},
 						},
 						{
+							// Note: raw table RPF check always uses DROP, not denyAction,
+							// because REJECT is not a valid target in the raw table.
 							Match:  iptables.Match().MarkSingleBitSet(0x40).RPFCheckFailed(),
-							Action: denyAction,
+							Action: iptables.DropAction{},
 						},
 						{
 							Match:  iptables.Match().MarkClear(0x40),
@@ -578,8 +581,10 @@ var _ = Describe("Static", func() {
 							Action: iptables.JumpAction{Target: ChainRpfSkip},
 						},
 						{
+							// Note: raw table RPF check always uses DROP, not denyAction,
+							// because REJECT is not a valid target in the raw table.
 							Match:  iptables.Match().MarkSingleBitSet(0x40).RPFCheckFailed(),
-							Action: denyAction,
+							Action: iptables.DropAction{},
 						},
 						{
 							Match:  iptables.Match().MarkClear(0x40),
@@ -1117,7 +1122,9 @@ var _ = Describe("Static", func() {
 						Action: iptables.JumpAction{Target: ChainRpfSkip},
 					})
 
-					chain.Rules = append(chain.Rules, rr.RPFilter(4, markFromWorkload, markFromWorkload, rr.OpenStackSpecialCasesEnabled, rr.IptablesFilterDenyAction())...)
+					// Note: RPFilter in the raw table always uses Drop, not IptablesFilterDenyAction,
+					// because REJECT is not a valid target in the raw table.
+					chain.Rules = append(chain.Rules, rr.RPFilter(4, markFromWorkload, markFromWorkload, rr.OpenStackSpecialCasesEnabled, rr.Drop())...)
 					chain.Rules = append(chain.Rules, generictables.Rule{
 						Match:  iptables.Match().MarkClear(markFromWorkload),
 						Action: iptables.JumpAction{Target: ChainDispatchFromHostEndpoint},
@@ -1234,7 +1241,7 @@ var _ = Describe("Static", func() {
 						Action: iptables.JumpAction{Target: ChainRpfSkip},
 					})
 
-					chain.Rules = append(chain.Rules, rr.RPFilter(6, markFromWorkload, markFromWorkload, rr.OpenStackSpecialCasesEnabled, rr.IptablesFilterDenyAction())...)
+					chain.Rules = append(chain.Rules, rr.RPFilter(6, markFromWorkload, markFromWorkload, rr.OpenStackSpecialCasesEnabled, rr.Drop())...)
 					chain.Rules = append(chain.Rules, generictables.Rule{
 						Match:  iptables.Match().MarkClear(markFromWorkload),
 						Action: iptables.JumpAction{Target: ChainDispatchFromHostEndpoint},


### PR DESCRIPTION
Fixes #7914

## Summary
When `iptablesFilterDenyAction` is set to `REJECT`, Felix fails to program the raw table because the REJECT target is only valid in the filter table, not the raw table. This causes calico-node to become not ready with iptables-restore errors like:

```
iptables-restore: line 5 failed
ip_tables: REJECT target: only valid in filter table, not raw
```

The fix changes the RPF (Reverse Path Filtering) check in the raw table to always use DROP instead of the configurable `IptablesFilterDenyAction`, since REJECT is not a valid target in the raw table.

## Changes
- Modified `StaticRawPreroutingChain` in `felix/rules/static.go` to use `r.Drop()` instead of `r.IptablesFilterDenyAction()` for the RPF check
- Updated corresponding test cases in `felix/rules/static_test.go` to expect DROP action for raw table RPF checks

## Testing
- Updated unit tests in `static_test.go` to verify that raw table RPF checks always use DROP regardless of the deny action configuration
- Verified Go syntax is correct with `go fmt`

## Release Note
```release-note
Fixed an issue where setting iptablesFilterDenyAction to REJECT would cause calico-node to fail when programming the raw table RPF check
```

**Diff stats:**
```
 felix/rules/static.go      |  4 +++-
 felix/rules/static_test.go | 25 ++++++++++++++++---------
 2 files changed, 19 insertions(+), 10 deletions(-)
```