### PR TITLE
Standardize ginkgo test parameters across Makefiles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,10 +63,10 @@ cd lib/httpmachinery && go test ./...
 make -C felix fv GINKGO_ARGS="-ginkgo.v"
 
 # Run specific FV tests by pattern
-make -C felix fv GINKGO_FOCUS="TestName" GINKGO_ARGS="-ginkgo.v"
+make -C felix fv FOCUS="TestName" GINKGO_ARGS="-ginkgo.v"
 
 # Felix FV in eBPF mode (BPF-SAFE tests only)
-make -C felix fv-bpf GINKGO_FOCUS="TestName" GINKGO_ARGS="-ginkgo.v"
+make -C felix fv-bpf FOCUS="TestName" GINKGO_ARGS="-ginkgo.v"
 
 # Felix FV in nftables mode
 make -C felix fv GINKGO_ARGS="-ginkgo.v" FELIX_FV_NFTABLES=Enabled
@@ -77,7 +77,7 @@ make -C felix fv GINKGO_ARGS="-ginkgo.v" FELIX_FV_NFTABLES=Enabled
 - Felix FV tests are in `felix/fv/`, using **Ginkgo v2** (`github.com/onsi/ginkgo/v2`)
 - Test IDs include all nested Context/Describe headings
 - **Always run FVs via Makefile** — builds required tooling and sets up permissions
-- Use `GINKGO_FOCUS="regex"` to target specific tests, `GINKGO_ARGS` for extra flags
+- Use `FOCUS="regex"` to target specific tests, `SKIP="regex"` to skip, `GINKGO_ARGS` for extra flags
 - Useful flags: `-ginkgo.dryRun` (list tests), `-ginkgo.v` (verbose), `FV_FELIX_LOG_LEVEL=debug`
 - **Prefer vanilla `go test` for new packages.** Only use Ginkgo if established pattern exists.
 - Felix "brain" is the calculation graph in `felix/calc/` — changes require calc graph "FV" tests (`felix/calc/calc_graph_fv_test.go`)

--- a/.claude/skills/ci-reproduce-on-gcp-vm/SKILL.md
+++ b/.claude/skills/ci-reproduce-on-gcp-vm/SKILL.md
@@ -118,10 +118,10 @@ ${ssh_cmd} "cd calico/felix && make FOCUS=TestPrecompiledBinariesAreLoadable ut-
 ${ssh_cmd} "cd calico/felix && make FOCUS=TestNATNodePortNoFWD ut-bpf"
 
 # Felix FV test
-${ssh_cmd} "cd calico/felix && make fv GINKGO_FOCUS='TestName'"
+${ssh_cmd} "cd calico/felix && make fv FOCUS='TestName'"
 
 # BPF FV test
