### PR TITLE
fix(bpf): enforce policy on established ambient mesh connections

### DIFF
--- a/e2e/pkg/tests/istio/istio.go
+++ b/e2e/pkg/tests/istio/istio.go
@@ -71,6 +71,30 @@ var _ = describe.CalicoDescribe(
 			var err error
 			cli, err = client.New(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create controller-runtime client")
+
+			// Disable CTLB (connect-time load balancing) for Istio ambient mode tests.
+			// CTLB intercepts connections at the socket level, which can bypass ztunnel's
+			// traffic interception and break policy enforcement.
+			originalFC := v3.NewFelixConfiguration()
+			gomega.Eventually(func() error {
+				return cli.Get(context.Background(), types.NamespacedName{Name: "default"}, originalFC)
+			}, 10*time.Second, 1*time.Second).Should(gomega.Succeed(), "failed to get default FelixConfiguration")
+
+			originalCTLB := originalFC.Spec.BPFConnectTimeLoadBalancing
+			ctlbDisabled := v3.BPFConnectTimeLBDisabled
+			gomega.Eventually(func() error {
+				return utils.UpdateFelixConfig(cli, func(spec *v3.FelixConfigurationSpec) {
+					spec.BPFConnectTimeLoadBalancing = &ctlbDisabled
+				})
+			}, 10*time.Second, 1*time.Second).Should(gomega.Succeed(), "failed to disable CTLB")
+
+			ginkgo.DeferCleanup(func() {
+				gomega.Eventually(func() error {
+					return utils.UpdateFelixConfig(cli, func(spec *v3.FelixConfigurationSpec) {
+						spec.BPFConnectTimeLoadBalancing = originalCTLB
+					})
+				}, 10*time.Second, 1*time.Second).Should(gomega.Succeed(), "failed to restore CTLB")
+			})
 		})
 
 		// Test: Full Istio Ambient Mode lifecycle with traffic encryption and Calico policy enforcement.

--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -898,8 +898,13 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 		CALI_CT_VERB("B: approved %d.", v->b_to_a.approved);
 
 		if (v->a_to_b.approved && v->b_to_a.approved) {
-			result.rc = CALI_CT_ESTABLISHED_BYPASS;
-			ct_result_set_flag(result.rc, CT_RES_CONFIRMED);
+			if (ct_value_get_flags(v) & CALI_CT_FLAG_AMBIENT) {
+				result.rc = CALI_CT_ESTABLISHED;
+				CALI_CT_DEBUG("Ambient connection: suppressing bypass");
+			} else {
+				result.rc = CALI_CT_ESTABLISHED_BYPASS;
+				ct_result_set_flag(result.rc, CT_RES_CONFIRMED);
+			}
 		} else {
 			result.rc = CALI_CT_ESTABLISHED;
 		}
@@ -911,6 +916,11 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_lookup(struct cali_tc_c
 			src_to_dst = &v->b_to_a;
 			dst_to_src = &v->a_to_b;
 		}
+
+		/* Only propagate the AMBIENT flag for NORMAL entries. Other flags
+		 * were previously not propagated and doing so could cause side
+		 * effects (e.g., SKIP_FIB being unexpectedly honored). */
+		result.flags = ct_value_get_flags(v) & CALI_CT_FLAG_AMBIENT;
 
 		break;
 	default:

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -42,6 +42,7 @@ enum cali_ct_type {
 #define CALI_CT_FLAG_SET_DSCP	0x8000 /* marks connections that needs to set DSCP */
 #define CALI_CT_FLAG_MAGLEV	0X10000 /* marks Maglev connections. Allows packets of an existing to arrive via a different tunnel after failover. */
 #define CALI_CT_FLAG_SEND_RESET	0x20000 /* marks connections where we should send a TCP RST on behalf of the workload */
+#define CALI_CT_FLAG_AMBIENT	0x40000 /* marks connections involving ambient mesh workloads; forces per-packet policy */
 
 struct calico_ct_leg {
 	__u64 bytes;

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -469,6 +469,21 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 			}
 			goto syn_force_policy;
 		}
