### PR TITLE
[BPF] Fix TC program detachment from veth host interfaces [v3.31]

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -4761,12 +4761,22 @@ func (trees bpfIfaceTrees) addIface(link netlink.Link) {
 		children:    make(map[int]*bpfIfaceNode),
 	}
 
-	if attrs.MasterIndex == 0 && attrs.ParentIndex == 0 {
-		trees.addIfaceStandAlone(intf)
-	} else if attrs.MasterIndex != 0 {
+	// Veth and netkit devices use ParentIndex to reference their peer, not a
+	// real parent in a device hierarchy (bond/bridge). Ignore ParentIndex
+	// for these types, but still respect MasterIndex — a veth can be
+	// genuinely enslaved to a bond or bridge.
+	isVethLike := false
+	switch link.Type() {
+	case "veth", "netkit":
+		isVethLike = true
+	}
+
+	if attrs.MasterIndex != 0 {
 		trees.addIfaceWithMaster(intf, attrs.MasterIndex)
-	} else if attrs.ParentIndex != 0 {
+	} else if attrs.ParentIndex != 0 && !isVethLike {
 		trees.addIfaceWithChild(intf, attrs.ParentIndex)
+	} else {
+		trees.addIfaceStandAlone(intf)
 	}
 }
 


### PR DESCRIPTION
## Summary

Cherry-pick of #12202 to release-v3.31.

- Veth and netkit devices use `ParentIndex` to reference their peer interface, not a real parent in a device hierarchy (bond/bridge). On some kernels (notably GCP), this caused Felix's interface tree to incorrectly classify eth0 as a child of eth20, triggering "XDP only" mode which detached TC programs from eth0.
- Without TC programs, VXLAN return traffic was not decapsulated, breaking NodePort forwarding through secondary NICs.
- Ignore `ParentIndex` for veth and netkit devices, but still respect `MasterIndex` so that veths genuinely enslaved to a bond or bridge are correctly placed in the interface hierarchy.

```release-note
ebpf: Fix that BPF programs could be incorrectly removed from workload interfaces on recent kernels due to change in kernel use of IFLA_LINK netlink message.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)