### PR TITLE
[BPF] Allow DHCPv4 packets to pass HEP RPF check

### DIFF
--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -121,7 +121,13 @@ static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 			}
 			break;
 		case BPF_FIB_LKUP_RET_NOT_FWDED:
-			if (ip_link_local(ctx->state->ip_src)) {
+			if (ip_link_local(ctx->state->ip_src)
+#ifndef IPVER6
+				|| (ctx->state->ip_proto == IPPROTO_UDP &&
+				    (ctx->state->sport == 67 || ctx->state->sport == 68 ||
+				     ctx->state->dport == 67 || ctx->state->dport == 68))
+#endif
+			) {
 #ifdef IPVER6
 				if (ip_link_local(ctx->state->ip_dst)){
 #else

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -73,7 +73,7 @@ static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 		.family = 2, /* AF_INET */
 #endif
 		.tot_len = 0,
-		.ifindex = ctx->skb->ingress_ifindex,
+		.ifindex = skb_ingress_ifindex(ctx->skb),
 		.l4_protocol = ctx->state->ip_proto,
 		.sport = bpf_htons(ctx->state->dport),
 		.dport = bpf_htons(ctx->state->sport),
@@ -124,13 +124,7 @@ static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 			}
 			break;
 		case BPF_FIB_LKUP_RET_NOT_FWDED:
-			if (ip_link_local(ctx->state->ip_src)
-#ifndef IPVER6
-				|| (ctx->state->ip_proto == IPPROTO_UDP &&
-				    ((ctx->state->sport == DHCPV4_CLIENT_PORT && ctx->state->dport == DHCPV4_SERVER_PORT) ||
-				     (ctx->state->sport == DHCPV4_SERVER_PORT && ctx->state->dport == DHCPV4_CLIENT_PORT)))
-#endif
-			) {
+			if (ip_link_local(ctx->state->ip_src)) {
 #ifdef IPVER6
 				if (ip_link_local(ctx->state->ip_dst)){
 #else
@@ -139,6 +133,15 @@ static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 					ret = RPF_RES_STRICT;
 				}
 			}
+#ifndef IPVER6
+			else if (ctx->state->ip_proto == IPPROTO_UDP &&
+				    ((ctx->state->sport == DHCPV4_CLIENT_PORT && ctx->state->dport == DHCPV4_SERVER_PORT) ||
+				     (ctx->state->sport == DHCPV4_SERVER_PORT && ctx->state->dport == DHCPV4_CLIENT_PORT))) {
+				CALI_DEBUG("Host RPF bypass: DHCPv4 packet (sport=%d, dport=%d)",
+						ctx->state->sport, ctx->state->dport);
+				ret = RPF_RES_LOOSE;
+			}
+#endif
 			break;
 
 	}

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -18,6 +18,7 @@
 
 #define DHCPV4_SERVER_PORT	67
 #define DHCPV4_CLIENT_PORT	68
+#define DHCPV4_MAGIC_COOKIE	0x63825363
 
 static CALI_BPF_INLINE int wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
@@ -137,9 +138,20 @@ static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 			else if (ctx->state->ip_proto == IPPROTO_UDP &&
 				    ((ctx->state->sport == DHCPV4_CLIENT_PORT && ctx->state->dport == DHCPV4_SERVER_PORT) ||
 				     (ctx->state->sport == DHCPV4_SERVER_PORT && ctx->state->dport == DHCPV4_CLIENT_PORT))) {
-				CALI_DEBUG("Host RPF bypass: DHCPv4 packet (sport=%d, dport=%d)",
-						ctx->state->sport, ctx->state->dport);
-				ret = RPF_RES_LOOSE;
+				/* Verify DHCP magic cookie (0x63825363) at offset 236
+				 * from the start of the UDP payload to confirm this is
+				 * a genuine DHCPv4 packet, not just any UDP traffic on
+				 * ports 67/68.
+				 */
+				__u32 magic = 0;
+				long udp_payload_off = skb_l4hdr_offset(ctx) + UDP_SIZE;
+
+				if (bpf_skb_load_bytes(ctx->skb, udp_payload_off + 236, &magic, 4) == 0 &&
+				    magic == bpf_htonl(DHCPV4_MAGIC_COOKIE)) {
+					CALI_DEBUG("Host RPF bypass: DHCPv4 packet (sport=%d, dport=%d)",
+							ctx->state->sport, ctx->state->dport);
+					ret = RPF_RES_LOOSE;
+				}
 			}
 #endif
 			break;

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -16,6 +16,9 @@
 #define RPF_RES_LOOSE		2
 #define RPF_RES_DISABLED	3
 
+#define DHCPV4_SERVER_PORT	67
+#define DHCPV4_CLIENT_PORT	68
+
 static CALI_BPF_INLINE int wep_rpf_check(struct cali_tc_ctx *ctx, struct cali_rt *r)
 {
         CALI_DEBUG("Workload RPF check src=" IP_FMT " skb iface=%d.",
@@ -124,8 +127,8 @@ static CALI_BPF_INLINE int hep_rpf_check(struct cali_tc_ctx *ctx)
 			if (ip_link_local(ctx->state->ip_src)
 #ifndef IPVER6
 				|| (ctx->state->ip_proto == IPPROTO_UDP &&
-				    (ctx->state->sport == 67 || ctx->state->sport == 68 ||
-				     ctx->state->dport == 67 || ctx->state->dport == 68))
+				    ((ctx->state->sport == DHCPV4_CLIENT_PORT && ctx->state->dport == DHCPV4_SERVER_PORT) ||
+				     (ctx->state->sport == DHCPV4_SERVER_PORT && ctx->state->dport == DHCPV4_CLIENT_PORT)))
 #endif
 			) {
 #ifdef IPVER6

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -855,6 +855,14 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					globals.Flags |= libbpf.GlobalsWorkloadSrcSpoofingConfigured
 				}
 
+				switch topts.rpfEnforce {
+				case "strict":
+					globals.Flags |= libbpf.GlobalsRPFOptionEnabled
+					globals.Flags |= libbpf.GlobalsRPFOptionStrict
+				case "loose":
+					globals.Flags |= libbpf.GlobalsRPFOptionEnabled
+				}
+
 				globals.DSCP = -1
 				if topts.dscp >= 0 {
 					globals.DSCP = topts.dscp
@@ -1239,6 +1247,7 @@ type testOpts struct {
 	dscp                          int8
 	istioDSCP                     int8
 	workloadSrcSpoofingConfigured bool
+	rpfEnforce                    string // "strict", "loose", or "" (disabled)
 }
 
 type testOption func(opts *testOpts)
@@ -1321,6 +1330,12 @@ func withEgressDSCP(value int8) testOption {
 func withObjName(name string) testOption {
 	return func(o *testOpts) {
 		o.objname = name
+	}
+}
+
+func withRPFEnforce(mode string) testOption {
+	return func(o *testOpts) {
+		o.rpfEnforce = mode
 	}
 }
 

--- a/felix/bpf/ut/rpf_test.go
+++ b/felix/bpf/ut/rpf_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket/layers"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// deleteDefaultRoutes removes only the default routes (0.0.0.0/0 or ::/0) for
+// the given address family and returns a function that restores them. Without a
+// default route, bpf_fib_lookup returns BPF_FIB_LKUP_RET_NOT_FWDED for IPs
+// that don't match a more specific route.
+func deleteDefaultRoutes(family int) func() {
+	routes, err := netlink.RouteList(nil, family)
+	if err != nil {
+		log.WithError(err).Warn("Failed to list routes")
+		return func() {}
+	}
+
+	var deleted []netlink.Route
+	for i := range routes {
+		// Default routes have nil or zero-length Dst.
+		if routes[i].Dst == nil || routes[i].Dst.IP.IsUnspecified() {
+			if err := netlink.RouteDel(&routes[i]); err != nil {
+				log.WithError(err).WithField("route", routes[i]).Warn("Failed to delete default route")
+			} else {
+				deleted = append(deleted, routes[i])
+			}
+		}
+	}
+
+	return func() {
+		for i := range deleted {
+			if err := netlink.RouteAdd(&deleted[i]); err != nil {
+				log.WithError(err).WithField("route", deleted[i]).Warn("Failed to restore default route")
+			}
+		}
+	}
+}
+
+// runWithoutDefaultRoutes deletes default routes for the given family, runs fn,
+// then restores them. The restore always runs even if fn panics.
+func runWithoutDefaultRoutes(family int, fn func()) {
+	restoreRoutes := deleteDefaultRoutes(family)
+	defer restoreRoutes()
+	fn()
+}
+
+func TestDHCPv4BypassesHEPRPF(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "DHrpf"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ip
+
+	// DHCP server -> client (offer/ack): sport=67, dport=68
+	// Use a random source IP that simulates an external DHCP server (e.g., AWS).
+	dhcpServerIP := net.IPv4(172, 31, 0, 1).To4()
+	ipHdr := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		SrcIP:    dhcpServerIP,
+		DstIP:    node1ip,
+		Protocol: layers.IPProtocolUDP,
+	}
+	udpHdr := &layers.UDP{
+		SrcPort: 67,
+		DstPort: 68,
+	}
+
+	_, _, _, _, pktBytes, err := testPacketV4(nil, ipHdr, udpHdr, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMap(ctMap)
+	defer resetCTMap(ctMap)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		runWithoutDefaultRoutes(netlink.FAMILY_V4, func() {
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT),
+				"DHCPv4 packet (sport=67, dport=68) should not be dropped by RPF")
+		})
+	}, withRPFEnforce("strict"))
+}
+
+func TestNonDHCPBlockedByHEPRPF(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "NDrpf"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ip
+
+	// Regular UDP packet (not DHCP) from an unroutable source.
+	unroutableIP := net.IPv4(172, 31, 0, 1).To4()
+	ipHdr := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		SrcIP:    unroutableIP,
+		DstIP:    node1ip,
+		Protocol: layers.IPProtocolUDP,
+	}
+	udpHdr := &layers.UDP{
+		SrcPort: 12345,
+		DstPort: 5678,
+	}
+
+	_, _, _, _, pktBytes, err := testPacketV4(nil, ipHdr, udpHdr, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMap(ctMap)
+	defer resetCTMap(ctMap)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		runWithoutDefaultRoutes(netlink.FAMILY_V4, func() {
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_SHOT),
+				"Non-DHCP packet from unroutable source should be dropped by RPF")
+		})
+	}, withRPFEnforce("strict"))
+}
+
+func TestDHCPv6LinkLocalBypassesHEPRPF(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "D6rpf"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ipV6
+
+	// DHCPv6 uses link-local addresses. The existing ip_link_local check
+	// in the NOT_FWDED path should allow these through.
+	linkLocalSrc := net.ParseIP("fe80::1").To16()
+	linkLocalDst := net.ParseIP("fe80::2").To16()
+	ipHdr := &layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		SrcIP:      linkLocalSrc,
+		DstIP:      linkLocalDst,
+		NextHeader: layers.IPProtocolUDP,
+	}
+	udpHdr := &layers.UDP{
+		SrcPort: 546,
+		DstPort: 547,
+	}
+
+	_, _, _, _, pktBytes, err := testPacketV6(nil, ipHdr, udpHdr, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMap(ctMapV6)
+	defer resetCTMap(ctMapV6)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		runWithoutDefaultRoutes(netlink.FAMILY_V6, func() {
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT),
+				"DHCPv6 link-local packet should not be dropped by RPF")
+		})
+	}, withIPv6(), withRPFEnforce("strict"))
+}
+
+func TestNonLinkLocalV6BlockedByHEPRPF(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "N6rpf"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ipV6
+
+	// Non-link-local source that has no route should be dropped.
+	unroutableSrc := net.ParseIP("2001:db8::dead").To16()
+	ipHdr := &layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		SrcIP:      unroutableSrc,
+		DstIP:      node1ipV6,
+		NextHeader: layers.IPProtocolUDP,
+	}
+	udpHdr := &layers.UDP{
+		SrcPort: 12345,
+		DstPort: 5678,
+	}
+
+	_, _, _, _, pktBytes, err := testPacketV6(nil, ipHdr, udpHdr, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMap(ctMapV6)
+	defer resetCTMap(ctMapV6)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		runWithoutDefaultRoutes(netlink.FAMILY_V6, func() {
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_SHOT),
+				"Non-link-local IPv6 packet from unroutable source should be dropped by RPF")
+		})
+	}, withIPv6(), withRPFEnforce("strict"))
+}

