### PR TITLE
Use the buildinfo package in the plugin installer

### DIFF
--- a/cni-plugin/cmd/install/install.go
+++ b/cni-plugin/cmd/install/install.go
@@ -18,13 +18,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/cni-plugin/pkg/install"
+	"github.com/projectcalico/calico/pkg/buildinfo"
 )
 
 // VERSION is filled out during the build process (using git describe output)
 var VERSION string
 
 func main() {
-	err := install.Install(VERSION)
+	err := install.Install(buildinfo.Version)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error installing CNI plugin")
 	}


### PR DESCRIPTION
The old `main.VERSION` constant is no longer in use.

Without this change, logs look like this:

> calico-node-8hl2n install-cni 2026-03-20 10:23:54.708 [INFO][1] cni-installer/install.go 226: CNI plugin version:

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
