### PR TITLE
Add tiger-bench block to benchmarking pipeline

### DIFF
--- a/.semaphore/end-to-end/pipelines/benchmarking.yml
+++ b/.semaphore/end-to-end/pipelines/benchmarking.yml
@@ -89,6 +89,35 @@ blocks:
         - name: BENCHMARKER_TEST_CONFIGS
           value: >
             '[{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"iptables"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"iptables"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"iptables"},{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"iptables"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"iptables"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"iptables"},{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"bpf"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"bpf"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"none","dataplane":"bpf"},{"testtype":"sto","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"bpf"},{"testtype":"qperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"bpf"},{"testtype":"iperf","numpolicies":[10,100,1000,10000],"encap":"vxlan","dataplane":"bpf"}]'
+
+  - name: Tiger-bench
+    dependencies: []
+    task:
+      secrets:
+        - name: tiger-bench
+      jobs:
+        - name: Tiger-bench tests Calico
+          execution_time_limit:
+            hours: 7
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          matrix:
+            - env_var: PRODUCT
+              values: ["calico"]
+      env_vars:
+        - name: USE_HASH_RELEASE
+          value: "true"
+        - name: K8S_VERSION
+          value: "stable"
+        - name: PROVISIONER
+          value: "aws-kubeadm"
+        - name: INSTALLER
+          value: "operator"
+        - name: TEST_TYPE
+          value: "tiger-bench"
+        - name: TIGER_BENCH_VERSION
+          value: "main"
+
 promotions:
   - name: Cleanup jobs
     pipeline_file: cleanup.yml


### PR DESCRIPTION
## Summary

- Adds a new `Tiger-bench` block to `.semaphore/end-to-end/pipelines/benchmarking.yml`
- Runs [tiger-bench](https://github.com/projectcalico/tiger-bench) on `aws-kubeadm` with the operator installer against hash releases
- Uses `TIGER_BENCH_VERSION: main` (the relevant changes landed in [PR#37](https://github.com/projectcalico/tiger-bench/pull/37), merged Feb 2026)
- Results will feed into the Kibana performance tracking dashboard on Lens, enabling per-hashrelease performance tracking for Calico OSS

## Test plan

- [ ] Verify the Tiger-bench block triggers correctly in the benchmarking pipeline
- [ ] Confirm results appear in the Kibana dashboard on Lens

🤖 Generated with [Claude Code](https://claude.com/claude-code)