-${ssh_cmd} "cd calico/felix && make fv-bpf GINKGO_FOCUS='TestName'"
+${ssh_cmd} "cd calico/felix && make fv-bpf FOCUS='TestName'"
 ```
 
 The first run will be slow (pulls Docker build images). Subsequent runs are faster.

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1178,7 +1178,7 @@ blocks:
               value: "true"
             - name: CALICO_API_GROUP
               value: projectcalico.org/v3
-            - name: GINKGO_SKIP
+            - name: SKIP
               value: "etcdv3 backend"
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1178,7 +1178,7 @@ blocks:
               value: "true"
             - name: CALICO_API_GROUP
               value: projectcalico.org/v3
-            - name: GINKGO_SKIP
+            - name: SKIP
               value: "etcdv3 backend"
       epilogue:
         always:

--- a/.semaphore/semaphore.yml.d/blocks/20-libcalico-go.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-libcalico-go.yml
@@ -27,7 +27,7 @@
             value: "true"
           - name: CALICO_API_GROUP
             value: projectcalico.org/v3
-          - name: GINKGO_SKIP
+          - name: SKIP
             value: "etcdv3 backend"
     epilogue:
       always:

--- a/api/Makefile
+++ b/api/Makefile
@@ -147,7 +147,9 @@ bin/list-gnp: examples/list-gnp/main.go
 	$(call build_binary, examples/list-gnp/main.go, $@)
 
 WHAT?=.
-GINKGO_FOCUS?=.*
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
 
 .PHONY:ut
 ut: kind-cluster-create
@@ -157,7 +159,7 @@ ut: kind-cluster-create
 		-e KUBECONFIG=/kubeconfig.yaml \
 		-v $(KIND_KUBECONFIG):/kubeconfig.yaml \
 		$(CALICO_BUILD) \
-		sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=api_ut.xml --output-dir=report/ -focus="$(GINKGO_FOCUS)" $(WHAT)'
+		sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=api_ut.xml --output-dir=report/ -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 ## Check if generated files are out of date
 .PHONY: check-generated-files

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -145,11 +145,13 @@ bin/LICENSE: ../LICENSE.md
 ###############################################################################
 # UTs
 ###############################################################################
+WHAT?=./...
+
 .PHONY: ut
 ## Run the tests in a container. Useful for CI, Mac dev
 ut: protobuf
 	mkdir -p report
-	$(DOCKER_RUN) $(CALICO_BUILD) /bin/bash -c "cd /go/src/$(PACKAGE_NAME) && gotestsum --junitfile report/app_policy_ut.xml -- -v ./..."
+	$(DOCKER_RUN) $(CALICO_BUILD) /bin/bash -c "cd /go/src/$(PACKAGE_NAME) && gotestsum --junitfile report/app_policy_ut.xml -- -v $(WHAT)"
 
 ###############################################################################
 # CI

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -97,11 +97,16 @@ $(CALICO_VERSION_HELPER_BIN): $(CALICO_VERSION_HELPER_SRC)
 ###############################################################################
 # UTs
 ###############################################################################
+WHAT?=calicoctl/*
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
+
 .PHONY: ut
 ## Run the tests in a container. Useful for CI, Mac dev.
 ut: bin/calicoctl-linux-$(ARCH)
 	mkdir -p report
-	$(DOCKER_RUN) -e CALICO_API_GROUP=$(CALICO_API_GROUP) $(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -cover -r --junit-report=calicoctl_ut.xml --output-dir=report/ $(GINKGO_ARGS) calicoctl/*'
+	$(DOCKER_RUN) -e CALICO_API_GROUP=$(CALICO_API_GROUP) $(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -cover -r --junit-report=calicoctl_ut.xml --output-dir=report/ -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 ###############################################################################
 # FVs

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -201,6 +201,10 @@ build-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
 ###############################################################################
 # Unit Tests
 ###############################################################################
+WHAT?=.
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
 
 fv:
 	@echo "No FV tests for CNI plugin"
@@ -267,7 +271,7 @@ ut-datastore:
 	$(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 			cd  /go/src/$(PACKAGE_NAME) && \
 			mkdir -p report && \
-			ginkgo -cover -r --junit-report=$(JUNIT_REPORT_NAME) --output-dir=report/ -skip-package pkg/install,containernetworking-plugins,flannel-cni-plugin $(GINKGO_ARGS)'
+			ginkgo -cover -r --junit-report=$(JUNIT_REPORT_NAME) --output-dir=report/ -skip-package pkg/install,containernetworking-plugins,flannel-cni-plugin -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 ###############################################################################
 # Install test

--- a/felix/.semaphore/batches.sh
+++ b/felix/.semaphore/batches.sh
@@ -30,7 +30,7 @@ run_batch() {
           FELIX_FV_NFTABLES="$FELIX_FV_NFTABLES"
           FV_EXTRA_REPORT_SUFFIX="$FV_EXTRA_REPORT_SUFFIX"
           FELIX_FV_BPFATTACHTYPE="$FELIX_FV_BPFATTACHTYPE"
-          GINKGO_FOCUS="${FV_FOCUS}"
+          FOCUS="${FV_FOCUS}"
           FV_NUM_BATCHES="$num_fv_batches"
           FV_BATCHES_TO_RUN="$batch"
           check-wireguard

--- a/felix/CLAUDE.md
+++ b/felix/CLAUDE.md
@@ -93,15 +93,15 @@ Key file: `dataplane/linux/int_dataplane.go`
 make ut
 ```
 
