### PR TITLE
[release-v3.30] Cherry-pick #12086: Use f1-standard-2 for OpenShift jobs to fix disk-full failures

### DIFF
--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -40,6 +40,10 @@ blocks:
   - name: Openshift OCP
     dependencies: []
     task:
+      agent:
+        machine:
+          type: f1-standard-2
+          os_image: ubuntu2204
       jobs:
         - name: hashrelease
           execution_time_limit:

--- a/.semaphore/end-to-end/pipelines/patch-verification.yml
+++ b/.semaphore/end-to-end/pipelines/patch-verification.yml
@@ -346,6 +346,10 @@ blocks:
             hours: 6
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          agent:
+            machine:
+              type: f1-standard-2
+              os_image: ubuntu2204
           env_vars:
             - name: OPENSHIFT_VERSION
               value: "4.18.17"

--- a/.semaphore/end-to-end/pipelines/upgrade.yml
+++ b/.semaphore/end-to-end/pipelines/upgrade.yml
@@ -137,6 +137,10 @@ blocks:
             hours: 4
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          agent:
+            machine:
+              type: f1-standard-2
+              os_image: ubuntu2204
           env_vars:
             - name: PROVISIONER
               value: aws-openshift


### PR DESCRIPTION
## Summary
Cherry-pick of #12086 to `release-v3.30`.

OCP jobs running on c1-standard-1 fail with "no space left on device" when the OpenShift installer extracts large binaries. Switch all OpenShift/OCP jobs to f1-standard-2 (8GB RAM, 45GB disk).

Note: `vpp.yml` was excluded from this cherry-pick as it does not exist on the `release-v3.30` branch.

Affected pipelines on this branch:
- iptables.yml: Openshift OCP block
- upgrade.yml: Openshift - 4.16 job
- patch-verification.yml: Openshift OCP job

## Test plan
- [ ] Verify OCP e2e jobs no longer hit disk-full failures on `release-v3.30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)