### PR TITLE
GC orphaned IPAMHandle CRDs in kube-controllers

### DIFF
--- a/kube-controllers/pkg/controllers/node/fake_client.go
+++ b/kube-controllers/pkg/controllers/node/fake_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,15 +39,17 @@ func NewFakeCalicoClient() *FakeCalicoClient {
 		handlesReleased:    make(map[string]bool),
 	}
 	return &FakeCalicoClient{
-		nodeClient: &nc,
-		ipamClient: &ipamClient,
+		nodeClient:    &nc,
+		ipamClient:    &ipamClient,
+		backendClient: &fakeBackendClient{deletedKeys: make(map[string]bool)},
 	}
 }
 
 // FakeCalicoClient is a fake client for use in the IPAM tests.
 type FakeCalicoClient struct {
-	nodeClient clientv3.NodeInterface
-	ipamClient ipam.Interface
+	nodeClient    clientv3.NodeInterface
+	ipamClient    ipam.Interface
+	backendClient *fakeBackendClient
 }
 
 // Expose helpers for tests to introspect/drive the fake IPAM client.
@@ -118,6 +120,61 @@ func (f *FakeCalicoClient) Tiers() clientv3.TierInterface {
 }
 
 func (f *FakeCalicoClient) Backend() bapi.Client {
+	return f.backendClient
+}
+
+// fakeBackendClient implements the subset of bapi.Client needed by the IPAM controller.
+type fakeBackendClient struct {
+	sync.Mutex
+	deletedKeys map[string]bool
+}
+
+func (f *fakeBackendClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+	f.Lock()
+	defer f.Unlock()
+	key, _ := model.KeyToDefaultPath(kvp.Key)
+	f.deletedKeys[key] = true
+	return kvp, nil
+}
+
+// Stub methods to satisfy bapi.Client.
+func (f *fakeBackendClient) Create(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) Apply(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) Watch(ctx context.Context, list model.ListInterface, options bapi.WatchOptions) (bapi.WatchInterface, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeBackendClient) EnsureInitialized() error {
+	return nil
+}
+
+func (f *fakeBackendClient) Clean() error {
+	return nil
+}
+
+func (f *fakeBackendClient) Close() error {
 	return nil
 }
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -174,6 +174,7 @@ func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs k
 		allocationsByBlock:          make(map[string]map[string]*allocation),
 		allocationState:             newAllocationState(),
 		handleTracker:               newHandleTracker(),
+		orphanHandleTracker:         newOrphanHandleTracker(leakGracePeriod),
 		kubernetesNodesByCalicoName: make(map[string]string),
 		confirmedLeaks:              make(map[string]*allocation),
 		nodesByBlock:                make(map[string]string),
@@ -231,6 +232,9 @@ type IPAMController struct {
 	// handleTracker is used to track which handles are in use, which are potentially leaked, and which are confirmed as leaks.
 	handleTracker *handleTracker
 
+	// orphanHandleTracker tracks IPAMHandle CRDs that have no matching allocations in any block.
+	orphanHandleTracker *orphanHandleTracker
+
 	// confirmedLeaks indexes allocations that are confirmed to be leaks and are awaiting cleanup.
 	confirmedLeaks map[string]*allocation
 
@@ -277,6 +281,7 @@ func (c *IPAMController) Start(stop chan struct{}) {
 func (c *IPAMController) RegisterWith(f *utils.DataFeed) {
 	f.RegisterForNotification(model.BlockKey{}, c.onUpdate)
 	f.RegisterForNotification(model.ResourceKey{}, c.onUpdate)
+	f.RegisterForNotification(model.IPAMHandleKey{}, c.onUpdate)
 	f.RegisterForSyncStatus(c.onStatusUpdate)
 }
 
@@ -292,6 +297,8 @@ func (c *IPAMController) onUpdate(update bapi.Update) {
 			c.syncerUpdates <- update.KVPair
 		}
 	case model.BlockKey:
+		c.syncerUpdates <- update.KVPair
+	case model.IPAMHandleKey:
 		c.syncerUpdates <- update.KVPair
 	}
 }
@@ -415,6 +422,9 @@ func (c *IPAMController) handleUpdate(upd any) {
 		case model.BlockKey:
 			c.handleBlockUpdate(upd)
 			return
+		case model.IPAMHandleKey:
+			c.handleIPAMHandleUpdate(upd)
+			return
 		}
 	}
 	log.WithField("update", upd).Warn("Unexpected update received")
