### PR TITLE
[v3.32] Make CRD validator compilation lazy and datastore-aware

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1684,7 +1684,7 @@ $(ENVTEST_ASSETS_MARKER):
 	mkdir -p $(ENVTEST_DIR)
 	rm -f $(ENVTEST_DIR)/.envtest-*
 	$(DOCKER_GO_BUILD) sh -c \
-		'go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
+		'go run sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251218032627-56d9e70af999 \
 		use --bin-dir $(ENVTEST_CONTAINER_DIR) -p path $(ENVTEST_K8S_VERSION)'
 	touch $@
 
@@ -1702,7 +1702,7 @@ $(ENVTEST_MIN_ASSETS_MARKER):
 	@echo "Setting up envtest binaries for minimum K8s $(ENVTEST_MIN_K8S_VERSION)..."
 	mkdir -p $(ENVTEST_DIR)
 	$(DOCKER_GO_BUILD) sh -c \
-		'go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
+		'go run sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251218032627-56d9e70af999 \
 		use --bin-dir $(ENVTEST_CONTAINER_DIR) -p path $(ENVTEST_MIN_K8S_VERSION)'
 	touch $@
 

--- a/libcalico-go/lib/clientv3/client.go
+++ b/libcalico-go/lib/clientv3/client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
+	validator "github.com/projectcalico/calico/libcalico-go/lib/validator/v3"
 )
 
 // client implements the client.Interface.
