### PR TITLE
Fix flaky TestRequestHandlerStopAndRequeue in guardian

### DIFF
--- a/guardian/pkg/asyncutil/async.go
+++ b/guardian/pkg/asyncutil/async.go
@@ -110,7 +110,7 @@ func NewCommandExecutor[C any, R any](ctx context.Context, errBuff ErrorBuffer, 
 		errBuff:             errBuff,
 		cmdChan:             make(chan Command[C, R], 100),
 		backlogChan:         make(chan Command[C, R], 100),
-		drainAndBacklogSig:  make(chan chan struct{}, 100),
+		drainAndBacklogSig:  make(chan chan struct{}),
 		resumeBackloggedSig: make(chan struct{}),
 		shutdownCompleteSig: make(chan struct{}),
 	}


### PR DESCRIPTION
The `drainAndBacklogSig` channel was buffered (capacity 100), so `DrainAndBacklog()` returned immediately without the executor loop necessarily having processed the signal. When `Resume()` was called next, Go's `select` could non-deterministically pick the resume case before the drain case, causing the resume to be consumed with no effect. The subsequent drain then had no matching resume, resulting in a deadlock — the test hung until the 10m timeout.

Fix is to make `drainAndBacklogSig` unbuffered so `DrainAndBacklog()` blocks until the executor loop receives the signal. This guarantees drain is always processed before resume. The channel never needs buffering — there's no use case for queuing multiple drain signals without the executor processing them.

Verified with 100 consecutive runs (`go test -count=100`), all passing.