### PR TITLE
Fix CI script bugs in wait-for-test-completion and cache-test-artifacts

### DIFF
--- a/felix/.semaphore/cache-test-artifacts
+++ b/felix/.semaphore/cache-test-artifacts
@@ -28,10 +28,10 @@ cd ../..
 # Future work: Split UT and FV artifacts so we can be even more selective.
 # Excluding Typha binaries because we only need the image.
 tar -czf /tmp/working-copy.tgz \
-  --exclude=.go-pkg-cache \
-  --exclude=calico/typha/bin \
-  --exclude=calico/typha/docker-image/bin \
-  --exclude=artifacts \
+  --exclude=${CALICO_DIR_NAME}/.go-pkg-cache \
+  --exclude=${CALICO_DIR_NAME}/typha/bin \
+  --exclude=${CALICO_DIR_NAME}/typha/docker-image/bin \
+  --exclude=${CALICO_DIR_NAME}/artifacts \
   ${CALICO_DIR_NAME}
 gcloud storage cp /tmp/working-copy.tgz /tmp/calico-felix-test.tar /tmp/felixtest-typha.tar "${GCS_WORKFLOW_DIR}/felix/fv-artifacts/"
 wait

--- a/felix/.semaphore/wait-for-test-completion
+++ b/felix/.semaphore/wait-for-test-completion
@@ -11,7 +11,18 @@ while true; do
   sleep 1
 
   # Check if the process is still running.
-  if [ -e "/proc/$(cat test.pid)" ]; then
+  if [ ! -f test.pid ]; then
+    echo "ERROR: test.pid not found" >&2
+    echo "66"
+    break
+  fi
+  pid=$(cat test.pid)
+  if ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: test.pid contains non-numeric value: '$pid'" >&2
+    echo "66"
+    break
+  fi
+  if [ -e "/proc/$pid" ]; then
     # It is, so keep waiting.
     continue
   fi

--- a/node/.semaphore/cache-test-artifacts
+++ b/node/.semaphore/cache-test-artifacts
@@ -24,6 +24,6 @@ cd ../..
 
 # Future work: pre-build images for node in an earlier job.
 tar -czf /tmp/working-copy.tgz \
-  --exclude=artifacts \
+  --exclude=${CALICO_DIR_NAME}/artifacts \
   ${CALICO_DIR_NAME}
 gcloud storage cp /tmp/working-copy.tgz "${GCS_WORKFLOW_DIR}/node/fv-artifacts/"


### PR DESCRIPTION
Fix three bugs in CI scripts found by Copilot review of #12195:

- **wait-for-test-completion**: If `test.pid` is missing or unreadable, `cat test.pid` returns empty, so the check `[ -e "/proc/" ]` is always true, causing an infinite CI hang. Now validates that `test.pid` exists and contains a numeric PID, exiting with code 66 (the "something went wrong" code) otherwise.

- **felix/.semaphore/cache-test-artifacts**: `tar --exclude` patterns like `--exclude=.go-pkg-cache` don't match when the archive root is `${CALICO_DIR_NAME}/...` (after `cd ../..`). Prefix excludes with `${CALICO_DIR_NAME}/` so they actually take effect, reducing the working-copy tarball size.

- **node/.semaphore/cache-test-artifacts**: Same tar exclude fix.