### PR TITLE
Run get-operator-crds before dirty check

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -337,6 +337,7 @@ blocks:
             - make -C libcalico-go gen-files
             - make -C felix gen-files
             - make -C goldmane gen-files
+            - make get-operator-crds
             - make gen-manifests
             - make fix-changed
             - make check-ocp-no-crds

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -337,6 +337,7 @@ blocks:
             - make -C libcalico-go gen-files
             - make -C felix gen-files
             - make -C goldmane gen-files
+            - make get-operator-crds
             - make gen-manifests
             - make fix-changed
             - make check-ocp-no-crds

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -106,6 +106,7 @@
           - make -C libcalico-go gen-files
           - make -C felix gen-files
           - make -C goldmane gen-files
+          - make get-operator-crds
           - make gen-manifests
           - make fix-changed
           - make check-ocp-no-crds


### PR DESCRIPTION
The hashrelease stage runs a check to make sure the operator CRDs are up to date. We should run this at the start of the build to fail fast.

**Release note:**
```release-note
TBD
```
