### PR TITLE
Add missing CEL order validation rules to v1 Tier CRD

### DIFF
--- a/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
@@ -78,3 +78,5 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}

--- a/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml
@@ -47,16 +47,34 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true

--- a/libcalico-go/config/crds_test.go
+++ b/libcalico-go/config/crds_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	calicoapi "github.com/projectcalico/api"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -66,4 +67,105 @@ func TestAllCRDs(t *testing.T) {
 			t.Fatal("CRD had no versions?")
 		}
 	}
+}
+
+// TestV1CRDsMatchV3CELRules verifies that the crd.projectcalico.org (v1) CRDs
+// have the same top-level CEL x-kubernetes-validations as the corresponding
+// projectcalico.org (v3) CRDs. The v1 CRDs back the Calico API server; if
+// their CEL rules drift from v3, validation that works in CRD mode will
+// silently stop working in API server mode.
+func TestV1CRDsMatchV3CELRules(t *testing.T) {
+	v1CRDs, err := AllCRDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3CRDs, err := calicoapi.AllCRDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a map from Kind -> v3 CRD for quick lookup.
+	v3ByKind := make(map[string]*v1.CustomResourceDefinition, len(v3CRDs))
+	for _, crd := range v3CRDs {
+		v3ByKind[crd.Spec.Names.Kind] = crd
+	}
+
+	for _, v1CRD := range v1CRDs {
+		kind := v1CRD.Spec.Names.Kind
+		v3CRD, ok := v3ByKind[kind]
+		if !ok {
+			continue
+		}
+
+		v1Schema := storageVersionSchema(v1CRD)
+		v3Schema := storageVersionSchema(v3CRD)
+		if v1Schema == nil || v3Schema == nil {
+			continue
+		}
+
+		// Compare top-level x-kubernetes-validations. These are the rules
+		// that reference self.metadata.name and can't be inherited from
+		// shared Spec types.
+		v3Rules := v3Schema.XValidations
+		v1Rules := v1Schema.XValidations
+
+		// Build maps keyed by message for bidirectional comparison.
+		v1RulesByMsg := make(map[string]v1.ValidationRule, len(v1Rules))
+		for _, r := range v1Rules {
+			v1RulesByMsg[r.Message] = r
+		}
+		v3RulesByMsg := make(map[string]v1.ValidationRule, len(v3Rules))
+		for _, r := range v3Rules {
+			v3RulesByMsg[r.Message] = r
+		}
+
+		// Check that every v3 rule exists in v1 with matching fields.
+		for _, v3Rule := range v3Rules {
+			v1Rule, ok := v1RulesByMsg[v3Rule.Message]
+			if !ok {
+				t.Errorf("%s: v3 CEL rule missing from v1 CRD: %q", kind, v3Rule.Message)
+				continue
+			}
+			if v1Rule.Rule != v3Rule.Rule {
+				t.Errorf("%s: CEL rule %q differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, v3Rule.Rule, v1Rule.Rule)
+			}
+			if ptrStr(v1Rule.Reason) != ptrStr(v3Rule.Reason) {
+				t.Errorf("%s: CEL rule %q reason differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, ptrStr(v3Rule.Reason), ptrStr(v1Rule.Reason))
+			}
+			if v1Rule.FieldPath != v3Rule.FieldPath {
+				t.Errorf("%s: CEL rule %q fieldPath differs:\n  v3: %s\n  v1: %s", kind, v3Rule.Message, v3Rule.FieldPath, v1Rule.FieldPath)
+			}
+		}
+
+		// Check that v1 doesn't have extra rules not in v3.
+		for _, v1Rule := range v1Rules {
+			if _, ok := v3RulesByMsg[v1Rule.Message]; !ok {
+				t.Errorf("%s: v1 CEL rule not present in v3 CRD: %q", kind, v1Rule.Message)
+			}
+		}
+	}
+}
+
+func ptrStr(p *v1.FieldValueErrorReason) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return string(*p)
+}
+
+// storageVersionSchema returns the OpenAPI v3 schema for the storage version
+// of the given CRD, or nil if none is found.
+func storageVersionSchema(crd *v1.CustomResourceDefinition) *v1.JSONSchemaProps {
+	for i := range crd.Spec.Versions {
+		if crd.Spec.Versions[i].Storage {
+			if crd.Spec.Versions[i].Schema != nil {
+				return crd.Spec.Versions[i].Schema.OpenAPIV3Schema
+			}
+			return nil
+		}
+	}
+	if len(crd.Spec.Versions) > 0 && crd.Spec.Versions[0].Schema != nil {
+		return crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	}
+	return nil
 }

--- a/libcalico-go/lib/apis/crd.projectcalico.org/v1/tier_types.go
+++ b/libcalico-go/lib/apis/crd.projectcalico.org/v1/tier_types.go
@@ -24,9 +24,13 @@ import (
 
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-admin' ? self.spec.defaultAction == 'Pass' : true", message="The 'kube-admin' tier must have default action 'Pass'"
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-baseline' ? self.spec.defaultAction == 'Pass' : true", message="The 'kube-baseline' tier must have default action 'Pass'"
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny' : true", message="The 'default' tier must have default action 'Deny'"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction) && self.spec.defaultAction == 'Pass') : true", message="The 'kube-admin' tier must have default action 'Pass'",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction) && self.spec.defaultAction == 'Pass') : true", message="The 'kube-baseline' tier must have default action 'Pass'",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default' ? (has(self.spec.defaultAction) && self.spec.defaultAction == 'Deny') : true", message="The 'default' tier must have default action 'Deny'",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order == 1000000.0)",message="default tier order must be 1000000",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order == 1000.0)",message="kube-admin tier order must be 1000",reason=FieldValueInvalid
+// +kubebuilder:validation:XValidation:rule="self.metadata.name != 'kube-baseline' || (has(self.spec.order) && self.spec.order == 10000000.0)",message="kube-baseline tier order must be 10000000",reason=FieldValueInvalid
+// +kubebuilder:subresource:status
 type Tier struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -5698,17 +5698,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -5729,6 +5729,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -5739,6 +5739,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -5708,17 +5708,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -5709,17 +5709,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -5740,6 +5740,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5724,6 +5724,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5693,17 +5693,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -5724,6 +5724,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -5693,17 +5693,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -5741,6 +5741,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -5710,17 +5710,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -5607,17 +5607,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -5638,6 +5638,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crds/policy.networking.k8s.io_clusternetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -5724,6 +5724,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -5693,17 +5693,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -40277,6 +40277,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/policy.networking.k8s.io_clusternetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -40246,17 +40246,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -40277,6 +40277,8 @@ spec:
                 self.spec.order == 10000000.0)
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 # Source: crd.projectcalico.org.v1/templates/calico/policy.networking.k8s.io_clusternetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -40246,17 +40246,35 @@ spec:
           type: object
           x-kubernetes-validations:
             - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
-                'Pass' : true"
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
-                == 'Pass' : true"
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
             - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
               rule:
-                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
-                : true"
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
       served: true
       storage: true
 ---


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/12441 to release-v3.32.

Adds CEL XValidation rules to the v1 Tier CRD to enforce correct order values for the default, kube-admin, and kube-baseline tiers. Also adds `has()` guards and `reason=FieldValueInvalid` to the existing defaultAction validation rules.

```release-note
None
```