### PR TITLE
fix(kube-controllers/migration): normalise default tier order during v1→v3 migration

### DIFF
--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -185,6 +185,8 @@ func TestLifecycle_Mainline(t *testing.T) {
 	// Tiers should exist in v3 with the internal annotation stripped.
 	tier1 := &apiv3.Tier{}
 	h.getV3Resource("default", tier1)
+	// The default tier's order is normalised to DefaultTierOrder during migration
+	// regardless of the v1 value, because the v3 API enforces this requirement.
 	g.Expect(tier1.Spec.Order).To(Equal(ptr.To(apiv3.DefaultTierOrder)))
 	g.Expect(tier1.Annotations).NotTo(HaveKey("projectcalico.org/metadata"))
 

--- a/kube-controllers/pkg/controllers/migration/migrators/convert.go
+++ b/kube-controllers/pkg/controllers/migration/migrators/convert.go
@@ -27,6 +27,13 @@ import (
 // internal metadata. It is filtered out during conversion.
 const internalMetadataAnnotation = "projectcalico.org/metadata"
 
+// DefaultConvert is the exported form of defaultConvert. It is intended for
+// resource-specific converters that need to augment the standard deep-copy
+// and metadata-cleaning step with additional normalisation logic.
+func DefaultConvert[T any](kvp *model.KVPair) (*T, error) {
+	return defaultConvert[T](kvp)
+}
+
 // defaultConvert performs a deep copy of the v1 resource and cleans server-side
 // metadata fields. The UID and OwnerReferences are preserved so callers can
 // use them for UID mapping and OwnerRef remapping before creation.

--- a/kube-controllers/pkg/controllers/migration/resources.go
+++ b/kube-controllers/pkg/controllers/migration/resources.go
@@ -19,6 +19,7 @@ import (
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/migration/migrators"
@@ -51,7 +52,9 @@ const (
 // handling.
 func NewMigrators(bc api.Client, rt client.Client) []migrators.ResourceMigrator {
 	return []migrators.ResourceMigrator{
-		migrators.New[apiv3.Tier, apiv3.TierList](apiv3.KindTier, OrderTiers, bc, rt),
+		migrators.New[apiv3.Tier, apiv3.TierList](apiv3.KindTier, OrderTiers, bc, rt,
+			migrators.WithConvert(convertTier),
+		),
 		migrators.New[apiv3.FelixConfiguration, apiv3.FelixConfigurationList](apiv3.KindFelixConfiguration, OrderConfigSingletons, bc, rt),
 		migrators.New[apiv3.BGPConfiguration, apiv3.BGPConfigurationList](apiv3.KindBGPConfiguration, OrderConfigSingletons, bc, rt),
 		migrators.New[apiv3.KubeControllersConfiguration, apiv3.KubeControllersConfigurationList](apiv3.KindKubeControllersConfiguration, OrderConfigSingletons, bc, rt),
@@ -81,6 +84,21 @@ func NewMigrators(bc api.Client, rt client.Client) []migrators.ResourceMigrator 
 		),
 		migrators.New[apiv3.CalicoNodeStatus, apiv3.CalicoNodeStatusList](apiv3.KindCalicoNodeStatus, OrderCalicoNodeStatus, bc, rt),
 	}
+}
+
+// convertTier converts a v1 Tier KVPair to a v3 Tier. It performs the standard
+// deep-copy and metadata cleanup, then normalises the default tier's Order to
+// apiv3.DefaultTierOrder. The v3 API server enforces this value for the default
+// tier, but v1 representations may carry a different order.
+func convertTier(kvp *model.KVPair) (*apiv3.Tier, error) {
+	tier, err := migrators.DefaultConvert[apiv3.Tier](kvp)
+	if err != nil {
+		return nil, err
+	}
+	if tier.Name == names.DefaultTierName {
+		tier.Spec.Order = ptr.To(apiv3.DefaultTierOrder)
+	}
+	return tier, nil
 }
 
 // convertIPAMBlock converts a model.AllocationBlock KVPair to a v3 IPAMBlock.


### PR DESCRIPTION
## Summary

The migration controller converts v1 Tier resources to v3 CRDs via a generic deep-copy. The v3 API server requires the `default` tier to have `Spec.Order == DefaultTierOrder` (1000000), but v1 representations may carry a different value. Without normalisation, `CreateV3` fails with:

```
Tier.projectcalico.org "default" is invalid: default tier order must be 1000000
```

This caused `TestLifecycle_Mainline`, `TestLifecycle_BackendListError`, `TestLifecycle_ConflictResolution`, `TestLifecycle_Rollback`, and `TestLifecycle_DeletionBlockedThenCompleted` to all fail in CI.

## Fix

- Exports `DefaultConvert` from the `migrators` package so resource-specific converters can reuse the standard metadata-cleaning logic
- Adds `convertTier` in `resources.go` which applies the standard deep-copy then overwrites `Spec.Order` with `DefaultTierOrder` for the `default` tier
- Wires `convertTier` into the Tier migrator registration
- Adds a comment in `TestLifecycle_Mainline` explaining why the default tier's order is normalised (the `DefaultTierOrder` assertion itself was already present in master)

## Test plan

Covered by CI — `TestLifecycle_*` FV tests and `migrators` unit tests all run in Semaphore.

```release-note
Fixed a bug where the v1→v3 datastore migration controller could fail to create the default Tier if its v1 Order field did not match the v3-required value.
```