### PR TITLE
Add make get-operator-crds to ci-preflight-checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ ci-preflight-checks:
 	$(MAKE) check-dockerfiles
 	$(MAKE) check-language
 	$(MAKE) generate
+	$(MAKE) get-operator-crds
 	$(MAKE) fix-all
 	$(MAKE) check-ocp-no-crds
 	$(MAKE) check-dirty

--- a/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
@@ -6639,8 +6639,10 @@ spec:
                     type: string
                 type: object
               nonPrivileged:
-                description: NonPrivileged configures Calico to be run in non-privileged
-                  containers as non-root users where possible.
+                description: |-
+                  Deprecated. NonPrivileged is deprecated and will be removed from the API in a future release.
+                  Enabling this field is not supported and will cause errors.
+                  NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.
                 type: string
               proxy:
                 description: |-
@@ -15090,8 +15092,10 @@ spec:
                         type: string
                     type: object
                   nonPrivileged:
-                    description: NonPrivileged configures Calico to be run in non-privileged
-                      containers as non-root users where possible.
+                    description: |-
+                      Deprecated. NonPrivileged is deprecated and will be removed from the API in a future release.
+                      Enabling this field is not supported and will cause errors.
+                      NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.
                     type: string
                   proxy:
                     description: |-

--- a/charts/tigera-operator/crds/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_tigerastatuses_crd.yaml
@@ -30,6 +30,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Available')].lastTransitionTime
       name: Since
       type: date
+    - description: Error message when the component is degraded.
+      jsonPath: .status.conditions[?(@.type=='Degraded')].message
+      name: Message
+      type: string
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Add a get-operator-crds to make ci-preflight-checks. This was causing issues with hashreleases where during PR we did not check for the generated files, but that target was run during hashrelease job. This would fail hashrelease as the files were marked as dirty
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
