### PR TITLE
Fix fix-changed to also format dirty working tree files

### DIFF
--- a/hack/format-changed-files.sh
+++ b/hack/format-changed-files.sh
@@ -26,12 +26,23 @@ echo "Detected parent branch: $parent_branch"
 file_list=$(mktemp)
 trap "rm -f $file_list" EXIT
 
-git diff -z --name-only --diff-filter=d --merge-base "$parent_branch" -- . | \
+# Collect files changed vs the parent branch...
+git diff -z --name-only --diff-filter=d --merge-base "$parent_branch" -- . > $file_list || true
+# ...and also any files that are dirty in the working tree (e.g. regenerated
+# by a previous build step like "make protobuf").
+git diff -z --name-only --diff-filter=d -- . >> $file_list || true
+
+# De-duplicate (sort -uz works with NUL-delimited input), filter to .go files,
+# and exclude vendored code.
+sorted_list=$(mktemp)
+trap "rm -f $file_list $sorted_list" EXIT
+sort -uz < $file_list | \
   grep -z -v -e '^vendor/' -e '^third_party/' | \
-  grep -z '\.go$' > $file_list || {
+  grep -z '\.go$' > $sorted_list || {
     echo "No files to format.";
     exit 0;
 }
+mv $sorted_list $file_list
 
 # Print the files we plan to change.
 echo "Formatting changed files:"


### PR DESCRIPTION
Just ran into a very confusing corner case on a release branch where running `make protobuf fix-changed` would generate the file but leave it unformatted/dirty.  Scenario:

* Target branch has the file unformatted.
* Intermediate commit on PR formats the file (say with `make fix-all`).
* Now `make protobuf fix-changed` regenerates the file but `fix-changed` sees no diff against the target branch so it skips the file and leaves it dirty.
* CI fails, but `make fix-changed` stubbornly does nothing when you run it locally(!)

This PR includes dirty files in the list of files that get formatted, so, after the `make protobuf` step, `make fix-changed` will format the generated file in this case.