### PR TITLE
feat(release): add release prep CLI command with structured output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ release/bin/release: $(shell find ./release -type f -name '*.go')
 
 # Prepare for a release (update version references, charts, manifests).
 release-prep: release/bin/release bin/gh
-	@release/bin/release release prep
+	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release prep
 
 # Install ghr for publishing to github.
 bin/ghr:
@@ -246,10 +246,11 @@ bin/ghr:
 
 # Install GitHub CLI
 bin/gh:
-	curl -sSL --retry 5 -o bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
-	tar -zxvf bin/gh.tgz -C bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh --strip-components=2
-	chmod +x $@
-	rm bin/gh.tgz
+	@mkdir -p bin
+	@curl -sSL --retry 5 -o bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
+	@tar -zxvf bin/gh.tgz -C bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh --strip-components=2
+	@chmod +x $@
+	@rm bin/gh.tgz
 
 # Build a release.
 release: release/bin/release

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,10 @@ e2e-run-cnp-test:
 release/bin/release: $(shell find ./release -type f -name '*.go')
 	$(MAKE) -C release
 
+# Prepare for a release (update version references, charts, manifests).
+release-prep: release/bin/release bin/gh
+	@release/bin/release release prep
+
 # Install ghr for publishing to github.
 bin/ghr:
 	$(DOCKER_RUN) -e GOBIN=/go/src/$(PACKAGE_NAME)/bin/ $(CALICO_BUILD) go install github.com/tcnksm/ghr@$(GHR_VERSION)
@@ -321,5 +325,5 @@ update-pins: update-go-build-pin update-calico-base-pin
 bin/gotestsum:
 	@GOBIN=$(REPO_ROOT)/bin go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
-postrelease-checks: release/bin/release bin/gotestsum
+postrelease-checks release-validate: release/bin/release bin/gotestsum
 	@release/bin/release release validate

--- a/release/RELEASING.md
+++ b/release/RELEASING.md
@@ -99,9 +99,12 @@ Once a new branch is cut, we need to ensure a new milestone exists to represent 
    ```
 
    This creates a `build-vX.Y.Z` branch, updates version references in charts and manifests,
-   runs `make generate`, and commits the changes. The version is auto-detected from git state.
+   runs `make generate`, generates release notes, and commits the changes.
+   The version is auto-detected from git state.
 
-1. Push the branch to `github.com/projectcalico/calico` and create a pull request. Get it reviewed and ensure it passes CI before moving to the next step.
+1. Review the generated release notes in `release-notes/<VERSION>-release-notes.md` for accuracy and format appropriately. Amend the commit if changes are needed.
+
+1. Get the PR reviewed and ensure it passes CI before moving to the next step.
 
 1. If this is the first release from this release branch i.e. `vX.Y.0`, create a new Calico X.Y.x PPA in launchpad
 

--- a/release/RELEASING.md
+++ b/release/RELEASING.md
@@ -13,7 +13,7 @@
     - [Setting up the branch](#setting-up-the-branch)
     - [Updating milestones for the new branch](#updating-milestones-for-the-new-branch)
   - [4. Performing a release](#4-performing-a-release)
-    - [4.a Create a temporary branch for this release against origin](#4a-create-a-temporary-branch-for-this-release-against-origin)
+    - [4.a Prepare the release branch](#4a-prepare-the-release-branch)
     - [4.b Build and publish the repository in Semaphore](#4b-build-and-publish-the-repository-in-semaphore)
     - [4.c Build and publish tigera/operator](#4c-build-and-publish-tigeraoperator)
     - [4.d Publish the release on Github](#4d-publish-the-release-on-github)
@@ -84,45 +84,22 @@ Once a new branch is cut, we need to ensure a new milestone exists to represent 
 
 ## 4. Performing a release
 
-### 4.a Create a temporary branch for this release against origin
+### 4.a Prepare the release branch
 
-1. Create a new branch `build-vX.Y.Z` based off of `release-vX.Y`.
+1. Checkout the release branch `release-vX.Y` and pull the latest changes.
 
    ```sh
    git checkout release-vX.Y && git pull origin release-vX.Y
    ```
 
-   ```sh
-   git checkout -b build-vX.Y.Z
-   ```
-
-1. Update version information in the following files:
-
-   - `charts/calico/values.yaml`: Calico version used in manifest generation.
-   - `charts/tigera-operator/values.yaml`: Versions of operator and calicoctl used in the helm chart and manifests.
-
-1. Update manifests (and other auto-generated code) by running the following command in the repository root.
+1. Run `make release-prep` to create a `build-vX.Y.Z` branch with updated charts, manifests, and release notes.
 
    ```sh
