### PR TITLE
Fix calico/test image build failure due to libexpat ABI mismatch

### DIFF
--- a/node/calico_test/Dockerfile
+++ b/node/calico_test/Dockerfile
@@ -38,12 +38,11 @@ FROM docker:25
 ARG ETCD_VERSION
 ARG TARGETARCH
 
-# Update apk repositories first
-RUN apk update
-
 # Running STs in this container requires that it has all dependencies installed
 # for executing the tests. Install these dependencies:
-RUN apk add --no-cache \
+# The upgrade ensures base image packages (e.g. libexpat) stay ABI-compatible
+# with newly installed packages (e.g. python3's pyexpat).
+RUN apk upgrade --no-cache && apk add --no-cache \
     curl \
     gcc \
     ip6tables \


### PR DESCRIPTION
The docker:25 base image (Alpine 3.20) ships with an older libexpat, but the python3 package from the Alpine repos was rebuilt against libexpat 2.7.0+. Since apk add does not upgrade pre-installed packages, pyexpat fails to load at runtime with:

  ImportError: Error relocating pyexpat...so:
  XML_SetAllocTrackerActivationThreshold: symbol not found

This breaks pip and prevents the test image from being built, causing calicoctl (and any other component using calico/test) ST failures.

Fix by running apk upgrade before apk add in a single RUN layer so that base image packages are upgraded to match the versions that newly installed packages were compiled against.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