@@ -466,6 +476,24 @@ func (c *IPAMController) handlePoolUpdate(kvp model.KVPair) {
 	} else {
 		poolName := kvp.Key.(model.ResourceKey).Name
 		c.onPoolDeleted(poolName)
+	}
+}
+
+// handleIPAMHandleUpdate processes create/update/delete events for IPAMHandle CRDs.
+func (c *IPAMController) handleIPAMHandleUpdate(kvp model.KVPair) {
+	handleID := kvp.Key.(model.IPAMHandleKey).HandleID
+	if kvp.Value != nil {
+		h := kvp.Value.(*model.IPAMHandle)
+		c.orphanHandleTracker.onHandleUpdate(handleID, h.Deleted)
+
+		// Check if this handle has any allocations. If not, mark as orphaned.
+		if _, ok := c.handleTracker.allocationsByHandle[handleID]; !ok {
+			c.orphanHandleTracker.markOrphaned(handleID)
+		} else {
+			c.orphanHandleTracker.markActive(handleID)
+		}
+	} else {
+		c.orphanHandleTracker.onHandleDeleted(handleID)
 	}
 }
 
@@ -551,6 +579,7 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 			c.allocationState.allocate(&alloc)
 		}
 		c.handleTracker.setAllocation(&alloc)
+		c.orphanHandleTracker.markActive(handle)
 		log.WithFields(alloc.fields()).Debug("New IP allocation")
 	}
 
@@ -574,6 +603,13 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 			// Needs release.
 			c.handleTracker.removeAllocation(alloc)
 			delete(c.allocationsByBlock[blockCIDR], id)
+
+			// If this handle has no more allocations, it may be orphaned.
+			if _, ok := c.handleTracker.allocationsByHandle[alloc.handle]; !ok {
+				if _, known := c.orphanHandleTracker.allHandles[alloc.handle]; known {
+					c.orphanHandleTracker.markOrphaned(alloc.handle)
+				}
+			}
 
 			// Also remove from the node view.
 			node := alloc.node()
@@ -599,6 +635,16 @@ func (c *IPAMController) onBlockDeleted(key model.BlockKey) {
 	// Remove allocations that were contributed by this block.
 	allocations := c.allocationsByBlock[blockCIDR]
 	for _, alloc := range allocations {
+		c.handleTracker.removeAllocation(alloc)
+		delete(c.confirmedLeaks, alloc.id())
+
+		// If this handle has no more allocations, it may be orphaned.
+		if _, ok := c.handleTracker.allocationsByHandle[alloc.handle]; !ok {
+			if _, known := c.orphanHandleTracker.allHandles[alloc.handle]; known {
+				c.orphanHandleTracker.markOrphaned(alloc.handle)
+			}
+		}
+
 		node := alloc.node()
 		if node != "" {
 			c.allocationState.release(alloc)
@@ -1193,6 +1239,12 @@ func (c *IPAMController) syncIPAM() error {
 		return err
 	}
 
+	// Clean up orphaned IPAMHandle CRDs that have no matching allocations in any block.
+	err = c.garbageCollectOrphanedHandles()
+	if err != nil {
+		return err
+	}
+
 	// Delete any nodes that we determined can be removed in checkAllocations. These
 	// nodes are no longer in the Kubernetes API, and have no valid allocations, so can be cleaned up entirely
 	// from Calico IPAM. Successfully released nodes are marked clean inside releaseNodes;
@@ -1287,6 +1339,40 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 			log.WithError(err).Warn("Failed to garbage collect one or more leaked IP addresses")
 			return err
 		}
+	}
+	return nil
+}
+
+// garbageCollectOrphanedHandles deletes IPAMHandle CRDs that have no matching
+// allocations in any block and have been orphaned for longer than the grace period.
+func (c *IPAMController) garbageCollectOrphanedHandles() error {
+	orphans := c.orphanHandleTracker.confirmedOrphans()
+	if len(orphans) == 0 {
+		return nil
+	}
+
+	type accessor interface {
+		Backend() bapi.Client
+	}
+	bc := c.client.(accessor).Backend()
+
+	log.WithField("num", len(orphans)).Info("Garbage collecting orphaned IPAMHandle CRDs")
+	for _, handleID := range orphans {
+		logc := log.WithField("handle", handleID)
+		logc.Info("Deleting orphaned IPAMHandle")
+		_, err := bc.DeleteKVP(context.TODO(), &model.KVPair{
+			Key: model.IPAMHandleKey{HandleID: handleID},
+		})
+		if err != nil {
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+				logc.Debug("Handle already deleted")
+			} else {
+				logc.WithError(err).Warn("Failed to delete orphaned IPAMHandle")
+				return err
+			}
+		}
+		// The syncer will deliver a delete event, which will call
+		// orphanHandleTracker.onHandleDeleted to clean up our tracking state.
 	}
 	return nil
 }

