### PR TITLE
Use f1-standard-2 for OpenShift jobs to fix disk-full failures

### DIFF
--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -40,6 +40,10 @@ blocks:
   - name: Openshift OCP
     dependencies: []
     task:
+      agent:
+        machine:
+          type: f1-standard-2
+          os_image: ubuntu2204
       jobs:
         - name: hashrelease
           execution_time_limit:

--- a/.semaphore/end-to-end/pipelines/patch-verification.yml
+++ b/.semaphore/end-to-end/pipelines/patch-verification.yml
@@ -348,6 +348,10 @@ blocks:
             hours: 6
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          agent:
+            machine:
+              type: f1-standard-2
+              os_image: ubuntu2204
           env_vars:
             - name: OPENSHIFT_VERSION
               value: "4.18.17"

--- a/.semaphore/end-to-end/pipelines/upgrade.yml
+++ b/.semaphore/end-to-end/pipelines/upgrade.yml
@@ -133,6 +133,10 @@ blocks:
             hours: 4
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          agent:
+            machine:
+              type: f1-standard-2
+              os_image: ubuntu2204
           env_vars:
             - name: PROVISIONER
               value: aws-openshift

--- a/.semaphore/end-to-end/pipelines/vpp.yml
+++ b/.semaphore/end-to-end/pipelines/vpp.yml
@@ -98,6 +98,10 @@ blocks:
             hours: 8
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          agent:
+            machine:
+              type: f1-standard-2
+              os_image: ubuntu2204
           matrix:
             - env_var: PROVISIONER
               values:
@@ -233,6 +237,10 @@ blocks:
             hours: 6
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          agent:
+            machine:
+              type: f1-standard-2
+              os_image: ubuntu2204
           matrix:
             - env_var: PROVISIONER
               values:


### PR DESCRIPTION
OCP jobs running on c1-standard-1 (the pipeline default) fail with "no space left on device" when the OpenShift installer extracts large binaries like cluster-api/kube-apiserver. The c1-standard-1 machine type has very limited disk (~1GB RAM, minimal disk).

Switch all OpenShift/OCP jobs to f1-standard-2 (8GB RAM, 45GB disk), consistent with certification.yml which already uses this machine type for its OCP jobs.

Affected pipelines:
- iptables.yml: Openshift OCP block
- upgrade.yml: Openshift - 4.16 job
- patch-verification.yml: Openshift OCP job
- vpp.yml: VPP-openshift and Iptables (Openshift) jobs

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
NA
```
