### PR TITLE
fix(release): add pinned components support for operator builds

### DIFF
--- a/release/internal/utils/files.go
+++ b/release/internal/utils/files.go
@@ -64,29 +64,42 @@ func CopyFile(src, dst string) error {
 	return nil
 }
 
-// PathExists validates if a given (relative or absolute) path exists
-func PathExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
+func pathInfo(path string) (os.FileInfo, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path for %s: %w", path, err)
 	}
-	if errors.Is(err, fs.ErrNotExist) {
-		return false, nil
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get info for path %s: %w", absPath, err)
 	}
-	return false, err
+	return info, nil
 }
 
 // DirExists validates if a given (relative or absolute) path exists and
 // is a directory (or as symlink to one)
 func DirExists(path string) (bool, error) {
-	stat, err := os.Stat(path)
-	if err == nil {
-		return stat.IsDir(), nil
+	info, err := pathInfo(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
-	if errors.Is(err, fs.ErrNotExist) {
-		return false, nil
+	return info.IsDir(), nil
+}
+
+// FileExists validates if a given (relative or absolute) path exists
+// and is a regular file
+func FileExists(path string) (bool, error) {
+	info, err := pathInfo(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
-	return false, err
+	return info.Mode().IsRegular(), nil
 }
 
 // CheckBinary searches the current PATH for a binary and returns an error if it's not found

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -55,7 +55,12 @@ type OperatorManager struct {
 	// calicoDir is the absolute path to the root directory of the calico repository
 	calicoDir string
 
+	// calicoVersion is the version of calico to use for the operator. This is only used for hashreleases.
 	calicoVersion string
+
+	// pinnedComponentsFile is the path to the file containing the pinned components for the operator.
+	// This is used for hashreleases and supersedes using calicoVersion.
+	pinnedComponentsFile string
 
 	// image is the name of the operator image (e.g. tigera/operator)
 	image string
@@ -120,7 +125,10 @@ func (o *OperatorManager) Build() error {
 	env = append(env, fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, r))
 	env = append(env, fmt.Sprintf("%s_IMAGE_PATH=%s", defaultProductEnvPrefix, i))
 	if o.isHashRelease {
-		if o.calicoVersion != "" {
+		if o.pinnedComponentsFile != "" {
+			env = append(env, fmt.Sprintf("%s_VERSIONS=%s", defaultProductEnvPrefix, o.pinnedComponentsFile))
+			logFields["pinned_components_file"] = o.pinnedComponentsFile
+		} else if o.calicoVersion != "" {
 			env = append(env, fmt.Sprintf("%s_VERSION=%s", defaultProductEnvPrefix, o.calicoVersion))
 			logFields["calico_version"] = o.calicoVersion
 		}
@@ -200,8 +208,13 @@ func (o *OperatorManager) PreBuildValidation() error {
 	if dirty {
 		errStack = errors.Join(errStack, fmt.Errorf("there are uncommitted changes in the repository, please commit or stash them"))
 	}
-	if o.isHashRelease && (o.calicoVersion == "" || o.calicoDir == "") {
-		errStack = errors.Join(errStack, errors.New("hashrelease requires calico version and directory to be specified"))
+	if o.isHashRelease {
+		if o.calicoVersion == "" && o.pinnedComponentsFile == "" {
+			errStack = errors.Join(errStack, errors.New("hashrelease requires either a calico version or the pinned components file to be specified"))
+		}
+		if o.calicoDir == "" {
+			errStack = errors.Join(errStack, errors.New("hashrelease requires the calico directory to be specified"))
+		}
 	}
 	if !o.validateBranch {
 		return errStack

--- a/release/pkg/manager/operator/options.go
+++ b/release/pkg/manager/operator/options.go
@@ -14,6 +14,12 @@
 
 package operator
 
+import (
+	"fmt"
+
+	"github.com/projectcalico/calico/release/internal/utils"
+)
+
 type Option func(*OperatorManager) error
 
 func WithOperatorDirectory(root string) Option {
@@ -103,6 +109,20 @@ func WithProductRegistry(registry string) Option {
 func WithImage(image string) Option {
 	return func(o *OperatorManager) error {
 		o.image = image
+		return nil
+	}
+}
+
+func WithPinnedComponents(filePath string) Option {
+	return func(o *OperatorManager) error {
+		exists, err := utils.FileExists(filePath)
+		if err != nil {
+			return fmt.Errorf("check pinned components file exists: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("pinned components file does not exist at path: %s", filePath)
+		}
+		o.pinnedComponentsFile = filePath
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `FileExists` utility function for validating regular file paths
- Adds `WithPinnedComponents` option to `OperatorManager` allowing hashrelease builds to pass a pinned components file directly to the operator, superseding `WithCalicoVersion`
- Updates `PreBuildValidation` to accept either a calico version or pinned components file for hashreleases