+		/* Ambient mesh connections must always go through policy so that
+		 * policy changes take effect on ztunnel's persistent connections.
+		 * For FROM_WEP (egress), the destination may be a service ClusterIP
+		 * that was DNATted — use the post-NAT IP from the CT result. */
+		if (CALI_F_WEP && (ctx->state->ct_result.flags & CALI_CT_FLAG_AMBIENT)) {
+			CALI_DEBUG("Ambient connection: forcing policy re-evaluation");
+			if (ct_result_rc(ctx->state->ct_result.rc) == CALI_CT_ESTABLISHED_DNAT) {
+				ctx->state->post_nat_ip_dst = ctx->state->ct_result.nat_ip;
+				ctx->state->post_nat_dport = ctx->state->ct_result.nat_port;
+			} else {
+				ctx->state->post_nat_ip_dst = ctx->state->ip_dst;
+				ctx->state->post_nat_dport = ctx->state->dport;
+			}
+			goto syn_force_policy;
+		}
 		goto skip_policy;
 	}
 
@@ -1368,6 +1383,17 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 		goto deny;
 	}
 
+	// Detect ambient mesh traffic and set state flag for CT entry creation.
+	// ISTIO_DSCP >= 0 is per-interface, set only on ambient workload interfaces.
+	// Check both SYN on existing CT (ct_result_is_syn) and new flows (CALI_CT_NEW)
+	// to ensure the flag is set when the CT entry is first created.
+	if (ISTIO_DSCP >= 0 && ctx->state->ip_proto == IPPROTO_TCP &&
+			(ct_result_is_syn(ctx->state->ct_result.rc) ||
+			 ct_result_rc(ctx->state->ct_result.rc) == CALI_CT_NEW)) {
+		ctx->state->flags |= CALI_ST_AMBIENT;
+		CALI_DEBUG("Ambient mesh workload detected");
+	}
+
 	// Set Istio DSCP mark, if traffic originates from a workload that's part of the mesh.
 	if (CALI_F_TO_WEP && ISTIO_DSCP >= 0 && ctx->state->ip_proto == IPPROTO_TCP && ct_result_is_syn(ctx->state->ct_result.rc)) {
 		ipv46_addr_t src_ip = ctx->state->ip_src;
@@ -1467,6 +1493,9 @@ int calico_tc_skb_new_flow_entrypoint(struct __sk_buff *skb)
 	}
 	if (state->flags & CALI_ST_SET_DSCP) {
 		ct_ctx_nat->flags |= CALI_CT_FLAG_SET_DSCP;
+	}
+	if (state->flags & CALI_ST_AMBIENT) {
+		ct_ctx_nat->flags |= CALI_CT_FLAG_AMBIENT;
 	}
 	if (CALI_F_TO_HOST && state->flags & CALI_ST_SKIP_FIB) {
 		ct_ctx_nat->flags |= CALI_CT_FLAG_SKIP_FIB;

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -171,6 +171,8 @@ enum cali_state_flags {
 	CALI_ST_SET_DSCP   = 0x2000,
 	/* CALI_ST_FIRST_FRAG is set if this packet is the first fragment of a fragmented IP packet */
 	CALI_ST_FIRST_FRAG        = 0x4000,
+	/* CALI_ST_AMBIENT is set when the packet is on an ambient mesh workload interface. */
+	CALI_ST_AMBIENT           = 0x8000,
 };
 
 struct cali_tc_ctx {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -873,7 +873,11 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					globals.DSCP = topts.dscp
 				}
 
-				globals.IstioDSCP = topts.istioDSCP
+				if topts.istioDSCP != 0 {
+					globals.IstioDSCP = topts.istioDSCP
+				} else {
+					globals.IstioDSCP = -1
+				}
 
 				if topts.ipv6 {
 					copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())

--- a/felix/bpf/ut/istio_test.go
+++ b/felix/bpf/ut/istio_test.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/ipsets"
+	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
+	"github.com/projectcalico/calico/felix/proto"
 )
 
 // TestIstioDSCPv4 tests the BPF implementation of Istio DSCP marking for IPv4 packets.
