### PR TITLE
Add workflow to sync operator CRDs hourly

### DIFF
--- a/.github/workflows/sync-operator-crds.yml
+++ b/.github/workflows/sync-operator-crds.yml
@@ -7,10 +7,6 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 * * * *'  # every hour
   workflow_dispatch: {}
 
-concurrency:
-  group: sync-operator-crds-${{ matrix.branch }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
   pull-requests: write
@@ -18,6 +14,9 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    concurrency:
+      group: sync-operator-crds-${{ matrix.branch }}
+      cancel-in-progress: true
     strategy:
       matrix:
         branch: [master, release-v3.31, release-v3.30]


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs hourly to pull operator CRD files from `tigera/operator` master into our Helm charts and regenerate manifests. If anything changed, it automatically creates or updates a PR via `peter-evans/create-pull-request`.

This keeps the operator CRDs in our charts in sync without manual intervention. The workflow also has a `workflow_dispatch` trigger for manual runs.