### PR TITLE
Disable sync-operator-crds workflow in forks

### DIFF
--- a/.github/workflows/sync-operator-crds.yml
+++ b/.github/workflows/sync-operator-crds.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   sync:
+    if: github.repository == 'projectcalico/calico'
     runs-on: ubuntu-latest
     concurrency:
       group: sync-operator-crds-${{ matrix.branch }}


### PR DESCRIPTION
## Summary
- Adds a repository guard (`if: github.repository == 'projectcalico/calico'`) to the `sync-operator-crds` workflow so it is a no-op in forks, preventing spurious automated PRs against branches that may not exist.

## Test plan
- [ ] Verify the workflow still runs on schedule in `projectcalico/calico`
- [ ] Verify the workflow is skipped when triggered in a fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)