### PR TITLE
e2e epilogue: fix GCS diags filename and add junit upload

### DIFF
--- a/.semaphore/end-to-end/scripts/global_epilogue.sh
+++ b/.semaphore/end-to-end/scripts/global_epilogue.sh
@@ -38,7 +38,7 @@ run_non_hcp_reports_and_diags() {
     echo "[INFO] global_epilogue: capturing diags"
     bz diags $VERBOSE |& tee ${BZ_LOGS_DIR}/diagnostic.log || true
     artifact push job ${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME} --destination semaphore/diags.tgz || true
-    upload_to_gcs "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" "diags.tgz"
+    upload_to_gcs "${BZ_LOCAL_DIR}/${DIAGS_ARCHIVE_FILENAME}" "${DIAGS_ARCHIVE_FILENAME}"
   fi
 
   delete_artifacts; delete_calicoctl
@@ -46,6 +46,7 @@ run_non_hcp_reports_and_diags() {
   REPORT_DIR=${REPORT_DIR:-"${BZ_LOCAL_DIR}/report/${TEST_TYPE}"}
   echo "[INFO] global_epilogue: pushing report artifacts"
   artifact push job ${REPORT_DIR} --destination semaphore/test-results || true
+  upload_to_gcs "${REPORT_DIR}/junit.xml" "junit.xml"
   cp ${REPORT_DIR}/junit.xml . || true
 
   echo "[INFO] publish new semaphore test results"
@@ -146,6 +147,7 @@ if [[ "${HCP_ENABLED}" == "true" ]]; then
 
   echo "[INFO] global_epilogue: hcp: pushing report artifacts"
   artifact push job ${BZ_PROFILES_PATH}/.report --destination semaphore/test-results || true
+  upload_to_gcs "${BZ_PROFILES_PATH}/.report/junit.xml" "junit.xml"
 
   echo "[INFO] publish new semaphore test results"
   test-results publish semaphore/test-results/junit.xml || true


### PR DESCRIPTION
## Summary

- **Fix broken diags filename in GCS.** The refactor in 8990c867e introduced `upload_to_gcs()` but hardcoded `"diags.tgz"` as the destination name, silently breaking the VPP team's tooling which expects `${DIAGS_ARCHIVE_FILENAME}` (e.g. `gcp-kubeadm-bz-calico-jmfe-diags.tgz`) — the format documented in `semaphore-logs.md`. This restores the original filename.

- **Upload junit.xml to GCS after every job.** Previously only `diags.tgz` and `logs.tgz` were uploaded to the bucket, so test results were unavailable. This adds `upload_to_gcs` calls for `junit.xml` in both the non-HCP and HCP epilogue paths. The upload is unconditional so results are preserved regardless of whether the job passed or failed.

## Test plan

- [ ] Trigger a VPP e2e run and confirm `gsutil ls gs://vpp-results/<date>/...` shows `<provisioner>-<cluster>-diags.tgz` (not `diags.tgz`)
- [ ] Confirm `junit.xml` appears alongside `diags.tgz` and `logs.tgz` in the GCS path after job completion
- [ ] Verify non-VPP pipelines continue to upload to `gs://semaphore_diags/<SEMAPHORE_JOB_ID>/` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)