### PR TITLE
Fix .orig backup causing duplicate IPAMBlock CRD in manifests

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -66,8 +66,8 @@ gen-files .generate_files: lint-cache-dir clean-generated
 	# Patch in manual tweaks to the generated CRDs.
 	# - Add nullable to IPAM block allocations field to allow null values in the allocations array.
 	# - Remove the profiles CRD. Profiles are backed by Namespaces in Kubernetes and the CRD is not needed.
-	patch -p2 < patches/0001-Add-nullable-to-IPAM-block-allocations-field.patch
-	rm -f config/crd/projectcalico.org_profiles.yaml
+	patch --no-backup-if-mismatch -p2 < patches/0001-Add-nullable-to-IPAM-block-allocations-field.patch
+	rm -f config/crd/*.orig config/crd/projectcalico.org_profiles.yaml
 
 	# Generate defaults
 	$(DOCKER_RUN) $(CALICO_BUILD) \

--- a/api/patches/0001-Add-nullable-to-IPAM-block-allocations-field.patch
+++ b/api/patches/0001-Add-nullable-to-IPAM-block-allocations-field.patch
@@ -11,7 +11,7 @@ diff --git a/api/config/crd/projectcalico.org_ipamblocks.yaml b/api/config/crd/p
 index a6159008d1..20beb8de45 100644
 --- a/api/config/crd/projectcalico.org_ipamblocks.yaml
 +++ b/api/config/crd/projectcalico.org_ipamblocks.yaml
-@@ -44,6 +44,9 @@ spec:
+@@ -48,6 +48,9 @@ spec:
                  allocations:
                    items:
                      type: integer
@@ -19,8 +19,8 @@ index a6159008d1..20beb8de45 100644
 +                    # to handle []*int properly itself.
 +                    nullable: true
                    type: array
+                   x-kubernetes-list-type: atomic
                  attributes:
-                   items:
 --
 2.34.1
 

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -1552,6 +1552,9 @@ spec:
                     - Enabled
                     - Disabled
                   type: string
+                bpfIPFragTimeout:
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
                 bpfJITHardening:
                   allOf:
                     - enum:
@@ -3058,111 +3061,6 @@ spec:
                     # TODO: This nullable is manually added in. We should update controller-gen
                     # to handle []*int properly itself.
                     nullable: true
-                  type: array
-                  x-kubernetes-list-type: atomic
-                attributes:
-                  items:
-                    properties:
-                      alternateOwnerAttrs:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      handle_id:
-                        type: string
-                      secondary:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  type: array
-                  x-kubernetes-list-type: atomic
-                cidr:
-                  format: cidr
-                  type: string
-                deleted:
-                  type: boolean
-                sequenceNumber:
-                  default: 0
-                  format: int64
-                  type: integer
-                sequenceNumberForAllocation:
-                  additionalProperties:
-                    format: int64
-                    type: integer
-                  type: object
-                strictAffinity:
-                  type: boolean
-                unallocated:
-                  items:
-                    type: integer
-                  type: array
-                  x-kubernetes-list-type: atomic
-              required:
-                - allocations
-                - attributes
-                - cidr
-                - strictAffinity
-                - unallocated
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources: {}
----
-# Source: calico/templates/kdd-crds.yaml
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
-  name: ipamblocks.projectcalico.org
-spec:
-  group: projectcalico.org
-  names:
-    kind: IPAMBlock
-    listKind: IPAMBlockList
-    plural: ipamblocks
-    singular: ipamblock
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-    - additionalPrinterColumns:
-        - description: The block CIDR
-          jsonPath: .spec.cidr
-          name: CIDR
-          type: string
-        - description: The block affinity
-          jsonPath: .spec.affinity
-          name: Affinity
-          type: string
-        - description: The time at which affinity was claimed
-          jsonPath: .spec.affinityClaimTime
-          name: ClaimTime
-          type: date
-      name: v3
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                affinity:
-                  pattern: ^(host|virtual):[a-zA-Z0-9\.\-_]+$
-                  type: string
-                affinityClaimTime:
-                  format: date-time
-                  type: string
-                allocations:
-                  items:
-                    type: integer
                   type: array
                   x-kubernetes-list-type: atomic
                 attributes:


### PR DESCRIPTION
The `patch` command in `api/Makefile` applies the IPAMBlock nullable patch with fuzz, creating a `.orig` backup file. Helm's `Files.Glob "crds-v3/*"` picks this up through the symlink, injecting a duplicate IPAMBlock CRD into `calico-v3-crds.yaml`.

- Add `--no-backup-if-mismatch` and explicit `.orig` cleanup after patch
- Update patch context to match current controller-gen output
- Regenerate `calico-v3-crds.yaml` manifest

```release-note
None
```