### PR TITLE
Bump knftables to v0.0.21 to fix nft segfault

### DIFF
--- a/app-policy/deps.txt
+++ b/app-policy/deps.txt
@@ -114,7 +114,7 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 k8s.io/kubernetes v1.33.10
 k8s.io/utils v0.0.0-20241210054802-24370beab758
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
-sigs.k8s.io/knftables v0.0.18
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.5
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v4 v4.6.0

--- a/cni-plugin/deps.txt
+++ b/cni-plugin/deps.txt
@@ -97,7 +97,7 @@ k8s.io/klog/v2 v2.130.1
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 k8s.io/utils v0.0.0-20241210054802-24370beab758
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
-sigs.k8s.io/knftables v0.0.18
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.5
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v4 v4.6.0

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -281,7 +281,7 @@ type Config struct {
 	KubernetesProvider felixconfig.Provider
 
 	// For testing purposes - allows unit tests to mock out the creation of the nftables dataplane.
-	NewNftablesDataplane func(knftables.Family, string) (knftables.Interface, error)
+	NewNftablesDataplane func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error)
 }
 
 type UpdateBatchResolver interface {

--- a/felix/dataplane/linux/int_dataplane_test.go
+++ b/felix/dataplane/linux/int_dataplane_test.go
@@ -43,13 +43,13 @@ var _ = Describe("Constructor test", func() {
 	kubernetesProvider := config.ProviderNone
 	routeSource := "CalicoIPAM"
 	var wireguardEncryptHostTraffic bool
-	var nftablesDataplane func(knftables.Family, string) (knftables.Interface, error)
+	var nftablesDataplane func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error)
 
 	BeforeEach(func() {
 		// For most tests here, mock out the creation of the nftables interface in a way
 		// that simulates "nft" being available.  We don't want these tests to depend on the
 		// actual kernel version or presence of nftables.
-		nftablesDataplane = func(knftables.Family, string) (knftables.Interface, error) {
+		nftablesDataplane = func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error) {
 			return nil, nil
 		}
 	})
@@ -126,7 +126,7 @@ var _ = Describe("Constructor test", func() {
 
 	Context("when nft is not available", func() {
 		BeforeEach(func() {
-			nftablesDataplane = func(knftables.Family, string) (knftables.Interface, error) {
+			nftablesDataplane = func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error) {
 				return nil, errors.New("could not find nftables binary: file not found")
 			}
 		})

--- a/felix/deps.txt
+++ b/felix/deps.txt
@@ -152,7 +152,7 @@ k8s.io/kubernetes v1.33.10
 k8s.io/utils v0.0.0-20241210054802-24370beab758
 modernc.org/memory v1.10.0
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
-sigs.k8s.io/knftables v0.0.18
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.5
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v4 v4.6.0

--- a/felix/nftables/fake_test.go
+++ b/felix/nftables/fake_test.go
@@ -127,6 +127,13 @@ func (f *fakeNFT) Check(ctx context.Context, tx *knftables.Transaction) error {
 	return f.fake.Check(ctx, tx)
 }
 
+// ListAll returns a map containing the names of all objects in the table,
+// grouped by object type.
+func (f *fakeNFT) ListAll(ctx context.Context) (map[string][]string, error) {
+	f.preList()
+	return f.fake.ListAll(ctx)
+}
+
 // List returns a list of the names of the objects of objectType ("chain", "set",
 // or "map") in the table. If there are no such objects, this will return an empty
 // list and no error.
@@ -167,6 +174,11 @@ func (f *fakeNFT) ListElements(ctx context.Context, objectType string, name stri
 		return nil, err
 	}
 	return f.fake.ListElements(ctx, objectType, name)
+}
+
+// ListCounters returns a list of the counters in the table.
+func (f *fakeNFT) ListCounters(ctx context.Context) ([]*knftables.Counter, error) {
+	return f.fake.ListCounters(ctx)
 }
 
 func (f *fakeNFT) maybeFailListElements(name string) error {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ type NftablesTable struct {
 type TableOptions struct {
 	// NewDataplane is an optional function to override the creation of the knftables client,
 	// used for testing.
-	NewDataplane func(knftables.Family, string) (knftables.Interface, error)
+	NewDataplane func(knftables.Family, string, ...knftables.Option) (knftables.Interface, error)
 
 	// Disabled can be set to true when running in iptables mode, triggering a cleanup
 	// of any Calico nftables content.

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1121,13 +1121,16 @@ func (t *NftablesTable) applyUpdates() error {
 		}
 
 		if err := t.runTransaction(tx); err != nil {
-			// Let's just print out the entire ruleset for debugging purposes.
-			cmd := t.newCmd("nft", "list", "ruleset")
+			// Dump our table's state for debugging. We scope this to our
+			// own table rather than using "nft list ruleset" to avoid
+			// parsing objects from other tables that may contain udata
+			// written by a newer nft, which can crash older nft binaries.
+			cmd := t.newCmd("nft", "list", "table", t.name)
 			output, err2 := cmd.Output()
 			if err2 != nil {
-				t.logCxt.WithError(err2).Error("Failed to load nftables ruleset")
+				t.logCxt.WithError(err2).Error("Failed to load nftables table state")
 			} else {
-				t.logCxt.WithField("ruleset", string(output)).Error("Current ruleset after error")
+				t.logCxt.WithField("tableState", string(output)).Error("Current table state after error")
 			}
 
 			t.logCxt.WithError(err).WithField("tx", tx.String()).Error("Failed to run nft transaction")

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ var _ = Describe("Table with an empty dataplane", func() {
 	var featureDetector *environment.FeatureDetector
 	var f *fakeNFT
 	BeforeEach(func() {
-		newDataplane := func(fam knftables.Family, name string) (knftables.Interface, error) {
+		newDataplane := func(fam knftables.Family, name string, _ ...knftables.Option) (knftables.Interface, error) {
 			f = NewFake(fam, name)
 			return f, nil
 		}
@@ -860,7 +860,7 @@ var _ = Describe("Insert early rules", func() {
 	var featureDetector *environment.FeatureDetector
 	var f *fakeNFT
 	BeforeEach(func() {
-		newDataplane := func(fam knftables.Family, name string) (knftables.Interface, error) {
+		newDataplane := func(fam knftables.Family, name string, _ ...knftables.Option) (knftables.Interface, error) {
 			f = NewFake(fam, name)
 			return f, nil
 		}
@@ -929,7 +929,7 @@ var _ = Describe("Disabled table cache invalidation", func() {
 	var f *fakeNFT
 
 	BeforeEach(func() {
-		newDataplane := func(fam knftables.Family, name string) (knftables.Interface, error) {
+		newDataplane := func(fam knftables.Family, name string, _ ...knftables.Option) (knftables.Interface, error) {
 			f = NewFake(fam, name)
 			return f, nil
 		}
@@ -1008,7 +1008,7 @@ var _ = Describe("Enabled table cache invalidation", func() {
 	var f *fakeNFT
 
 	BeforeEach(func() {
-		newDataplane := func(fam knftables.Family, name string) (knftables.Interface, error) {
+		newDataplane := func(fam knftables.Family, name string, _ ...knftables.Option) (knftables.Interface, error) {
 			f = NewFake(fam, name)
 			return f, nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	modernc.org/memory v1.10.0
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/kind v0.29.0
-	sigs.k8s.io/knftables v0.0.18
+	sigs.k8s.io/knftables v0.0.21
 	sigs.k8s.io/network-policy-api v0.1.5
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1060,8 +1060,8 @@ sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7np
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.29.0 h1:3TpCsyh908IkXXpcSnsMjWdwdWjIl7o9IMZImZCWFnI=
 sigs.k8s.io/kind v0.29.0/go.mod h1:ldWQisw2NYyM6k64o/tkZng/1qQW7OlzcN5a8geJX3o=
-sigs.k8s.io/knftables v0.0.18 h1:6Duvmu0s/HwGifKrtl6G3AyAPYlWiZqTgS8bkVMiyaE=
-sigs.k8s.io/knftables v0.0.18/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
+sigs.k8s.io/knftables v0.0.21 h1:mby+JtzhJH1Ucnq++ZJaM+ViQBY5JzIyX4bSCP8K5YQ=
+sigs.k8s.io/knftables v0.0.21/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/kustomize/api v0.19.0 h1:F+2HB2mU1MSiR9Hp1NEgoU2q9ItNOaBJl0I4Dlus5SQ=
 sigs.k8s.io/kustomize/api v0.19.0/go.mod h1:/BbwnivGVcBh1r+8m3tH1VNxJmHSk1PzP5fkP6lbL1o=
 sigs.k8s.io/kustomize/kyaml v0.19.0 h1:RFge5qsO1uHhwJsu3ipV7RNolC7Uozc0jUBC/61XSlA=

--- a/kube-controllers/deps.txt
+++ b/kube-controllers/deps.txt
@@ -123,7 +123,7 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 k8s.io/kubernetes v1.33.10
 k8s.io/utils v0.0.0-20241210054802-24370beab758
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
-sigs.k8s.io/knftables v0.0.18
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.5
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v4 v4.6.0

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -152,7 +152,7 @@ k8s.io/kubernetes v1.33.10
 k8s.io/utils v0.0.0-20241210054802-24370beab758
 modernc.org/memory v1.10.0
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
-sigs.k8s.io/knftables v0.0.18
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.5
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v4 v4.6.0


### PR DESCRIPTION
knftables v0.0.18 used unscoped `nft list sets/maps` which traverses all kernel nftables tables. On systems where the host nft creates objects with udata, this crashes the older nft binary in the calico-node container. v0.0.20+ scopes `List()` to `nft list table <family> <table>`, avoiding the crash. This is the same fix kube-proxy applied in https://github.com/kubernetes/kubernetes/pull/137501.

The v0.0.21 API also adds a variadic `Option` parameter to `knftables.New`, so the `NewDataplane` function type and test stubs are updated to match.

Fixes https://github.com/projectcalico/calico/issues/11750

```release-note
Fix nftables segfault on systems with newer nft versions (Debian Trixie, Fedora 42+) by bumping knftables to v0.0.21.
```