@@ -56,6 +57,15 @@ func New(config apiconfig.CalicoAPIConfig) (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Enable in-process CRD validation (CEL rules, OpenAPI constraints,
+	// schema defaulting) for etcd mode. In KDD mode the kube-apiserver
+	// handles this on admission, so we skip it to avoid the expensive
+	// CEL compilation cost.
+	if config.Spec.DatastoreType == apiconfig.EtcdV3 {
+		validator.SetCRDValidationEnabled(true)
+	}
+
 	return client{
 		config:    config,
 		backend:   be,

--- a/libcalico-go/lib/validator/v3/crd_schemas.go
+++ b/libcalico-go/lib/validator/v3/crd_schemas.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	calicoapi "github.com/projectcalico/api"
+	"github.com/sirupsen/logrus"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	celvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	schemadefaulting "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	schemavalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+)
+
+// crdSchemaRegistry holds parsed CRD schemas and their lazily compiled
+// validators. A non-nil registry pointer means CRD validation is enabled.
+type crdSchemaRegistry struct {
+	loadOnce sync.Once
+	loadErr  error
+	schemas  map[string]*crdSchema
+}
+
+// DefaultAndValidate applies CRD schema defaults to obj in-place and then
+// runs CRD validation rules (OpenAPI schema constraints + CEL
+// x-kubernetes-validations). For create operations pass nil for oldObj.
+// Returns nil if the object's Kind has no CRD schema or if defaulting and
+// validation both succeed.
+func (r *crdSchemaRegistry) DefaultAndValidate(ctx context.Context, kind string, obj, oldObj any) field.ErrorList {
+	r.load()
+	if r.loadErr != nil {
+		return field.ErrorList{field.InternalError(nil, r.loadErr)}
+	}
+
+	s, ok := r.schemas[kind]
+	if !ok {
+		return nil
+	}
+	s.compile(kind)
+
+	// Apply CRD schema defaults.
+	if s.structural != nil {
+		schemadefaulting.Default(obj, s.structural)
+	}
+
+	var allErrs field.ErrorList
+
+	// Run OpenAPI schema validation (MinItems, MaxLength, Pattern, Enum, etc.).
+	if s.schemaValidator != nil {
+		allErrs = append(allErrs, schemavalidation.ValidateCustomResource(nil, obj, s.schemaValidator)...)
+	}
+
+	// Run CEL validation (x-kubernetes-validations rules).
+	if s.celValidator != nil {
+		celErrs, _ := s.celValidator.Validate(ctx, nil, nil, obj, oldObj, int64(celconfig.RuntimeCELCostBudget))
+		allErrs = append(allErrs, celErrs...)
+	}
+
+	return allErrs
+}
+
+// load parses all embedded CRDs and stores their schemas. Safe for
+// concurrent use; the actual work runs at most once.
+func (r *crdSchemaRegistry) load() {
+	r.loadOnce.Do(func() {
+		r.schemas = make(map[string]*crdSchema)
+
+		crds, err := calicoapi.AllCRDs()
+		if err != nil {
+			r.loadErr = fmt.Errorf("failed to load CRDs: %w", err)
+			return
+		}
+
+		for _, crd := range crds {
+			kind := crd.Spec.Names.Kind
+			if len(crd.Spec.Versions) == 0 {
+				continue
+			}
+
+			// Find the storage version's schema.
+			var version *apiextensionsv1.CustomResourceDefinitionVersion
+			for i := range crd.Spec.Versions {
+				if crd.Spec.Versions[i].Storage {
+					version = &crd.Spec.Versions[i]
+					break
+				}
+			}
+			if version == nil {
+				version = &crd.Spec.Versions[0]
+			}
+			if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+				continue
+			}
+
+			internalSchema := &apiextensions.JSONSchemaProps{}
+			err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(
+				version.Schema.OpenAPIV3Schema,
+				internalSchema,
+				nil,
+			)
+			if err != nil {
+				logrus.WithError(err).WithField("kind", kind).Warn("Failed to convert CRD schema to internal format")
+				continue
+			}
+
+			r.schemas[kind] = &crdSchema{rawSchema: internalSchema}
+		}
+	})
+}
+
+// crdSchema holds the raw schema and lazily-compiled validators for a
+// single CRD Kind.
+type crdSchema struct {
+	rawSchema *apiextensions.JSONSchemaProps
+
+	compileOnce     sync.Once
+	celValidator    *celvalidation.Validator
+	schemaValidator schemavalidation.SchemaCreateValidator
+	structural      *structuralschema.Structural
+}
+
+// compile builds the OpenAPI schema validator, structural schema, and
+// CEL validator from the raw schema. Safe for concurrent use; the actual
+// work runs at most once.
+func (s *crdSchema) compile(kind string) {
+	s.compileOnce.Do(func() {
+		sv, _, err := schemavalidation.NewSchemaValidator(s.rawSchema)
+		if err != nil {
+			logrus.WithError(err).WithField("kind", kind).Warn("Failed to create schema validator from CRD")
+		} else {
+			s.schemaValidator = sv
+		}
+
+		structural, err := structuralschema.NewStructural(s.rawSchema)
+		if err != nil {
+			logrus.WithError(err).WithField("kind", kind).Warn("Failed to create structural schema from CRD")
+			return
+		}
+		s.structural = structural
+
+		v := celvalidation.NewValidator(structural, true, celconfig.PerCallLimit)
+		if v != nil {
+			s.celValidator = v
+		}
+
+		logrus.WithField("kind", kind).Debug("Compiled CRD validators")
+	})
+}
+
+// crdRegistry is the sole package-level variable. A non-nil value means
+// CRD validation is enabled; nil means disabled (KDD mode).
+var crdRegistry atomic.Pointer[crdSchemaRegistry]
+
+// SetCRDValidationEnabled controls whether Validate() applies CRD schema
+// defaults and runs CRD validation rules (CEL + OpenAPI constraints). When
+// enabled, schemas are loaded lazily on first use and validators are
+// compiled per-Kind on demand. This should be enabled when there is no
+// kube-apiserver to enforce CRD rules (i.e., etcd datastore mode).
+func SetCRDValidationEnabled(enabled bool) {
+	if enabled {
+		crdRegistry.CompareAndSwap(nil, &crdSchemaRegistry{})
+	} else {
+		crdRegistry.Store(nil)
+	}
+}

--- a/libcalico-go/lib/validator/v3/crd_validation.go
+++ b/libcalico-go/lib/validator/v3/crd_validation.go
@@ -20,107 +20,10 @@ import (
 	"fmt"
 	"reflect"
 
-	calicoapi "github.com/projectcalico/api"
-	"github.com/sirupsen/logrus"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
-	celvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
-	schemadefaulting "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
-	schemavalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	celconfig "k8s.io/apiserver/pkg/apis/cel"
 )
-
-var (
-	// celValidators maps CRD Kind to its compiled CEL validator.
-	celValidators map[string]*celvalidation.Validator
-
-	// schemaValidators maps CRD Kind to its OpenAPI schema validator, which
-	// enforces constraints like MinItems, MaxLength, Pattern, Enum, etc.
-	schemaValidators map[string]schemavalidation.SchemaCreateValidator
-
-	// schemas maps CRD Kind to its structural schema.
-	schemas map[string]*structuralschema.Structural
-
-	// crdInitErr captures any error from init() so callers can surface it.
-	crdInitErr error
-)
-
-// init loads all embedded CRDs, converts their schemas, and compiles
-// validators for CEL rules and OpenAPI schema constraints.
-func init() {
-	celValidators = make(map[string]*celvalidation.Validator)
-	schemaValidators = make(map[string]schemavalidation.SchemaCreateValidator)
-	schemas = make(map[string]*structuralschema.Structural)
-
-	crds, err := calicoapi.AllCRDs()
-	if err != nil {
-		crdInitErr = fmt.Errorf("failed to load CRDs: %w", err)
-		return
-	}
-
-	for _, crd := range crds {
-		kind := crd.Spec.Names.Kind
-		if len(crd.Spec.Versions) == 0 {
-			continue
-		}
-
-		// Find the storage version's schema.
-		var version *apiextensionsv1.CustomResourceDefinitionVersion
-		for i := range crd.Spec.Versions {
-			if crd.Spec.Versions[i].Storage {
-				version = &crd.Spec.Versions[i]
-				break
-			}
-		}
-		if version == nil {
-			version = &crd.Spec.Versions[0]
-		}
-		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
-			continue
-		}
-
-		// Convert v1 JSONSchemaProps to internal.
-		internalSchema := &apiextensions.JSONSchemaProps{}
-		err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(
-			version.Schema.OpenAPIV3Schema,
-			internalSchema,
-			nil,
-		)
-		if err != nil {
-			logrus.WithError(err).WithField("kind", kind).Warn("Failed to convert CRD schema to internal format")
-			continue
-		}
-
-		// Build OpenAPI schema validator for constraints like MinItems,
-		// MaxLength, Pattern, Enum, Required, etc.
-		sv, _, err := schemavalidation.NewSchemaValidator(internalSchema)
-		if err != nil {
-			logrus.WithError(err).WithField("kind", kind).Warn("Failed to create schema validator from CRD")
-		} else {
-			schemaValidators[kind] = sv
-		}
-
-		// Convert to structural schema for CEL compilation.
-		structural, err := structuralschema.NewStructural(internalSchema)
-		if err != nil {
-			logrus.WithError(err).WithField("kind", kind).Warn("Failed to create structural schema from CRD")
-			continue
-		}
-		schemas[kind] = structural
-
-		// Compile CEL validator. Returns nil if no x-kubernetes-validations exist.
-		v := celvalidation.NewValidator(structural, true, celconfig.PerCallLimit)
-		if v != nil {
-			celValidators[kind] = v
-		}
-
-		logrus.WithField("kind", kind).Debug("Compiled CRD validators")
-	}
-}
 
 // defaultAndValidateCRD applies CRD schema defaults to the object in-place
 // and then runs CRD validation rules (OpenAPI schema constraints + CEL
@@ -130,11 +33,12 @@ func init() {
 // For create operations, pass nil for oldObj.
 // For update operations, pass the previous version as oldObj.
 //
-// Returns nil if the object's Kind has no CRD schema, or if defaulting and
-// validation both succeed.
+// Returns nil if CRD validation is disabled, the object's Kind has no CRD
+// schema, or if defaulting and validation both succeed.
 func defaultAndValidateCRD(ctx context.Context, obj runtime.Object, oldObj runtime.Object) field.ErrorList {
-	if crdInitErr != nil {
-		return field.ErrorList{field.InternalError(nil, crdInitErr)}
+	reg := crdRegistry.Load()
+	if reg == nil {
+		return nil
 	}
 
 	kind := resolveKind(obj)
@@ -146,30 +50,16 @@ func defaultAndValidateCRD(ctx context.Context, obj runtime.Object, oldObj runti
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("failed to convert object to unstructured: %w", err))}
 	}
 
-	// Apply CRD schema defaults to the unstructured representation.
-	applyCRDDefaults(unstructuredObj, kind)
-
-	// Validate the defaulted unstructured data.
-	var allErrs field.ErrorList
-
-	// Run OpenAPI schema validation (MinItems, MaxLength, Pattern, Enum, etc.).
-	if sv, ok := schemaValidators[kind]; ok {
-		allErrs = append(allErrs, schemavalidation.ValidateCustomResource(nil, unstructuredObj, sv)...)
-	}
-
-	// Run CEL validation (x-kubernetes-validations rules).
-	if cv, ok := celValidators[kind]; ok {
-		var unstructuredOldObj any
-		if oldObj != nil {
-			unstructuredOldObj, err = toUnstructured(oldObj)
-			if err != nil {
-				return field.ErrorList{field.InternalError(nil, fmt.Errorf("failed to convert old object to unstructured: %w", err))}
-			}
+	var unstructuredOldObj any
+	if oldObj != nil {
+		unstructuredOldObj, err = toUnstructured(oldObj)
+		if err != nil {
+			return field.ErrorList{field.InternalError(nil, fmt.Errorf("failed to convert old object to unstructured: %w", err))}
 		}
-
-		celErrs, _ := cv.Validate(ctx, nil, nil, unstructuredObj, unstructuredOldObj, int64(celconfig.RuntimeCELCostBudget))
-		allErrs = append(allErrs, celErrs...)
 	}
+
+	// Delegate defaulting and validation to the registry.
+	allErrs := reg.DefaultAndValidate(ctx, kind, unstructuredObj, unstructuredOldObj)
 
 	// Convert the defaulted unstructured data back into the typed object so
 	// the caller sees the applied defaults. We use the converter here (rather
@@ -182,14 +72,6 @@ func defaultAndValidateCRD(ctx context.Context, obj runtime.Object, oldObj runti
 	}
 
 	return allErrs
-}
-
-// applyCRDDefaults applies CRD schema default values to an unstructured
-// object representation in-place. This is a no-op if the kind has no schema.
-func applyCRDDefaults(unstructuredObj any, kind string) {
-	if s, ok := schemas[kind]; ok {
-		schemadefaulting.Default(unstructuredObj, s)
-	}
 }
 
 // resolveKind returns the Kind string for a runtime.Object, falling back to

--- a/libcalico-go/lib/validator/v3/crd_validation_test.go
+++ b/libcalico-go/lib/validator/v3/crd_validation_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
 
+func init() {
+	SetCRDValidationEnabled(true)
+}
+
 // crdTestCase defines a single CRD validation test. Each case passes a
 // runtime.Object through the full Validate() path and checks whether an
 // error containing errSubstr is produced.


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#12338

The CRD validation `init()` eagerly compiles CEL validators for all 40+ CRDs at package import time. This costs ~33-54 MB per process depending on the number of CEL rules in the CRD schemas. The calico-node container runs 8+ separate processes of the same binary via runit (felix, confd, startup, monitor-addresses, allocate-tunnel-addrs, etc.), each paying this cost independently. On a kind cluster with a 512Mi calico-node memory limit, this exceeds the budget and causes OOMKill.

In KDD mode (the vast majority of deployments), the kube-apiserver already enforces CRD validation rules on admission — the in-process CEL compilation is redundant.

This PR replaces the `init()` with a `crdSchemaRegistry` that:

- Is disabled by default. `clientv3.New()` enables it only for etcd datastores via `SetCRDValidationEnabled(true)`.
- Loads CRD schemas lazily on first use (~9 MB, cheap).
- Compiles CEL and OpenAPI validators per-Kind on demand, so a process that only validates Node objects never compiles the expensive policy CRD validators (~3 MB each).
- Is concurrency-safe via `sync.Once` at both the registry and per-Kind level.
- Exposes a single `DefaultAndValidate()` method — callers don't interact with the underlying schema data structures.

The only package-level state is a single `atomic.Pointer[crdSchemaRegistry]`.

```release-note
None
```

<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 12338
- **Original Commit SHA**: 08f16e2ed9
- **Source Repo**: `projectcalico/calico`
- **Source Branch**: `master`
- **Target Branch**: `release-v3.32`
</details>