-Runs all Go unit tests (via Ginkgo with coverage). Skips `fv/`, `k8sfv/`, and `bpf/ut/` packages. Pass `GINKGO_ARGS` for extra flags (e.g., `GINKGO_ARGS="-focus=TestName"`).
+Runs all Go unit tests (via Ginkgo with coverage). Skips `fv/`, `k8sfv/`, and `bpf/ut/` packages. Use `FOCUS="regex"` to target specific tests, `SKIP="regex"` to skip, and `GINKGO_ARGS` for extra flags.
 
 ### Functional Tests
 
 ```bash
-make fv GINKGO_FOCUS="TestName"
+make fv FOCUS="TestName"
 ```
 
-Runs functional tests from `fv/`. Requires container images to be built first. `GINKGO_FOCUS` filters by test name (supports regex). Can be parallelized with `FV_NUM_BATCHES` and `FV_BATCHES_TO_RUN`.
+Runs functional tests from `fv/`. Requires container images to be built first. `FOCUS` filters by test name (supports regex). Can be parallelized with `FV_NUM_BATCHES` and `FV_BATCHES_TO_RUN`.
 
 ### BPF-Specific Tests
 
@@ -137,7 +137,7 @@ make FOCUS="TestPrecompiledBinariesAreLoadable" ut-bpf
 BPF functional tests run the standard FV suite with the BPF dataplane enabled:
 
 ```bash
-make fv-bpf GINKGO_FOCUS="TestName"
+make fv-bpf FOCUS="TestName"
 ```
 
 Tests in `fv/bpf_*_test.go` are focused on the BPF dataplane itself. Tests prefixed with `_BPF-SAFE_` in other FV files test Calico's general behavior and are largely the same across all dataplanes. The dataplane tests in `fv/bpf_*_test.go` can be refined with a matrix prefix:
@@ -158,13 +158,13 @@ Tests in `fv/bpf_*_test.go` are focused on the BPF dataplane itself. Tests prefi
 Example: run a specific BPF FV test only for IPv4 UDP with no tunnel:
 
 ```bash
-make fv-bpf GINKGO_FOCUS="ipv4 udp, ct=true, log=debug, tunnel=none, dsr=false.*MyTestName"
+make fv-bpf FOCUS="ipv4 udp, ct=true, log=debug, tunnel=none, dsr=false.*MyTestName"
 ```
 
 ### Nftables Functional Tests
 
 ```bash
-make fv-nft GINKGO_FOCUS="TestName"
+make fv-nft FOCUS="TestName"
 ```
 
 Runs FV tests with the nftables backend enabled (`FELIX_FV_NFTABLES=Enabled`).

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -284,6 +284,10 @@ $(FELIX_CONTAINER_CREATED): $(IMAGE_DEPS) \
 ###############################################################################
 
 UT_PACKAGES_TO_SKIP?=fv,k8sfv,bpf/ut
+WHAT?=.
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
 
 # The old XDP tests rely on the Apache BPF programs being built.  The UTs that
 # rely on the GPL BPF programs are skipped by this target; they run under the
@@ -291,7 +295,7 @@ UT_PACKAGES_TO_SKIP?=fv,k8sfv,bpf/ut
 .PHONY: ut
 ut combined.coverprofile: $(SRC_FILES) $(LIBBPF_A) $(BPF_APACHE_O_FILES)
 	@echo Running Go UTs.
-	$(DOCKER_RUN) $(CALICO_BUILD) ./utils/run-coverage -skip-package $(UT_PACKAGES_TO_SKIP) $(GINKGO_ARGS)
+	$(DOCKER_RUN) $(CALICO_BUILD) ./utils/run-coverage -skip-package $(UT_PACKAGES_TO_SKIP) -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)
 
 ###############################################################################
 # FV Tests
