### PR TITLE
Clean stale BPF .d files before building in node Makefile

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -201,11 +201,10 @@ $(LIBBPF_A): $(shell find ../felix/bpf-gpl/libbpf -type f -name '*.[ch]')
 
 filesystem/usr/lib/calico/bpf: $(shell find ../felix/bpf-gpl -type f) $(shell find ../felix/bpf-apache -type f)
 	rm -rf filesystem/usr/lib/calico/bpf/ && mkdir -p filesystem/usr/lib/calico/bpf/
-	# Clean stale .d dependency files that may reference headers from a previous
+	# Clean stale build artifacts that may reference headers from a previous
 	# build environment (e.g., Docker container with different clang version).
-	find ../felix/bpf-gpl -maxdepth 1 -name '*.d' -delete 2>/dev/null || true
-	find ../felix/bpf-gpl/ut -maxdepth 1 -name '*.d' -delete 2>/dev/null || true
-	find ../felix/bpf-apache -maxdepth 1 -name '*.d' -delete 2>/dev/null || true
+	make -C ../felix/bpf-gpl clean
+	make -C ../felix/bpf-apache clean
 	make -C ../felix build-bpf ARCH=$(ARCH)
 	cp -r ../felix/bpf-gpl/bin/* $@
 	cp -r ../felix/bpf-apache/bin/* $@


### PR DESCRIPTION
The BPF Makefile generates `.d` dependency files that record header paths from the build environment. When a previous build ran inside Docker (with e.g. clang-18), those `.d` files reference container-specific paths like `/usr/lib/clang/18/include/stdbool.h`. A subsequent host build (e.g., `make kind-k8st-setup`) then fails because Make tries to satisfy those stale dependencies and can't find the headers.

This cleans `.d` files before invoking `build-bpf` so dependency tracking always starts fresh. Previously this required a `git clean -ffxd` from the repo root to fix.