### PR TITLE
Add postrelease test for operator images list [master]

### DIFF
--- a/release/pkg/postrelease/operator_images_test.go
+++ b/release/pkg/postrelease/operator_images_test.go
@@ -29,7 +29,7 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 
 	// Run the operator image with --print-images=list to get the list of images it uses.
 	t.Logf("Running operator image %s with --print-images=list", fqOperatorImage)
-	runCmd := exec.Command("docker", "run", "--rm", fqOperatorImage, "--print-images=list")
+	runCmd := exec.Command("docker", "run", "--rm", fqOperatorImage, "--print-images=listcalico")
 	out, err := runCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("failed to run operator image %s with --print-images=list: %v\n%s", fqOperatorImage, err, string(out))
@@ -51,7 +51,7 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 		if line == "" {
 			continue
 		}
-		if !strings.HasPrefix(line, tigeraPrefix) {
+		if strings.Contains(line, operator.DefaultImage) {
 			continue
 		}
 		// Extract the image name from the fully qualified image reference.

--- a/release/pkg/postrelease/operator_images_test.go
+++ b/release/pkg/postrelease/operator_images_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
@@ -27,10 +28,8 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 		t.Fatalf("failed to pull operator image %s: %v\n%s", fqOperatorImage, err, string(out))
 	}
 
-	// Run the operator image with --print-images=list to get the list of images it uses.
 	t.Logf("Running operator image %s with --print-images=listcalico", fqOperatorImage)
-	runCmd := exec.Command("docker", "run", "--rm", fqOperatorImage, "--print-images=listcalico")
-	out, err := runCmd.CombinedOutput()
+	out, err := command.Run("docker", []string{"run", "--rm", fqOperatorImage, "--print-images=listcalico"})
 	if err != nil {
 		t.Fatalf("failed to run operator image %s with --print-images=listcalico: %v\n%s", fqOperatorImage, err, string(out))
 	}

--- a/release/pkg/postrelease/operator_images_test.go
+++ b/release/pkg/postrelease/operator_images_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+package postrelease
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/projectcalico/calico/release/internal/registry"
+	"github.com/projectcalico/calico/release/pkg/manager/operator"
+)
+
+func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
+	t.Parallel()
+
+	checkVersion(t, operatorVersion)
+	checkImages(t, images)
+
+	fqOperatorImage := fmt.Sprintf("%s/%s:%s", operator.DefaultRegistry, operator.DefaultImage, operatorVersion)
+
+	// Pull the operator image.
+	t.Logf("Pulling operator image %s", fqOperatorImage)
+	pullCmd := exec.Command("docker", "pull", fqOperatorImage)
+	if out, err := pullCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to pull operator image %s: %v\n%s", fqOperatorImage, err, string(out))
+	}
+
+	// Run the operator image with --print-images=list to get the list of images it uses.
+	t.Logf("Running operator image %s with --print-images=list", fqOperatorImage)
+	runCmd := exec.Command("docker", "run", "--rm", fqOperatorImage, "--print-images=list")
+	out, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run operator image %s with --print-images=list: %v\n%s", fqOperatorImage, err, string(out))
+	}
+
+	// Build a set of expected image names from the images flag.
+	expectedImages := make(map[string]bool)
+	for image := range strings.SplitSeq(images, " ") {
+		if image != "" {
+			expectedImages[image] = true
+		}
+	}
+
+	// Parse the output and check that every quay.io/calico image is in our expected list.
+	tigeraPrefix := registry.DefaultCalicoRegistry + "/"
+	var missing []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, tigeraPrefix) {
+			continue
+		}
+		// Extract the image name from the fully qualified image reference.
+		// e.g. "quay.io/calico/node:v3.31.1" -> "node"
+		withoutRegistry := strings.TrimPrefix(line, tigeraPrefix)
+		imageName, _, _ := strings.Cut(withoutRegistry, ":")
+		if imageName == "" {
+			continue
+		}
+
+		// The operator image itself is not expected in the images list.
+		if strings.Contains(operator.DefaultImage, imageName) {
+			continue
+		}
+
+		if !expectedImages[imageName] {
+			missing = append(missing, fmt.Sprintf("%s (from %s)", imageName, line))
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Fatalf("The following quay.io/calico images printed by the operator are not in the expected images list:\n  %s\nExpected images: %s",
+			strings.Join(missing, "\n  "),
+			images)
+	}
+	t.Logf("All quay.io/calico images from operator --print-images=list are in the expected images list")
+}

--- a/release/pkg/postrelease/operator_images_test.go
+++ b/release/pkg/postrelease/operator_images_test.go
@@ -28,11 +28,11 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 	}
 
 	// Run the operator image with --print-images=list to get the list of images it uses.
-	t.Logf("Running operator image %s with --print-images=list", fqOperatorImage)
+	t.Logf("Running operator image %s with --print-images=listcalico", fqOperatorImage)
 	runCmd := exec.Command("docker", "run", "--rm", fqOperatorImage, "--print-images=listcalico")
 	out, err := runCmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("failed to run operator image %s with --print-images=list: %v\n%s", fqOperatorImage, err, string(out))
+		t.Fatalf("failed to run operator image %s with --print-images=listcalico: %v\n%s", fqOperatorImage, err, string(out))
 	}
 
 	// Build a set of expected image names from the images flag.
@@ -43,8 +43,8 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 		}
 	}
 
-	// Parse the output and check that every quay.io/calico image is in our expected list.
-	tigeraPrefix := registry.DefaultCalicoRegistry + "/"
+	// Parse the output and check that every calico image is in our expected list.
+	calicoPrefix := registry.DefaultCalicoRegistry + "/"
 	var missing []string
 	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
 		line = strings.TrimSpace(line)
@@ -56,14 +56,9 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 		}
 		// Extract the image name from the fully qualified image reference.
 		// e.g. "quay.io/calico/node:v3.31.1" -> "node"
-		withoutRegistry := strings.TrimPrefix(line, tigeraPrefix)
+		withoutRegistry := strings.TrimPrefix(line, calicoPrefix)
 		imageName, _, _ := strings.Cut(withoutRegistry, ":")
 		if imageName == "" {
-			continue
-		}
-
-		// The operator image itself is not expected in the images list.
-		if strings.Contains(operator.DefaultImage, imageName) {
 			continue
 		}
 
@@ -73,9 +68,9 @@ func TestOperatorPrintedImagesInExpectedList(t *testing.T) {
 	}
 
 	if len(missing) > 0 {
-		t.Fatalf("The following quay.io/calico images printed by the operator are not in the expected images list:\n  %s\nExpected images: %s",
+		t.Fatalf("The following calico images printed by the operator are not in the expected images list:\n  %s\nExpected images: %s",
 			strings.Join(missing, "\n  "),
 			images)
 	}
-	t.Logf("All quay.io/calico images from operator --print-images=list are in the expected images list")
+	t.Logf("All calico images from operator --print-images=list are in the expected images list")
 }


### PR DESCRIPTION
This adds a test to the postrelease test suite which does the following:

1. Pulls the Operator image for this release and runs it with `--print-images=list`
2. Finds any `quay.io/calico` images
3. Verifies that those images are being checked for in our postrelease tests

For example, if we add a new image, `enfrobulate`, to Operator, then it will be listed as `quay.io/calico/enfrobulate:v3.32.3`. When the release tool triggers these tests it passes a list of images to test for; if `enfrobulate` is not one of those images, this test will fail.

This ensures that when new images are added we don't risk missing them in our postrelease tests, and potentially in other places where release tool may need to know about or interact with images.
