### PR TITLE
Preserve hack/test/kind/infra/operator directory

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -158,6 +158,7 @@ clean: clean-windows
 	rm -rf $(BUILD_DEPS)
 	rm -rf filesystem/included-source
 	rm -rf $(REPO_ROOT)/hack/test/kind/infra/operator
+	mkdir $(REPO_ROOT)/hack/test/kind/infra/operator
 	rm -rf dist
 	rm -rf bin
 	# We build these as part of the node build, so clean them as part of the clean.


### PR DESCRIPTION
This directory is checked in but was being deleted by the clean target in node/Makefile:

    rm -rf $(REPO_ROOT)/hack/test/kind/infra/operator

This might be the cause of the hashrelease build currently failing with

    FATAL[0067]main.go:85 main.main() Error running app                             error="there are uncommitted changes in the repository, please commit or stash them before publishing the release"

I've reproduced a failing build with "sem debug" and then "git status" shows:

    semaphore@semaphore-vm:~/calico/release$ git status
    On branch master
    Your branch is up to date with 'origin/master'.

    Changes not staged for commit:
      (use "git add/rm <file>..." to update what will be committed)
      (use "git restore <file>..." to discard changes in working directory)
    	deleted:    ../hack/test/kind/infra/operator

    no changes added to commit (use "git add" and/or "git commit -a")

So it looks like the immediate problem in the hashrelease build is hack/test/kind/infra/operator having been deleted.  I don't know for sure if that is because of a make clean in node, but it seems like a good guess.