### PR TITLE
fix(manifests): use regex for image registry matching in generate.sh

### DIFF
--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -178,8 +178,7 @@ done
 ##########################################################################
 echo "Replacing image versions for static manifests"
 for img in $NON_HELM_MANIFEST_IMAGES; do
-  curr_img=${defaultRegistry}/${img}
   new_img=${REGISTRY}/${img}
-  echo "$curr_img:$defaultCalicoVersion --> $new_img:$CALICO_VERSION"
-  find . -type f -exec sed -i "s|${curr_img}:[A-Za-z0-9_.-]*|${new_img}:$CALICO_VERSION|g" {} \;
+  echo "Update $img image to $new_img:$CALICO_VERSION"
+  find . -type f -exec sed -i "s|image: [a-zA-Z0-9/._-]*/${img}:[A-Za-z0-9_.-]*|image: ${new_img}:$CALICO_VERSION|g" {} \;
 done


### PR DESCRIPTION
The static manifest image replacement in `manifests/generate.sh` used an exact match on `${defaultRegistry}/${img}` to find and replace image references. This fails when the registry in the generated manifests doesn't match `defaultRegistry` — the sed pattern silently matches nothing and leaves those images unchanged.

Replace with a regex pattern (`[a-zA-Z0-9/._-]*/${img}`) that matches any registry prefix, so images are correctly updated regardless of the source registry.

**Release note:**
```release-note
None
```