### PR TITLE
fix(release/operator): split calico registry for operator build

### DIFF
--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -110,8 +110,15 @@ func (o *OperatorManager) Build() error {
 		return err
 	}
 	env, logFields := o.env()
-	logFields["calico_registry"] = o.productRegistry
-	env = append(env, fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, o.productRegistry))
+	logFields["product_registry"] = o.productRegistry
+	r, i, err := o.productRegistryParts()
+	if err != nil {
+		return err
+	}
+	logFields[fmt.Sprintf("%s_registry", strings.ToLower(defaultProductEnvPrefix))] = o.productRegistry
+	logFields[fmt.Sprintf("%s_image_path", strings.ToLower(defaultProductEnvPrefix))] = o.productRegistry
+	env = append(env, fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, r))
+	env = append(env, fmt.Sprintf("%s_IMAGE_PATH=%s", defaultProductEnvPrefix, i))
 	if o.isHashRelease {
 		if o.calicoVersion != "" {
 			env = append(env, fmt.Sprintf("%s_VERSION=%s", defaultProductEnvPrefix, o.calicoVersion))
@@ -156,6 +163,26 @@ func (o *OperatorManager) env() ([]string, logrus.Fields) {
 		env = append(env, "DEBUG=true")
 	}
 	return env, logFields
+}
+
+// productRegistryParts splits the product registry into registry and image path.
+// Typically the product registry is something like "docker.io/calico" or "quay.io/calico".
+// This function splits it into "docker.io" and "calico" or "quay.io" and "calico".
+func (o *OperatorManager) productRegistryParts() (registry string, imagePath string, err error) {
+	// Split and filter out empty parts from double slashes or trailing slashes.
+	var parts []string
+	for _, part := range strings.Split(o.productRegistry, "/") {
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	if len(parts) < 2 {
+		err = fmt.Errorf("failed to parse product registry: %s", o.productRegistry)
+		return
+	}
+	registry = strings.Join(parts[:len(parts)-1], "/") + "/"
+	imagePath = parts[len(parts)-1] + "/"
+	return
 }
 
 func (o *OperatorManager) PreBuildValidation() error {

--- a/release/pkg/manager/operator/manager_test.go
+++ b/release/pkg/manager/operator/manager_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import "testing"
+
+func TestProductRegistryParts(t *testing.T) {
+	for _, tc := range []struct {
+		registry     string
+		expRegistry  string
+		expNamespace string
+		shouldErr    bool
+	}{
+		{
+			registry:     "my-registry/my-namespace",
+			expRegistry:  "my-registry/",
+			expNamespace: "my-namespace/",
+		},
+		{
+			registry:  "my-registry",
+			shouldErr: true,
+		},
+		{
+			registry:     "my-registry/extra/my-namespace",
+			expRegistry:  "my-registry/extra/",
+			expNamespace: "my-namespace/",
+		},
+		{
+			registry:     "my-registry/extra/more/my-namespace",
+			expRegistry:  "my-registry/extra/more/",
+			expNamespace: "my-namespace/",
+		},
+		{
+			registry:     "my-registry//extra/more/my-namespace",
+			expRegistry:  "my-registry/extra/more/",
+			expNamespace: "my-namespace/",
+		},
+		{
+			registry:     "my-registry//extra/more/my-namespace/",
+			expRegistry:  "my-registry/extra/more/",
+			expNamespace: "my-namespace/",
+		},
+	} {
+		t.Run(tc.registry, func(t *testing.T) {
+			m := &OperatorManager{
+				productRegistry: tc.registry,
+			}
+			registry, namespace, err := m.productRegistryParts()
+			if tc.shouldErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if registry != tc.expRegistry {
+				t.Errorf("expected registry %s but got %s", tc.expRegistry, registry)
+			}
+			if namespace != tc.expNamespace {
+				t.Errorf("expected namespace %s but got %s", tc.expNamespace, namespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
this restores some changes that were removed in #11996, while operator now handles its image split, it does not handle product registry/image parts split

**Release note:**
```release-note
TBD
```