@@ -417,5 +419,240 @@ func TestIstioDSCPv6(t *testing.T) {
 			actualDSCP := ipv6R.TrafficClass >> 2
 			Expect(actualDSCP).To(Equal(preDSCP), "Expected DSCP not changed when feature disabled, got %d", actualDSCP)
 		}, withIPv6())
+	})
+}
+
+// TestIstioAmbientPolicyEnforcementV4 tests that policy changes take effect on
+// established connections for ambient mesh workloads. This is the fix for the bug
+// where ztunnel's persistent connections bypass policy re-evaluation due to the
+// BPF fast-path (CALI_CT_ESTABLISHED_BYPASS).
+func TestIstioAmbientPolicyEnforcementV4(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfIfaceName = "IWep"
+	defer func() {
+		bpfIfaceName = ""
+		skbMark = 0
+	}()
+
+	ctMap := conntrack.Map()
+	Expect(ctMap.EnsureExists()).NotTo(HaveOccurred())
+	defer resetCTMap(ctMap)
+
+	ifIndex := 1
+	istioDSCP := uint8(26)
+
+	// Setup routes for source and destination workloads
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	Expect(rtMap.Update(rtKey, rtVal)).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+
+	// Add source IP to Istio WEPs IP set
+	ipsetMap := ipsets.Map()
+	Expect(ipsetMap.EnsureExists()).NotTo(HaveOccurred())
+	ipsetEntry := ipsets.ProtoIPSetMemberToBPFEntry(ipsets.AllIstioWEPsID, fmt.Sprintf("%s/32", srcIP.String()))
+	Expect(ipsetMap.Update(ipsetEntry.AsBytes(), ipsets.DummyValue)).NotTo(HaveOccurred())
+	defer func() {
+		_ = ipsetMap.Delete(ipsetEntry.AsBytes())
+	}()
+
+	rulesDefaultDeny := &polprog.Rules{
+		Tiers: []polprog.Tier{{
+			Name: "base tier",
+			Policies: []polprog.Policy{{
+				Name:  "deny all",
+				Rules: []polprog.Rule{{Rule: &proto.Rule{Action: "Deny"}}},
+			}},
+		}},
+	}
+
+	// Ignore the unused import warnings by using the variables
+	_ = gopacket.Default
+	_ = layers.LayerTypeEthernet
+
+	t.Run("Ambient: established connection re-evaluates policy on deny", func(t *testing.T) {
+		// Step 1: Send TCP SYN from_wep to create CT entry (with allow policy)
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54321,
+				DstPort:    80,
+				SYN:        true,
+				Seq:        1000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		}, withIstioDSCP(istioDSCP))
+
+		// Step 2: Send TCP SYN to_wep (creates full CT entry with ambient flag)
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54321,
+				DstPort:    80,
+				SYN:        true,
+				Seq:        1000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		}, withIstioDSCP(istioDSCP))
+
+		// Step 3: Send TCP ACK to_wep with allow policy - should be allowed
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54321,
+				DstPort:    80,
+				ACK:        true,
+				Seq:        1001,
+				Ack:        2000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC), "Established ambient connection with allow policy should pass")
+		}, withIstioDSCP(istioDSCP))
+
+		// Step 4: Send TCP ACK to_wep with DENY policy - should be DENIED
+		// This is the core bug fix test: without the fix, this would pass because
+		// the established connection is fast-pathed and policy is never re-evaluated.
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultDeny, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54321,
+				DstPort:    80,
+				ACK:        true,
+				Seq:        1002,
+				Ack:        2000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_SHOT), "Established ambient connection with deny policy MUST be denied")
+		}, withIstioDSCP(istioDSCP))
+	})
+
+	t.Run("Non-ambient: established connection bypasses policy (existing behavior)", func(t *testing.T) {
+		// Reset CT map for a clean test
+		resetCTMap(ctMap)
+
+		// Step 1: Send TCP SYN from_wep WITHOUT ambient (no istioDSCP)
+		skbMark = 0
+		runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54322,
+				DstPort:    80,
+				SYN:        true,
+				Seq:        1000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+		})
+
+		// Step 2: Send TCP SYN to_wep (no ambient)
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54322,
+				DstPort:    80,
+				SYN:        true,
+				Seq:        1000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		})
+
+		// Step 3: Send TCP ACK to_wep with deny policy - should STILL be allowed
+		// because non-ambient connections get fast-pathed (existing behavior)
+		skbMark = tcdefs.MarkSeen
+		runBpfTest(t, "calico_to_workload_ep", rulesDefaultDeny, func(bpfrun bpfProgRunFn) {
+			tcpHdr := &layers.TCP{
+				SrcPort:    54322,
+				DstPort:    80,
+				ACK:        true,
+				Seq:        1001,
+				Ack:        2000,
+				Window:     65535,
+				DataOffset: 5,
+			}
+
+			ipv4Hdr := *ipv4Default
+			ipv4Hdr.SrcIP = srcIP
+			ipv4Hdr.DstIP = dstIP
+			ipv4Hdr.Protocol = layers.IPProtocolTCP
+
+			_, _, _, _, pktBytes, err := testPacketV4(nil, &ipv4Hdr, tcpHdr, []byte{})
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC), "Non-ambient established connection should still be fast-pathed (allowed despite deny policy)")
+		})
 	})
 }


