### PR TITLE
refactor(release): remove operator-init image from release tooling

### DIFF
--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -16,7 +16,6 @@ package pinnedversion
 
 import (
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -104,18 +103,8 @@ type PinnedVersion struct {
 	Components     map[string]registry.Component `yaml:"components"`
 }
 
-// operatorComponents returns a map of the Tigera operator and its init image components.
-func (p *PinnedVersion) operatorComponents() map[string]registry.Component {
-	op := registry.OperatorComponent{Component: p.TigeraOperator}
-	opInit := op.InitImage()
-	return map[string]registry.Component{
-		op.Image:     op.Component,
-		opInit.Image: opInit,
-	}
-}
-
 // ImageComponents returns a map of all components that produce images
-// including Tigera operator and its init image if includeOperator is true.
+// including Tigera operator if includeOperator is true.
 //
 // Images returned from this function are expected to eventually be in the format "<registry>/<image-name>"
 // e.g. "quay.io/calico/node" where <registry> is "quay.io/calico" and <image-name> is "node".
@@ -136,7 +125,7 @@ func (p *PinnedVersion) ImageComponents(includeOperator bool) map[string]registr
 	}
 
 	if includeOperator {
-		maps.Copy(components, p.operatorComponents())
+		components[p.TigeraOperator.Image] = p.TigeraOperator
 	}
 	return components
 }
@@ -284,15 +273,13 @@ func retrievePinnedVersion(outputDir string) (PinnedVersion, error) {
 	return pinnedVersionFile[0], nil
 }
 
-// RetrievePinnedOperatorVersion retrieves the operator version from the pinned version file.
-func RetrievePinnedOperator(outputDir string) (registry.OperatorComponent, error) {
+// RetrievePinnedOperator retrieves the Tigera operator component from the pinned version file.
+func RetrievePinnedOperator(outputDir string) (registry.Component, error) {
 	pinnedVersion, err := retrievePinnedVersion(outputDir)
 	if err != nil {
-		return registry.OperatorComponent{}, err
+		return registry.Component{}, err
 	}
-	return registry.OperatorComponent{
-		Component: pinnedVersion.TigeraOperator,
-	}, nil
+	return pinnedVersion.TigeraOperator, nil
 }
 
 // LoadHashrelease loads the hashrelease from the pinned version file.

--- a/release/internal/pinnedversion/pinnedversion_test.go
+++ b/release/internal/pinnedversion/pinnedversion_test.go
@@ -122,7 +122,6 @@ func TestImageComponents(t *testing.T) {
 			"istio-proxyv2":                {Version: "v3.31.0", Image: "istio-proxyv2"},
 			"istio-ztunnel":                {Version: "v3.31.0", Image: "istio-ztunnel"},
 			"tigera/operator":              {Version: "v1.40.0-v3.31.0", Image: "tigera/operator", Registry: "docker.io"},
-			"tigera/operator-init":         {Version: "v1.40.0-v3.31.0", Image: "tigera/operator-init", Registry: "docker.io"},
 		}
 		actualComponents := p.ImageComponents(true)
 		if diff := cmp.Diff(expectedComponents, actualComponents); diff != "" {

--- a/release/internal/registry/component.go
+++ b/release/internal/registry/component.go
@@ -33,15 +33,3 @@ func (c Component) String() string {
 	}
 	return fmt.Sprintf("%s/%s:%s", c.Registry, c.Image, c.Version)
 }
-
-type OperatorComponent struct {
-	Component
-}
-
-func (c OperatorComponent) InitImage() Component {
-	return Component{
-		Version:  c.Version,
-		Image:    fmt.Sprintf("%s-init", c.Image),
-		Registry: c.Registry,
-	}
-}

--- a/release/internal/registry/component_test.go
+++ b/release/internal/registry/component_test.go
@@ -58,22 +58,3 @@ func TestComponentString(t *testing.T) {
 		})
 	}
 }
-
-func TestOperatorComponentInitImage(t *testing.T) {
-	c := OperatorComponent{
-		Component: Component{
-			Version:  "1.2.3",
-			Image:    "nameprefix/operator",
-			Registry: "quay.io",
-		},
-	}
-	want := Component{
-		Version:  "1.2.3",
-		Image:    "nameprefix/operator-init",
-		Registry: "quay.io",
-	}
-	got := c.InitImage()
-	if got != want {
-		t.Errorf("expected init image %s, got %s", want.String(), got.String())
-	}
-}


### PR DESCRIPTION
For hashreleases, we were previously building an `operator-init` image. Since delegating to using the tooling in operator (), this is no longer being done as operator tooling does not build the `operator-init` image. Additionally, the `operator-init` image is not used anywhere and is actually just `operator` retagged as `operator-init`

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
