### PR TITLE
e2e: auto-detect RELEASE_STREAM from branch name

### DIFF
--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -76,7 +76,14 @@ export DOCKER_UCP_VERSION=${DOCKER_UCP_VERSION:-"3.3.0"}
 export ENABLE_ALP=${ENABLE_ALP:-"false"}
 export USE_HASH_RELEASE=${USE_HASH_RELEASE:-"true"}
 export USE_LATEST_RELEASE=${USE_LATEST_RELEASE:-"false"}
-export RELEASE_STREAM=${RELEASE_STREAM:-master}
+if [ -z "${RELEASE_STREAM}" ]; then
+  _branch="${SEMAPHORE_GIT_BRANCH:-master}"
+  if [[ "${_branch}" =~ ^release-(v[0-9]+\.[0-9]+)$ ]]; then
+    export RELEASE_STREAM="${BASH_REMATCH[1]}"
+  else
+    export RELEASE_STREAM="master"
+  fi
+fi
 export K8S_E2E_EXTRA_FLAGS=${K8S_E2E_EXTRA_FLAGS:-" --e2ecfg.calicoctl-opensource-image=calico/ctl:release-${RELEASE_STREAM} "}
 export HELM_PATCH=${HELM_PATCH:-"0"}
 export CALICOCTL_INSTALL_TYPE=${CALICOCTL_INSTALL_TYPE:-"binary"}
@@ -96,8 +103,6 @@ export GS_BUCKET=${GS_BUCKET-semaphore_diags}
 export BANZAI_CORE_BRANCH=${BANZAI_CORE_BRANCH:-""}
 export BZ_TASK_VERSION=${BZ_TASK_VERSION:-"v2.8.1"}
 export SEMAPHORE_AGENT_UPLOAD_JOB_LOGS=${SEMAPHORE_AGENT_UPLOAD_JOB_LOGS:-"when-trimmed"}
-
-export RELEASE_STREAM=${RELEASE_STREAM:-master}
 
 if [[ "${BANZAI_CORE_BRANCH}" != "" ]]; then BANZAI_CORE_BRANCH="--core-branch ${BANZAI_CORE_BRANCH}"; fi
 

--- a/.semaphore/end-to-end/scripts/global_prologue.sh
+++ b/.semaphore/end-to-end/scripts/global_prologue.sh
@@ -76,14 +76,7 @@ export DOCKER_UCP_VERSION=${DOCKER_UCP_VERSION:-"3.3.0"}
 export ENABLE_ALP=${ENABLE_ALP:-"false"}
 export USE_HASH_RELEASE=${USE_HASH_RELEASE:-"true"}
 export USE_LATEST_RELEASE=${USE_LATEST_RELEASE:-"false"}
-if [ -z "${RELEASE_STREAM}" ]; then
-  _branch="${SEMAPHORE_GIT_BRANCH:-master}"
-  if [[ "${_branch}" =~ ^release-(v[0-9]+\.[0-9]+)$ ]]; then
-    export RELEASE_STREAM="${BASH_REMATCH[1]}"
-  else
-    export RELEASE_STREAM="master"
-  fi
-fi
+export RELEASE_STREAM=${RELEASE_STREAM:-$( _branch="${SEMAPHORE_GIT_BRANCH:-master}"; [[ "${_branch}" =~ ^release-(v[0-9]+\.[0-9]+)$ ]] && echo "${BASH_REMATCH[1]}" || echo "master" )}
 export K8S_E2E_EXTRA_FLAGS=${K8S_E2E_EXTRA_FLAGS:-" --e2ecfg.calicoctl-opensource-image=calico/ctl:release-${RELEASE_STREAM} "}
 export HELM_PATCH=${HELM_PATCH:-"0"}
 export CALICOCTL_INSTALL_TYPE=${CALICOCTL_INSTALL_TYPE:-"binary"}


### PR DESCRIPTION
Currently `RELEASE_STREAM` has a hardcoded default that must be manually updated when cutting a release branch. As noted in #12415, this is easy to forget.

This change auto-detects `RELEASE_STREAM` from the Semaphore branch name (`$SEMAPHORE_GIT_BRANCH`):
- On a `release-vX.Y` branch → sets `RELEASE_STREAM=vX.Y`
- On `master` or any other branch → defaults to `master`
- If `RELEASE_STREAM` is already set as an env var (manual override) → that value wins

Fixes the footgun noted in #12415.