### PR TITLE
[BPF] Add native netkit BPF attachment support to Felix

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1114,9 +1114,9 @@ blocks:
             - export FV_FOCUS='_BPF_.*ct=true'
             - export NUM_FV_BATCHES=10
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-        - name: "Felix: BPF program-loading check on 25.10 (nftables)"
+        - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
           execution_time_limit:
-            minutes: 30
+            minutes: 60
           env_vars:
             - name: FELIX_TEST_GROUP
               value: "bpf-25.10-nft-no-fv-with-ut"
@@ -1124,10 +1124,11 @@ blocks:
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
               value: "30"
+            - name: FELIX_FV_NETKIT
+              value: "Enabled"
           commands:
             - source felix/.semaphore/fv-prologue
-            # Only run the UT that checks that the precompiled BPF binaries are loadable.
-            - export UT_FOCUS="TestPrecompiledBinariesAreLoadable"
+            - export NUM_FV_BATCHES=60
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
         - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
           execution_time_limit:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1123,7 +1123,7 @@ blocks:
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
-              value: "30"
+              value: "60"
             - name: FELIX_FV_NETKIT
               value: "Enabled"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3169,9 +3169,9 @@ blocks:
             - export FV_FOCUS='_BPF_.*ct=true'
             - export NUM_FV_BATCHES=10
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-        - name: "Felix: BPF program-loading check on 25.10 (nftables)"
+        - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
           execution_time_limit:
-            minutes: 30
+            minutes: 60
           env_vars:
             - name: FELIX_TEST_GROUP
               value: "bpf-25.10-nft-no-fv-with-ut"
@@ -3179,10 +3179,11 @@ blocks:
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
               value: "30"
+            - name: FELIX_FV_NETKIT
+              value: "Enabled"
           commands:
             - source felix/.semaphore/fv-prologue
-            # Only run the UT that checks that the precompiled BPF binaries are loadable.
-            - export UT_FOCUS="TestPrecompiledBinariesAreLoadable"
+            - export NUM_FV_BATCHES=60
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
         - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
           execution_time_limit:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3178,7 +3178,7 @@ blocks:
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
-              value: "30"
+              value: "60"
             - name: FELIX_FV_NETKIT
               value: "Enabled"
           commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -247,9 +247,9 @@
           - export FV_FOCUS='_BPF_.*ct=true'
           - export NUM_FV_BATCHES=10
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
-      - name: "Felix: BPF program-loading check on 25.10 (nftables)"
+      - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
         execution_time_limit:
-          minutes: 30
+          minutes: 60
         env_vars:
           - name: FELIX_TEST_GROUP
             value: "bpf-25.10-nft-no-fv-with-ut"
@@ -257,10 +257,11 @@
             value: "tc"
           - name: JOB_TIMEOUT_MINUTES
             value: "30"
+          - name: FELIX_FV_NETKIT
+            value: "Enabled"
         commands:
           - source felix/.semaphore/fv-prologue
-          # Only run the UT that checks that the precompiled BPF binaries are loadable.
-          - export UT_FOCUS="TestPrecompiledBinariesAreLoadable"
+          - export NUM_FV_BATCHES=60
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
       - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
         execution_time_limit:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -256,7 +256,7 @@
           - name: FELIX_FV_BPFATTACHTYPE
             value: "tc"
           - name: JOB_TIMEOUT_MINUTES
-            value: "30"
+            value: "60"
           - name: FELIX_FV_NETKIT
             value: "Enabled"
         commands:

--- a/felix/.semaphore/batches.sh
+++ b/felix/.semaphore/batches.sh
@@ -28,6 +28,7 @@ run_batch() {
         make
           --directory=${CALICO_DIR_NAME}/felix
           FELIX_FV_NFTABLES="$FELIX_FV_NFTABLES"
+          FELIX_FV_NETKIT="$FELIX_FV_NETKIT"
           FV_EXTRA_REPORT_SUFFIX="$FV_EXTRA_REPORT_SUFFIX"
           FELIX_FV_BPFATTACHTYPE="$FELIX_FV_BPFATTACHTYPE"
           GINKGO_FOCUS="${FV_FOCUS}"

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -405,6 +405,7 @@ fv-no-prereqs:
 	  ARCH=$(ARCH) \
 	  FELIX_FV_ENABLE_BPF="$(FELIX_FV_ENABLE_BPF)" \
 	  FELIX_FV_NFTABLES="$(FELIX_FV_NFTABLES)" \
+	  FELIX_FV_NETKIT="$(FELIX_FV_NETKIT)" \
 	  FV_RACE_DETECTOR_ENABLED=$(FV_RACE_DETECTOR_ENABLED) \
 	  FV_BINARY=$(FV_BINARY) \
 	  CALICO_API_GROUP=$(CALICO_API_GROUP) \
@@ -424,6 +425,9 @@ fv-bpf:
 
 fv-bpf-no-prereqs:
 	$(MAKE) fv-no-prereqs FELIX_FV_ENABLE_BPF=true
+
+fv-bpf-netkit:
+	$(MAKE) fv FELIX_FV_ENABLE_BPF=true FELIX_FV_NETKIT=Enabled
 
 fv-nft:
 	$(MAKE) fv FELIX_FV_NFTABLES=Enabled

--- a/felix/bpf-gpl/fib_co_re.h
+++ b/felix/bpf-gpl/fib_co_re.h
@@ -196,6 +196,10 @@ skip_redir_ifindex:
 
 		if (state->ct_result.ifindex_fwd == CT_INVALID_IFINDEX) {
 			CALI_DEBUG("ifindex_fwd is CT_INVALID_IFINDEX, doing FIB lookup");
+			__u32 __fib_ifindex = ctx->skb->ifindex;
+			if (CALI_F_FROM_WEP && ctx->globals->data.host_ifindex) {
+				__fib_ifindex = ctx->globals->data.host_ifindex;
+			}
 			*fib_params(ctx) = (struct bpf_fib_lookup) {
 #ifdef IPVER6
 				.family = 10, /* AF_INET6 */
@@ -203,7 +207,7 @@ skip_redir_ifindex:
 				.family = 2, /* AF_INET */
 #endif
 				.tot_len = 0,
-				.ifindex = ctx->skb->ifindex,
+				.ifindex = __fib_ifindex,
 				.l4_protocol = state->ip_proto,
 			};
 

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -30,6 +30,7 @@ struct name {                              \
 	__s8 istio_dscp;                       \
 	__u32 maglev_lut_size;                 \
 	__u32 ipfrag_timeout;                  \
+	__u32 host_ifindex;                    \
 }
 
 DECLARE_TC_GLOBAL_DATA(cali_tc_global_data, ipv6_addr_t);

--- a/felix/bpf-gpl/qos.h
+++ b/felix/bpf-gpl/qos.h
@@ -44,10 +44,15 @@ static CALI_BPF_INLINE int qos_enforce_packet_rate(struct cali_tc_ctx *ctx)
 	}
 #endif
 
-	// Retrieve qos map where TBF state is kept
+	// Retrieve qos map where TBF state is kept.
+	// For netkit, skb->ifindex is the peer (container-side) ifindex, but the
+	// QoS map is keyed by the host-side ifindex.  Use host_ifindex from
+	// globals when available.
 	struct calico_qos_val *qos;
+	__u32 __qos_ifindex = ctx->globals->data.host_ifindex ?
+		ctx->globals->data.host_ifindex : ctx->skb->ifindex;
 	struct calico_qos_key key = {
-		.ifindex = ctx->skb->ifindex,
+		.ifindex = __qos_ifindex,
 #if CALI_F_INGRESS
 		.ingress = 1,
 #else // CALI_F_EGRESS

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -18,10 +18,16 @@
 
 static CALI_BPF_INLINE int wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
-        CALI_DEBUG("Workload RPF check src=" IP_FMT " skb iface=%d.",
-                        debug_ip(ctx->state->ip_src), ctx->skb->ifindex);
+        /* For netkit, skb->ifindex is the peer (container-side) ifindex, but
+         * routes are keyed by host-side ifindex.  Use host_ifindex from
+         * globals when available. */
+        __u32 rpf_ifindex = ctx->globals->data.host_ifindex ?
+                ctx->globals->data.host_ifindex : ctx->skb->ifindex;
+
+        CALI_DEBUG("Workload RPF check src=" IP_FMT " rpf iface=%d.",
+                        debug_ip(ctx->state->ip_src), rpf_ifindex);
         if (!r) {
-				if (WORKLOAD_SRC_SPOOFING_CONFIGURED && cali_allowsource_lookup(&ctx->state->ip_src, ctx->skb->ifindex)) {
+				if (WORKLOAD_SRC_SPOOFING_CONFIGURED && cali_allowsource_lookup(&ctx->state->ip_src, rpf_ifindex)) {
 						CALI_INFO("Workload RPF bypass: allowing spoofed source IP");
 						ctx->state->flags |= CALI_ST_SUPPRESS_CT_STATE;
 						return RPF_RES_STRICT;
@@ -38,9 +44,9 @@ static CALI_BPF_INLINE int wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt
                 CALI_INFO("Workload RPF fail: not a local workload.");
                 return RPF_RES_FAIL;
         }
-        if (CALI_RT_IFINDEX(r) != ctx->skb->ifindex) {
+        if (CALI_RT_IFINDEX(r) != rpf_ifindex) {
                 CALI_INFO("Workload RPF fail skb iface (%d) != route iface (%d)",
-                                ctx->skb->ifindex, CALI_RT_IFINDEX(r));
+                                rpf_ifindex, CALI_RT_IFINDEX(r));
                 return RPF_RES_FAIL;
         }
 

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -207,14 +207,21 @@ struct cali_tc_ctx {
 				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "State map lookup failed: DROP");	\
 				bpf_exit(TC_ACT_SHOT);				\
 			}							\
-			void * counters = counters_get(skb->ifindex);		\
-			if (!counters) {					\
-				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "no counters for %d: DROP", skb->ifindex);		\
-				bpf_exit(TC_ACT_SHOT);				\
-			}							\
 			struct cali_tc_globals *gl = state_get_globals_tc();	\
 			if (!gl) {						\
 				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "no globals: DROP");		\
+				bpf_exit(TC_ACT_SHOT);				\
+			}							\
+			/* Use host_ifindex from globals for the counters lookup.  \
+			 * For netkit, skb->ifindex is the peer ifindex which      \
+			 * differs from the primary (host-side) ifindex that the   \
+			 * maps are keyed by. host_ifindex is always the primary.  \
+			 */							\
+			__u32 __ifindex = gl->data.host_ifindex ?		\
+				gl->data.host_ifindex : skb->ifindex;		\
+			void * counters = counters_get(__ifindex);		\
+			if (!counters) {					\
+				CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "no counters for %d: DROP", __ifindex);	\
 				bpf_exit(TC_ACT_SHOT);				\
 			}							\
 			struct pkt_scratch *scratch = (void *)(gl->__scratch); 	\

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2357,6 +2357,12 @@ func LoadObject(file string, data libbpf.GlobalData, mapsToBePinned ...string) (
 }
 
 func LoadObjectWithOptions(file string, data libbpf.GlobalData, configurator ObjectConfigurator, mapsToBePinned ...string) (*libbpf.Obj, error) {
+	return LoadObjectWithPinOverrides(file, data, configurator, nil, mapsToBePinned...)
+}
+
+// LoadObjectWithPinOverrides loads a BPF object with optional map pin path overrides.
+// mapPinOverrides maps C map names (e.g. "cali_progs_ing2") to alternate pin paths.
+func LoadObjectWithPinOverrides(file string, data libbpf.GlobalData, configurator ObjectConfigurator, mapPinOverrides map[string]string, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	obj, err := libbpf.OpenObject(file)
 	if err != nil {
 		return nil, err
@@ -2368,7 +2374,7 @@ func LoadObjectWithOptions(file string, data libbpf.GlobalData, configurator Obj
 		}
 	}
 
-	return loadObject(obj, data, mapsToBePinned...)
+	return loadObject(obj, data, mapPinOverrides, mapsToBePinned...)
 }
 
 func LoadObjectWithLogBuffer(file string, data libbpf.GlobalData, logBuf []byte, mapsToBePinned ...string) (*libbpf.Obj, error) {
@@ -2377,10 +2383,10 @@ func LoadObjectWithLogBuffer(file string, data libbpf.GlobalData, logBuf []byte,
 		return nil, err
 	}
 
-	return loadObject(obj, data, mapsToBePinned...)
+	return loadObject(obj, data, nil, mapsToBePinned...)
 }
 
