### PR TITLE
Fix hashrelease build failure for istio-ztunnel image

### DIFF
--- a/istio/Dockerfile-ztunnel
+++ b/istio/Dockerfile-ztunnel
@@ -4,11 +4,9 @@
 # The binary is built separately using the Makefile, which compiles ztunnel with Calico patches applied.
 
 ARG CALICO_BASE
-ARG ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY
-ARG ISTIO_ZTUNNEL_VERSION
-ARG BRANCH_NAME
+ARG ISTIO_ZTUNNEL_BASE_IMAGE
 
-FROM ${ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY}/calico/istio-ztunnel:v${ISTIO_ZTUNNEL_VERSION}-${BRANCH_NAME} AS ztunnel
+FROM ${ISTIO_ZTUNNEL_BASE_IMAGE} AS ztunnel
 
 FROM scratch AS source
 

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -19,7 +19,7 @@ BUILD_IMAGES ?= $(CI_BUILD_IMAGES) $(ISTIO_ZTUNNEL_IMAGE)
 ISTIO_VERSION ?= 1.28.1
 ISTIO_ZTUNNEL_VERSION ?= $(shell grep -E '^ZTUNNEL_VERSION[[:space:]]*=' $(REPO_ROOT)/third_party/istio-ztunnel/Makefile | cut -d '=' -f2 | tr -d ' ')
 ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY ?= quay.io
-BRANCH_NAME ?= $(if $(SEMAPHORE_GIT_BRANCH),$(SEMAPHORE_GIT_BRANCH),master)
+ISTIO_ZTUNNEL_BRANCH_NAME ?= $(if $(BRANCH_NAME),$(BRANCH_NAME),$(if $(SEMAPHORE_GIT_BRANCH),$(SEMAPHORE_GIT_BRANCH),master))
 
 ##############################################################################
 # Include lib.Makefile before anything else
@@ -113,7 +113,7 @@ $(ISTIO_PROXYV2_IMAGE_CREATED): Dockerfile-proxyv2 bin/pilot-agent-$(ARCH) bin/L
 # istio-ztunnel image
 $(ISTIO_ZTUNNEL_IMAGE): $(ISTIO_ZTUNNEL_IMAGE_CREATED)
 $(ISTIO_ZTUNNEL_IMAGE_CREATED): Dockerfile-ztunnel bin/LICENSE
-	$(DOCKER_BUILD) --build-arg ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY=$(ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY) --build-arg ISTIO_ZTUNNEL_VERSION=$(ISTIO_ZTUNNEL_VERSION) --build-arg BRANCH_NAME=$(BRANCH_NAME) -t $(ISTIO_ZTUNNEL_IMAGE):latest-$(ARCH) -f Dockerfile-ztunnel .
+	$(DOCKER_BUILD) --build-arg ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY=$(ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY) --build-arg ISTIO_ZTUNNEL_VERSION=$(ISTIO_ZTUNNEL_VERSION) --build-arg BRANCH_NAME=$(ISTIO_ZTUNNEL_BRANCH_NAME) -t $(ISTIO_ZTUNNEL_IMAGE):latest-$(ARCH) -f Dockerfile-ztunnel .
 	$(MAKE) retag-build-images-with-registries BUILD_IMAGES=$(ISTIO_ZTUNNEL_IMAGE) VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -18,8 +18,8 @@ BUILD_IMAGES ?= $(CI_BUILD_IMAGES) $(ISTIO_ZTUNNEL_IMAGE)
 # Upstream version (configurable)
 ISTIO_VERSION ?= 1.28.1
 ISTIO_ZTUNNEL_VERSION ?= $(shell grep -E '^ZTUNNEL_VERSION[[:space:]]*=' $(REPO_ROOT)/third_party/istio-ztunnel/Makefile | cut -d '=' -f2 | tr -d ' ')
-ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY ?= quay.io
-ISTIO_ZTUNNEL_BRANCH_NAME ?= $(if $(BRANCH_NAME),$(BRANCH_NAME),$(if $(SEMAPHORE_GIT_BRANCH),$(SEMAPHORE_GIT_BRANCH),master))
+BRANCH_NAME ?= $(PIN_BRANCH)
+ISTIO_ZTUNNEL_BASE_IMAGE ?= quay.io/calico/istio-ztunnel:v$(ISTIO_ZTUNNEL_VERSION)-$(BRANCH_NAME)
 
 ##############################################################################
 # Include lib.Makefile before anything else
@@ -113,7 +113,7 @@ $(ISTIO_PROXYV2_IMAGE_CREATED): Dockerfile-proxyv2 bin/pilot-agent-$(ARCH) bin/L
 # istio-ztunnel image
 $(ISTIO_ZTUNNEL_IMAGE): $(ISTIO_ZTUNNEL_IMAGE_CREATED)
 $(ISTIO_ZTUNNEL_IMAGE_CREATED): Dockerfile-ztunnel bin/LICENSE
-	$(DOCKER_BUILD) --build-arg ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY=$(ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY) --build-arg ISTIO_ZTUNNEL_VERSION=$(ISTIO_ZTUNNEL_VERSION) --build-arg BRANCH_NAME=$(ISTIO_ZTUNNEL_BRANCH_NAME) -t $(ISTIO_ZTUNNEL_IMAGE):latest-$(ARCH) -f Dockerfile-ztunnel .
+	$(DOCKER_BUILD) --build-arg ISTIO_ZTUNNEL_BASE_IMAGE=$(ISTIO_ZTUNNEL_BASE_IMAGE) -t $(ISTIO_ZTUNNEL_IMAGE):latest-$(ARCH) -f Dockerfile-ztunnel .
 	$(MAKE) retag-build-images-with-registries BUILD_IMAGES=$(ISTIO_ZTUNNEL_IMAGE) VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/istio/Makefile
+++ b/istio/Makefile
@@ -19,6 +19,7 @@ BUILD_IMAGES ?= $(CI_BUILD_IMAGES) $(ISTIO_ZTUNNEL_IMAGE)
 ISTIO_VERSION ?= 1.28.1
 ISTIO_ZTUNNEL_VERSION ?= $(shell grep -E '^ZTUNNEL_VERSION[[:space:]]*=' $(REPO_ROOT)/third_party/istio-ztunnel/Makefile | cut -d '=' -f2 | tr -d ' ')
 ISTIO_ZTUNNEL_BASE_IMAGE_REGISTRY ?= quay.io
+BRANCH_NAME ?= $(if $(SEMAPHORE_GIT_BRANCH),$(SEMAPHORE_GIT_BRANCH),master)
 
 ##############################################################################
 # Include lib.Makefile before anything else

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -95,7 +95,6 @@ var (
 		"third_party/envoy-gateway",
 		"third_party/envoy-proxy",
 		"third_party/envoy-ratelimit",
-		"third_party/istio-ztunnel",
 		"typha",
 		"webhooks",
 		"whisker",


### PR DESCRIPTION
The hashrelease "Build and publish" job was failing because BRANCH_NAME was unset when building the istio-ztunnel image, causing the base image reference to resolve to quay.io/calico/istio-ztunnel:v1.28.1- (missing branch suffix). Add a default for BRANCH_NAME in istio/Makefile that uses SEMAPHORE_GIT_BRANCH when available, falling bck to "master", matching the pattern used in calico-private for THIRD_PARTY_RELEASE_BRANCH.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note-not-required
TBD
```
