### PR TITLE
Backport HEP policy evaluation signature changes from calico-private

### DIFF
--- a/app-policy/checker/check.go
+++ b/app-policy/checker/check.go
@@ -61,8 +61,16 @@ const (
 	unknownIndex = -2
 )
 
+// PolicyEndpoint is an interface for endpoint types that can be evaluated against
+// tiered policies and profiles. Both *proto.WorkloadEndpoint and *proto.HostEndpoint
+// satisfy this interface via protobuf-generated getter methods.
+type PolicyEndpoint interface {
+	GetTiers() []*proto.TierInfo
+	GetProfileIds() []string
+}
+
 // Evaluate evaluates the flow against the policy store and returns the trace of rules.
-func Evaluate(dir rules.RuleDir, store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, flow Flow) []*calc.RuleID {
+func Evaluate(dir rules.RuleDir, store *policystore.PolicyStore, ep PolicyEndpoint, flow Flow) []*calc.RuleID {
 	_, trace := checkTiers(store, ep, dir, flow)
 	return trace
 }
@@ -99,7 +107,7 @@ func ipToEndpointKeys(store *policystore.PolicyStore, addr ip.Addr) []proto.Work
 
 // checkStore applies the tiered policy plus any config based corrections and returns OK if the
 // check passes or PERMISSION_DENIED if the check fails.
-func checkStore(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
+func checkStore(store *policystore.PolicyStore, ep PolicyEndpoint, dir rules.RuleDir, req Flow) (s status.Status) {
 	// Check using the configured policy
 	s, _ = checkTiers(store, ep, dir, req)
 	return
@@ -108,7 +116,7 @@ func checkStore(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 // checkTiers applies the tiered policy in the given store and returns OK if the check passes, or PERMISSION_DENIED if
 // the check fails. Note, if no policy matches, the default is PERMISSION_DENIED. It returns the trace of rules that
 // were evaluated.
-func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir rules.RuleDir, flow Flow) (s status.Status, trace []*calc.RuleID) {
+func checkTiers(store *policystore.PolicyStore, ep PolicyEndpoint, dir rules.RuleDir, flow Flow) (s status.Status, trace []*calc.RuleID) {
 	s = status.Status{Code: PERMISSION_DENIED}
 	if ep == nil {
 		return
@@ -117,7 +125,7 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 	request := NewRequestCache(store, flow)
 	defer handlePanic(&s)
 
-	for _, tier := range ep.Tiers {
+	for _, tier := range ep.GetTiers() {
 		log.Debugf("Checking tier %s", tier.GetName())
 		policies := getPoliciesByDirection(dir, tier)
 		if len(policies) == 0 {
@@ -174,8 +182,8 @@ func checkTiers(store *policystore.PolicyStore, ep *proto.WorkloadEndpoint, dir 
 	}
 
 	// If we reach here, there were either no tiers, or a policy PASSed the request.
-	if len(ep.ProfileIds) > 0 {
-		for i, name := range ep.ProfileIds {
+	if len(ep.GetProfileIds()) > 0 {
+		for i, name := range ep.GetProfileIds() {
 			pID := proto.ProfileID{Name: name}
 			profile := store.ProfileByID[ftypes.ProtoToProfileID(&pID)]
 			action, ruleIndex := checkProfile(profile, dir, request)

--- a/app-policy/policystore/store.go
+++ b/app-policy/policystore/store.go
@@ -40,6 +40,7 @@ type PolicyStore struct {
 	IPSetByID          map[string]IPSet
 	Endpoint           *proto.WorkloadEndpoint
 	Endpoints          map[types.WorkloadEndpointID]*proto.WorkloadEndpoint
+	HostEndpoints      map[types.HostEndpointID]*proto.HostEndpoint
 	ServiceAccountByID map[types.ServiceAccountID]*proto.ServiceAccountUpdate
 	NamespaceByID      map[types.NamespaceID]*proto.NamespaceUpdate
 }
@@ -48,6 +49,7 @@ func NewPolicyStore() *PolicyStore {
 	return &PolicyStore{
 		IPToIndexes:        apptypes.NewIPToEndpointsIndex(),
 		Endpoints:          make(map[types.WorkloadEndpointID]*proto.WorkloadEndpoint),
+		HostEndpoints:      make(map[types.HostEndpointID]*proto.HostEndpoint),
 		RWMutex:            sync.RWMutex{},
 		IPSetByID:          make(map[string]IPSet),
 		ProfileByID:        make(map[types.ProfileID]*proto.Profile),

--- a/felix/collector/collector.go
+++ b/felix/collector/collector.go
@@ -889,37 +889,73 @@ func (c *collector) evaluatePendingRuleTraceForLocalEp(data *Data) {
 	}
 
 	c.policyStoreManager.DoWithReadLock(func(ps *policystore.PolicyStore) {
-		// Evaluate ingress if destination is local workload endpoint
-		if data.DstEp != nil && !data.DstEp.IsHostEndpoint() && data.DstEp.IsLocal() {
+		// Evaluate ingress if destination is a local endpoint (workload or host).
+		if isLocalEp(data.DstEp) {
 			c.evaluatePendingRuleTrace(rules.RuleDirIngress, ps, data.DstEp, flow, &data.IngressPendingRuleIDs)
 		}
 
-		// Evaluate egress if source is local workload endpoint
-		if data.SrcEp != nil && !data.SrcEp.IsHostEndpoint() && data.SrcEp.IsLocal() {
+		// Evaluate egress if source is a local endpoint (workload or host).
+		if isLocalEp(data.SrcEp) {
 			c.evaluatePendingRuleTrace(rules.RuleDirEgress, ps, data.SrcEp, flow, &data.EgressPendingRuleIDs)
 		}
 	})
 }
 
+// isLocalEp returns true if the endpoint is a non-nil local endpoint (workload or host).
+func isLocalEp(ep calc.EndpointData) bool {
+	return ep != nil && ep.IsLocal()
+}
+
 // evaluatePendingRuleTrace evaluates the pending rule trace for the given direction and endpoint,
 // and updates the ruleIDs if they are different.
 func (c *collector) evaluatePendingRuleTrace(direction rules.RuleDir, store *policystore.PolicyStore, ep calc.EndpointData, flow TupleAsFlow, ruleIDs *[]*calc.RuleID) {
-	// Get the proto.WorkloadEndpoint, needed for the evaluation, from the policy store.
-	if protoEp := c.lookupProtoWorkloadEndpoint(store, ep.Key()); protoEp != nil {
-		trace := checker.Evaluate(direction, store, protoEp, &flow)
-		if !equal(*ruleIDs, trace) {
-			*ruleIDs = append([]*calc.RuleID(nil), trace...)
-			log.Tracef("Updated pending %s, tuple: %v, rule trace: %v", direction, flow, ruleIDs)
+	if ep == nil {
+		return
+	}
+	protoEp, ok := c.lookupPolicyEndpoint(store, ep)
+	if !ok {
+		// Endpoint is not yet tracked by the PolicyStore — preserve existing ruleIDs
+		// rather than wiping them.
+		return
+	}
+	trace := checker.Evaluate(direction, store, protoEp, &flow)
+	if !equal(*ruleIDs, trace) {
+		*ruleIDs = append([]*calc.RuleID(nil), trace...)
+		log.Tracef("Updated pending %s, tuple: %v, rule trace: %v", direction, flow, ruleIDs)
+	}
+}
+
+// lookupPolicyEndpoint returns the PolicyEndpoint (either a *proto.WorkloadEndpoint or
+// *proto.HostEndpoint) from the policy store, dispatching based on the endpoint key type.
+// Must be called with the read lock on the policy store.
+func (c *collector) lookupPolicyEndpoint(store *policystore.PolicyStore, ep calc.EndpointData) (checker.PolicyEndpoint, bool) {
+	switch ep.Key().(type) {
+	case model.WorkloadEndpointKey:
+		protoEp := c.lookupProtoWorkloadEndpoint(store, ep.Key())
+		if protoEp == nil {
+			return nil, false
 		}
-	} else {
-		log.WithField("endpoint", ep.Key()).Trace("The endpoint is not yet tracked by the PolicyStore")
+		return protoEp, true
+	case model.HostEndpointKey:
+		protoEp := c.lookupProtoHostEndpoint(store, ep.Key())
+		if protoEp == nil {
+			return nil, false
+		}
+		return protoEp, true
+	default:
+		log.WithField("key", ep.Key()).Warn("Unknown endpoint key type in lookupPolicyEndpoint")
+		return nil, false
 	}
 }
 
 // lookupProtoWorkloadEndpoint returns the proto.WorkloadEndpoint from the policy store. Must be
 // called with the read lock on the policy store.
 func (c *collector) lookupProtoWorkloadEndpoint(store *policystore.PolicyStore, key model.Key) *proto.WorkloadEndpoint {
-	if store == nil || store.Endpoints == nil {
+	if store == nil {
+		return nil
+	}
+	if store.Endpoints == nil {
+		log.Warn("PolicyStore.Endpoints is nil; store was not initialized via NewPolicyStore()")
 		return nil
 	}
 	epKey := prototypes.WorkloadEndpointID{
@@ -928,6 +964,27 @@ func (c *collector) lookupProtoWorkloadEndpoint(store *policystore.PolicyStore, 
 		EndpointId:     getEndpointIDFromKey(key),
 	}
 	return store.Endpoints[epKey]
+}
+
+// lookupProtoHostEndpoint returns the proto.HostEndpoint from the policy store. Must be
+// called with the read lock on the policy store.
+func (c *collector) lookupProtoHostEndpoint(store *policystore.PolicyStore, key model.Key) *proto.HostEndpoint {
+	if store == nil {
+		return nil
+	}
+	if store.HostEndpoints == nil {
+		log.Warn("PolicyStore.HostEndpoints is nil; store was not initialized via NewPolicyStore()")
+		return nil
+	}
+	endpointID := getEndpointIDFromKey(key)
+	if endpointID == "" {
+		log.WithField("key", key).Warn("Could not extract endpoint ID from key")
+		return nil
+	}
+	hepKey := prototypes.HostEndpointID{
+		EndpointId: endpointID,
+	}
+	return store.HostEndpoints[hepKey]
 }
 
 func extractTupleFromDataplaneStats(d *proto.DataplaneStats) (tuple.Tuple, error) {
@@ -1019,6 +1076,8 @@ func equal(a, b []*calc.RuleID) bool {
 func getEndpointIDFromKey(key model.Key) string {
 	switch k := key.(type) {
 	case model.WorkloadEndpointKey:
+		return k.EndpointID
+	case model.HostEndpointKey:
 		return k.EndpointID
 	default:
 		return ""


### PR DESCRIPTION
## Summary
- Backport signature changes from calico-private PR [#10234](https://github.com/tigera/calico-private/pull/10234) to minimize OSS/private codebase drift
- Add `PolicyEndpoint` interface to the checker package so `Evaluate`, `checkStore`, and `checkTiers` accept both `*proto.WorkloadEndpoint` and `*proto.HostEndpoint`
- Add shared collector infrastructure (`lookupPolicyEndpoint`, `lookupProtoHostEndpoint`, `isLocalEp`, `getEndpointIDFromKey` extension) to align the pending rule trace pipeline signatures with calico-private

These are signature-only changes — HEP flow log collection remains gated by the existing "Ignore HEP reporters" block in `getDataAndUpdateEndpoints`, so there is no behavioral change in OSS.

## Context
The parent PR (calico-private #10234) implements HEP policy evaluation and flow log support as a prerequisite for [PMREQ-727](https://tigera.atlassian.net/browse/PMREQ-727). Per discussion in [#core](https://tigera.slack.com/archives/CC08CBB43/p1775591883861339), the HEP flow log feature itself stays private, but the signature changes should be backported to avoid merge conflicts when future OSS work is picked into private.

## Release Note

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PMREQ-727]: https://tigera.atlassian.net/browse/PMREQ-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