### PR TITLE
Fix flaky TestSyncServerCancelBeforeInSync

### DIFF
--- a/app-policy/syncher/syncserver.go
+++ b/app-policy/syncher/syncserver.go
@@ -107,7 +107,12 @@ func (s *SyncClient) Sync(cxt context.Context) {
 				return
 			}
 
-			time.Sleep(PolicySyncRetryTime)
+			select {
+			case <-time.After(PolicySyncRetryTime):
+			case <-cxt.Done():
+				s.inSync = false
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
The retry sleep in `SyncClient.Sync` used `time.Sleep(PolicySyncRetryTime)`, which blocks unconditionally for 1s after a server disconnect. This ignores context cancellation, so when the test cancels the client context during the retry sleep, `Sync` doesn't return until the sleep finishes. The test's default 1s `Eventually` timeout races against the 1s retry sleep, causing the flake.

Replace the `time.Sleep` with a `select` on `time.After` and `cxt.Done()` so the retry delay is interruptible by context cancellation.