### PR TITLE
Fix type mismatches and fd leaks in libbpf CGO bridge

### DIFF
--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -93,10 +93,12 @@ void bpf_get_prog_name(uint prog_id, char *prog_name) {
 	__u32 len = sizeof(info);
 	int err = bpf_prog_get_info_by_fd(prog_fd, &info, &len);
 	if (err) {
+		close(prog_fd);
 		set_errno(err);
 		return;
 	}
 	memcpy(prog_name, info.name, strlen(info.name));
+	close(prog_fd);
 }
 
 struct bpf_link *bpf_link_open(char *path) {

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -365,15 +365,15 @@ int bpf_program_attach_xdp(struct bpf_object *obj, char *name, int ifIndex, int 
 
 	int prog_fd = bpf_program__fd(prog);
 	if (prog_fd < 0) {
-		errno = -prog_fd;
-		return prog_fd;
+		err = prog_fd;
+		goto out;
 	}
 
 	err = bpf_xdp_attach(ifIndex, prog_fd, flags, &opts);
-	set_errno(err);
-	return err;
 
 out:
+	if (opts.old_prog_fd >= 0)
+		close(opts.old_prog_fd);
 	set_errno(err);
 	return err;
 }

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -90,7 +90,7 @@ void bpf_get_prog_name(uint prog_id, char *prog_name) {
 		set_errno(-prog_fd);
 		return;
         }
-	int len = sizeof(info);
+	__u32 len = sizeof(info);
 	int err = bpf_prog_get_info_by_fd(prog_fd, &info, &len);
 	if (err) {
 		set_errno(err);
@@ -280,7 +280,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 		.ipfrag_timeout = ipfrag_timeout,
 	};
 
-	strncpy(v4.iface_name, iface_name, sizeof(v4.iface_name));
+	strncpy((char *)v4.iface_name, iface_name, sizeof(v4.iface_name));
 	v4.iface_name[sizeof(v4.iface_name)-1] = '\0';
 
 	struct cali_tc_global_data v6 = v4;
@@ -415,7 +415,7 @@ void bpf_xdp_set_globals(struct bpf_map *map, char *iface_name, uint *jumps, uin
 	struct cali_xdp_preamble_globals data = {
 	};
 
-	strncpy(data.v4.iface_name, iface_name, sizeof(data.v4.iface_name));
+	strncpy((char *)data.v4.iface_name, iface_name, sizeof(data.v4.iface_name));
 	data.v4.iface_name[sizeof(data.v4.iface_name)-1] = '\0';
 	data.v6 = data.v4;
 


### PR DESCRIPTION
Fix type mismatches and file descriptor leaks in `felix/bpf/libbpf/libbpf_api.h`.

**Type fixes (clang -Wpointer-sign):**
- `int len` → `__u32 len` for `bpf_prog_get_info_by_fd()` which expects `__u32 *info_len`
- Add `(char *)` casts for `strncpy()` into `__u8[16]` iface_name fields

**File descriptor leak fixes:**
- `bpf_get_prog_name()`: close the fd from `bpf_prog_get_fd_by_id()` on both success and error paths
- `bpf_program_attach_xdp()`: close the `old_prog_fd` from `bpf_prog_get_fd_by_id()` via a single `out` cleanup label; call `set_errno()` after `close()` to avoid errno clobbering

**Release note:**
```release-note
Fix file descriptor leaks in BPF program info lookup and XDP attach operations.
```