--- a/felix/bpf/ut/rpf_test.go
+++ b/felix/bpf/ut/rpf_test.go
@@ -15,6 +15,7 @@
 package ut_test
 
 import (
+	"encoding/binary"
 	"net"
 	"testing"
 
@@ -64,6 +65,17 @@ func runWithoutDefaultRoutes(family int, fn func()) {
 	fn()
 }
 
+// makeDHCPv4Payload builds a minimal BOOTP/DHCP payload with the magic cookie
+// (0x63825363) at offset 236, which is where the BPF RPF bypass checks for it.
+func makeDHCPv4Payload(op byte) []byte {
+	payload := make([]byte, 240)
+	payload[0] = op                                          // op: 1=BOOTREQUEST, 2=BOOTREPLY
+	payload[1] = 1                                           // htype: Ethernet
+	payload[2] = 6                                           // hlen: 6 (MAC address length)
+	binary.BigEndian.PutUint32(payload[236:240], 0x63825363) // DHCP magic cookie
+	return payload
+}
+
 func TestDHCPv4BypassesHEPRPF(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -89,7 +101,8 @@ func TestDHCPv4BypassesHEPRPF(t *testing.T) {
 		DstPort: 68,
 	}
 
-	_, _, _, _, pktBytes, err := testPacketV4(nil, ipHdr, udpHdr, nil)
+	dhcpPayload := makeDHCPv4Payload(2) // BOOTREPLY (offer/ack)
+	_, _, _, _, pktBytes, err := testPacketV4(nil, ipHdr, udpHdr, dhcpPayload)
 	Expect(err).NotTo(HaveOccurred())
 
 	resetCTMap(ctMap)
@@ -102,6 +115,54 @@ func TestDHCPv4BypassesHEPRPF(t *testing.T) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res.Retval).NotTo(Equal(resTC_ACT_SHOT),
 				"DHCPv4 packet (sport=67, dport=68) should not be dropped by RPF")
+		})
+	}, withRPFEnforce("strict"))
+}
+
+func TestDHCPv4PortsWithoutMagicCookieBlockedByHEPRPF(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "DMrpf"
+	defer func() { bpfIfaceName = "" }()
+	defer cleanUpMaps()
+
+	hostIP = node1ip
+
+	// UDP packet on DHCP ports but WITHOUT the magic cookie — should be dropped.
+	dhcpServerIP := net.IPv4(172, 31, 0, 1).To4()
+	ipHdr := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		SrcIP:    dhcpServerIP,
+		DstIP:    node1ip,
+		Protocol: layers.IPProtocolUDP,
+	}
+	udpHdr := &layers.UDP{
+		SrcPort: 67,
+		DstPort: 68,
+	}
+
+	// Payload with correct size but wrong magic cookie.
+	badPayload := make([]byte, 240)
+	badPayload[0] = 2 // BOOTREPLY
+	badPayload[1] = 1 // Ethernet
+	badPayload[2] = 6
+	// No magic cookie at offset 236 (all zeros).
+
+	_, _, _, _, pktBytes, err := testPacketV4(nil, ipHdr, udpHdr, badPayload)
+	Expect(err).NotTo(HaveOccurred())
+
+	resetCTMap(ctMap)
+	defer resetCTMap(ctMap)
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		runWithoutDefaultRoutes(netlink.FAMILY_V4, func() {
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_SHOT),
+				"UDP packet on DHCP ports without magic cookie should be dropped by RPF")
 		})
 	}, withRPFEnforce("strict"))
 }