### PR DESCRIPTION
## Summary

- Fix BPF fast-path (`CALI_CT_ESTABLISHED_BYPASS`) bypassing policy re-evaluation for Istio ambient mesh (ztunnel) connections
- Disable CTLB in Istio ambient e2e tests (incompatible with ambient mode)
- Temporary workaround for calico-system tier policies blocking cross-node ztunnel<->istiod in BPF mode without CTLB

## Problem

When Istio ambient mode is enabled on a CalicoBPF cluster, ztunnel maintains persistent HBONE connections to workload pods. These get both `a_to_b.approved` and `b_to_a.approved` set in conntrack, resulting in `CALI_CT_ESTABLISHED_BYPASS`. All subsequent packets skip policy — so applying a new deny policy has no effect on existing ztunnel connections.

## Approach

Add `CALI_CT_FLAG_AMBIENT` to mark conntrack entries for ambient mesh workloads (detected via `ISTIO_DSCP` on the interface). For connections with this flag, the conntrack lookup suppresses the bypass (returns `ESTABLISHED` instead of `BYPASS`), forcing per-packet policy re-evaluation on both ingress (TO_WEP) and egress (FROM_WEP) paths. This ensures policy changes take immediate effect on ztunnel's persistent connections.

On the TO_WEP path, the `tc.c` change handles ambient detection and routes ambient ESTABLISHED connections through `syn_force_policy` for full policy evaluation. FROM_WEP ambient connections also hit policy because the bypass is suppressed in conntrack.

The `daemon.go` workaround creates an allow-all override policy for ztunnel+istiod when BPF+ambient+CTLB-disabled is detected, working around operator-managed policies that don't resolve correctly cross-node without CTLB.

### Known limitation: egress policy on OSS ambient

Egress policies with destination selectors (e.g., `app == 'allowed-svc'`) cannot distinguish between HBONE-tunneled destinations on open-source Calico. All ambient egress goes through ztunnel on port 15008 — BPF sees the HBONE tunnel, not the original destination. This is a policy model limitation with upstream Istio ambient, not a bug in the fix.

## Test plan

- [x] BPF unit test `TestIstioAmbientPolicyEnforcementV4` — ambient deny enforced + non-ambient fast-path preserved
- [x] Existing `TestIstioDSCPv4` passes (no regression)
- [x] Manual e2e on CalicoBPF cluster: deploy Istio ambient, apply ingress deny, verify blocked, remove, verify resumes
- [x] Manual e2e: selective ingress deny (one service blocked, another unaffected)
- [ ] Istio ambient e2e tests pass

**Release note:**
```release-note
ebpf: Fix dataplane to enforce network policy changes on established Istio ambient mesh (ztunnel) connections. Previously, policy updates had no effect on existing ztunnel connections due to the conntrack fast-path bypass.
```