### PR TITLE
Fix operator RBAC for tiered network policy management

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -526,7 +526,7 @@ rules:
       - update
       - delete
 {{- end }}
-  # For Tiers controller, the operator needs to read/watch access to NetworkPolicies and GlobalNetworkPolicies.
+  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
@@ -536,6 +536,9 @@ rules:
       - get
       - list
       - watch
+      - create
+      - update
+      - delete
   # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -503,7 +503,7 @@ rules:
       - list
       - watch
       - delete
-  # For Tiers controller, the operator needs to read/watch access to NetworkPolicies and GlobalNetworkPolicies.
+  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
@@ -513,6 +513,9 @@ rules:
       - get
       - list
       - watch
+      - create
+      - update
+      - delete
   # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -574,7 +574,7 @@ rules:
       - list
       - watch
       - delete
-  # For Tiers controller, the operator needs to read/watch access to NetworkPolicies and GlobalNetworkPolicies.
+  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
@@ -584,6 +584,9 @@ rules:
       - get
       - list
       - watch
+      - create
+      - update
+      - delete
   # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -482,7 +482,7 @@ rules:
       - create
       - update
       - delete
-  # For Tiers controller, the operator needs to read/watch access to NetworkPolicies and GlobalNetworkPolicies.
+  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
@@ -492,6 +492,9 @@ rules:
       - get
       - list
       - watch
+      - create
+      - update
+      - delete
   # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org


### PR DESCRIPTION
## Summary
- The operator's ClusterRole was missing create/update/delete permissions for `networkpolicies` and `globalnetworkpolicies` in the `projectcalico.org` API group.
- With tiered policy enabled, the webhook intercepts policy creates and checks RBAC on the `projectcalico.org` group directly, causing the operator to get denied when managing calico-system network policies.
- This caused multiple TigeraStatus resources (calico, goldmane, tiers, whisker, apiserver) to go Degraded shortly after initial availability.