### PR TITLE
Fix flaky guardian tests

### DIFF
--- a/guardian/pkg/asyncutil/async.go
+++ b/guardian/pkg/asyncutil/async.go
@@ -226,10 +226,10 @@ func (executor *commandExecutor[C, R]) drainBacklogChannel() {
 }
 
 func (executor *commandExecutor[C, R]) execBacklog(shutdownCtx context.Context) (context.Context, func()) {
-	// Just in case there's anything left on the backlog channel ensure it's drained off and added to the backlog slice.
-	if len(executor.backlog) > 0 {
-		executor.drainBacklogChannel()
-	}
+	// Drain the backlog channel unconditionally. Commands cancelled during drain
+	// are placed on backlogChan asynchronously and may not have been read by the
+	// select loop before Resume was received.
+	executor.drainBacklogChannel()
 
 	ctx, stopCommands := context.WithCancel(shutdownCtx)
 	for _, cmd := range executor.backlog {


### PR DESCRIPTION
Follow-up to #12042. Two flaky tests in guardian.

**asyncutil: `TestRequestHandlerStopAndRequeue` deadlock**

There's a second race beyond what #12042 fixed. `execBacklog()` only drained `backlogChan` when the `backlog` slice was already non-empty. But commands cancelled during `DrainAndBacklog` write to `backlogChan` asynchronously from `executeCommand` goroutines — and the `select` loop may not have read those items off `backlogChan` before `Resume` arrives. When that happens, the `backlog` slice is empty, `execBacklog` skips the channel drain entirely, and the commands are lost. The test then deadlocks waiting on results that will never come.

Fix: drain `backlogChan` unconditionally in `execBacklog()`.

**tunnel: `TestDial` spurious "session shutdown"**

Two races. First, `handleConnection`'s deferred `session.Close()` ran while the client was still reading the response — the `doneCh` signal came too late (after session teardown in LIFO defer order). Fixed by having the server wait on a `clientDoneCh` signal before returning, so the client drives shutdown timing.

Second, the default 100ms yamux keepalive interval caused spurious session shutdowns under load. Keepalive isn't what these tests are exercising, so disabled it via `WithDialerKeepAliveSettings`.

Both verified with 1000 iterations under `-race` with zero failures.