### PR TITLE
Suppress BIRD kernel route installation for WireGuard peers

### DIFF
--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -124,6 +124,9 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 		"numOfAcceptedFiltersForBGPExport": len(config.BGPExportFilterForEnabledIPPools),
 	}).Debug("Processed ippools")
 
+	// Process WireGuard peer filter for kernel programming.
+	c.processWireguardPeerFilter(config, ipVersion)
+
 	// Update cache with write lock.
 	c.configCacheMutex.Lock()
 	c.configCache[ipVersion] = &bgpConfigCache{
@@ -970,6 +973,60 @@ func (c *client) processIPPools(pc *processorContext, config *types.BirdBGPConfi
 	slices.Sort(config.BGPExportFilterForEnabledIPPools)
 
 	return nil
+}
+
+// processWireguardPeerFilter generates BIRD kernel filter reject statements for peers
+// that have WireGuard enabled. When WireGuard is active on a remote node, Felix handles
+// routing via the WireGuard device, so BIRD should not install kernel routes for those
+// peers (they would fail with ENETUNREACH if the peer isn't on the same L2 segment).
+func (c *client) processWireguardPeerFilter(config *types.BirdBGPConfig, ipVersion int) {
+	ipAddrSuffix := "ip_addr_v4"
+	wgAddrSuffix := "wireguard_addr_v4"
+	if ipVersion == 6 {
+		ipAddrSuffix = "ip_addr_v6"
+		wgAddrSuffix = "wireguard_addr_v6"
+	}
+
+	hostKVs, err := c.GetValues([]string{"/calico/bgp/v1/host"})
+	if err != nil {
+		log.WithError(err).Debug("Failed to get host data for WireGuard peer filter")
+		return
+	}
+
+	// Build maps of hostname → BGP IP and hostname → WireGuard address.
+	bgpIPs := make(map[string]string)
+	wgAddrs := make(map[string]string)
+	for key, value := range hostKVs {
+		parts := strings.Split(key, "/")
+		if len(parts) < 7 {
+			continue
+		}
+		hostname := parts[5]
+		field := parts[6]
+
+		if field == ipAddrSuffix && value != "" {
+			bgpIPs[hostname] = value
+		}
+		if field == wgAddrSuffix && value != "" {
+			wgAddrs[hostname] = value
+		}
+	}
+
+	for hostname, bgpIP := range bgpIPs {
+		if hostname == NodeName {
+			continue
+		}
+		if _, hasWG := wgAddrs[hostname]; !hasWG {
+			continue
+		}
+		statement := fmt.Sprintf(
+			"  if (defined(bgp_next_hop) && bgp_next_hop = %s) then { reject; } # WireGuard routes handled by Felix.",
+			bgpIP,
+		)
+		config.WireguardPeerKernelFilter = append(config.WireguardPeerKernelFilter, statement)
+	}
+
+	slices.Sort(config.WireguardPeerKernelFilter)
 }
 
 // This function generates BIRD statements for an IPPool to be used as BIRD filters based on the following input:

--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -993,10 +993,12 @@ func (c *client) processWireguardPeerFilter(config *types.BirdBGPConfig, ipVersi
 		return
 	}
 
-	// Build maps of hostname → BGP IP and hostname → WireGuard address.
+	// Build maps of hostname to BGP IP and hostname to WireGuard address.
 	bgpIPs := make(map[string]string)
 	wgAddrs := make(map[string]string)
 	for key, value := range hostKVs {
+		// Keys look like /calico/bgp/v1/host/<hostname>/<field>, which splits
+		// into 7 parts (the leading slash gives an empty first element).
 		parts := strings.Split(key, "/")
 		if len(parts) < 7 {
 			continue
@@ -1012,6 +1014,14 @@ func (c *client) processWireguardPeerFilter(config *types.BirdBGPConfig, ipVersi
 		}
 	}
 
+	// If the local node isn't running WireGuard, it reaches every peer over the
+	// normal BGP path, so leave BIRD's kernel routes in place. Only nodes that
+	// route to WireGuard peers via the WireGuard device should reject them.
+	if _, localHasWG := wgAddrs[NodeName]; !localHasWG {
+		return
+	}
+
+	// Reject BIRD's kernel route for each remote peer running WireGuard.
 	for hostname, bgpIP := range bgpIPs {
 		if hostname == NodeName {
 			continue
@@ -1019,10 +1029,7 @@ func (c *client) processWireguardPeerFilter(config *types.BirdBGPConfig, ipVersi
 		if _, hasWG := wgAddrs[hostname]; !hasWG {
 			continue
 		}
-		statement := fmt.Sprintf(
-			"  if (defined(bgp_next_hop) && bgp_next_hop = %s) then { reject; } # WireGuard routes handled by Felix.",
-			bgpIP,
-		)
+		statement := fmt.Sprintf("  if (defined(bgp_next_hop) && bgp_next_hop = %s) then { reject; } # WireGuard routes handled by Felix.", bgpIP)
 		config.WireguardPeerKernelFilter = append(config.WireguardPeerKernelFilter, statement)
 	}
 

--- a/confd/pkg/backends/calico/ippools_test.go
+++ b/confd/pkg/backends/calico/ippools_test.go
@@ -544,6 +544,35 @@ func Test_processWireguardPeerFilter_AllWireguard(t *testing.T) {
 	}
 }
 
+// Test_processWireguardPeerFilter_LocalNoWireguard covers a mixed cluster where
+// the local node isn't running WireGuard but a remote peer is. The local node
+// routes to that peer over the normal BGP path, so we must not reject BIRD's
+// kernel route for it.
+func Test_processWireguardPeerFilter_LocalNoWireguard(t *testing.T) {
+	originalNodeName := NodeName
+	NodeName = "local-node"
+	defer func() {
+		NodeName = originalNodeName
+	}()
+
+	cache := map[string]string{
+		"/calico/bgp/v1/host/local-node/ip_addr_v4": "10.0.0.1",
+
+		"/calico/bgp/v1/host/remote-wg/ip_addr_v4":        "10.0.0.2",
+		"/calico/bgp/v1/host/remote-wg/wireguard_addr_v4": "192.168.1.2",
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{NodeName: NodeName}
+
+	c.processWireguardPeerFilter(config, 4)
+
+	if len(config.WireguardPeerKernelFilter) != 0 {
+		t.Errorf("Expected empty WireguardPeerKernelFilter, got: %#v",
+			config.WireguardPeerKernelFilter)
+	}
+}
+
 func ippoolTestCasesToKVPairs(t *testing.T, tcs []ippoolTestCase, ipVersion int) map[string]string {
 	cache := map[string]string{}
 	for _, tc := range tcs {

--- a/confd/pkg/backends/calico/ippools_test.go
+++ b/confd/pkg/backends/calico/ippools_test.go
@@ -421,6 +421,129 @@ func Test_processIPPoolsV6_FelixProgramsClusterRoutes(t *testing.T) {
 	}
 }
 
+func Test_processWireguardPeerFilterV4(t *testing.T) {
+	originalNodeName := NodeName
+	NodeName = "local-node"
+	defer func() {
+		NodeName = originalNodeName
+	}()
+
+	cache := map[string]string{
+		"/calico/bgp/v1/host/local-node/ip_addr_v4":        "10.0.0.1",
+		"/calico/bgp/v1/host/local-node/wireguard_addr_v4": "192.168.1.1",
+
+		"/calico/bgp/v1/host/remote-wg/ip_addr_v4":        "10.0.0.2",
+		"/calico/bgp/v1/host/remote-wg/wireguard_addr_v4": "192.168.1.2",
+
+		"/calico/bgp/v1/host/remote-nowg/ip_addr_v4": "10.0.0.3",
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{NodeName: NodeName}
+
+	c.processWireguardPeerFilter(config, 4)
+
+	expected := []string{
+		`  if (defined(bgp_next_hop) && bgp_next_hop = 10.0.0.2) then { reject; } # WireGuard routes handled by Felix.`,
+	}
+
+	if !reflect.DeepEqual(config.WireguardPeerKernelFilter, expected) {
+		t.Errorf("WireguardPeerKernelFilter mismatch:\n  got:  %#v\n  want: %#v",
+			config.WireguardPeerKernelFilter, expected)
+	}
+}
+
+func Test_processWireguardPeerFilterV6(t *testing.T) {
+	originalNodeName := NodeName
+	NodeName = "local-node"
+	defer func() {
+		NodeName = originalNodeName
+	}()
+
+	cache := map[string]string{
+		"/calico/bgp/v1/host/local-node/ip_addr_v6":        "fd00::1",
+		"/calico/bgp/v1/host/local-node/wireguard_addr_v6": "fd01::1",
+
+		"/calico/bgp/v1/host/remote-wg/ip_addr_v6":        "fd00::2",
+		"/calico/bgp/v1/host/remote-wg/wireguard_addr_v6": "fd01::2",
+
+		"/calico/bgp/v1/host/remote-nowg/ip_addr_v6": "fd00::3",
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{NodeName: NodeName}
+
+	c.processWireguardPeerFilter(config, 6)
+
+	expected := []string{
+		`  if (defined(bgp_next_hop) && bgp_next_hop = fd00::2) then { reject; } # WireGuard routes handled by Felix.`,
+	}
+
+	if !reflect.DeepEqual(config.WireguardPeerKernelFilter, expected) {
+		t.Errorf("WireguardPeerKernelFilter mismatch:\n  got:  %#v\n  want: %#v",
+			config.WireguardPeerKernelFilter, expected)
+	}
+}
+
+func Test_processWireguardPeerFilter_NoWireguard(t *testing.T) {
+	originalNodeName := NodeName
+	NodeName = "local-node"
+	defer func() {
+		NodeName = originalNodeName
+	}()
+
+	cache := map[string]string{
+		"/calico/bgp/v1/host/local-node/ip_addr_v4": "10.0.0.1",
+		"/calico/bgp/v1/host/remote-a/ip_addr_v4":   "10.0.0.2",
+		"/calico/bgp/v1/host/remote-b/ip_addr_v4":   "10.0.0.3",
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{NodeName: NodeName}
+
+	c.processWireguardPeerFilter(config, 4)
+
+	if len(config.WireguardPeerKernelFilter) != 0 {
+		t.Errorf("Expected empty WireguardPeerKernelFilter, got: %#v",
+			config.WireguardPeerKernelFilter)
+	}
+}
+
+func Test_processWireguardPeerFilter_AllWireguard(t *testing.T) {
+	originalNodeName := NodeName
+	NodeName = "local-node"
+	defer func() {
+		NodeName = originalNodeName
+	}()
+
+	cache := map[string]string{
+		"/calico/bgp/v1/host/local-node/ip_addr_v4":        "10.0.0.1",
+		"/calico/bgp/v1/host/local-node/wireguard_addr_v4": "192.168.1.1",
+
+		"/calico/bgp/v1/host/remote-a/ip_addr_v4":        "10.0.0.2",
+		"/calico/bgp/v1/host/remote-a/wireguard_addr_v4": "192.168.1.2",
+
+		"/calico/bgp/v1/host/remote-b/ip_addr_v4":        "10.0.0.3",
+		"/calico/bgp/v1/host/remote-b/wireguard_addr_v4": "192.168.1.3",
+	}
+
+	c := newTestClient(cache, nil)
+	config := &types.BirdBGPConfig{NodeName: NodeName}
+
+	c.processWireguardPeerFilter(config, 4)
+
+	expected := []string{
+		`  if (defined(bgp_next_hop) && bgp_next_hop = 10.0.0.2) then { reject; } # WireGuard routes handled by Felix.`,
+		`  if (defined(bgp_next_hop) && bgp_next_hop = 10.0.0.3) then { reject; } # WireGuard routes handled by Felix.`,
+	}
+	slices.Sort(expected)
+
+	if !reflect.DeepEqual(config.WireguardPeerKernelFilter, expected) {
+		t.Errorf("WireguardPeerKernelFilter mismatch:\n  got:  %#v\n  want: %#v",
+			config.WireguardPeerKernelFilter, expected)
+	}
+}
+
 func ippoolTestCasesToKVPairs(t *testing.T, tcs []ippoolTestCase, ipVersion int) map[string]string {
 	cache := map[string]string{}
 	for _, tc := range tcs {

--- a/confd/pkg/backends/types/bird_bgp_config.go
+++ b/confd/pkg/backends/types/bird_bgp_config.go
@@ -36,6 +36,7 @@ type BirdBGPConfig struct {
 	BGPExportFilterForEnabledIPPools  []string
 	KernelFilterForIPPools            []string
 	SetMetricForBGPRoutes             []string
+	WireguardPeerKernelFilter         []string
 	NormalRoutePriority               int // IPv4 or IPv6 normal route priority (default 1024)
 }
 

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, er
 
 	// Extract the separate bits of BGP config - these are stored as separate keys in the
 	// v1 model.  For a delete these will all be nil.
-	var asNum, ipv4, netv4, ipv6, netv6, rrClusterID any
+	var asNum, ipv4, netv4, ipv6, netv6, rrClusterID, wgAddrV4, wgAddrV6 any
 	var node *internalapi.Node
 	var ok bool
 	if kvp.Value != nil {
@@ -91,6 +91,15 @@ func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, er
 				asNum = bgp.ASNumber.String()
 			}
 			rrClusterID = bgp.RouteReflectorClusterID
+		}
+
+		if wg := node.Spec.Wireguard; wg != nil {
+			if wg.InterfaceIPv4Address != "" {
+				wgAddrV4 = wg.InterfaceIPv4Address
+			}
+			if wg.InterfaceIPv6Address != "" {
+				wgAddrV6 = wg.InterfaceIPv6Address
+			}
 		}
 	}
 
@@ -141,6 +150,22 @@ func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, er
 				Name:     "rr_cluster_id",
 			},
 			Value:    rrClusterID,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "wireguard_addr_v4",
+			},
+			Value:    wgAddrV4,
+			Revision: kvp.Revision,
+		},
+		{
+			Key: model.NodeBGPConfigKey{
+				Nodename: name,
+				Name:     "wireguard_addr_v6",
+			},
+			Value:    wgAddrV6,
 			Revision: kvp.Revision,
 		},
 	}

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor.go
@@ -68,6 +68,13 @@ func (c *bgpNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, er
 		ipv4 = ""
 		ipv6 = ""
 		rrClusterID = ""
+
+		// Emit the WireGuard keys as blank strings rather than leaving them nil when
+		// unset. confd treats a nil-valued node key as a signal that the node's config
+		// is being removed and drops the node from its BGP IP cache, which breaks
+		// unrelated per-peer logic (e.g. passive mode). Blank keeps the node present.
+		wgAddrV4 = ""
+		wgAddrV6 = ""
 		if bgp := node.Spec.BGP; bgp != nil {
 			if len(bgp.IPv4Address) != 0 {
 				ip, cidr, perr := net.ParseCIDROrIP(bgp.IPv4Address)

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 		Kind: internalapi.KindNode,
 		Name: "bgpnode1",
 	}
-	numBgpConfigs := 6
+	numBgpConfigs := 8
 	up := updateprocessors.NewBGPNodeUpdateProcessor(false)
 
 	BeforeEach(func() {
@@ -50,12 +50,14 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 		res := internalapi.NewNode()
 		res.Name = "bgpnode1"
 		expected := map[string]any{
-			"ip_addr_v4":    "",
-			"ip_addr_v6":    "",
-			"network_v4":    nil,
-			"network_v6":    nil,
-			"as_num":        nil,
-			"rr_cluster_id": "",
+			"ip_addr_v4":        "",
+			"ip_addr_v6":        "",
+			"network_v4":        nil,
+			"network_v6":        nil,
+			"as_num":            nil,
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		kvps, err := up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -93,12 +95,14 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			IPv4Address: "1.2.3.4",
 		}
 		expected = map[string]any{
-			"ip_addr_v4":    "1.2.3.4",
-			"ip_addr_v6":    "",
-			"network_v4":    "1.2.3.4/32",
-			"network_v6":    nil,
-			"as_num":        nil,
-			"rr_cluster_id": "",
+			"ip_addr_v4":        "1.2.3.4",
+			"ip_addr_v6":        "",
+			"network_v4":        "1.2.3.4/32",
+			"network_v6":        nil,
+			"as_num":            nil,
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -119,12 +123,14 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			IPv6Address: "aa:bb:cc::",
 		}
 		expected = map[string]any{
-			"ip_addr_v4":    "",
-			"ip_addr_v6":    "aa:bb:cc::",
-			"network_v4":    nil,
-			"network_v6":    "aa:bb:cc::/128",
-			"as_num":        nil,
-			"rr_cluster_id": "",
+			"ip_addr_v4":        "",
+			"ip_addr_v6":        "aa:bb:cc::",
+			"network_v4":        nil,
+			"network_v6":        "aa:bb:cc::/128",
+			"as_num":            nil,
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -148,12 +154,75 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			ASNumber:    &asn,
 		}
 		expected = map[string]any{
-			"ip_addr_v4":    "1.2.3.4",
-			"ip_addr_v6":    "aa:bb:cc::ffff",
-			"network_v4":    "1.2.3.0/24",
-			"network_v6":    "aa:bb:cc::ff00/120",
-			"as_num":        "12345",
-			"rr_cluster_id": "",
+			"ip_addr_v4":        "1.2.3.4",
+			"ip_addr_v6":        "aa:bb:cc::ffff",
+			"network_v4":        "1.2.3.0/24",
+			"network_v6":        "aa:bb:cc::ff00/120",
+			"as_num":            "12345",
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v3NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("converting a Node with WireGuard addresses")
+		res = internalapi.NewNode()
+		res.Name = "bgpnode1"
+		res.Spec.BGP = &internalapi.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/24",
+		}
+		res.Spec.Wireguard = &internalapi.NodeWireguardSpec{
+			InterfaceIPv4Address: "10.0.0.1",
+			InterfaceIPv6Address: "fd00::1",
+		}
+		expected = map[string]any{
+			"ip_addr_v4":        "1.2.3.4",
+			"ip_addr_v6":        "",
+			"network_v4":        "1.2.3.0/24",
+			"network_v6":        nil,
+			"as_num":            nil,
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": "10.0.0.1",
+			"wireguard_addr_v6": "fd00::1",
+		}
+		kvps, err = up.Process(&model.KVPair{
+			Key:   v3NodeKey1,
+			Value: res,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		checkExpectedConfigs(
+			kvps,
+			isNodeBgpConfig,
+			numBgpConfigs,
+			expected,
+		)
+
+		By("converting a Node with nil Wireguard spec")
+		res = internalapi.NewNode()
+		res.Name = "bgpnode1"
+		res.Spec.BGP = &internalapi.NodeBGPSpec{
+			IPv4Address: "1.2.3.4/24",
+		}
+		res.Spec.Wireguard = nil
+		expected = map[string]any{
+			"ip_addr_v4":        "1.2.3.4",
+			"ip_addr_v6":        "",
+			"network_v4":        "1.2.3.0/24",
+			"network_v6":        nil,
+			"as_num":            nil,
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -205,12 +274,14 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 		})
 		// IPv4 address should be blank, network should be nil (deleted)
 		expected := map[string]any{
-			"ip_addr_v4":    "",
-			"ip_addr_v6":    "aa:bb:cc::ffff",
-			"network_v4":    nil,
-			"network_v6":    "aa:bb:cc::ff00/120",
-			"as_num":        "12345",
-			"rr_cluster_id": "",
+			"ip_addr_v4":        "",
+			"ip_addr_v6":        "aa:bb:cc::ffff",
+			"network_v4":        nil,
+			"network_v6":        "aa:bb:cc::ff00/120",
+			"as_num":            "12345",
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		Expect(err).To(HaveOccurred())
 		checkExpectedConfigs(
@@ -233,12 +304,14 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 		})
 		// IPv6 address should be blank, network should be nil (deleted)
 		expected = map[string]any{
-			"ip_addr_v4":    "1.2.3.4",
-			"ip_addr_v6":    "",
-			"network_v4":    "1.2.3.0/24",
-			"network_v6":    nil,
-			"as_num":        nil,
-			"rr_cluster_id": "",
+			"ip_addr_v4":        "1.2.3.4",
+			"ip_addr_v6":        "",
+			"network_v4":        "1.2.3.0/24",
+			"network_v6":        nil,
+			"as_num":            nil,
+			"rr_cluster_id":     "",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		Expect(err).To(HaveOccurred())
 		checkExpectedConfigs(
@@ -257,12 +330,14 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			RouteReflectorClusterID: "255.0.0.1",
 		}
 		expected := map[string]any{
-			"ip_addr_v4":    "172.17.0.2",
-			"ip_addr_v6":    "",
-			"network_v4":    "172.17.0.0/24",
-			"network_v6":    nil,
-			"as_num":        nil,
-			"rr_cluster_id": "255.0.0.1",
+			"ip_addr_v4":        "172.17.0.2",
+			"ip_addr_v6":        "",
+			"network_v4":        "172.17.0.0/24",
+			"network_v6":        nil,
+			"as_num":            nil,
+			"rr_cluster_id":     "255.0.0.1",
+			"wireguard_addr_v4": nil,
+			"wireguard_addr_v6": nil,
 		}
 		kvps, err := up.Process(&model.KVPair{
 			Key:   v3NodeKey1,

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/bgpnodeprocessor_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        nil,
 			"as_num":            nil,
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		kvps, err := up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -101,8 +101,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        nil,
 			"as_num":            nil,
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -129,8 +129,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        "aa:bb:cc::/128",
 			"as_num":            nil,
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -160,8 +160,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        "aa:bb:cc::ff00/120",
 			"as_num":            "12345",
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -221,8 +221,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        nil,
 			"as_num":            nil,
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		kvps, err = up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -280,8 +280,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        "aa:bb:cc::ff00/120",
 			"as_num":            "12345",
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		Expect(err).To(HaveOccurred())
 		checkExpectedConfigs(
@@ -310,8 +310,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        nil,
 			"as_num":            nil,
 			"rr_cluster_id":     "",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		Expect(err).To(HaveOccurred())
 		checkExpectedConfigs(
@@ -336,8 +336,8 @@ var _ = Describe("Test the (BGP) Node update processor", func() {
 			"network_v6":        nil,
 			"as_num":            nil,
 			"rr_cluster_id":     "255.0.0.1",
-			"wireguard_addr_v4": nil,
-			"wireguard_addr_v6": nil,
+			"wireguard_addr_v4": "",
+			"wireguard_addr_v6": "",
 		}
 		kvps, err := up.Process(&model.KVPair{
 			Key:   v3NodeKey1,
@@ -428,7 +428,6 @@ func assertBlockAffinityUpdate(kvps []*model.KVPair, expected *model.KVPair) {
 	e := fmt.Sprintf("%v \n\nnot found in\n\n [", expected)
 	for _, k := range kvps {
 		e = fmt.Sprintf("%s\n%#v", e, *k)
-
 	}
 	e += "]"
 	Expect(errors.New(e)).NotTo(HaveOccurred())

--- a/node/filesystem/etc/calico/confd/conf.d/bird6_ipam.toml
+++ b/node/filesystem/etc/calico/confd/conf.d/bird6_ipam.toml
@@ -2,10 +2,13 @@
 src = "bird6_ipam.cfg.template"
 dest = "/etc/calico/confd/config/bird6_ipam.cfg"
 prefix = "/calico"
+# Watch all hosts, not just the local one: the WireGuard peer kernel filter
+# rejects routes to any peer running WireGuard, so a remote node enabling
+# WireGuard must re-render this template.
 keys = [
     "/bgpconfig",
     "/v1/ipam/v6/pool",
-    "/bgp/v1/host//NODENAME",
+    "/bgp/v1/host",
     "/staticroutesv6",
     "/rejectcidrsv6",
 ]

--- a/node/filesystem/etc/calico/confd/conf.d/bird_ipam.toml
+++ b/node/filesystem/etc/calico/confd/conf.d/bird_ipam.toml
@@ -2,10 +2,13 @@
 src = "bird_ipam.cfg.template"
 dest = "/etc/calico/confd/config/bird_ipam.cfg"
 prefix = "/calico"
+# Watch all hosts, not just the local one: the WireGuard peer kernel filter
+# rejects routes to any peer running WireGuard, so a remote node enabling
+# WireGuard must re-render this template.
 keys = [
     "/bgpconfig",
     "/v1/ipam/v4/pool",
-    "/bgp/v1/host//NODENAME",
+    "/bgp/v1/host",
     "/staticroutes",
     "/rejectcidrs",
 ]

--- a/node/filesystem/etc/calico/confd/templates/bird6_ipam.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird6_ipam.cfg.template
@@ -78,6 +78,9 @@ filter calico_kernel_programming {
 {{- range $line := $config.SetMetricForBGPRoutes }}
 {{ $line }}
 {{- end}}
+{{- range $line := $config.WireguardPeerKernelFilter }}
+{{ $line }}
+{{- end}}
 {{- range $line := $config.KernelFilterForIPPools }}
 {{ $line }}
 {{- end}}

--- a/node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -77,6 +77,9 @@ filter calico_kernel_programming {
 {{- range $line := $config.SetMetricForBGPRoutes }}
 {{ $line }}
 {{- end}}
+{{- range $line := $config.WireguardPeerKernelFilter }}
+{{ $line }}
+{{- end}}
 {{- range $line := $config.KernelFilterForIPPools }}
 {{ $line }}
 {{- end}}

--- a/node/tests/k8st/tests/wireguard_bgp_routes_test.go
+++ b/node/tests/k8st/tests/wireguard_bgp_routes_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// wireguard_bgp_routes_test.go is a kind-only system test for the WireGuard BGP
+// peer filter. With WireGuard enabled in a no-encap pool, BIRD must not install
+// kernel routes to a WireGuard peer's block - Felix routes that traffic over
+// the WireGuard device instead. kind nodes share an L2 segment, so without the
+// filter BIRD would install (and win) the route; the test asserts BIRD is
+// suppressed while cross-node pod connectivity still works over WireGuard.
+
+package k8stests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	e2eutils "github.com/projectcalico/calico/e2e/pkg/utils"
+	"github.com/projectcalico/calico/node/tests/k8st/utils"
+)
+
+// wgBGPPoolCIDR is a dedicated no-encap IPPool for this test, kept separate so
+// its block routes are easy to match in `ip route`.
+const wgBGPPoolCIDR = "203.0.114.0/24"
+
+// TestWireguardBGPRouteSuppression enables WireGuard cluster-wide in a no-encap
+// pool, then asserts that the client node's kernel route to the server's block
+// is not owned by BIRD (the WireGuard peer filter suppresses it) while the
+// server pod stays reachable across nodes over the WireGuard device.
+func TestWireguardBGPRouteSuppression(t *testing.T) {
+	defer utils.CollectDiagsOnFailure(t)()
+
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	t.Cleanup(cancel)
+
+	cli := newClient(g)
+
+	// Need two workers so the server and client land on different nodes -
+	// otherwise there is no cross-node route to inspect. NodeInfo returns the
+	// control-plane node first, then workers.
+	nodes, _, _ := utils.NodeInfo(t)
+	g.Expect(len(nodes)).To(BeNumerically(">=", 3),
+		"need a control-plane node and at least two workers")
+	serverNode, clientNode := nodes[1], nodes[2]
+
+	// With every node running WireGuard, each node's BIRD rejects kernel routes
+	// to its peers' blocks and lets Felix route them over wireguard.cali.
+	t.Cleanup(setWireguardEnabled(ctx, g, cli, true))
+
+	// The peer filter only targets no-encap BGP routes; VXLAN and IPIP routes
+	// are already suppressed by their own tunnel-route filters.
+	pool := &v3.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "wireguard-bgp-pool"},
+		Spec: v3.IPPoolSpec{
+			CIDR:        wgBGPPoolCIDR,
+			IPIPMode:    v3.IPIPModeNever,
+			VXLANMode:   v3.VXLANModeNever,
+			NATOutgoing: true,
+			BlockSize:   26,
+		},
+	}
+	g.Expect(cli.Create(ctx, pool)).To(Succeed(), "creating IPPool")
+	t.Cleanup(func() { deletePool(t, cli, pool.Name) })
+
+	// WireGuard has to actually come up, otherwise the filter never engages.
+	waitForWireguardDevice(t, g, serverNode)
+	waitForWireguardDevice(t, g, clientNode)
+
+	nsName := e2eutils.GenerateRandomName("wireguard-bgp")
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	g.Expect(cli.Create(ctx, ns)).To(Succeed(), "creating namespace")
+	t.Cleanup(func() { _ = cli.Delete(context.Background(), ns) })
+
+	server := routeOwnerPod(nsName, "server", serverNode, pool.Name, true)
+	g.Expect(cli.Create(ctx, server)).To(Succeed(), "creating server pod")
+	t.Cleanup(func() { _ = cli.Delete(context.Background(), server) })
+
+	client := routeOwnerPod(nsName, "client", clientNode, pool.Name, false)
+	g.Expect(cli.Create(ctx, client)).To(Succeed(), "creating client pod")
+	t.Cleanup(func() { _ = cli.Delete(context.Background(), client) })
+
+	serverIP := waitForPodIP(ctx, g, cli, server, corev1.IPv4Protocol)
+	t.Logf("Server pod %s/%s scheduled on %s with IP %s", nsName, server.Name, serverNode, serverIP)
+	waitForPodIP(ctx, g, cli, client, corev1.IPv4Protocol)
+
+	// Cross-node pod connectivity must keep working with the WireGuard peer
+	// filter in effect - Felix carries the traffic over the WireGuard device.
+	g.Eventually(func() error {
+		_, err := utils.ExecInPod(t, nsName, client.Name,
+			fmt.Sprintf("curl --silent --show-error --max-time 5 http://%s/clientip", serverIP+":80"),
+			utils.RunOptions{AllowFail: true, SuppressErrLog: true})
+		return err
+	}, "120s", "1s").Should(Succeed(),
+		"client pod could not reach server pod %s across nodes", serverIP)
+
+	// The fix itself: BIRD must not own a kernel route to the server's block on
+	// the client node. Match the server's block exactly so we don't trip over
+	// the client's own local block (its blackhole route is always BIRD-owned).
+	// Without the filter BIRD installs the peer route (kind nodes share an L2, so
+	// it otherwise succeeds) and fights Felix's WireGuard route.
+	_, serverBlock, err := net.ParseCIDR(fmt.Sprintf("%s/%d", serverIP, pool.Spec.BlockSize))
+	g.Expect(err).NotTo(HaveOccurred(), "computing server block CIDR from %s/%d", serverIP, pool.Spec.BlockSize)
+	utils.AssertNoRouteWithProto(t, clientNode, serverBlock.String(), utils.RouteProtoBIRD)
+}
+
+// setWireguardEnabled flips WireguardEnabled on the default FelixConfiguration
+// and returns an idempotent restore function.
+func setWireguardEnabled(ctx context.Context, g *WithT, cli ctrlclient.Client, enabled bool) func() {
+	cfg := &v3.FelixConfiguration{}
+	g.Expect(cli.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, cfg)).
+		To(Succeed(), "fetching default FelixConfiguration")
+
+	var original *bool
+	if cfg.Spec.WireguardEnabled != nil {
+		v := *cfg.Spec.WireguardEnabled
+		original = &v
+	}
+
+	cfg.Spec.WireguardEnabled = &enabled
+	g.Expect(cli.Update(ctx, cfg)).To(Succeed(), "setting WireguardEnabled=%v", enabled)
+
+	restored := false
+	return func() {
+		if restored {
+			return
+		}
+		restored = true
+		// Re-fetch and write back the original, retrying to absorb concurrent
+		// updates.
+		g.Eventually(func() error {
+			cur := &v3.FelixConfiguration{}
+			rctx, rcancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer rcancel()
+			if err := cli.Get(rctx, ctrlclient.ObjectKey{Name: "default"}, cur); err != nil {
+				return err
+			}
+			cur.Spec.WireguardEnabled = original
+			return cli.Update(rctx, cur)
+		}, "20s", "1s").Should(Succeed(), "restoring original WireguardEnabled")
+	}
+}
+
+// waitForWireguardDevice waits for wireguard.cali to appear in the calico-node
+// host namespace on nodeName. A missing interface usually means the node's
+// kernel lacks the wireguard module, so fail loudly rather than skip.
+func waitForWireguardDevice(t testing.TB, g *WithT, nodeName string) {
+	t.Helper()
+	g.Eventually(func() error {
+		_, err := utils.ExecInCalicoNode(t, nodeName, "ip link show wireguard.cali",
+			utils.RunOptions{AllowFail: true, SuppressErrLog: true})
+		return err
+	}, "120s", "2s").Should(Succeed(),
+		"wireguard.cali never appeared on node %s - is the wireguard kernel module available?", nodeName)
+}

--- a/node/tests/k8st/utils/routes.go
+++ b/node/tests/k8st/utils/routes.go
@@ -144,3 +144,30 @@ func AssertRouteOwnership(t testing.TB, nodeName, dstSubstring, expectedDev stri
 			nodeName, expectedDev, expectedProto, routes)
 	}, 60*time.Second, time.Second).Should(Succeed(), "route ownership assertion failed")
 }
+
+// AssertNoRouteWithProto waits until the main routing table on nodeName has no
+// route matching dstSubstring owned by proto, then confirms that holds for a
+// short window. Used to verify a component has stopped programming a route (e.g.
+// BIRD once the WireGuard peer filter takes effect). Eventually rather than an
+// immediate check because BIRD may briefly hold the route until the filter
+// converges; the trailing Consistently guards against it reappearing.
+func AssertNoRouteWithProto(t testing.TB, nodeName, dstSubstring string, proto RouteProto) {
+	t.Helper()
+	t.Logf("Waiting for no %s-owned route to %q on node %s", proto, dstSubstring, nodeName)
+	check := func() error {
+		routes, err := GetNodeRoutes(t, nodeName, dstSubstring)
+		if err != nil {
+			return err
+		}
+		for _, r := range routes {
+			if r.Proto == proto {
+				return fmt.Errorf("unexpected %s-owned route on node %s: %s", proto, nodeName, r.Raw)
+			}
+		}
+		return nil
+	}
+	NewWithT(t).Eventually(check, 90*time.Second, 3*time.Second).Should(Succeed(),
+		"expected %s to withdraw its route to %q on node %s", proto, dstSubstring, nodeName)
+	NewWithT(t).Consistently(check, 10*time.Second, 2*time.Second).Should(Succeed(),
+		"%s-owned route to %q on node %s reappeared", proto, dstSubstring, nodeName)
+}


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico/issues/11596

When WireGuard is enabled alongside BGP with no encapsulation, BIRD tries to install kernel routes for BGP-learned prefixes using the remote node's IP as the next hop. If the remote node isn't on the same L2 segment (e.g., nodes with only public IPs), the kernel rejects these with "Network is unreachable". Pod-to-pod traffic still works because Felix programs routes through the WireGuard device directly, so BIRD's routes are redundant.

This PR suppresses BIRD's kernel route installation for routes whose next hop is a WireGuard-enabled node, similar to how VXLAN routes are already handled. The suppression is per-peer rather than per-pool, so mixed clusters where some nodes have WireGuard and others don't (e.g., external BGP peers) work correctly.

```release-note
Fixes repetitive "Network is unreachable" errors when WireGuard is enabled in conjunction with BGP in some setups.
```