### PR TITLE
Do not default loadbalancer config when not part of ENABLED_CONTROLLE…

### DIFF
--- a/kube-controllers/pkg/config/config_fv_test.go
+++ b/kube-controllers/pkg/config/config_fv_test.go
@@ -190,12 +190,12 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 			Expect(out.Status.RunningConfig.Controllers.Policy).To(BeNil())
 			Expect(out.Status.RunningConfig.Controllers.WorkloadEndpoint).To(BeNil())
 			Expect(out.Status.RunningConfig.Controllers.ServiceAccount).To(BeNil())
+			Expect(out.Status.RunningConfig.Controllers.LoadBalancer).To(BeNil())
 
 			// These fields are defaulted
 			Expect(out.Status.RunningConfig.HealthChecks).To(Equal(v3.Enabled))
 			Expect(out.Status.RunningConfig.LogSeverityScreen).To(Equal("Info"))
 			Expect(out.Status.RunningConfig.EtcdV3CompactionPeriod).To(Equal(&metav1.Duration{Duration: time.Minute * 10}))
-			Expect(out.Status.RunningConfig.Controllers.LoadBalancer.AssignIPs).To(Equal(v3.AllServices))
 		})
 	})
 
@@ -243,6 +243,19 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 			kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kcc.Status.EnvironmentVars).To(Equal(map[string]string{"ENABLED_CONTROLLERS": "node"}))
+		})
+
+		It("should not default loadbalancer config if not part of ENABLED_CONTROLLERS", func() {
+			// Wait until controller is up and has set status
+			var kcc *v3.KubeControllersConfiguration
+			Eventually(func() map[string]string {
+				var err error
+				kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return kcc.Status.EnvironmentVars
+			}, time.Second*10, time.Millisecond*500).Should(Equal(map[string]string{"ENABLED_CONTROLLERS": "node"}))
+
+			Expect(kcc.Status.RunningConfig.Controllers.LoadBalancer).To(BeNil())
 		})
 	})
 })

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -392,14 +392,6 @@ func mergeLoadBalancer(status *v3.KubeControllersConfigurationStatus, rCfg *RunC
 			rCfg.Controllers.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
 			status.RunningConfig.Controllers.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
 		}
-	} else {
-		// We can enable the LoadBalancer controller as it won't be assigning any IPs if IPPool for LoadBalancer is not set
-		rCfg.Controllers.LoadBalancer = &LoadBalancerControllerConfig{
-			AssignIPs: v3.AllServices,
-		}
-		status.RunningConfig.Controllers.LoadBalancer = &v3.LoadBalancerControllerConfig{
-			AssignIPs: v3.AllServices,
-		}
 	}
 }
 
@@ -630,8 +622,12 @@ func mergeEnabledControllers(envVars map[string]string, status *v3.KubeControlle
 				rc.ServiceAccount = &GenericControllerConfig{}
 				sc.ServiceAccount = &v3.ServiceAccountControllerConfig{}
 			case "loadbalancer":
-				rc.LoadBalancer = &LoadBalancerControllerConfig{}
-				sc.LoadBalancer = &v3.LoadBalancerControllerConfig{}
+				rc.LoadBalancer = &LoadBalancerControllerConfig{
+					AssignIPs: v3.AllServices,
+				}
+				sc.LoadBalancer = &v3.LoadBalancerControllerConfig{
+					AssignIPs: v3.AllServices,
+				}
 			case "flannelmigration":
 				log.WithField(EnvEnabledControllers, v).Fatal("cannot run flannelmigration with other controllers")
 			default:


### PR DESCRIPTION
Cherry-pick (#11728)

* Do not default loadbalancer config when not part of ENABLED_CONTROLLERS

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Updates LoadBalancer controller to not run when not explicitly configured as part of ENABLED_CONTROLLERS
```
