### PR TITLE
Fix libbpf clone failure in git worktrees

### DIFF
--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -126,11 +126,11 @@ $(LIBBPF_FILE_CREATED):
 ifeq ("$(wildcard ./$(LIBBPF_DIR))", "")
 	$(info "Directory does not exist.")
 	@echo "Directory does not exist."
-	git clone --depth 1 --single-branch https://github.com/libbpf/libbpf.git
+	env -u GIT_DIR -u GIT_WORK_TREE git clone --depth 1 --single-branch https://github.com/libbpf/libbpf.git
 endif
 	rm -rf .libbpf-*
 	cd $(LIBBPF_DIR) && \
-		git fetch --tags && git checkout $(LIBBPF_VERSION)
+		env -u GIT_DIR -u GIT_WORK_TREE git fetch --tags && env -u GIT_DIR -u GIT_WORK_TREE git checkout $(LIBBPF_VERSION)
 	touch $(LIBBPF_FILE_CREATED)
 
 


### PR DESCRIPTION
The GIT_DIR and GIT_WORK_TREE env vars set by lib.Makefile for worktree support leak into the libbpf git commands, causing 'working tree already exists' errors. Unset them for the clone/fetch/checkout operations.