--- a/kube-controllers/pkg/controllers/node/ipam_allocation.go
+++ b/kube-controllers/pkg/controllers/node/ipam_allocation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,75 @@ func newHandleTracker() *handleTracker {
 	return &handleTracker{
 		allocationsByHandle: map[string]map[string]*allocation{},
 	}
+}
+
+// orphanHandleTracker tracks IPAMHandle CRDs that have no matching allocations
+// in any block. Handles are candidates for deletion after a grace period.
+type orphanHandleTracker struct {
+	// allHandles stores every IPAMHandle CRD received from the syncer, keyed by handle ID.
+	allHandles map[string]handleInfo
+
+	// candidates tracks handles that appear to be orphaned, keyed by handle ID.
+	// The value is the time the handle was first observed with no allocations.
+	candidates map[string]time.Time
+
+	leakGracePeriod *time.Duration
+}
+
+type handleInfo struct {
+	handleID string
+	deleted  bool
+}
+
+func newOrphanHandleTracker(leakGracePeriod *time.Duration) *orphanHandleTracker {
+	return &orphanHandleTracker{
+		allHandles:      map[string]handleInfo{},
+		candidates:      map[string]time.Time{},
+		leakGracePeriod: leakGracePeriod,
+	}
+}
+
+// onHandleUpdate records a handle CRD from the syncer.
+func (t *orphanHandleTracker) onHandleUpdate(handleID string, deleted bool) {
+	t.allHandles[handleID] = handleInfo{handleID: handleID, deleted: deleted}
+}
+
+// onHandleDeleted removes a handle from all tracking state.
+func (t *orphanHandleTracker) onHandleDeleted(handleID string) {
+	delete(t.allHandles, handleID)
+	delete(t.candidates, handleID)
+}
+
+// markOrphaned records a handle as having no allocations. If it was already
+// tracked, the original timestamp is preserved.
+func (t *orphanHandleTracker) markOrphaned(handleID string) {
+	if _, ok := t.candidates[handleID]; !ok {
+		log.WithField("handle", handleID).Info("IPAMHandle has no allocations, candidate for GC")
+		t.candidates[handleID] = time.Now()
+	}
+}
+
+// markActive removes a handle from the orphan candidate set.
+func (t *orphanHandleTracker) markActive(handleID string) {
+	if _, ok := t.candidates[handleID]; ok {
+		log.WithField("handle", handleID).Debug("IPAMHandle is active again, removing from orphan candidates")
+		delete(t.candidates, handleID)
+	}
+}
+
+// confirmedOrphans returns handle IDs that have been orphaned for longer than
+// the grace period and are safe to delete.
+func (t *orphanHandleTracker) confirmedOrphans() []string {
+	if t.leakGracePeriod == nil || *t.leakGracePeriod <= 0 {
+		return nil
+	}
+	var result []string
+	for handleID, firstSeen := range t.candidates {
+		if time.Since(firstSeen) > *t.leakGracePeriod {
+			result = append(result, handleID)
+		}
+	}
+	return result
 }
 
 // allocation is an internal structure used by the IPAM garbage collector to track IPAM

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -2388,6 +2388,98 @@ var _ = Describe("IPAM controller UTs", func() {
 			return fakeClient.affinityReleased("node-y")
 		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-y should be released after error is cleared")
 	})
