### PR TITLE
Fix prologue hang caused by needrestart interactive prompt

### DIFF
--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -21,7 +21,8 @@ set -o pipefail
 echo "[INFO] starting prologue"
 
 echo "[INFO] Configuring needrestart to auto mode to prevent interactive prompts hanging CI jobs..."
-if [ -d /etc/needrestart ]; then sudo mkdir -p /etc/needrestart/conf.d && echo '$nrconf{restart} = '"'"'a'"'"';' | sudo tee /etc/needrestart/conf.d/50-autorestart.conf > /dev/null; fi
+sudo mkdir -p /etc/needrestart/conf.d 2>/dev/null || true
+printf '\044nrconf{restart} = '\''a'\'';\n' | sudo tee /etc/needrestart/conf.d/50-autorestart.conf > /dev/null 2>/dev/null || true
 
 echo "[INFO] Clean out language tools we don't use to free up disk"
 sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*} /root/.local/share/heroku /usr/local/lib/heroku


### PR DESCRIPTION
## Summary
- On c1 Ubuntu 22.04 machines, apt operations trigger needrestart's interactive TUI dialog which hangs indefinitely in CI (no TTY)
- This consumed entire 4-hour job budgets in the upgrade pipeline — 5 of 6 jobs timed out in prologue
- Fix: configure needrestart to auto-restart mode via conf.d drop-in at prologue start
- Same fix as release-v3.30 PR #12136

## Test plan
- [ ] Verify upgrade/patch-verification pipeline jobs no longer hang in prologue

🤖 Generated with [Claude Code](https://claude.com/claude-code)