### PR TITLE
Fix OpenShift agent override breaking pipeline compilation

### DIFF
--- a/.semaphore/end-to-end/pipelines/patch-verification.yml
+++ b/.semaphore/end-to-end/pipelines/patch-verification.yml
@@ -342,28 +342,6 @@ blocks:
             - name: IP_FAMILY
               value: ipv4
 
-        # operator, calicocni, 4.18, amd64, bpf, ipv4, openshift, RHCOS, kdd, n/a, no-kube-proxy, autohep
-        - name: Openshift OCP
-          execution_time_limit:
-            hours: 6
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          agent:
-            machine:
-              type: f1-standard-2
-              os_image: ubuntu2204
-          env_vars:
-            - name: OPENSHIFT_VERSION
-              value: "4.18.17"
-            - name: PROVISIONER
-              value: aws-openshift
-            - name: INSTALLER
-              value: operator
-            - name: DATAPLANE
-              value: "CalicoBPF"
-            - name: IP_FAMILY
-              value: ipv4
-
         # helmerator, calicocni, stable-3, arm64, bpf, ipv4, EKS, kdd, wireguard, amazonlinux2023, no-kube-proxy, nodelocaldns, [bpf lb interop, bpf DSR]
         - name: EKS w/ calico CNI
           execution_time_limit:
@@ -519,3 +497,30 @@ blocks:
               value: "true"
             # - name: ENABLE_NODE_LOCAL_DNS_CACHE # nodelocaldns - doesn't appear to work with RKE2
             #   value: "true"
+
+  # operator, calicocni, 4.18, amd64, bpf, ipv4, openshift, RHCOS, kdd, n/a, no-kube-proxy, autohep
+  # Openshift needs f1-standard-2 (more disk) so it lives in its own block.
+  - name: "Openshift"
+    dependencies: []
+    task:
+      agent:
+        machine:
+          type: f1-standard-2
+          os_image: ubuntu2204
+      jobs:
+        - name: Openshift OCP
+          execution_time_limit:
+            hours: 6
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: OPENSHIFT_VERSION
+              value: "4.18.17"
+            - name: PROVISIONER
+              value: aws-openshift
+            - name: INSTALLER
+              value: operator
+            - name: DATAPLANE
+              value: "CalicoBPF"
+            - name: IP_FAMILY
+              value: ipv4

--- a/.semaphore/end-to-end/pipelines/upgrade.yml
+++ b/.semaphore/end-to-end/pipelines/upgrade.yml
@@ -128,26 +128,6 @@ blocks:
             - env_var: DATAPLANE
               values: ["CalicoBPF"]
 
-        - name: Openshift - 4.16
-          execution_time_limit:
-            hours: 4
-          commands:
-            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
-          agent:
-            machine:
-              type: f1-standard-2
-              os_image: ubuntu2204
-          env_vars:
-            - name: PROVISIONER
-              value: aws-openshift
-          matrix:
-            - env_var: OPENSHIFT_VERSION
-              values: ["4.19.20"]
-            - env_var: DATAPLANE
-              values: ["CalicoIptables"]
-            - env_var: INSTALLER
-              values: ["operator"]
-
         - name: RKE2
           execution_time_limit:
             hours: 4
@@ -165,6 +145,30 @@ blocks:
               values: ["operator"]
             - env_var: DATAPLANE
               values: ["CalicoIptables"]
+
+  - name: calico tests - openshift
+    dependencies: []
+    task:
+      agent:
+        machine:
+          type: f1-standard-2
+          os_image: ubuntu2204
+      jobs:
+        - name: Openshift
+          execution_time_limit:
+            hours: 4
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: PROVISIONER
+              value: aws-openshift
+          matrix:
+            - env_var: OPENSHIFT_VERSION
+              values: ["4.19.20"]
+            - env_var: DATAPLANE
+              values: ["CalicoIptables"]
+            - env_var: INSTALLER
+              values: ["operator"]
 
 promotions:
   - name: Cleanup jobs


### PR DESCRIPTION
## Summary

- Same fix as #12133 (release-v3.30), applied to master
- Commit 2d7ee941a placed `agent` overrides at the **job level** in `upgrade.yml` and `patch-verification.yml`, which Semaphore's schema does not allow — only **task-level** `agent` is valid
- Both pipelines fail immediately at compilation with `"Schema does not allow additional properties"` at `#/blocks/N/task/jobs/M/agent`
- Fix: extract each OpenShift job into its own block so `agent` sits at the task level

## Test plan

- [ ] Confirm upgrade and patch-verification pipelines compile and jobs start on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)