### PR TITLE
Force deterministic ordering in manifests/generate.sh

### DIFF
--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 # This script updates the manifests in this directory using helm.
 # Values files for the manifests in this directory can be found in
 # ../calico/charts/values.

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -21,37 +21,6 @@ metadata:
     name: tigera-operator
     openshift.io/run-level: "0"
 ---
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: tigera-operator-secrets
-  namespace: tigera-operator
-  labels:
-    k8s-app: tigera-operator
-subjects:
-  - kind: ServiceAccount
-    name: tigera-operator
-    namespace: tigera-operator
-roleRef:
-  kind: ClusterRole
-  name: tigera-operator-secrets
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: tigera-operator
-  labels:
-    k8s-app: tigera-operator
-subjects:
-  - kind: ServiceAccount
-    name: tigera-operator
-    namespace: tigera-operator
-roleRef:
-  kind: ClusterRole
-  name: tigera-operator
-  apiGroup: rbac.authorization.k8s.io
----
 # Permissions required to manipulate operator secrets for a Calico cluster.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -730,6 +699,37 @@ rules:
       - update
     resourceNames:
       - istiod
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tigera-operator-secrets
+  namespace: tigera-operator
+  labels:
+    k8s-app: tigera-operator
+subjects:
+  - kind: ServiceAccount
+    name: tigera-operator
+    namespace: tigera-operator
+roleRef:
+  kind: ClusterRole
+  name: tigera-operator-secrets
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tigera-operator
+  labels:
+    k8s-app: tigera-operator
+subjects:
+  - kind: ServiceAccount
+    name: tigera-operator
+    namespace: tigera-operator
+roleRef:
+  kind: ClusterRole
+  name: tigera-operator
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
LC_ALL is an environment variable that overrides all other locale settings (LANG, LC_COLLATE, etc.). In this context, it matters because it directly controls how the shell sorts strings, including the output of ls.


  Why the ordering was non-deterministic:
  In the manifests/generate.sh script, files were being collected using ls ocp.


   1. Standard/POSIX Locale (C): Sorts strictly by byte value (ASCII). Under this locale, 02-role- comes before 02-rolebinding- because the hyphen - (ASCII 45) is compared against the b in binding (ASCII 98).
   2. Modern Locales (e.g., en_US.UTF-8): Use more complex "natural" sorting rules. These often ignore certain punctuation or treat case differently. In some of these locales, rolebinding is sorted before role because the collation logic groups similar
      words together regardless of the hyphens.


  The Impact:
  Because different developers (and different CI runners) have different default locales, the ls command was returning the files in different orders. Since the script appends these files into a single manifest (tigera-operator-ocp-upgrade.yaml), the
  final resource order would change depending on who ran the script.