### PR TITLE
Kind: Patch cluster routing mode in the installation resource to Felix

### DIFF
--- a/hack/test/kind/deploy_resources.sh
+++ b/hack/test/kind/deploy_resources.sh
@@ -165,6 +165,11 @@ echo
 echo "Install Calico using the helm chart"
 ${HELM} install calico ${CHART} -f ${VALUES_FILE} -n tigera-operator --create-namespace
 
+if [[ "$CLUSTER_ROUTING" == "FELIX" ]]; then
+  echo "Patching installation resource to Felix cluster routing mode"
+  ${kubectl} patch installation default --type='merge' -p '{"spec": {"calicoNetwork": {"clusterRoutingMode":"Felix"}}}'
+fi
+
 echo "Install calicoctl as a pod"
 ${kubectl} apply -f ${INFRA_DIR}/calicoctl.yaml
 echo
@@ -193,11 +198,6 @@ wait_pod_ready calicoctl -n kube-system
 
 echo "Calico is running."
 echo
-
-if [[ "$CLUSTER_ROUTING" == "FELIX" ]]; then
-  echo "Patching installation resource to Felix cluster routing mode"
-  ${kubectl} patch installation default --type='merge' -p '{"spec": {"calicoNetwork": {"clusterRoutingMode":"Felix"}}}'
-fi
 
 echo "Install MetalLB controller for allocating LoadBalancer IPs"
 ${kubectl} create ns metallb-system || true


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

With the introduction of `ClusterRoutingMode` in Operator, the corresponding `programClusterRoutes` option in `FelixConfiguration` and `BGPConfiguration` is over written by Operator. This makes setting the current cluster routing mode in e2e ineffective. This PR fixes the issue by patching the installation resource instead.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
