### PR TITLE
Fix ExternalNode ingress test to use framework.Context

### DIFF
--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -628,7 +628,7 @@ var _ = describe.CalicoDescribe(
 		}
 
 		// External node scenarios run from a machine outside the cluster via SSH.
-		Context("external node", Label("ExternalNode"), func() {
+		framework.Context("external node", describe.WithExternalNode(), func() {
 			for _, scenario := range ingressScenarioTable {
 				s := scenario // capture loop variable
 				if s.srcNode != "external" {


### PR DESCRIPTION
217e18f074 switched the external node ingress `Context` from `describe.WithExternalNode()` to raw `Label("ExternalNode")` to fix an "Unknown Decorator" error. The real problem was that raw ginkgo `Context` doesn't understand framework label decorators - the fix should have been to use `framework.Context` instead.

With raw `Label("ExternalNode")`, the label is only set as Ginkgo metadata. `framework.Context` + `describe.WithExternalNode()` adds both `[ExternalNode]` to the description text and the Ginkgo label, which is needed for `--ginkgo.skip` matching (enterprise CI still uses focus/skip) and is consistent with how other tests (maglev, egress gateways, etc.) use `describe.WithExternalNode()`.

```release-note
None
```