### PR TITLE
Generate BIRD config files with changes of programClusterRoutes in BGPConfig

### DIFF
--- a/confd/etc/calico/confd/conf.d/bird6_ipam.toml
+++ b/confd/etc/calico/confd/conf.d/bird6_ipam.toml
@@ -6,6 +6,7 @@ keys = [
     "/v1/ipam/v6/pool",
     "/bgp/v1/host//NODENAME",
     "/bgp/v1/global/svc_loadbalancer_ips",
+    "/bgp/v1/global/program_cluster_routes",
     "/staticroutesv6",
     "/rejectcidrsv6",
 ]

--- a/confd/etc/calico/confd/conf.d/bird_ipam.toml
+++ b/confd/etc/calico/confd/conf.d/bird_ipam.toml
@@ -6,6 +6,7 @@ keys = [
     "/v1/ipam/v4/pool",
     "/bgp/v1/host//NODENAME",
     "/bgp/v1/global/svc_loadbalancer_ips",
+    "/bgp/v1/global/program_cluster_routes",
     "/staticroutes",
     "/rejectcidrs",
 ]

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1241,6 +1241,7 @@ func (c *client) updateBGPConfigCache(resName string, v3res *apiv3.BGPConfigurat
 		c.getNodeMeshRestartTimeKVPair(v3res, model.GlobalBGPConfigKey{})
 		c.getNodeMeshPasswordKVPair(v3res, model.GlobalBGPConfigKey{})
 		c.getIgnoredInterfacesKVPair(v3res, model.GlobalBGPConfigKey{})
+		c.getProgramClusterRoutesKVPair(v3res, model.GlobalBGPConfigKey{})
 
 		// Update service load balancer aggregation setting
 		if v3res != nil && v3res.Spec.ServiceLoadBalancerAggregation != nil {
@@ -1535,6 +1536,15 @@ func (c *client) getIgnoredInterfacesKVPair(v3res *apiv3.BGPConfiguration, key a
 		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(ignoredIfacesKey, strings.Join(v3res.Spec.IgnoredInterfaces, ",")))
 	} else {
 		c.updateCache(api.UpdateTypeKVDeleted, getKVPair(ignoredIfacesKey))
+	}
+}
+
+func (c *client) getProgramClusterRoutesKVPair(v3res *apiv3.BGPConfiguration, key any) {
+	programClusterRoutesKey := getBGPConfigKey("program_cluster_routes", key)
+	if v3res != nil && v3res.Spec.ProgramClusterRoutes != nil {
+		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(programClusterRoutesKey, *v3res.Spec.ProgramClusterRoutes))
+	} else {
+		c.updateCache(api.UpdateTypeKVDeleted, getKVPair(programClusterRoutesKey))
 	}
 }
 

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/confd/pkg/backends/calico/ippools_test.go
+++ b/confd/pkg/backends/calico/ippools_test.go
@@ -547,7 +547,7 @@ func TestUpdateBGPConfigCache_ProgramClusterRoutes_UpdateThenDelete(t *testing.T
 	c.updateBGPConfigCache("default", res, &svcAdvertisement, &updatePeersV1, &updateReasons)
 	require.Equal(t, "Disabled", c.cache[programClusterRoutesCacheKey])
 
-	// Seconf: set ProgramClusterRoutes=Enabled and confirm cache is populated
+	// Second: set ProgramClusterRoutes=Enabled and confirm cache is populated
 	// via the full updateBGPConfigCache entrypoint (exercises wiring at
 	// client.go's global branch).
 	res = &v3.BGPConfiguration{

--- a/confd/pkg/backends/calico/ippools_test.go
+++ b/confd/pkg/backends/calico/ippools_test.go
@@ -268,7 +268,7 @@ func Test_processIPPoolsV6(t *testing.T) {
 	}
 }
 
-func Test_processIPPoolsV4_BGPDisabledWithinCluster(t *testing.T) {
+func Test_processIPPoolsV4_FelixProgramsClusterRoutes(t *testing.T) {
 	forKernelStatements := []string{
 		// IPv4 IPIP Encapsulation cases.
 		`  if (net ~ 10.10.0.0/16) then { reject; } # Cluster routes are handled by Felix.`,
@@ -345,7 +345,7 @@ func Test_processIPPoolsV4_BGPDisabledWithinCluster(t *testing.T) {
 	}
 }
 
-func Test_processIPPoolsV6_BGPDisabledWithinCluster(t *testing.T) {
+func Test_processIPPoolsV6_FelixProgramsClusterRoutes(t *testing.T) {
 	forKernelStatements := []string{
 		// IPv6 IPIP Encapsulation cases.
 		`  if (net ~ dead:beef:10::/64) then { reject; } # Cluster routes are handled by Felix.`,
@@ -458,4 +458,129 @@ func filterExpectedStatements(statements []string, filterAction string) (filtere
 		}
 	}
 	return
+}
+
+// programClusterRoutesCacheKey is the confd cache key that mirrors
+// BGPConfiguration.Spec.ProgramClusterRoutes into BIRD config.
+const programClusterRoutesCacheKey = "/calico/bgp/v1/global/program_cluster_routes"
+
+func strPtr(s string) *string { return &s }
+
+func TestGetProgramClusterRoutesKVPair(t *testing.T) {
+	// Initially, set ProgramClusterRoutes to Enabled.
+	c := &client{cache: make(map[string]string)}
+	res := &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Enabled"),
+		},
+	}
+	c.getProgramClusterRoutesKVPair(res, model.GlobalBGPConfigKey{})
+	require.Equal(t, "Enabled", c.cache[programClusterRoutesCacheKey])
+
+	// Switch ProgramClusterRoutes to Disabled.
+	res = &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Disabled"),
+		},
+	}
+	c.getProgramClusterRoutesKVPair(res, model.GlobalBGPConfigKey{})
+	require.Equal(t, "Disabled", c.cache[programClusterRoutesCacheKey])
+
+	// Switch ProgramClusterRoutes to Enabled.
+	res = &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Enabled"),
+		},
+	}
+	c.getProgramClusterRoutesKVPair(res, model.GlobalBGPConfigKey{})
+	require.Equal(t, "Enabled", c.cache[programClusterRoutesCacheKey])
+
+	// Unsetting ProgramClusterRoutes.
+	res = &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: nil,
+		},
+	}
+	c.getProgramClusterRoutesKVPair(res, model.GlobalBGPConfigKey{})
+	require.NotContains(t, c.cache, programClusterRoutesCacheKey)
+}
+
+func TestGetProgramClusterRoutesKVPair_NilResourceDeletesCacheEntry(t *testing.T) {
+	c := &client{cache: map[string]string{
+		programClusterRoutesCacheKey: "Disabled",
+	}}
+	c.getProgramClusterRoutesKVPair(nil, model.GlobalBGPConfigKey{})
+	require.NotContains(t, c.cache, programClusterRoutesCacheKey)
+}
+
+// ProgramClusterRoutes is intentionally wired as global-only in
+// updateBGPConfigCache (client.go): the per-node branch does not call
+// getProgramClusterRoutesKVPair. This test pins that behavior — if per-node
+// support is ever added, this test should be updated along with the call site.
+func TestGetProgramClusterRoutesKVPair_PerNodeKeyDoesNotWriteGlobal(t *testing.T) {
+	c := &client{cache: make(map[string]string)}
+	res := &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Enabled"),
+		},
+	}
+	c.getProgramClusterRoutesKVPair(res, model.NodeBGPConfigKey{Nodename: "nodeX"})
+	require.NotContains(t, c.cache, programClusterRoutesCacheKey)
+}
+
+func TestUpdateBGPConfigCache_ProgramClusterRoutes_UpdateThenDelete(t *testing.T) {
+	c := &client{cache: make(map[string]string)}
+	var (
+		svcAdvertisement bool
+		updatePeersV1    bool
+		updateReasons    []string
+	)
+
+	// First: set ProgramClusterRoutes=Disabled and confirm cache is populated
+	// via the full updateBGPConfigCache entrypoint (exercises wiring at
+	// client.go's global branch).
+	res := &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Disabled"),
+		},
+	}
+	c.updateBGPConfigCache("default", res, &svcAdvertisement, &updatePeersV1, &updateReasons)
+	require.Equal(t, "Disabled", c.cache[programClusterRoutesCacheKey])
+
+	// Seconf: set ProgramClusterRoutes=Enabled and confirm cache is populated
+	// via the full updateBGPConfigCache entrypoint (exercises wiring at
+	// client.go's global branch).
+	res = &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Enabled"),
+		},
+	}
+	c.updateBGPConfigCache("default", res, &svcAdvertisement, &updatePeersV1, &updateReasons)
+	require.Equal(t, "Enabled", c.cache[programClusterRoutesCacheKey])
+
+	// Finally: clear the field and confirm the cache entry is removed.
+	res = &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: nil,
+		},
+	}
+	c.updateBGPConfigCache("default", res, &svcAdvertisement, &updatePeersV1, &updateReasons)
+	require.NotContains(t, c.cache, programClusterRoutesCacheKey)
+}
+
+func TestUpdateBGPConfigCache_ProgramClusterRoutes_PerNodeResourceNameSkipsGlobalKey(t *testing.T) {
+	c := &client{cache: make(map[string]string)}
+	var (
+		svcAdvertisement bool
+		updatePeersV1    bool
+		updateReasons    []string
+	)
+
+	res := &v3.BGPConfiguration{
+		Spec: v3.BGPConfigurationSpec{
+			ProgramClusterRoutes: strPtr("Enabled"),
+		},
+	}
+	c.updateBGPConfigCache("node.nodeX", res, &svcAdvertisement, &updatePeersV1, &updateReasons)
+	require.NotContains(t, c.cache, programClusterRoutesCacheKey)
 }


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

This PR fixes a bug where BIRD configs are not updated with `programClusterRoutes` changes in `BGPConfiguration`. This result in different issues like both Felix and BIRD try to program cluster routes (as reported by https://tigera.atlassian.net/browse/CORE-12641) or neither one programs cluster routes leading to connectivity issue. 

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
