### PR TITLE
Add e2e tests on GCP kubeadm promotion for local binary testing

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -581,7 +581,9 @@ blocks:
       secrets:
         - name: banzai-secrets
       prologue:
-        commands_file: .semaphore/end-to-end/scripts/global_prologue.sh
+        commands:
+          - checkout
+          - source .semaphore/end-to-end/scripts/global_prologue.sh
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -581,7 +581,9 @@ blocks:
       secrets:
         - name: banzai-secrets
       prologue:
-        commands_file: .semaphore/end-to-end/scripts/global_prologue.sh
+        commands:
+          - checkout
+          - source .semaphore/end-to-end/scripts/global_prologue.sh
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
@@ -7,7 +7,9 @@
     secrets:
       - name: banzai-secrets
     prologue:
-      commands_file: .semaphore/end-to-end/scripts/global_prologue.sh
+      commands:
+        - checkout
+        - source .semaphore/end-to-end/scripts/global_prologue.sh
     epilogue:
       always:
         commands:


### PR DESCRIPTION
Add a new Semaphore pipeline that runs e2e tests against a gcp-kubeadm cluster using the locally-built e2e binary (via RUN_LOCAL_TESTS). This triggers automatically when files in the e2e/ directory change.

The pipeline provisions a gcp-kubeadm cluster via banzai, builds the e2e binary from the monorepo checkout, and runs sig-calico Conformance tests with the CalicoBPF dataplane using parallel ginkgo execution.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
