### PR TITLE
Harden webhook server against DoS attacks

### DIFF
--- a/webhooks/cmd/main.go
+++ b/webhooks/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -182,7 +183,12 @@ func handleRequest(w http.ResponseWriter, r *http.Request, handler utils.Admissi
 	obj, gvk, err := decodeAdmissionReview(w, r)
 	if err != nil {
 		logrus.Error(err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		} else {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 		return
 	}
 

--- a/webhooks/cmd/main.go
+++ b/webhooks/cmd/main.go
@@ -30,7 +30,6 @@ import (
 	calicoclient "github.com/projectcalico/api/pkg/client/clientset_generated/clientset"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/time/rate"
 	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -52,8 +51,6 @@ var (
 	clientCAFile string
 	logLevel     string
 	port         int
-	rateLimit    float64
-	rateBurst    int
 )
 
 var WebhookCommand = &cobra.Command{
@@ -79,8 +76,6 @@ func init() {
 	WebhookCommand.Flags().StringVar(&clientCAFile, "client-ca-file", "", "If set, enables mTLS by requiring and verifying client certificates signed by this CA.")
 	WebhookCommand.Flags().IntVar(&port, "port", 6443, "Secure port that the webhook listens on")
 	WebhookCommand.Flags().StringVar(&logLevel, "log-level", "info", "Logrus log level to output (trace, debug, info, warning, error, fatal, panic)")
-	WebhookCommand.Flags().Float64Var(&rateLimit, "rate-limit", 25, "Maximum sustained requests per second across all webhook endpoints.")
-	WebhookCommand.Flags().IntVar(&rateBurst, "rate-burst", 50, "Maximum burst of requests allowed above the sustained rate limit.")
 }
 
 func main() {
@@ -121,9 +116,8 @@ func serveWebhookTLS(cmd *cobra.Command, args []string) {
 		logrus.WithError(err).Fatal("Failed to create Calico clientset")
 	}
 
-	// Register webhook handlers with rate limiting.
-	limiter := rate.NewLimiter(rate.Limit(rateLimit), rateBurst)
-	registerHooks(cs, calicoCS, limiter)
+	// Register webhook handlers.
+	registerHooks(cs, calicoCS)
 
 	// Create and run the server.
 	cfg, err := ctls.NewTLSConfig()
@@ -133,11 +127,11 @@ func serveWebhookTLS(cmd *cobra.Command, args []string) {
 	if clientCAFile != "" {
 		caCert, err := os.ReadFile(clientCAFile)
 		if err != nil {
-			logrus.WithError(err).Fatal("Failed to read client CA file")
+			logrus.WithError(err).Fatalf("Failed to read client CA file %q", clientCAFile)
 		}
 		certPool := x509.NewCertPool()
 		if !certPool.AppendCertsFromPEM(caCert) {
-			logrus.Fatal("Failed to parse client CA certificate")
+			logrus.Fatalf("Failed to parse client CA certificate from %q: file must contain PEM-encoded certificates", clientCAFile)
 		}
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 		cfg.ClientCAs = certPool
@@ -159,13 +153,11 @@ func serveWebhookTLS(cmd *cobra.Command, args []string) {
 	}
 }
 
-func registerHooks(cs kubernetes.Interface, calicoCS calicoclient.Interface, limiter *rate.Limiter) {
-	handle := rateLimitedHandleFn(limiter)
-	rbac.RegisterHook(cs, calicoCS.ProjectcalicoV3().Tiers(), utils.HandleFn(handle))
-	clusterinfo.RegisterHook(utils.HandleFn(handle))
+func registerHooks(cs kubernetes.Interface, calicoCS calicoclient.Interface) {
+	rbac.RegisterHook(cs, calicoCS.ProjectcalicoV3().Tiers(), utils.HandleFn(handleFn))
+	clusterinfo.RegisterHook(utils.HandleFn(handleFn))
 
-	// Readiness endpoint is not rate-limited — if health checks are rejected,
-	// Kubernetes restarts the pod, which amplifies a DoS.
+	// Register a readiness endpoint that can be used by Kubernetes to check the health of the webhook server.
 	http.HandleFunc("/readyz", readyFn())
 }
 
@@ -177,18 +169,10 @@ func readyFn() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
-// rateLimitedHandleFn returns a HandleFn that enforces a global rate limit
-// on all webhook endpoints.
-func rateLimitedHandleFn(limiter *rate.Limiter) func(handler utils.AdmissionReviewHandler) func(http.ResponseWriter, *http.Request) {
-	return func(handler utils.AdmissionReviewHandler) func(http.ResponseWriter, *http.Request) {
-		return func(w http.ResponseWriter, r *http.Request) {
-			if !limiter.Allow() {
-				logrus.Warn("Rate limit exceeded, rejecting request")
-				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
-				return
-			}
-			handleRequest(w, r, handler)
-		}
+// handleFn implements utils.HandleFn to allow registration of webhooks.
+func handleFn(handler utils.AdmissionReviewHandler) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		handleRequest(w, r, handler)
 	}
 }
 

--- a/webhooks/cmd/main.go
+++ b/webhooks/cmd/main.go
@@ -17,16 +17,20 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	calicoclient "github.com/projectcalico/api/pkg/client/clientset_generated/clientset"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/time/rate"
 	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,7 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/cli"
 
-	"github.com/projectcalico/calico/crypto/pkg/tls"
+	ctls "github.com/projectcalico/calico/crypto/pkg/tls"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/calico/pkg/buildinfo"
 	"github.com/projectcalico/calico/webhooks/pkg/clusterinfo"
@@ -43,10 +47,13 @@ import (
 )
 
 var (
-	certFile string
-	keyFile  string
-	logLevel string
-	port     int
+	certFile     string
+	keyFile      string
+	clientCAFile string
+	logLevel     string
+	port         int
+	rateLimit    float64
+	rateBurst    int
 )
 
 var WebhookCommand = &cobra.Command{
@@ -69,8 +76,11 @@ var VersionCommand = &cobra.Command{
 func init() {
 	WebhookCommand.Flags().StringVar(&certFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert).")
 	WebhookCommand.Flags().StringVar(&keyFile, "tls-private-key-file", "", "File containing the default x509 private key matching --tls-cert-file.")
+	WebhookCommand.Flags().StringVar(&clientCAFile, "client-ca-file", "", "If set, enables mTLS by requiring and verifying client certificates signed by this CA.")
 	WebhookCommand.Flags().IntVar(&port, "port", 6443, "Secure port that the webhook listens on")
 	WebhookCommand.Flags().StringVar(&logLevel, "log-level", "info", "Logrus log level to output (trace, debug, info, warning, error, fatal, panic)")
+	WebhookCommand.Flags().Float64Var(&rateLimit, "rate-limit", 25, "Maximum sustained requests per second across all webhook endpoints.")
+	WebhookCommand.Flags().IntVar(&rateBurst, "rate-burst", 50, "Maximum burst of requests allowed above the sustained rate limit.")
 }
 
 func main() {
@@ -111,17 +121,35 @@ func serveWebhookTLS(cmd *cobra.Command, args []string) {
 		logrus.WithError(err).Fatal("Failed to create Calico clientset")
 	}
 
-	// Register webhook handlers.
-	registerHooks(cs, calicoCS)
+	// Register webhook handlers with rate limiting.
+	limiter := rate.NewLimiter(rate.Limit(rateLimit), rateBurst)
+	registerHooks(cs, calicoCS, limiter)
 
 	// Create and run the server.
-	cfg, err := tls.NewTLSConfig()
+	cfg, err := ctls.NewTLSConfig()
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create TLS config")
 	}
+	if clientCAFile != "" {
+		caCert, err := os.ReadFile(clientCAFile)
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to read client CA file")
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(caCert) {
+			logrus.Fatal("Failed to parse client CA certificate")
+		}
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+		cfg.ClientCAs = certPool
+		logrus.Info("mTLS enabled: requiring and verifying client certificates")
+	}
 	server := &http.Server{
-		Addr:      fmt.Sprintf(":%d", port),
-		TLSConfig: cfg,
+		Addr:           fmt.Sprintf(":%d", port),
+		TLSConfig:      cfg,
+		ReadTimeout:    5 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		IdleTimeout:    30 * time.Second,
+		MaxHeaderBytes: 1 << 20, // 1MB
 	}
 
 	logrus.Infof("Listening on port %d", port)
@@ -131,11 +159,13 @@ func serveWebhookTLS(cmd *cobra.Command, args []string) {
 	}
 }
 
-func registerHooks(cs kubernetes.Interface, calicoCS calicoclient.Interface) {
-	rbac.RegisterHook(cs, calicoCS.ProjectcalicoV3().Tiers(), utils.HandleFn(handleFn))
-	clusterinfo.RegisterHook(utils.HandleFn(handleFn))
+func registerHooks(cs kubernetes.Interface, calicoCS calicoclient.Interface, limiter *rate.Limiter) {
+	handle := rateLimitedHandleFn(limiter)
+	rbac.RegisterHook(cs, calicoCS.ProjectcalicoV3().Tiers(), utils.HandleFn(handle))
+	clusterinfo.RegisterHook(utils.HandleFn(handle))
 
-	// Register a readiness endpoint that can be used by Kubernetes to check the health of the webhook server.
+	// Readiness endpoint is not rate-limited — if health checks are rejected,
+	// Kubernetes restarts the pod, which amplifies a DoS.
 	http.HandleFunc("/readyz", readyFn())
 }
 
@@ -147,17 +177,25 @@ func readyFn() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
-// handleFn implements utils.HandleFn to allow registration of webhooks.
-func handleFn(handler utils.AdmissionReviewHandler) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		handleRequest(w, r, handler)
+// rateLimitedHandleFn returns a HandleFn that enforces a global rate limit
+// on all webhook endpoints.
+func rateLimitedHandleFn(limiter *rate.Limiter) func(handler utils.AdmissionReviewHandler) func(http.ResponseWriter, *http.Request) {
+	return func(handler utils.AdmissionReviewHandler) func(http.ResponseWriter, *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if !limiter.Allow() {
+				logrus.Warn("Rate limit exceeded, rejecting request")
+				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+				return
+			}
+			handleRequest(w, r, handler)
+		}
 	}
 }
 
 // handleRequest handles an incoming HTTP request, decodes the AdmissionReview, processes it, and writes the response.
 func handleRequest(w http.ResponseWriter, r *http.Request, handler utils.AdmissionReviewHandler) {
 	// Decode the AdmissionReview request.
-	obj, gvk, err := decodeAdmissionReview(r)
+	obj, gvk, err := decodeAdmissionReview(w, r)
 	if err != nil {
 		logrus.Error(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -185,13 +223,19 @@ func handleRequest(w http.ResponseWriter, r *http.Request, handler utils.Admissi
 	}
 }
 
-func decodeAdmissionReview(r *http.Request) (runtime.Object, *schema.GroupVersionKind, error) {
+// maxRequestBodyBytes is the maximum size of an admission review request body.
+// The Kubernetes API server limits API objects to 3MB, so an AdmissionReview
+// wrapping a Calico resource will not legitimately exceed this.
+const maxRequestBodyBytes = 3 << 20 // 3MB
+
+func decodeAdmissionReview(w http.ResponseWriter, r *http.Request) (runtime.Object, *schema.GroupVersionKind, error) {
 	var body []byte
 	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		} else {
-			return nil, nil, fmt.Errorf("could not read request body: %v", err)
+			return nil, nil, fmt.Errorf("could not read request body: %w", err)
 		}
 	} else {
 		return nil, nil, fmt.Errorf("empty body")


### PR DESCRIPTION
The webhook HTTP server was vulnerable to memory exhaustion via unbounded request body reads (`io.ReadAll` with no size limit). An in-cluster attacker could OOM the webhook pod by streaming a large chunked HTTP POST to the webhook service.

Defense-in-depth hardening applied to `webhooks/cmd/main.go`:

- **Request body limit**: Wrap `r.Body` with `http.MaxBytesReader` capped at 3MB, matching the Kubernetes API server's own object size limit. Oversized requests are rejected and the connection is torn down.
- **HTTP server timeouts**: `ReadTimeout=5s` (prevents slow-loris — the API server's own webhook timeout is 5s so there's no point reading longer), `WriteTimeout=10s` (covers processing including SubjectAccessReview calls), `IdleTimeout=30s` (caps idle keep-alive connections to prevent connection exhaustion).
- **Explicit MaxHeaderBytes**: Set to 1MB (same as Go's default, but explicit for auditability).
- **Optional mTLS**: New `--client-ca-file` flag enables mutual TLS authentication. When set, the webhook requires and verifies client certificates signed by the specified CA. Off by default since most clusters don't configure the API server to present client certs to webhooks.

```release-note
None
```