### PR TITLE
Use fully qualified resource names in calicoctl cluster diags

### DIFF
--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -309,7 +309,12 @@ func collectCalicoResource(dir string) {
 
 	// Phase 1: Discover Calico resources via CRD listing. This finds resources registered as
 	// CustomResourceDefinitions (both crd.projectcalico.org/v1 and projectcalico.org/v3 CRD modes).
-	buf, err := common.Exec([]string{"kubectl", "get", "customresourcedefinition", "-o", "go-template", "--template", "{{range .items}}{{.metadata.name}} {{end}}"})
+	// The template outputs "name=version" pairs where name is the CRD metadata.name (<plural>.<group>)
+	// and version is the storage version. We use these to construct fully qualified resource identifiers
+	// (<plural>.<version>.<group>) to avoid ambiguity when multiple API groups define the same resource
+	// name (e.g., apiservers.operator.tigera.io vs apiservers.config.openshift.io).
+	buf, err := common.Exec([]string{"kubectl", "get", "customresourcedefinition", "-o", "go-template", "--template",
+		"{{range .items}}{{.metadata.name}}={{range .spec.versions}}{{if .storage}}{{.name}}{{end}}{{end}} {{end}}"})
 	if err != nil {
 		fmt.Printf("Couldn't list CRDs: %s\n", err)
 		if buf != nil {
@@ -317,19 +322,33 @@ func collectCalicoResource(dir string) {
 		}
 	} else {
 		crds := strings.Fields(buf.String())
-		for _, resource := range crds {
-			if !strings.Contains(resource, "projectcalico") && !strings.Contains(resource, "tigera") {
+		for _, entry := range crds {
+			parts := strings.SplitN(entry, "=", 2)
+			crdName := parts[0]
+			if !strings.Contains(crdName, "projectcalico") && !strings.Contains(crdName, "tigera") {
 				continue
 			}
-			collected.Add(resource)
+			collected.Add(crdName)
+
+			// Build the fully qualified resource: <plural>.<version>.<group>.
+			resource := crdName
+			if len(parts) == 2 && parts[1] != "" {
+				dotIdx := strings.Index(crdName, ".")
+				if dotIdx > 0 {
+					plural := crdName[:dotIdx]
+					group := crdName[dotIdx+1:]
+					resource = fmt.Sprintf("%s.%s.%s", plural, parts[1], group)
+				}
+			}
+
 			commands = append(commands, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
-				FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.yaml", dir, crdName),
 			}, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
-				FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.txt", dir, crdName),
 			})
 		}
 	}
@@ -337,7 +356,8 @@ func collectCalicoResource(dir string) {
 	// Phase 2: Discover v3 resources via the projectcalico.org API group. When the Calico API
 	// server is running, v3 resources are served via API aggregation rather than CRDs, so they
 	// won't appear in the CRD listing above. This catches them regardless of serving mode.
-	buf, err = common.Exec([]string{"kubectl", "api-resources", "--api-group=projectcalico.org", "-o", "name"})
+	// Use --no-headers with default output to get APIVERSION and NAME columns for fully qualified lookups.
+	buf, err = common.Exec([]string{"kubectl", "api-resources", "--api-group=projectcalico.org", "--no-headers"})
 	if err != nil {
 		log.WithError(err).Warn("Couldn't list api-resources for projectcalico.org group, skipping v3 API resource discovery")
 		fmt.Printf("Couldn't list api-resources for projectcalico.org group, skipping v3 API resource discovery: %s\n", err)
@@ -345,20 +365,47 @@ func collectCalicoResource(dir string) {
 			fmt.Printf("\tcmd output:\n\t\t%s", buf.String())
 		}
 	} else {
-		apiResources := strings.Fields(buf.String())
-		for _, resource := range apiResources {
-			if collected.Contains(resource) {
+		for _, line := range strings.Split(buf.String(), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 3 {
 				continue
 			}
-			collected.Add(resource)
+			// api-resources output columns: NAME SHORTNAMES APIVERSION NAMESPACED KIND
+			// (SHORTNAMES may be empty, but fields are whitespace-separated so columns shift)
+			// The APIVERSION column contains <group>/<version> and KIND is always last.
+			// Find the APIVERSION field which contains a '/'.
+			var plural, apiVersion string
+			plural = fields[0]
+			for _, f := range fields[1:] {
+				if strings.Contains(f, "/") {
+					apiVersion = f
+					break
+				}
+			}
+
+			crdName := plural + ".projectcalico.org"
+			if collected.Contains(crdName) {
+				continue
+			}
+			collected.Add(crdName)
+
+			// Build fully qualified resource: <plural>.<version>.<group>.
+			resource := crdName
+			if apiVersion != "" {
+				parts := strings.SplitN(apiVersion, "/", 2)
+				if len(parts) == 2 {
+					resource = fmt.Sprintf("%s.%s.%s", plural, parts[1], parts[0])
+				}
+			}
+
 			commands = append(commands, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
-				FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.yaml", dir, crdName),
 			}, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
-				FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.txt", dir, crdName),
 			})
 		}
 	}


### PR DESCRIPTION
When collecting CRD resources, use the <plural>.<version>.<group> format (e.g., apiservers.v1.operator.tigera.io) instead of just <plural>.<group>. This avoids ambiguity when multiple API groups define resources with the same plural name (e.g., apiservers.operator.tigera.io vs apiservers.config.openshift.io).

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Use fully qualified resource names in calicoctl cluster diags to avoid clashes with Openshift and other APIVersions.
```
