### PR TITLE
Fix goroutine leak in FilterUpdates on netlink reconnect

### DIFF
--- a/felix/ifacemonitor/update_filter.go
+++ b/felix/ifacemonitor/update_filter.go
@@ -58,9 +58,9 @@ func FilterUpdates(ctx context.Context,
 	defer close(linkOutC)
 
 	// Drain input channels on exit to unblock netlink goroutines that may
-	// be blocked on a channel send.  The netlink library closes these
-	// channels when its goroutines exit (after seeing the closed socket),
-	// so the drain goroutines will eventually terminate.
+	// be blocked on a channel send.  Callers must ensure the input channels
+	// are eventually closed (e.g., by closing the netlink subscription) so
+	// that the drain goroutines can terminate.
 	defer func() {
 		go func() {
 			for range linkInC {

--- a/felix/ifacemonitor/update_filter_test.go
+++ b/felix/ifacemonitor/update_filter_test.go
@@ -234,6 +234,8 @@ func TestUpdateFilter_FilterUpdates_RouteUpdateDelOnly(t *testing.T) {
 func TestUpdateFilter_FilterUpdates_LinkSenderNotBlockedAfterCancel(t *testing.T) {
 	t.Log("After cancel, senders on the link input channel should not block")
 	harness, cancel := setUpFilterTest(t)
+	defer close(harness.LinkIn)
+	defer close(harness.RouteIn)
 
 	// Fill the link input channel buffer so the next send would block
 	// if FilterUpdates isn't draining.
@@ -248,10 +250,11 @@ func TestUpdateFilter_FilterUpdates_LinkSenderNotBlockedAfterCancel(t *testing.T
 
 	// Send many more items than the buffer can hold.  The drain goroutine
 	// must be actively consuming for these sends to succeed.
+	deadline := time.After(time.Second)
 	for range cap(harness.LinkIn) * 10 {
 		select {
 		case harness.LinkIn <- linkUpd:
-		case <-time.After(time.Second):
+		case <-deadline:
 			t.Fatal("send on link input channel blocked after FilterUpdates cancelled")
 		}
 	}
@@ -260,6 +263,8 @@ func TestUpdateFilter_FilterUpdates_LinkSenderNotBlockedAfterCancel(t *testing.T
 func TestUpdateFilter_FilterUpdates_RouteSenderNotBlockedAfterCancel(t *testing.T) {
 	t.Log("After cancel, senders on the route input channel should not block")
 	harness, cancel := setUpFilterTest(t)
+	defer close(harness.LinkIn)
+	defer close(harness.RouteIn)
 
 	// Fill the route input channel buffer.
 	routeUpd := routeUpdate("10.0.0.1/16", true, 2)
@@ -271,10 +276,11 @@ func TestUpdateFilter_FilterUpdates_RouteSenderNotBlockedAfterCancel(t *testing.
 	cancel()
 	Eventually(harness.RouteOut, chanPollTime, chanPollIntvl).Should(BeClosed())
 
+	deadline := time.After(time.Second)
 	for range cap(harness.RouteIn) * 10 {
 		select {
 		case harness.RouteIn <- routeUpd:
-		case <-time.After(time.Second):
+		case <-deadline:
 			t.Fatal("send on route input channel blocked after FilterUpdates cancelled")
 		}
 	}


### PR DESCRIPTION
The netlink library's subscription goroutines do blocking sends on the
update channels. When `FilterUpdates` returns on context cancellation, it
stops consuming from those channels. If a netlink goroutine is blocked
on a send at that point, it never reaches `Receive()` to see the closed
socket, leaking the goroutine. This happens on every reconnect cycle.

Fix: drain both input channels concurrently after context cancellation so
that blocked netlink goroutines can proceed to exit.

CORE-12500
Fixes #12157

**Release note:**
```release-note
Fix a goroutine leak in Felix's interface monitor that could occur on netlink reconnect.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)