@@ -374,7 +378,8 @@ fv-no-prereqs:
 	  CERTS_PATH=$(CERTS_PATH) \
 	  PRIVATE_KEY=`pwd`/private.key \
 	  GINKGO_ARGS='$(GINKGO_ARGS)' \
-	  GINKGO_FOCUS="$(GINKGO_FOCUS)" \
+	  FOCUS="$(FOCUS)" \
+	  SKIP="$(SKIP)" \
 	  ARCH=$(ARCH) \
 	  FELIX_FV_ENABLE_BPF="$(FELIX_FV_ENABLE_BPF)" \
 	  FELIX_FV_NFTABLES="$(FELIX_FV_NFTABLES)" \
@@ -539,12 +544,12 @@ release-build: .release-$(VERSION).created
 .PHONY: ut-no-cover
 ut-no-cover: $(SRC_FILES) $(LIBBPF_A) $(BPF_APACHE_O_FILES)
 	@echo Running Go UTs without coverage.
-	$(DOCKER_GO_BUILD) ginkgo -r -skip-package $(UT_PACKAGES_TO_SKIP) $(GINKGO_ARGS)
+	$(DOCKER_GO_BUILD) ginkgo -r -skip-package $(UT_PACKAGES_TO_SKIP) -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)
 
 .PHONY: ut-watch
 ut-watch: $(SRC_FILES) $(LIBBPF_A) $(BPF_APACHE_O_FILES)
 	@echo Watching go UTs for changes...
-	$(DOCKER_GO_BUILD) ginkgo watch -r -skip-package $(UT_PACKAGES_TO_SKIP) $(GINKGO_ARGS)
+	$(DOCKER_GO_BUILD) ginkgo watch -r -skip-package $(UT_PACKAGES_TO_SKIP) -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)
 
 .PHONY: bin/bpf.test
 bin/bpf.test: $(GENERATED_FILES) $(shell find bpf/ -name '*.go')

--- a/felix/fv/run-batches
+++ b/felix/fv/run-batches
@@ -20,7 +20,8 @@
 : ${FV_BINARY:=bin/calico-felix-amd64}
 : ${PRIVATE_KEY:=$(pwd)/private.key}
 : ${GINKGO_ARGS:=}
-: ${GINKGO_FOCUS:=.*}
+: ${FOCUS:=.*}
+: ${SKIP:=}
 
 mkdir -p cwlogs
 export FV_CWLOGDIR=$(pwd)/cwlogs
@@ -34,7 +35,8 @@ for batch in ${FV_BATCHES_TO_RUN}; do
       --ginkgo.seed 1 \
       --ginkgo.silence-skips \
       --ginkgo.slow-spec-threshold=${FV_SLOW_SPEC_THRESH} \
-      --ginkgo.focus="${GINKGO_FOCUS}" \
+      --ginkgo.skip="${SKIP}" \
+      --ginkgo.focus="${FOCUS}" \
       ${GINKGO_ARGS}
     status=$?
     echo "Test batch $batch completed with status $status"

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -26,14 +26,13 @@ clean:
 # Tests
 ###############################################################################
 
-WHAT?=.
-GINKGO_FOCUS?=.*
+WHAT?=./...
 
 .PHONY:ut
 ## Run the fast set of unit tests in a container.
 ut:
 	$(DOCKER_RUN) --privileged $(CALICO_BUILD) \
-		sh -c 'cd /go/src/$(PACKAGE_NAME) && go test ./...'
+		sh -c 'cd /go/src/$(PACKAGE_NAME) && go test $(WHAT)'
 
 fv:
 	$(DOCKER_RUN) $(CALICO_BUILD) \

--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -130,15 +130,16 @@ ut-cover:
 	./run-uts
 
 WHAT?=.
-GINKGO_FOCUS?=.*
-GINKGO_SKIP?=
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
 
 .PHONY:ut
 ## Run the fast set of unit tests in a container.
 ut:
 	mkdir -p report
 	$(DOCKER_RUN) --privileged $(CALICO_BUILD) \
