### PR TITLE
Fix prologue hang caused by needrestart interactive prompt

### DIFF
--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -21,7 +21,8 @@ set -o pipefail
 echo "[INFO] starting prologue"
 
 echo "[INFO] Configuring needrestart to auto mode to prevent interactive prompts hanging CI jobs..."
-if [ -d /etc/needrestart ]; then sudo mkdir -p /etc/needrestart/conf.d && echo '$nrconf{restart} = '"'"'a'"'"';' | sudo tee /etc/needrestart/conf.d/50-autorestart.conf > /dev/null; fi
+sudo mkdir -p /etc/needrestart/conf.d 2>/dev/null || true
+printf '\044nrconf{restart} = '\''a'\'';\n' | sudo tee /etc/needrestart/conf.d/50-autorestart.conf > /dev/null 2>/dev/null || true
 
 echo "[INFO] Clean out language tools we don't use to free up disk"
 sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*} /root/.local/share/heroku /usr/local/lib/heroku


### PR DESCRIPTION
## Summary
- On c1 Ubuntu 22.04 machines, `install-package --skip-update unzip` (and other apt operations) trigger needrestart's interactive TUI dialog asking which services to restart
- Since there is no TTY in CI, this dialog hangs indefinitely, consuming the entire 4-hour job execution budget
- 5 of 6 upgrade jobs (AKS, EKS, kubeadm-iptables, kubeadm-bpf, RKE2) all timed out in the prologue due to this
- Fix: configure needrestart to auto-restart mode (`$nrconf{restart} = 'a'`) via a conf.d drop-in file at the start of the prologue, before any apt operations
- This affects all pipelines using global_prologue.sh on c1 machines

## Test plan
- [ ] Verify the upgrade pipeline jobs no longer hang in prologue
- [ ] Verify patch-verification pipeline jobs are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)