### PR TITLE
Update the list of calico images for kind cluster to include istio images

### DIFF
--- a/hack/test/kind/infra/calico_versions.yml
+++ b/hack/test/kind/infra/calico_versions.yml
@@ -42,3 +42,11 @@ components:
     version: test-build
   guardian:
     version: test-build
+  istio-pilot:
+    version: test-build
+  istio-install-cni:
+    version: test-build
+  istio-ztunnel:
+    version: test-build
+  istio-proxyv2:
+    version: test-build


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Update the list of calico images needed for kind cluster. This is needed due to adding Istio to Calico OSS in this Operator PR: https://github.com/tigera/operator/pull/4536

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
