### PR TITLE
Remove flaky host-side veth MAC assertion in CNI test

### DIFF
--- a/cni-plugin/tests/calico_cni_test.go
+++ b/cni-plugin/tests/calico_cni_test.go
@@ -140,7 +140,9 @@ var _ = Describe("CalicoCni", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hostVeth.Attrs().Flags.String()).Should(ContainSubstring("up"))
 			Expect(hostVeth.Attrs().MTU).Should(Equal(1500))
-			Expect(hostVeth.Attrs().HardwareAddr.String()).Should(Equal("ee:ee:ee:ee:ee:ee"))
+			// Note: we don't assert the host-side MAC here. The CNI plugin sets it to
+			// ee:ee:ee:ee:ee:ee but some kernel versions reset veth MACs asynchronously
+			// (e.g., during IPv6 link-local address setup), causing flaky test failures.
 
 			// Assert hostVeth sysctl values are set to what we expect for IPv4.
 			err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostVethName), "1")


### PR DESCRIPTION
The CNI unit test asserts that the host-side veth MAC is ee:ee:ee:ee:ee:ee, but
some kernel versions reset veth MACs asynchronously (e.g., during IPv6 link-local
address setup). By the time the test reads the interface, the MAC may have changed
even though the CNI plugin successfully set it.

The production code already handles this gracefully -- it retries with readback
verification, and falls back to the kernel-generated MAC if the set doesn't stick.
No reason for the test to assert on something the kernel doesn't guarantee.