### PR TITLE
Add Feature:Goldmane label to staged policy e2e tests

### DIFF
--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -75,6 +75,7 @@ var features = map[string]bool{
 	"QoS":             true,
 	"Datapath":        true,
 	"Istio":           true,
+	"Goldmane":        true,
 }
 
 // RequiresNoEncap marks tests that require unencapsulated traffic to function.

--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -75,7 +75,6 @@ var features = map[string]bool{
 	"QoS":             true,
 	"Datapath":        true,
 	"Istio":           true,
-	"Goldmane":        true,
 }
 
 // RequiresNoEncap marks tests that require unencapsulated traffic to function.
@@ -84,6 +83,14 @@ var features = map[string]bool{
 // or cloud clusters with appropriate configuration.
 func RequiresNoEncap() any {
 	return framework.WithLabel("NoEncap")
+}
+
+// RequiresGoldmane marks tests that depend on Goldmane (and Whisker) being installed
+// in the cluster. These tests read flow logs via the Whisker API, which requires
+// the Goldmane flow aggregation backend. Skip on clusters without Goldmane
+// via --ginkgo.skip=RequiresGoldmane.
+func RequiresGoldmane() any {
+	return framework.WithLabel("RequiresGoldmane")
 }
 
 // RequiresBGPMesh marks tests that depend on the BGP node-to-node mesh being the sole

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -37,6 +37,7 @@ import (
 var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithCategory(describe.Policy),
+	describe.WithFeature("Goldmane"),
 	"staged network policy",
 	func() {
 		var (

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -37,7 +37,7 @@ import (
 var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithCategory(describe.Policy),
-	describe.WithFeature("Goldmane"),
+	describe.RequiresGoldmane(),
 	"staged network policy",
 	func() {
 		var (


### PR DESCRIPTION
The staged policy e2e tests depend on Whisker (backed by Goldmane) to read flow logs and verify staged policy behavior. On clusters where Goldmane is not installed (e.g., enterprise clusters using a different flow log backend), these tests fail in BeforeEach with "Whisker is not installed in the cluster".

Adding `Feature:Goldmane` to the feature label set and applying it to the staged policy Describe block allows these tests to be skipped via `--ginkgo.skip` on clusters without Goldmane.

```release-note
None
```