### PR TITLE
Retry on conflict when setting RR config in BGP advert tests

### DIFF
--- a/node/tests/k8st/tests/test_bgp_advert.py
+++ b/node/tests/k8st/tests/test_bgp_advert.py
@@ -161,6 +161,16 @@ EOF
         # transient conflict errors.
         retry_until_success(lambda: self.clear_rr_config(self.nodes[2]))
 
+    def set_rr_config(self, node):
+        json_str = calicoctl("get node %s -o json" % node)
+        node_dict = json.loads(json_str)
+        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
+        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
+        calicoctl("""apply -f - << EOF
+%s
+EOF
+""" % json.dumps(node_dict))
+
     def clear_rr_config(self, node):
         json_str = calicoctl("get node %s -o json" % node)
         node_dict = json.loads(json_str)
@@ -851,15 +861,9 @@ EOF
         calicoctl("get bgppeers -o yaml")
         calicoctl("get bgpconfigs -o yaml")
 
-        # Update the node-2 to behave as a route-reflector
-        json_str = calicoctl("get node %s -o json" % self.nodes[2])
-        node_dict = json.loads(json_str)
-        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
-        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
-        calicoctl("""apply -f - << EOF
-%s
-EOF
-""" % json.dumps(node_dict))
+        # Update the node-2 to behave as a route-reflector, using a retry
+        # to avoid transient conflict errors.
+        retry_until_success(lambda: self.set_rr_config(self.nodes[2]))
 
         # Disable node-to-node mesh, add cluster and external IP CIDRs to
         # advertise, and configure BGP peering between the cluster nodes and the
@@ -971,15 +975,9 @@ EOF
         calicoctl("get bgppeers -o yaml")
         calicoctl("get bgpconfigs -o yaml")
 
-        # Update the node-2 to behave as a route-reflector
-        json_str = calicoctl("get node %s -o json" % self.nodes[2])
-        node_dict = json.loads(json_str)
-        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
-        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
-        calicoctl("""apply -f - << EOF
-%s
-EOF
-""" % json.dumps(node_dict))
+        # Update the node-2 to behave as a route-reflector, using a retry
+        # to avoid transient conflict errors.
+        retry_until_success(lambda: self.set_rr_config(self.nodes[2]))
 
         # Disable node-to-node mesh, add cluster and external IP CIDRs to
         # advertise, and configure BGP peering between the cluster nodes and the

--- a/node/tests/k8st/tests/test_bgp_advert_v6.py
+++ b/node/tests/k8st/tests/test_bgp_advert_v6.py
@@ -144,6 +144,16 @@ EOF
         # transient conflict errors.
         retry_until_success(lambda: self.clear_rr_config(self.nodes[2]))
 
+    def set_rr_config(self, node):
+        json_str = calicoctl("get node %s -o json" % node)
+        node_dict = json.loads(json_str)
+        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
+        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
+        calicoctl("""apply -f - << EOF
+%s
+EOF
+""" % json.dumps(node_dict))
+
     def clear_rr_config(self, node):
         json_str = calicoctl("get node %s -o json" % node)
         node_dict = json.loads(json_str)
@@ -596,15 +606,9 @@ EOF
         calicoctl("get bgppeers -o yaml")
         calicoctl("get bgpconfigs -o yaml")
 
-        # Update the node-2 to behave as a route-reflector
-        json_str = calicoctl("get node %s -o json" % self.nodes[2])
-        node_dict = json.loads(json_str)
-        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
-        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
-        calicoctl("""apply -f - << EOF
-%s
-EOF
-""" % json.dumps(node_dict))
+        # Update the node-2 to behave as a route-reflector, using a retry
+        # to avoid transient conflict errors.
+        retry_until_success(lambda: self.set_rr_config(self.nodes[2]))
 
         # Disable node-to-node mesh, add cluster and external IP CIDRs to
         # advertise, and configure BGP peering between the cluster nodes and the
@@ -705,15 +709,9 @@ EOF
         calicoctl("get bgppeers -o yaml")
         calicoctl("get bgpconfigs -o yaml")
 
-        # Update the node-2 to behave as a route-reflector
-        json_str = calicoctl("get node %s -o json" % self.nodes[2])
-        node_dict = json.loads(json_str)
-        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
-        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
-        calicoctl("""apply -f - << EOF
-%s
-EOF
-""" % json.dumps(node_dict))
+        # Update the node-2 to behave as a route-reflector, using a retry
+        # to avoid transient conflict errors.
+        retry_until_success(lambda: self.set_rr_config(self.nodes[2]))
 
         # Disable node-to-node mesh, add cluster and external IP CIDRs to
         # advertise, and configure BGP peering between the cluster nodes and the


### PR DESCRIPTION
The `tearDown` already retries `clear_rr_config` via `retry_until_success` to handle transient update conflicts on the Node resource, but the setup paths in `test_rr` and `test_single_ip_lb_rr` did an inline get-modify-apply without retry. If the node controller updates the Node between the get and the apply, we hit an update conflict and the test fails.

This extracts `set_rr_config` (parallel to `clear_rr_config`) and wraps all call sites in `retry_until_success`. Fixes both `test_bgp_advert.py` and `test_bgp_advert_v6.py`.