### PR TITLE
Fix typo in BIRD socket connection log message

### DIFF
--- a/calicoctl/calicoctl/commands/node/status.go
+++ b/calicoctl/calicoctl/commands/node/status.go
@@ -222,7 +222,7 @@ func printBIRDPeers(ipv string) error {
 	if err != nil {
 		// If that fails, try connecting to bird socket in `/var/run/bird` (which is the
 		// default socket location for bird install) for non-containerized installs
-		log.Debugln("Failed to connect to BIRD socket in /var/run/calic, trying /var/run/bird")
+		log.Debugln("Failed to connect to BIRD socket in /var/run/calico, trying /var/run/bird")
 		c, err = net.Dial("unix", fmt.Sprintf("/var/run/bird/bird%s.ctl", birdSuffix))
 		if err != nil {
 			fmt.Printf("Error querying BIRD: unable to connect to BIRDv%s socket: %v", ipv, err)


### PR DESCRIPTION
Change "/var/run/calic" to "/var/run/calico" in debug log.
