### PR TITLE
Exclude istio/ and third_party/ from gen-deps-files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,8 @@ gen-semaphore-yaml:
 	                          RELEASE_BRANCH_PREFIX=$(RELEASE_BRANCH_PREFIX) \
 	                          go run ./hack/cmd/deps $(DEPS_ARGS) generate-semaphore-yamls"
 
-GO_DIRS=$(shell find -name '*.go' | grep -v -e './lib/' -e './pkg/' | grep -o --perl '^./\K[^/]+' | sort -u)
+GO_DIRS_EXCLUDE=./lib/ ./pkg/ ./istio/ ./third_party/
+GO_DIRS=$(shell find -name '*.go' | grep -v $(addprefix -e ,$(GO_DIRS_EXCLUDE)) | grep -o --perl '^./\K[^/]+' | sort -u)
 DEP_FILES=$(patsubst %, %/deps.txt, $(GO_DIRS))
 
 gen-deps-files:

--- a/istio/deps.txt
+++ b/istio/deps.txt
@@ -1,5 +1,0 @@
-!!! GENERATED FILE, DO NOT EDIT !!!
-This file contains the list of modules that this package depends on
-in order to trigger CI on changes
-
-go 1.25.7


### PR DESCRIPTION
These directories do not contain project source code — they download, patch, and build vendored code at specific versions. Generating deps.txt for them is incorrect since their Go files are transient build artifacts, not tracked dependencies.

If some run `make gen-deps-files` after a `make -C istio build` it will result creating an `istio/deps.txt` file.

Remove the erroneously generated istio/deps.txt and add both directories to GO_DIRS_EXCLUDE. Also refactor the exclude list to use Make's addprefix for cleaner, more maintainable grep flags.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note-not-required
TBD
```