+
+	It("should garbage collect orphaned IPAMHandle CRDs", func() {
+		c.Start(stopChan)
+
+		// Simulate an orphaned handle arriving via the syncer — a handle with
+		// no corresponding block allocations. This happens when the IPAM release
+		// process is interrupted (CNI plugin killed, kube-controllers crash).
+		orphanedHandleID := "k8s-pod-network.orphaned-handle-abc123"
+		c.onUpdate(bapi.Update{
+			KVPair: model.KVPair{
+				Key:   model.IPAMHandleKey{HandleID: orphanedHandleID},
+				Value: &model.IPAMHandle{HandleID: orphanedHandleID, Block: map[string]int{}},
+			},
+			UpdateType: bapi.UpdateTypeKVNew,
+		})
+
+		// Also add a handle that HAS a matching allocation — it should NOT be GC'd.
+		activeHandleID := "k8s-pod-network.active-handle-def456"
+		c.onUpdate(bapi.Update{
+			KVPair: model.KVPair{
+				Key:   model.IPAMHandleKey{HandleID: activeHandleID},
+				Value: &model.IPAMHandle{HandleID: activeHandleID, Block: map[string]int{"10.0.50.0/30": 1}},
+			},
+			UpdateType: bapi.UpdateTypeKVNew,
+		})
+
+		// Create a block allocation referencing the active handle.
+		idx := 0
+		cidr := net.MustParseCIDR("10.0.50.0/30")
+		aff := "host:some-node"
+		c.onUpdate(bapi.Update{
+			KVPair: model.KVPair{
+				Key: model.BlockKey{CIDR: cidr},
+				Value: &model.AllocationBlock{
+					CIDR:        cidr,
+					Affinity:    &aff,
+					Allocations: []*int{&idx, nil, nil, nil},
+					Unallocated: []int{1, 2, 3},
+					Attributes: []model.AllocationAttribute{
+						{
+							HandleID: &activeHandleID,
+							ActiveOwnerAttrs: map[string]string{
+								ipam.AttributeNode:      "some-node",
+								ipam.AttributePod:       "active-pod",
+								ipam.AttributeNamespace: "default",
+							},
+						},
+					},
+				},
+			},
+			UpdateType: bapi.UpdateTypeKVNew,
+		})
+
+		// Wait for the block to be processed.
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			_, ok := c.allBlocks["10.0.50.0/30"]
+			return ok
+		}, 1*time.Second, 50*time.Millisecond).Should(BeTrue())
+
+		// Verify orphan tracking state.
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			_, orphaned := c.orphanHandleTracker.candidates[orphanedHandleID]
+			_, activeOrphaned := c.orphanHandleTracker.candidates[activeHandleID]
+			return orphaned && !activeOrphaned
+		}, 1*time.Second, 50*time.Millisecond).Should(BeTrue(),
+			"orphaned handle should be a candidate, active handle should not")
+
+		// Trigger a sync so the GC runs.
+		c.fullScanNextSync("test: orphan handle gc")
+		c.onStatusUpdate(bapi.InSync)
+
+		// The orphaned handle should be deleted after the grace period.
+		fakeBackend := cli.(*FakeCalicoClient).backendClient
+		Eventually(func() bool {
+			fakeBackend.Lock()
+			defer fakeBackend.Unlock()
+			key, _ := model.KeyToDefaultPath(model.IPAMHandleKey{HandleID: orphanedHandleID})
+			return fakeBackend.deletedKeys[key]
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(),
+			"orphaned IPAMHandle should be deleted after grace period")
+
+		// The active handle should NOT be deleted.
+		fakeBackend.Lock()
+		activeKey, _ := model.KeyToDefaultPath(model.IPAMHandleKey{HandleID: activeHandleID})
+		Expect(fakeBackend.deletedKeys[activeKey]).To(BeFalse(),
+			"active IPAMHandle must not be deleted")
+		fakeBackend.Unlock()
+	})
 })
 
 // createBlock creates a block based on the given pods and CIDR, and sends it as an update to the controller.

--- a/kube-controllers/pkg/controllers/utils/syncer.go
+++ b/kube-controllers/pkg/controllers/utils/syncer.go
@@ -52,6 +52,9 @@ func NewDataFeed(c client.Interface, dataStore string) *DataFeed {
 			ListInterface: model.ResourceListOptions{Kind: apiv3.KindIPPool},
 		},
 		{
+			ListInterface: model.IPAMHandleListOptions{},
+		},
+		{
 			ListInterface: model.ResourceListOptions{Kind: apiv3.KindHostEndpoint},
 		},
 


### PR DESCRIPTION
IPAMHandle CRDs can be left behind when the IPAM release process is interrupted (CNI plugin killed, kube-controllers crash, etc). The handle CRD persists but has no corresponding allocations in any block. These accumulate over time and pollute etcd — on long-lived clusters with high pod churn, tens of thousands of orphaned handles can accumulate (see #8548 for a real example with 30k+ orphaned handles).

kube-controllers previously had no visibility into orphaned handles at all. It only tracked handles that had active allocations in blocks.

This adds an `orphanHandleTracker` that watches IPAMHandle CRDs via the syncer DataFeed and cross-references them against block allocations tracked by `handleTracker`. When a handle has no allocations for longer than the leak grace period, it is deleted. The tracking is event-driven from both sides:

- Block allocation removal: when a handle loses its last allocation, check if the handle CRD still exists and mark it as an orphan candidate
- Handle CRD arrival: when a new/updated handle CRD arrives with no matching allocations, mark it as an orphan candidate
- Grace period: same as the existing leak grace period, to avoid deleting handles that are briefly empty during normal operation

Also includes the `handleTracker`/`confirmedLeaks` cleanup fix for `onBlockDeleted` that was identified in a separate investigation (#11115).

Fixes https://github.com/projectcalico/calico/issues/8548

```release-note
Garbage collect orphaned IPAMHandle CRDs that have no matching allocations in any IPAM block, preventing unbounded accumulation of stale handle resources in etcd.
```