### PR TITLE
LoadBalancer IPAM: support spec.loadBalancerIP and spec.externalIPs as fallback

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -512,9 +512,9 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 		return
 	}
 
-	loadBalancerIPs, ipv4pools, ipv6pools, err := c.parseAnnotations(svc.Annotations)
+	loadBalancerIPs, ipv4pools, ipv6pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to parse annotations for service %s/%s", svc.Namespace, svc.Name)
+		log.WithError(err).Errorf("Failed to parse requested IPs for service %s/%s", svc.Namespace, svc.Name)
 		return
 	}
 
@@ -667,7 +667,7 @@ func (c *loadBalancerController) assignIP(svc *v1.Service) ([]string, error) {
 		return nil, err
 	}
 
-	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
+	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
 		return nil, err
 	}
@@ -861,9 +861,9 @@ func (c *loadBalancerController) resolvePools(poolIDs []string, isv4 bool) ([]cn
 	return poolCIDRs, nil
 }
 
-// IsCalicoManagedLoadBalancer returns if Calico should try to assign IP address for the LoadBalancer
+// IsCalicoManagedLoadBalancer returns if Calico should try to assign IP address for the LoadBalancer.
 // We assign IPs only if the loadBalancer controller assignIP is set to AllService
-// or in RequestedOnlyServices if the service has calico annotation
+// or in RequestedOnlyServices if the service has a calico annotation, spec.loadBalancerIP, or spec.externalIPs.
 func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool {
 	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false
@@ -883,10 +883,12 @@ func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool 
 
 		if svc.Annotations[annotationIPv4Pools] != "" ||
 			svc.Annotations[annotationIPv6Pools] != "" ||
-			svc.Annotations[annotationLoadBalancerIP] != "" {
+			svc.Annotations[annotationLoadBalancerIP] != "" ||
+			svc.Spec.LoadBalancerIP != "" ||
+			len(svc.Spec.ExternalIPs) > 0 {
 
 			if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != calicoLoadBalancerClass {
-				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer annotation set with spec.LoadBalancerClass != calico is not supported")
+				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer IP request set with spec.LoadBalancerClass != calico is not supported")
 				return false
 			}
 			return true
@@ -956,6 +958,64 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 			}
 		}
 	}
