### PR TITLE
Fix etcd IPAM GC test race in Ordered suite

### DIFF
--- a/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
@@ -45,6 +45,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		c         client.Interface
 		k8sClient *fake.Clientset
 		stopCh    chan struct{}
+		ips       *testutils.TestBlockAllocator
 	)
 
 	const kNodeName = "k8snodename"
@@ -64,6 +65,10 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		p.Spec.Disabled = false
 		_, err := c.IPPools().Create(context.Background(), p, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		// Each test gets an IP from a different /26 block to avoid races with
+		// the controller's async block GC from the previous test.
+		ips = testutils.NewTestBlockAllocator("192.168.0.0", 26)
 
 		// Create the fake K8s client and start the in-process node controller.
 		// We use a single controller for all tests (matching how the Docker-based
@@ -147,6 +152,8 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 	})
 
 	It("should properly garbage collect IP addresses for mismatched node names", func() {
+		testIP := ips.NextIP()
+
 		// Create a kubernetes node.
 		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: kNodeName}}
 		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), kn, metav1.CreateOptions{})
@@ -161,7 +168,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		handleA := "handleA"
 		attrs := map[string]string{"node": cNodeName, "pod": "pod-a", "namespace": "default"}
 		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: cNodeName,
+			IP: net.MustParseIP(testIP), HandleID: &handleA, Attrs: attrs, Hostname: cNodeName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -189,6 +196,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 	})
 
 	It("should never garbage collect IP addresses that do not belong to Kubernetes pods", func() {
+		testIP := ips.NextIP()
 		commonNodeName := "common-node-name"
 
 		// Create a kubernetes node.
@@ -207,7 +215,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		handleA := "handleA"
 		attrs := map[string]string{"node": commonNodeName}
 		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
+			IP: net.MustParseIP(testIP), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -250,6 +258,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 	})
 
 	It("should garbage collect IP addresses if there is no Calico node, even if there happens to be a Kubernetes node", func() {
+		testIP := ips.NextIP()
 		commonNodeName := "common-node-name"
 
 		// Create a kubernetes node.
@@ -261,7 +270,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		handleA := "handleA"
 		attrs := map[string]string{"node": commonNodeName, "pod": "pod-a", "namespace": "default"}
 		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
+			IP: net.MustParseIP(testIP), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -279,12 +288,14 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 	})
 
 	It("should garbage collect IP addresses if there is no Calico node AND no Kubernetes node", func() {
+		testIP := ips.NextIP()
+
 		// Allocate an IP address on a node that doesn't exist.
 		commonNodeName := "common-node-name"
 		handleA := "handleA"
 		attrs := map[string]string{"node": commonNodeName, "pod": "pod-a", "namespace": "default"}
 		err := c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
+			IP: net.MustParseIP(testIP), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/kube-controllers/tests/testutils/ipam.go
+++ b/kube-controllers/tests/testutils/ipam.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync/atomic"
+)
+
+// TestBlockAllocator hands out IPs from distinct CIDR blocks within a pool.
+// In Ordered test suites with a shared IPAM controller, the controller's
+// async block GC from test N can race with test N+1's allocations on the
+// same block. Allocating from a different block per test eliminates this.
+type TestBlockAllocator struct {
+	baseIP    uint32
+	blockSize uint32
+	next      uint32
+}
+
+// NewTestBlockAllocator creates an allocator that returns IPs from successive
+// blocks within the given pool. blockBits is the CIDR prefix length of each
+// block (e.g., 26 for /26 blocks of 64 IPs).
+func NewTestBlockAllocator(poolBase string, blockBits int) *TestBlockAllocator {
+	ip := net.ParseIP(poolBase).To4()
+	if ip == nil {
+		panic(fmt.Sprintf("invalid IPv4 address: %s", poolBase))
+	}
+	return &TestBlockAllocator{
+		baseIP:    binary.BigEndian.Uint32(ip),
+		blockSize: 1 << uint(32-blockBits),
+	}
+}
+
+// NextIP returns the first usable IP (.1 offset) in the next unused block.
+// Safe for concurrent use.
+func (a *TestBlockAllocator) NextIP() string {
+	n := atomic.AddUint32(&a.next, 1) - 1
+	ipNum := a.baseIP + n*a.blockSize + 1
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, ipNum)
+	return ip.String()
+}


### PR DESCRIPTION
The conversion to Ordered suites in #12035 introduced a race in the etcd IPAM GC tests. All four tests allocate from the same IP (192.168.0.1 in block 192.168.0.0/26), so the shared controller's async block GC from one test can race with the next test's `AssignIP` on the same block, causing a "resource does not exist: BlockKey" panic.

Fix is to give each test its own /26 block via a `TestBlockAllocator` utility, so there's no cross-test contention. The allocator lives in testutils so future Ordered IPAM suites can reuse it.

```release-note
None
```