-func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapsToBePinned ...string) (*libbpf.Obj, error) {
+func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapPinOverrides map[string]string, mapsToBePinned ...string) (*libbpf.Obj, error) {
 	success := false
 	defer func() {
 		if !success {
@@ -2416,16 +2422,19 @@ func loadObject(obj *libbpf.Obj, data libbpf.GlobalData, mapsToBePinned ...strin
 		}
 
 		log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())
-		pinDir := MapPinDir()
+		pinPath := path.Join(MapPinDir(), mapName)
+		if override, ok := mapPinOverrides[mapName]; ok {
+			pinPath = override
+		}
 		// If mapsToBePinned is not specified, pin all the maps.
 		if len(mapsToBePinned) == 0 {
-			if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
+			if err := m.SetPinPath(pinPath); err != nil {
 				return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
 			}
 		} else {
 			for _, name := range mapsToBePinned {
 				if mapName == name {
-					if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
+					if err := m.SetPinPath(pinPath); err != nil {
 						return nil, fmt.Errorf("error pinning map %s k %d v %d: %w", mapName, m.KeySize(), m.ValueSize(), err)
 					}
 				}

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,9 +22,9 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
-	CtlbPinDir         = "ctlb"
-	TcxPinDir          = DefaultBPFfsPath + "/tcx"
-	NetkitPinDir       = DefaultBPFfsPath + "/netkit"
+	CtlbPinDir   = "ctlb"
+	TcxPinDir    = DefaultBPFfsPath + "/tcx"
+	NetkitPinDir = DefaultBPFfsPath + "/netkit"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -24,6 +24,7 @@ const (
 	ObjectDir    = "/usr/lib/calico/bpf"
 	CtlbPinDir   = "ctlb"
 	TcxPinDir    = DefaultBPFfsPath + "/tcx"
+	NetkitPinDir = DefaultBPFfsPath + "/netkit"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -22,9 +22,9 @@ const (
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
-	CtlbPinDir   = "ctlb"
-	TcxPinDir    = DefaultBPFfsPath + "/tcx"
-	NetkitPinDir = DefaultBPFfsPath + "/netkit"
+	CtlbPinDir         = "ctlb"
+	TcxPinDir          = DefaultBPFfsPath + "/tcx"
+	NetkitPinDir       = DefaultBPFfsPath + "/netkit"
 )
 
 func GetCgroupV2Path() string {

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -57,19 +57,19 @@ type IPMaps struct {
 }
 
 type CommonMaps struct {
-	StateMap             maps.Map
-	IfStateMap           maps.Map
-	RuleCountersMap      maps.Map
-	CountersMap          maps.Map
-	ProgramsMaps         []maps.Map
-	JumpMaps             []maps.MapWithDeleteIfExists
-	NetkitProgramsMaps   []maps.Map
-	NetkitJumpMaps       []maps.MapWithDeleteIfExists
-	XDPProgramsMap       maps.Map
-	XDPJumpMap           maps.MapWithDeleteIfExists
-	ProfilingMap         maps.Map
-	CTLBProgramsMaps     []maps.Map
-	QoSMap               maps.MapWithUpdateWithFlags
+	StateMap           maps.Map
+	IfStateMap         maps.Map
+	RuleCountersMap    maps.Map
+	CountersMap        maps.Map
+	ProgramsMaps       []maps.Map
+	JumpMaps           []maps.MapWithDeleteIfExists
+	NetkitProgramsMaps []maps.Map
+	NetkitJumpMaps     []maps.MapWithDeleteIfExists
+	XDPProgramsMap     maps.Map
+	XDPJumpMap         maps.MapWithDeleteIfExists
+	ProfilingMap       maps.Map
+	CTLBProgramsMaps   []maps.Map
+	QoSMap             maps.MapWithUpdateWithFlags
 }
 
 type Maps struct {

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -57,17 +57,19 @@ type IPMaps struct {
 }
 
 type CommonMaps struct {
-	StateMap         maps.Map
-	IfStateMap       maps.Map
-	RuleCountersMap  maps.Map
-	CountersMap      maps.Map
-	ProgramsMaps     []maps.Map
-	JumpMaps         []maps.MapWithDeleteIfExists
-	XDPProgramsMap   maps.Map
-	XDPJumpMap       maps.MapWithDeleteIfExists
-	ProfilingMap     maps.Map
-	CTLBProgramsMaps []maps.Map
-	QoSMap           maps.MapWithUpdateWithFlags
+	StateMap             maps.Map
+	IfStateMap           maps.Map
+	RuleCountersMap      maps.Map
+	CountersMap          maps.Map
+	ProgramsMaps         []maps.Map
+	JumpMaps             []maps.MapWithDeleteIfExists
+	NetkitProgramsMaps   []maps.Map
+	NetkitJumpMaps       []maps.MapWithDeleteIfExists
+	XDPProgramsMap       maps.Map
+	XDPJumpMap           maps.MapWithDeleteIfExists
+	ProfilingMap         maps.Map
+	CTLBProgramsMaps     []maps.Map
+	QoSMap               maps.MapWithUpdateWithFlags
 }
 
 type Maps struct {
@@ -105,6 +107,11 @@ func getCommonMaps() *CommonMaps {
 	jumpMaps := jump.Maps()
 	for _, jm := range jumpMaps {
 		commonMaps.JumpMaps = append(commonMaps.JumpMaps, jm.(maps.MapWithDeleteIfExists))
+	}
+	commonMaps.NetkitProgramsMaps = hook.NewNetkitProgramsMaps()
+	netkitJumpMaps := jump.NetkitMaps()
+	for _, jm := range netkitJumpMaps {
+		commonMaps.NetkitJumpMaps = append(commonMaps.NetkitJumpMaps, jm.(maps.MapWithDeleteIfExists))
 	}
 	return commonMaps
 }
@@ -202,8 +209,12 @@ func (c *CommonMaps) slice() []maps.Map {
 		c.QoSMap,
 	}
 	mapslice = append(mapslice, c.ProgramsMaps...)
+	mapslice = append(mapslice, c.NetkitProgramsMaps...)
 	mapslice = append(mapslice, c.CTLBProgramsMaps...)
 	for _, m := range c.JumpMaps {
+		mapslice = append(mapslice, m)
+	}
+	for _, m := range c.NetkitJumpMaps {
 		mapslice = append(mapslice, m)
 	}
 	return mapslice

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -67,13 +67,12 @@ const (
 var All = []Hook{Ingress, Egress, XDP}
 
 type AttachType struct {
-	Hook           Hook
-	Family         int
-	Type           tcdefs.EndpointType
-	LogLevel       string
-	ToHostDrop     bool
-	DSR            bool
-	ProgAttachType string // "TC", "TCX", or "Netkit" — used as cache key to separate programs with different expected_attach_type
+	Hook       Hook
+	Family     int
+	Type       tcdefs.EndpointType
+	LogLevel   string
+	ToHostDrop bool
+	DSR        bool
 }
 
 func (at AttachType) ObjectFile() string {
@@ -135,9 +134,6 @@ func ObjectFile(at AttachType) string {
 	objectFilesLock.Lock()
 	defer objectFilesLock.Unlock()
 
-	// ProgAttachType is not part of the object file selection — the same
-	// BPF object is used for TC, TCX, and Netkit. Zero it out for lookup.
-	at.ProgAttachType = ""
 	return objectFiles[at]
 }
 

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -135,6 +135,9 @@ func ObjectFile(at AttachType) string {
 	objectFilesLock.Lock()
 	defer objectFilesLock.Unlock()
 
+	// ProgAttachType is not part of the object file selection — the same
+	// BPF object is used for TC, TCX, and Netkit. Zero it out for lookup.
+	at.ProgAttachType = ""
 	return objectFiles[at]
 }
 

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -67,12 +67,13 @@ const (
 var All = []Hook{Ingress, Egress, XDP}
 
 type AttachType struct {
-	Hook       Hook
-	Family     int
-	Type       tcdefs.EndpointType
-	LogLevel   string
-	ToHostDrop bool
-	DSR        bool
+	Hook           Hook
+	Family         int
+	Type           tcdefs.EndpointType
+	LogLevel       string
+	ToHostDrop     bool
+	DSR            bool
+	ProgAttachType string // "TC", "TCX", or "Netkit" — used as cache key to separate programs with different expected_attach_type
 }
 
 func (at AttachType) ObjectFile() string {

--- a/felix/bpf/hook/map.go
+++ b/felix/bpf/hook/map.go
@@ -179,11 +179,19 @@ func MergeLayouts(layouts ...Layout) Layout {
 	return ret
 }
 
+// programCacheKey combines AttachType with the BPF program attach type string
+// ("TC", "TCX", or "Netkit") to differentiate cache entries for programs that
+// share the same object file but require different expected_attach_type values.
+type programCacheKey struct {
+	AttachType
+	ProgAttachType string
+}
+
 type ProgramsMap struct {
 	*bpfmaps.PinnedMap
 
 	programsLock sync.Mutex
-	programs     map[AttachType]*program
+	programs     map[programCacheKey]*program
 
 	expectedAttachType string
 	nextIdx            atomic.Int64
@@ -325,7 +333,7 @@ func NewEgressProgramsMap() bpfmaps.Map {
 func newProgramsMap(ProgramsMapParameters bpfmaps.MapParameters, expectedAttachType string) bpfmaps.Map {
 	return &ProgramsMap{
 		PinnedMap:          bpfmaps.NewPinnedMap(ProgramsMapParameters),
-		programs:           make(map[AttachType]*program),
+		programs:           make(map[programCacheKey]*program),
 		expectedAttachType: expectedAttachType,
 	}
 }
@@ -340,7 +348,7 @@ func NewXDPProgramsMap() bpfmaps.Map {
 			Name:       "xdp_cali_progs",
 			Version:    3,
 		}),
-		programs: make(map[AttachType]*program),
+		programs: make(map[programCacheKey]*program),
 	}
 }
 
@@ -351,7 +359,8 @@ func (pm *ProgramsMap) LoadObj(at AttachType, progType string, disabledOptional 
 	}
 	log.WithField("AttachType", at).Debugf("Looked up file for attach type: %s", file)
 
-	pi := pm.getOrCreateProgramInfo(at)
+	cacheKey := programCacheKey{AttachType: at, ProgAttachType: progType}
+	pi := pm.getOrCreateProgramInfo(cacheKey)
 
 	// Loading is protected by the program lock to ensure that we do not
 	// load the same object multiple times in parallel.  Two goroutines may
@@ -388,13 +397,13 @@ func (pm *ProgramsMap) LoadObj(at AttachType, progType string, disabledOptional 
 	}, nil
 }
 
-func (pm *ProgramsMap) getOrCreateProgramInfo(at AttachType) *program {
+func (pm *ProgramsMap) getOrCreateProgramInfo(key programCacheKey) *program {
 	pm.programsLock.Lock()
 	defer pm.programsLock.Unlock()
-	pi, ok := pm.programs[at]
+	pi, ok := pm.programs[key]
 	if !ok {
 		pi = &program{}
-		pm.programs[at] = pi
+		pm.programs[key] = pi
 	}
 	return pi
 }
@@ -618,7 +627,7 @@ func (pm *ProgramsMap) ResetForTesting() {
 	// We keep the same pinned map but reset the accounting as the map is
 	// replaced by repinning by the user.
 	pm.nextIdx.Store(0)
-	pm.programs = make(map[AttachType]*program)
+	pm.programs = make(map[programCacheKey]*program)
 }
 
 func (pm *ProgramsMap) Programs() map[AttachType]Layout {
@@ -626,8 +635,8 @@ func (pm *ProgramsMap) Programs() map[AttachType]Layout {
 	defer pm.programsLock.Unlock()
 
 	progs := make(map[AttachType]Layout, len(pm.programs))
-	for at, prog := range pm.programs {
-		progs[at] = prog.layout
+	for key, prog := range pm.programs {
+		progs[key.AttachType] = prog.layout
 	}
 
 	return progs

--- a/felix/bpf/hook/map.go
+++ b/felix/bpf/hook/map.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
+	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	bpfmaps "github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
@@ -186,6 +187,12 @@ type ProgramsMap struct {
 
 	expectedAttachType string
 	nextIdx            atomic.Int64
+
+	// mapPinOverrides maps C object map names (e.g. "cali_progs_ing2") to
+	// alternate pin paths. Used by netkit ProgramsMaps to redirect prog_array
+	// maps to a netkit-specific directory, so that netkit programs (which have
+	// a different expected_attach_type) get their own prog_array instances.
+	mapPinOverrides map[string]string
 }
 
 type program struct {
@@ -218,6 +225,93 @@ func NewProgramsMaps() []bpfmaps.Map {
 		NewIngressProgramsMap(),
 		NewEgressProgramsMap(),
 	}
+}
+
+var NetkitIngressProgramsMapParameters = bpfmaps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: maxPrograms,
+	Name:       "cali_p_nk_ing",
+	Version:    2,
+}
+
+var NetkitEgressProgramsMapParameters = bpfmaps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: maxPrograms,
+	Name:       "cali_p_nk_egr",
+	Version:    2,
+}
+
+func NewNetkitProgramsMaps() []bpfmaps.Map {
+	return []bpfmaps.Map{
+		NewNetkitIngressProgramsMap(),
+		NewNetkitEgressProgramsMap(),
+	}
+}
+
+func NewNetkitIngressProgramsMap() bpfmaps.Map {
+	pm := newProgramsMap(NetkitIngressProgramsMapParameters, "ingress")
+	pmTyped := pm.(*ProgramsMap)
+	pmTyped.mapPinOverrides = netkitPinOverrides(
+		IngressProgramsMapParameters, NetkitIngressProgramsMapParameters,
+		jump.IngressMapParameters, jump.NetkitIngressMapParameters,
+	)
+	return pm
+}
+
+func NewNetkitEgressProgramsMap() bpfmaps.Map {
+	pm := newProgramsMap(NetkitEgressProgramsMapParameters, "egress")
+	pmTyped := pm.(*ProgramsMap)
+	pmTyped.mapPinOverrides = netkitPinOverrides(
+		EgressProgramsMapParameters, NetkitEgressProgramsMapParameters,
+		jump.EgressMapParameters, jump.NetkitEgressMapParameters,
+	)
+	return pm
+}
+
+// netkitPinOverrides builds a map from the C object's prog_array map names
+// to netkit-specific pin paths. The kernel requires all programs in a prog_array
+// to have the same expected_attach_type; netkit programs (BPF_NETKIT_PEER/PRIMARY)
+// are incompatible with TC/TCX programs, so they need separate prog_array instances.
+// TC and TCX can share prog_arrays because the kernel treats their attach types as
+// compatible within BPF_PROG_TYPE_SCHED_CLS.
+func netkitPinOverrides(
+	tcProgs, nkProgs bpfmaps.MapParameters,
+	tcJump, nkJump bpfmaps.MapParameters,
+) map[string]string {
+	return map[string]string{
+		tcProgs.VersionedName(): nkProgs.VersionedFilename(),
+		tcJump.VersionedName():  nkJump.VersionedFilename(),
+	}
+}
+
+// NetkitPinOverridesIngress returns pin path overrides for ingress prog_array maps.
+func NetkitPinOverridesIngress() map[string]string {
+	return netkitPinOverrides(
+		IngressProgramsMapParameters, NetkitIngressProgramsMapParameters,
+		jump.IngressMapParameters, jump.NetkitIngressMapParameters,
+	)
+}
+
+// NetkitPinOverridesEgress returns pin path overrides for egress prog_array maps.
+func NetkitPinOverridesEgress() map[string]string {
+	return netkitPinOverrides(
+		EgressProgramsMapParameters, NetkitEgressProgramsMapParameters,
+		jump.EgressMapParameters, jump.NetkitEgressMapParameters,
+	)
+}
+
+// NetkitPinOverridesBoth returns pin path overrides for both ingress and egress
+// prog_array maps. Used when the attach point is copied for both directions.
+func NetkitPinOverridesBoth() map[string]string {
+	m := NetkitPinOverridesIngress()
+	for k, v := range NetkitPinOverridesEgress() {
+		m[k] = v
+	}
+	return m
 }
 
 func NewIngressProgramsMap() bpfmaps.Map {
@@ -420,11 +514,15 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 		if err := pm.setMapSize(m); err != nil {
 			return fmt.Errorf("error setting map size %s : %w", mapName, err)
 		}
-		if err := m.SetPinPath(path.Join(bpfdefs.GlobalPinDir, mapName)); err != nil {
+		pinPath := path.Join(bpfdefs.GlobalPinDir, mapName)
+		if override, ok := pm.mapPinOverrides[mapName]; ok {
+			pinPath = override
+		}
+		if err := m.SetPinPath(pinPath); err != nil {
 			return fmt.Errorf("error pinning map %s: %w", mapName, err)
 		}
 		log.Debugf("map %s k %d v %d pinned to %s for generic object file %s",
-			mapName, m.KeySize(), m.ValueSize(), path.Join(bpfdefs.GlobalPinDir, mapName), file)
+			mapName, m.KeySize(), m.ValueSize(), pinPath, file)
 	}
 
 	switch progAttachType {

--- a/felix/bpf/hook/map.go
+++ b/felix/bpf/hook/map.go
@@ -427,7 +427,8 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 			mapName, m.KeySize(), m.ValueSize(), path.Join(bpfdefs.GlobalPinDir, mapName), file)
 	}
 
-	if progAttachType == "TCX" {
+	switch progAttachType {
+	case "TCX":
 		for prog, err := obj.FirstProgram(); prog != nil && err == nil; prog, err = prog.NextProgram() {
 			attachType := libbpf.AttachTypeTcxEgress
 			if pm.expectedAttachType == "ingress" {
@@ -435,6 +436,19 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 			}
 			if err := obj.SetAttachType(prog.Name(), attachType); err != nil {
 				return fmt.Errorf("error setting attach type for program %s: %w", prog.Name(), err)
+			}
+		}
+	case "Netkit":
+		for prog, err := obj.FirstProgram(); prog != nil && err == nil; prog, err = prog.NextProgram() {
+			// Map direction to netkit attach type:
+			// ingress ProgramsMap (traffic from pod) -> BPF_NETKIT_PEER
+			// egress ProgramsMap (traffic to pod) -> BPF_NETKIT_PRIMARY
+			attachType := libbpf.AttachTypeNetkitPrimary
+			if pm.expectedAttachType == "ingress" {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+			if err := obj.SetAttachType(prog.Name(), attachType); err != nil {
+				return fmt.Errorf("error setting netkit attach type for program %s: %w", prog.Name(), err)
 			}
 		}
 	}

--- a/felix/bpf/hook/map.go
+++ b/felix/bpf/hook/map.go
@@ -534,33 +534,37 @@ func (pm *ProgramsMap) configureMapsAndPrograms(obj *libbpf.Obj, file, progAttac
 			mapName, m.KeySize(), m.ValueSize(), pinPath, file)
 	}
 
-	switch progAttachType {
-	case "TCX":
+	if attachType, ok := linkAttachType(progAttachType, pm.expectedAttachType == "ingress"); ok {
 		for prog, err := obj.FirstProgram(); prog != nil && err == nil; prog, err = prog.NextProgram() {
-			attachType := libbpf.AttachTypeTcxEgress
-			if pm.expectedAttachType == "ingress" {
-				attachType = libbpf.AttachTypeTcxIngress
-			}
 			if err := obj.SetAttachType(prog.Name(), attachType); err != nil {
-				return fmt.Errorf("error setting attach type for program %s: %w", prog.Name(), err)
-			}
-		}
-	case "Netkit":
-		for prog, err := obj.FirstProgram(); prog != nil && err == nil; prog, err = prog.NextProgram() {
-			// Map direction to netkit attach type:
-			// ingress ProgramsMap (traffic from pod) -> BPF_NETKIT_PEER
-			// egress ProgramsMap (traffic to pod) -> BPF_NETKIT_PRIMARY
-			attachType := libbpf.AttachTypeNetkitPrimary
-			if pm.expectedAttachType == "ingress" {
-				attachType = libbpf.AttachTypeNetkitPeer
-			}
-			if err := obj.SetAttachType(prog.Name(), attachType); err != nil {
-				return fmt.Errorf("error setting netkit attach type for program %s: %w", prog.Name(), err)
+				return fmt.Errorf("error setting %s attach type for program %s: %w", progAttachType, prog.Name(), err)
 			}
 		}
 	}
 
 	return nil
+}
+
+// linkAttachType returns the libbpf attach type for the given link-based
+// attachment mode and direction. The bool is false for modes that don't
+// use libbpf-link attachment.
+func linkAttachType(progAttachType string, ingress bool) (uint32, bool) {
+	switch progAttachType {
+	case "TCX":
+		if ingress {
+			return libbpf.AttachTypeTcxIngress, true
+		}
+		return libbpf.AttachTypeTcxEgress, true
+	case "Netkit":
+		// Map direction to netkit attach type:
+		// ingress ProgramsMap (traffic from pod) -> BPF_NETKIT_PEER
+		// egress ProgramsMap (traffic to pod) -> BPF_NETKIT_PRIMARY
+		if ingress {
+			return libbpf.AttachTypeNetkitPeer, true
+		}
+		return libbpf.AttachTypeNetkitPrimary, true
+	}
+	return 0, false
 }
 
 func (pm *ProgramsMap) setMapSize(m *libbpf.Map) error {

--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -74,6 +74,35 @@ func XDPMap() maps.Map {
 	return maps.NewPinnedMap(XDPMapParameters)
 }
 
+// Netkit maps are identical to TC maps but pinned to a separate directory
+// so that netkit-attached programs (which have a different expected_attach_type)
+// get their own prog_array instances. The kernel requires all programs in a
+// prog_array to share the same expected_attach_type.
+var NetkitIngressMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: TCMaxEntries,
+	Name:       "cali_j_nk_ing",
+	Version:    2,
+}
+
+var NetkitEgressMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: TCMaxEntries,
+	Name:       "cali_j_nk_egr",
+	Version:    2,
+}
+
+func NetkitMaps() []maps.Map {
+	return []maps.Map{
+		maps.NewPinnedMap(NetkitIngressMapParameters),
+		maps.NewPinnedMap(NetkitEgressMapParameters),
+	}
+}
+
 func Key(idx int) []byte {
 	var k [4]byte
 	binary.LittleEndian.PutUint32(k[:], uint32(idx))

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -615,6 +615,7 @@ func (t *TcGlobalData) Set(m *Map) error {
 		C.short(t.IstioDSCP),
 		C.uint(t.MaglevLUTSize),
 		C.uint(t.IPFragTimeout),
+		C.uint(t.HostIfindex),
 	)
 
 	return err

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -306,6 +306,22 @@ func (o *Obj) AttachTCX(secName, ifName string) (*Link, error) {
 	return &Link{link: link}, nil
 }
 
+func (o *Obj) AttachNetkit(secName, ifName string) (*Link, error) {
+	cSecName := C.CString(secName)
+	cIfName := C.CString(ifName)
+	defer C.free(unsafe.Pointer(cSecName))
+	defer C.free(unsafe.Pointer(cIfName))
+	ifIndex, err := C.if_nametoindex(cIfName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting ifindex for %s: %w", ifName, err)
+	}
+	link, err := C.bpf_netkit_program_attach(o.obj, cSecName, C.int(ifIndex))
+	if err != nil {
+		return nil, fmt.Errorf("error attaching netkit program: %w", err)
+	}
+	return &Link{link: link}, nil
+}
+
 func (o *Obj) AttachXDP(ifName, progName string, oldID int, mode uint) (int, error) {
 	cProgName := C.CString(progName)
 	cIfName := C.CString(ifName)
@@ -551,6 +567,9 @@ const (
 	AttachTypeTcxIngress uint32 = C.BPF_TCX_INGRESS
 	AttachTypeTcxEgress  uint32 = C.BPF_TCX_EGRESS
 	AttachTypeXDP        uint32 = C.BPF_XDP
+
+	AttachTypeNetkitPrimary uint32 = C.BPF_NETKIT_PRIMARY
+	AttachTypeNetkitPeer    uint32 = C.BPF_NETKIT_PEER
 )
 
 func (t *TcGlobalData) Set(m *Map) error {

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -150,7 +150,7 @@ void bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, b
 
 struct bpf_link* bpf_tcx_program_attach(struct bpf_object *obj, char *secName, int ifIndex)
 {
-	DECLARE_LIBBPF_OPTS(bpf_tcx_opts, attach); 
+	DECLARE_LIBBPF_OPTS(bpf_tcx_opts, attach);
 	struct bpf_program *prog = bpf_object__find_program_by_name(obj, secName);
 	if (!prog) {
 		errno = ENOENT;
@@ -163,6 +163,23 @@ struct bpf_link* bpf_tcx_program_attach(struct bpf_object *obj, char *secName, i
         }
         set_errno(err);
         return link;
+}
+
+struct bpf_link* bpf_netkit_program_attach(struct bpf_object *obj, char *secName, int ifIndex)
+{
+	DECLARE_LIBBPF_OPTS(bpf_netkit_opts, attach);
+	struct bpf_program *prog = bpf_object__find_program_by_name(obj, secName);
+	if (!prog) {
+		errno = ENOENT;
+		return NULL;
+	}
+	struct bpf_link *link = bpf_program__attach_netkit(prog, ifIndex, &attach);
+	int err = libbpf_get_error(link);
+	if (err) {
+		link = NULL;
+	}
+	set_errno(err);
+	return link;
 }
 
 void bpf_tc_program_detach(int ifindex, int handle, int pref, bool ingress)

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -278,7 +278,8 @@ void bpf_tc_set_globals(struct bpf_map *map,
 			short dscp,
 			short istio_dscp,
 			uint maglev_lut_size,
-			uint ipfrag_timeout)
+			uint ipfrag_timeout,
+			uint host_ifindex)
 {
 	struct cali_tc_global_data v4 = {
 		.tunnel_mtu = tmtu,
@@ -297,6 +298,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 		.istio_dscp = istio_dscp,
 		.maglev_lut_size = maglev_lut_size,
 		.ipfrag_timeout = ipfrag_timeout,
+		.host_ifindex = host_ifindex,
 	};
 
 	strncpy((char *)v4.iface_name, iface_name, sizeof(v4.iface_name));

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -51,6 +51,7 @@ type TcGlobalData struct {
 	IstioDSCP     int8
 	MaglevLUTSize uint32
 	IPFragTimeout uint32
+	HostIfindex   uint32
 }
 
 type XDPGlobalData struct {

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -200,6 +200,8 @@ const (
 	AttachTypeTcxIngress                 uint32 = 12345
 	AttachTypeTcxEgress                  uint32 = 12345
 	AttachTypeXDP                        uint32 = 12345
+	AttachTypeNetkitPrimary              uint32 = 12345
+	AttachTypeNetkitPeer                 uint32 = 12345
 )
 
 func (m *Map) SetSize(size int) error {

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -256,6 +256,10 @@ func (o *Obj) AttachTCX(secName, ifName string) (*Link, error) {
 	panic("LIBBPF syscall stub")
 }
 
+func (o *Obj) AttachNetkit(secName, ifName string) (*Link, error) {
+	panic("LIBBPF syscall stub")
+}
+
 func OpenObjectWithLogBuffer(filename string, buf []byte) (*Obj, error) {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -528,7 +528,14 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 		IstioDSCP:     ap.IstioDSCP,
 		MaglevLUTSize: ap.MaglevLUTSize,
 		IPFragTimeout: ap.IPFragTimeout,
-		HostIfindex:   uint32(ap.IfIndex),
+	}
+
+	// Only set HostIfindex for netkit interfaces. For netkit, skb->ifindex
+	// is the peer's ifindex which differs from the primary that maps are
+	// keyed by. For TC/TCX, skb->ifindex already matches the host-side
+	// interface, so we leave HostIfindex as 0 to use the skb->ifindex fallback.
+	if string(ap.AttachType) == AttachOptionNetkit {
+		globalData.HostIfindex = uint32(ap.IfIndex)
 	}
 
 	if ap.Profiling == "Enabled" {

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -125,8 +125,11 @@ func (ap *AttachPoint) loadObject(file string, configurator bpf.ObjectConfigurat
 // (pin absent or link severed). Returns err!=nil on hard failures.
 func (ap *AttachPoint) tryUpdateExistingLink(obj *libbpf.Obj, progPinPath string) (needsReattach bool, err error) {
 	if _, err := os.Stat(progPinPath); err != nil {
-		// Pin does not exist; caller must attach anew.
-		return true, nil
+		if os.IsNotExist(err) {
+			// Pin does not exist; caller must attach anew.
+			return true, nil
+		}
+		return false, fmt.Errorf("error stating link pin %s: %w", progPinPath, err)
 	}
 	link, err := libbpf.OpenLink(progPinPath)
 	if err != nil {
@@ -146,21 +149,23 @@ func (ap *AttachPoint) tryUpdateExistingLink(obj *libbpf.Obj, progPinPath string
 	return false, nil
 }
 
-func (ap *AttachPoint) attachTCXProgram(binaryToLoad string) error {
-	obj, err := ap.loadObject(binaryToLoad, func(obj *libbpf.Obj) error {
-		attachType := libbpf.AttachTypeTcxEgress
-		if ap.Hook == hook.Ingress {
-			attachType = libbpf.AttachTypeTcxIngress
-		}
-		return obj.SetAttachType("cali_tc_preamble", attachType)
-	})
+// attachLinkProgram loads, configures, and attaches the BPF preamble using
+// libbpf-link-based attachment (TCX or netkit). The differences between the
+// two are captured by the per-mode setAttachType / attach closures and the
+// pin path.
+func (ap *AttachPoint) attachLinkProgram(
+	binaryToLoad, pinPath string,
+	setAttachType func(*libbpf.Obj) error,
+	attach func(*libbpf.Obj) (*libbpf.Link, error),
+) error {
+	obj, err := ap.loadObject(binaryToLoad, setAttachType)
 	if err != nil {
 		ap.Log().Warn("Failed to load program")
 		return fmt.Errorf("object %w", err)
 	}
 	defer obj.Close()
 
-	needsReattach, err := ap.tryUpdateExistingLink(obj, ap.ProgPinPath())
+	needsReattach, err := ap.tryUpdateExistingLink(obj, pinPath)
 	if err != nil {
 		return err
 	}
@@ -168,16 +173,32 @@ func (ap *AttachPoint) attachTCXProgram(binaryToLoad string) error {
 		return nil
 	}
 
-	link, err := obj.AttachTCX("cali_tc_preamble", ap.Iface)
+	link, err := attach(obj)
 	if err != nil {
 		return err
 	}
 	defer link.Close()
-	err = link.Pin(ap.ProgPinPath())
-	if err != nil {
-		return fmt.Errorf("error pinning link %w", err)
+	if err := link.Pin(pinPath); err != nil {
+		return fmt.Errorf("error pinning link %s: %w", pinPath, err)
 	}
 	return nil
+}
+
+func (ap *AttachPoint) attachTCXProgram(binaryToLoad string) error {
+	return ap.attachLinkProgram(
+		binaryToLoad,
+		ap.ProgPinPath(),
+		func(obj *libbpf.Obj) error {
+			attachType := libbpf.AttachTypeTcxEgress
+			if ap.Hook == hook.Ingress {
+				attachType = libbpf.AttachTypeTcxIngress
+			}
+			return obj.SetAttachType("cali_tc_preamble", attachType)
+		},
+		func(obj *libbpf.Obj) (*libbpf.Link, error) {
+			return obj.AttachTCX("cali_tc_preamble", ap.Iface)
+		},
+	)
 }
 
 // AttachProgram attaches a BPF program from a file to the TC attach point
@@ -256,40 +277,23 @@ func (ap *AttachPoint) NetkitProgPinPath() string {
 }
 
 func (ap *AttachPoint) attachNetkitProgram(binaryToLoad string) error {
-	obj, err := ap.loadObject(binaryToLoad, func(obj *libbpf.Obj) error {
-		// Map TC hook direction to netkit attach type:
-		// hook.Ingress (traffic from pod) -> BPF_NETKIT_PEER (peer transmits)
-		// hook.Egress (traffic to pod) -> BPF_NETKIT_PRIMARY (primary transmits)
-		attachType := libbpf.AttachTypeNetkitPrimary
-		if ap.Hook == hook.Ingress {
-			attachType = libbpf.AttachTypeNetkitPeer
-		}
-		return obj.SetAttachType("cali_tc_preamble", attachType)
-	})
-	if err != nil {
-		ap.Log().Warn("Failed to load program for netkit")
-		return fmt.Errorf("object %w", err)
-	}
-	defer obj.Close()
-
-	needsReattach, err := ap.tryUpdateExistingLink(obj, ap.NetkitProgPinPath())
-	if err != nil {
-		return err
-	}
-	if !needsReattach {
-		return nil
-	}
-
-	link, err := obj.AttachNetkit("cali_tc_preamble", ap.Iface)
-	if err != nil {
-		return err
-	}
-	defer link.Close()
-	err = link.Pin(ap.NetkitProgPinPath())
-	if err != nil {
-		return fmt.Errorf("error pinning netkit link: %w", err)
-	}
-	return nil
+	return ap.attachLinkProgram(
+		binaryToLoad,
+		ap.NetkitProgPinPath(),
+		func(obj *libbpf.Obj) error {
+			// Map TC hook direction to netkit attach type:
+			// hook.Ingress (traffic from pod) -> BPF_NETKIT_PEER (peer transmits)
+			// hook.Egress (traffic to pod) -> BPF_NETKIT_PRIMARY (primary transmits)
+			attachType := libbpf.AttachTypeNetkitPrimary
+			if ap.Hook == hook.Ingress {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+			return obj.SetAttachType("cali_tc_preamble", attachType)
+		},
+		func(obj *libbpf.Obj) (*libbpf.Link, error) {
+			return obj.AttachNetkit("cali_tc_preamble", ap.Iface)
+		},
+	)
 }
 
 func (ap *AttachPoint) detachNetkitProgram() error {

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -82,6 +82,7 @@ type AttachPoint struct {
 	MaglevLUTSize                 uint32
 	IPFragTimeout                 uint32
 	ProgramsMap                   maps.Map
+	MapPinOverrides               map[string]string // prog_array pin path overrides for netkit
 }
 
 // AttachOptionNetkit is used internally to signal netkit attachment.
@@ -101,7 +102,7 @@ func (ap *AttachPoint) Log() *log.Entry {
 }
 
 func (ap *AttachPoint) loadObject(file string, configurator bpf.ObjectConfigurator) (*libbpf.Obj, error) {
-	obj, err := bpf.LoadObjectWithOptions(file, ap.Configure(), configurator)
+	obj, err := bpf.LoadObjectWithPinOverrides(file, ap.Configure(), configurator, ap.MapPinOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s: %w", file, err)
 	}

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -83,16 +83,22 @@ type AttachPoint struct {
 	IPFragTimeout                 uint32
 	ProgramsMap                   maps.Map
 	MapPinOverrides               map[string]string // prog_array pin path overrides for netkit
+	// Netkit is an internal signal set by Felix when it auto-detects a netkit
+	// workload interface. It is intentionally separate from AttachType (which
+	// holds the user-facing TC/TCX enum) to avoid conflating an internal
+	// override with a validated API type.
+	Netkit bool
 }
 
-// AttachOptionNetkit is used internally to signal netkit attachment.
-// It is not part of the public API (not user-configurable); Felix auto-selects
-// it when it detects a netkit device.
+// AttachOptionNetkit is the program-attach-type string used by the hook loader
+// to select netkit-specific BPF object variants. It is not part of the public
+// API — Felix sets Netkit=true on the AttachPoint when it detects a netkit
+// device and derives this string from that flag.
 const AttachOptionNetkit = "Netkit"
 
 // IsNetkit reports whether this attach point targets a netkit device.
 func (ap *AttachPoint) IsNetkit() bool {
-	return string(ap.AttachType) == AttachOptionNetkit
+	return ap.Netkit
 }
 
 var ErrDeviceNotFound = errors.New("device not found")

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -84,6 +84,11 @@ type AttachPoint struct {
 	ProgramsMap                   maps.Map
 }
 
+// AttachOptionNetkit is used internally to signal netkit attachment.
+// It is not part of the public API (not user-configurable); Felix auto-selects
+// it when it detects a netkit device.
+const AttachOptionNetkit = "Netkit"
+
 var ErrDeviceNotFound = errors.New("device not found")
 var ErrInterrupted = errors.New("dump interrupted")
 
@@ -156,6 +161,19 @@ func (ap *AttachPoint) AttachProgram() error {
 	// configuration further to the selected set of programs.
 
 	binaryToLoad := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("tc_preamble_%s.o", ap.Hook))
+	if ap.AttachType == AttachOptionNetkit {
+		err := ap.attachNetkitProgram(binaryToLoad)
+		if err != nil {
+			return fmt.Errorf("error attaching netkit program %s:%s: %w", ap.Iface, ap.Hook, err)
+		}
+		// Clean up legacy TC and TCX attachments from previous runs.
+		_ = RemoveQdisc(ap.Iface)
+		if _, err := os.Stat(ap.ProgPinPath()); err == nil {
+			_ = ap.detachTcxProgram()
+		}
+		logCxt.Info("Program attached to netkit.")
+		return nil
+	}
 	if ap.AttachType == apiv3.BPFAttachOptionTCX {
 		err := ap.attachTCXProgram(binaryToLoad)
 		if err != nil {
@@ -206,6 +224,72 @@ func (ap *AttachPoint) ProgPinPath() string {
 	return path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_%s", strings.ReplaceAll(ap.Iface, ".", ""), ap.Hook))
 }
 
+func (ap *AttachPoint) NetkitProgPinPath() string {
+	return path.Join(bpfdefs.NetkitPinDir, fmt.Sprintf("%s_%s", strings.ReplaceAll(ap.Iface, ".", ""), ap.Hook))
+}
+
+func (ap *AttachPoint) attachNetkitProgram(binaryToLoad string) error {
+	logCxt := log.WithField("attachPoint", ap)
+	obj, err := ap.loadObject(binaryToLoad, func(obj *libbpf.Obj) error {
+		// Map TC hook direction to netkit attach type:
+		// hook.Ingress (traffic from pod) -> BPF_NETKIT_PEER (peer transmits)
+		// hook.Egress (traffic to pod) -> BPF_NETKIT_PRIMARY (primary transmits)
+		attachType := libbpf.AttachTypeNetkitPrimary
+		if ap.Hook == hook.Ingress {
+			attachType = libbpf.AttachTypeNetkitPeer
+		}
+		return obj.SetAttachType("cali_tc_preamble", attachType)
+	})
+	if err != nil {
+		logCxt.Warn("Failed to load program for netkit")
+		return fmt.Errorf("object %w", err)
+	}
+	defer obj.Close()
+	progPinPath := ap.NetkitProgPinPath()
+	if _, err := os.Stat(progPinPath); err == nil {
+		link, err := libbpf.OpenLink(progPinPath)
+		if err != nil {
+			return fmt.Errorf("error opening link %s: %w", progPinPath, err)
+		}
+		defer link.Close()
+		if err := link.Update(obj, "cali_tc_preamble"); err != nil {
+			if errors.Is(err, unix.ENOLINK) {
+				logCxt.Debug("Netkit link severed from interface, re-attaching")
+				os.Remove(progPinPath)
+				goto attachNew
+			}
+			return fmt.Errorf("error updating program %s: %w", progPinPath, err)
+		}
+		return nil
+	}
+attachNew:
+	link, err := obj.AttachNetkit("cali_tc_preamble", ap.Iface)
+	if err != nil {
+		return err
+	}
+	defer link.Close()
+	err = link.Pin(progPinPath)
+	if err != nil {
+		return fmt.Errorf("error pinning netkit link: %w", err)
+	}
+	return nil
+}
+
+func (ap *AttachPoint) detachNetkitProgram() error {
+	progPinPath := ap.NetkitProgPinPath()
+	defer os.Remove(progPinPath)
+	link, err := libbpf.OpenLink(progPinPath)
+	if err != nil {
+		return fmt.Errorf("error opening netkit link %s: %w", progPinPath, err)
+	}
+	defer link.Close()
+	err = link.Detach()
+	if err != nil {
+		return fmt.Errorf("error detaching netkit link %s: %w", progPinPath, err)
+	}
+	return nil
+}
+
 func (ap *AttachPoint) detachTcxProgram() error {
 	progPinPath := ap.ProgPinPath()
 	defer os.Remove(progPinPath)
@@ -230,7 +314,11 @@ func (ap *AttachPoint) detachTcProgram() error {
 }
 
 func (ap *AttachPoint) DetachProgram() error {
-	err := ap.detachTcxProgram()
+	err := ap.detachNetkitProgram()
+	if err != nil {
+		log.Warnf("error detaching netkit program from %s hook %s : %s", ap.Iface, ap.Hook, err)
+	}
+	err = ap.detachTcxProgram()
 	if err != nil {
 		log.Warnf("error detaching tcx program from %s hook %s : %s", ap.Iface, ap.Hook, err)
 	}
@@ -573,4 +661,46 @@ var IsTcxSupported = sync.OnceValue(func() bool {
 	defer obj.Close()
 	_, err = obj.AttachTCX("cali_tcx_test", name)
 	return err == nil
+})
+
+var IsNetkitSupported = sync.OnceValue(func() bool {
+	name := "testNk"
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Flags = net.FlagUp
+	nk := &netlink.Netkit{
+		LinkAttrs: la,
+		Mode:      netlink.NETKIT_MODE_L2,
+	}
+	err := netlink.LinkAdd(nk)
+	if err != nil {
+		log.WithError(err).Debug("Netkit not supported on this kernel")
+		return false
+	}
+
+	defer func() {
+		if err := netlink.LinkDel(nk); err != nil {
+			log.Warnf("failed to delete netkit interface %s: %s", name, err)
+		}
+	}()
+
+	// Use LoadObjectWithOptions with a configurator to set the netkit attach
+	// type before loading. bpf.LoadObject calls Load() internally, so we
+	// must set the attach type in the configurator callback.
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, "tcx_test.o")
+	obj, err := bpf.LoadObjectWithOptions(binaryToLoad, &libbpf.TcGlobalData{}, func(obj *libbpf.Obj) error {
+		return obj.SetAttachType("cali_tcx_test", libbpf.AttachTypeNetkitPrimary)
+	})
+	if err != nil {
+		log.WithError(err).Debug("Failed to load test object for netkit probe")
+		return false
+	}
+	defer obj.Close()
+	link, err := obj.AttachNetkit("cali_tcx_test", name)
+	if err != nil {
+		log.WithError(err).Debug("Netkit BPF attachment not supported")
+		return false
+	}
+	link.Close()
+	return true
 })

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -90,6 +90,11 @@ type AttachPoint struct {
 // it when it detects a netkit device.
 const AttachOptionNetkit = "Netkit"
 
+// IsNetkit reports whether this attach point targets a netkit device.
+func (ap *AttachPoint) IsNetkit() bool {
+	return string(ap.AttachType) == AttachOptionNetkit
+}
+
 var ErrDeviceNotFound = errors.New("device not found")
 var ErrInterrupted = errors.New("dump interrupted")
 
@@ -109,8 +114,33 @@ func (ap *AttachPoint) loadObject(file string, configurator bpf.ObjectConfigurat
 	return obj, nil
 }
 
+// tryUpdateExistingLink attempts to update a previously-pinned BPF link.
+// Returns needsReattach=true when the caller should create a fresh attachment
+// (pin absent or link severed). Returns err!=nil on hard failures.
+func (ap *AttachPoint) tryUpdateExistingLink(obj *libbpf.Obj, progPinPath string) (needsReattach bool, err error) {
+	if _, err := os.Stat(progPinPath); err != nil {
+		// Pin does not exist; caller must attach anew.
+		return true, nil
+	}
+	link, err := libbpf.OpenLink(progPinPath)
+	if err != nil {
+		return false, fmt.Errorf("error opening link %s: %w", progPinPath, err)
+	}
+	defer link.Close()
+	if err := link.Update(obj, "cali_tc_preamble"); err != nil {
+		if errors.Is(err, unix.ENOLINK) {
+			// The link was severed from the interface; remove the stale pin
+			// and let the caller re-attach.
+			ap.Log().Debug("Link severed from interface, re-attaching")
+			os.Remove(progPinPath)
+			return true, nil
+		}
+		return false, fmt.Errorf("error updating program %s: %w", progPinPath, err)
+	}
+	return false, nil
+}
+
 func (ap *AttachPoint) attachTCXProgram(binaryToLoad string) error {
-	logCxt := log.WithField("attachPoint", ap)
 	obj, err := ap.loadObject(binaryToLoad, func(obj *libbpf.Obj) error {
 		attachType := libbpf.AttachTypeTcxEgress
 		if ap.Hook == hook.Ingress {
@@ -119,35 +149,25 @@ func (ap *AttachPoint) attachTCXProgram(binaryToLoad string) error {
 		return obj.SetAttachType("cali_tc_preamble", attachType)
 	})
 	if err != nil {
-		logCxt.Warn("Failed to load program")
+		ap.Log().Warn("Failed to load program")
 		return fmt.Errorf("object %w", err)
 	}
 	defer obj.Close()
-	progPinPath := ap.ProgPinPath()
-	if _, err := os.Stat(progPinPath); err == nil {
-		link, err := libbpf.OpenLink(progPinPath)
-		if err != nil {
-			return fmt.Errorf("error opening link %s : %w", progPinPath, err)
-		}
-		defer link.Close()
-		if err := link.Update(obj, "cali_tc_preamble"); err != nil {
-			if errors.Is(err, unix.ENOLINK) {
-				// The link was deleted out from under us, so try attaching a new one.
-				logCxt.Debug("Link severed from interface, re-attaching")
-				os.Remove(progPinPath)
-				goto attachNew
-			}
-			return fmt.Errorf("error updating program %s : %w", progPinPath, err)
-		}
+
+	needsReattach, err := ap.tryUpdateExistingLink(obj, ap.ProgPinPath())
+	if err != nil {
+		return err
+	}
+	if !needsReattach {
 		return nil
 	}
-attachNew:
+
 	link, err := obj.AttachTCX("cali_tc_preamble", ap.Iface)
 	if err != nil {
 		return err
 	}
 	defer link.Close()
-	err = link.Pin(progPinPath)
+	err = link.Pin(ap.ProgPinPath())
 	if err != nil {
 		return fmt.Errorf("error pinning link %w", err)
 	}
@@ -162,7 +182,7 @@ func (ap *AttachPoint) AttachProgram() error {
 	// configuration further to the selected set of programs.
 
 	binaryToLoad := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("tc_preamble_%s.o", ap.Hook))
-	if ap.AttachType == AttachOptionNetkit {
+	if ap.IsNetkit() {
 		err := ap.attachNetkitProgram(binaryToLoad)
 		if err != nil {
 			return fmt.Errorf("error attaching netkit program %s:%s: %w", ap.Iface, ap.Hook, err)
@@ -230,7 +250,6 @@ func (ap *AttachPoint) NetkitProgPinPath() string {
 }
 
 func (ap *AttachPoint) attachNetkitProgram(binaryToLoad string) error {
-	logCxt := log.WithField("attachPoint", ap)
 	obj, err := ap.loadObject(binaryToLoad, func(obj *libbpf.Obj) error {
 		// Map TC hook direction to netkit attach type:
 		// hook.Ingress (traffic from pod) -> BPF_NETKIT_PEER (peer transmits)
@@ -242,34 +261,25 @@ func (ap *AttachPoint) attachNetkitProgram(binaryToLoad string) error {
 		return obj.SetAttachType("cali_tc_preamble", attachType)
 	})
 	if err != nil {
-		logCxt.Warn("Failed to load program for netkit")
+		ap.Log().Warn("Failed to load program for netkit")
 		return fmt.Errorf("object %w", err)
 	}
 	defer obj.Close()
-	progPinPath := ap.NetkitProgPinPath()
-	if _, err := os.Stat(progPinPath); err == nil {
-		link, err := libbpf.OpenLink(progPinPath)
-		if err != nil {
-			return fmt.Errorf("error opening link %s: %w", progPinPath, err)
-		}
-		defer link.Close()
-		if err := link.Update(obj, "cali_tc_preamble"); err != nil {
-			if errors.Is(err, unix.ENOLINK) {
-				logCxt.Debug("Netkit link severed from interface, re-attaching")
-				os.Remove(progPinPath)
-				goto attachNew
-			}
-			return fmt.Errorf("error updating program %s: %w", progPinPath, err)
-		}
+
+	needsReattach, err := ap.tryUpdateExistingLink(obj, ap.NetkitProgPinPath())
+	if err != nil {
+		return err
+	}
+	if !needsReattach {
 		return nil
 	}
-attachNew:
+
 	link, err := obj.AttachNetkit("cali_tc_preamble", ap.Iface)
 	if err != nil {
 		return err
 	}
 	defer link.Close()
-	err = link.Pin(progPinPath)
+	err = link.Pin(ap.NetkitProgPinPath())
 	if err != nil {
 		return fmt.Errorf("error pinning netkit link: %w", err)
 	}
@@ -315,15 +325,17 @@ func (ap *AttachPoint) detachTcProgram() error {
 }
 
 func (ap *AttachPoint) DetachProgram() error {
-	err := ap.detachNetkitProgram()
-	if err != nil {
-		log.Warnf("error detaching netkit program from %s hook %s : %s", ap.Iface, ap.Hook, err)
+	if _, err := os.Stat(ap.NetkitProgPinPath()); err == nil {
+		if err := ap.detachNetkitProgram(); err != nil {
+			log.Warnf("error detaching netkit program from %s hook %s : %s", ap.Iface, ap.Hook, err)
+		}
 	}
-	err = ap.detachTcxProgram()
-	if err != nil {
-		log.Warnf("error detaching tcx program from %s hook %s : %s", ap.Iface, ap.Hook, err)
+	if _, err := os.Stat(ap.ProgPinPath()); err == nil {
+		if err := ap.detachTcxProgram(); err != nil {
+			log.Warnf("error detaching tcx program from %s hook %s : %s", ap.Iface, ap.Hook, err)
+		}
 	}
-	err = ap.detachTcProgram()
+	err := ap.detachTcProgram()
 	if err != nil {
 		log.Warnf("error detaching tc program from %s hook %s : %s", ap.Iface, ap.Hook, err)
 	}
@@ -534,7 +546,7 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 	// is the peer's ifindex which differs from the primary that maps are
 	// keyed by. For TC/TCX, skb->ifindex already matches the host-side
 	// interface, so we leave HostIfindex as 0 to use the skb->ifindex fallback.
-	if string(ap.AttachType) == AttachOptionNetkit {
+	if ap.IsNetkit() {
 		globalData.HostIfindex = uint32(ap.IfIndex)
 	}
 
@@ -673,7 +685,12 @@ var IsTcxSupported = sync.OnceValue(func() bool {
 })
 
 var IsNetkitSupported = sync.OnceValue(func() bool {
-	name := "testNk"
+	name := "cali_nk_probe"
+	// Clean up a stale probe device that may have been left behind by a
+	// previous crash before the deferred cleanup could run.
+	if old, err := netlink.LinkByName(name); err == nil {
+		_ = netlink.LinkDel(old)
+	}
 	la := netlink.NewLinkAttrs()
 	la.Name = name
 	la.Flags = net.FlagUp

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -528,6 +528,7 @@ func (ap *AttachPoint) Configure() *libbpf.TcGlobalData {
 		IstioDSCP:     ap.IstioDSCP,
 		MaglevLUTSize: ap.MaglevLUTSize,
 		IPFragTimeout: ap.IPFragTimeout,
+		HostIfindex:   uint32(ap.IfIndex),
 	}
 
 	if ap.Profiling == "Enabled" {

--- a/felix/bpf/tc/cleanup.go
+++ b/felix/bpf/tc/cleanup.go
@@ -128,7 +128,8 @@ func CleanUpProgramsAndPins() {
 			}
 		}
 	}
-	// Remove all tcx pins
+	// Remove all tcx and netkit pins
 	os.RemoveAll(bpfdefs.TcxPinDir)
+	os.RemoveAll(bpfdefs.NetkitPinDir)
 	bpf.CleanUpCalicoPins(bpfdefs.DefaultBPFfsPath)
 }

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -1336,6 +1336,84 @@ func TestAttachTcx(t *testing.T) {
 	Expect(len(tcxProgs)).To(Equal(1))
 }
 
+func TestAttachNetkit(t *testing.T) {
+	RegisterTestingT(t)
+
+	if !tc.IsNetkitSupported() {
+		t.Skip("Netkit not supported on this kernel")
+	}
+
+	bpfmaps, err := bpfmap.CreateBPFMaps(false)
+	Expect(err).NotTo(HaveOccurred())
+
+	loglevel := "off"
+	bpfConfig := &linux.Config{
+		Hostname:              "uthost",
+		BPFLogLevel:           loglevel,
+		BPFDataIfacePattern:   regexp.MustCompile("^hostep[12]"),
+		VXLANMTU:              1000,
+		VXLANPort:             1234,
+		BPFNodePortDSREnabled: false,
+		RulesConfig: rules.Config{
+			EndpointToHostAction: "RETURN",
+		},
+		BPFExtToServiceConnmark: 0,
+		BPFPolicyDebugEnabled:   true,
+		BPFAttachType:           v3.BPFAttachOptionTCX, // Global default is TCX; netkit is auto-detected per device.
+	}
+
+	bpfEpMgr, err := newBPFTestEpMgr(
+		bpfConfig,
+		bpfmaps,
+		regexp.MustCompile("^workloadep[0123]"),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create a netkit device instead of a veth. Felix should auto-detect it
+	// and use native netkit BPF attachment.
+	workload0 := createNetkitName("workloadep0")
+	defer deleteLink(workload0)
+
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
+	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
+	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+		Id: &proto.WorkloadEndpointID{
+			OrchestratorId: "k8s",
+			WorkloadId:     "workloadep0",
+			EndpointId:     "workloadep0",
+		},
+		Endpoint: &proto.WorkloadEndpoint{Name: "workloadep0"},
+	})
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+
+	// Netkit should not create a qdisc.
+	hasQdisc, err := tc.HasQdisc("workloadep0")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(hasQdisc).To(BeFalse())
+
+	// No TC programs should be attached.
+	progs, err := tc.ListAttachedPrograms("workloadep0", hook.Ingress.String(), true)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(progs)).To(Equal(0))
+
+	// No TCX programs should be attached.
+	tcxProgs, err := tc.ListAttachedTcxPrograms("workloadep0", "ingress")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(tcxProgs)).To(Equal(0))
+
+	// No TCX pins should exist.
+	_, err = os.Stat(bpfdefs.TcxPinDir + "/workloadep0_ingress")
+	Expect(err).To(HaveOccurred())
+
+	// Netkit pins should exist for both ingress and egress.
+	_, err = os.Stat(bpfdefs.NetkitPinDir + "/workloadep0_ingress")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = os.Stat(bpfdefs.NetkitPinDir + "/workloadep0_egress")
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func TestLogFilters(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -169,36 +169,36 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(programsIng.Count()).To(Equal(expectedIngCount))
 		Expect(programsEg.Count()).To(Equal(expectedEgCount))
 		Expect(atIng).To(HaveKey(hook.AttachType{
-			Hook:           hook.Ingress,
-			Family:         4,
-			Type:           tcdefs.EpTypeHost,
-			LogLevel:       loglevel,
-			ToHostDrop:     false,
-			DSR:            false,
+			Hook:       hook.Ingress,
+			Family:     4,
+			Type:       tcdefs.EpTypeHost,
+			LogLevel:   loglevel,
+			ToHostDrop: false,
+			DSR:        false,
 		}))
 		Expect(atEg).To(HaveKey(hook.AttachType{
-			Hook:           hook.Egress,
-			Family:         4,
-			Type:           tcdefs.EpTypeHost,
-			LogLevel:       loglevel,
-			ToHostDrop:     false,
-			DSR:            false,
+			Hook:       hook.Egress,
+			Family:     4,
+			Type:       tcdefs.EpTypeHost,
+			LogLevel:   loglevel,
+			ToHostDrop: false,
+			DSR:        false,
 		}))
 		Expect(atIng).NotTo(HaveKey(hook.AttachType{
-			Hook:           hook.Ingress,
-			Family:         6,
-			Type:           tcdefs.EpTypeHost,
-			LogLevel:       loglevel,
-			ToHostDrop:     false,
-			DSR:            false,
+			Hook:       hook.Ingress,
+			Family:     6,
+			Type:       tcdefs.EpTypeHost,
+			LogLevel:   loglevel,
+			ToHostDrop: false,
+			DSR:        false,
 		}))
 		Expect(atEg).NotTo(HaveKey(hook.AttachType{
-			Hook:           hook.Egress,
-			Family:         6,
-			Type:           tcdefs.EpTypeHost,
-			LogLevel:       loglevel,
-			ToHostDrop:     false,
-			DSR:            false,
+			Hook:       hook.Egress,
+			Family:     6,
+			Type:       tcdefs.EpTypeHost,
+			LogLevel:   loglevel,
+			ToHostDrop: false,
+			DSR:        false,
 		}))
 
 		ifstateMap := ifstateMapDump(commonMaps.IfStateMap)
@@ -228,36 +228,36 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			Expect(programsEg.Count()).To(Equal(expectedEgCount))
 
 			Expect(atIng).To(HaveKey(hook.AttachType{
-				Hook:           hook.Ingress,
-				Family:         4,
-				Type:           tcdefs.EpTypeHost,
-				LogLevel:       loglevel,
-				ToHostDrop:     false,
-				DSR:            false,
+				Hook:       hook.Ingress,
+				Family:     4,
+				Type:       tcdefs.EpTypeHost,
+				LogLevel:   loglevel,
+				ToHostDrop: false,
+				DSR:        false,
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
-				Hook:           hook.Egress,
-				Family:         4,
-				Type:           tcdefs.EpTypeHost,
-				LogLevel:       loglevel,
-				ToHostDrop:     false,
-				DSR:            false,
+				Hook:       hook.Egress,
+				Family:     4,
+				Type:       tcdefs.EpTypeHost,
+				LogLevel:   loglevel,
+				ToHostDrop: false,
+				DSR:        false,
 			}))
 			Expect(atIng).To(HaveKey(hook.AttachType{
-				Hook:           hook.Ingress,
-				Family:         6,
-				Type:           tcdefs.EpTypeHost,
-				LogLevel:       loglevel,
-				ToHostDrop:     false,
-				DSR:            false,
+				Hook:       hook.Ingress,
+				Family:     6,
+				Type:       tcdefs.EpTypeHost,
+				LogLevel:   loglevel,
+				ToHostDrop: false,
+				DSR:        false,
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
-				Hook:           hook.Egress,
-				Family:         6,
-				Type:           tcdefs.EpTypeHost,
-				LogLevel:       loglevel,
-				ToHostDrop:     false,
-				DSR:            false,
+				Hook:       hook.Egress,
+				Family:     6,
+				Type:       tcdefs.EpTypeHost,
+				LogLevel:   loglevel,
+				ToHostDrop: false,
+				DSR:        false,
 			}))
 
 		}
@@ -398,37 +398,37 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(programsIng.Count()).To(Equal(expectedIngCount))
 		Expect(programsEg.Count()).To(Equal(expectedEgCount))
 		Expect(atIng).To(HaveKey(hook.AttachType{
-			Hook:           hook.Ingress,
-			Family:         4,
-			Type:           tcdefs.EpTypeWorkload,
-			LogLevel:       loglevel,
-			ToHostDrop:     false,
-			DSR:            false,
+			Hook:       hook.Ingress,
+			Family:     4,
+			Type:       tcdefs.EpTypeWorkload,
+			LogLevel:   loglevel,
+			ToHostDrop: false,
+			DSR:        false,
 		}))
 		Expect(atEg).To(HaveKey(hook.AttachType{
-			Hook:           hook.Egress,
-			Family:         4,
-			Type:           tcdefs.EpTypeWorkload,
-			LogLevel:       loglevel,
-			ToHostDrop:     false,
-			DSR:            false,
+			Hook:       hook.Egress,
+			Family:     4,
+			Type:       tcdefs.EpTypeWorkload,
+			LogLevel:   loglevel,
+			ToHostDrop: false,
+			DSR:        false,
 		}))
 		if ipv6Enabled {
 			Expect(atIng).To(HaveKey(hook.AttachType{
-				Hook:           hook.Ingress,
-				Family:         6,
-				Type:           tcdefs.EpTypeWorkload,
-				LogLevel:       loglevel,
-				ToHostDrop:     false,
-				DSR:            false,
+				Hook:       hook.Ingress,
+				Family:     6,
+				Type:       tcdefs.EpTypeWorkload,
+				LogLevel:   loglevel,
+				ToHostDrop: false,
+				DSR:        false,
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
-				Hook:           hook.Egress,
-				Family:         6,
-				Type:           tcdefs.EpTypeWorkload,
-				LogLevel:       loglevel,
-				ToHostDrop:     false,
-				DSR:            false,
+				Hook:       hook.Egress,
+				Family:     6,
+				Type:       tcdefs.EpTypeWorkload,
+				LogLevel:   loglevel,
+				ToHostDrop: false,
+				DSR:        false,
 			}))
 		}
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -175,7 +175,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			LogLevel:       loglevel,
 			ToHostDrop:     false,
 			DSR:            false,
-			ProgAttachType: "TCX",
 		}))
 		Expect(atEg).To(HaveKey(hook.AttachType{
 			Hook:           hook.Egress,
@@ -184,7 +183,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			LogLevel:       loglevel,
 			ToHostDrop:     false,
 			DSR:            false,
-			ProgAttachType: "TCX",
 		}))
 		Expect(atIng).NotTo(HaveKey(hook.AttachType{
 			Hook:           hook.Ingress,
@@ -193,7 +191,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			LogLevel:       loglevel,
 			ToHostDrop:     false,
 			DSR:            false,
-			ProgAttachType: "TCX",
 		}))
 		Expect(atEg).NotTo(HaveKey(hook.AttachType{
 			Hook:           hook.Egress,
@@ -202,7 +199,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			LogLevel:       loglevel,
 			ToHostDrop:     false,
 			DSR:            false,
-			ProgAttachType: "TCX",
 		}))
 
 		ifstateMap := ifstateMapDump(commonMaps.IfStateMap)
@@ -238,7 +234,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				LogLevel:       loglevel,
 				ToHostDrop:     false,
 				DSR:            false,
-				ProgAttachType: "TCX",
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
 				Hook:           hook.Egress,
@@ -247,7 +242,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				LogLevel:       loglevel,
 				ToHostDrop:     false,
 				DSR:            false,
-				ProgAttachType: "TCX",
 			}))
 			Expect(atIng).To(HaveKey(hook.AttachType{
 				Hook:           hook.Ingress,
@@ -256,7 +250,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				LogLevel:       loglevel,
 				ToHostDrop:     false,
 				DSR:            false,
-				ProgAttachType: "TCX",
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
 				Hook:           hook.Egress,
@@ -265,7 +258,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				LogLevel:       loglevel,
 				ToHostDrop:     false,
 				DSR:            false,
-				ProgAttachType: "TCX",
 			}))
 
 		}
@@ -412,7 +404,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			LogLevel:       loglevel,
 			ToHostDrop:     false,
 			DSR:            false,
-			ProgAttachType: "TCX",
 		}))
 		Expect(atEg).To(HaveKey(hook.AttachType{
 			Hook:           hook.Egress,
@@ -421,7 +412,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			LogLevel:       loglevel,
 			ToHostDrop:     false,
 			DSR:            false,
-			ProgAttachType: "TCX",
 		}))
 		if ipv6Enabled {
 			Expect(atIng).To(HaveKey(hook.AttachType{
@@ -431,7 +421,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				LogLevel:       loglevel,
 				ToHostDrop:     false,
 				DSR:            false,
-				ProgAttachType: "TCX",
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
 				Hook:           hook.Egress,
@@ -440,7 +429,6 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 				LogLevel:       loglevel,
 				ToHostDrop:     false,
 				DSR:            false,
-				ProgAttachType: "TCX",
 			}))
 		}
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -169,36 +169,40 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(programsIng.Count()).To(Equal(expectedIngCount))
 		Expect(programsEg.Count()).To(Equal(expectedEgCount))
 		Expect(atIng).To(HaveKey(hook.AttachType{
-			Hook:       hook.Ingress,
-			Family:     4,
-			Type:       tcdefs.EpTypeHost,
-			LogLevel:   loglevel,
-			ToHostDrop: false,
-			DSR:        false,
+			Hook:           hook.Ingress,
+			Family:         4,
+			Type:           tcdefs.EpTypeHost,
+			LogLevel:       loglevel,
+			ToHostDrop:     false,
+			DSR:            false,
+			ProgAttachType: "TCX",
 		}))
 		Expect(atEg).To(HaveKey(hook.AttachType{
-			Hook:       hook.Egress,
-			Family:     4,
-			Type:       tcdefs.EpTypeHost,
-			LogLevel:   loglevel,
-			ToHostDrop: false,
-			DSR:        false,
+			Hook:           hook.Egress,
+			Family:         4,
+			Type:           tcdefs.EpTypeHost,
+			LogLevel:       loglevel,
+			ToHostDrop:     false,
+			DSR:            false,
+			ProgAttachType: "TCX",
 		}))
 		Expect(atIng).NotTo(HaveKey(hook.AttachType{
-			Hook:       hook.Ingress,
-			Family:     6,
-			Type:       tcdefs.EpTypeHost,
-			LogLevel:   loglevel,
-			ToHostDrop: false,
-			DSR:        false,
+			Hook:           hook.Ingress,
+			Family:         6,
+			Type:           tcdefs.EpTypeHost,
+			LogLevel:       loglevel,
+			ToHostDrop:     false,
+			DSR:            false,
+			ProgAttachType: "TCX",
 		}))
 		Expect(atEg).NotTo(HaveKey(hook.AttachType{
-			Hook:       hook.Egress,
-			Family:     6,
-			Type:       tcdefs.EpTypeHost,
-			LogLevel:   loglevel,
-			ToHostDrop: false,
-			DSR:        false,
+			Hook:           hook.Egress,
+			Family:         6,
+			Type:           tcdefs.EpTypeHost,
+			LogLevel:       loglevel,
+			ToHostDrop:     false,
+			DSR:            false,
+			ProgAttachType: "TCX",
 		}))
 
 		ifstateMap := ifstateMapDump(commonMaps.IfStateMap)
@@ -228,36 +232,40 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			Expect(programsEg.Count()).To(Equal(expectedEgCount))
 
 			Expect(atIng).To(HaveKey(hook.AttachType{
-				Hook:       hook.Ingress,
-				Family:     4,
-				Type:       tcdefs.EpTypeHost,
-				LogLevel:   loglevel,
-				ToHostDrop: false,
-				DSR:        false,
+				Hook:           hook.Ingress,
+				Family:         4,
+				Type:           tcdefs.EpTypeHost,
+				LogLevel:       loglevel,
+				ToHostDrop:     false,
+				DSR:            false,
+				ProgAttachType: "TCX",
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
-				Hook:       hook.Egress,
-				Family:     4,
-				Type:       tcdefs.EpTypeHost,
-				LogLevel:   loglevel,
-				ToHostDrop: false,
-				DSR:        false,
+				Hook:           hook.Egress,
+				Family:         4,
+				Type:           tcdefs.EpTypeHost,
+				LogLevel:       loglevel,
+				ToHostDrop:     false,
+				DSR:            false,
+				ProgAttachType: "TCX",
 			}))
 			Expect(atIng).To(HaveKey(hook.AttachType{
-				Hook:       hook.Ingress,
-				Family:     6,
-				Type:       tcdefs.EpTypeHost,
-				LogLevel:   loglevel,
-				ToHostDrop: false,
-				DSR:        false,
+				Hook:           hook.Ingress,
+				Family:         6,
+				Type:           tcdefs.EpTypeHost,
+				LogLevel:       loglevel,
+				ToHostDrop:     false,
+				DSR:            false,
+				ProgAttachType: "TCX",
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
-				Hook:       hook.Egress,
-				Family:     6,
-				Type:       tcdefs.EpTypeHost,
-				LogLevel:   loglevel,
-				ToHostDrop: false,
-				DSR:        false,
+				Hook:           hook.Egress,
+				Family:         6,
+				Type:           tcdefs.EpTypeHost,
+				LogLevel:       loglevel,
+				ToHostDrop:     false,
+				DSR:            false,
+				ProgAttachType: "TCX",
 			}))
 
 		}
@@ -398,37 +406,41 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(programsIng.Count()).To(Equal(expectedIngCount))
 		Expect(programsEg.Count()).To(Equal(expectedEgCount))
 		Expect(atIng).To(HaveKey(hook.AttachType{
-			Hook:       hook.Ingress,
-			Family:     4,
-			Type:       tcdefs.EpTypeWorkload,
-			LogLevel:   loglevel,
-			ToHostDrop: false,
-			DSR:        false,
+			Hook:           hook.Ingress,
+			Family:         4,
+			Type:           tcdefs.EpTypeWorkload,
+			LogLevel:       loglevel,
+			ToHostDrop:     false,
+			DSR:            false,
+			ProgAttachType: "TCX",
 		}))
 		Expect(atEg).To(HaveKey(hook.AttachType{
-			Hook:       hook.Egress,
-			Family:     4,
-			Type:       tcdefs.EpTypeWorkload,
-			LogLevel:   loglevel,
-			ToHostDrop: false,
-			DSR:        false,
+			Hook:           hook.Egress,
+			Family:         4,
+			Type:           tcdefs.EpTypeWorkload,
+			LogLevel:       loglevel,
+			ToHostDrop:     false,
+			DSR:            false,
+			ProgAttachType: "TCX",
 		}))
 		if ipv6Enabled {
 			Expect(atIng).To(HaveKey(hook.AttachType{
-				Hook:       hook.Ingress,
-				Family:     6,
-				Type:       tcdefs.EpTypeWorkload,
-				LogLevel:   loglevel,
-				ToHostDrop: false,
-				DSR:        false,
+				Hook:           hook.Ingress,
+				Family:         6,
+				Type:           tcdefs.EpTypeWorkload,
+				LogLevel:       loglevel,
+				ToHostDrop:     false,
+				DSR:            false,
+				ProgAttachType: "TCX",
 			}))
 			Expect(atEg).To(HaveKey(hook.AttachType{
-				Hook:       hook.Egress,
-				Family:     6,
-				Type:       tcdefs.EpTypeWorkload,
-				LogLevel:   loglevel,
-				ToHostDrop: false,
-				DSR:        false,
+				Hook:           hook.Egress,
+				Family:         6,
+				Type:           tcdefs.EpTypeWorkload,
+				LogLevel:       loglevel,
+				ToHostDrop:     false,
+				DSR:            false,
+				ProgAttachType: "TCX",
 			}))
 		}
 

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -94,6 +94,19 @@ func createVethName(name string) netlink.Link {
 	return veth
 }
 
+func createNetkitName(name string) netlink.Link {
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Flags = net.FlagUp
+	var nk netlink.Link = &netlink.Netkit{
+		LinkAttrs: la,
+		Mode:      netlink.NETKIT_MODE_L2,
+	}
+	err := netlink.LinkAdd(nk)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create test netkit: %q", name))
+	return nk
+}
+
 func createHostIf(name string) netlink.Link {
 	la := netlink.NewLinkAttrs()
 	la.Name = name

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -321,13 +321,13 @@ type bpfEndpointManager struct {
 	legacyCleanUp           bool
 	hostIfaceTrees          bpfIfaceTrees
 
-	jumpMapAllocs          map[hook.Hook]*jumpMapAlloc
-	netkitJumpMapAllocs    map[hook.Hook]*jumpMapAlloc
-	policyTcAllowFDs       [2]bpf.ProgFD
-	policyTcDenyFDs        [2]bpf.ProgFD
-	policyNetkitAllowFDs   [2]bpf.ProgFD
-	policyNetkitDenyFDs    [2]bpf.ProgFD
-	netkitPoliciesLoaded   sync.Once
+	jumpMapAllocs        map[hook.Hook]*jumpMapAlloc
+	netkitJumpMapAllocs  map[hook.Hook]*jumpMapAlloc
+	policyTcAllowFDs     [2]bpf.ProgFD
+	policyTcDenyFDs      [2]bpf.ProgFD
+	policyNetkitAllowFDs [2]bpf.ProgFD
+	policyNetkitDenyFDs  [2]bpf.ProgFD
+	netkitPoliciesLoaded sync.Once
 
 	ruleRenderer bpfAllowChainRenderer
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1051,22 +1051,34 @@ func (m *bpfEndpointManager) reclaimPolicyIdx(name string, ipFamily int, iface *
 	if ipFamily == 6 {
 		idx = &iface.dpState.v6
 	}
+	isNetkit := iface.info.ifaceType == IfaceTypeNetkit
 	for _, attachHook := range []hook.Hook{hook.XDP, hook.Ingress, hook.Egress} {
-		if err := m.jumpMapDelete(attachHook, idx.policyIdx[attachHook]); err != nil {
+		// XDP is never netkit-attached; only ingress/egress use netkit jump maps.
+		useNetkit := isNetkit && attachHook != hook.XDP
+		if err := m.jumpMapDelete(attachHook, idx.policyIdx[attachHook], useNetkit); err != nil {
 			logrus.WithError(err).Warn("Policy program may leak.")
 		}
-		if err := m.jumpMapAllocs[attachHook].Put(idx.policyIdx[attachHook], name); err != nil {
+		allocs := m.jumpMapAllocs
+		if useNetkit {
+			allocs = m.netkitJumpMapAllocs
+		}
+		if err := allocs[attachHook].Put(idx.policyIdx[attachHook], name); err != nil {
 			logrus.WithError(err).Errorf("Policy family %d, hook %s", ipFamily, attachHook)
 		}
 	}
 }
 
 func (m *bpfEndpointManager) reclaimFilterIdx(name string, iface *bpfInterface) {
+	isNetkit := iface.info.ifaceType == IfaceTypeNetkit
+	allocs := m.jumpMapAllocs
+	if isNetkit {
+		allocs = m.netkitJumpMapAllocs
+	}
 	for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
-		if err := m.jumpMapDelete(attachHook, iface.dpState.filterIdx[attachHook]); err != nil {
+		if err := m.jumpMapDelete(attachHook, iface.dpState.filterIdx[attachHook], isNetkit); err != nil {
 			logrus.WithError(err).Warn("Filter program may leak.")
 		}
-		if err := m.jumpMapAllocs[attachHook].Put(iface.dpState.filterIdx[attachHook], name); err != nil {
+		if err := allocs[attachHook].Put(iface.dpState.filterIdx[attachHook], name); err != nil {
 			logrus.WithError(err).Errorf("Filter hook %s", attachHook)
 		}
 		iface.dpState.filterIdx[attachHook] = -1
@@ -1316,7 +1328,13 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 	m.withIface(update.Name, func(iface *bpfInterface) (forceDirty bool) {
 		ifaceIsUp := update.State == ifacemonitor.StateUp
 		iface.info.masterIfIndex = masterIfIndex
-		iface.info.ifaceType = curIfaceType
+		// Only update ifaceType when we successfully determined it;
+		// IfaceTypeUnknown means getIfaceLink failed (e.g. device
+		// already removed), so preserve the previous type for correct
+		// jump map cleanup.
+		if curIfaceType != IfaceTypeUnknown {
+			iface.info.ifaceType = curIfaceType
+		}
 		// Note, only need to handle the mapping and unmapping of the host-* endpoint here.
 		// For specific host endpoints OnHEPUpdate doesn't depend on iface state, and has
 		// already stored and mapped as needed.
@@ -1579,6 +1597,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 				} {
 					if idx := fn(); idx != -1 {
 						_ = jumpMapDeleteSubProgs(m.commonMaps.JumpMaps[hook.Ingress], idx, jump.TCMaxEntryPoints)
+						_ = jumpMapDeleteSubProgs(m.commonMaps.NetkitJumpMaps[hook.Ingress], idx, jump.TCMaxEntryPoints)
 					}
 				}
 				for _, fn := range []func() int{
@@ -1588,6 +1607,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 				} {
 					if idx := fn(); idx != -1 {
 						_ = jumpMapDeleteSubProgs(m.commonMaps.JumpMaps[hook.Egress], idx, jump.TCMaxEntryPoints)
+						_ = jumpMapDeleteSubProgs(m.commonMaps.NetkitJumpMaps[hook.Egress], idx, jump.TCMaxEntryPoints)
 					}
 				}
 			} else {
@@ -2423,7 +2443,7 @@ func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInt
 		}
 	} else {
 		for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
-			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook]); err != nil {
+			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook], isNetkit); err != nil {
 				logrus.WithError(err).Warn("Filter program may leak.")
 			}
 			if err := filterAllocs[attachHook].Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
@@ -2463,7 +2483,7 @@ func (m *bpfEndpointManager) dataIfaceStateFillJumps(ap *tc.AttachPoint, xdpMode
 		}
 	} else {
 		for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
-			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook]); err != nil {
+			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook], false); err != nil {
 				logrus.WithError(err).Warn("Filter program may leak.")
 			}
 			if err := m.jumpMapAllocs[attachHook].Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
@@ -3505,6 +3525,15 @@ func (m *bpfEndpointManager) isWorkloadIface(iface string) bool {
 	return m.workloadIfaceRegex.MatchString(iface)
 }
 
+// isNetkitAttachPoint checks if the given attach point corresponds to a netkit
+// interface by looking up the interface type in the tracked interfaces map.
+func (m *bpfEndpointManager) isNetkitAttachPoint(ap attachPoint) bool {
+	if tcAP, ok := ap.(*tc.AttachPoint); ok {
+		return string(tcAP.AttachType) == tc.AttachOptionNetkit
+	}
+	return false
+}
+
 func (m *bpfEndpointManager) isDataIface(iface string) bool {
 	return m.dataIfaceRegex.MatchString(iface) ||
 		(m.hostNetworkedNATMode != hostNetworkedNATDisabled && (iface == dataplanedefs.BPFOutDev || iface == "lo"))
@@ -4126,15 +4155,16 @@ func (m *bpfEndpointManager) ensureNoProgram(ap attachPoint) error {
 	})
 	m.ifacesLock.Unlock()
 
+	isNetkit := m.isNetkitAttachPoint(ap)
 	if m.v4 != nil {
-		if err := m.jumpMapDelete(ap.HookName(), state.v4.policyIdx[ap.HookName()]); err != nil {
+		if err := m.jumpMapDelete(ap.HookName(), state.v4.policyIdx[ap.HookName()], isNetkit); err != nil {
 			logrus.WithError(err).Warn("Policy program may leak.")
 		}
 		m.removePolicyDebugInfo(ap.IfaceName(), 4, ap.HookName())
 	}
 	// Forget the policy debug info
 	if m.v6 != nil {
-		if err := m.jumpMapDelete(ap.HookName(), state.v6.policyIdx[ap.HookName()]); err != nil {
+		if err := m.jumpMapDelete(ap.HookName(), state.v6.policyIdx[ap.HookName()], isNetkit); err != nil {
 			logrus.WithError(err).Warn("Policy program may leak.")
 		}
 		m.removePolicyDebugInfo(ap.IfaceName(), 6, ap.HookName())
@@ -4529,15 +4559,19 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 	return insns, nil
 }
 
-func (m *bpfEndpointManager) jumpMapDelete(h hook.Hook, idx int) error {
+func (m *bpfEndpointManager) jumpMapDelete(h hook.Hook, idx int, isNetkit bool) error {
 	if idx < 0 {
 		return nil
 	}
-	logrus.WithFields(logrus.Fields{"hook": h, "index": idx}).Debug("Deleting jump map entry")
+	logrus.WithFields(logrus.Fields{"hook": h, "index": idx, "netkit": isNetkit}).Debug("Deleting jump map entry")
 	jumpMap := m.commonMaps.XDPJumpMap
 	stride := jump.XDPMaxEntryPoints
 	if h != hook.XDP {
-		jumpMap = m.commonMaps.JumpMaps[h]
+		if isNetkit {
+			jumpMap = m.commonMaps.NetkitJumpMaps[h]
+		} else {
+			jumpMap = m.commonMaps.JumpMaps[h]
+		}
 		stride = jump.TCMaxEntryPoints
 	}
 
@@ -4557,7 +4591,12 @@ func (m *bpfEndpointManager) removePolicyProgram(ap attachPoint, ipFamily proto.
 		pm = m.commonMaps.XDPJumpMap
 	} else {
 		stride = jump.TCMaxEntryPoints
-		pm = m.commonMaps.JumpMaps[ap.HookName()]
+		isNetkit := m.isNetkitAttachPoint(ap)
+		if isNetkit {
+			pm = m.commonMaps.NetkitJumpMaps[ap.HookName()]
+		} else {
+			pm = m.commonMaps.JumpMaps[ap.HookName()]
+		}
 	}
 
 	if err := jumpMapDeleteSubProgs(pm, idx, stride); err != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -141,6 +141,7 @@ const (
 	IfaceTypeL3
 	IfaceTypeBond
 	IfaceTypeBondSlave
+	IfaceTypeNetkit
 	IfaceTypeUnknown
 )
 
@@ -2395,6 +2396,7 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		endpointID   *types.WorkloadEndpointID
 		ifaceUp      bool
 		ifindex      int
+		ifaceType    IfaceType
 		hasIstioDSCP bool
 	)
 
@@ -2405,6 +2407,7 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		ifindex = iface.info.ifIndex
 		endpointID = iface.info.endpointID
 		state = iface.dpState
+		ifaceType = iface.info.ifaceType
 		hasIstioDSCP = iface.info.hasIstioDSCP
 		return false
 	})
@@ -2421,25 +2424,29 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	// datastore.  If we don't have an endpoint then we'll attach a program to block traffic and we'll
 	// get the jump map ready to insert the policy if the endpoint shows up.
 
-	// Attach the qdisc first; it is shared between the directions.
-	existed, err := m.dp.ensureQdisc(ifaceName)
-	if err != nil {
-		if isLinkNotFoundError(err) {
-			// Interface is gone, nothing to do.
-			logrus.WithField("ifaceName", ifaceName).Debug(
-				"Ignoring request to program interface that is not present.")
-			return state, nil
+	// Netkit devices don't need a qdisc — only legacy TC does.
+	if ifaceType != IfaceTypeNetkit {
+		// Attach the qdisc first; it is shared between the directions.
+		existed, err := m.dp.ensureQdisc(ifaceName)
+		if err != nil {
+			if isLinkNotFoundError(err) {
+				// Interface is gone, nothing to do.
+				logrus.WithField("ifaceName", ifaceName).Debug(
+					"Ignoring request to program interface that is not present.")
+				return state, nil
+			}
+			return state, err
 		}
-		return state, err
-	}
-	if !existed {
-		// Cannot be ready if the qdisc is not there so no program can be
-		// attached. Do the full attach!
-		state.v4Readiness = ifaceNotReady
-		state.v6Readiness = ifaceNotReady
+		if !existed {
+			// Cannot be ready if the qdisc is not there so no program can be
+			// attached. Do the full attach!
+			state.v4Readiness = ifaceNotReady
+			state.v6Readiness = ifaceNotReady
+		}
 	}
 
 	var (
+		err                   error
 		ingressErr, egressErr error
 		err4, err6            error
 		ingressAP4, egressAP4 *tc.AttachPoint
@@ -2468,6 +2475,13 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 
 	ap := m.calculateTCAttachPoint(ifaceName)
 	ap.IfIndex = ifindex
+
+	// For netkit devices, override the attachment mechanism to use native netkit BPF
+	// attachment instead of TC/TCX. This is per-device: veth and netkit endpoints can
+	// coexist on the same node.
+	if ifaceType == IfaceTypeNetkit && tc.IsNetkitSupported() {
+		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
+	}
 	if wep != nil && wep.QosControls != nil {
 		// QoSControls are present, update state
 
@@ -3863,8 +3877,8 @@ func (m *bpfEndpointManager) ensureQdisc(iface string) (bool, error) {
 	return tc.EnsureQdisc(iface)
 }
 
-func (m *bpfEndpointManager) loadTCObj(at hook.AttachType, pm *hook.ProgramsMap) (hook.Layout, error) {
-	result, err := pm.LoadObj(at, string(m.bpfAttachType), m.disabledOptionalProgs)
+func (m *bpfEndpointManager) loadTCObj(at hook.AttachType, pm *hook.ProgramsMap, progAttachType string) (hook.Layout, error) {
+	result, err := pm.LoadObj(at, progAttachType, m.disabledOptionalProgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3875,7 +3889,7 @@ func (m *bpfEndpointManager) loadTCObj(at hook.AttachType, pm *hook.ProgramsMap)
 	}
 
 	at.LogLevel = "off"
-	resultNoDebug, err := pm.LoadObj(at, string(m.bpfAttachType), m.disabledOptionalProgs)
+	resultNoDebug, err := pm.LoadObj(at, progAttachType, m.disabledOptionalProgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3914,24 +3928,29 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 	var err error
 
 	if aptc, ok := ap.(*tc.AttachPoint); ok {
+		// Derive the program attach type from the attach point. For netkit
+		// devices this will be "Netkit", otherwise it comes from the global config.
+		progAttachType := string(aptc.AttachType)
+
 		at := hook.AttachType{
-			Hook:       aptc.HookName(),
-			Type:       aptc.Type,
-			LogLevel:   aptc.LogLevel,
-			ToHostDrop: aptc.ToHostDrop,
-			DSR:        aptc.DSR,
+			Hook:           aptc.HookName(),
+			Family:         int(ipFamily),
+			Type:           aptc.Type,
+			LogLevel:       aptc.LogLevel,
+			ToHostDrop:     aptc.ToHostDrop,
+			DSR:            aptc.DSR,
+			ProgAttachType: progAttachType,
 		}
 
-		at.Family = int(ipFamily)
 		policyIdx := aptc.PolicyIdxV4
 		ap.Log().Debugf("ensureProgramLoaded %d", ipFamily)
 		if ipFamily == proto.IPVersion_IPV6 {
-			if aptc.HookLayoutV6, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap)); err != nil {
+			if aptc.HookLayoutV6, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap), progAttachType); err != nil {
 				return fmt.Errorf("loading generic v%d tc hook program: %w", ipFamily, err)
 			}
 			policyIdx = aptc.PolicyIdxV6
 		} else {
-			if aptc.HookLayoutV4, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap)); err != nil {
+			if aptc.HookLayoutV4, err = m.loadTCObj(at, aptc.ProgramsMap.(*hook.ProgramsMap), progAttachType); err != nil {
 				return fmt.Errorf("loading generic v%d tc hook program: %w", ipFamily, err)
 			}
 		}
@@ -4719,6 +4738,8 @@ func (m *bpfEndpointManager) getIfaceTypeFromLink(link netlink.Link) IfaceType {
 	}
 
 	switch link.Type() {
+	case "netkit":
+		return IfaceTypeNetkit
 	case "ipip":
 		return IfaceTypeIPIP
 	case "wireguard":

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2582,6 +2582,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		// so we set overrides for both ingress and egress here. The ProgramsMap
 		// is set per-direction in wepApplyPolicyToDirection.
 		ap.MapPinOverrides = hook.NetkitPinOverridesBoth()
+		// bpf_redirect_peer requires a TC ingress context (skb_at_tc_ingress),
+		// but netkit programs run in xmit context. Disable redirect_peer so the
+		// FIB path uses plain bpf_redirect instead.
+		ap.RedirectPeer = false
 	}
 	if wep != nil && wep.QosControls != nil {
 		// QoSControls are present, update state

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2601,7 +2601,7 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	// netkit BPF attachment instead of TC/TCX. Only workload interfaces are ours to
 	// manage this way — other netkit devices (host/data interfaces) are not ours.
 	if ifaceType == IfaceTypeNetkit && m.isWorkloadIface(ifaceName) && tc.IsNetkitSupported() {
-		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
+		ap.Netkit = true
 		// Netkit programs have a different expected_attach_type and cannot
 		// share prog_array maps with TC/TCX programs. Use separate maps.
 		// Note: the AP is copied for both directions in applyPolicyToWeps,
@@ -4063,6 +4063,9 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 		// Derive the program attach type from the attach point. For netkit
 		// devices this will be "Netkit", otherwise it comes from the global config.
 		progAttachType := string(aptc.AttachType)
+		if aptc.IsNetkit() {
+			progAttachType = tc.AttachOptionNetkit
+		}
 
 		at := hook.AttachType{
 			Hook:       aptc.HookName(),

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -321,9 +321,13 @@ type bpfEndpointManager struct {
 	legacyCleanUp           bool
 	hostIfaceTrees          bpfIfaceTrees
 
-	jumpMapAllocs    map[hook.Hook]*jumpMapAlloc
-	policyTcAllowFDs [2]bpf.ProgFD
-	policyTcDenyFDs  [2]bpf.ProgFD
+	jumpMapAllocs          map[hook.Hook]*jumpMapAlloc
+	netkitJumpMapAllocs    map[hook.Hook]*jumpMapAlloc
+	policyTcAllowFDs       [2]bpf.ProgFD
+	policyTcDenyFDs        [2]bpf.ProgFD
+	policyNetkitAllowFDs   [2]bpf.ProgFD
+	policyNetkitDenyFDs    [2]bpf.ProgFD
+	netkitPoliciesLoaded   sync.Once
 
 	ruleRenderer bpfAllowChainRenderer
 
@@ -553,6 +557,10 @@ func NewBPFEndpointManager(
 			hook.Ingress: newJumpMapAlloc("ingress", jump.TCMaxEntryPoints),
 			hook.Egress:  newJumpMapAlloc("egress", jump.TCMaxEntryPoints),
 			hook.XDP:     newJumpMapAlloc("xdp", jump.XDPMaxEntryPoints),
+		},
+		netkitJumpMapAllocs: map[hook.Hook]*jumpMapAlloc{
+			hook.Ingress: newJumpMapAlloc("netkit-ingress", jump.TCMaxEntryPoints),
+			hook.Egress:  newJumpMapAlloc("netkit-egress", jump.TCMaxEntryPoints),
 		},
 		ruleRenderer:     iptablesRuleRenderer,
 		onStillAlive:     livenessCallback,
@@ -803,7 +811,11 @@ func (m *bpfEndpointManager) repinJumpMaps() error {
 	for _, mp := range m.commonMaps.JumpMaps {
 		mps = append(mps, mp)
 	}
+	for _, mp := range m.commonMaps.NetkitJumpMaps {
+		mps = append(mps, mp)
+	}
 	mps = append(mps, m.commonMaps.ProgramsMaps...)
+	mps = append(mps, m.commonMaps.NetkitProgramsMaps...)
 	for _, mp := range mps {
 		pin := path.Join(tmp, mp.GetName())
 		if err := libbpf.ObjPin(int(mp.MapFD()), pin); err != nil {
@@ -1696,59 +1708,113 @@ func (m *bpfEndpointManager) syncIfaceProperties() error {
 	return nil
 }
 
-// loadDefaultPolicies loads the default allow and deny policy programs for the given hook
-// and not policy direction.
+// loadDefaultPolicies loads the default allow and deny policy programs for the given hook.
 func (m *bpfEndpointManager) loadDefaultPolicies(hk hook.Hook) error {
+	allowFD, denyFD, err := m.loadDefaultPolicyPrograms(hk, string(m.bpfAttachType), nil)
+	if err != nil {
+		return err
+	}
+	m.policyTcAllowFDs[hk] = allowFD
+	m.policyTcDenyFDs[hk] = denyFD
+	return nil
+}
+
+// ensureNetkitDefaultPolicies lazily loads netkit default policy programs on first use.
+func (m *bpfEndpointManager) ensureNetkitDefaultPolicies() error {
+	var loadErr error
+	m.netkitPoliciesLoaded.Do(func() {
+		for _, hk := range []hook.Hook{hook.Ingress, hook.Egress} {
+			var pinOverrides map[string]string
+			if hk == hook.Ingress {
+				pinOverrides = hook.NetkitPinOverridesIngress()
+			} else {
+				pinOverrides = hook.NetkitPinOverridesEgress()
+			}
+			allowFD, denyFD, err := m.loadDefaultPolicyPrograms(hk, tc.AttachOptionNetkit, pinOverrides)
+			if err != nil {
+				loadErr = fmt.Errorf("loading netkit default policies for %s: %w", hk, err)
+				return
+			}
+			m.policyNetkitAllowFDs[hk] = allowFD
+			m.policyNetkitDenyFDs[hk] = denyFD
+		}
+	})
+	return loadErr
+}
+
+// loadDefaultPolicyPrograms loads the default allow/deny policy programs for the
+// given hook and attach type. mapPinOverrides allows redirecting prog_array maps
+// to alternate pin paths (used for netkit).
+func (m *bpfEndpointManager) loadDefaultPolicyPrograms(
+	hk hook.Hook,
+	progAttachType string,
+	mapPinOverrides map[string]string,
+) (allowFD, denyFD bpf.ProgFD, err error) {
 	file := path.Join(bpfdefs.ObjectDir, fmt.Sprintf("policy_default_%s.o", hk))
 	obj, err := libbpf.OpenObject(file)
 	if err != nil {
-		return fmt.Errorf("file %s: %w", file, err)
+		return 0, 0, fmt.Errorf("file %s: %w", file, err)
 	}
 
-	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
-		mapName := m.Name()
+	for mp, err := obj.FirstMap(); mp != nil && err == nil; mp, err = mp.NextMap() {
+		mapName := mp.Name()
 		if strings.HasPrefix(mapName, ".rodata") {
 			continue
 		}
 		if size := maps.Size(mapName); size != 0 {
-			if err := m.SetSize(size); err != nil {
-				return fmt.Errorf("error resizing map %s: %w", mapName, err)
+			if err := mp.SetSize(size); err != nil {
+				return 0, 0, fmt.Errorf("error resizing map %s: %w", mapName, err)
 			}
 		}
-		if err := m.SetPinPath(path.Join(bpfdefs.GlobalPinDir, mapName)); err != nil {
-			return fmt.Errorf("error pinning map %s: %w", mapName, err)
+		pinPath := path.Join(bpfdefs.GlobalPinDir, mapName)
+		if override, ok := mapPinOverrides[mapName]; ok {
+			pinPath = override
+		}
+		if err := mp.SetPinPath(pinPath); err != nil {
+			return 0, 0, fmt.Errorf("error pinning map %s: %w", mapName, err)
 		}
 	}
 
-	if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+	switch progAttachType {
+	case string(apiv3.BPFAttachOptionTCX):
 		for p, err := obj.FirstProgram(); p != nil && err == nil; p, err = p.NextProgram() {
 			attachType := libbpf.AttachTypeTcxEgress
 			if hk == hook.Ingress {
 				attachType = libbpf.AttachTypeTcxIngress
 			}
 			if err := obj.SetAttachType(p.Name(), attachType); err != nil {
-				return fmt.Errorf("error setting attach type for program %s: %w", p.Name(), err)
+				return 0, 0, fmt.Errorf("error setting attach type for program %s: %w", p.Name(), err)
+			}
+		}
+	case tc.AttachOptionNetkit:
+		for p, err := obj.FirstProgram(); p != nil && err == nil; p, err = p.NextProgram() {
+			attachType := libbpf.AttachTypeNetkitPrimary
+			if hk == hook.Ingress {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+			if err := obj.SetAttachType(p.Name(), attachType); err != nil {
+				return 0, 0, fmt.Errorf("error setting netkit attach type for program %s: %w", p.Name(), err)
 			}
 		}
 	}
 
 	if err := obj.Load(); err != nil {
-		return fmt.Errorf("default policies: %w", err)
+		return 0, 0, fmt.Errorf("default policies (%s): %w", progAttachType, err)
 	}
 
 	fd, err := obj.ProgramFD("calico_tc_deny")
 	if err != nil {
-		return fmt.Errorf("failed to load default deny policy program: %w", err)
+		return 0, 0, fmt.Errorf("failed to load default deny policy program: %w", err)
 	}
-	m.policyTcDenyFDs[hk] = bpf.ProgFD(fd)
+	denyFD = bpf.ProgFD(fd)
 
 	fd, err = obj.ProgramFD("calico_tc_allow")
 	if err != nil {
-		return fmt.Errorf("failed to load default allow policy program: %w", err)
+		return 0, 0, fmt.Errorf("failed to load default allow policy program: %w", err)
 	}
-	m.policyTcAllowFDs[hk] = bpf.ProgFD(fd)
+	allowFD = bpf.ProgFD(fd)
 
-	return nil
+	return allowFD, denyFD, nil
 }
 
 func (m *bpfEndpointManager) CompleteDeferredWork() error {
@@ -2279,11 +2345,15 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 	}
 }
 
-func (m *bpfEndpointManager) allocJumpIndicesForWEP(ifaceName string, idx *bpfInterfaceJumpIndices) error {
+func (m *bpfEndpointManager) allocJumpIndicesForWEP(ifaceName string, isNetkit bool, idx *bpfInterfaceJumpIndices) error {
+	allocs := m.jumpMapAllocs
+	if isNetkit {
+		allocs = m.netkitJumpMapAllocs
+	}
 	for _, h := range []hook.Hook{hook.Ingress, hook.Egress} {
 		if idx.policyIdx[h] == -1 {
 			var err error
-			idx.policyIdx[h], err = m.jumpMapAllocs[h].Get(ifaceName)
+			idx.policyIdx[h], err = allocs[h].Get(ifaceName)
 			if err != nil {
 				return err
 			}
@@ -2320,9 +2390,11 @@ func (m *bpfEndpointManager) allocJumpIndicesForDataIface(ifaceName string, xdpM
 func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInterfaceState) error {
 	var err error
 
+	isNetkit := string(ap.AttachType) == tc.AttachOptionNetkit
+
 	// Allocate indices for IPv4
 	if m.v4 != nil {
-		err = m.allocJumpIndicesForWEP(ap.IfaceName(), &state.v4)
+		err = m.allocJumpIndicesForWEP(ap.IfaceName(), isNetkit, &state.v4)
 		if err != nil {
 			return err
 		}
@@ -2330,16 +2402,20 @@ func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInt
 
 	// Allocate indices for IPv6
 	if m.v6 != nil {
-		err = m.allocJumpIndicesForWEP(ap.IfaceName(), &state.v6)
+		err = m.allocJumpIndicesForWEP(ap.IfaceName(), isNetkit, &state.v6)
 		if err != nil {
 			return err
 		}
 	}
 
+	filterAllocs := m.jumpMapAllocs
+	if isNetkit {
+		filterAllocs = m.netkitJumpMapAllocs
+	}
 	if ap.LogLevel == "debug" {
 		for _, h := range []hook.Hook{hook.Ingress, hook.Egress} {
 			if state.filterIdx[h] == -1 {
-				state.filterIdx[h], err = m.jumpMapAllocs[h].Get(ap.IfaceName())
+				state.filterIdx[h], err = filterAllocs[h].Get(ap.IfaceName())
 				if err != nil {
 					return err
 				}
@@ -2350,7 +2426,7 @@ func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInt
 			if err := m.jumpMapDelete(attachHook, state.filterIdx[attachHook]); err != nil {
 				logrus.WithError(err).Warn("Filter program may leak.")
 			}
-			if err := m.jumpMapAllocs[attachHook].Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
+			if err := filterAllocs[attachHook].Put(state.filterIdx[attachHook], ap.IfaceName()); err != nil {
 				logrus.WithError(err).Errorf("Filter hook %s", attachHook)
 			}
 			state.filterIdx[attachHook] = -1
@@ -2500,6 +2576,12 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	// manage this way — other netkit devices (host/data interfaces) are not ours.
 	if ifaceType == IfaceTypeNetkit && m.isWorkloadIface(ifaceName) && tc.IsNetkitSupported() {
 		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
+		// Netkit programs have a different expected_attach_type and cannot
+		// share prog_array maps with TC/TCX programs. Use separate maps.
+		// Note: the AP is copied for both directions in applyPolicyToWeps,
+		// so we set overrides for both ingress and egress here. The ProgramsMap
+		// is set per-direction in wepApplyPolicyToDirection.
+		ap.MapPinOverrides = hook.NetkitPinOverridesBoth()
 	}
 	if wep != nil && wep.QosControls != nil {
 		// QoSControls are present, update state
@@ -3257,9 +3339,10 @@ func (d *bpfEndpointManagerDataplane) configureTCAttachPoint(policyDirection Pol
 		}
 	}
 
-	ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[hook.Ingress]
-	if ap.Hook == hook.Egress {
-		ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[hook.Egress]
+	if string(ap.AttachType) == tc.AttachOptionNetkit {
+		ap.ProgramsMap = d.mgr.commonMaps.NetkitProgramsMaps[ap.Hook]
+	} else {
+		ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[ap.Hook]
 	}
 
 	if d.mgr.FlowLogsEnabled() {
@@ -3975,14 +4058,24 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 		}
 
 		jmpMap := m.commonMaps.JumpMaps[aptc.Hook]
+		allowFDs := m.policyTcAllowFDs
+		denyFDs := m.policyTcDenyFDs
+		if string(aptc.AttachType) == tc.AttachOptionNetkit {
+			jmpMap = m.commonMaps.NetkitJumpMaps[aptc.Hook]
+			if err := m.ensureNetkitDefaultPolicies(); err != nil {
+				return err
+			}
+			allowFDs = m.policyNetkitAllowFDs
+			denyFDs = m.policyNetkitDenyFDs
+		}
 		// Load default policy before the real policy is created and loaded.
 		switch at.DefaultPolicy() {
 		case hook.DefPolicyAllow:
 			err = maps.UpdateMapEntry(jmpMap.MapFD(),
-				jump.Key(policyIdx), jump.Value(m.policyTcAllowFDs[aptc.Hook].FD()))
+				jump.Key(policyIdx), jump.Value(allowFDs[aptc.Hook].FD()))
 		case hook.DefPolicyDeny:
 			err = maps.UpdateMapEntry(jmpMap.MapFD(),
-				jump.Key(policyIdx), jump.Value(m.policyTcDenyFDs[aptc.Hook].FD()))
+				jump.Key(policyIdx), jump.Value(denyFDs[aptc.Hook].FD()))
 		}
 
 		if err != nil {
@@ -4168,7 +4261,12 @@ func (m *bpfEndpointManager) loadTCLogFilter(ap *tc.AttachPoint) (fileDescriptor
 	}
 
 	attachType := uint32(0)
-	if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+	if string(ap.AttachType) == tc.AttachOptionNetkit {
+		attachType = libbpf.AttachTypeNetkitPrimary
+		if ap.Hook == hook.Ingress {
+			attachType = libbpf.AttachTypeNetkitPeer
+		}
+	} else if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
 		attachType = libbpf.AttachTypeTcxIngress
 		if ap.Hook == hook.Egress {
 			attachType = libbpf.AttachTypeTcxEgress
@@ -4191,7 +4289,11 @@ func (m *bpfEndpointManager) updateLogFilter(ap attachPoint) error {
 			return err
 		}
 		defer fd.Close()
-		if err := m.commonMaps.JumpMaps[t.Hook].Update(jump.Key(idx), jump.Value(fd.FD())); err != nil {
+		jmpMap := m.commonMaps.JumpMaps[t.Hook]
+		if string(t.AttachType) == tc.AttachOptionNetkit {
+			jmpMap = m.commonMaps.NetkitJumpMaps[t.Hook]
+		}
+		if err := jmpMap.Update(jump.Key(idx), jump.Value(fd.FD())); err != nil {
 			return fmt.Errorf("failed to update %s policy jump map [%d]=%d: %w", ap.HookName(), idx, fd.FD(), err)
 		}
 
@@ -4318,7 +4420,13 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 	if apTc, ok := ap.(*tc.AttachPoint); ok {
 		staticProgsMap = apTc.ProgramsMap
 		polProgsMap = m.commonMaps.JumpMaps[apTc.Hook]
-		if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
+		if string(apTc.AttachType) == tc.AttachOptionNetkit {
+			polProgsMap = m.commonMaps.NetkitJumpMaps[apTc.Hook]
+			attachType = libbpf.AttachTypeNetkitPrimary
+			if apTc.Hook == hook.Ingress {
+				attachType = libbpf.AttachTypeNetkitPeer
+			}
+		} else if m.bpfAttachType == apiv3.BPFAttachOptionTCX {
 			attachType = libbpf.AttachTypeTcxIngress
 			if apTc.Hook == hook.Egress {
 				attachType = libbpf.AttachTypeTcxEgress

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -327,7 +327,8 @@ type bpfEndpointManager struct {
 	policyTcDenyFDs      [2]bpf.ProgFD
 	policyNetkitAllowFDs [2]bpf.ProgFD
 	policyNetkitDenyFDs  [2]bpf.ProgFD
-	netkitPoliciesLoaded sync.Once
+	netkitPoliciesLoaded bool
+	netkitPoliciesMu     sync.Mutex
 
 	ruleRenderer bpfAllowChainRenderer
 
@@ -1741,25 +1742,30 @@ func (m *bpfEndpointManager) loadDefaultPolicies(hk hook.Hook) error {
 
 // ensureNetkitDefaultPolicies lazily loads netkit default policy programs on first use.
 func (m *bpfEndpointManager) ensureNetkitDefaultPolicies() error {
-	var loadErr error
-	m.netkitPoliciesLoaded.Do(func() {
-		for _, hk := range []hook.Hook{hook.Ingress, hook.Egress} {
-			var pinOverrides map[string]string
-			if hk == hook.Ingress {
-				pinOverrides = hook.NetkitPinOverridesIngress()
-			} else {
-				pinOverrides = hook.NetkitPinOverridesEgress()
-			}
-			allowFD, denyFD, err := m.loadDefaultPolicyPrograms(hk, tc.AttachOptionNetkit, pinOverrides)
-			if err != nil {
-				loadErr = fmt.Errorf("loading netkit default policies for %s: %w", hk, err)
-				return
-			}
-			m.policyNetkitAllowFDs[hk] = allowFD
-			m.policyNetkitDenyFDs[hk] = denyFD
+	m.netkitPoliciesMu.Lock()
+	defer m.netkitPoliciesMu.Unlock()
+
+	if m.netkitPoliciesLoaded {
+		return nil
+	}
+
+	for _, hk := range []hook.Hook{hook.Ingress, hook.Egress} {
+		var pinOverrides map[string]string
+		if hk == hook.Ingress {
+			pinOverrides = hook.NetkitPinOverridesIngress()
+		} else {
+			pinOverrides = hook.NetkitPinOverridesEgress()
 		}
-	})
-	return loadErr
+		allowFD, denyFD, err := m.loadDefaultPolicyPrograms(hk, tc.AttachOptionNetkit, pinOverrides)
+		if err != nil {
+			return fmt.Errorf("loading netkit default policies for %s: %w", hk, err)
+		}
+		m.policyNetkitAllowFDs[hk] = allowFD
+		m.policyNetkitDenyFDs[hk] = denyFD
+	}
+
+	m.netkitPoliciesLoaded = true
+	return nil
 }
 
 // loadDefaultPolicyPrograms loads the default allow/deny policy programs for the
@@ -2410,7 +2416,7 @@ func (m *bpfEndpointManager) allocJumpIndicesForDataIface(ifaceName string, xdpM
 func (m *bpfEndpointManager) wepStateFillJumps(ap *tc.AttachPoint, state *bpfInterfaceState) error {
 	var err error
 
-	isNetkit := string(ap.AttachType) == tc.AttachOptionNetkit
+	isNetkit := ap.IsNetkit()
 
 	// Allocate indices for IPv4
 	if m.v4 != nil {
@@ -3363,7 +3369,7 @@ func (d *bpfEndpointManagerDataplane) configureTCAttachPoint(policyDirection Pol
 		}
 	}
 
-	if string(ap.AttachType) == tc.AttachOptionNetkit {
+	if ap.IsNetkit() {
 		ap.ProgramsMap = d.mgr.commonMaps.NetkitProgramsMaps[ap.Hook]
 	} else {
 		ap.ProgramsMap = d.mgr.commonMaps.ProgramsMaps[ap.Hook]
@@ -3525,14 +3531,6 @@ func (m *bpfEndpointManager) isWorkloadIface(iface string) bool {
 	return m.workloadIfaceRegex.MatchString(iface)
 }
 
-// isNetkitAttachPoint checks if the given attach point corresponds to a netkit
-// interface by looking up the interface type in the tracked interfaces map.
-func (m *bpfEndpointManager) isNetkitAttachPoint(ap attachPoint) bool {
-	if tcAP, ok := ap.(*tc.AttachPoint); ok {
-		return string(tcAP.AttachType) == tc.AttachOptionNetkit
-	}
-	return false
-}
 
 func (m *bpfEndpointManager) isDataIface(iface string) bool {
 	return m.dataIfaceRegex.MatchString(iface) ||
@@ -4068,13 +4066,12 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 		progAttachType := string(aptc.AttachType)
 
 		at := hook.AttachType{
-			Hook:           aptc.HookName(),
-			Family:         int(ipFamily),
-			Type:           aptc.Type,
-			LogLevel:       aptc.LogLevel,
-			ToHostDrop:     aptc.ToHostDrop,
-			DSR:            aptc.DSR,
-			ProgAttachType: progAttachType,
+			Hook:       aptc.HookName(),
+			Family:     int(ipFamily),
+			Type:       aptc.Type,
+			LogLevel:   aptc.LogLevel,
+			ToHostDrop: aptc.ToHostDrop,
+			DSR:        aptc.DSR,
 		}
 
 		policyIdx := aptc.PolicyIdxV4
@@ -4093,7 +4090,7 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 		jmpMap := m.commonMaps.JumpMaps[aptc.Hook]
 		allowFDs := m.policyTcAllowFDs
 		denyFDs := m.policyTcDenyFDs
-		if string(aptc.AttachType) == tc.AttachOptionNetkit {
+		if aptc.IsNetkit() {
 			jmpMap = m.commonMaps.NetkitJumpMaps[aptc.Hook]
 			if err := m.ensureNetkitDefaultPolicies(); err != nil {
 				return err
@@ -4155,7 +4152,10 @@ func (m *bpfEndpointManager) ensureNoProgram(ap attachPoint) error {
 	})
 	m.ifacesLock.Unlock()
 
-	isNetkit := m.isNetkitAttachPoint(ap)
+	isNetkit := false
+	if tcAP, ok := ap.(*tc.AttachPoint); ok {
+		isNetkit = tcAP.IsNetkit()
+	}
 	if m.v4 != nil {
 		if err := m.jumpMapDelete(ap.HookName(), state.v4.policyIdx[ap.HookName()], isNetkit); err != nil {
 			logrus.WithError(err).Warn("Policy program may leak.")
@@ -4295,7 +4295,7 @@ func (m *bpfEndpointManager) loadTCLogFilter(ap *tc.AttachPoint) (fileDescriptor
 	}
 
 	attachType := uint32(0)
-	if string(ap.AttachType) == tc.AttachOptionNetkit {
+	if ap.IsNetkit() {
 		attachType = libbpf.AttachTypeNetkitPrimary
 		if ap.Hook == hook.Ingress {
 			attachType = libbpf.AttachTypeNetkitPeer
@@ -4324,7 +4324,7 @@ func (m *bpfEndpointManager) updateLogFilter(ap attachPoint) error {
 		}
 		defer fd.Close()
 		jmpMap := m.commonMaps.JumpMaps[t.Hook]
-		if string(t.AttachType) == tc.AttachOptionNetkit {
+		if t.IsNetkit() {
 			jmpMap = m.commonMaps.NetkitJumpMaps[t.Hook]
 		}
 		if err := jmpMap.Update(jump.Key(idx), jump.Value(fd.FD())); err != nil {
@@ -4454,7 +4454,7 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 	if apTc, ok := ap.(*tc.AttachPoint); ok {
 		staticProgsMap = apTc.ProgramsMap
 		polProgsMap = m.commonMaps.JumpMaps[apTc.Hook]
-		if string(apTc.AttachType) == tc.AttachOptionNetkit {
+		if apTc.IsNetkit() {
 			polProgsMap = m.commonMaps.NetkitJumpMaps[apTc.Hook]
 			attachType = libbpf.AttachTypeNetkitPrimary
 			if apTc.Hook == hook.Ingress {
@@ -4591,7 +4591,10 @@ func (m *bpfEndpointManager) removePolicyProgram(ap attachPoint, ipFamily proto.
 		pm = m.commonMaps.XDPJumpMap
 	} else {
 		stride = jump.TCMaxEntryPoints
-		isNetkit := m.isNetkitAttachPoint(ap)
+		isNetkit := false
+		if tcAP, ok := ap.(*tc.AttachPoint); ok {
+			isNetkit = tcAP.IsNetkit()
+		}
 		if isNetkit {
 			pm = m.commonMaps.NetkitJumpMaps[ap.HookName()]
 		} else {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1175,6 +1175,18 @@ func cleanupTcxPins(iface string) {
 	}
 }
 
+func cleanupNetkitPins(iface string) {
+	for _, attachHook := range []hook.Hook{hook.Ingress, hook.Egress} {
+		ap := tc.AttachPoint{
+			AttachPoint: bpf.AttachPoint{
+				Iface: iface,
+				Hook:  attachHook,
+			},
+		}
+		os.Remove(ap.NetkitProgPinPath())
+	}
+}
+
 func (m *bpfEndpointManager) cleanupOldTcAttach(iface string) error {
 	ap := tc.AttachPoint{
 		AttachPoint: bpf.AttachPoint{
@@ -1240,12 +1252,13 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 		return
 	}
 
-	if update.State == ifacemonitor.StateNotPresent && m.bpfAttachType == apiv3.BPFAttachOptionTCX {
-		// Delete the tcx pins if the interface is gone.
+	if update.State == ifacemonitor.StateNotPresent {
+		// Delete tcx/netkit pins if the interface is gone.
 		// Check if the interface still exists, as we might get events out of order.
 		_, err := m.dp.getIfaceLink(update.Name)
 		if err != nil {
 			cleanupTcxPins(update.Name)
+			cleanupNetkitPins(update.Name)
 		}
 	}
 	// Should be safe without the lock since there shouldn't be any active background threads
@@ -1279,6 +1292,12 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			allIfaces.Discard(update.Name)
 			m.hostIfaceTrees.deleteIface(update.Name)
 			m.dirtyIfaceNames.AddSet(allIfaces)
+		}
+	} else if update.State != ifacemonitor.StateNotPresent {
+		// For workload interfaces, detect netkit devices so Felix can use
+		// native BPF attachment instead of TC/TCX.
+		if link, err := m.dp.getIfaceLink(update.Name); err == nil {
+			curIfaceType = m.getIfaceTypeFromLink(link)
 		}
 	}
 
@@ -2476,10 +2495,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	ap := m.calculateTCAttachPoint(ifaceName)
 	ap.IfIndex = ifindex
 
-	// For netkit devices, override the attachment mechanism to use native netkit BPF
-	// attachment instead of TC/TCX. This is per-device: veth and netkit endpoints can
-	// coexist on the same node.
-	if ifaceType == IfaceTypeNetkit && tc.IsNetkitSupported() {
+	// For workload netkit devices, override the attachment mechanism to use native
+	// netkit BPF attachment instead of TC/TCX. Only workload interfaces are ours to
+	// manage this way — other netkit devices (host/data interfaces) are not ours.
+	if ifaceType == IfaceTypeNetkit && m.isWorkloadIface(ifaceName) && tc.IsNetkitSupported() {
 		ap.AttachType = apiv3.BPFAttachOption(tc.AttachOptionNetkit)
 	}
 	if wep != nil && wep.QosControls != nil {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -3531,7 +3531,6 @@ func (m *bpfEndpointManager) isWorkloadIface(iface string) bool {
 	return m.workloadIfaceRegex.MatchString(iface)
 }
 
-
 func (m *bpfEndpointManager) isDataIface(iface string) bool {
 	return m.dataIfaceRegex.MatchString(iface) ||
 		(m.hostNetworkedNATMode != hostNetworkedNATDisabled && (iface == dataplanedefs.BPFOutDev || iface == "lo"))

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1801,25 +1801,10 @@ func (m *bpfEndpointManager) loadDefaultPolicyPrograms(
 		}
 	}
 
-	switch progAttachType {
-	case string(apiv3.BPFAttachOptionTCX):
+	if attachType, ok := linkAttachTypeForHook(progAttachType, hk); ok {
 		for p, err := obj.FirstProgram(); p != nil && err == nil; p, err = p.NextProgram() {
-			attachType := libbpf.AttachTypeTcxEgress
-			if hk == hook.Ingress {
-				attachType = libbpf.AttachTypeTcxIngress
-			}
 			if err := obj.SetAttachType(p.Name(), attachType); err != nil {
-				return 0, 0, fmt.Errorf("error setting attach type for program %s: %w", p.Name(), err)
-			}
-		}
-	case tc.AttachOptionNetkit:
-		for p, err := obj.FirstProgram(); p != nil && err == nil; p, err = p.NextProgram() {
-			attachType := libbpf.AttachTypeNetkitPrimary
-			if hk == hook.Ingress {
-				attachType = libbpf.AttachTypeNetkitPeer
-			}
-			if err := obj.SetAttachType(p.Name(), attachType); err != nil {
-				return 0, 0, fmt.Errorf("error setting netkit attach type for program %s: %w", p.Name(), err)
+				return 0, 0, fmt.Errorf("error setting %s attach type for program %s: %w", progAttachType, p.Name(), err)
 			}
 		}
 	}
@@ -1841,6 +1826,28 @@ func (m *bpfEndpointManager) loadDefaultPolicyPrograms(
 	allowFD = bpf.ProgFD(fd)
 
 	return allowFD, denyFD, nil
+}
+
+// linkAttachTypeForHook returns the libbpf attach type for the given
+// link-based attachment mode and hook direction. The bool is false for
+// modes that don't use libbpf-link attachment (e.g. classic TC).
+func linkAttachTypeForHook(progAttachType string, hk hook.Hook) (uint32, bool) {
+	switch progAttachType {
+	case string(apiv3.BPFAttachOptionTCX):
+		if hk == hook.Ingress {
+			return libbpf.AttachTypeTcxIngress, true
+		}
+		return libbpf.AttachTypeTcxEgress, true
+	case tc.AttachOptionNetkit:
+		// Map TC hook direction to netkit attach type:
+		// hook.Ingress (traffic from pod) -> BPF_NETKIT_PEER (peer transmits)
+		// hook.Egress (traffic to pod) -> BPF_NETKIT_PRIMARY (primary transmits)
+		if hk == hook.Ingress {
+			return libbpf.AttachTypeNetkitPeer, true
+		}
+		return libbpf.AttachTypeNetkitPrimary, true
+	}
+	return 0, false
 }
 
 func (m *bpfEndpointManager) CompleteDeferredWork() error {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -3234,7 +3234,7 @@ func (m *bpfEndpointManager) getEndpointType(ifaceName string) tcdefs.EndpointTy
 	ifaceType := m.nameToIface[ifaceName].info.ifaceType
 	m.ifacesLock.Unlock()
 	switch ifaceType {
-	case IfaceTypeData, IfaceTypeVXLAN, IfaceTypeBond, IfaceTypeBondSlave:
+	case IfaceTypeData, IfaceTypeVXLAN, IfaceTypeBond, IfaceTypeBondSlave, IfaceTypeNetkit:
 		if ifaceName == "vxlan.calico" || ifaceName == "vxlan-v6.calico" {
 			return tcdefs.EpTypeVXLAN
 		}

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -465,6 +465,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		jumpMapEgr = mock.NewMockMap(progsParamsEg)
 		commonMaps.JumpMaps = append(commonMaps.JumpMaps, jumpMapIng)
 		commonMaps.JumpMaps = append(commonMaps.JumpMaps, jumpMapEgr)
+		// Netkit jump maps are needed even in non-netkit tests because the
+		// bpfEndpointManager indexes into them unconditionally (e.g. syncIfStateMap).
 		commonMaps.NetkitJumpMaps = append(commonMaps.NetkitJumpMaps, mock.NewMockMap(progsParamsIng))
 		commonMaps.NetkitJumpMaps = append(commonMaps.NetkitJumpMaps, mock.NewMockMap(progsParamsEg))
 		xdpJumpMap = mock.NewMockMap(progsParamsIng)
@@ -1102,6 +1104,37 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			genHostMetadataV6Update("1::4")()
 			Expect(dp.numOfAttaches("cali12345:ingress")).To(Equal(5))
 			Expect(dp.numOfAttaches("cali12345:egress")).To(Equal(5))
+		})
+	})
+
+	Context("with netkit workload endpoint", func() {
+		JustBeforeEach(func() {
+			newBpfEpMgr(false)
+			err := dp.createIface("calinkit0", 50, "netkit")
+			Expect(err).NotTo(HaveOccurred())
+			genWLUpdate("calinkit0")()
+			genIfaceUpdate("calinkit0", ifacemonitor.StateUp, 50)()
+		})
+
+		It("should detect netkit interface type", func() {
+			bpfEpMgr.ifacesLock.Lock()
+			iface := bpfEpMgr.nameToIface["calinkit0"]
+			bpfEpMgr.ifacesLock.Unlock()
+			Expect(iface.info.ifaceType).To(Equal(IfaceTypeNetkit))
+		})
+
+		It("should allocate jump indices for netkit workload", func() {
+			bpfEpMgr.ifacesLock.Lock()
+			iface := bpfEpMgr.nameToIface["calinkit0"]
+			bpfEpMgr.ifacesLock.Unlock()
+			// Netkit workload should have policy indices allocated.
+			Expect(iface.dpState.v4.policyIdx[hook.Ingress]).To(BeNumerically(">=", 0))
+			Expect(iface.dpState.v4.policyIdx[hook.Egress]).To(BeNumerically(">=", 0))
+		})
+
+		It("should clean up netkit jump maps on interface removal", func() {
+			genIfaceUpdate("calinkit0", ifacemonitor.StateNotPresent, 50)()
+			genWLUpdateEpRemove("calinkit0")()
 		})
 	})
 

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -465,6 +465,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		jumpMapEgr = mock.NewMockMap(progsParamsEg)
 		commonMaps.JumpMaps = append(commonMaps.JumpMaps, jumpMapIng)
 		commonMaps.JumpMaps = append(commonMaps.JumpMaps, jumpMapEgr)
+		commonMaps.NetkitJumpMaps = append(commonMaps.NetkitJumpMaps, mock.NewMockMap(progsParamsIng))
+		commonMaps.NetkitJumpMaps = append(commonMaps.NetkitJumpMaps, mock.NewMockMap(progsParamsEg))
 		xdpJumpMap = mock.NewMockMap(progsParamsIng)
 		commonMaps.XDPJumpMap = xdpJumpMap
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -915,6 +915,9 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			if testOpts.protocol != "udp" { // No need to run these tests per-protocol.
 				It("should recover if the BPF programs are removed", func() {
+					if infrastructure.NetkitMode() {
+						Skip("Netkit uses bpf_link; removing pins doesn't detach programs")
+					}
 					flapInterface := func() {
 						By("Flapping interface")
 						tc.Felixes[0].Exec("ip", "link", "set", "down", w[0].InterfaceName)

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -262,6 +262,16 @@ func BPFAttachType() string {
 	return strings.ToLower(os.Getenv("FELIX_FV_BPFATTACHTYPE"))
 }
 
+// bpfProgPinDir returns the BPF program pin directory for the current
+// attach mode.  In netkit mode, workload programs are pinned under
+// NetkitPinDir; in TCX mode they use TcxPinDir.
+func bpfProgPinDir() string {
+	if infrastructure.NetkitMode() {
+		return bpfdefs.NetkitPinDir
+	}
+	return bpfdefs.TcxPinDir
+}
+
 func describeBPFTests(opts ...bpfTestOpt) bool {
 	if !BPFMode() {
 		// Non-BPF run.
@@ -928,7 +938,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						if BPFAttachType() == "tc" {
 							tc.Felixes[0].Exec("tc", "filter", "del", "ingress", "dev", w[0].InterfaceName)
 						} else {
-							tc.Felixes[0].Exec("rm", "-rf", path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_ingress", w[0].InterfaceName)))
+							tc.Felixes[0].Exec("rm", "-rf", path.Join(bpfProgPinDir(), fmt.Sprintf("%s_ingress", w[0].InterfaceName)))
 						}
 
 						// Removing the ingress program should break connectivity due to the lack of "seen" mark.
@@ -950,7 +960,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								fmt.Sprintf("from wep not loaded for %s", w[0].InterfaceName))
 						} else {
 							Eventually(func() string {
-								out, _ := tc.Felixes[0].ExecOutput("stat", path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_ingress", w[0].InterfaceName)))
+								out, _ := tc.Felixes[0].ExecOutput("stat", path.Join(bpfProgPinDir(), fmt.Sprintf("%s_ingress", w[0].InterfaceName)))
 								return out
 							}, "5s", "200ms").ShouldNot(ContainSubstring("No such file or directory"),
 								fmt.Sprintf("from wep not loaded for %s", w[0].InterfaceName))
@@ -960,7 +970,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						if BPFAttachType() == "tc" {
 							tc.Felixes[0].Exec("tc", "filter", "del", "egress", "dev", w[0].InterfaceName)
 						} else {
-							tc.Felixes[0].Exec("rm", "-rf", path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_egress", w[0].InterfaceName)))
+							tc.Felixes[0].Exec("rm", "-rf", path.Join(bpfProgPinDir(), fmt.Sprintf("%s_egress", w[0].InterfaceName)))
 						}
 						// Removing the egress program doesn't stop traffic.
 
@@ -976,7 +986,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								fmt.Sprintf("to wep not loaded for %s", w[0].InterfaceName))
 						} else {
 							Eventually(func() string {
-								out, _ := tc.Felixes[0].ExecOutput("stat", path.Join(bpfdefs.TcxPinDir, fmt.Sprintf("%s_egress", w[0].InterfaceName)))
+								out, _ := tc.Felixes[0].ExecOutput("stat", path.Join(bpfProgPinDir(), fmt.Sprintf("%s_egress", w[0].InterfaceName)))
 								return out
 							}, "5s", "200ms").ShouldNot(ContainSubstring("No such file or directory"),
 								fmt.Sprintf("from wep not loaded for %s", w[0].InterfaceName))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1212,39 +1212,31 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					// as part of this test. There can be other preamble programs
 					// from previous tests and we want to ignore those when checking that programs are cleaned up after disabling BPF.
 					getPreambleProgramIDs := func() set.Set[int] {
-						var bpfnetTCX []struct {
-							TC []struct {
-								Name string `json:"name"`
-								ID   int    `json:"prog_id"`
-							} `json:"tc"`
-						}
-
+						// bpftool net show -j puts both TC/TCX and netkit
+						// programs under the "tc" key. Older bpftool uses "id"
+						// for the program ID while newer versions use "prog_id".
+						// Parse both and take whichever is set.
 						var bpfnet []struct {
 							TC []struct {
-								Name string `json:"name"`
-								ID   int    `json:"id"`
+								Name   string `json:"name"`
+								ID     int    `json:"id"`
+								ProgID int    `json:"prog_id"`
 							} `json:"tc"`
 						}
 						out, err := tc.Felixes[0].ExecOutput("bpftool", "net", "show", "-j")
 						Expect(err).NotTo(HaveOccurred())
 						preambleIDs := set.New[int]()
-						if BPFAttachType() == "tc" {
-							err = json.Unmarshal([]byte(out), &bpfnet)
-							Expect(err).NotTo(HaveOccurred())
-							for _, entry := range bpfnet {
-								for _, prog := range entry.TC {
-									if strings.Contains(prog.Name, "cali_tc_pream") {
-										preambleIDs.Add(prog.ID)
+						err = json.Unmarshal([]byte(out), &bpfnet)
+						Expect(err).NotTo(HaveOccurred())
+						for _, entry := range bpfnet {
+							for _, prog := range entry.TC {
+								if strings.Contains(prog.Name, "cali_tc_pream") {
+									id := prog.ProgID
+									if id == 0 {
+										id = prog.ID
 									}
-								}
-							}
-						} else {
-							err = json.Unmarshal([]byte(out), &bpfnetTCX)
-							Expect(err).NotTo(HaveOccurred())
-							for _, entry := range bpfnetTCX {
-								for _, prog := range entry.TC {
-									if strings.Contains(prog.Name, "cali_tc_pream") {
-										preambleIDs.Add(prog.ID)
+									if id != 0 {
+										preambleIDs.Add(id)
 									}
 								}
 							}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3726,28 +3726,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 						var tcpd *tcpdump.TCPDump
 						if testOpts.protocol == "tcp" {
-							iface := w[1][1].InterfaceName
-							srcIP := clusterIP
-							tcpdHost := tc.Felixes[1]
-							if testOpts.connTimeEnabled {
-								iface = "eth0"
-								switch testOpts.tunnel {
-								case "vxlan":
-									iface = "vxlan.calico"
-								case "wireguard":
-									iface = "wireguard.cali"
-									if testOpts.ipv6 {
-										iface = "wireguard.cali-v6"
-									}
-								case "ipip":
-									iface = "tunl0"
-								}
-								srcIP = w[0][0].IP
-								tcpdHost = tc.Felixes[0]
-							}
-							tcpd = tcpdHost.AttachTCPDump(iface)
+							tcpd = w[1][1].AttachTCPDump()
 							tcpd.SetLogEnabled(true)
 
+							srcIP := clusterIP
+							if testOpts.connTimeEnabled {
+								srcIP = w[0][0].IP
+							}
 							ipRegex := "IP"
 							if testOpts.ipv6 {
 								ipRegex = "IP6"

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1866,14 +1866,18 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							tcpdump1.SetLogEnabled(true)
 							tcpdump1.AddMatcher("udp-frags", regexp.MustCompile(
 								fmt.Sprintf("%s.* > %s.*", externalClient.IP, w[0][0].IP)))
-							tcpdump1.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP)
+							// Exclude packets with the DF flag set so incidental
+							// probe traffic (e.g., the connectivity checker) does
+							// not pollute the fragment count; pktgen sends with
+							// --ip-dnf=n so its fragments have DF=0.
+							tcpdump1.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP, "and", "ip[6] & 0x40 = 0")
 							defer tcpdump1.Stop()
 
 							tcpdump0 := w[0][0].AttachTCPDump()
 							tcpdump0.SetLogEnabled(true)
 							tcpdump0.AddMatcher("udp-pod-frags", regexp.MustCompile(
 								fmt.Sprintf("%s.* > %s.*", externalClient.IP, w[0][0].IP)))
-							tcpdump0.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP)
+							tcpdump0.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP, "and", "ip[6] & 0x40 = 0")
 							defer tcpdump0.Stop()
 
 							// Wait for the new policy to be programmed and BPF

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1878,6 +1878,10 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 							// Wait for the new policy to be programmed and BPF
 							// dataplane to settle before sending fragmented traffic.
+							// Reset expectations first so CheckConnectivity does not
+							// re-fire the ext-client probe from above, which would
+							// land on tcpdump1 and inflate the fragment count.
+							cc.ResetExpectations()
 							cc.Expect(Some, w[0][0], w[1][0])
 							cc.CheckConnectivity()
 							cc.ResetExpectations()

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1876,6 +1876,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							tcpdump0.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP)
 							defer tcpdump0.Stop()
 
+							// Wait for the new policy to be programmed and BPF
+							// dataplane to settle before sending fragmented traffic.
+							cc.Expect(Some, w[0][0], w[1][0])
+							cc.CheckConnectivity()
+							cc.ResetExpectations()
+
 							// Send a packet with large payload without the DNF flag
 							// 16,000 bytes is the typical limit on the size of a
 							// single skb, which in turn is the limit on the size

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -696,9 +696,17 @@ func (f *Felix) BPFNumPolProgramsTotalByEntryPointFn(entryPointIdx int, ingressO
 
 func (f *Felix) BPFNumPolProgramsByEntryPoint(entryPointIdx int, ingressOrEgress string) (contiguous, total int) {
 	gapSeen := false
-	jmpMapName := jump.EgressMapParameters.VersionedName()
-	if ingressOrEgress == "egress" {
-		jmpMapName = jump.IngressMapParameters.VersionedName()
+	var jmpMapName string
+	if NetkitMode() {
+		jmpMapName = jump.NetkitEgressMapParameters.VersionedName()
+		if ingressOrEgress == "egress" {
+			jmpMapName = jump.NetkitIngressMapParameters.VersionedName()
+		}
+	} else {
+		jmpMapName = jump.EgressMapParameters.VersionedName()
+		if ingressOrEgress == "egress" {
+			jmpMapName = jump.IngressMapParameters.VersionedName()
+		}
 	}
 	pinnedMap := "/sys/fs/bpf/tc/globals/" + jmpMapName
 	for i := range jump.MaxSubPrograms {

--- a/felix/fv/infrastructure/modes.go
+++ b/felix/fv/infrastructure/modes.go
@@ -20,3 +20,9 @@ import "os"
 func NFTMode() bool {
 	return os.Getenv("FELIX_FV_NFTABLES") == "Enabled"
 }
+
+// NetkitMode returns true if FV tests are configured to use netkit devices
+// instead of veth pairs for workload endpoints.
+func NetkitMode() bool {
+	return os.Getenv("FELIX_FV_NETKIT") == "Enabled"
+}

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -47,7 +48,7 @@ const usage = `test-workload, test workload for Felix FV testing.
 If <interface-name> is "", the workload will start in the current namespace.
 
 Usage:
-  test-workload [--protocol=<protocol>] [--namespace-path=<path>] [--sidecar-iptables] [--mtu=<mtu>] [--listen-any-ip] <interface-name> <ip-address> <ports>
+  test-workload [--protocol=<protocol>] [--namespace-path=<path>] [--sidecar-iptables] [--mtu=<mtu>] [--listen-any-ip] [--netkit] <interface-name> <ip-address> <ports>
 `
 
 func main() {
@@ -81,6 +82,10 @@ func main() {
 	listenAnyIP := false
 	if arg, ok := arguments["--listen-any-ip"]; ok && arg.(bool) {
 		listenAnyIP = true
+	}
+	useNetkit := false
+	if arg, ok := arguments["--netkit"]; ok && arg.(bool) {
+		useNetkit = true
 	}
 
 	ports := strings.Split(portsStr, ",")
@@ -118,11 +123,6 @@ func main() {
 		}
 		log.WithField("namespace", namespace.Path()).Debug("Created namespace")
 
-		conf := types.NetConf{
-			MTU:       mtu,
-			NumQueues: 1,
-		}
-		dp := linux.NewLinuxDataplane(conf, log.WithField("ns", namespace.Path()))
 		hostVethName := interfaceName
 		var addrs []*cniv1.IPConfig
 		if ipv4Addr != "" {
@@ -153,15 +153,25 @@ func main() {
 		panicIfError(err)
 
 		defer hostNlHandle.Close()
-		_, err = dp.DoWorkloadNetnsSetUp(
-			hostNlHandle,
-			namespace.Path(),
-			addrs,
-			"eth0",
-			hostVethName,
-			routes,
-			nil,
-		)
+
+		if useNetkit {
+			err = doNetkitSetUp(hostNlHandle, namespace, addrs, "eth0", hostVethName, routes, mtu)
+		} else {
+			conf := types.NetConf{
+				MTU:       mtu,
+				NumQueues: 1,
+			}
+			dp := linux.NewLinuxDataplane(conf, log.WithField("ns", namespace.Path()))
+			_, err = dp.DoWorkloadNetnsSetUp(
+				hostNlHandle,
+				namespace.Path(),
+				addrs,
+				"eth0",
+				hostVethName,
+				routes,
+				nil,
+			)
+		}
 		panicIfError(err)
 	} else {
 		namespace, err = ns.GetCurrentNS()
@@ -434,6 +444,191 @@ func loopRespondingToPackets(logCxt *log.Entry, p net.PacketConn) {
 			logCxt.WithError(err).WithField("remoteAddr", addr).Info("Responded")
 		}
 	}
+}
+
+// doNetkitSetUp creates a netkit L2 pair instead of a veth pair for the workload.
+// The primary (host-side) end stays in the host namespace; the peer is moved into
+// the workload namespace. IP addresses, routes and sysctls are configured to match
+// what DoWorkloadNetnsSetUp does for veth pairs.
+func doNetkitSetUp(
+	hostNlHandle *netlink.Handle,
+	workloadNS ns.NetNS,
+	ipAddrs []*cniv1.IPConfig,
+	contIfName string,
+	hostIfName string,
+	routes []*net.IPNet,
+	mtu int,
+) error {
+	// Clean up if host-side interface already exists.
+	if oldLink, err := hostNlHandle.LinkByName(hostIfName); err == nil {
+		if err = hostNlHandle.LinkDel(oldLink); err != nil {
+			return fmt.Errorf("failed to delete old host interface %v: %v", hostIfName, err)
+		}
+		log.Infof("Cleaned up old host interface: %v", hostIfName)
+	}
+
+	// Determine IP versions present.
+	var hasIPv4, hasIPv6 bool
+	for _, addr := range ipAddrs {
+		if addr.Address.IP.To4() != nil {
+			hasIPv4 = true
+			addr.Address.Mask = net.CIDRMask(32, 32)
+		} else if addr.Address.IP.To16() != nil {
+			hasIPv6 = true
+			addr.Address.Mask = net.CIDRMask(128, 128)
+		}
+	}
+
+	// Create netkit in host namespace, with peer placed in workload namespace.
+	la := netlink.NewLinkAttrs()
+	la.Name = hostIfName
+	la.MTU = mtu
+	nk := &netlink.Netkit{
+		LinkAttrs: la,
+		Mode:      netlink.NETKIT_MODE_L2,
+	}
+	nk.SetPeerAttrs(&netlink.LinkAttrs{
+		Name:      contIfName,
+		Namespace: netlink.NsFd(int(workloadNS.Fd())),
+	})
+	if err := netlink.LinkAdd(nk); err != nil {
+		return fmt.Errorf("failed to add netkit pair (%s, %s): %w", hostIfName, contIfName, err)
+	}
+	log.Infof("Created netkit pair: host=%s container=%s (in workload NS)", hostIfName, contIfName)
+
+	// Configure host-side interface: MAC, proxy_arp, bring up.
+	hostLink, err := hostNlHandle.LinkByName(hostIfName)
+	if err != nil {
+		return fmt.Errorf("failed to find host-side netkit %s: %w", hostIfName, err)
+	}
+	hostMAC, _ := net.ParseMAC("ee:ee:ee:ee:ee:ee")
+	if err := hostNlHandle.LinkSetHardwareAddr(hostLink, hostMAC); err != nil {
+		log.Warnf("Failed to set MAC on %s: %v (using kernel-assigned MAC)", hostIfName, err)
+	}
+
+	// Host-side sysctls (proxy_arp, forwarding, etc.)
+	if hasIPv4 {
+		writeProcSysOrLog("/proc/sys/net/ipv4/conf/%s/route_localnet", hostIfName, "1")
+		writeProcSysOrLog("/proc/sys/net/ipv4/neigh/%s/proxy_delay", hostIfName, "0")
+		writeProcSysOrLog("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostIfName, "1")
+		writeProcSysOrLog("/proc/sys/net/ipv4/conf/%s/forwarding", hostIfName, "1")
+	}
+	if hasIPv6 {
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/accept_dad", hostIfName, "0")
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/disable_ipv6", hostIfName, "0")
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/proxy_ndp", hostIfName, "1")
+		writeProcSysOrLog("/proc/sys/net/ipv6/conf/%s/forwarding", hostIfName, "1")
+	}
+
+	if err := hostNlHandle.LinkSetUp(hostLink); err != nil {
+		return fmt.Errorf("failed to set %s up: %w", hostIfName, err)
+	}
+
+	// Configure container-side interface inside the workload namespace.
+	err = workloadNS.Do(func(_ ns.NetNS) error {
+		contLink, err := netlink.LinkByName(contIfName)
+		if err != nil {
+			return fmt.Errorf("failed to find container netkit %s: %w", contIfName, err)
+		}
+
+		if hasIPv6 {
+			// Disable DAD before bringing the interface up.
+			if err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/accept_dad", contIfName), "0"); err != nil {
+				return err
+			}
+		}
+
+		if err := netlink.LinkSetUp(contLink); err != nil {
+			return fmt.Errorf("failed to set %s up: %w", contIfName, err)
+		}
+
+		// Add IP addresses.
+		for _, addr := range ipAddrs {
+			if err := netlink.AddrAdd(contLink, &netlink.Addr{IPNet: &addr.Address}); err != nil {
+				return fmt.Errorf("failed to add IP %v to %s: %w", addr.Address, contIfName, err)
+			}
+		}
+
+		// Add IPv4 routes.
+		if hasIPv4 {
+			gw := net.IPv4(169, 254, 1, 1)
+			gwNet := &net.IPNet{IP: gw, Mask: net.CIDRMask(32, 32)}
+			if err := netlink.RouteAdd(&netlink.Route{
+				LinkIndex: contLink.Attrs().Index,
+				Scope:     netlink.SCOPE_LINK,
+				Dst:       gwNet,
+			}); err != nil {
+				return fmt.Errorf("failed to add gateway route: %w", err)
+			}
+			for _, r := range routes {
+				if r.IP.To4() == nil {
+					continue
+				}
+				if err := netlink.RouteAdd(&netlink.Route{
+					LinkIndex: contLink.Attrs().Index,
+					Dst:       r,
+					Gw:        gw,
+				}); err != nil {
+					return fmt.Errorf("failed to add IPv4 route %v: %w", r, err)
+				}
+			}
+		}
+
+		// Add IPv6 routes.
+		if hasIPv6 {
+			// Enable IPv6 in the namespace.
+			_ = writeProcSys("/proc/sys/net/ipv6/conf/all/disable_ipv6", "0")
+			_ = writeProcSys("/proc/sys/net/ipv6/conf/default/disable_ipv6", "0")
+			_ = writeProcSys("/proc/sys/net/ipv6/conf/lo/disable_ipv6", "0")
+
+			// Get the host-side link-local address for use as IPv6 gateway.
+			var hostIPv6 net.IP
+			for i := range 10 {
+				if i > 0 {
+					time.Sleep(50 * time.Millisecond)
+				}
+				addrs, err := hostNlHandle.AddrList(hostLink, netlink.FAMILY_V6)
+				if err == nil && len(addrs) > 0 {
+					hostIPv6 = addrs[0].IP
+					break
+				}
+			}
+			if hostIPv6 == nil {
+				return fmt.Errorf("failed to get IPv6 link-local address for %s", hostIfName)
+			}
+			for _, r := range routes {
+				if r.IP.To4() != nil {
+					continue
+				}
+				if err := netlink.RouteAdd(&netlink.Route{
+					LinkIndex: contLink.Attrs().Index,
+					Dst:       r,
+					Gw:        hostIPv6,
+				}); err != nil {
+					return fmt.Errorf("failed to add IPv6 route %v: %w", r, err)
+				}
+			}
+		}
+
+		// Container-side sysctls (rp_filter, etc.)
+		if hasIPv4 {
+			_ = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", contIfName), "1")
+		}
+
+		return nil
+	})
+	return err
+}
+
+func writeProcSysOrLog(pathFmt, ifName, value string) {
+	path := fmt.Sprintf(pathFmt, ifName)
+	if err := writeProcSys(path, value); err != nil {
+		log.Warnf("Failed to write %s=%s: %v", path, value, err)
+	}
+}
+
+func writeProcSys(path, value string) error {
+	return os.WriteFile(path, []byte(value), 0644)
 }
 
 func panicIfError(err error) {

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -489,6 +489,7 @@ func doNetkitSetUp(
 	}
 	nk.SetPeerAttrs(&netlink.LinkAttrs{
 		Name:      contIfName,
+		MTU:       mtu,
 		Namespace: netlink.NsFd(int(workloadNS.Fd())),
 	})
 	if err := netlink.LinkAdd(nk); err != nil {

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -263,8 +263,13 @@ func (w *Workload) Start(cleanupProvider CleanupProvider) error {
 	if w.IP6 != "" {
 		wIP = wIP + "," + w.IP6
 	}
-	command := fmt.Sprintf("echo $$; exec test-workload %v '%v' '%v' '%v'",
+	var netkitArg string
+	if infrastructure.NetkitMode() {
+		netkitArg = "--netkit"
+	}
+	command := fmt.Sprintf("echo $$; exec test-workload %v %v '%v' '%v' '%v'",
 		protoArg,
+		netkitArg,
 		w.InterfaceName,
 		wIP,
 		w.Ports,


### PR DESCRIPTION
## Summary

Native netkit BPF attachment support for Felix. When Felix detects a workload endpoint using a netkit device (instead of veth), it attaches BPF programs via the netkit attach API rather than TC/TCX. Full BPF FV suite passes with netkit on Ubuntu 25.10.

### Core netkit support

- **Netkit detection and attachment**: Felix auto-detects netkit workload interfaces and uses `BPF_NETKIT_PRIMARY`/`BPF_NETKIT_PEER` attachment instead of TC/TCX
- **Separate prog_array maps**: Netkit programs have a different `expected_attach_type` and cannot share `prog_array` maps with TC/TCX programs. New maps with pin path overrides
- **host_ifindex in globals**: Netkit peer programs see the peer ifindex in `skb->ifindex`; added `host_ifindex` to globals for correct FIB, QoS, counter, and RPF map lookups
- **No bpf_redirect_peer for netkit**: Netkit programs run in xmit context where `bpf_redirect_peer` silently drops; uses plain `bpf_redirect` via FIB instead
- **Non-cgo stub**: `AttachNetkit` stub in `libbpf_stub.go` for architectures without BPF support

### BPF dataplane fixes for netkit

- **Workload RPF check**: Use `host_ifindex` from globals so the route ifindex comparison works correctly
- **QoS packet rate**: Use `host_ifindex` for QoS map key lookup
- **Netkit peer MTU**: Set MTU on the peer (container-side) LinkAttrs so it matches the host side

### Felix jump map cleanup for netkit

- **jumpMapDelete / reclaimPolicyIdx / reclaimFilterIdx / removePolicyProgram / ensureNoProgram**: Select correct jump map (netkit vs TC) based on interface type
- **Preserve ifaceType on interface down**: When `getIfaceLink` fails during down events, preserve the previously-known type for correct cleanup
- **syncIfStateMap**: Clean both TC and netkit jump maps for gone interfaces

### FV test fixes

- **Backend replacement test**: Use workload-side tcpdump (inside pod namespace) instead of host-side
- **Program recovery test**: Use `bpfProgPinDir()` helper to select `NetkitPinDir` vs `TcxPinDir`
- **Policy scale test**: Query correct netkit jump maps in `BPFNumPolProgramsByEntryPoint`
- **UT fix**: Initialize `NetkitJumpMaps` in `bpf_ep_mgr_test.go` common maps setup

### CI

- Full BPF FV run with netkit on Ubuntu 25.10 (replaces UT-only 25.10 check)
- FV test infrastructure: `--netkit` flag for test-workload, `FELIX_FV_NETKIT=Enabled` env var

```release-note
ebpf: Add native netkit BPF attachment support. Felix auto-detects netkit workload interfaces and attaches BPF programs via the netkit API instead of TC/TCX, with correct handling of ifindex differences, separate prog_array maps, and jump map cleanup.
```

## Test plan

- [x] Full BPF FV suite with netkit on Ubuntu 25.10 CI runner -- all green
- [x] BPF FV suite with TCX (default) -- no regressions
- [x] bpf_ep_mgr unit tests pass
