### PR TITLE
fix(key-cert-provisioner): use %v for unexpected CSR watch object

### DIFF
--- a/key-cert-provisioner/pkg/k8s/certificate.go
+++ b/key-cert-provisioner/pkg/k8s/certificate.go
@@ -48,7 +48,7 @@ func watchCSR(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls.X509CSR) e
 	for event := range (*watcher).ResultChan() {
 		chcsr, ok := event.Object.(*certv1.CertificateSigningRequest)
 		if !ok {
-			return fmt.Errorf("unexpected type in CertificateSigningRequest channel: %o", event.Object)
+			return fmt.Errorf("unexpected type in CertificateSigningRequest channel: %v", event.Object)
 		}
 		if chcsr.Name == cfg.CSRName && chcsr.Status.Conditions != nil && len(chcsr.Status.Certificate) > 0 {
 			approved := false


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

The CSR watch path formats an unexpected object with `%o`, which is intended for octal integer output. Use `%v` so error messages show a readable representation for arbitrary types.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fix key-cert provisioner CSR watch errors to display unexpected objects with default formatting instead of misleading octal output.
```