### PR TITLE
Fix tunnel IPs getting REMOTE_WORKLOAD from containing IPAM block

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -747,6 +747,8 @@ func (c *L3RouteResolver) flush() {
 		poolAllowsCrossSubnet := false
 		var blockSeen bool
 		var blockNodeName string
+		var blockTypes proto.RouteType
+		var hasTunnelRef bool
 		for _, entry := range buf {
 			ri := entry.Data.(RouteInfo)
 			if len(ri.Pools) > 0 {
@@ -774,12 +776,17 @@ func (c *L3RouteResolver) flush() {
 					blockNodeName = ri.Blocks[0].NodeName
 				}
 				rt.DstNodeName = ri.Blocks[0].NodeName
-				if rt.DstNodeName == c.myNodeName {
-					logCxt.Debug("Local workload route.")
-					rt.Types |= proto.RouteType_LOCAL_WORKLOAD
+
+				// Accumulate the workload type flags from block entries, but don't apply
+				// them to the route yet. A block entry may be a parent of the CIDR we're
+				// resolving (e.g., a /26 block containing a /32 tunnel IP). The workload
+				// type is only correct if the route isn't a tunnel ref; see below.
+				if ri.Blocks[0].NodeName == c.myNodeName {
+					logCxt.Debug("Local workload route (from block).")
+					blockTypes |= proto.RouteType_LOCAL_WORKLOAD
 				} else {
-					logCxt.Debug("Remote workload route.")
-					rt.Types |= proto.RouteType_REMOTE_WORKLOAD
+					logCxt.Debug("Remote workload route (from block).")
+					blockTypes |= proto.RouteType_REMOTE_WORKLOAD
 				}
 			}
 			if len(ri.Host.NodeNames) > 0 {
@@ -819,6 +826,7 @@ func (c *L3RouteResolver) flush() {
 				} else {
 					// This is a tunnel ref, set type and also store the tunnel type in the route. It is possible for
 					// multiple tunnels to have the same IP, so collate all tunnel types on the same node.
+					hasTunnelRef = true
 					if ri.Refs[0].NodeName == c.myNodeName {
 						rt.Types |= proto.RouteType_LOCAL_TUNNEL
 					} else {
@@ -843,6 +851,14 @@ func (c *L3RouteResolver) flush() {
 					}
 				}
 			}
+		}
+
+		// Apply the accumulated block workload type flags unless the route is a tunnel
+		// IP. A tunnel IP that happens to fall within an IPAM block should not get
+		// REMOTE_WORKLOAD — that causes isRemoteTunnelRoute() in the route manager to
+		// program a spurious /32 directly-connected route on the tunnel device.
+		if blockSeen && !hasTunnelRef {
+			rt.Types |= blockTypes
 		}
 
 		var ipFamily int

--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -748,6 +748,7 @@ func (c *L3RouteResolver) flush() {
 		var blockSeen bool
 		var blockNodeName string
 		var blockTypes proto.RouteType
+		var blockMatchesRoute bool
 		var hasTunnelRef bool
 		for _, entry := range buf {
 			ri := entry.Data.(RouteInfo)
@@ -777,10 +778,17 @@ func (c *L3RouteResolver) flush() {
 				}
 				rt.DstNodeName = ri.Blocks[0].NodeName
 
+				// Track whether this block entry is at the same CIDR as the route we're
+				// resolving (e.g., a /32 block for a /32 tunnel IP from a dedicated tunnel
+				// pool) vs a parent block that merely contains it.
+				if entry.CIDR == cidr {
+					blockMatchesRoute = true
+				}
+
 				// Accumulate the workload type flags from block entries, but don't apply
-				// them to the route yet. A block entry may be a parent of the CIDR we're
-				// resolving (e.g., a /26 block containing a /32 tunnel IP). The workload
-				// type is only correct if the route isn't a tunnel ref; see below.
+				// them to the route yet. A parent block entry (e.g., a /26 block containing
+				// a /32 tunnel IP) should not contribute REMOTE_WORKLOAD to a tunnel route.
+				// The flags are applied after the full trie walk; see below.
 				if ri.Blocks[0].NodeName == c.myNodeName {
 					logCxt.Debug("Local workload route (from block).")
 					blockTypes |= proto.RouteType_LOCAL_WORKLOAD
@@ -854,10 +862,14 @@ func (c *L3RouteResolver) flush() {
 		}
 
 		// Apply the accumulated block workload type flags unless the route is a tunnel
-		// IP. A tunnel IP that happens to fall within an IPAM block should not get
-		// REMOTE_WORKLOAD — that causes isRemoteTunnelRoute() in the route manager to
-		// program a spurious /32 directly-connected route on the tunnel device.
-		if blockSeen && !hasTunnelRef {
+		// IP that merely falls within a parent block. A tunnel IP inside a larger block
+		// (e.g., a /32 inside a /26) should not get REMOTE_WORKLOAD — that causes
+		// isRemoteTunnelRoute() in the route manager to program a spurious /32 route.
+		//
+		// However, if the block is at the same CIDR as the route (e.g., a /32 block from
+		// a dedicated tunnel pool), the workload type is still needed so the route manager
+		// programs the correct directly-connected route.
+		if blockSeen && (!hasTunnelRef || blockMatchesRoute) {
 			rt.Types |= blockTypes
 		}
 

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,6 +142,99 @@ var _ = Describe("L3RouteResolver", func() {
 			Expect(rt.SameSubnet).NotTo(BeTrue())
 		})
 	})
+	Describe("tunnel IP within IPAM block", func() {
+		var l3RR *L3RouteResolver
+		var eventBuf rtEventsMock
+
+		BeforeEach(func() {
+			eventBuf = make(rtEventsMock, 100)
+			l3RR = NewL3RouteResolver("local-host", eventBuf, true, "CalicoIPAM")
+			l3RR.OnAlive = func() {}
+		})
+
+		drainEvents := func() []*proto.RouteUpdate {
+			var routes []*proto.RouteUpdate
+			for {
+				select {
+				case ev := <-eventBuf:
+					if rt, ok := ev.(*proto.RouteUpdate); ok {
+						routes = append(routes, rt)
+					}
+				default:
+					return routes
+				}
+			}
+		}
+
+		findRoute := func(routes []*proto.RouteUpdate, dst string) *proto.RouteUpdate {
+			for _, rt := range routes {
+				if rt.Dst == dst {
+					return rt
+				}
+			}
+			return nil
+		}
+
+		// Set up a remote host with a VXLAN tunnel IP that falls within an IPAM block.
+		// The tunnel IP 10.0.1.0 is the first address of the /29 block 10.0.1.0/29.
+		// In production (KIND clusters), this causes the tunnel route to get REMOTE_WORKLOAD
+		// OR'd in alongside REMOTE_TUNNEL, which triggers spurious /32 route programming.
+		It("should not add REMOTE_WORKLOAD to a tunnel IP just because it falls within a block", func() {
+			// Add the IP pool.
+			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+			pool := model.IPPool{
+				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
+				VXLANMode: encap.Always,
+			}
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: pool.CIDR},
+					Value: &pool,
+				},
+			})
+			drainEvents()
+
+			// Add the IPAM block (10.0.1.0/29) with affinity to remote-host.
+			remoteAffinity := "host:remote-host"
+			blockCIDR := net.MustParseCIDR("10.0.1.0/29")
+			l3RR.OnBlockUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.BlockKey{CIDR: blockCIDR},
+					Value: &model.AllocationBlock{
+						CIDR:        blockCIDR,
+						Affinity:    &remoteAffinity,
+						Allocations: make([]*int, 8),
+						Unallocated: []int{0, 1, 2, 3, 4, 5, 6, 7},
+					},
+				},
+			})
+			drainEvents()
+
+			// Add the remote host IP and VXLAN tunnel address via OnHostIPUpdate +
+			// a direct tunnel address update. The tunnel IP 10.0.1.0 falls within
+			// the block 10.0.1.0/29.
+			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+				V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
+				VXLANAddr: ip.FromString("10.0.1.0"),
+			})
+			l3RR.flush()
+
+			routes := drainEvents()
+
+			// Find the tunnel route for 10.0.1.0/32.
+			tunnelRoute := findRoute(routes, "10.0.1.0/32")
+			Expect(tunnelRoute).NotTo(BeNil(), "expected a route for the tunnel IP 10.0.1.0/32")
+
+			// The tunnel route should only have REMOTE_TUNNEL, not REMOTE_WORKLOAD.
+			// If REMOTE_WORKLOAD is present, the route manager will incorrectly program
+			// an extra /32 directly-connected route on the tunnel device.
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_TUNNEL).NotTo(BeZero(),
+				"tunnel route should have REMOTE_TUNNEL type")
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).To(BeZero(),
+				"tunnel route should NOT have REMOTE_WORKLOAD just because it falls within a block")
+		})
+	})
+
 	Describe("l3rrNodeInfo UTs", func() {
 		It("should not return empty IP addresses in AddressesAsCIDRs()", func() {
 			var (

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -233,6 +233,58 @@ var _ = Describe("L3RouteResolver", func() {
 			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).To(BeZero(),
 				"tunnel route should NOT have REMOTE_WORKLOAD just because it falls within a block")
 		})
+
+		It("should add REMOTE_WORKLOAD to a tunnel IP in a /32 block", func() {
+			// A dedicated tunnel pool with blockSize=32 creates /32 blocks for each
+			// tunnel IP. In this case the block IS the tunnel IP, and the route manager
+			// needs REMOTE_WORKLOAD to program the directly-connected /32 route.
+			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+			pool := model.IPPool{
+				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
+				VXLANMode: encap.Always,
+			}
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: pool.CIDR},
+					Value: &pool,
+				},
+			})
+			drainEvents()
+
+			// Add a /32 IPAM block at the same CIDR as the tunnel IP.
+			remoteAffinity := "host:remote-host"
+			blockCIDR := net.MustParseCIDR("10.0.1.0/32")
+			l3RR.OnBlockUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.BlockKey{CIDR: blockCIDR},
+					Value: &model.AllocationBlock{
+						CIDR:        blockCIDR,
+						Affinity:    &remoteAffinity,
+						Allocations: make([]*int, 1),
+						Unallocated: []int{0},
+					},
+				},
+			})
+			drainEvents()
+
+			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+				V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
+				VXLANAddr: ip.FromString("10.0.1.0"),
+			})
+			l3RR.flush()
+
+			routes := drainEvents()
+
+			tunnelRoute := findRoute(routes, "10.0.1.0/32")
+			Expect(tunnelRoute).NotTo(BeNil(), "expected a route for the tunnel IP 10.0.1.0/32")
+
+			// With a /32 block, the tunnel route should have BOTH types so the route
+			// manager programs a directly-connected route.
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_TUNNEL).NotTo(BeZero(),
+				"tunnel route should have REMOTE_TUNNEL type")
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).NotTo(BeZero(),
+				"tunnel route in /32 block should have REMOTE_WORKLOAD")
+		})
 	})
 
 	Describe("l3rrNodeInfo UTs", func() {


### PR DESCRIPTION
When a tunnel IP (VXLAN/IPIP) falls within an IPAM block -- which is the normal case, since tunnel IPs are allocated from the same pool as workloads -- the `l3_route_resolver` was unconditionally OR'ing `REMOTE_WORKLOAD` into the route type from the parent block entry. Combined with `REMOTE_TUNNEL` from the tunnel ref, this produced route type 17 (`REMOTE_TUNNEL | REMOTE_WORKLOAD`), which caused `isRemoteTunnelRoute()` in `route_mgr.go` to return true. The route manager then programmed a spurious /32 directly-connected route on the tunnel device:

```
192.168.110.128/26 via 172.18.0.2 dev vxlan.calico onlink mtu 1450   # block route (correct)
192.168.110.128 dev vxlan.calico scope link mtu 1450                  # /32 route (spurious)
```

The trie walk in `flush()` iterates from root to leaf, accumulating type flags from pools, blocks, and refs. The fix defers the block-derived workload type flags (`LOCAL_WORKLOAD`/`REMOTE_WORKLOAD`) and only applies them after the full walk if the route is not a tunnel ref. Workload refs (including borrowed IPs) still get the block types as before -- this is important because borrowed workloads legitimately need both `REMOTE_WORKLOAD` (from the block's per-allocation entry on a different node) and `LOCAL_WORKLOAD` (from the local WEP ref).

The bug was order-dependent in the trie: it only manifested when the IPAM block existed before the tunnel IP ref was added, because `UpdateBlockRoute` doesn't call `markChildrenDirty`. The existing calc graph FV tests happened to process KVs in an order that avoided it. A new unit test (included) reproduces the issue by setting up the block first, then adding the node with the tunnel IP.

Builds on the failing test from #12179. Related to @mazdakn's work in #12122.