### PR TITLE
Fix race in node GPL source tarball under parallel builds

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -284,10 +284,14 @@ $(BIRD_SOURCE): .bird-source.created
 
 # include GPL felix code in the image.
 $(FELIX_GPL_SOURCE): .felix-gpl-source.created
-.felix-gpl-source.created: $(shell find ../felix/bpf-gpl -type f)
+.felix-gpl-source.created: $(shell find ../felix/bpf-gpl -type f -not -name '*.ll' -not -name '*.o' -not -name '*.d' -not -path '*/libbpf/*')
 	rm -rf filesystem/included-source/felix*
 	mkdir -p filesystem/included-source/
-	tar cf $(FELIX_GPL_SOURCE) ../felix/bpf-gpl --use-compress-program="xz -T0"
+	tar cf $(FELIX_GPL_SOURCE) \
+		--exclude='*.ll' --exclude='*.o' --exclude='*.d' \
+		--exclude='libbpf' \
+		--use-compress-program="xz -T0" \
+		../felix/bpf-gpl
 	touch $@
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- Exclude BPF build artifacts (*.ll, *.o, *.d) and the cloned libbpf directory from the GPL source tarball in the node image build
- Also exclude them from the `find`-based Make dependency so build artifacts don't trigger unnecessary rebuilds

The BPF compilation creates transient `.ll` files in `felix/bpf-gpl/` that get deleted after compiling to `.o`. Under parallel builds (`-j`), `tar` races with the BPF build and fails when files appear/disappear mid-archive. These are compiled outputs, not source, so they don't belong in the GPL source bundle anyway.

## Test plan
- [ ] Verify node image builds correctly with `make -C node image`
- [ ] Verify parallel `make -j kind-build-images` no longer races on the tarball step