### PR DESCRIPTION
  DHCPv4 packets (UDP port 67/68) often use 0.0.0.0 or non-routable source                                                                                                               
  addresses, causing bpf_fib_lookup to return BPF_FIB_LKUP_RET_NOT_FWDED
  and the HEP RPF check to drop the packet. This extends the existing                                                                                                                    
  link-local bypass in hep_rpf_check to also accept IPv4 UDP packets with
  source or destination port 67 or 68.                                                                                                                                                   
                                                                        
  **Why this is needed**                                                                                                                                                                     
                                                                        
  systemd-networkd's DHCP client uses an AF_PACKET SOCK_DGRAM socket with                                                                                                                
  ETH_P_IP for receiving DHCP responses. In the Linux kernel's
  __netif_receive_skb_core(), ETH_P_IP sockets are registered in                                                                                                                         
  ptype_base which is delivered after TC ingress — unlike ETH_P_ALL                                                                                                                      
  sockets (ptype_all) which are delivered before TC. This means BPF programs                                                                                                             
  on TC ingress that drop packets prevent ETH_P_IP AF_PACKET sockets from                                                                                                                
  receiving them.                                                                                                                                                                        
                                                                                                                                                                                         
  When systemd-networkd restarts, it flushes IPs and routes, then starts a                                                                                                               
  fresh DHCP exchange. The DHCP server's unicast offer fails the BPF RPF check
  (no route to server's source IP after flush), and the TC TC_ACT_SHOT drop                                                                                                              
  prevents systemd-networkd from receiving the offer — leaving the host without                                                                                                          
  an IP address.
                                                                                                                                                                                         
  In contrast, dhclient uses AF_PACKET SOCK_RAW with ETH_P_ALL, which   
  is delivered before TC ingress and is unaffected by BPF drops.
                                                                                                                                                                                         
  Standard Linux does not have this problem because the kernel's own RPF check
  (rp_filter) runs in the IP stack, which is after AF_PACKET delivery —                                                                                                                  
  so DHCP clients always receive packets regardless of RPF settings.    
                                                                                                                                                                                         
  **Magic cookie validation**                                                                                                                                                                
                                                                                                                                                                                         
  To avoid blindly bypassing RPF for any UDP traffic on ports 67/68, the bypass                                                                                                          
  verifies the DHCP magic cookie (0x63825363) at offset 236 in the UDP payload.
  This magic cookie is mandatory in all DHCPv4 packets per                                                                                                                               
  RFC 2132 Section 2 (https://www.rfc-editor.org/rfc/rfc2132#section-2)                                                                                                                                                              
  (originally defined in RFC 1497).                                                                                                                                                      
                                                                                                                                                                                         
  The DHCP bypass is IPv4-only (#ifndef IPVER6) since DHCPv6 uses                                                                                                                        
  link-local addresses which are already handled.                       


**Release note:**
```release-note
ebpf: Fix dataplane dropping DHCPv4 packets due to HEP reverse path filtering when source address is not routable.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)