### PR TITLE
Fix missing ARG in istio ztunnel Dockerfile

### DIFF
--- a/istio/Dockerfile-ztunnel
+++ b/istio/Dockerfile-ztunnel
@@ -4,6 +4,7 @@
 # The binary is built separately using the Makefile, which compiles ztunnel with Calico patches applied.
 
 ARG CALICO_BASE
+ARG ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY
 ARG ISTIO_ZTUNNEL_VERSION
 ARG BRANCH_NAME
 


### PR DESCRIPTION
Add missing ARG ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY declaration before the first FROM, so the build-arg is correctly substituted in the FROM instruction. Without it, the base image reference resolves to an invalid path and breaks the CD pipeline.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note-not-required
TBD
```