+	return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
+}
+
+// requestedLoadBalancerIPs returns the IPs, IPv4 pools, and IPv6 pools requested for a service.
+// It checks the Calico annotation first, then falls back to spec.loadBalancerIP (deprecated)
+// and spec.externalIPs if no annotation-based IPs are specified.
+func (c *loadBalancerController) requestedLoadBalancerIPs(svc *v1.Service) ([]cnet.IP, []cnet.IPNet, []cnet.IPNet, error) {
+	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if _, ok := svc.Annotations[annotationLoadBalancerIP]; ok {
+		return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
+	}
+
+	var specIPs []cnet.IP
+
+	if svc.Spec.LoadBalancerIP != "" {
+		ip := cnet.ParseIP(svc.Spec.LoadBalancerIP)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("could not parse spec.loadBalancerIP %q as a valid IP address", svc.Spec.LoadBalancerIP)
+		}
+		specIPs = append(specIPs, *ip)
+	}
+
+	for _, extIP := range svc.Spec.ExternalIPs {
+		ip := cnet.ParseIP(extIP)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("could not parse spec.externalIPs entry %q as a valid IP address", extIP)
+		}
+		duplicate := false
+		for _, existing := range specIPs {
+			if existing.String() == ip.String() {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			specIPs = append(specIPs, *ip)
+		}
+	}
+
+	if len(specIPs) > 0 {
+		ipv4, ipv6 := 0, 0
+		for _, ip := range specIPs {
+			if ip.To4() != nil {
+				ipv4++
+			} else {
+				ipv6++
+			}
+		}
+		if ipv4 > 1 || ipv6 > 1 {
+			return nil, nil, nil, fmt.Errorf("at most one IPv4 and one IPv6 address can be specified via spec fields; found %d IPv4 and %d IPv6", ipv4, ipv6)
+		}
+		return specIPs, ipv4Pools, ipv6Pools, nil
+	}
+
 	return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
 }
 

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -519,14 +519,14 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 	}
 
 	if loadBalancerIPs != nil {
-		// Check that service has assigned IPs to the ones specified in annotations
+		// Check that service has assigned IPs matching the requested IPs
 		lbIPs := make(map[string]bool)
 		for _, ip := range loadBalancerIPs {
 			lbIPs[ip.String()] = true
 		}
 		for ip := range c.allocationTracker.ipsByService[svcKey] {
 			if _, ok := lbIPs[ip]; !ok {
-				log.Infof("Removing IP assignment (%s) for Service %s/%s; no longer in annotations.", ip, svc.Namespace, svc.Name)
+				log.Infof("Removing IP assignment (%s) for Service %s/%s; no longer in requested IPs.", ip, svc.Namespace, svc.Name)
 				err = c.releaseIP(svcKey, ip)
 				if err != nil {
 					log.WithError(err).Errorf("Failed to release IP for %s/%s", svc.Namespace, svc.Name)

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -538,21 +538,21 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 		return
 	}
 
-	loadBalancerIPs, ipv4pools, ipv6pools, err := c.parseAnnotations(svc.Annotations)
+	loadBalancerIPs, ipv4pools, ipv6pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to parse annotations for service %s/%s", svc.Namespace, svc.Name)
+		log.WithError(err).Errorf("Failed to parse requested IPs for service %s/%s", svc.Namespace, svc.Name)
 		return
 	}
 
 	if loadBalancerIPs != nil {
-		// Check that service has assigned IPs to the ones specified in annotations
+		// Check that service has assigned IPs matching the requested IPs
 		lbIPs := make(map[string]bool)
 		for _, ip := range loadBalancerIPs {
 			lbIPs[ip.String()] = true
 		}
 		for ip := range c.allocationTracker.ipsByService[svcKey] {
 			if _, ok := lbIPs[ip]; !ok {
-				log.Infof("Removing IP assignment (%s) for Service %s/%s; no longer in annotations.", ip, svc.Namespace, svc.Name)
+				log.Infof("Removing IP assignment (%s) for Service %s/%s; no longer in requested IPs.", ip, svc.Namespace, svc.Name)
 				err = c.releaseIP(svcKey, ip)
 				if err != nil {
 					log.WithError(err).Errorf("Failed to release IP for %s/%s", svc.Namespace, svc.Name)
@@ -693,7 +693,7 @@ func (c *loadBalancerController) assignIP(svc *v1.Service) ([]string, error) {
 		return nil, err
 	}
 
-	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
+	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
 		return nil, err
 	}
@@ -887,9 +887,9 @@ func (c *loadBalancerController) resolvePools(poolIDs []string, isv4 bool) ([]cn
 	return poolCIDRs, nil
 }
 
-// IsCalicoManagedLoadBalancer returns if Calico should try to assign IP address for the LoadBalancer
+// IsCalicoManagedLoadBalancer returns if Calico should try to assign IP address for the LoadBalancer.
 // We assign IPs only if the loadBalancer controller assignIP is set to AllService
-// or in RequestedOnlyServices if the service has calico annotation
+// or in RequestedOnlyServices if the service has a calico annotation, spec.loadBalancerIP, or spec.externalIPs.
 func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool {
 	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false
@@ -909,10 +909,12 @@ func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool 
 
 		if svc.Annotations[annotationIPv4Pools] != "" ||
 			svc.Annotations[annotationIPv6Pools] != "" ||
-			svc.Annotations[annotationLoadBalancerIP] != "" {
+			svc.Annotations[annotationLoadBalancerIP] != "" ||
+			svc.Spec.LoadBalancerIP != "" ||
+			len(svc.Spec.ExternalIPs) > 0 {
 
 			if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != calicoLoadBalancerClass {
-				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer annotation set with spec.LoadBalancerClass != calico is not supported")
+				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer IP request set with spec.LoadBalancerClass != calico is not supported")
 				return false
 			}
 			return true
@@ -982,6 +984,64 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 			}
 		}
 	}
+	return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
+}
+
+// requestedLoadBalancerIPs returns the IPs, IPv4 pools, and IPv6 pools requested for a service.
+// It checks the Calico annotation first, then falls back to spec.loadBalancerIP (deprecated)
+// and spec.externalIPs if no annotation-based IPs are specified.
+func (c *loadBalancerController) requestedLoadBalancerIPs(svc *v1.Service) ([]cnet.IP, []cnet.IPNet, []cnet.IPNet, error) {
+	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if _, ok := svc.Annotations[annotationLoadBalancerIP]; ok {
+		return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
+	}
+
+	var specIPs []cnet.IP
+
+	if svc.Spec.LoadBalancerIP != "" {
+		ip := cnet.ParseIP(svc.Spec.LoadBalancerIP)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("could not parse spec.loadBalancerIP %q as a valid IP address", svc.Spec.LoadBalancerIP)
+		}
+		specIPs = append(specIPs, *ip)
+	}
+
+	for _, extIP := range svc.Spec.ExternalIPs {
+		ip := cnet.ParseIP(extIP)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("could not parse spec.externalIPs entry %q as a valid IP address", extIP)
+		}
+		duplicate := false
+		for _, existing := range specIPs {
+			if existing.String() == ip.String() {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			specIPs = append(specIPs, *ip)
+		}
+	}
+
+	if len(specIPs) > 0 {
+		ipv4, ipv6 := 0, 0
+		for _, ip := range specIPs {
+			if ip.To4() != nil {
+				ipv4++
+			} else {
+				ipv6++
+			}
+		}
+		if ipv4 > 1 || ipv6 > 1 {
+			return nil, nil, nil, fmt.Errorf("at most one IPv4 and one IPv6 address can be specified via spec fields; found %d IPv4 and %d IPv6", ipv4, ipv6)
+		}
+		return specIPs, ipv4Pools, ipv6Pools, nil
+	}
+
 	return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
 }
 

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -576,7 +576,7 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 			}
 		}
 	} else {
-		// No annotations are specified, check that the IPs assigned aren't from Manual pool from earlier assignment
+		// No specific IPs or pools requested (annotation or spec), check that assigned IPs aren't from a Manual pool
 		for ip := range c.allocationTracker.ipsByService[svcKey] {
 			pool, err := c.poolForIP(ip)
 			if err != nil {
@@ -584,12 +584,12 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 				return
 			}
 			if pool != nil {
-				// We want to release the address if annotation changed and we are no longer requesting IP from manual pool,
+				// Release if the service no longer requests a Manual-pool IP (via annotation or spec fields).
 				// if pool is nil we can skip this and the address will be removed during the next IPAM sync
 				//
 				// AssignmentMode should never be nil due to defaulting, but we check it just in case.
 				if pool.Spec.AssignmentMode != nil && *pool.Spec.AssignmentMode == api.Manual {
-					log.Infof("Removing IP assignment (%s) for Service %s/%s. No annotations but IP is from a 'Manual' IP pool.", ip, svc.Namespace, svc.Name)
+					log.Infof("Removing IP assignment (%s) for Service %s/%s. No requested IPs but IP is from a 'Manual' IP pool.", ip, svc.Namespace, svc.Name)
 					err = c.releaseIP(svcKey, ip)
 					if err != nil {
 						log.WithError(err).Errorf("Failed to release IP for %s/%s", svc.Namespace, svc.Name)
@@ -696,18 +696,11 @@ func (c *loadBalancerController) assignIP(svc *v1.Service) ([]string, error) {
 		return nil, err
 	}
 
+	// requestedLoadBalancerIPs already resolves Calico annotations and falls back to
+	// spec.loadBalancerIP / spec.externalIPs when the annotation is absent.
 	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
 		return nil, err
-	}
-
-	// Fall back to spec.loadBalancerIP when no specific IP was requested via annotation.
-	if loadBalancerIPs == nil && svc.Spec.LoadBalancerIP != "" {
-		ip := cnet.ParseIP(svc.Spec.LoadBalancerIP)
-		if ip == nil {
-			return nil, fmt.Errorf("invalid IP in spec.loadBalancerIP: %s", svc.Spec.LoadBalancerIP)
-		}
-		loadBalancerIPs = []cnet.IP{*ip}
 	}
 
 	var assignedIPs []string
@@ -1000,8 +993,10 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 }
 
 // requestedLoadBalancerIPs returns the IPs, IPv4 pools, and IPv6 pools requested for a service.
-// It checks the Calico annotation first, then falls back to spec.loadBalancerIP (deprecated)
-// and spec.externalIPs if no annotation-based IPs are specified.
+// Presence of the Calico projectcalico.org/loadBalancerIPs annotation always takes precedence
+// (even when empty/null); only when the annotation key is absent do we fall back to
+// spec.loadBalancerIP (deprecated) and spec.externalIPs. Callers (syncService, assignIP) should
+// treat the returned IP list as the full set of "requested IPs" regardless of source.
 func (c *loadBalancerController) requestedLoadBalancerIPs(svc *v1.Service) ([]cnet.IP, []cnet.IPNet, []cnet.IPNet, error) {
 	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
 	if err != nil {

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -541,21 +541,21 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 		return
 	}
 
-	loadBalancerIPs, ipv4pools, ipv6pools, err := c.parseAnnotations(svc.Annotations)
+	loadBalancerIPs, ipv4pools, ipv6pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to parse annotations for service %s/%s", svc.Namespace, svc.Name)
+		log.WithError(err).Errorf("Failed to parse requested IPs for service %s/%s", svc.Namespace, svc.Name)
 		return
 	}
 
 	if loadBalancerIPs != nil {
-		// Check that service has assigned IPs to the ones specified in annotations
+		// Check that service has assigned IPs matching the requested IPs
 		lbIPs := make(map[string]bool)
 		for _, ip := range loadBalancerIPs {
 			lbIPs[ip.String()] = true
 		}
 		for ip := range c.allocationTracker.ipsByService[svcKey] {
 			if _, ok := lbIPs[ip]; !ok {
-				log.Infof("Removing IP assignment (%s) for Service %s/%s; no longer in annotations.", ip, svc.Namespace, svc.Name)
+				log.Infof("Removing IP assignment (%s) for Service %s/%s; no longer in requested IPs.", ip, svc.Namespace, svc.Name)
 				err = c.releaseIP(svcKey, ip)
 				if err != nil {
 					log.WithError(err).Errorf("Failed to release IP for %s/%s", svc.Namespace, svc.Name)
@@ -696,7 +696,7 @@ func (c *loadBalancerController) assignIP(svc *v1.Service) ([]string, error) {
 		return nil, err
 	}
 
-	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
+	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.requestedLoadBalancerIPs(svc)
 	if err != nil {
 		return nil, err
 	}
@@ -899,9 +899,9 @@ func (c *loadBalancerController) resolvePools(poolIDs []string, isv4 bool) ([]cn
 	return poolCIDRs, nil
 }
 
-// IsCalicoManagedLoadBalancer returns if Calico should try to assign IP address for the LoadBalancer
+// IsCalicoManagedLoadBalancer returns if Calico should try to assign IP address for the LoadBalancer.
 // We assign IPs only if the loadBalancer controller assignIP is set to AllService
-// or in RequestedOnlyServices if the service has calico annotation
+// or in RequestedOnlyServices if the service has a calico annotation, spec.loadBalancerIP, or spec.externalIPs.
 func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool {
 	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false
@@ -922,7 +922,8 @@ func IsCalicoManagedLoadBalancer(svc *v1.Service, assignIPs api.AssignIPs) bool 
 		if svc.Annotations[annotationIPv4Pools] != "" ||
 			svc.Annotations[annotationIPv6Pools] != "" ||
 			svc.Annotations[annotationLoadBalancerIP] != "" ||
-			svc.Spec.LoadBalancerIP != "" {
+			svc.Spec.LoadBalancerIP != "" ||
+			len(svc.Spec.ExternalIPs) > 0 {
 
 			if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != calicoLoadBalancerClass {
 				log.WithFields(log.Fields{"svc": svc.Name, "ns": svc.Namespace}).Warn("calico LoadBalancer IP request set with spec.LoadBalancerClass != calico is not supported")
@@ -995,6 +996,64 @@ func (c *loadBalancerController) parseAnnotations(annotations map[string]string)
 			}
 		}
 	}
+	return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
+}
+
+// requestedLoadBalancerIPs returns the IPs, IPv4 pools, and IPv6 pools requested for a service.
+// It checks the Calico annotation first, then falls back to spec.loadBalancerIP (deprecated)
+// and spec.externalIPs if no annotation-based IPs are specified.
+func (c *loadBalancerController) requestedLoadBalancerIPs(svc *v1.Service) ([]cnet.IP, []cnet.IPNet, []cnet.IPNet, error) {
+	loadBalancerIPs, ipv4Pools, ipv6Pools, err := c.parseAnnotations(svc.Annotations)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if _, ok := svc.Annotations[annotationLoadBalancerIP]; ok {
+		return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
+	}
+
+	var specIPs []cnet.IP
+
+	if svc.Spec.LoadBalancerIP != "" {
+		ip := cnet.ParseIP(svc.Spec.LoadBalancerIP)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("could not parse spec.loadBalancerIP %q as a valid IP address", svc.Spec.LoadBalancerIP)
+		}
+		specIPs = append(specIPs, *ip)
+	}
+
+	for _, extIP := range svc.Spec.ExternalIPs {
+		ip := cnet.ParseIP(extIP)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("could not parse spec.externalIPs entry %q as a valid IP address", extIP)
+		}
+		duplicate := false
+		for _, existing := range specIPs {
+			if existing.String() == ip.String() {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			specIPs = append(specIPs, *ip)
+		}
+	}
+
+	if len(specIPs) > 0 {
+		ipv4, ipv6 := 0, 0
+		for _, ip := range specIPs {
+			if ip.To4() != nil {
+				ipv4++
+			} else {
+				ipv6++
+			}
+		}
+		if ipv4 > 1 || ipv6 > 1 {
+			return nil, nil, nil, fmt.Errorf("at most one IPv4 and one IPv6 address can be specified via spec fields; found %d IPv4 and %d IPv6", ipv4, ipv6)
+		}
+		return specIPs, ipv4Pools, ipv6Pools, nil
+	}
+
 	return loadBalancerIPs, ipv4Pools, ipv6Pools, nil
 }
 

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -197,6 +197,25 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 
 		svc.Annotations = map[string]string{}
 
+		// spec.loadBalancerIP should trigger management in RequestedServicesOnly mode
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeTrue())
+		svc.Spec.LoadBalancerIP = ""
+
+		// spec.externalIPs should trigger management in RequestedServicesOnly mode
+		svc.Spec.ExternalIPs = []string{"10.0.0.2"}
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeTrue())
+
+		// spec.externalIPs with non-calico LoadBalancerClass should not be managed
+		loadBalancerClass = "not-calico"
+		svc.Spec.LoadBalancerClass = &loadBalancerClass
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeFalse())
+		svc.Spec.LoadBalancerClass = nil
+		svc.Spec.ExternalIPs = nil
+
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)
 		Expect(managed).To(BeFalse())
@@ -450,6 +469,83 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 
 		_, v6cidr, _ := net.ParseCIDR(ipv6Pool.Spec.CIDR)
 		Expect(ipv6Pools).To(Equal([]cnet.IPNet{{IPNet: *v6cidr}}))
+	})
+
+	It("should fall back to spec fields when annotation is absent", func() {
+		// No annotation, no spec fields → nil IPs
+		svc.Annotations = nil
+		loadBalancerIPs, _, _, err := c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(BeNil())
+
+		// spec.loadBalancerIP set, no annotation → use spec IP
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(Equal([]cnet.IP{*cnet.ParseIP("10.0.0.1")}))
+		svc.Spec.LoadBalancerIP = ""
+
+		// spec.externalIPs set, no annotation → use spec IPs
+		svc.Spec.ExternalIPs = []string{"10.0.0.2"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(Equal([]cnet.IP{*cnet.ParseIP("10.0.0.2")}))
+		svc.Spec.ExternalIPs = nil
+
+		// Both spec.loadBalancerIP and spec.externalIPs set (different IPs, one v4 each)
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		svc.Spec.ExternalIPs = []string{"10.0.0.2"}
+		_, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("at most one IPv4"))
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// spec.loadBalancerIP and spec.externalIPs with same IP → deduplication
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		svc.Spec.ExternalIPs = []string{"10.0.0.1"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(HaveLen(1))
+		Expect(loadBalancerIPs[0].String()).To(Equal("10.0.0.1"))
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// Dual-stack via spec fields: one v4 loadBalancerIP + one v6 externalIP
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		svc.Spec.ExternalIPs = []string{"ff06::c3"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(HaveLen(2))
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// Annotation takes precedence over spec fields
+		svc.Annotations = map[string]string{
+			annotationLoadBalancerIP: "[\"10.0.0.4\"]",
+		}
+		svc.Spec.LoadBalancerIP = "10.0.0.99"
+		svc.Spec.ExternalIPs = []string{"10.0.0.100"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(Equal([]cnet.IP{*cnet.ParseIP("10.0.0.4")}))
+		svc.Annotations = nil
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// Invalid spec.loadBalancerIP
+		svc.Spec.LoadBalancerIP = "not-an-ip"
+		_, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.loadBalancerIP"))
+		svc.Spec.LoadBalancerIP = ""
+
+		// Invalid spec.externalIPs entry
+		svc.Spec.ExternalIPs = []string{"also-not-an-ip"}
+		_, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.externalIPs"))
+		svc.Spec.ExternalIPs = nil
 	})
 
 	It("should remove Calico ips from service status", func() {

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -196,6 +196,25 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 
 		svc.Annotations = map[string]string{}
 
+		// spec.loadBalancerIP should trigger management in RequestedServicesOnly mode
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeTrue())
+		svc.Spec.LoadBalancerIP = ""
+
+		// spec.externalIPs should trigger management in RequestedServicesOnly mode
+		svc.Spec.ExternalIPs = []string{"10.0.0.2"}
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeTrue())
+
+		// spec.externalIPs with non-calico LoadBalancerClass should not be managed
+		loadBalancerClass = "not-calico"
+		svc.Spec.LoadBalancerClass = &loadBalancerClass
+		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.RequestedServicesOnly)
+		Expect(managed).To(BeFalse())
+		svc.Spec.LoadBalancerClass = nil
+		svc.Spec.ExternalIPs = nil
+
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		managed = IsCalicoManagedLoadBalancer(&svc, apiv3.AllServices)
 		Expect(managed).To(BeFalse())
@@ -449,6 +468,83 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 
 		_, v6cidr, _ := net.ParseCIDR(ipv6Pool.Spec.CIDR)
 		Expect(ipv6Pools).To(Equal([]cnet.IPNet{{IPNet: *v6cidr}}))
+	})
+
+	It("should fall back to spec fields when annotation is absent", func() {
+		// No annotation, no spec fields → nil IPs
+		svc.Annotations = nil
+		loadBalancerIPs, _, _, err := c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(BeNil())
+
+		// spec.loadBalancerIP set, no annotation → use spec IP
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(Equal([]cnet.IP{*cnet.ParseIP("10.0.0.1")}))
+		svc.Spec.LoadBalancerIP = ""
+
+		// spec.externalIPs set, no annotation → use spec IPs
+		svc.Spec.ExternalIPs = []string{"10.0.0.2"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(Equal([]cnet.IP{*cnet.ParseIP("10.0.0.2")}))
+		svc.Spec.ExternalIPs = nil
+
+		// Both spec.loadBalancerIP and spec.externalIPs set (different IPs, one v4 each)
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		svc.Spec.ExternalIPs = []string{"10.0.0.2"}
+		_, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("at most one IPv4"))
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// spec.loadBalancerIP and spec.externalIPs with same IP → deduplication
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		svc.Spec.ExternalIPs = []string{"10.0.0.1"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(HaveLen(1))
+		Expect(loadBalancerIPs[0].String()).To(Equal("10.0.0.1"))
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// Dual-stack via spec fields: one v4 loadBalancerIP + one v6 externalIP
+		svc.Spec.LoadBalancerIP = "10.0.0.1"
+		svc.Spec.ExternalIPs = []string{"ff06::c3"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(HaveLen(2))
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// Annotation takes precedence over spec fields
+		svc.Annotations = map[string]string{
+			annotationLoadBalancerIP: "[\"10.0.0.4\"]",
+		}
+		svc.Spec.LoadBalancerIP = "10.0.0.99"
+		svc.Spec.ExternalIPs = []string{"10.0.0.100"}
+		loadBalancerIPs, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loadBalancerIPs).To(Equal([]cnet.IP{*cnet.ParseIP("10.0.0.4")}))
+		svc.Annotations = nil
+		svc.Spec.LoadBalancerIP = ""
+		svc.Spec.ExternalIPs = nil
+
+		// Invalid spec.loadBalancerIP
+		svc.Spec.LoadBalancerIP = "not-an-ip"
+		_, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.loadBalancerIP"))
+		svc.Spec.LoadBalancerIP = ""
+
+		// Invalid spec.externalIPs entry
+		svc.Spec.ExternalIPs = []string{"also-not-an-ip"}
+		_, _, _, err = c.requestedLoadBalancerIPs(&svc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.externalIPs"))
+		svc.Spec.ExternalIPs = nil
 	})
 
 	It("should remove Calico ips from service status", func() {


### PR DESCRIPTION
## Description

When the `projectcalico.org/loadBalancerIPs` annotation is not set, the LoadBalancer IPAM controller now falls back to `Service.spec.loadBalancerIP` (deprecated) and `Service.spec.externalIPs` for manual IP assignment.

This allows gradual migration from standard Kubernetes fields to the Calico-specific annotation without updating all Helm charts at once.

Fixes #11815

## Changes

**`loadbalancer_controller.go`**:
- Added `requestedLoadBalancerIPs(svc)` method that wraps `parseAnnotations` and falls back to spec fields when no annotation-based IPs are specified
- Updated `IsCalicoManagedLoadBalancer` to recognize `spec.loadBalancerIP` and `spec.externalIPs` in `RequestedServicesOnly` mode
- Updated `syncService` and `assignIP` to use the new method

**`loadbalancer_controller_ut_test.go`**:
- Added tests for `requestedLoadBalancerIPs` covering: spec-only fallback, annotation precedence, deduplication, dual-stack, error cases
- Added tests for `IsCalicoManagedLoadBalancer` with `spec.loadBalancerIP` and `spec.externalIPs`

## Behavior

| Configuration | Result |
|---|---|
| Annotation set | Annotation IPs used (unchanged) |
| No annotation, `spec.loadBalancerIP` set | Spec IP used for assignment |
| No annotation, `spec.externalIPs` set | External IPs used for assignment |
| Both `spec.loadBalancerIP` and `spec.externalIPs` | Combined (deduplicated, max 1 IPv4 + 1 IPv6) |
| Annotation + spec fields | Annotation takes precedence |
