### PR TITLE
Use install-package instead of apt-get for prologue tool installs

### DIFF
--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -42,8 +42,7 @@ RANDOM_TOKEN2=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 4 || true)
 echo "[INFO] random tokens: ${RANDOM_TOKEN1} ${RANDOM_TOKEN2}"
 
 echo "[INFO] Installing jq..."
-sudo apt-get -o Acquire::Retries=5 update  -y
-sudo apt-get install -o Acquire::Retries=5 jq -y
+install-package --skip-update jq
 
 echo "[INFO] exporting default env vars..."
 export SEMAPHORE_PIPELINE_STARTED_AT=$(date +%s)
@@ -149,11 +148,11 @@ azure_cli_cmd="$azure_cli_cmd; az login --service-principal -u ${AZ_SP_ID} -p ${
 if [[ $PROVISIONER =~ ^azr-.* ]]; then eval "$azure_cli_cmd"; fi
 
 install_tools_cmd="echo \"[INFO] installing addtional tools for c1...\""
-install_tools_cmd="$install_tools_cmd; echo \"[INFO] Installing unzip...\" && sudo NEEDRESTART_SUSPEND=1 NEEDRESTART_MODE=a apt-get install -o Acquire::Retries=5 unzip -y && sudo needrestart -r a"
+install_tools_cmd="$install_tools_cmd; echo \"[INFO] Installing unzip...\" && install-package --skip-update unzip"
 install_tools_cmd="$install_tools_cmd; echo \"[INFO] Installing requests...\" && pip3 install --retries=20 --upgrade requests"
 if [[ $SEMAPHORE_AGENT_MACHINE_TYPE =~ ^c1-.* ]]; then eval "$install_tools_cmd"; fi
 
-if [[ "$CREATE_WINDOWS_NODES" == "true" ]]; then echo "[INFO] Installing putty-tools..."; sudo NEEDRESTART_SUSPEND=1 NEEDRESTART_MODE=a apt-get install -o Acquire::Retries=5 -y putty-tools && sudo needrestart -r a; fi
+if [[ "$CREATE_WINDOWS_NODES" == "true" ]]; then echo "[INFO] Installing putty-tools..."; install-package --skip-update putty-tools; fi
 
 echo "[INFO] Installing Banzai CLI..."
 [[ -n "${BZ_VERSION}" ]] && export BZ_RELEASE=tags/${BZ_VERSION} || export BZ_RELEASE=latest


### PR DESCRIPTION
Replace apt-get with Semaphore's install-package --skip-update for installing jq, unzip, and putty-tools in global_prologue.sh. This avoids intermittent DNS resolution failures when apt mirrors (de.archive.ubuntu.com) are unreachable on Semaphore agents.

python3-pip and google-cloud-cli cannot be converted because their dependency trees are not in the Semaphore package cache.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
NA
```
