### PR TITLE
Fix spurious Felix restarts from transient encapsulation changes

### DIFF
--- a/felix/calc/encapsulation_resolver.go
+++ b/felix/calc/encapsulation_resolver.go
@@ -98,6 +98,9 @@ func (r *EncapsulationResolver) triggerCalculation() {
 			"newVXLANEnabled":   newEncap.VXLANEnabled,
 			"oldVXLANEnabledV6": r.config.Encapsulation.VXLANEnabledV6,
 			"newVXLANEnabledV6": newEncap.VXLANEnabledV6,
+			"numIPIPPools":      len(r.encapCalc.ipipPools),
+			"numVXLANPools":     len(r.encapCalc.vxlanPools),
+			"numVXLANPoolsV6":   len(r.encapCalc.vxlanPoolsv6),
 		}).Info("EncapsulationResolver: Encapsulation changed.")
 	}
 

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -1325,14 +1325,66 @@ func (fc *DataplaneConnector) sendMessagesToDataplaneDriver() {
 			}()
 			if msg.IpipEnabled != encap.IPIPEnabled || msg.VxlanEnabled != encap.VXLANEnabled ||
 				msg.VxlanEnabledV6 != encap.VXLANEnabledV6 {
-				log.Warn("IPIP and/or VXLAN encapsulation changed, need to restart.")
-				fc.shutDownProcess(reasonEncapChanged)
+				log.WithFields(log.Fields{
+					"ipip":       msg.IpipEnabled,
+					"vxlan":      msg.VxlanEnabled,
+					"vxlanV6":    msg.VxlanEnabledV6,
+					"oldIpip":    encap.IPIPEnabled,
+					"oldVxlan":   encap.VXLANEnabled,
+					"oldVxlanV6": encap.VXLANEnabledV6,
+				}).Warn("IPIP and/or VXLAN encapsulation change reported by calc graph.")
+				// Re-verify by listing IP pools directly from the datastore.
+				// This guards against transient pool data anomalies from
+				// watcher resyncs triggering unnecessary restarts.
+				if fc.confirmEncapChanged() {
+					log.Warn("Encapsulation change confirmed from datastore, restarting.")
+					fc.shutDownProcess(reasonEncapChanged)
+				} else {
+					log.Warn("Encapsulation change NOT confirmed from datastore, ignoring transient update.")
+				}
 			}
 		}
 		if err := fc.dataplane.SendMessage(msg); err != nil {
 			fc.shutDownProcess("Failed to write to dataplane driver")
 		}
 	}
+}
+
+// confirmEncapChanged re-lists IP pools from the datastore and recomputes
+// the encapsulation state.  Returns true if the fresh computation differs
+// from the startup state, confirming that a restart is needed.  This
+// filters out transient pool data anomalies that can arise from watcher
+// resyncs without delaying legitimate encapsulation changes.
+func (fc *DataplaneConnector) confirmEncapChanged() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ippoolKVPList, err := fc.datastore.List(ctx, model.ResourceListOptions{Kind: apiv3.KindIPPool}, "")
+	if err != nil {
+		log.WithError(err).Warn("Failed to list IP pools for encapsulation verification; assuming change is real.")
+		return true
+	}
+
+	fc.configLock.Lock()
+	cfg := fc.config
+	startupEncap := fc.config.Encapsulation
+	fc.configLock.Unlock()
+
+	freshCalc := calc.NewEncapsulationCalculator(cfg, ippoolKVPList)
+	freshEncap := config.Encapsulation{
+		IPIPEnabled:    freshCalc.IPIPEnabled(),
+		VXLANEnabled:   freshCalc.VXLANEnabled(),
+		VXLANEnabledV6: freshCalc.VXLANEnabledV6(),
+	}
+
+	if freshEncap != startupEncap {
+		log.WithFields(log.Fields{
+			"startup": startupEncap,
+			"fresh":   freshEncap,
+		}).Info("Fresh encapsulation computation differs from startup.")
+		return true
+	}
+	log.WithField("encap", freshEncap).Info("Fresh encapsulation computation matches startup; transient change.")
+	return false
 }
 
 func (fc *DataplaneConnector) shutDownProcess(reason string) {


### PR DESCRIPTION
## Description

When the calc graph's EncapsulationResolver reports an encapsulation change
(e.g., VXLAN enabled→disabled), the daemon now re-verifies by listing IP pools
directly from the datastore before restarting. If the fresh computation matches
the startup state, the change was transient (e.g., from a watcher resync race)
and is ignored.

This fixes a flaking FV test (`_BPF-SAFE_ VXLAN topology ... with mismatched
MTU interface pattern / should configure MTU correctly based on IP pools`) where
a spurious pool update with empty VXLANMode arrived in the calc graph, causing
Felix to restart without VXLAN even though the datastore pool had
VXLANMode=Always.

### Root cause from log analysis

1. A transient IP pool update arrives in the calc graph with `VXLANMode=""`
   (NO_ENCAP) even though the Kubernetes pool has `VXLANMode=Always`
2. The EncapsulationResolver computes `VXLANEnabled=false` and sends it to the
   daemon
3. The daemon sees a mismatch with its startup encapsulation and restarts Felix
4. The restarted Felix runs without VXLAN — never programs `vxlan.calico` in BPF
5. The test times out after 60s waiting for BPF program attachment

The spurious update coincides with a config_batcher flush, suggesting a
syncer/watcher resync race condition.

### Changes

- **`felix/daemon/daemon.go`**: Add `confirmEncapChanged()` method that re-lists
  IP pools from the datastore and recomputes encapsulation before committing to a
  restart. On error (e.g., datastore unreachable), falls back to restarting.
- **`felix/calc/encapsulation_resolver.go`**: Add pool counts to encapsulation
  change log messages for better diagnostics.

## Release Note
```release-note
Felix no longer restarts unnecessarily due to transient encapsulation state changes from watcher resyncs. 
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)