-		sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=libcalico_go_ut.xml --output-dir=report/ -skip "\[Datastore\]" -focus="$(GINKGO_FOCUS)" $(WHAT)'
+		sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=libcalico_go_ut.xml --output-dir=report/ -skip "\[Datastore\]$${SKIP:+|$$SKIP}" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 .PHONY:fv
 ## Run functional tests against a real datastore in a container.
@@ -162,7 +163,7 @@ fv-fast:
 		-e CALICO_API_GROUP=$(CALICO_API_GROUP) \
 		-v $(KIND_KUBECONFIG):/kubeconfig.yaml \
 		--dns $(shell docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' coredns) \
-		$(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=libcalico_go_fv.xml --output-dir=report/ -skip "$(GINKGO_SKIP)" -focus "$(GINKGO_FOCUS).*\[Datastore\]|\[Datastore\].*$(GINKGO_FOCUS)" $(GINKGO_ARGS) $(WHAT)'
+		$(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=libcalico_go_fv.xml --output-dir=report/ -skip "$(SKIP)" -focus "$(FOCUS).*\[Datastore\]|\[Datastore\].*$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 # Create a kind cluster, and deploy some resources required for the libcalico-go tests.
 # TODO: Remove the need for this extra target, these should be created by the tests that need them.

--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -139,7 +139,7 @@ GINKGO_ARGS?=
 ut:
 	mkdir -p report
 	$(DOCKER_RUN) --privileged $(CALICO_BUILD) \
-		sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=libcalico_go_ut.xml --output-dir=report/ -skip "\[Datastore\]$${SKIP:+|$$SKIP}" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
+		sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=libcalico_go_ut.xml --output-dir=report/ -skip "\[Datastore\]$(if $(SKIP),|$(SKIP))" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 .PHONY:fv
 ## Run functional tests against a real datastore in a container.

--- a/node/Makefile
+++ b/node/Makefile
@@ -130,12 +130,10 @@ WINDOWS_ARCHIVE_FILES := \
 MICROSOFT_SDN_VERSION := 0d7593e5c8d4c2347079a7a6dbd9eb034ae19a44
 MICROSOFT_SDN_GITHUB_RAW_URL := https://raw.githubusercontent.com/microsoft/SDN/$(MICROSOFT_SDN_VERSION)
 
-# Variables used by the tests
-ST_TO_RUN?=tests/st/
-K8ST_TO_RUN?=tests/
-# Can exclude the slower tests with "-m 'not slow'"
-ST_OPTIONS?=
-
+# Variables used by the k8st tests
+K8ST_WHAT?=tests/
+K8ST_FOCUS?=
+K8ST_PYTEST_ARGS?=
 K8ST_REPORT_FILENAME ?= k8s-tests.xml
 
 # Filesystem of the node container that is checked in to this repository.
@@ -382,7 +380,7 @@ kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG)
 	    --net host \
 	${TEST_CONTAINER_NAME} \
 	    sh -c 'echo "container started.." && \
-	     cd /code/tests/k8st && pytest $(K8ST_TO_RUN) -v --junit-xml="/code/report/$(K8ST_REPORT_FILENAME)"'
+	     cd /code/tests/k8st && pytest $(K8ST_WHAT) -v $(if $(K8ST_FOCUS),-k "$(K8ST_FOCUS)") $(K8ST_PYTEST_ARGS) --junit-xml="/code/report/$(K8ST_REPORT_FILENAME)"'
 
 ###############################################################################
 # CI/CD

--- a/node/Makefile
+++ b/node/Makefile
@@ -130,10 +130,13 @@ WINDOWS_ARCHIVE_FILES := \
 MICROSOFT_SDN_VERSION := 0d7593e5c8d4c2347079a7a6dbd9eb034ae19a44
 MICROSOFT_SDN_GITHUB_RAW_URL := https://raw.githubusercontent.com/microsoft/SDN/$(MICROSOFT_SDN_VERSION)
 
-# Variables used by the k8st tests
-K8ST_WHAT?=tests/
-K8ST_FOCUS?=
-K8ST_PYTEST_ARGS?=
+# Variables used by tests
+WHAT?=.
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
+PYTEST_WHAT?=tests/
+PYTEST_ARGS?=
 K8ST_REPORT_FILENAME ?= k8s-tests.xml
 
 # Filesystem of the node container that is checked in to this repository.
@@ -304,11 +307,6 @@ WHAT=$(shell find . -name "*_test.go" | xargs dirname | sort -u)
 endif
 
 ## Run the ginkgo tests.
-WHAT?=.
-FOCUS?=.*
-SKIP?=
-GINKGO_ARGS?=
-
 ut fv: $(LIBBPF_A) run-k8s-apiserver
 	mkdir -p report
 	$(DOCKER_RUN) \
@@ -380,7 +378,7 @@ kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG)
 	    --net host \
 	${TEST_CONTAINER_NAME} \
 	    sh -c 'echo "container started.." && \
-	     cd /code/tests/k8st && pytest $(K8ST_WHAT) -v $(if $(K8ST_FOCUS),-k "$(K8ST_FOCUS)") $(K8ST_PYTEST_ARGS) --junit-xml="/code/report/$(K8ST_REPORT_FILENAME)"'
+	     cd /code/tests/k8st && pytest $(PYTEST_WHAT) -v $(if $(filter-out .*,$(FOCUS)),-k "$(FOCUS)") $(PYTEST_ARGS) --junit-xml="/code/report/$(K8ST_REPORT_FILENAME)"'
 
 ###############################################################################
 # CI/CD

