### PR TITLE
Add libbpf dependency to build-bpf target

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -210,7 +210,7 @@ PROD_BPF_GPL_PROGS=$(addprefix bin/bpf/, $(notdir $(BPF_GPL_O_FILES)))
 PROD_BPF_PROGS=$(PROD_BPF_APACHE_PROGS) $(PROD_BPF_GPL_PROGS)
 
 .PHONY: build-bpf clean-bpf
-build-bpf: $(PROD_BPF_PROGS) $(BPF_GPL_UT_O_FILES)
+build-bpf: $(LIBBPF_A) $(PROD_BPF_PROGS) $(BPF_GPL_UT_O_FILES)
 
 $(PROD_BPF_PROGS) &: $(BPF_APACHE_O_FILES) $(BPF_GPL_O_FILES)
 	rm -rf bin/bpf


### PR DESCRIPTION
The `build-bpf` felix target was missing an explicit dependency on $(LIBBPF_A), which meant libbpf might not be built before the BPF programs that depend on it. Add it as a prerequisite to ensure correct build ordering.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
