### PR TITLE
Make publishing images more resilient to transient external registry issues 

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1031,41 +1031,42 @@ ifeq ($(findstring quay.io,$(REGISTRY)),quay.io)
 	)
 endif
 
+# retry_docker_cmd retries a docker command up to a specified number of times.
+# Usage: $(call retry_docker_cmd,<description>,<docker command>,<max retries>,<retry delay>)
+define retry_docker_cmd
+	i=1; \
+	while [ $$i -le $(3) ]; do \
+		$(2) && break; \
+		echo "WARNING: $(1) failed (attempt $$i/$(3)), retrying in $(4)s..."; \
+		if [ $$i -eq $(3) ]; then exit 1; fi; \
+		sleep $(4); \
+		i=$$((i + 1)); \
+	done
+endef
+
+# Configuration options for retrying docker commands 
+MANIFEST_RETRIES ?= 5
+MANIFEST_RETRY_DELAY ?= 5
+
 # push-image-arch-to-registry-% pushes the build / arch image specified by $* and BUILD_IMAGE to the registry
 # specified by REGISTRY.
 push-image-arch-to-registry-%:
 # If the registry we want to push to doesn't not support manifests don't push the ARCH image.
-	$(DOCKER) push --quiet $(call filter-registry,$(REGISTRY))$(BUILD_IMAGE):$(IMAGETAG)-$*
+	$(call retry_docker_cmd,docker push with quiet flag,$(DOCKER) push --quiet $(call filter-registry,$(REGISTRY))$(BUILD_IMAGE):$(IMAGETAG)-$*,$(MANIFEST_RETRIES),$(MANIFEST_RETRY_DELAY))
 	$(if $(filter $*,amd64),\
-		$(DOCKER) push $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG),\
+		$(call retry_docker_cmd,docker push,$(DOCKER) push $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG),$(MANIFEST_RETRIES),$(MANIFEST_RETRY_DELAY))\
 		$(NOECHO) $(NOOP)\
 	)
 
 # push multi-arch manifest where supported.
-MANIFEST_RETRIES ?= 5
-MANIFEST_RETRY_DELAY ?= 5
 push-manifests: var-require-all-IMAGETAG  $(addprefix sub-manifest-,$(call escapefs,$(PUSH_MANIFEST_IMAGES)))
 sub-manifest-%:
 	@if [ -z "$(MANIFEST_RETRIES)" ] || ! printf '%s\n' "$(MANIFEST_RETRIES)" | grep -Eq '^[0-9]+$$' || [ "$(MANIFEST_RETRIES)" -lt 1 ]; then \
 		echo "ERROR: MANIFEST_RETRIES must be a positive integer, got '$(MANIFEST_RETRIES)'"; \
 		exit 1; \
 	fi
-	i=1; \
-	while [ $$i -le $(MANIFEST_RETRIES) ]; do \
-		$(DOCKER) manifest create $(call unescapefs,$*):$(IMAGETAG) $(addprefix --amend ,$(addprefix $(call unescapefs,$*):$(IMAGETAG)-,$(VALIDARCHES))) && break; \
-		echo "WARNING: docker manifest create failed (attempt $$i/$(MANIFEST_RETRIES)), retrying in $(MANIFEST_RETRY_DELAY)s..."; \
-		if [ $$i -eq $(MANIFEST_RETRIES) ]; then exit 1; fi; \
-		sleep $(MANIFEST_RETRY_DELAY); \
-		i=$$((i + 1)); \
-	done
-	i=1; \
-	while [ $$i -le $(MANIFEST_RETRIES) ]; do \
-		$(DOCKER) manifest push --purge $(call unescapefs,$*):$(IMAGETAG) && break; \
-		echo "WARNING: docker manifest push failed (attempt $$i/$(MANIFEST_RETRIES)), retrying in $(MANIFEST_RETRY_DELAY)s..."; \
-		if [ $$i -eq $(MANIFEST_RETRIES) ]; then exit 1; fi; \
-		sleep $(MANIFEST_RETRY_DELAY); \
-		i=$$((i + 1)); \
-	done
+	$(call retry_docker_cmd,docker manifest create,$(DOCKER) manifest create $(call unescapefs,$*):$(IMAGETAG) $(addprefix --amend ,$(addprefix $(call unescapefs,$*):$(IMAGETAG)-,$(VALIDARCHES))),$(MANIFEST_RETRIES),$(MANIFEST_RETRY_DELAY))
+	$(call retry_docker_cmd,docker manifest push,$(DOCKER) manifest push --purge $(call unescapefs,$*):$(IMAGETAG),$(MANIFEST_RETRIES),$(MANIFEST_RETRY_DELAY))
 
 push-manifests-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME
 	$(MAKE) push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"


### PR DESCRIPTION
Add a retry loop around the docker manifest create command in lib.Makefile to handle transient registry errors.

Changes in this PR: 
  - MANIFEST_RETRIES (default 5) — number of attempts for each docker manifest command
  - MANIFEST_RETRY_DELAY (default 5 seconds) — wait between retries
  - Both manifest create and manifest push are wrapped in retry loops that:
    - break on success
    - Log a warning with the attempt number on failure
    - exit 1 after exhausting all retries (preserving the original failure behavior)
  - Both variables use ?= so they can be overridden from the command line or environment if needed
  
### Background

Here's some context for what this PR is trying to guard against. 

We sometimes run into issues when attempting to publish images to Quay (e.g. our hashrelease images). 

You'll see in our builds a transient quay.io registry error like this: 
```
  docker manifest create quay.io/calico/envoy-proxy:master --amend quay.io/calico/envoy-proxy:master-amd64 --amend
  quay.io/calico/envoy-proxy:master-arm64
  unsupported manifest media type and no default available: application/grpc
```

The assumption is: 
- This is an internal quay.io infrastructure issue (gRPC is used internally between quay components, and it leaked through to the client)
- It is transient 

We often kick CI builds after running into Quay issues and the problem vanishes on follow-up builds. 

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
