### PR TITLE
Fix FV-TEST-START logging to only fire for tests in the current batch

### DIFF
--- a/felix/fv/fv_suite_test.go
+++ b/felix/fv/fv_suite_test.go
@@ -84,10 +84,6 @@ func TestFv(t *testing.T) {
 	RunSpecs(t, "FV: Felix "+descSuffix, suiteConfig, reporterConfig)
 }
 
-var _ = BeforeEach(func() {
-	_, _ = fmt.Fprintf(realStdout, "\nFV-TEST-START: %s", CurrentSpecReport().FullText())
-})
-
 var _ = JustAfterEach(func() {
 	if CurrentSpecReport().Failed() {
 		_, _ = fmt.Fprintf(realStdout, "\n")
@@ -154,6 +150,12 @@ func configureManualSharding() error {
 		} else {
 			fmt.Printf("️[SHARD-RUN] Batch %d executing: %s\n", currentBatch, specReport.LeafNodeText)
 		}
+	})
+
+	// Register the FV-TEST-START log _after_ the shard-skip BeforeEach
+	// so it only fires for tests this batch actually runs.
+	BeforeEach(func() {
+		_, _ = fmt.Fprintf(realStdout, "\nFV-TEST-START: %s", CurrentSpecReport().FullText())
 	})
 
 	return nil


### PR DESCRIPTION
The FV-TEST-START BeforeEach was registered at package init time, before the shard-skip BeforeEach registered in configureManualSharding(). This meant every batch logged FV-TEST-START for every test (even skipped ones), bloating CI logs past 16MB and hiding which test was actually running when resource issues occurred.

Move the logging BeforeEach into configureManualSharding() so it is registered after the shard-skip check. Ginkgo's Skip() in the first BeforeEach prevents subsequent BeforeEach hooks from running, so FV-TEST-START now only fires for tests the batch actually executes.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
