### PR TITLE
Fix flannel/canal migration script path in pipeline configs

### DIFF
--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -748,7 +748,7 @@ blocks:
           execution_time_limit:
             hours: 7
           commands:
-            - ./scripts/body_flannel-migration.sh
+            - ~/calico/.semaphore/end-to-end/scripts/body_flannel-migration.sh
           matrix:
             - env_var: DOWNLEVEL_MANIFEST
               values:

--- a/.semaphore/end-to-end/pipelines/patch-verification.yml
+++ b/.semaphore/end-to-end/pipelines/patch-verification.yml
@@ -143,7 +143,7 @@ blocks:
           execution_time_limit:
             hours: 7
           commands:
-            - ./scripts/body_flannel-migration.sh
+            - ~/calico/.semaphore/end-to-end/scripts/body_flannel-migration.sh
           env_vars:
             - name: DOWNLEVEL_MANIFEST
               value: "https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
@@ -214,7 +214,7 @@ blocks:
           execution_time_limit:
             hours: 7
           commands:
-            - ./scripts/body_flannel-migration.sh
+            - ~/calico/.semaphore/end-to-end/scripts/body_flannel-migration.sh
           env_vars:
             - name: DOWNLEVEL_MANIFEST
               value: "https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/canal.yaml"


### PR DESCRIPTION
## Summary
- The `body_flannel-migration.sh` script was added to `.semaphore/end-to-end/scripts/` in #12112, but the pipeline YAML files still reference the old banzai-calico path (`./scripts/body_flannel-migration.sh`)
- This causes both the Flannel migration and Canal migration jobs to fail immediately with "No such file or directory"
- Update the path to match `body_standard.sh`: `~/calico/.semaphore/end-to-end/scripts/body_flannel-migration.sh`
- Affects `patch-verification.yml` (2 jobs) and `iptables.yml` (1 job)

## Example failing jobs
- [Flannel migration (patch-verification)](https://tigera-delivery.semaphoreci.com/jobs/16e2b820-4d2a-43c9-a046-018999f55c07)
- [Canal migration (patch-verification)](https://tigera-delivery.semaphoreci.com/jobs/42f171fa-f0e0-4e14-a292-f56345a0dda7)

## Test plan
- [ ] Run patch-verification pipeline — Flannel migration and Canal migration jobs should now find the script and proceed to provision

🤖 Generated with [Claude Code](https://claude.com/claude-code)