### PR TITLE
Add --retry to curl calls in Dockerfiles and Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ get-operator-crds: var-require-all-OPERATOR_ORGANIZATION-OPERATOR_GIT_REPO-OPERA
 	cd ./charts/crd.projectcalico.org.v1/templates/ && \
 	for file in operator.tigera.io_*.yaml; do \
 		echo "downloading $$file from operator repo"; \
-		curl -fsSL https://raw.githubusercontent.com/$(OPERATOR_ORGANIZATION)/$(OPERATOR_GIT_REPO)/$(OPERATOR_BRANCH)/pkg/imports/crds/operator/$${file} -o $${file}; \
+		curl -fsSL --retry 5 https://raw.githubusercontent.com/$(OPERATOR_ORGANIZATION)/$(OPERATOR_GIT_REPO)/$(OPERATOR_BRANCH)/pkg/imports/crds/operator/$${file} -o $${file}; \
 		cp $${file} ../../projectcalico.org.v3/templates/$${file}; \
 	done
 	$(MAKE) fix-changed
@@ -225,7 +225,7 @@ bin/ghr:
 
 # Install GitHub CLI
 bin/gh:
-	curl -sSL -o bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
+	curl -sSL --retry 5 -o bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
 	tar -zxvf bin/gh.tgz -C bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh --strip-components=2
 	chmod +x $@
 	rm bin/gh.tgz

--- a/confd/Makefile
+++ b/confd/Makefile
@@ -127,7 +127,8 @@ bin/calico-node:
 	chmod +x $@
 
 bin/etcdctl:
-	curl -sSf -L --retry 5  https://github.com/coreos/etcd/releases/download/$(ETCD_VERSION)/etcd-$(ETCD_VERSION)-linux-$(ARCH).tar.gz | tar -xz -C bin --strip-components=1 etcd-$(ETCD_VERSION)-linux-$(ARCH)/etcdctl
+	curl -sSfL --retry 5 -o /tmp/etcd.tar.gz https://github.com/coreos/etcd/releases/download/$(ETCD_VERSION)/etcd-$(ETCD_VERSION)-linux-$(ARCH).tar.gz
+	tar -xz -C bin --strip-components=1 -f /tmp/etcd.tar.gz etcd-$(ETCD_VERSION)-linux-$(ARCH)/etcdctl && rm -f /tmp/etcd.tar.gz
 
 bin/calicoctl:
 	make -C ../calicoctl build

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -44,7 +44,8 @@ COPY patches/svlogd_use_0644_permission_instead_of_0744.patch /svlogd_use_0644_p
 
 # runit is not available in ubi or AlmaLinux repos so build it.
 # get it from the debian repos as the official website doesn't support https
-RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz | tar xz -C /root && \
+RUN curl -sSfL --retry 5 -o /tmp/runit.tar.gz https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
+    tar xz -C /root -f /tmp/runit.tar.gz && rm -f /tmp/runit.tar.gz && \
     cd /root/admin/runit-${RUNIT_VER} && \
     patch -p1 < /svlogd_use_0644_permission_instead_of_0744.patch && \
     package/compile

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -43,7 +43,8 @@ COPY patches/svlogd_use_0644_permission_instead_of_0744.patch /svlogd_use_0644_p
 
 # runit is not available in ubi or AlmaLinux repos so build it.
 # get it from the debian repos as the official website doesn't support https
-RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz | tar xz -C /root && \
+RUN curl -sSfL --retry 5 -o /tmp/runit.tar.gz https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
+    tar xz -C /root -f /tmp/runit.tar.gz && rm -f /tmp/runit.tar.gz && \
     cd /root/admin/runit-${RUNIT_VER} && \
     patch -p1 < /svlogd_use_0644_permission_instead_of_0744.patch && \
     package/compile

--- a/node/calico_test/Dockerfile
+++ b/node/calico_test/Dockerfile
@@ -63,8 +63,9 @@ RUN apk add --no-cache \
     tshark
 
 # Install etcdctl
-RUN curl -sfL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-${TARGETARCH}.tar.gz | \
-    tar xz --strip-components 1 -C /usr/local/bin etcd-${ETCD_VERSION}-linux-${TARGETARCH}/etcdctl
+RUN curl -sSfL --retry 5 -o /tmp/etcd.tar.gz https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar xz --strip-components 1 -C /usr/local/bin -f /tmp/etcd.tar.gz etcd-${ETCD_VERSION}-linux-${TARGETARCH}/etcdctl && \
+    rm -f /tmp/etcd.tar.gz
 
 COPY requirements.txt /requirements.txt
 RUN pip3 install -r /requirements.txt --break-system-packages

--- a/process/testing/aso/Makefile
+++ b/process/testing/aso/Makefile
@@ -123,7 +123,8 @@ $(BINDIR)/helm:
 CRANE_ARCH = $(subst amd64,x86_64,$(ARCH))
 $(BINDIR)/crane:
 	mkdir -p $(@D)
-	curl -sSfL --retry 5 https://github.com/google/go-containerregistry/releases/download/$(CRANE_VERSION)/go-containerregistry_Linux_$(CRANE_ARCH).tar.gz | tar xz -C $(@D) crane
+	curl -sSfL --retry 5 -o /tmp/crane.tar.gz https://github.com/google/go-containerregistry/releases/download/$(CRANE_VERSION)/go-containerregistry_Linux_$(CRANE_ARCH).tar.gz
+	tar xz -C $(@D) -f /tmp/crane.tar.gz crane && rm -f /tmp/crane.tar.gz
 	touch $@
 
 .PHONY: clean

--- a/third_party/envoy-gateway/Makefile
+++ b/third_party/envoy-gateway/Makefile
@@ -25,7 +25,8 @@ ENVOY_GATEWAY_DOWNLOADED=.envoy-gateway.downloaded
 init-source: $(ENVOY_GATEWAY_DOWNLOADED)
 $(ENVOY_GATEWAY_DOWNLOADED):
 	mkdir -p envoy-gateway
-	curl -sfL https://github.com/envoyproxy/gateway/archive/refs/tags/$(ENVOY_GATEWAY_VERSION).tar.gz | tar xz --strip-components 1 -C envoy-gateway
+	curl -sSfL --retry 5 -o /tmp/envoy-gateway.tar.gz https://github.com/envoyproxy/gateway/archive/refs/tags/$(ENVOY_GATEWAY_VERSION).tar.gz
+	tar xz --strip-components 1 -C envoy-gateway -f /tmp/envoy-gateway.tar.gz && rm -f /tmp/envoy-gateway.tar.gz
 
 # 	Apply patches for the specified Envoy Gateway version if patches directory exists.
 # 	This code checks for the presence of a patches directory corresponding to ENVOY_GATEWAY_VERSION.


### PR DESCRIPTION
## Summary
- Add `--retry 3` to curl calls that were missing retry logic in Dockerfiles and Makefiles
- Several curl calls (e.g., etcd download in node/calico_test, runit download in node Dockerfiles) had no retry, causing transient GitHub download failures to break CI builds
- Other curl calls in the repo already had `--retry 5` or `--retry 9` -- this brings the stragglers in line

## Test plan
- [ ] Verify CI passes