### PR TITLE
Fix migration deadlock: remove APIService before conflict detection

### DIFF
--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -532,7 +532,7 @@ func (m *migrationController) handleMigrating(logCtx *logrus.Entry, dm *Datastor
 	setPhaseMetric(DatastoreMigrationPhaseConverged)
 	logCtx.Info("Migration converged, unlocking datastore")
 
-	// Step 4: Unlock the datastore.
+	// Step 3: Unlock the datastore.
 	if err := m.unlockV3CRDDatastore(logCtx); err != nil {
 		return err
 	}

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -380,6 +380,12 @@ func (m *migrationController) handlePending(logCtx *logrus.Entry, dm *DatastoreM
 		"installType":      installType,
 	}).Info("Detected installation details")
 
+	// Save and delete the APIService to unregister the API server. This will
+	// route future requests to the projectcalico.org/v3 API to CRDs instead.
+	if err := m.saveAndDeleteAPIService(logCtx, dm); err != nil {
+		return err
+	}
+
 	// Pre-check conflicts: detect v3 resources that differ from their v1 source
 	// before starting migration. This avoids locking the datastore only to
 	// discover conflicts mid-migration.
@@ -418,17 +424,18 @@ func (m *migrationController) handleMigrating(logCtx *logrus.Entry, dm *Datastor
 	logCtx.Info("Migration in progress")
 	dm.Status.Message = "Migrating resources"
 
-	// Step 1: Save and delete the APIService to route v3 requests to CRDs.
+	// The APIService was already saved and deleted during handlePending
+	// (before conflict detection). Ensure it's gone in case we're resuming.
 	if err := m.saveAndDeleteAPIService(logCtx, dm); err != nil {
 		return err
 	}
 
-	// Step 2: Create v3 ClusterInformation with DatastoreReady=false to lock the datastore.
+	// Step 1: Create v3 ClusterInformation with DatastoreReady=false to lock the datastore.
 	if err := m.lockDatastore(logCtx); err != nil {
 		return err
 	}
 
-	// Step 3: Migrate all resources in order.
+	// Step 2: Migrate all resources in order.
 	allMigrators := m.migrators
 	sort.Slice(allMigrators, func(i, j int) bool {
 		return allMigrators[i].Order() < allMigrators[j].Order()

--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -197,7 +197,7 @@ func TestLifecycle_Mainline(t *testing.T) {
 	// Tiers should exist in v3 with the internal annotation stripped.
 	tier1 := &apiv3.Tier{}
 	h.getV3Resource("default", tier1)
-	g.Expect(tier1.Spec.Order).To(Equal(ptr.To(float64(100))))
+	g.Expect(tier1.Spec.Order).To(Equal(ptr.To(apiv3.DefaultTierOrder)))
 	g.Expect(tier1.Annotations).NotTo(HaveKey("projectcalico.org/metadata"))
 
 	tier2 := &apiv3.Tier{}
@@ -307,12 +307,12 @@ func TestLifecycle_ConflictResolution(t *testing.T) {
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
-	// Pre-create a v3 Tier with a different spec than the v1 source.
+	// Pre-create a v3 Tier with a different DefaultAction than the v1 source.
 	// This triggers conflict detection in handlePending.
-	deny := apiv3.Deny
+	pass := apiv3.Pass
 	conflictingTier := &apiv3.Tier{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
-		Spec:       apiv3.TierSpec{Order: ptr.To(float64(999)), DefaultAction: &deny},
+		Spec:       apiv3.TierSpec{Order: ptr.To(apiv3.DefaultTierOrder), DefaultAction: &pass},
 	}
 	g.Expect(fvRTClient.Create(ctx, conflictingTier)).To(Succeed())
 	t.Cleanup(func() {
@@ -340,10 +340,11 @@ func TestLifecycle_ConflictResolution(t *testing.T) {
 
 	gate.release(DatastoreMigrationPhaseWaitingForConflictResolution)
 
-	// Fix the conflict by updating the v3 Tier to match the v1 spec.
+	// Fix the conflict by updating the v3 Tier's DefaultAction to match v1.
 	tier := &apiv3.Tier{}
 	h.getV3Resource("default", tier)
-	tier.Spec.Order = ptr.To(float64(100))
+	deny := apiv3.Deny
+	tier.Spec.DefaultAction = &deny
 	g.Expect(fvRTClient.Update(ctx, tier)).To(Succeed())
 
 	// The controller should re-check, find no conflicts, transition through

--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -307,16 +307,16 @@ func TestLifecycle_ConflictResolution(t *testing.T) {
 		clusterInfo: mainlineV1ClusterInfo(),
 	}
 
-	// Pre-create a v3 Tier with a different DefaultAction than the v1 source.
-	// This triggers conflict detection in handlePending.
-	pass := apiv3.Pass
+	// Pre-create a v3 Tier with a different Order than the v1 source.
+	// This triggers conflict detection in handlePending. We use a non-default
+	// tier because CEL validation locks the default tier's Order and DefaultAction.
 	conflictingTier := &apiv3.Tier{
-		ObjectMeta: metav1.ObjectMeta{Name: "default"},
-		Spec:       apiv3.TierSpec{Order: ptr.To(apiv3.DefaultTierOrder), DefaultAction: &pass},
+		ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+		Spec:       apiv3.TierSpec{Order: ptr.To(float64(999)), DefaultAction: actionPtr(apiv3.Deny)},
 	}
 	g.Expect(fvRTClient.Create(ctx, conflictingTier)).To(Succeed())
 	t.Cleanup(func() {
-		if err := fvRTClient.Delete(ctx, &apiv3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "default"}}); err != nil {
+		if err := fvRTClient.Delete(ctx, &apiv3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "custom"}}); err != nil {
 			t.Logf("cleanup: deleting tier: %v", err)
 		}
 	})
@@ -336,15 +336,14 @@ func TestLifecycle_ConflictResolution(t *testing.T) {
 	g.Expect(dm.Status.Conditions).To(HaveLen(1))
 	g.Expect(dm.Status.Conditions[0].Type).To(Equal(conditionTypeConflict))
 	g.Expect(dm.Status.Conditions[0].Reason).To(Equal(conditionReasonResourceMismatch))
-	g.Expect(dm.Status.Conditions[0].Message).To(ContainSubstring("Tier/default"))
+	g.Expect(dm.Status.Conditions[0].Message).To(ContainSubstring("Tier/custom"))
 
 	gate.release(DatastoreMigrationPhaseWaitingForConflictResolution)
 
-	// Fix the conflict by updating the v3 Tier's DefaultAction to match v1.
+	// Fix the conflict by updating the v3 Tier's Order to match v1.
 	tier := &apiv3.Tier{}
-	h.getV3Resource("default", tier)
-	deny := apiv3.Deny
-	tier.Spec.DefaultAction = &deny
+	h.getV3Resource("custom", tier)
+	tier.Spec.Order = ptr.To(float64(100))
 	g.Expect(fvRTClient.Update(ctx, tier)).To(Succeed())
 
 	// The controller should re-check, find no conflicts, transition through

--- a/kube-controllers/pkg/controllers/migration/resources_for_test.go
+++ b/kube-controllers/pkg/controllers/migration/resources_for_test.go
@@ -50,7 +50,7 @@ func mainlineV1Resources() map[string][]*model.KVPair {
 						UID:         v1TierDefaultUID,
 						Annotations: v1InternalAnnotations,
 					},
-					Spec: apiv3.TierSpec{Order: ptr.To(float64(100)), DefaultAction: actionPtr(apiv3.Deny)},
+					Spec: apiv3.TierSpec{Order: ptr.To(apiv3.DefaultTierOrder), DefaultAction: actionPtr(apiv3.Deny)},
 				},
 			},
 			{
@@ -108,7 +108,7 @@ func conflictV1Resources() map[string][]*model.KVPair {
 						Annotations: v1InternalAnnotations,
 					},
 					Spec: apiv3.TierSpec{
-						Order:         ptr.To(float64(100)),
+						Order:         ptr.To(apiv3.DefaultTierOrder),
 						DefaultAction: actionPtr(apiv3.Deny),
 					},
 				},

--- a/kube-controllers/pkg/controllers/migration/resources_for_test.go
+++ b/kube-controllers/pkg/controllers/migration/resources_for_test.go
@@ -94,21 +94,23 @@ func mainlineV1Resources() map[string][]*model.KVPair {
 	}
 }
 
-// conflictV1Resources returns v1 backend data with a single Tier. Used with a
-// pre-existing v3 Tier that has a different spec to trigger conflict detection.
+// conflictV1Resources returns v1 backend data with a non-default Tier whose
+// spec will differ from a pre-existing v3 Tier, triggering conflict detection.
+// We use a non-default tier because CEL validation locks the default tier's
+// Order and DefaultAction to fixed values.
 func conflictV1Resources() map[string][]*model.KVPair {
 	return map[string][]*model.KVPair{
 		apiv3.KindTier: {
 			{
-				Key: model.ResourceKey{Kind: apiv3.KindTier, Name: "default"},
+				Key: model.ResourceKey{Kind: apiv3.KindTier, Name: "custom"},
 				Value: &apiv3.Tier{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "default",
+						Name:        "custom",
 						UID:         v1TierDefaultUID,
 						Annotations: v1InternalAnnotations,
 					},
 					Spec: apiv3.TierSpec{
-						Order:         ptr.To(apiv3.DefaultTierOrder),
+						Order:         ptr.To(float64(100)),
 						DefaultAction: actionPtr(apiv3.Deny),
 					},
 				},


### PR DESCRIPTION
The conflict pre-check in `handlePending` reads v3 resources via `GetV3`, which goes through the aggregated API server. The API server normalizes data on read — e.g., dropping zero-valued `omitempty` fields like `BlockAffinity.Type`. This causes `SpecsEqual` to see spurious mismatches between the converted v1 source and the v3 response, so the migration gets stuck in `WaitingForConflictResolution` forever. The `saveAndDeleteAPIService` call that would fix the comparison only runs in `handleMigrating`, which is never reached because the conflict check gates entry to that phase.

Fix is to move `saveAndDeleteAPIService` into `handlePending` before `DetectConflicts`, so v3 reads go through CRD storage directly and we get a consistent comparison.

Also fixes test failures caused by the recent CEL tier order validation (2e93519e14) — the migration test was seeding the default tier with order 100, which now fails the `default tier order must be 1000000` validation. Updated seed data to use `apiv3.DefaultTierOrder`, and the conflict resolution test now uses a `DefaultAction` mismatch instead of an order mismatch.

```release-note
None
```