### PR TITLE
Fix BPF VXLAN packet drop during rolling upgrade to 3.31

### DIFF
--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -6,6 +6,7 @@
 #define __CALI_FIB_CO_RE_H__
 
 #include "profiling.h"
+#include <linux/if_packet.h>
 
 static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 {
@@ -358,6 +359,9 @@ allow:
 			CALI_INFO("Final result=DENY (%d). Program execution time: %lluns",
 					reason, prog_end_time-state->prog_start_time);
 		} else {
+			if (CALI_F_VXLAN && CALI_F_TO_HOST) {
+				bpf_skb_change_type(ctx->skb, PACKET_HOST);
+			}
 			CALI_INFO("Final result=ALLOW rc %d. Program execution time: %lluns",
 					rc, prog_end_time-state->prog_start_time);
 		}


### PR DESCRIPTION
## Summary

- Fix VXLAN packets being dropped on 3.30 nodes during a rolling upgrade to 3.31. In 3.31 the VXLAN device uses flow-based mode, which changes the inner destination MAC in encapsulated packets. When a 3.30 node receives these packets, the kernel sets `pkt_type` to `PACKET_OTHERHOST` (because the inner MAC doesn't match `vxlan.calico`), causing them to be silently dropped after decapsulation.
- The fix calls `bpf_skb_change_type(PACKET_HOST)` for allowed packets arriving on the VXLAN interface, ensuring the kernel delivers them correctly regardless of the inner MAC address.

Fixes https://github.com/projectcalico/calico/issues/11910

## Release note
```release-note
ebpf: Fixed issue where VXLAN traffic was dropped on nodes still running Calico 3.30 during a rolling upgrade to 3.31. This caused connectivity failures for host-networked pods communicating via Kubernetes services across nodes at different versions. Upgrading to this 3.30 patch release before upgrading to 3.31 resolves the issue.
```

## Test plan

- [ ] Deploy a mixed 3.30/3.31 cluster with BPF dataplane and VXLAN encapsulation
- [ ] Verify host-networked pod → Kubernetes service → pod connectivity works across 3.31→3.30 node boundaries
- [ ] Verify 3.30→3.30 traffic is unaffected (no-op path)
- [ ] Run BPF FV tests with VXLAN enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)