### PR TITLE
e2e: fix staged policy test cleanup order

### DIFF
--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -247,6 +247,22 @@ var _ = describe.CalicoDescribe(
 			})
 
 			Context("StagedKubernetesNetworkPolicy", func() {
+				var (
+					knpPolicy   *v3.StagedKubernetesNetworkPolicy
+					knpEnforced *networkingv1.NetworkPolicy
+				)
+
+				AfterEach(func() {
+					if knpEnforced != nil {
+						Expect(cli.Delete(context.TODO(), knpEnforced)).ShouldNot(HaveOccurred())
+						knpEnforced = nil
+					}
+					if knpPolicy != nil {
+						Expect(cli.Delete(context.TODO(), knpPolicy)).ShouldNot(HaveOccurred())
+						knpPolicy = nil
+					}
+				})
+
 				It("should enforce a deny policy", func() {
 					// test connection from client to server - it should NOT fail
 					checker.ExpectSuccess(client1, server.ClusterIP().Port(serverPort))
@@ -254,18 +270,12 @@ var _ = describe.CalicoDescribe(
 
 					// create policy
 					podSelector := metav1.LabelSelector{MatchLabels: server.Pod().Labels}
-					policy := CreateStagedKubernetesNetworkPolicyIngressDeny("service-deny-in", server.Pod().Namespace, podSelector)
-					Expect(cli.Create(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					})
+					knpPolicy = CreateStagedKubernetesNetworkPolicyIngressDeny("service-deny-in", server.Pod().Namespace, podSelector)
+					Expect(cli.Create(context.TODO(), knpPolicy)).ShouldNot(HaveOccurred())
 
 					// enforce the policy
-					_, enforced := ConvertStagedKubernetesPolicyToK8SEnforced(policy)
-					Expect(cli.Create(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					})
+					_, knpEnforced = ConvertStagedKubernetesPolicyToK8SEnforced(knpPolicy)
+					Expect(cli.Create(context.TODO(), knpEnforced)).ShouldNot(HaveOccurred())
 
 					// test connection from client to server - it should fail
 					checker.ResetExpectations()
@@ -275,6 +285,22 @@ var _ = describe.CalicoDescribe(
 			})
 
 			Context("StagedNetworkPolicy", func() {
+				var (
+					snpPolicy   *v3.StagedNetworkPolicy
+					snpEnforced *v3.NetworkPolicy
+				)
+
+				AfterEach(func() {
+					if snpEnforced != nil {
+						Expect(cli.Delete(context.TODO(), snpEnforced)).ShouldNot(HaveOccurred())
+						snpEnforced = nil
+					}
+					if snpPolicy != nil {
+						Expect(cli.Delete(context.TODO(), snpPolicy)).ShouldNot(HaveOccurred())
+						snpPolicy = nil
+					}
+				})
+
 				It("should enforce a deny policy", func() {
 					// test connection from client to server - it should NOT fail
 					checker.ExpectSuccess(client1, server.ClusterIP().Port(serverPort))
@@ -284,18 +310,12 @@ var _ = describe.CalicoDescribe(
 					ingress := []v3.Rule{{Action: v3.Deny}}
 					selector := fmt.Sprintf("pod-name==\"%s\"", server.Name())
 					order := 200.0
-					policy := CreateStagedNetworkPolicy("service-deny-in", customTier, server.Pod().Namespace, order, selector, ingress, nil)
-					Expect(cli.Create(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					})
+					snpPolicy = CreateStagedNetworkPolicy("service-deny-in", customTier, server.Pod().Namespace, order, selector, ingress, nil)
+					Expect(cli.Create(context.TODO(), snpPolicy)).ShouldNot(HaveOccurred())
 
 					// enforce the policy
-					_, enforced := ConvertStagedPolicyToEnforced(policy)
-					Expect(cli.Create(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					})
+					_, snpEnforced = ConvertStagedPolicyToEnforced(snpPolicy)
+					Expect(cli.Create(context.TODO(), snpEnforced)).ShouldNot(HaveOccurred())
 
 					// test connection from client to server - it should fail
 					checker.ResetExpectations()
@@ -305,6 +325,22 @@ var _ = describe.CalicoDescribe(
 			})
 
 			Context("StagedGlobalNetworkPolicy", func() {
+				var (
+					sgnpPolicy   *v3.StagedGlobalNetworkPolicy
+					sgnpEnforced *v3.GlobalNetworkPolicy
+				)
+
+				AfterEach(func() {
+					if sgnpEnforced != nil {
+						Expect(cli.Delete(context.TODO(), sgnpEnforced)).ShouldNot(HaveOccurred())
+						sgnpEnforced = nil
+					}
+					if sgnpPolicy != nil {
+						Expect(cli.Delete(context.TODO(), sgnpPolicy)).ShouldNot(HaveOccurred())
+						sgnpPolicy = nil
+					}
+				})
+
 				It("should enforce a deny policy", func() {
 					// test connection from client to server - it should NOT fail
 					checker.ExpectSuccess(client1, server.ClusterIP().Port(serverPort))
@@ -315,18 +351,12 @@ var _ = describe.CalicoDescribe(
 					selector := fmt.Sprintf("pod-name==\"%s\"", server.Name())
 					order := 200.0
 					policyName := utils.GenerateRandomName("service-deny-in")
-					policy := CreateStagedGlobalNetworkPolicy(policyName, customTier, order, selector, ingress, nil)
-					Expect(cli.Create(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), policy)).ShouldNot(HaveOccurred())
-					})
+					sgnpPolicy = CreateStagedGlobalNetworkPolicy(policyName, customTier, order, selector, ingress, nil)
+					Expect(cli.Create(context.TODO(), sgnpPolicy)).ShouldNot(HaveOccurred())
 
 					// enforce the policy
-					_, enforced := ConvertStagedGlobalPolicyToEnforced(policy)
-					Expect(cli.Create(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					DeferCleanup(func() {
-						Expect(cli.Delete(context.TODO(), enforced)).ShouldNot(HaveOccurred())
-					})
+					_, sgnpEnforced = ConvertStagedGlobalPolicyToEnforced(sgnpPolicy)
+					Expect(cli.Create(context.TODO(), sgnpEnforced)).ShouldNot(HaveOccurred())
 
 					// test connection from client to server - it should fail
 					checker.ResetExpectations()

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -254,11 +254,11 @@ var _ = describe.CalicoDescribe(
 
 				AfterEach(func() {
 					if knpEnforced != nil {
-						Expect(cli.Delete(context.TODO(), knpEnforced)).ShouldNot(HaveOccurred())
+						Expect(ctrlclient.IgnoreNotFound(cli.Delete(context.TODO(), knpEnforced))).ShouldNot(HaveOccurred())
 						knpEnforced = nil
 					}
 					if knpPolicy != nil {
-						Expect(cli.Delete(context.TODO(), knpPolicy)).ShouldNot(HaveOccurred())
+						Expect(ctrlclient.IgnoreNotFound(cli.Delete(context.TODO(), knpPolicy))).ShouldNot(HaveOccurred())
 						knpPolicy = nil
 					}
 				})
@@ -292,11 +292,11 @@ var _ = describe.CalicoDescribe(
 
 				AfterEach(func() {
 					if snpEnforced != nil {
-						Expect(cli.Delete(context.TODO(), snpEnforced)).ShouldNot(HaveOccurred())
+						Expect(ctrlclient.IgnoreNotFound(cli.Delete(context.TODO(), snpEnforced))).ShouldNot(HaveOccurred())
 						snpEnforced = nil
 					}
 					if snpPolicy != nil {
-						Expect(cli.Delete(context.TODO(), snpPolicy)).ShouldNot(HaveOccurred())
+						Expect(ctrlclient.IgnoreNotFound(cli.Delete(context.TODO(), snpPolicy))).ShouldNot(HaveOccurred())
 						snpPolicy = nil
 					}
 				})
@@ -332,11 +332,11 @@ var _ = describe.CalicoDescribe(
 
 				AfterEach(func() {
 					if sgnpEnforced != nil {
-						Expect(cli.Delete(context.TODO(), sgnpEnforced)).ShouldNot(HaveOccurred())
+						Expect(ctrlclient.IgnoreNotFound(cli.Delete(context.TODO(), sgnpEnforced))).ShouldNot(HaveOccurred())
 						sgnpEnforced = nil
 					}
 					if sgnpPolicy != nil {
-						Expect(cli.Delete(context.TODO(), sgnpPolicy)).ShouldNot(HaveOccurred())
+						Expect(ctrlclient.IgnoreNotFound(cli.Delete(context.TODO(), sgnpPolicy))).ShouldNot(HaveOccurred())
 						sgnpPolicy = nil
 					}
 				})


### PR DESCRIPTION
## Summary

The three `enforcing staged-policies` tests (`StagedKubernetesNetworkPolicy`, `StagedNetworkPolicy`, `StagedGlobalNetworkPolicy`) were failing in `[AfterEach]` with:

```
Cannot delete a non-empty tier
operation delete is not supported on e2e-staged-tier-XXXXX: Cannot delete a non-empty tier
```

**Root cause:** In Ginkgo v2, `DeferCleanup` registered inside an `It` block runs *after* all `AfterEach` nodes. The tests used `DeferCleanup` to delete the staged and enforced policies, but the outer `AfterEach` deleted the tier first — while those policies were still inside it.

**Fix:** Promote policy variables to context scope and delete them in an inner `AfterEach` per context. Ginkgo runs inner `AfterEach` nodes before outer ones, so the policies are removed from the tier before the tier itself is deleted.

The actual staged policy enforcement was working correctly throughout — the failure was purely in test cleanup.

## Test plan

- [ ] Re-run the `[sig-calico] staged network policy enforcing staged-policies` tests and confirm all three `should enforce a deny policy` specs pass cleanly with no AfterEach errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)