### PR TITLE
Fix node image build race with BPF object files

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -139,7 +139,7 @@ ST_OPTIONS?=
 K8ST_REPORT_FILENAME ?= k8s-tests.xml
 
 # Filesystem of the node container that is checked in to this repository.
-NODE_CONTAINER_FILES=$(shell find ./filesystem -type f)
+NODE_CONTAINER_FILES=$(shell find ./filesystem -type f -not -path './filesystem/usr/lib/calico/bpf/*')
 
 # Calculate a timestamp for any build artefacts.
 DATE:=$(shell date -u +'%FT%T%z')


### PR DESCRIPTION
`NODE_CONTAINER_FILES` uses `$(shell find ./filesystem -type f)` which runs at Makefile parse time. If a previous build left BPF `.o` files in `filesystem/usr/lib/calico/bpf/`, those get captured as explicit prerequisites of the node image target. But then the `filesystem/usr/lib/calico/bpf` recipe does `rm -rf` and rebuilds from scratch - so Make tries to satisfy prerequisites that no longer exist and fails with "No rule to make target" errors during parallel builds (e.g., `make kind-build-images`).

The BPF directory is already tracked as a dependency via `BUILD_DEPS` -> `IMAGE_DEPS`, so we just exclude it from the `find`.

```release-note
None
```