--- a/node/Makefile
+++ b/node/Makefile
@@ -306,6 +306,11 @@ WHAT=$(shell find . -name "*_test.go" | xargs dirname | sort -u)
 endif
 
 ## Run the ginkgo tests.
+WHAT?=.
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
+
 ut fv: $(LIBBPF_A) run-k8s-apiserver
 	mkdir -p report
 	$(DOCKER_RUN) \
@@ -313,7 +318,7 @@ ut fv: $(LIBBPF_A) run-k8s-apiserver
 	-e KUBECONFIG=/go/src/github.com/projectcalico/calico/hack/test/certs/kubeconfig \
 	-e ETCD_ENDPOINTS=http://$(LOCAL_IP_ENV):2379 \
 	-e CALICO_API_GROUP=$(CALICO_API_GROUP) \
-	$(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=node_ut.xml --output-dir=report/ $(GINKGO_ARGS) .'
+	$(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r --junit-report=node_ut.xml --output-dir=report/ -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)'
 
 ###############################################################################
 # System tests

--- a/node/README.md
+++ b/node/README.md
@@ -64,26 +64,25 @@ For `k8s-test` Kubernetes tests, you will need to have `kubectl` setup on your m
 
 ## How can I run a subset of the tests?
 
-If you want to run tests for a specific package for more iterative development, you can filter down into a subset of tests using the following parameters:
-- For filtering `st` tests, use `ST_TO_RUN`
-- For filtering `k8s-test` tests, use `K8ST_TO_RUN`
+If you want to run tests for a specific package for more iterative development, you can filter down into a subset of the `k8s-test` tests using the following parameters:
+- `PYTEST_WHAT` - path to test files/directories (default: `tests/`)
+- `FOCUS` - pytest `-k` keyword expression to filter tests
+- `PYTEST_ARGS` - additional pytest arguments
 
-For example, the following only runs tests within the `bgp` subfolder of the `st` category:
+For example, the following only runs tests from a single file:
 ```
-make st ST_TO_RUN="tests/st/bgp/"
-```
-
-To only run tests from a single file (e.g. `test_bgp.py`), use the following:
-```
-make st ST_TO_RUN="tests/st/bgp/test_bgp.py"
+make kind-k8st-run-test PYTEST_WHAT="tests/test_bgp_advert.py"
 ```
 
-To only run a single test within a test file use the below syntax:
+To filter by keyword expression (pytest `-k`):
 ```
-make st ST_TO_RUN="tests/st/bgp/test_bgp.py:TestReadiness.test_readiness_multihost"
+make kind-k8st-run-test FOCUS="bgp"
 ```
 
-The above examples should apply in the same fashion if you are using `K8ST_TO_RUN` instead for the `k8s-test` category.
+To exclude slow tests:
+```
+make kind-k8st-run-test PYTEST_ARGS="-m 'not slow'"
+```
 
 ## How do I debug tests?
 There are a number of possible avenues you can use to debug failing tests.

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -135,6 +135,11 @@ $(TYPHA_IMAGE): $(TYPHA_CONTAINER_MARKER)
 ###############################################################################
 # Unit Tests
 ###############################################################################
+WHAT?=.
+FOCUS?=.*
+SKIP?=
+GINKGO_ARGS?=
+
 .PHONY: ut
 ut combined.coverprofile: $(SRC_FILES)
 	@echo Running Go UTs.
@@ -199,12 +204,12 @@ release-publish-latest: release-prereqs
 .PHONY: ut-no-cover
 ut-no-cover: $(SRC_FILES)
 	@echo Running Go UTs without coverage.
-	$(DOCKER_RUN) $(CALICO_BUILD) ginkgo -r
+	$(DOCKER_RUN) $(CALICO_BUILD) ginkgo -r -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)
 
 .PHONY: ut-watch
 ut-watch: $(SRC_FILES)
 	@echo Watching go UTs for changes...
