### PR TITLE
fix(felix): return NFLogReader subscribe error from Start

### DIFF
--- a/felix/collector/iptables.go
+++ b/felix/collector/iptables.go
@@ -76,7 +76,7 @@ func (r *NFLogReader) Start() error {
 		// started before a later one failed), ensure we signal shutdown so
 		// any started goroutines are cleaned up instead of leaking.
 		r.Stop()
-		return err
+		return fmt.Errorf("NFLogReader failed to subscribe: %w", err)
 	}
 
 	r.wg.Go(func() {

--- a/felix/collector/iptables.go
+++ b/felix/collector/iptables.go
@@ -72,6 +72,10 @@ func NewNFLogReader(lookupsCache *calc.LookupsCache, inGrp, eGrp, bufSize int, s
 
 func (r *NFLogReader) Start() error {
 	if err := r.subscribe(); err != nil {
+		// If subscribe() partially succeeded (e.g., one NFLOG subscription
+		// started before a later one failed), ensure we signal shutdown so
+		// any started goroutines are cleaned up instead of leaking.
+		r.Stop()
 		return err
 	}
 

--- a/felix/collector/iptables.go
+++ b/felix/collector/iptables.go
@@ -72,7 +72,7 @@ func NewNFLogReader(lookupsCache *calc.LookupsCache, inGrp, eGrp, bufSize int, s
 
 func (r *NFLogReader) Start() error {
 	if err := r.subscribe(); err != nil {
-		return nil
+		return err
 	}
 
 	r.wg.Go(func() {


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

`NFLogReader.Start()` called `subscribe()` but returned `nil` on error, so NFLog subscription failures were silently treated as success. Return the error so callers can handle setup failures.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fix flow log NFLog reader Start() ignoring NFLog subscription failures and returning success.
```