### PR TITLE
[release-v3.30] Cherry-pick #11826: Add Talos runs to overnights

### DIFF
--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -125,7 +125,7 @@ blocks:
             - name: KUBE_PROXY_MANAGEMENT
               value: "Enabled"
 
-        - name: AWS, no encap, DSR
+        - name: AWS-Talos, no encap, DSR
           execution_time_limit:
             hours: 7
           commands:
@@ -138,7 +138,7 @@ blocks:
             - name: ENABLE_BPF_DSR
               value: "true"
             - name: PROVISIONER
-              value: "aws-kubeadm"
+              value: "aws-talos"
             - name: ENCAPSULATION_TYPE
               value: "None"
             - name: BGP_STATUS

--- a/.semaphore/end-to-end/pipelines/nftables.yml
+++ b/.semaphore/end-to-end/pipelines/nftables.yml
@@ -72,6 +72,24 @@ blocks:
             - name: ENABLE_WIREGUARD
               value: "true"
 
+  - name: Nftables, Talos
+    dependencies: []
+    task:
+      jobs:
+        - name: Nftables, Talos
+          execution_time_limit:
+            hours: 7
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          matrix:
+            - env_var: K8S_VERSION
+              values: ["stable"]
+          env_vars:
+            - name: PROVISIONER
+              value: aws-talos
+            - name: ENCAPSULATION_TYPE
+              value: "VXLAN"
+
   - name: Nftables mode, EKS
     dependencies: []
     task:


### PR DESCRIPTION
## Summary
Cherry-pick of #11826 to `release-v3.30`.

Adds aws-talos runs to the overnight BPF and nftables e2e pipelines for coverage on Talos clusters.

Note: only the meaningful commit was cherry-picked; the CI hack/unhack commits were excluded.

## Test plan
- [ ] Verify Talos overnight jobs appear and run on `release-v3.30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)