### PR TITLE
Add delete permission on apiservices for operator

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -340,6 +340,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -340,6 +340,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -411,6 +411,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -378,6 +378,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - discovery.k8s.io
     resources:


### PR DESCRIPTION
The operator needs to be able to delete the aggregated `v3.projectcalico.org`
APIService when it auto-detects native v3 CRDs mode. Without this permission,
the operator gets a forbidden error trying to clean up the old aggregation
server objects, and the apiserver component never comes up.

The operator's `apiserver.go` adds `aggregationAPIServerObjects` (which includes
the APIService) to `objsToDelete` when `RequiresAggregationServer` is false,
but the helm chart ClusterRole only had `list`, `watch`, `create`, `update`
on `apiservices` — no `delete`.