### PR TITLE
Fix Felix FV flakes from node creation retry and NAT map polling

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2412,11 +2412,11 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						} else {
 							deletedSvcNATKey = nat.NewNATKey(net.ParseIP(clusterIP), port, numericProto)
 						}
-						Eventually(func() bool {
+						Eventually(func(g Gomega) {
 							natmaps, _, _ := dumpNATMapsAny(familyInt, tc.Felixes[0])
-							_, ok := natmaps[deletedSvcNATKey]
-							return ok
-						}, "30s", "1s").Should(BeFalse(), "first service's NAT key should have been removed")
+							g.Expect(natmaps).NotTo(BeEmpty(), "NAT map dump returned no entries; dump may have failed")
+							g.Expect(natmaps).NotTo(HaveKey(deletedSvcNATKey), "first service's NAT key should have been removed")
+						}, "30s", "1s").Should(Succeed())
 
 						By("And still having connectivity...")
 						cc.ExpectSome(externalClient, TargetIP(ip[0]), port)

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -832,7 +832,7 @@ func (kds *K8sDatastoreInfra) AddNode(felix *Felix, v4CIDR *net.IPNet, v6CIDR *n
 	log.WithField("nodeIn", nodeIn).Debug("Node defined")
 	var nodeOut *v1.Node
 	var err error
-	delay := 1 * time.Second
+	delay := 3 * time.Second
 	for i := range 5 {
 		nodeOut, err = kds.K8sClient.CoreV1().Nodes().Create(context.Background(), nodeIn, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
Follow-up to #12022 which reduced Felix FV test runtime. Two changes in that PR introduced potential flakes:

**Node creation retry delay (likely cause of 7 FV failures on #12016).** The initial retry delay for node creation was reduced from 3s to 1s when switching to exponential backoff. Under CI load, the transient conditions that trigger retries (e.g., API server not yet ready for the node object) typically need ~3s to resolve, so the shorter first attempt fails more often and can exhaust retries. 5 of 7 failures were in `BeforeEach` setup, which is where node creation happens. Restored the initial delay to 3s while keeping the backoff pattern.

**NAT map polling in external IP overlap test (defensive fix).** The `Eventually` that polls for a deleted service's NAT key used `dumpNATMapsAny` with all return errors discarded (`_, _, _`). If the map dump fails transiently (e.g., the `Expect` inside `dumpBPFMap` panics, which Gomega's `Eventually` catches), the callback returns the zero value `false` — which is exactly what `Should(BeFalse())` expects. So a transient dump failure looks like the key was successfully removed. Switched to `Eventually(func(g Gomega))` style with explicit checks that the map is non-empty before asserting the key is gone.