### PR TITLE
fix(release): anchor regex pattern for GitHub PR URL extraction

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1690,7 +1690,7 @@ func (r *CalicoManager) createPrepPR(baseBranch, prepBranch string) error {
 	pr, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", args, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			if m := regexp.MustCompile(`https://github\.com/\S+/pull/\d+`).FindString(err.Error()); m != "" {
+			if m := regexp.MustCompile(`https://github\.com/[\w.-]+/[\w.-]+/pull/\d+`).FindString(err.Error()); m != "" {
 				pr = m
 			} else {
 				pr = fmt.Sprintf("https://github.com/%s/%s/pulls?q=is%%3Aopen+head%%3A%s", r.githubOrg, r.repo, prepBranch)

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1686,16 +1686,23 @@ func (r *CalicoManager) createPrepPR(baseBranch, prepBranch string) error {
 			"--label", "release-note-not-required,docs-not-required",
 		}...)
 	}
+	fallbackURL := fmt.Sprintf("https://github.com/%s/%s/pulls?q=is%%3Aopen+head%%3A%s", r.githubOrg, r.repo, prepBranch)
 	logrus.WithField("args", args).Debug("Creating PR for release preparation")
 	pr, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", args, nil)
 	if err != nil {
+		pr = fallbackURL
 		if strings.Contains(err.Error(), "already exists") {
-			if m := regexp.MustCompile(`https://github\.com/[\w.-]+/[\w.-]+/pull/\d+`).FindString(err.Error()); m != "" {
-				pr = m
-			} else {
-				pr = fmt.Sprintf("https://github.com/%s/%s/pulls?q=is%%3Aopen+head%%3A%s", r.githubOrg, r.repo, prepBranch)
+			if m := regexp.MustCompile(`(?:^|\s)(https://github\.com/[\w.-]+/[\w.-]+/pull/\d+)(?:$|\s)`).FindStringSubmatch(err.Error()); len(m) > 1 {
+				if u, err := url.Parse(m[1]); err != nil {
+					logrus.WithField("PR", pr).Warn("PR already exists but could not parse URL from error, find using fallback PR URL")
+					return fmt.Errorf("parsing URL for PR: %w", err)
+				} else if u.Host != "github.com" || !strings.Contains(m[1], fmt.Sprintf("%s/%s/pull/", r.githubOrg, r.repo)) {
+					logrus.WithField("PR", pr).Warn("PR already exists but error returned an unexpected URL, find using fallback PR URL")
+					return fmt.Errorf("unexpected URL format for PR: %s", m[1])
+				}
+				pr = m[1]
 			}
-			logrus.Warnf("PR already exists, skipping creation. Find PR at: %s", pr)
+			logrus.WithField("PR", pr).Warn("PR already exists, skipping creation")
 			return r.switchToBaseBranch(baseBranch)
 		}
 		logrus.WithError(err).Error("Failed to create PR for release preparation")


### PR DESCRIPTION
Fix CodeQL [code-scanning alert #70](https://github.com/projectcalico/calico/security/code-scanning/70) (`go/regex/missing-regexp-anchor`, CWE-20) introduced by #12314.

The regex used to extract a GitHub PR URL from `gh` CLI error output used `\S+` which matches any non-whitespace and could theoretically match across URL path segments. Replaced with `[\w.-]+/[\w.-]+` to constrain matching to valid GitHub org/repo name characters only.

**Release note:**
```release-note
None
```