### PR TITLE
Parallelize kind-build-images for faster kind-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,8 @@ CLUSTER_ROUTING ?= BIRD
 
 ## Build all test images, create a kind cluster, and deploy Calico on it.
 .PHONY: kind-up
-kind-up: kind-build-images
+kind-up:
+	$(MAKE) -j$(shell nproc) kind-build-images
 	$(MAKE) kind-cluster-create CALICO_API_GROUP=$(KIND_CALICO_API_GROUP)
 	$(MAKE) kind-deploy
 

--- a/hack/test/kind/infra/.gitignore
+++ b/hack/test/kind/infra/.gitignore
@@ -1,0 +1,2 @@
+# Cached operator clone for build-operator.sh
+operator/

--- a/hack/test/kind/infra/build-operator.sh
+++ b/hack/test/kind/infra/build-operator.sh
@@ -2,21 +2,35 @@
 
 # This script produces a custom operator build that is used
 # in the ST and e2e tests in this repo.
+#
+# It caches the cloned operator repo across runs. Only the actual Go
+# compile and Docker image build run on subsequent invocations.
 
-# Clone the repository if needed.
 set -e
 REPO=${REPO:-tigera/operator}
 BRANCH=${BRANCH:-master}
 
-rm -rf operator/
-echo "Cloning https://github.com/${REPO} @ ${BRANCH}"
-git clone --depth=1 https://github.com/${REPO} -b ${BRANCH} operator
+# Reuse the existing clone if branch matches, otherwise start fresh.
+if [ -d operator/.git ]; then
+  existing_branch=$(git -C operator rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [ "$existing_branch" = "$BRANCH" ]; then
+    echo "Reusing cached operator clone (branch: ${BRANCH}), pulling latest..."
+    git -C operator fetch --depth=1 origin ${BRANCH}
+    git -C operator reset --hard origin/${BRANCH}
+  else
+    echo "Branch changed (${existing_branch} -> ${BRANCH}), re-cloning..."
+    rm -rf operator/
+    git clone --depth=1 https://github.com/${REPO} -b ${BRANCH} operator
+  fi
+else
+  echo "Cloning https://github.com/${REPO} @ ${BRANCH}"
+  git clone --depth=1 https://github.com/${REPO} -b ${BRANCH} operator
+fi
 
-# Modify the versions that are in-use to match our locally built images.
 pushd operator
 
 if [ -n "$COMMIT" ]; then
-  # If the latest operator has issues, fetch a known working commit as a workaround."
+  # If the latest operator has issues, fetch a known working commit as a workaround.
   echo "Fetch commit $COMMIT"
   git fetch origin $COMMIT
   git checkout $COMMIT
@@ -32,7 +46,6 @@ find . -name '*.go' | xargs sed -i 's/PullIfNotPresent/PullNever/g'
 make image
 docker tag tigera/operator:latest docker.io/tigera/operator:test-build
 
-# Clean up after ourselves.
 popd
-rm -rf operator/
+# Don't rm -rf operator/ -- keep it cached for next run.
 set +e

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1622,9 +1622,10 @@ $(REPO_ROOT)/whisker/.image.created-$(ARCH):
 $(REPO_ROOT)/whisker-backend/.image.created-$(ARCH): $(call local-deps-go-files,whisker-backend)
 	$(MAKE) -C $(REPO_ROOT)/whisker-backend image
 
-# Operator is built from a separate repo/branch and depends on all other
-# images being built first.
-$(REPO_ROOT)/.stamp.operator: $(KIND_IMAGE_MARKERS) $(KIND_INFRA_DIR)/calico_versions.yml
+# Operator is built from a separate repo/branch. It only needs
+# calico_versions.yml (a static file with version strings), not the
+# actual built images, so it can run in parallel with component builds.
+$(REPO_ROOT)/.stamp.operator: $(KIND_INFRA_DIR)/calico_versions.yml
 	cd $(KIND_INFRA_DIR) && BRANCH=$(OPERATOR_BRANCH) ./build-operator.sh
 	touch $@
 
@@ -1661,7 +1662,8 @@ kind-deploy:
 # Rebuild any images whose source files have changed, load onto the kind
 # cluster, and restart pods.
 .PHONY: kind-reload
-kind-reload: kind-build-images
+kind-reload:
+	$(MAKE) -j$(shell nproc) kind-build-images
 	KIND=$(KIND) KIND_NAME=$(KIND_NAME) $(REPO_ROOT)/hack/test/kind/load_images.sh $(KIND_IMAGES)
 	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) delete pods -n calico-system --all
 	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f $(KIND_INFRA_DIR)/calicoctl.yaml


### PR DESCRIPTION
Build component images concurrently during `kind-up` and `kind-reload` by invoking `kind-build-images` with `make -j$(nproc)` instead of sequentially. The stamp file targets in `lib.Makefile` are independent of each other, so they run safely in parallel.

The operator build no longer depends on all image markers -- it only needs `calico_versions.yml` (a static file with version strings), so it builds in parallel with everything else instead of waiting for all component images to finish first.

The operator clone is also cached across runs to skip the `git clone` on subsequent builds.

```release-note
None
```