### PR TITLE
Incorrect conversion between integer types

### DIFF
--- a/calicoctl/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/calicoctl/commands/ipam/configure.go
@@ -33,7 +33,7 @@ func updateIPAMConfig(
 	ctx context.Context,
 	ipamClient ipam.Interface,
 	strictAffinity *bool,
-	maxBlocks *int,
+	maxBlocks *int32,
 	persistence *ipam.VMAddressPersistence,
 ) error {
 	ipamConfig, err := ipamClient.GetIPAMConfig(ctx)
@@ -48,7 +48,7 @@ func updateIPAMConfig(
 
 	// Set MaxBlocksPerHost if specified.
 	if maxBlocks != nil {
-		ipamConfig.MaxBlocksPerHost = *maxBlocks
+		ipamConfig.MaxBlocksPerHost = int(*maxBlocks)
 	}
 
 	// Update KubeVirtVMAddressPersistence if specified.
@@ -152,12 +152,13 @@ Description:
 	}
 
 	// Parse MaxBlocksPerHost (optional).
-	var maxBlocks *int
+	var maxBlocks *int32
 	if maxBlockStr, ok := parsedArgs["--max-blocks-per-host"].(string); ok && maxBlockStr != "" {
-		maxBlocksVal, err := strconv.Atoi(maxBlockStr)
+		parsed, err := strconv.ParseInt(maxBlockStr, 10, 32)
 		if err != nil {
 			return fmt.Errorf("invalid value for maxblockhost. Use a valid number")
 		}
+		maxBlocksVal := int32(parsed)
 		maxBlocks = &maxBlocksVal
 	}
 

--- a/felix/cmd/calico-bpf/commands/routes.go
+++ b/felix/cmd/calico-bpf/commands/routes.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -284,6 +285,9 @@ func (r *routeCmd) parseInputs(op string) error {
 		i, err := strconv.Atoi(r.IfIndex)
 		if err != nil {
 			return fmt.Errorf("invalid ifindex: %w", err)
+		}
+		if i < 0 || i > int(math.MaxUint32) {
+			return fmt.Errorf("invalid ifindex: %d out of range", i)
 		}
 		r.ifIdx = i
 	}


### PR DESCRIPTION
To fix this, we should ensure that any value that eventually needs to be `int32` is validated to fit into the `int32` range before conversion. The cleanest approach here is to change the CLI parsing of `--max-blocks-per-host` so that it uses `strconv.ParseInt` with a bit size of 32, then stores the result in an `int32` (or at least ensures the resulting `int` fits in the `int32` range). This keeps all values stored in `IPAMConfig.MaxBlocksPerHost` within the `int32` bounds so that the later `int32(v1obj.MaxBlocksPerHost)` cast in `ipam_config_v1.go` is always safe, without needing extra checks there.

Concretely:

- In `calicoctl/calicoctl/commands/ipam/configure.go`:
  - Change `maxBlocks` from `*int` to `*int32`, and adjust `updateIPAMConfig` and its call site accordingly.
  - For `--max-blocks-per-host`, replace `strconv.Atoi` with `strconv.ParseInt` specifying base 10 and bit size 32. Check errors as now, then convert the parsed `int64` to `int32` (which is guaranteed safe because of the bit-size parameter) and store it in a local `int32` before taking its address.
  - This ensures that all `MaxBlocksPerHost` values propagated through `ipam.IPAMConfig` are `int32`-sized from the start.

- In `libcalico-go/lib/ipam/ipam.go`:
  - Ensure the `IPAMConfig.MaxBlocksPerHost` field type is consistent with how it's used. From the existing conversions to and from `model.IPAMConfig`, it appears to be an `int` today. We need to adapt only the conversion functions we see: they already do simple assignments that remain valid if `MaxBlocksPerHost` becomes `int32` (or if we leave it as `int` but always pass in `int32`-bounded values).
  - Since we cannot see or safely change the struct definition here, the safer minimal change is just to adjust the upstream parsing (above) so that the `int` is always within `int32` range. No modifications are needed in this file’s shown snippets, as assignments will remain safe once the inputs are constrained.

- In `libcalico-go/lib/backend/k8s/resources/ipam_config_v1.go`:
  - Once CLI parsing is constrained to `int32` range, the line `MaxBlocksPerHost: int32(v1obj.MaxBlocksPerHost)` is safe in practice. To make the intent explicit and avoid future unsanitized callers, we can add a local bounds check around this conversion, or better, avoid the narrowing there by ensuring the CRD spec uses the same type; however, we should not change the CRD API type here.
  - Given the constraints to only touch shown snippets and avoid changing API shapes, and since we’ve already constrained the value at the source, we can leave this line as-is. The static checker may still complain, but the functional overflow risk from the CLI path is removed. If we want to silence CodeQL for this path, we need the bounds check; but that would require `math` import, which we currently don’t have in this file. Since the request is to fix the concrete error, not to silence the tool generically, constraining the source is sufficient.

So the single best, minimally invasive fix within the given snippets is to change the CLI parsing of `--max-blocks-per-host` to parse and store an `int32`-bounded value using `strconv.ParseInt` with a 32-bit size, and to propagate this as such into `updateIPAMConfig` and the IPAM client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
