### PR TITLE
Restore marvin-github-ssh-private-key secret to GCP e2e block

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -579,6 +579,7 @@ blocks:
       - Prerequisites
     task:
       secrets:
+        - name: marvin-github-ssh-private-key
         - name: banzai-secrets
       prologue:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -579,6 +579,7 @@ blocks:
       - Prerequisites
     task:
       secrets:
+        - name: marvin-github-ssh-private-key
         - name: banzai-secrets
       prologue:
         commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
@@ -5,6 +5,7 @@
     - Prerequisites
   task:
     secrets:
+      - name: marvin-github-ssh-private-key
       - name: banzai-secrets
     prologue:
       commands:


### PR DESCRIPTION
This secret mounts SSH keys into ~/.keys/ which global_prologue.sh needs for ssh-add and subsequent banzai initialization. It was incorrectly removed as part of initialization failure investigation; the actual cause was commands_file in task.prologue (fixed in prior commit).

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