-	$(DOCKER_RUN) $(CALICO_BUILD) ginkgo watch -r
+	$(DOCKER_RUN) $(CALICO_BUILD) ginkgo watch -r -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)
 
 # Launch a browser with Go coverage stats for the whole project.
 .PHONY: cover-browser

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -143,7 +143,7 @@ GINKGO_ARGS?=
 .PHONY: ut
 ut combined.coverprofile: $(SRC_FILES)
 	@echo Running Go UTs.
-	$(DOCKER_RUN) $(CALICO_BUILD) ./utils/run-coverage
+	$(DOCKER_RUN) $(CALICO_BUILD) ./utils/run-coverage -skip="$(SKIP)" -focus="$(FOCUS)" $(GINKGO_ARGS) $(WHAT)
 
 ###############################################################################
 # CI/CD

--- a/typha/utils/run-coverage
+++ b/typha/utils/run-coverage
@@ -21,7 +21,7 @@ test_pkgs=$(go list -buildvcs=false -f '{{ if .TestGoFiles | or .XTestGoFiles }}
 test ! -z "$test_pkgs"
 echo "Packages with tests: $test_pkgs"
 
-ginkgo -cover -covermode=count -coverpkg=${go_dirs} ${GINKGO_ARGS} -r
+ginkgo -cover -covermode=count -coverpkg=${go_dirs} -r "$@"
 gocovmerge $(find . -name 'coverprofile.out') > combined.coverprofile
 
 # Print the coverage.  We use sed to remove the verbose prefix and trim down


### PR DESCRIPTION
Supersedes #11773 (rebased on master to clean up the commit history).

Standardizes environment variable inputs for ginkgo test targets (ut, fv, st) across all component Makefiles to use consistent parameter names:

- `FOCUS` - ginkgo focus string (default: `.*`)
- `SKIP` - ginkgo skip string (default: empty)
- `GINKGO_ARGS` - additional ginkgo arguments (default: empty)
- `WHAT` - packages to test (default varies by component)

Components that use `gotestsum` (app-policy) or plain `go test` (hack) only get `WHAT` since the ginkgo-specific params don't apply.

Updated Makefiles: api, app-policy, calicoctl, cni-plugin, felix, hack, libcalico-go, typha. Also updates `felix/fv/run-batches` and the Semaphore CI config to use the new parameter names.

```
# Examples
make -C felix fv FOCUS="BPF"
make -C felix ut FOCUS="Wireguard"
make -C libcalico-go ut SKIP="SlowTest"
make -C felix ut GINKGO_ARGS="-ginkgo.v"
make -C api ut WHAT="./pkg/client"
```