### PR TITLE
Add missing CEL order validation rules to v1 Tier CRD

### DIFF
--- a/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
@@ -89,17 +89,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/libcalico-go/config/crds_test.go
+++ b/libcalico-go/config/crds_test.go
@@ -109,12 +109,17 @@ func TestV1CRDsMatchV3CELRules(t *testing.T) {
 		v3Rules := v3Schema.XValidations
 		v1Rules := v1Schema.XValidations
 
-		// Build a set of v1 rules keyed by message for comparison.
+		// Build maps keyed by message for bidirectional comparison.
 		v1RulesByMsg := make(map[string]v1.ValidationRule, len(v1Rules))
 		for _, r := range v1Rules {
 			v1RulesByMsg[r.Message] = r
 		}
+		v3RulesByMsg := make(map[string]v1.ValidationRule, len(v3Rules))
+		for _, r := range v3Rules {
+			v3RulesByMsg[r.Message] = r
+		}
 
+		// Check that every v3 rule exists in v1 with matching fields.
 		for _, v3Rule := range v3Rules {
 			v1Rule, ok := v1RulesByMsg[v3Rule.Message]
 			if !ok {
@@ -124,8 +129,28 @@ func TestV1CRDsMatchV3CELRules(t *testing.T) {
 			if v1Rule.Rule != v3Rule.Rule {
 				t.Errorf("%s: CEL rule %q differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, v3Rule.Rule, v1Rule.Rule)
 			}
+			if v1Rule.Reason != v3Rule.Reason {
+				t.Errorf("%s: CEL rule %q reason differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, ptrStr(v3Rule.Reason), ptrStr(v1Rule.Reason))
+			}
+			if v1Rule.FieldPath != v3Rule.FieldPath {
+				t.Errorf("%s: CEL rule %q fieldPath differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, v3Rule.FieldPath, v1Rule.FieldPath)
+			}
+		}
+
+		// Check that v1 doesn't have extra rules not in v3.
+		for _, v1Rule := range v1Rules {
+			if _, ok := v3RulesByMsg[v1Rule.Message]; !ok {
+				t.Errorf("%s: v1 CEL rule not present in v3 CRD: %q", kind, v1Rule.Message)
+			}
 		}
 	}
+}
+
+func ptrStr(p *v1.FieldValueErrorReason) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return string(*p)
 }
 
 // storageVersionSchema returns the OpenAPI v3 schema for the storage version

--- a/libcalico-go/config/crds_test.go
+++ b/libcalico-go/config/crds_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	calicoapi "github.com/projectcalico/api"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -66,4 +67,80 @@ func TestAllCRDs(t *testing.T) {
 			t.Fatal("CRD had no versions?")
 		}
 	}
+}
+
+// TestV1CRDsMatchV3CELRules verifies that the crd.projectcalico.org (v1) CRDs
+// have the same top-level CEL x-kubernetes-validations as the corresponding
+// projectcalico.org (v3) CRDs. The v1 CRDs back the Calico API server; if
+// their CEL rules drift from v3, validation that works in CRD mode will
+// silently stop working in API server mode.
+func TestV1CRDsMatchV3CELRules(t *testing.T) {
+	v1CRDs, err := AllCRDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3CRDs, err := calicoapi.AllCRDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a map from Kind -> v3 CRD for quick lookup.
+	v3ByKind := make(map[string]*v1.CustomResourceDefinition, len(v3CRDs))
+	for _, crd := range v3CRDs {
+		v3ByKind[crd.Spec.Names.Kind] = crd
+	}
+
+	for _, v1CRD := range v1CRDs {
+		kind := v1CRD.Spec.Names.Kind
+		v3CRD, ok := v3ByKind[kind]
+		if !ok {
+			continue
+		}
+
+		v1Schema := storageVersionSchema(v1CRD)
+		v3Schema := storageVersionSchema(v3CRD)
+		if v1Schema == nil || v3Schema == nil {
+			continue
+		}
+
+		// Compare top-level x-kubernetes-validations. These are the rules
+		// that reference self.metadata.name and can't be inherited from
+		// shared Spec types.
+		v3Rules := v3Schema.XValidations
+		v1Rules := v1Schema.XValidations
+
+		// Build a set of v1 rules keyed by message for comparison.
+		v1RulesByMsg := make(map[string]v1.ValidationRule, len(v1Rules))
+		for _, r := range v1Rules {
+			v1RulesByMsg[r.Message] = r
+		}
+
+		for _, v3Rule := range v3Rules {
+			v1Rule, ok := v1RulesByMsg[v3Rule.Message]
+			if !ok {
+				t.Errorf("%s: v3 CEL rule missing from v1 CRD: %q", kind, v3Rule.Message)
+				continue
+			}
+			if v1Rule.Rule != v3Rule.Rule {
+				t.Errorf("%s: CEL rule %q differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, v3Rule.Rule, v1Rule.Rule)
+			}
+		}
+	}
+}
+
+// storageVersionSchema returns the OpenAPI v3 schema for the storage version
+// of the given CRD, or nil if none is found.
+func storageVersionSchema(crd *v1.CustomResourceDefinition) *v1.JSONSchemaProps {
+	for i := range crd.Spec.Versions {
+		if crd.Spec.Versions[i].Storage {
+			if crd.Spec.Versions[i].Schema != nil {
+				return crd.Spec.Versions[i].Schema.OpenAPIV3Schema
+			}
+			return nil
+		}
+	}
+	if len(crd.Spec.Versions) > 0 && crd.Spec.Versions[0].Schema != nil {
+		return crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	}
+	return nil
 }

--- a/libcalico-go/config/crds_test.go
+++ b/libcalico-go/config/crds_test.go
@@ -129,7 +129,7 @@ func TestV1CRDsMatchV3CELRules(t *testing.T) {
 			if v1Rule.Rule != v3Rule.Rule {
 				t.Errorf("%s: CEL rule %q differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, v3Rule.Rule, v1Rule.Rule)
 			}
-			if v1Rule.Reason != v3Rule.Reason {
+			if ptrStr(v1Rule.Reason) != ptrStr(v3Rule.Reason) {
 				t.Errorf("%s: CEL rule %q reason differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, ptrStr(v3Rule.Reason), ptrStr(v1Rule.Reason))
 			}
 			if v1Rule.FieldPath != v3Rule.FieldPath {

--- a/libcalico-go/lib/apis/crd.projectcalico.org/v1/tier_types.go
+++ b/libcalico-go/lib/apis/crd.projectcalico.org/v1/tier_types.go
@@ -24,9 +24,12 @@ import (
 
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-admin' ? self.spec.defaultAction == 'Pass' : true", message="The 'kube-admin' tier must have default action 'Pass'"
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-baseline' ? self.spec.defaultAction == 'Pass' : true", message="The 'kube-baseline' tier must have default action 'Pass'"
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny' : true", message="The 'default' tier must have default action 'Deny'"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction) && self.spec.defaultAction == 'Pass') : true", message="The 'kube-admin' tier must have default action 'Pass'",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction) && self.spec.defaultAction == 'Pass') : true", message="The 'kube-baseline' tier must have default action 'Pass'",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default' ? (has(self.spec.defaultAction) && self.spec.defaultAction == 'Deny') : true", message="The 'default' tier must have default action 'Deny'",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order == 1000000.0)",message="default tier order must be 1000000",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order == 1000.0)",message="kube-admin tier order must be 1000",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'kube-baseline' || (has(self.spec.order) && self.spec.order == 10000000.0)",message="kube-baseline tier order must be 10000000",reason=FieldValueInvalid
 // +kubebuilder:subresource:status
 type Tier struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -6954,17 +6954,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -6964,17 +6964,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -6965,17 +6965,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -6949,17 +6949,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -6949,17 +6949,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -6966,17 +6966,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -6863,17 +6863,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -6949,17 +6949,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -41502,17 +41502,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -41502,17 +41502,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
       subresources:


### PR DESCRIPTION
The crd.projectcalico.org Tier CRD (which backs the Calico API server) was missing the order validation rules that exist on the projectcalico.org Tier CRD. This meant that in API server mode, modifying the order of the default, kube-admin, or kube-baseline tiers was silently accepted, since the aggregated API server strategy has no validation and the backing CRD lacked the rules.

Also strengthens the existing defaultAction rules with `has()` guards and `reason` fields to match the v3 CRD, and adds a test that compares top-level CEL rules between v3 and v1 CRDs to prevent future drift.

```release-note
Fix missing CEL validation on v1 Tier CRD that allowed modifying built-in tier order in API server mode.
```