### PR TITLE
Fix data race in bpfEndpointManager HostEndpoint comparisons

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -47,6 +47,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
+	googleproto "google.golang.org/protobuf/proto"
 	k8sv1 "k8s.io/api/core/v1"
 
 	"github.com/projectcalico/calico/felix/bpf"
@@ -1266,7 +1267,7 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceStateUpdate) {
 			iface.info.isUP = true
 			m.updateIfaceStateMap(update.Name, iface)
 		} else {
-			if m.wildcardExists && reflect.DeepEqual(m.hostIfaceToEpMap[update.Name], m.wildcardHostEndpoint) {
+			if m.wildcardExists && googleproto.Equal(m.hostIfaceToEpMap[update.Name], m.wildcardHostEndpoint) {
 				logrus.Debugf("Unmap host-* endpoint for %v", update.Name)
 				m.removeHEPFromIndexes(update.Name, m.wildcardHostEndpoint)
 				delete(m.hostIfaceToEpMap, update.Name)
@@ -3424,7 +3425,7 @@ func (m *bpfEndpointManager) OnHEPUpdate(hostIfaceToEpMap map[string]*proto.Host
 	// to change as to make this worthwhile.
 
 	// If the host-* endpoint is changing, mark all workload interfaces as dirty.
-	if (wildcardExists != m.wildcardExists) || !reflect.DeepEqual(wildcardHostEndpoint, m.wildcardHostEndpoint) {
+	if (wildcardExists != m.wildcardExists) || !googleproto.Equal(wildcardHostEndpoint, m.wildcardHostEndpoint) {
 		logrus.Infof("Host-* endpoint is changing; was %v, now %v", m.wildcardHostEndpoint, wildcardHostEndpoint)
 		m.removeHEPFromIndexes(allInterfaces, m.wildcardHostEndpoint)
 		m.wildcardHostEndpoint = wildcardHostEndpoint
@@ -3441,7 +3442,7 @@ func (m *bpfEndpointManager) OnHEPUpdate(hostIfaceToEpMap map[string]*proto.Host
 	// Loop through existing host endpoints, in case they are changing or disappearing.
 	for ifaceName, existingEp := range m.hostIfaceToEpMap {
 		newEp, stillExists := hostIfaceToEpMap[ifaceName]
-		if stillExists && reflect.DeepEqual(newEp, existingEp) {
+		if stillExists && googleproto.Equal(newEp, existingEp) {
 			logrus.Debugf("No change to host endpoint for ifaceName=%v", ifaceName)
 		} else {
 			m.removeHEPFromIndexes(ifaceName, existingEp)


### PR DESCRIPTION
Fix a data race between the Felix dataplane thread and the collector thread
when comparing `*proto.HostEndpoint` protobuf messages.

`reflect.DeepEqual` on protobuf messages races with concurrent `.String()`
or `.ProtoReflect()` calls because those methods lazily initialize internal
metadata via `atomic.StorePointer`. Switching to `proto.Equal` from
`google.golang.org/protobuf/proto` eliminates the race since it is designed
for safe use on protobuf messages.

The race was caught by the Go race detector during FV teardown:

```
Read at 0x00c000226300 by goroutine 292:
  reflect.DeepEqual()
  bpfEndpointManager.OnHEPUpdate()
      bpf_ep_mgr.go:3498

Previous write at 0x00c000226300 by goroutine 314:
  sync/atomic.StorePointer()
  proto.(*HostEndpoint).ProtoReflect()
      felixbackend.pb.go:4182
  proto.(*ToDataplane).String()
  collector.(*collector).loopProcessingDataplaneInfoUpdates.func1()
      collector.go:449
```

**Release note:**
```release-note
Fix a data race in Felix's BPF endpoint manager when comparing HostEndpoint
protobuf messages, which could cause flaky race-detector failures or subtle
logic errors under concurrent access.
```