-   make generate
+   make release-prep
    ```
 
-1. Follow the steps in [writing release notes](#release-notes) to generate candidate release notes.
-
-   Then, add the newly created release note file to git.
-
-   ```sh
-   git add release-notes/<VERSION>-release-notes.md
-   ```
-
-   > [!TIP]
-   > You likely have a draft from [step 2.4](#2-verify-the-code-is-ready-for-release) that you can edit and finalize.
-
-1. Commit your changes. For example:
-
-   ```sh
-   git commit -m "build: vX.Y.Z release"
-   ```
+   This creates a `build-vX.Y.Z` branch, updates version references in charts and manifests,
+   runs `make generate`, and commits the changes. The version is auto-detected from git state.
 
 1. Push the branch to `github.com/projectcalico/calico` and create a pull request. Get it reviewed and ensure it passes CI before moving to the next step.
 

--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -49,7 +49,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				releaseBranchPrefixFlag,
 				devTagSuffixFlag,
 				operatorBranchFlag,
-				gitPublishFlag,
+				localFlag,
 				skipValidationFlag,
 			},
 			Action: func(_ context.Context, c *cli.Command) error {
@@ -73,7 +73,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					branch.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					branch.WithRepoManager(calicoManager),
 					branch.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					branch.WithPublish(c.Bool(gitPublishFlag.Name)))
+					branch.WithPublish(!c.Bool(localFlag.Name)))
 				return m.CutReleaseBranch()
 			},
 		},

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -82,13 +82,6 @@ var (
 		Sources: cli.EnvVars("DEV_TAG_SUFFIX"),
 		Value:   "0.dev",
 	}
-	gitPublishFlag = &cli.BoolFlag{
-		Name:    "git-publish",
-		Aliases: []string{"publish-git"},
-		Usage:   "Push git changes to remote. If false, all changes are local.",
-		Sources: cli.EnvVars("PUBLISH_GIT"),
-		Value:   true,
-	}
 	baseBranchFlag = &cli.StringFlag{
 		Name:    "base-branch",
 		Aliases: []string{"base", "main-branch"},
@@ -101,6 +94,16 @@ var (
 			}
 			return nil
 		},
+	}
+)
+
+// Mode flags control the execution mode of the release tool.
+var (
+	localFlag = &cli.BoolFlag{
+		Name:    "local",
+		Usage:   "Run all actions locally without remote changes",
+		Sources: cli.EnvVars("LOCAL"),
+		Value:   false,
 	}
 )
 

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -181,7 +181,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if c.String(orgFlag.Name) == utils.TigeraOrg {
 					logrus.Warn("Release notes are not supported for Tigera releases, skipping...")
 				} else {
-					if _, err := outputs.ReleaseNotes(utils.ProjectCalicoOrg, c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(hashrel.Source, releaseNotesDir), releaseVersion); err != nil {
+					if _, err := outputs.ReleaseNotes(utils.ProjectCalicoOrg, c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(hashrel.Source, outputs.ReleaseNotesDir), releaseVersion); err != nil {
 						return err
 					}
 				}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -268,7 +268,7 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			r := calico.NewManager(opts...)
 			prepErr := r.PrepareRelease()
 
-			// Write structured summary regardless of success/failure.
+			// Write structured summary for the PrepareRelease step.
 			summary := outputs.StepSummary{
 				Status:    "success",
 				Started:   started,

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -70,7 +70,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				// Generate the release notes.
-				filePath, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(cfg.RepoRootDir, releaseNotesDir), ver)
+				filePath, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, "", ver)
 				if err != nil {
 					return fmt.Errorf("failed to generate release notes: %w", err)
 				}
@@ -260,9 +260,8 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			}
 
 			// Generate release notes before prep so they're included in the commit.
-			releaseNotesPath := filepath.Join(cfg.RepoRootDir, releaseNotesDir)
-			if _, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, releaseNotesPath, ver); err != nil {
-				logrus.WithError(err).Warn("Failed to generate release notes — continuing with prep")
+			if _, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, "", ver); err != nil {
+				return fmt.Errorf("generate release notes: %w", err)
 			}
 
 			r := calico.NewManager(opts...)

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
 
+	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/pinnedversion"
 	"github.com/projectcalico/calico/release/internal/utils"
@@ -214,6 +215,24 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 	}
 }
 
+func determineOperatorReleaseVersion(c *cli.Command, tmpDir string) (string, error) {
+	// Clone the operator repository to determine the operator version.
+	operatorDir := filepath.Join(tmpDir, operator.DefaultRepoName)
+	if err := operator.Clone(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name), operatorDir); err != nil {
+		return "", fmt.Errorf("clone operator repository: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(operatorDir) }()
+	operatorGitVer, err := command.GitVersion(operatorDir, true)
+	if err != nil {
+		return "", fmt.Errorf("determine operator git version: %w", err)
+	}
+	operatorVer, err := version.DetermineReleaseVersion(version.New(operatorGitVer), operator.DefaultDevTagSuffix)
+	if err != nil {
+		return "", err
+	}
+	return operatorVer.FormattedString(), nil
+}
+
 func releasePrepCommand(cfg *Config) *cli.Command {
 	return &cli.Command{
 		Name:  "prep",
@@ -224,11 +243,16 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			repoRemoteFlag,
 			releaseBranchPrefixFlag,
 			devTagSuffixFlag,
+			operatorOrgFlag,
+			operatorRepoFlag,
+			operatorBranchFlag,
 			githubTokenFlag,
+			skipBranchCheckFlag,
 			skipValidationFlag,
 			localFlag,
 		},
 		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
+			// Determine the versions to use for the release.
 			ver, err := version.DetermineReleaseVersion(version.GitVersion(), c.String(devTagSuffixFlag.Name))
 			if err != nil {
 				return "", nil, err
@@ -236,35 +260,37 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			outs := map[string]any{
 				"version": ver.FormattedString(),
 			}
-			operatorVer, err := version.DetermineOperatorVersion(cfg.RepoRootDir)
+			operatorVer, err := determineOperatorReleaseVersion(c, cfg.TmpDir)
 			if err != nil {
-				return ver.FormattedString(), outs, err
+				return "", outs, err
 			}
-			outs["operator"] = operatorVer.FormattedString()
+			outs["operator"] = operatorVer
 
+			// Generate release notes
+			if _, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, "", ver); err != nil {
+				return ver.FormattedString(), outs, fmt.Errorf("generate release notes: %w", err)
+			}
+
+			// Prepare the release using the manager.
 			opts := []calico.Option{
 				calico.WithRepoRoot(cfg.RepoRootDir),
 				calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 				calico.WithVersion(ver.FormattedString()),
-				calico.WithOperatorVersion(operatorVer.FormattedString()),
+				calico.WithOperatorVersion(operatorVer),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 				calico.WithTmpDir(cfg.TmpDir),
 				calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-				calico.WithReleaseBranchValidation(!c.Bool(skipValidationFlag.Name)),
+				calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 				calico.WithPublishGitRef(!c.Bool(localFlag.Name)),
 			}
-
-			if _, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, "", ver); err != nil {
-				return ver.FormattedString(), outs, fmt.Errorf("generate release notes: %w", err)
-			}
-
 			r := calico.NewManager(opts...)
-			if err := r.PrepareRelease(); err != nil {
+			branch, err := r.PrepareRelease()
+			if err != nil {
 				return ver.FormattedString(), outs, err
 			}
-			outs["branch"] = fmt.Sprintf("build-%s", ver.FormattedString())
+			outs["branch"] = branch
 			return ver.FormattedString(), outs, nil
 		})),
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
@@ -51,6 +52,9 @@ func releaseCommand(cfg *Config) *cli.Command {
 
 func releaseSubCommands(cfg *Config) []*cli.Command {
 	return []*cli.Command{
+		// Prepare for a release.
+		releasePrepCommand(cfg),
+
 		// Build release notes prior to a release.
 		{
 			Name:  "generate-release-notes",
@@ -144,7 +148,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 					calico.WithPublishImages(c.Bool(publishImagesFlag.Name)),
-					calico.WithPublishGitTag(c.Bool(publishGitTagFlag.Name)),
+					calico.WithPublishGitRef(c.Bool(publishGitTagFlag.Name)),
 					calico.WithPublishGithubRelease(c.Bool(publishGitHubReleaseFlag.Name)),
 					calico.WithGithubToken(c.String(githubTokenFlag.Name)),
 					calico.WithPublishCharts(c.Bool(publishChartsFlag.Name)),
@@ -207,6 +211,82 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 			}
 			o := operator.NewManager(opOpts...)
 			return o.ReleasePublic()
+		},
+	}
+}
+
+func releasePrepCommand(cfg *Config) *cli.Command {
+	return &cli.Command{
+		Name:  "prep",
+		Usage: "Prepare for a Calico release",
+		Flags: []cli.Flag{
+			orgFlag,
+			repoFlag,
+			repoRemoteFlag,
+			releaseBranchPrefixFlag,
+			devTagSuffixFlag,
+			githubTokenFlag,
+			skipValidationFlag,
+			localFlag,
+		},
+		Action: func(_ context.Context, c *cli.Command) error {
+			configureLogging("release-prep.log")
+
+			started := time.Now()
+
+			// Determine the versions to use for the release.
+			ver, err := version.DetermineReleaseVersion(version.GitVersion(), c.String(devTagSuffixFlag.Name))
+			if err != nil {
+				return err
+			}
+			operatorVer, err := version.DetermineOperatorVersion(cfg.RepoRootDir)
+			if err != nil {
+				return err
+			}
+
+			// Configure the manager.
+			opts := []calico.Option{
+				calico.WithRepoRoot(cfg.RepoRootDir),
+				calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
+				calico.WithVersion(ver.FormattedString()),
+				calico.WithOperatorVersion(operatorVer.FormattedString()),
+				calico.WithGithubOrg(c.String(orgFlag.Name)),
+				calico.WithRepoName(c.String(repoFlag.Name)),
+				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
+				calico.WithTmpDir(cfg.TmpDir),
+				calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+				calico.WithReleaseBranchValidation(!c.Bool(skipValidationFlag.Name)),
+				calico.WithPublishGitRef(!c.Bool(localFlag.Name)),
+			}
+
+			// Generate release notes before prep so they're included in the commit.
+			releaseNotesPath := filepath.Join(cfg.RepoRootDir, releaseNotesDir)
+			if _, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, releaseNotesPath, ver); err != nil {
+				logrus.WithError(err).Warn("Failed to generate release notes — continuing with prep")
+			}
+
+			r := calico.NewManager(opts...)
+			prepErr := r.PrepareRelease()
+
+			// Write structured summary regardless of success/failure.
+			summary := outputs.StepSummary{
+				Status:    "success",
+				Started:   started,
+				Completed: time.Now(),
+				Outputs: map[string]any{
+					"branch":   fmt.Sprintf("build-%s", ver.FormattedString()),
+					"operator": operatorVer.FormattedString(),
+				},
+			}
+			if prepErr != nil {
+				summary.Status = "failure"
+			}
+			outputDir := outputs.SummaryOutputDir(cfg.RepoRootDir)
+			if err := outputs.WriteSummary(outputDir, ver.FormattedString(), "release-prep", summary); err != nil {
+				logrus.WithError(err).Warn("Failed to write summary file")
+			}
+
+			return prepErr
 		},
 	}
 }

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
@@ -229,22 +228,20 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			skipValidationFlag,
 			localFlag,
 		},
-		Action: func(_ context.Context, c *cli.Command) error {
-			configureLogging("release-prep.log")
-
-			started := time.Now()
-
-			// Determine the versions to use for the release.
+		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
 			ver, err := version.DetermineReleaseVersion(version.GitVersion(), c.String(devTagSuffixFlag.Name))
 			if err != nil {
-				return err
+				return "", nil, err
+			}
+			outs := map[string]any{
+				"version": ver.FormattedString(),
 			}
 			operatorVer, err := version.DetermineOperatorVersion(cfg.RepoRootDir)
 			if err != nil {
-				return err
+				return ver.FormattedString(), outs, err
 			}
+			outs["operator"] = operatorVer.FormattedString()
 
-			// Configure the manager.
 			opts := []calico.Option{
 				calico.WithRepoRoot(cfg.RepoRootDir),
 				calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
@@ -259,34 +256,17 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithPublishGitRef(!c.Bool(localFlag.Name)),
 			}
 
-			// Generate release notes before prep so they're included in the commit.
 			if _, err := outputs.ReleaseNotes(c.String(orgFlag.Name), c.String(githubTokenFlag.Name), cfg.RepoRootDir, "", ver); err != nil {
-				return fmt.Errorf("generate release notes: %w", err)
+				return ver.FormattedString(), outs, fmt.Errorf("generate release notes: %w", err)
 			}
 
 			r := calico.NewManager(opts...)
-			prepErr := r.PrepareRelease()
-
-			// Write structured summary for the PrepareRelease step.
-			summary := outputs.StepSummary{
-				Status:    "success",
-				Started:   started,
-				Completed: time.Now(),
-				Outputs: map[string]any{
-					"branch":   fmt.Sprintf("build-%s", ver.FormattedString()),
-					"operator": operatorVer.FormattedString(),
-				},
+			if err := r.PrepareRelease(); err != nil {
+				return ver.FormattedString(), outs, err
 			}
-			if prepErr != nil {
-				summary.Status = "failure"
-			}
-			outputDir := outputs.SummaryOutputDir(cfg.RepoRootDir)
-			if err := outputs.WriteSummary(outputDir, ver.FormattedString(), "release-prep", summary); err != nil {
-				logrus.WithError(err).Warn("Failed to write summary file")
-			}
-
-			return prepErr
-		},
+			outs["branch"] = fmt.Sprintf("build-%s", ver.FormattedString())
+			return ver.FormattedString(), outs, nil
+		})),
 	}
 }
 

--- a/release/cmd/shared.go
+++ b/release/cmd/shared.go
@@ -32,9 +32,6 @@ var (
 	// debug controls whether or not to emit debug level logging.
 	debug bool
 
-	// releaseNotesDir is the directory where release notes are stored
-	releaseNotesDir = "release-notes"
-
 	// releaseOutputPath is the directory where all outputs are stored
 	// relative to the repo root
 	releaseOutputPath = []string{utils.ReleaseFolderName, "_output"}
@@ -48,7 +45,6 @@ func logPrettifier(f *runtime.Frame) (string, string) {
 
 // configureLogging sets up logging to both stdout and a file.
 func configureLogging(filename string) {
-
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/release/cmd/shared.go
+++ b/release/cmd/shared.go
@@ -15,15 +15,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/snowzach/rotatefilehook"
 	cli "github.com/urfave/cli/v3"
 
+	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/slack"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
@@ -71,6 +74,51 @@ func configureLogging(filename string) {
 	}
 
 	logrus.AddHook(rotateFileHook)
+}
+
+// withLogging wraps a cli.ActionFunc with automatic log file configuration
+// derived from the command's full name (e.g. "release prep" -> "release-prep.log").
+func withLogging(action cli.ActionFunc) cli.ActionFunc {
+	return func(ctx context.Context, c *cli.Command) error {
+		cmdName := strings.TrimSpace(strings.TrimPrefix(c.FullName(), c.Root().Name))
+		logFileName := strings.ReplaceAll(cmdName, " ", "-") + ".log"
+		configureLogging(logFileName)
+		return action(ctx, c)
+	}
+}
+
+// SummaryAction is a command action that returns a version string,
+// structured outputs, and an error. The version identifies the summary
+// file path. Outputs are included in the summary YAML.
+type SummaryAction func(context.Context, *cli.Command) (string, map[string]any, error)
+
+// withSummary wraps a SummaryAction with timing, status, and summary file
+// emission. The step name identifies the summary file (e.g. "release-prep").
+// Summary write failures are logged but never mask the action error.
+func withSummary(cfg *Config, step string, action SummaryAction) cli.ActionFunc {
+	return func(ctx context.Context, c *cli.Command) error {
+		started := time.Now()
+		ver, outputsMap, actionErr := action(ctx, c)
+
+		status := "success"
+		if actionErr != nil {
+			status = "failure"
+		}
+		if ver == "" {
+			ver = "unknown"
+		}
+		summary := outputs.StepSummary{
+			Status:    status,
+			Started:   started,
+			Completed: time.Now(),
+			Outputs:   outputsMap,
+		}
+		outputDir := outputs.SummaryOutputDir(cfg.RepoRootDir)
+		if err := outputs.WriteSummary(outputDir, ver, step, summary); err != nil {
+			logrus.WithError(err).Warn("Failed to write summary file")
+		}
+		return actionErr
+	}
 }
 
 // slackConfig returns a config for slack based on the CLI context.

--- a/release/internal/outputs/releasenotes.go
+++ b/release/internal/outputs/releasenotes.go
@@ -33,6 +33,8 @@ import (
 	"github.com/projectcalico/calico/release/internal/version"
 )
 
+const ReleaseNotesDir = "release-notes"
+
 const (
 	releaseNoteRequiredLabel = "release-note-required"
 	closedState              = issueState("closed")
@@ -194,10 +196,13 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 	if githubToken == "" {
 		return "", fmt.Errorf("github token not set, set GITHUB_TOKEN environment variable")
 	}
-	if outputDir == "" {
-		logrus.Warn("No directory is set, using current directory")
-		outputDir = "."
+	if outputDir == "" && repoRootDir == "" {
+		return "", fmt.Errorf("either outputDir or repoRootDir must be set")
 	}
+	if outputDir == "" {
+		outputDir = releaseNoteDirPath(repoRootDir)
+	}
+
 	logrus.Infof("Generating release notes for %s", ver.FormattedString())
 	milestone := ver.Milestone(utils.ProductName)
 	githubClient := github.NewTokenClient(context.Background(), githubToken)
@@ -249,10 +254,22 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 	if len(releaseNoteDataList) == 0 {
 		logrus.WithField("milestone", milestone).Warn("No closed issues requiring release notes found in milestone")
 	}
-	releaseNoteFilePath := filepath.Join(outputDir, fmt.Sprintf("%s-release-notes.md", ver.FormattedString()))
+	releaseNoteFilePath := releaseNoteFilePathFromDir(outputDir, ver.FormattedString())
 	if err := outputReleaseNotes(releaseNoteDataList, releaseNoteFilePath); err != nil {
 		logrus.WithError(err).Error("Failed to output release notes")
 		return "", err
 	}
 	return releaseNoteFilePath, nil
+}
+
+func releaseNoteDirPath(rootDir string) string {
+	return filepath.Join(rootDir, ReleaseNotesDir)
+}
+
+func releaseNoteFilePathFromDir(dir, version string) string {
+	return filepath.Join(dir, fmt.Sprintf("%s-release-notes.md", version))
+}
+
+func ReleaseNoteFilePath(repoRootDir, version string) string {
+	return releaseNoteFilePathFromDir(releaseNoteDirPath(repoRootDir), version)
 }

--- a/release/internal/outputs/releasenotes.go
+++ b/release/internal/outputs/releasenotes.go
@@ -202,6 +202,10 @@ func ReleaseNotes(owner, githubToken, repoRootDir, outputDir string, ver version
 	if outputDir == "" {
 		outputDir = releaseNoteDirPath(repoRootDir)
 	}
+	if owner != utils.ProjectCalicoOrg {
+		logrus.WithField("org", owner).Warnf("generating release notes outside of %s GitHub organization is not supported, switching back to %s", utils.ProjectCalicoOrg, utils.ProjectCalicoOrg)
+		owner = utils.ProjectCalicoOrg
+	}
 
 	logrus.Infof("Generating release notes for %s", ver.FormattedString())
 	milestone := ver.Milestone(utils.ProductName)

--- a/release/internal/outputs/summary.go
+++ b/release/internal/outputs/summary.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// StepSummary represents structured output for a release step.
+// It is written to <baseDir>/summary/<version>/<step>.yaml after each release step.
+type StepSummary struct {
+	Status    string         `yaml:"status"`
+	Started   time.Time      `yaml:"started"`
+	Completed time.Time      `yaml:"completed"`
+	Outputs   map[string]any `yaml:"outputs,omitempty"`
+}
+
+// SummaryOutputDir returns the base output directory for step summaries
+// within the given repo root.
+func SummaryOutputDir(repoRootDir string) string {
+	return filepath.Join(repoRootDir, "release", "_output")
+}
+
+// WriteSummary writes a summary YAML file to <baseDir>/summary/<version>/<step>.yaml.
+// Errors are returned but callers should log and continue — summary failure should not
+// block the release.
+func WriteSummary(baseDir, version, step string, s StepSummary) error {
+	dir := filepath.Join(baseDir, "summary", version)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating output dir: %w", err)
+	}
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshaling summary: %w", err)
+	}
+	return os.WriteFile(filepath.Join(dir, step+".yaml"), data, 0o644)
+}

--- a/release/internal/outputs/summary_test.go
+++ b/release/internal/outputs/summary_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestWriteSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	started := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	completed := time.Date(2026, 1, 15, 10, 5, 0, 0, time.UTC)
+
+	s := StepSummary{
+		Status:    "success",
+		Started:   started,
+		Completed: completed,
+		Outputs: map[string]any{
+			"branch": "build-v3.32.0",
+		},
+	}
+
+	if err := WriteSummary(tmpDir, "v3.32.0", "release-prep", s); err != nil {
+		t.Fatalf("WriteSummary() error = %v", err)
+	}
+
+	outPath := filepath.Join(tmpDir, "summary", "v3.32.0", "release-prep.yaml")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed to read summary file: %v", err)
+	}
+
+	var got StepSummary
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal summary: %v", err)
+	}
+
+	if got.Status != s.Status {
+		t.Errorf("Status = %q, want %q", got.Status, s.Status)
+	}
+	if got.Outputs["branch"] != s.Outputs["branch"] {
+		t.Errorf("Outputs[branch] = %v, want %v", got.Outputs["branch"], s.Outputs["branch"])
+	}
+}
+
+func TestWriteSummary_CreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseDir := filepath.Join(tmpDir, "nested", "_output")
+
+	s := StepSummary{
+		Status: "success",
+	}
+
+	if err := WriteSummary(baseDir, "v3.32.0", "release-prep", s); err != nil {
+		t.Fatalf("WriteSummary() error = %v", err)
+	}
+
+	outPath := filepath.Join(baseDir, "summary", "v3.32.0", "release-prep.yaml")
+	if _, err := os.Stat(outPath); os.IsNotExist(err) {
+		t.Error("expected summary file to be created")
+	}
+}
+
+func TestWriteSummary_FailureStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	s := StepSummary{
+		Status: "failure",
+	}
+
+	if err := WriteSummary(tmpDir, "v3.32.0", "release-prep", s); err != nil {
+		t.Fatalf("WriteSummary() error = %v", err)
+	}
+
+	outPath := filepath.Join(tmpDir, "summary", "v3.32.0", "release-prep.yaml")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed to read summary file: %v", err)
+	}
+
+	var got StepSummary
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal summary: %v", err)
+	}
+
+	if got.Status != "failure" {
+		t.Errorf("Status = %q, want %q", got.Status, "failure")
+	}
+}
+
+func TestWriteSummary_OmitsEmptyOutputs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	s := StepSummary{
+		Status: "success",
+	}
+
+	if err := WriteSummary(tmpDir, "v3.32.0", "release-prep", s); err != nil {
+		t.Fatalf("WriteSummary() error = %v", err)
+	}
+
+	outPath := filepath.Join(tmpDir, "summary", "v3.32.0", "release-prep.yaml")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed to read summary file: %v", err)
+	}
+
+	var m map[string]any
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if _, ok := m["outputs"]; ok {
+		t.Error("expected 'outputs' to be omitted when empty")
+	}
+}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -492,6 +492,16 @@ func (r *CalicoManager) TagRelease(ver string) error {
 // modifyHelmChartsValues modifies values in helm charts to use the correct version.
 // This is only necessary for hashreleases or new branch cut.
 func (r *CalicoManager) modifyHelmChartsValues() error {
+	if err := r.modifyOperatorChartValues(); err != nil {
+		return err
+	}
+	if err := r.modifyCalicoChartsValues(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CalicoManager) modifyOperatorChartValues() error {
 	operatorChartFilePath := filepath.Join(r.repoRoot, "charts", "tigera-operator", "values.yaml")
 	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.operatorVersion), operatorChartFilePath}, nil); err != nil {
 		logrus.WithError(err).Errorf("Failed to update operator version in %s", operatorChartFilePath)
@@ -500,6 +510,15 @@ func (r *CalicoManager) modifyHelmChartsValues() error {
 	if _, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/tag: .*/tag: %s/g`, r.calicoVersion), operatorChartFilePath}, nil); err != nil {
 		logrus.WithError(err).Errorf("Failed to update calicoctl version in %s", operatorChartFilePath)
 		return fmt.Errorf("failed to update calicoctl version in %s: %w", operatorChartFilePath, err)
+	}
+	return nil
+}
+
+func (r *CalicoManager) modifyCalicoChartsValues() error {
+	calicoChartFilePath := filepath.Join(r.repoRoot, "charts", "calico", "values.yaml")
+	if out, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, r.calicoVersion), calicoChartFilePath}, nil); err != nil {
+		logrus.Error(out)
+		return fmt.Errorf("failed to update version in %s: %w", calicoChartFilePath, err)
 	}
 	return nil
 }
