### PR TITLE
Fix apiserver name in RBAC comments and add patch verb

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -538,8 +538,9 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
-  # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
+  # For tiered network policy actions, calico-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org
     resourceNames:
@@ -563,7 +564,7 @@ rules:
       - list
       - watch
       - get
-  # For tiered network policy actions, tigera-apiserver requires get authorization on the associated tier.
+  # For tiered network policy actions, calico-apiserver requires get authorization on the associated tier.
   - apiGroups:
       - projectcalico.org
     resourceNames:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -515,8 +515,9 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
-  # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
+  # For tiered network policy actions, calico-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org
     resourceNames:
@@ -540,7 +541,7 @@ rules:
       - list
       - watch
       - get
-  # For tiered network policy actions, tigera-apiserver requires get authorization on the associated tier.
+  # For tiered network policy actions, calico-apiserver requires get authorization on the associated tier.
   - apiGroups:
       - projectcalico.org
     resourceNames:

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -586,8 +586,9 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
-  # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
+  # For tiered network policy actions, calico-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org
     resourceNames:
@@ -611,7 +612,7 @@ rules:
       - list
       - watch
       - get
-  # For tiered network policy actions, tigera-apiserver requires get authorization on the associated tier.
+  # For tiered network policy actions, calico-apiserver requires get authorization on the associated tier.
   - apiGroups:
       - projectcalico.org
     resourceNames:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -494,8 +494,9 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
-  # For tiered network policy actions, tigera-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
+  # For tiered network policy actions, calico-apiserver requires that we authorize the operator for the tier.networkpolicies and tier.globalnetworkpolicies pseudo-kinds.
   - apiGroups:
       - projectcalico.org
     resourceNames:
@@ -519,7 +520,7 @@ rules:
       - list
       - watch
       - get
-  # For tiered network policy actions, tigera-apiserver requires get authorization on the associated tier.
+  # For tiered network policy actions, calico-apiserver requires get authorization on the associated tier.
   - apiGroups:
       - projectcalico.org
     resourceNames:


### PR DESCRIPTION
Follow-up to #12083. Fixes two issues in the operator ClusterRole:

- The comments incorrectly reference "tigera-apiserver" — the component is called "calico-apiserver" in both OSS and enterprise.
- Adds the `patch` verb to the networkpolicies/globalnetworkpolicies RBAC rule alongside the existing create/update/delete.