### PR TITLE
Use the buildinfo package in check-status

### DIFF
--- a/kube-controllers/cmd/check-status/main.go
+++ b/kube-controllers/cmd/check-status/main.go
@@ -21,10 +21,8 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/status"
+	"github.com/projectcalico/calico/pkg/buildinfo"
 )
-
-// VERSION is filled out during the build process (using git describe output)
-var VERSION string
 
 // main is the main entry point into the anx controller.
 func main() {
@@ -42,7 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 	if *version {
-		fmt.Println(VERSION)
+		buildinfo.PrintVersion()
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
The old `main.VERSION` constant is no longer in use.

Before:

```console
$ make bin/check-status-linux-amd64 && bin/check-status-linux-amd64 -v
make: 'bin/check-status-linux-amd64' is up to date.


```

After:

```console
$ make bin/check-status-linux-amd64 && bin/check-status-linux-amd64 -v
make: 'bin/check-status-linux-amd64' is up to date.
Version:      v3.32.0-0.dev-1171-gf8a10fde908d
Build date:   2026-03-20T09:50:36+0000
Git commit:   f8a10fde908d9304e159a84b4d2c4717638dadb2
```


<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