@@ -1503,11 +1522,6 @@ func (r *CalicoManager) SetupReleaseBranch(branch string) error {
 		"calico_version":   r.calicoVersion,
 		"operator_version": r.operatorVersion,
 	}).Debug("Updating versions in helm charts to release branches")
-	calicoChartFilePath := filepath.Join(r.repoRoot, "charts", "calico", "values.yaml")
-	if out, err := r.runner.Run("sed", []string{"-i", fmt.Sprintf(`s/version: .*/version: %s/g`, branch), calicoChartFilePath}, nil); err != nil {
-		logrus.Error(out)
-		return fmt.Errorf("failed to update version in %s: %w", calicoChartFilePath, err)
-	}
 	if err := r.modifyHelmChartsValues(); err != nil {
 		return err
 	}
@@ -1583,10 +1597,10 @@ func (r *CalicoManager) prepareReleaseCleanup(baseBranch, prepBranch string) {
 // PrepareRelease performs release preparation for Calico.
 // It validates the repo state, creates a build branch, updates version references
 // in charts and manifests, and commits the changes.
-// If publishGitRef is true, the branch is pushed to the remote.
-func (r *CalicoManager) PrepareRelease() error {
+// If publishTag is true, the branch is pushed to the remote.
+func (r *CalicoManager) PrepareRelease() (string, error) {
 	if err := r.prepPrereqs(); err != nil {
-		return err
+		return "", err
 	}
 
 	ver := version.New(r.calicoVersion)
@@ -1601,14 +1615,14 @@ func (r *CalicoManager) PrepareRelease() error {
 	defer r.prepareReleaseCleanup(baseBranch, prepBranch)
 
 	if err := r.switchToPrepBranch(prepBranch); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := r.updateAndCommitPrep(); err != nil {
-		return err
+		return "", err
 	}
 
-	return r.pushPrepBranch(baseBranch, prepBranch)
+	return prepBranch, r.pushPrepBranch(baseBranch, prepBranch)
 }
 
 // switchToPrepBranch records the current branch for cleanup, then creates
@@ -1637,7 +1651,7 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 	); err != nil {
 		return fmt.Errorf("failed to stage files: %w", err)
 	}
-	if _, err := r.git("commit", "-m", fmt.Sprintf("Prepare release %s", r.calicoVersion)); err != nil {
+	if _, err := r.git("commit", "-m", fmt.Sprintf("build: %s release", r.calicoVersion)); err != nil {
 		return fmt.Errorf("failed to commit changes: %w", err)
 	}
 	return nil
@@ -1646,8 +1660,8 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 // pushPrepBranch pushes the prep branch to remote and creates a PR if not in local mode.
 func (r *CalicoManager) pushPrepBranch(baseBranch, prepBranch string) error {
 	if !r.publishGitRef {
-		logrus.WithField("branch", prepBranch).Info("Local mode: skipping push and PR creation")
-		return nil
+		logrus.WithField("branch", prepBranch).Warn("Local mode: skipping branch push and PR creation")
+		return r.switchToBaseBranch(baseBranch)
 	}
 
 	if _, err := r.git("push", "--force-with-lease", r.remote, prepBranch); err != nil {
@@ -1696,7 +1710,6 @@ func (r *CalicoManager) switchToBaseBranch(baseBranch string) error {
 		logrus.Error(out)
 		return fmt.Errorf("failed to switch back to base branch %s: %w", baseBranch, err)
 	}
-	logrus.WithField("baseBranch", baseBranch).Info("Switched back to base branch after PR creation")
 	return nil
 }
 
@@ -1720,6 +1733,8 @@ func (r *CalicoManager) prepPrereqs() error {
 			return fmt.Errorf("failed to determine current git branch: %w", err)
 		} else if branch == defaultBranch {
 			return fmt.Errorf("cannot cut release from branch: %s", branch)
+		} else if r.publishGitRef && !strings.HasPrefix(branch, r.releaseBranchPrefix) {
+			return fmt.Errorf("current branch is %s, expected to be a release branch with prefix %s. Please switch to the appropriate release branch to cut the release", branch, r.releaseBranchPrefix)
 		}
 	}
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -52,6 +52,10 @@ var (
 		"cni-plugin",
 	}
 
+	defaultOrg    = utils.ProjectCalicoOrg
+	defaultRepo   = utils.CalicoRepoName
+	defaultBranch = utils.DefaultBranch
+
 	metadataFileName = "metadata.yaml"
 
 	helmIndexFileName = "index.yaml"
@@ -70,7 +74,7 @@ func NewManager(opts ...Option) *CalicoManager {
 		publishImages:     true,
 		publishCharts:     true,
 		archiveImages:     true,
-		publishTag:        true,
+		publishGitRef:     true,
 		publishGithub:     true,
 		imageRegistries:   defaultRegistries,
 		helmRegistries:    registry.DefaultHelmRegistries,
@@ -158,7 +162,7 @@ type CalicoManager struct {
 	// Fine-tuning configuration for publishing.
 	publishImages bool
 	publishCharts bool
-	publishTag    bool
+	publishGitRef bool
 	publishGithub bool
 	awsProfile    string
 	s3Bucket      string
@@ -697,12 +701,12 @@ func (r *CalicoManager) releasePrereqs() error {
 	// Check that we're not on the master branch. We never cut releases from master.
 	if branch, err := r.determineBranch(); err != nil {
 		return fmt.Errorf("failed to determine branch: %s", err)
-	} else if branch == "master" {
+	} else if branch == defaultBranch {
 		return fmt.Errorf("cannot cut release from branch: %s", branch)
 	}
 
 	// If we are releasing to projectcalico/calico, make sure we are releasing to the default registries.
-	if r.githubOrg == utils.ProjectCalicoOrg && r.repo == utils.CalicoRepoName {
+	if r.githubOrg == defaultOrg && r.repo == defaultRepo {
 		if !reflect.DeepEqual(r.imageRegistries, defaultRegistries) {
 			return fmt.Errorf("image registries cannot be different from default registries for a release")
 		}
@@ -1165,7 +1169,7 @@ func (r *CalicoManager) buildContainerImages() error {
 }
 
 func (r *CalicoManager) publishGitTag() error {
-	if !r.publishTag {
+	if !r.publishGitRef {
 		logrus.Info("Skipping git tag")
 		return nil
 	}
@@ -1554,6 +1558,162 @@ func (r *CalicoManager) SetupReleaseBranch(branch string) error {
 	if out, err := r.git("commit", "-m", fmt.Sprintf("Updates for %s release branch", branch)); err != nil {
 		logrus.Error(out)
 		return fmt.Errorf("failed to commit changes: %s", err)
+	}
+
+	return nil
+}
+
+// PrepareRelease performs release preparation for Calico.
+// It validates the repo state, creates a build branch, updates version references
+// in charts and manifests, and commits the changes.
+// If publishGitRef is true, the branch is pushed to the remote.
+func (r *CalicoManager) PrepareRelease() error {
+	if err := r.prepPrereqs(); err != nil {
+		return err
+	}
+
+	ver := version.New(r.calicoVersion)
+	baseBranch, err := r.determineBranch()
+	if err != nil {
+		logrus.WithError(err).Error("Failed to determine current branch, will use default branch for release preparation")
+		baseBranch = fmt.Sprintf("%s-%s", r.releaseBranchPrefix, ver.Stream())
+		logrus.WithField("baseBranch", baseBranch).Info("Using default branch for release preparation")
+	}
+
+	defer func() {
+		if _, err := r.git("switch", "-f", baseBranch); err != nil {
+			logrus.WithError(err).Errorf("Failed to reset to %q branch", baseBranch)
+		}
+	}()
+
+	prepBranch := fmt.Sprintf("build-%s", ver)
+
+	if err := r.switchToPrepBranch(prepBranch); err != nil {
+		return err
+	}
+
+	if err := r.updateAndCommitPrep(); err != nil {
+		return err
+	}
+
+	return r.pushPrepBranch(baseBranch, prepBranch)
+}
+
+// switchToPrepBranch records the current branch for cleanup, then creates
+// and switches to the prep branch. Safe to re-run (force-creates).
+func (r *CalicoManager) switchToPrepBranch(prepBranch string) error {
+	if out, err := r.git("switch", "-C", prepBranch); err != nil {
+		logrus.Error(out)
+		return fmt.Errorf("create branch %s: %w", prepBranch, err)
+	}
+	return nil
+}
+
+// updateAndCommitPrep updates charts and manifests, then stages and commits.
+func (r *CalicoManager) updateAndCommitPrep() error {
+	if err := r.modifyHelmChartsValues(); err != nil {
+		return fmt.Errorf("failed to update chart versions: %w", err)
+	}
+	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "generate"); err != nil {
+		return fmt.Errorf("failed to run make generate: %w", err)
+	}
+
+	if _, err := r.git("add",
+		filepath.Join(r.repoRoot, "charts"),
+		filepath.Join(r.repoRoot, "manifests"),
+		filepath.Join(r.repoRoot, "release-notes"),
+	); err != nil {
+		return fmt.Errorf("failed to stage files: %w", err)
+	}
+	if _, err := r.git("commit", "-m", fmt.Sprintf("Prepare release %s", r.calicoVersion)); err != nil {
+		return fmt.Errorf("failed to commit changes: %w", err)
+	}
+	return nil
+}
+
+// pushPrepBranch pushes the prep branch to remote and creates a PR if not in local mode.
+// Calls the cleanup function to return to the base branch.
+func (r *CalicoManager) pushPrepBranch(baseBranch, prepBranch string) error {
+	if !r.publishGitRef {
+		logrus.WithField("branch", prepBranch).Info("Local mode: skipping push and PR creation")
+		return nil
+	}
+
+	if _, err := r.git("push", "--force-with-lease", r.remote, prepBranch); err != nil {
+		return fmt.Errorf("failed to push %q branch: %w", prepBranch, err)
+	}
+	logrus.WithField("branch", prepBranch).Info("Pushed preparation branch to remote")
+
+	return r.createPrepPR(baseBranch, prepBranch)
+}
+
+// createPrepPR creates a pull request for the prep branch.
+func (r *CalicoManager) createPrepPR(baseBranch, prepBranch string) error {
+	out, err := r.git("config", "--get", "remote.origin.url")
+	if err != nil {
+		return fmt.Errorf("failed to get remote origin url: %s", err)
+	}
+	owner := strings.Split(out[strings.Index(out, "git@github.com:")+len("git@github.com:"):strings.LastIndex(out, ".git")], "/")[0]
+	args := []string{
+		"pr", "create", "--fill",
+		"--repo", fmt.Sprintf("%s/%s", r.githubOrg, r.repo),
+		"--base", baseBranch,
+	}
+
+	if owner != r.githubOrg {
+		args = append(args, "--head", fmt.Sprintf("%s:%s", owner, prepBranch))
+	} else {
+		args = append(args, "--head", prepBranch)
+	}
+	if r.githubOrg == defaultOrg && r.repo == defaultRepo {
+		args = append(args, []string{
+			"--reviewer", fmt.Sprintf("%s/release-team", r.githubOrg),
+			"--label", "release-note-not-required,docs-not-required",
+		}...)
+	}
+	logrus.WithField("args", args).Debug("Creating PR for release preparation")
+	pr, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", args, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			logrus.Warnf("PR already exists, skipping creation. Find PR at: https://github.com/%s/%s/pulls?q=is%%3Aopen+head%%3A%s", r.githubOrg, r.repo, prepBranch)
+			return nil
+		}
+		logrus.WithError(err).Error("Failed to create PR for release preparation")
+		return fmt.Errorf("failed to create PR: %s", err)
+	}
+	logrus.WithField("PR", strings.TrimSpace(pr)).Info("Created PR for release preparation")
+	return nil
+}
+
+// prepPrereqs validates that the repo is in a suitable state for release preparation.
+func (r *CalicoManager) prepPrereqs() error {
+	if !r.validate {
+		logrus.Warn("Skipping release preparation validation")
+		return nil
+	}
+
+	// Check that the git repo is clean.
+	if dirty, err := utils.GitIsDirty(r.repoRoot); dirty || err != nil {
+		return fmt.Errorf("there are uncommitted changes in the repository, please commit or stash them before preparing the release")
+	}
+
+	// Check that we're not on the default branch (master). We never prep releases from the default branch.
+	if r.validateBranch {
+		if branch, err := r.determineBranch(); err != nil {
+			return fmt.Errorf("failed to determine current git branch: %w", err)
+		} else if branch == defaultBranch {
+			return fmt.Errorf("cannot cut release from branch: %s", branch)
+		}
+	}
+
+	// Check that the versions are release version.
+	versionRegex := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	if !versionRegex.MatchString(r.operatorVersion) {
+		return fmt.Errorf("operator version (%s) is not a release version", r.operatorVersion)
+	}
+	versionRegex = regexp.MustCompile(`^v\d+\.\d+\.\d+(-\d+.\d+)?$`)
+	if !versionRegex.MatchString(r.calicoVersion) {
+		return fmt.Errorf("version (%s) is not a release version", r.calicoVersion)
 	}
 
 	return nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
 	"github.com/projectcalico/calico/release/internal/imagescanner"
+	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
@@ -1351,7 +1352,7 @@ func (r *CalicoManager) updateHelmChartIndex() error {
 func (r *CalicoManager) assertReleaseNotesPresent(ver string) error {
 	// Validate that the release notes for this version are present,
 	// fail if not.
-	releaseNotesPath := filepath.Join(r.repoRoot, "release-notes", fmt.Sprintf("%s-release-notes.md", ver))
+	releaseNotesPath := outputs.ReleaseNoteFilePath(r.repoRoot, ver)
 	releaseNotesStat, err := os.Stat(releaseNotesPath)
 	if err != nil {
 		return fmt.Errorf("release notes file is invalid: %s", err.Error())
@@ -1563,6 +1564,22 @@ func (r *CalicoManager) SetupReleaseBranch(branch string) error {
 	return nil
 }
 
+func (r *CalicoManager) prepareReleaseCleanup(baseBranch, prepBranch string) {
+	curr, err := r.determineBranch()
+	if err != nil {
+		logrus.WithError(err).Error("Failed to determine current branch during cleanup")
+		return
+	}
+	if curr == baseBranch {
+		return
+	}
+	if curr == prepBranch {
+		logrus.Warnf("An error occurred while preparing the %s release, investigate the issue and fix if necessary.\nTo re-run the release preparation, use the following command:\n\n\tgit switch -f %s", prepBranch, baseBranch)
+		return
+	}
+	logrus.WithField("branch", curr).Warn("Unexpected branch during release preparation cleanup, expected to be on base or prep branch")
+}
+
 // PrepareRelease performs release preparation for Calico.
 // It validates the repo state, creates a build branch, updates version references
 // in charts and manifests, and commits the changes.
@@ -1579,14 +1596,9 @@ func (r *CalicoManager) PrepareRelease() error {
 		baseBranch = fmt.Sprintf("%s-%s", r.releaseBranchPrefix, ver.Stream())
 		logrus.WithField("baseBranch", baseBranch).Info("Using default branch for release preparation")
 	}
-
-	defer func() {
-		if _, err := r.git("switch", "-f", baseBranch); err != nil {
-			logrus.WithError(err).Errorf("Failed to reset to %q branch", baseBranch)
-		}
-	}()
-
 	prepBranch := fmt.Sprintf("build-%s", ver)
+
+	defer r.prepareReleaseCleanup(baseBranch, prepBranch)
 
 	if err := r.switchToPrepBranch(prepBranch); err != nil {
 		return err
@@ -1621,7 +1633,7 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 	if _, err := r.git("add",
 		filepath.Join(r.repoRoot, "charts"),
 		filepath.Join(r.repoRoot, "manifests"),
-		filepath.Join(r.repoRoot, "release-notes"),
+		filepath.Join(r.repoRoot, outputs.ReleaseNotesDir),
 	); err != nil {
 		return fmt.Errorf("failed to stage files: %w", err)
 	}
@@ -1632,7 +1644,6 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 }
 
 // pushPrepBranch pushes the prep branch to remote and creates a PR if not in local mode.
-// Calls the cleanup function to return to the base branch.
 func (r *CalicoManager) pushPrepBranch(baseBranch, prepBranch string) error {
 	if !r.publishGitRef {
 		logrus.WithField("branch", prepBranch).Info("Local mode: skipping push and PR creation")
@@ -1649,21 +1660,11 @@ func (r *CalicoManager) pushPrepBranch(baseBranch, prepBranch string) error {
 
 // createPrepPR creates a pull request for the prep branch.
 func (r *CalicoManager) createPrepPR(baseBranch, prepBranch string) error {
-	out, err := r.git("config", "--get", "remote.origin.url")
-	if err != nil {
-		return fmt.Errorf("failed to get remote origin url: %s", err)
-	}
-	owner := strings.Split(out[strings.Index(out, "git@github.com:")+len("git@github.com:"):strings.LastIndex(out, ".git")], "/")[0]
 	args := []string{
 		"pr", "create", "--fill",
 		"--repo", fmt.Sprintf("%s/%s", r.githubOrg, r.repo),
 		"--base", baseBranch,
-	}
-
-	if owner != r.githubOrg {
-		args = append(args, "--head", fmt.Sprintf("%s:%s", owner, prepBranch))
-	} else {
-		args = append(args, "--head", prepBranch)
+		"--head", prepBranch,
 	}
 	if r.githubOrg == defaultOrg && r.repo == defaultRepo {
 		args = append(args, []string{
@@ -1675,13 +1676,27 @@ func (r *CalicoManager) createPrepPR(baseBranch, prepBranch string) error {
 	pr, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", args, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			logrus.Warnf("PR already exists, skipping creation. Find PR at: https://github.com/%s/%s/pulls?q=is%%3Aopen+head%%3A%s", r.githubOrg, r.repo, prepBranch)
-			return nil
+			if m := regexp.MustCompile(`https://github\.com/\S+/pull/\d+`).FindString(err.Error()); m != "" {
+				pr = m
+			} else {
+				pr = fmt.Sprintf("https://github.com/%s/%s/pulls?q=is%%3Aopen+head%%3A%s", r.githubOrg, r.repo, prepBranch)
+			}
+			logrus.Warnf("PR already exists, skipping creation. Find PR at: %s", pr)
+			return r.switchToBaseBranch(baseBranch)
 		}
 		logrus.WithError(err).Error("Failed to create PR for release preparation")
 		return fmt.Errorf("failed to create PR: %s", err)
 	}
 	logrus.WithField("PR", strings.TrimSpace(pr)).Info("Created PR for release preparation")
+	return r.switchToBaseBranch(baseBranch)
+}
+
+func (r *CalicoManager) switchToBaseBranch(baseBranch string) error {
+	if out, err := r.git("switch", "-f", baseBranch); err != nil {
+		logrus.Error(out)
+		return fmt.Errorf("failed to switch back to base branch %s: %w", baseBranch, err)
+	}
+	logrus.WithField("baseBranch", baseBranch).Info("Switched back to base branch after PR creation")
 	return nil
 }
 
@@ -1693,7 +1708,9 @@ func (r *CalicoManager) prepPrereqs() error {
 	}
 
 	// Check that the git repo is clean.
-	if dirty, err := utils.GitIsDirty(r.repoRoot); dirty || err != nil {
+	if dirty, err := utils.GitIsDirty(r.repoRoot); err != nil {
+		return fmt.Errorf("failed to check if git repo is clean: %w", err)
+	} else if dirty {
 		return fmt.Errorf("there are uncommitted changes in the repository, please commit or stash them before preparing the release")
 	}
 
@@ -1704,6 +1721,22 @@ func (r *CalicoManager) prepPrereqs() error {
 		} else if branch == defaultBranch {
 			return fmt.Errorf("cannot cut release from branch: %s", branch)
 		}
+	}
+
+	// If publishing, check that we are not on a fork branch. We want to ensure releases are always cut from the main repo
+	if r.publishGitRef {
+		owner, err := r.remoteOwner()
+		if err != nil {
+			return err
+		}
+		if owner != r.githubOrg {
+			return fmt.Errorf("current git remote is %s, expected to be from %s. Please switch to a branch from the main repo to cut the release", owner, r.githubOrg)
+		}
+	}
+
+	// Check that the release notes are present for this version.
+	if err := r.assertReleaseNotesPresent(r.calicoVersion); err != nil {
+		return err
 	}
 
 	// Check that the versions are release version.
@@ -1717,4 +1750,39 @@ func (r *CalicoManager) prepPrereqs() error {
 	}
 
 	return nil
+}
+
+// remoteOwner extracts the GitHub owner (org or user) from the configured git remote URL.
+func (r *CalicoManager) remoteOwner() (string, error) {
+	out, err := r.git("config", "--get", fmt.Sprintf("remote.%s.url", r.remote))
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote %s url: %w", r.remote, err)
+	}
+	return ownerFromRemoteURL(strings.TrimSpace(out))
+}
+
+// ownerFromRemoteURL extracts the GitHub owner (org or user) from a git remote URL.
+// Supports SSH (git@github.com:owner/repo.git),
+// HTTPS (https://github.com/owner/repo.git), and variants without .git suffix.
+func ownerFromRemoteURL(raw string) (string, error) {
+	raw = strings.TrimSuffix(raw, ".git")
+
+	// SSH: git@github.com:owner/repo
+	if i := strings.Index(raw, ":"); i >= 0 && !strings.Contains(raw[:i], "/") {
+		parts := strings.Split(raw[i+1:], "/")
+		if len(parts) >= 2 {
+			return parts[len(parts)-2], nil
+		}
+		return "", fmt.Errorf("unable to determine owner from remote URL %q", raw)
+	}
+
+	// HTTPS: https://github.com/owner/repo — require scheme prefix.
+	if strings.Contains(raw, "://") {
+		parts := strings.Split(raw, "/")
+		if len(parts) >= 2 {
+			return parts[len(parts)-2], nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to determine owner from remote URL %q", raw)
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1711,7 +1711,7 @@ func (r *CalicoManager) prepPrereqs() error {
 	if !versionRegex.MatchString(r.operatorVersion) {
 		return fmt.Errorf("operator version (%s) is not a release version", r.operatorVersion)
 	}
-	versionRegex = regexp.MustCompile(`^v\d+\.\d+\.\d+(-\d+.\d+)?$`)
+	versionRegex = regexp.MustCompile(`^v\d+\.\d+\.\d+(-\d+\.\d+)?$`)
 	if !versionRegex.MatchString(r.calicoVersion) {
 		return fmt.Errorf("version (%s) is not a release version", r.calicoVersion)
 	}

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calico
+
+import "testing"
+
+func TestOwnerFromRemoteURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "SSH with .git suffix",
+			url:  "git@github.com:projectcalico/calico.git",
+			want: "projectcalico",
+		},
+		{
+			name: "SSH without .git suffix",
+			url:  "git@github.com:projectcalico/calico",
+			want: "projectcalico",
+		},
+		{
+			name: "HTTPS with .git suffix",
+			url:  "https://github.com/projectcalico/calico.git",
+			want: "projectcalico",
+		},
+		{
+			name: "HTTPS without .git suffix",
+			url:  "https://github.com/projectcalico/calico",
+			want: "projectcalico",
+		},
+		{
+			name: "SSH fork",
+			url:  "git@github.com:myFork/calico.git",
+			want: "myFork",
+		},
+		{
+			name: "HTTPS fork",
+			url:  "https://github.com/myFork/calico.git",
+			want: "myFork",
+		},
+		{
+			name: "SSH with nested path",
+			url:  "git@github.com:org/sub/repo.git",
+			want: "sub",
+		},
+		{
+			name:    "bare hostname no path",
+			url:     "github.com",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "local path",
+			url:     "/tmp/repo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ownerFromRemoteURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ownerFromRemoteURL(%q) = %q, want error", tt.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ownerFromRemoteURL(%q) error = %v", tt.url, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ownerFromRemoteURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -125,9 +125,9 @@ func WithPublishCharts(publish bool) Option {
 	}
 }
 
-func WithPublishGitTag(publish bool) Option {
+func WithPublishGitRef(publish bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishTag = publish
+		r.publishGitRef = publish
 		return nil
 	}
 }

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -34,6 +34,7 @@ const (
 	DefaultRepoName            = "operator"
 	DefaultBranchName          = utils.DefaultBranch
 	DefaultReleaseBranchPrefix = "release"
+	DefaultDevTagSuffix        = "0.dev"
 	DefaultRegistry            = "quay.io"
 )
 

--- a/release/pkg/postrelease/github_test.go
+++ b/release/pkg/postrelease/github_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-github/v53/github"
 
+	"github.com/projectcalico/calico/release/internal/outputs"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/internal/version"
 )
@@ -84,7 +85,7 @@ func TestGitHubReleaseNotes(t *testing.T) {
 
 	checkVersion(t, releaseVersion)
 
-	_, _, resp, err := githubClient().Repositories.GetContents(context.Background(), githubOrg, githubRepo, fmt.Sprintf("release-notes/%s-release-notes.md", releaseVersion), &github.RepositoryContentGetOptions{
+	_, _, resp, err := githubClient().Repositories.GetContents(context.Background(), githubOrg, githubRepo, fmt.Sprintf("%s/%s-release-notes.md", outputs.ReleaseNotesDir, releaseVersion), &github.RepositoryContentGetOptions{
 		Ref: releaseVersion,
 	})
 	if err != nil || resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
Add `release prep` CLI subcommand that automates pre-release branch preparation:
- Creates `build-vX.Y.Z` branch, updates charts/manifests via `make generate`, and commits
- Generates release notes and includes them in the prep commit
- Emits structured step summary YAML output for automation
- Replaces `--git-publish` flag with `--local` for consistent opt-out semantics
- Simplifies RELEASING.md to reference `make release-prep` and adds a review step for generated release notes

**Testing**
- [x] creating prep branch in fork against projectcalico/calico
  ```sh
  $ make release-prep SKIP_BRANCH_CHECK=true
  INFO[0000]version.go:197 version.GitVersion() Current git describe                          out=v3.33.0-0.dev-138-g53f0f02714fe
  INFO[0002]releasenotes.go:210 outputs.ReleaseNotes() Generating release notes for v3.33.0         
  WARNING[0005]releasenotes.go:221 outputs.ReleaseNotes() Failed to retrieve milestone for bird         error="milestone not found"
  INFO[0005]manager.go:101 calico.NewManager() Using repo root                               repoRoot=/home/draper/work/calico/.worktrees/maestro-v0-release-prep
  INFO[0005]manager.go:115 calico.NewManager() Using GitHub configuration                    org=projectcalico remote=origin repo=calico
  FATAL[0005]main.go:85 main.main() Error running app                             error="current git remote is radTuti, expected to be from projectcalico. Please switch to a branch from the main repo to cut the release"
  make: *** [Makefile:241: release-prep] Error 1
  ```
- [x] creating prep branch using `make release-prep SKIP_BRANCH_CHECK=true ORGANIZATION=radTuti` [PR](https://github.com/radTuti/calico/pull/3)
- [x] run again once the PR is available (NOTE: log trimmed)
  ```sh
  $ make release-prep SKIP_BRANCH_CHECK=true ORGANIZATION=radTuti
  INFO[0000]version.go:197 version.GitVersion() Current git describe                          out=v3.33.0-0.dev-138-gfae519324786
  WARNING[0011]releasenotes.go:206 outputs.ReleaseNotes() generating release notes outside of projectcalico GitHub organization is not supported, switching back to projectcalico  org=radTuti
  INFO[0011]releasenotes.go:210 outputs.ReleaseNotes() Generating release notes for v3.33.0         
  WARNING[0016]releasenotes.go:221 outputs.ReleaseNotes() Failed to retrieve milestone for bird         error="milestone not found"
  INFO[0016]manager.go:101 calico.NewManager() Using repo root                               repoRoot=/home/draper/work/calico/.worktrees/maestro-v0-release-prep
  INFO[0016]manager.go:115 calico.NewManager() Using GitHub configuration                    org=radTuti remote=origin repo=calico
  INFO[0125]manager.go:1670 calico.(*CalicoManager).pushPrepBranch() Pushed preparation branch to remote           branch=build-v3.33.0
  WARNING[0126]manager.go:1698 calico.(*CalicoManager).createPrepPR() PR already exists, skipping creation. Find PR at: https://github.com/radTuti/calico/pull/3 
  ```

**Release note:**
```release-note
TBD
```