### PR TITLE
Fix pagination bug in sync-operator-crds branch discovery

### DIFF
--- a/.github/workflows/sync-operator-crds.yml
+++ b/.github/workflows/sync-operator-crds.yml
@@ -22,8 +22,11 @@ jobs:
         id: branches
         run: |
           # Get master + the two most recent release branches (by semver).
-          branches=$(gh api repos/${{ github.repository }}/branches --paginate --jq '
-            [.[] | select(.name | test("^release-v[0-9]+\\.[0-9]+$")) | .name]
+          # Pipe to jq separately so --slurp combines all pages before filtering.
+          # Using --jq with --paginate applies the filter per-page, which can
+          # produce multiple JSON arrays and break $GITHUB_OUTPUT.
+          branches=$(gh api repos/${{ github.repository }}/branches --paginate | jq -sc '
+            [flatten[] | select(.name | test("^release-v[0-9]+\\.[0-9]+$")) | .name]
             | sort_by(ltrimstr("release-v") | split(".") | map(tonumber))
             | .[-2:]
             | ["master"] + .


### PR DESCRIPTION
`gh api --paginate --jq` applies the jq filter per-page, so when branches span multiple API response pages we get multiple JSON arrays instead of one. This breaks `$GITHUB_OUTPUT` parsing.

Currently works by luck because the release branches happen to land on the first page, but will break as soon as more branches exist.

Fix by piping to `jq --slurp` separately so all pages are combined before filtering.

**Release note:**
```release-note
None
```