### PR TITLE
Add host-identifying prefix to BPF log output in FV tests

### DIFF
--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -34,6 +34,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
+	bpfutils "github.com/projectcalico/calico/felix/bpf/utils"
 	"github.com/projectcalico/calico/felix/dataplane/linux/qos"
 )
 
@@ -522,7 +523,7 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 
 	logIface := ap.Iface
 	if ap.Type != tcdefs.EpTypeWorkload {
-		if prefix := fvLogPrefix(); prefix != "" {
+		if prefix := bpfutils.FVLogPrefix(); prefix != "" {
 			logIface = prefix + logIface
 		}
 	}
@@ -534,24 +535,6 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 
 	return globalData
 }
-
-// fvLogPrefix returns a short host-identifying prefix (e.g. "f0-") when running
-// inside a Felix FV test container (hostname ends with "-felixfv"). Returns ""
-// in production so there is no impact on non-test deployments.
-var fvLogPrefix = sync.OnceValue(func() string {
-	hostname, err := os.Hostname()
-	if err != nil || !strings.HasSuffix(hostname, "-felixfv") {
-		return ""
-	}
-	// Hostname format: felix-<id>-<pid>-<counter>-felixfv
-	// Extract the <id> part after "felix-".
-	if !strings.HasPrefix(hostname, "felix-") {
-		return ""
-	}
-	rest := hostname[len("felix-"):]
-	idx, _, _ := strings.Cut(rest, "-")
-	return "f" + idx + "-"
-})
 
 var IsTcxSupported = sync.OnceValue(func() bool {
 	name := "testTcx"

--- a/felix/bpf/utils/utils.go
+++ b/felix/bpf/utils/utils.go
@@ -181,6 +181,24 @@ func isMount(path string) (bool, error) {
 	return false, nil
 }
 
+// FVLogPrefix returns a short host-identifying prefix (e.g. "f0-") when running
+// inside a Felix FV test container (hostname ends with "-felixfv"). Returns ""
+// in production so there is no impact on non-test deployments.
+var FVLogPrefix = sync.OnceValue(func() string {
+	hostname, err := os.Hostname()
+	if err != nil || !strings.HasSuffix(hostname, "-felixfv") {
+		return ""
+	}
+	// Hostname format: felix-<id>-<pid>-<counter>-felixfv
+	// Extract the <id> part after "felix-".
+	if !strings.HasPrefix(hostname, "felix-") {
+		return ""
+	}
+	rest := hostname[len("felix-"):]
+	idx, _, _ := strings.Cut(rest, "-")
+	return "f" + idx + "-"
+})
+
 func RemoveBPFSpecialDevices() {
 	bpfin, err := netlink.LinkByName(dataplanedefs.BPFInDev)
 	if err != nil {

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -16,10 +16,8 @@ package xdp
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"strings"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -29,6 +27,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
+	bpfutils "github.com/projectcalico/calico/felix/bpf/utils"
 )
 
 const DetachedID = 0
@@ -110,7 +109,7 @@ func (ap *AttachPoint) Configuration() *libbpf.XDPGlobalData {
 		globalData.JumpsV6[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdxV6)
 	}
 	logIface := ap.Iface
-	if prefix := fvLogPrefix(); prefix != "" {
+	if prefix := bpfutils.FVLogPrefix(); prefix != "" {
 		logIface = prefix + logIface
 	}
 	in := []byte("---------------")
@@ -216,19 +215,3 @@ func (ap *AttachPoint) ProgramID() (int, error) {
 	}
 	return progID, nil
 }
-
-// fvLogPrefix returns a short host-identifying prefix (e.g. "f0-") when running
-// inside a Felix FV test container (hostname ends with "-felixfv"). Returns ""
-// in production so there is no impact on non-test deployments.
-var fvLogPrefix = sync.OnceValue(func() string {
-	hostname, err := os.Hostname()
-	if err != nil || !strings.HasSuffix(hostname, "-felixfv") {
-		return ""
-	}
-	if !strings.HasPrefix(hostname, "felix-") {
-		return ""
-	}
-	rest := hostname[len("felix-"):]
-	idx, _, _ := strings.Cut(rest, "-")
-	return "f" + idx + "-"
-})


### PR DESCRIPTION
## Summary
- Adds a short prefix (f0-, f1-, f2-) to the BPF `iface_name` log field for non-workload interfaces when running inside FV test containers
- Makes it easy to identify which Felix instance a BPF log line belongs to when debugging multi-node FV tests
- Zero production impact — prefix is only active when hostname matches the FV pattern (`felix-<id>-...-felixfv`)
- Workload interfaces (cali* veths) are excluded since they already have unique names

## Test plan
- [ ] Run BPF FV test: `make -C felix fv-bpf GINKGO_FOCUS="BPF dual stack basic in-cluster connectivity" GINKGO_ARGS="-ginkgo.v"`
- [ ] Verify BPF logs show `f0-eth0-I:` / `f1-eth0-E:` instead of `eth0-I:` / `eth0-E:`
- [ ] Verify workload interface logs remain unchanged (e.g. `cali1234abcde`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)