### PR TITLE
[v3.30] Fix blocksByNode leak in IPAM controller

### DIFF
--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -502,6 +502,9 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 		if n, ok := c.nodesByBlock[blockCIDR]; ok {
 			delete(c.nodesByBlock, blockCIDR)
 			delete(c.blocksByNode[n], blockCIDR)
+			if len(c.blocksByNode[n]) == 0 {
+				delete(c.blocksByNode, n)
+			}
 		}
 	}
 
@@ -608,6 +611,9 @@ func (c *IPAMController) onBlockDeleted(key model.BlockKey) {
 	if n := c.nodesByBlock[blockCIDR]; n != "" {
 		// The block was assigned to a node, make sure to update internal cache.
 		delete(c.blocksByNode[n], blockCIDR)
+		if len(c.blocksByNode[n]) == 0 {
+			delete(c.blocksByNode, n)
+		}
 	}
 	delete(c.allBlocks, blockCIDR)
 	delete(c.nodesByBlock, blockCIDR)
@@ -777,6 +783,9 @@ func (c *IPAMController) releaseUnusedBlocks() error {
 		// accidentally release all of the node's blocks.
 		delete(c.emptyBlocks, blockCIDR)
 		delete(c.blocksByNode[node], blockCIDR)
+		if len(c.blocksByNode[node]) == 0 {
+			delete(c.blocksByNode, node)
+		}
 		delete(c.nodesByBlock, blockCIDR)
 		delete(c.allBlocks, blockCIDR)
 


### PR DESCRIPTION
Partial cherry-pick of #12279 to release-v3.30. Only the blocksByNode map leak fix applies — the RetryController and batch processor fixes target code that doesn't exist on this branch.

**Release note:**
```release-note
Fix blocksByNode map leak in kube-controllers IPAM controller that could cause increasing memory usage when blocks are deleted.
```