### PR TITLE
Use ListAll() to reduce nft subprocesses during resync

### DIFF
--- a/felix/nftables/fake_test.go
+++ b/felix/nftables/fake_test.go
@@ -58,6 +58,9 @@ type fakeNFT struct {
 	// Allow overriding the next ListElements response for one or more sets to be an error.
 	ListElementsErrors map[string]error
 
+	// Allow overriding the next ListAll response to be an error.
+	ListAllError error
+
 	// Track the number of List calls (simulates nft process spawns).
 	ListCallCount int
 }
@@ -131,7 +134,20 @@ func (f *fakeNFT) Check(ctx context.Context, tx *knftables.Transaction) error {
 // grouped by object type.
 func (f *fakeNFT) ListAll(ctx context.Context) (map[string][]string, error) {
 	f.preList()
+	if err := f.takeListAllError(); err != nil {
+		logrus.WithError(err).Info("Returning test error from ListAll")
+		return nil, err
+	}
 	return f.fake.ListAll(ctx)
+}
+
+func (f *fakeNFT) takeListAllError() error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	err := f.ListAllError
+	f.ListAllError = nil
+	return err
 }
 
 // List returns a list of the names of the objects of objectType ("chain", "set",

--- a/felix/nftables/maps.go
+++ b/felix/nftables/maps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ type MapsDataplane interface {
 
 	MapUpdates() *MapUpdates
 	FinishMapUpdates(updates *MapUpdates)
-	LoadDataplaneState() error
+	LoadDataplaneState(ctx context.Context, mapNames []string) error
 }
 
 var _ MapsDataplane = &Maps{}
@@ -278,10 +278,9 @@ func (s *Maps) filterAndCanonicaliseMembers(mtype MapType, members map[string][]
 	return filtered
 }
 
-// tryResync attempts to bring our state into sync with the dataplane.  It scans the contents of the
-// maps in the dataplane and queues up updates to any maps that are out-of-sync.
-func (s *Maps) LoadDataplaneState() error {
-	// Log the time spent as we exit the function.
+// LoadDataplaneState resyncs map state using the provided list of map names
+// (typically obtained from a ListAll call by the caller).
+func (s *Maps) LoadDataplaneState(ctx context.Context, maps []string) error {
 	resyncStart := time.Now()
 	defer func() {
 		s.logCxt.WithFields(logrus.Fields{
@@ -292,23 +291,7 @@ func (s *Maps) LoadDataplaneState() error {
 		}).Debug("Finished Maps resync")
 	}()
 
-	// Clear the dataplane metadata view, we'll build it back up again as we scan.
 	s.mapNameToProgrammedMetadata.Dataplane().DeleteAll()
-
-	// Load from the dataplane. Update our Dataplane() maps with the actual contents
-	// of the data plane.
-	//
-	// For any map that doesn't match the desired data plane state, we'll queue up an update.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-	maps, err := s.nft.List(ctx, "map")
-	if err != nil {
-		if knftables.IsNotFound(err) {
-			// Table doesn't exist - nothing to resync.
-			return nil
-		}
-		return fmt.Errorf("error listing nftables maps: %s", err)
-	}
 
 	// We'll process each map in parallel, so we need a struct to hold the results.
 	// Once knftables is augmented to support reading many maps at once, we can remove this.
@@ -377,7 +360,7 @@ func (s *Maps) LoadDataplaneState() error {
 
 		memberTracker := s.getOrCreateMemberTracker(mapName)
 		numExtrasExpected := memberTracker.PendingDeletions().Len()
-		err = memberTracker.Dataplane().ReplaceFromIter(func(f func(k MapMember)) error {
+		err := memberTracker.Dataplane().ReplaceFromIter(func(f func(k MapMember)) error {
 			for item := range elemsSet.All() {
 				f(item)
 			}

--- a/felix/nftables/maps.go
+++ b/felix/nftables/maps.go
@@ -291,6 +291,7 @@ func (s *Maps) LoadDataplaneState(ctx context.Context, maps []string) error {
 		}).Debug("Finished Maps resync")
 	}()
 
+	// Clear the dataplane metadata view, we'll build it back up again as we scan.
 	s.mapNameToProgrammedMetadata.Dataplane().DeleteAll()
 
 	// We'll process each map in parallel, so we need a struct to hold the results.

--- a/felix/nftables/maps_test.go
+++ b/felix/nftables/maps_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -176,7 +176,7 @@ var _ = Describe("Maps with empty data plane", func() {
 		Expect(f.Run(context.TODO(), tx)).NotTo(HaveOccurred())
 
 		// Resync with dataplane.
-		Expect(s.LoadDataplaneState()).NotTo(HaveOccurred())
+		Expect(loadMapsDataplaneState(f, s)).NotTo(HaveOccurred())
 
 		// Should be no work to do.
 		Expect(s.MapUpdates()).To(Equal(&nftables.MapUpdates{
@@ -195,7 +195,7 @@ var _ = Describe("Maps with empty data plane", func() {
 		Expect(f.Run(context.TODO(), tx)).NotTo(HaveOccurred())
 
 		// Resync with dataplane. We should now detect the new element and queue it for removal.
-		Expect(s.LoadDataplaneState()).NotTo(HaveOccurred())
+		Expect(loadMapsDataplaneState(f, s)).NotTo(HaveOccurred())
 		upd := s.MapUpdates()
 		Expect(upd.MapToAddedMembers).To(HaveLen(0))
 		Expect(upd.MapToDeletedMembers).To(HaveLen(1))
@@ -226,7 +226,7 @@ var _ = Describe("Maps with empty data plane", func() {
 		Expect(f.Run(context.TODO(), tx)).NotTo(HaveOccurred())
 
 		// A resync should fix both the map and the elements.
-		Expect(s.LoadDataplaneState()).NotTo(HaveOccurred())
+		Expect(loadMapsDataplaneState(f, s)).NotTo(HaveOccurred())
 		upd = s.MapUpdates()
 		Expect(upd.MapToAddedMembers).To(HaveLen(1))
 		Expect(upd.MapToDeletedMembers).To(HaveLen(0))
@@ -251,7 +251,7 @@ var _ = Describe("Maps with empty data plane", func() {
 		Expect(f.Run(context.Background(), tx)).NotTo(HaveOccurred())
 
 		// Trigger a resync.
-		Expect(s.LoadDataplaneState()).NotTo(HaveOccurred())
+		Expect(loadMapsDataplaneState(f, s)).NotTo(HaveOccurred())
 
 		// Expect queued deletions for all the maps.
 		upd := s.MapUpdates()
@@ -281,7 +281,7 @@ var _ = Describe("Maps with empty data plane", func() {
 		Expect(f.Run(context.Background(), tx)).NotTo(HaveOccurred())
 
 		// Trigger a resync. We should delete the unexpected map.
-		Expect(s.LoadDataplaneState()).NotTo(HaveOccurred())
+		Expect(loadMapsDataplaneState(f, s)).NotTo(HaveOccurred())
 
 		// Expect the set to be deleted.
 		upd := s.MapUpdates()
@@ -315,7 +315,7 @@ var _ = Describe("Maps with empty data plane", func() {
 		s.AddOrReplaceMap(meta, nil)
 
 		// Load the dataplane state. We should delete the unexpected map.
-		Expect(s.LoadDataplaneState()).NotTo(HaveOccurred())
+		Expect(loadMapsDataplaneState(f, s)).NotTo(HaveOccurred())
 
 		// Expect members to be correct. We should remove the unexpected members despite not knowing the type.
 		// NOTE: We currently have no way to know or change the type of the map via knftables.
@@ -329,6 +329,15 @@ var _ = Describe("Maps with empty data plane", func() {
 		s.FinishMapUpdates(upd)
 	})
 })
+
+func loadMapsDataplaneState(f *fakeNFT, s *nftables.Maps) error {
+	ctx := context.TODO()
+	mapNames, err := f.List(ctx, "map")
+	if err != nil {
+		return fmt.Errorf("listing maps: %w", err)
+	}
+	return s.LoadDataplaneState(ctx, mapNames)
+}
 
 func addMapToTx(tx *knftables.Transaction, m nftables.MapMetadata, elements map[string][]string) {
 	tx.Add(&knftables.Map{

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -646,8 +646,25 @@ func (t *NftablesTable) decrefChain(chainName string) {
 }
 
 func (t *NftablesTable) loadDataplaneState() {
-	// Sync maps.
-	if err := t.LoadDataplaneState(); err != nil {
+	// Fetch all object names from the dataplane in a single nft invocation.
+	// This replaces separate List("map") and List("chain") calls, halving
+	// the number of nft subprocesses during resync.
+	ctx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	defer cancel()
+	allObjects, err := t.nft.ListAll(ctx)
+	if err != nil {
+		if knftables.IsNotFound(err) {
+			t.logCxt.Debug("Table not found in dataplane, nothing to load.")
+		} else {
+			t.logCxt.WithError(err).Warn("Failed to list all nftables objects")
+		}
+		// Fall through — maps and chains will get empty slices, which is
+		// correct when the table doesn't exist yet.
+		allObjects = map[string][]string{}
+	}
+
+	// Sync maps using the pre-fetched map names.
+	if err := t.LoadDataplaneState(ctx, allObjects["map"]); err != nil {
 		t.logCxt.WithError(err).Warn("Failed to load maps state")
 	}
 
@@ -660,7 +677,7 @@ func (t *NftablesTable) loadDataplaneState() {
 
 	t.lastReadTime = t.timeNow()
 
-	dataplaneHashes, dataplaneRules := t.getHashesAndRulesFromDataplane()
+	dataplaneHashes, dataplaneRules := t.getHashesAndRulesFromDataplane(allObjects["chain"])
 
 	// Check that the rules we think we've programmed are still there and mark any inconsistent
 	// chains for refresh.
@@ -766,7 +783,7 @@ func (t *NftablesTable) expectedHashesForInsertAppendChain(chainName string) (al
 // represented by an empty string. The 'rules' map contains an entry for each non-Calico chain in the table that
 // contains inserts. It is used to generate deletes using the full rule, rather than deletes by line number, to avoid
 // race conditions on chains we don't fully control.
-func (t *NftablesTable) getHashesAndRulesFromDataplane() (hashes map[string][]string, rules map[string][]*knftables.Rule) {
+func (t *NftablesTable) getHashesAndRulesFromDataplane(chainNames []string) (hashes map[string][]string, rules map[string][]*knftables.Rule) {
 	retries := 3
 	retryDelay := 100 * time.Millisecond
 
@@ -774,7 +791,7 @@ func (t *NftablesTable) getHashesAndRulesFromDataplane() (hashes map[string][]st
 	// us from spamming a panic into the log when we're being gracefully shut down by a SIGTERM.
 	for {
 		t.onStillAlive()
-		hashes, rules, err := t.attemptToGetHashesAndRulesFromDataplane()
+		hashes, rules, err := t.attemptToGetHashesAndRulesFromDataplane(chainNames)
 		if err != nil {
 			countNumListErrors.Inc()
 			var stderr string
@@ -796,8 +813,10 @@ func (t *NftablesTable) getHashesAndRulesFromDataplane() (hashes map[string][]st
 	}
 }
 
-// attemptToGetHashesAndRulesFromDataplane reads nftables state and loads it into memory.
-func (t *NftablesTable) attemptToGetHashesAndRulesFromDataplane() (hashes map[string][]string, rules map[string][]*knftables.Rule, err error) {
+// attemptToGetHashesAndRulesFromDataplane reads nftables state and loads it
+// into memory. If chainNames is non-nil, it is used directly (from a prior
+// ListAll call). If nil, chain names are fetched via List.
+func (t *NftablesTable) attemptToGetHashesAndRulesFromDataplane(chainNames []string) (hashes map[string][]string, rules map[string][]*knftables.Rule, err error) {
 	startTime := t.timeNow()
 	defer func() {
 		saveDuration := t.timeNow().Sub(startTime)
@@ -808,7 +827,7 @@ func (t *NftablesTable) attemptToGetHashesAndRulesFromDataplane() (hashes map[st
 		}
 	}()
 
-	t.logCxt.Debug("Attmempting to get hashes and rules from nftables")
+	t.logCxt.Debug("Attempting to get hashes and rules from nftables")
 
 	hashes = make(map[string][]string)
 	rules = make(map[string][]*knftables.Rule)
@@ -816,18 +835,20 @@ func (t *NftablesTable) attemptToGetHashesAndRulesFromDataplane() (hashes map[st
 	ctx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
 	defer cancel()
 
-	// Add chains. We need to query this separately, as chains may exist without rules.
-	countNumListCalls.Inc()
-	allChains, err := t.nft.List(ctx, "chain")
-	if err != nil {
-		if knftables.IsNotFound(err) {
-			err = nil
-			return
+	if chainNames == nil {
+		countNumListCalls.Inc()
+		chainNames, err = t.nft.List(ctx, "chain")
+		if err != nil {
+			if knftables.IsNotFound(err) {
+				err = nil
+				return
+			}
+			countNumListErrors.Inc()
+			return nil, nil, err
 		}
-		countNumListErrors.Inc()
-		return nil, nil, err
 	}
-	for _, chain := range allChains {
+
+	for _, chain := range chainNames {
 		hashes[chain] = []string{}
 		rules[chain] = []*knftables.Rule{}
 	}
@@ -1182,13 +1203,16 @@ func (t *NftablesTable) applyUpdates() error {
 		}
 
 		if err := t.runTransaction(tx); err != nil {
-			// Let's just print out the entire ruleset for debugging purposes.
-			cmd := t.newCmd("nft", "list", "ruleset")
+			// Dump our table's state for debugging. We scope this to our
+			// own table rather than using "nft list ruleset" to avoid
+			// parsing objects from other tables that may contain udata
+			// written by a newer nft, which can crash older nft binaries.
+			cmd := t.newCmd("nft", "list", "table", t.name)
 			output, err2 := cmd.Output()
 			if err2 != nil {
-				t.logCxt.WithError(err2).Error("Failed to load nftables ruleset")
+				t.logCxt.WithError(err2).Error("Failed to load nftables table state")
 			} else {
-				t.logCxt.WithField("ruleset", string(output)).Error("Current ruleset after error")
+				t.logCxt.WithField("tableState", string(output)).Error("Current table state after error")
 			}
 
 			t.logCxt.WithError(err).WithField("tx", tx.String()).Error("Failed to run nft transaction")
@@ -1256,7 +1280,7 @@ func (t *NftablesTable) CheckRulesPresent(chain string, rules []generictables.Ru
 	features := t.featureDetector.GetFeatures()
 	hashes := CalculateRuleHashes(chain, rules, features)
 
-	dpHashes, _ := t.getHashesAndRulesFromDataplane()
+	dpHashes, _ := t.getHashesAndRulesFromDataplane(nil)
 	dpHashesSet := set.New[string]()
 	for _, h := range dpHashes[chain] {
 		dpHashesSet.Add(h)

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -651,14 +651,16 @@ func (t *NftablesTable) decrefChain(chainName string) {
 func (t *NftablesTable) loadDataplaneState() {
 	// List all of our table's objects in a single nft invocation, giving us the
 	// map and chain names without a separate List call for each type.
-	listCtx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	listCtx, listCancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	defer listCancel()
+	countNumListCalls.Inc()
 	allObjects, err := t.nft.ListAll(listCtx)
-	cancel()
 	if err != nil {
 		if !knftables.IsNotFound(err) {
 			// A transient list failure shouldn't be treated as an empty table:
 			// that would clear our in-memory view and trigger spurious
 			// reprogramming. Skip this resync and try again on the next one.
+			countNumListErrors.Inc()
 			t.logCxt.WithError(err).Warn("Failed to list nftables objects, skipping resync")
 			return
 		}
@@ -669,8 +671,8 @@ func (t *NftablesTable) loadDataplaneState() {
 
 	// Sync maps using the pre-fetched map names. Give the maps resync its own
 	// timeout so a slow one doesn't eat into the chain read below.
-	mapsCtx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
-	defer cancel()
+	mapsCtx, mapsCancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	defer mapsCancel()
 	if err := t.LoadDataplaneState(mapsCtx, allObjects[objectTypeMap]); err != nil {
 		t.logCxt.WithError(err).Warn("Failed to load maps state")
 	}
@@ -847,6 +849,9 @@ func (t *NftablesTable) attemptToGetHashesFromDataplane(chainNames []string) (ha
 		chainNames, err = t.nft.List(ctx, objectTypeChain)
 		if err != nil {
 			if knftables.IsNotFound(err) {
+				// No chains means the table isn't programmed yet, so there are
+				// no hashes to read. Return an empty map rather than an error.
+				t.logCxt.Debug("No chains in dataplane, table not programmed yet.")
 				err = nil
 				return
 			}
@@ -953,13 +958,7 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 				continue
 			} else {
 				t.logCxt.WithError(err).Error("Failed to program nftables, loading diags before panic.")
-				cmd := t.newCmd("nft", "list", "table", string(t.family), t.name)
-				output, err2 := cmd.Output()
-				if err2 != nil {
-					t.logCxt.WithError(err2).Error("Failed to load nftables state")
-				} else {
-					t.logCxt.WithField("state", string(output)).Error("Current state of nftables")
-				}
+				t.dumpTableState()
 				t.logCxt.WithError(err).Panic("Failed to program nftables, giving up after retries")
 			}
 		}
@@ -1174,18 +1173,7 @@ func (t *NftablesTable) applyUpdates() error {
 		}
 
 		if err := t.runTransaction(tx); err != nil {
-			// Dump our table's state for debugging. We scope this to our
-			// own table rather than using "nft list ruleset" to avoid
-			// parsing objects from other tables that may contain udata
-			// written by a newer nft, which can crash older nft binaries.
-			cmd := t.newCmd("nft", "list", "table", string(t.family), t.name)
-			output, err2 := cmd.Output()
-			if err2 != nil {
-				t.logCxt.WithError(err2).Error("Failed to load nftables table state")
-			} else {
-				t.logCxt.WithField("tableState", string(output)).Error("Current table state after error")
-			}
-
+			t.dumpTableState()
 			t.logCxt.WithError(err).WithField("tx", tx.String()).Error("Failed to run nft transaction")
 			return fmt.Errorf("error performing nft transaction: %s", err)
 		}
@@ -1223,6 +1211,21 @@ func (t *NftablesTable) applyUpdates() error {
 		t.InvalidateDataplaneCache("post-write")
 	}
 	return nil
+}
+
+// dumpTableState logs our table's current contents for debugging after a
+// programming failure. We scope this to our own table rather than using
+// "nft list ruleset" to avoid parsing objects from other tables that may
+// contain udata written by a newer nft, which can crash older nft binaries.
+// See #11750.
+func (t *NftablesTable) dumpTableState() {
+	cmd := t.newCmd("nft", "list", "table", string(t.family), t.name)
+	output, err := cmd.Output()
+	if err != nil {
+		t.logCxt.WithError(err).Error("Failed to load nftables table state")
+		return
+	}
+	t.logCxt.WithField("tableState", string(output)).Error("Current nftables table state")
 }
 
 func (t *NftablesTable) runTransaction(tx *knftables.Transaction) error {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -642,8 +642,25 @@ func (t *NftablesTable) decrefChain(chainName string) {
 }
 
 func (t *NftablesTable) loadDataplaneState() {
-	// Sync maps.
-	if err := t.LoadDataplaneState(); err != nil {
+	// Fetch all object names from the dataplane in a single nft invocation.
+	// This replaces separate List("map") and List("chain") calls, halving
+	// the number of nft subprocesses during resync.
+	ctx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	defer cancel()
+	allObjects, err := t.nft.ListAll(ctx)
+	if err != nil {
+		if knftables.IsNotFound(err) {
+			t.logCxt.Debug("Table not found in dataplane, nothing to load.")
+		} else {
+			t.logCxt.WithError(err).Warn("Failed to list all nftables objects")
+		}
+		// Fall through — maps and chains will get empty slices, which is
+		// correct when the table doesn't exist yet.
+		allObjects = map[string][]string{}
+	}
+
+	// Sync maps using the pre-fetched map names.
+	if err := t.LoadDataplaneState(ctx, allObjects["map"]); err != nil {
 		t.logCxt.WithError(err).Warn("Failed to load maps state")
 	}
 
@@ -656,7 +673,7 @@ func (t *NftablesTable) loadDataplaneState() {
 
 	t.lastReadTime = t.timeNow()
 
-	dataplaneHashes := t.getHashesFromDataplane()
+	dataplaneHashes := t.getHashesFromDataplane(allObjects["chain"])
 
 	// Check that the rules we think we've programmed are still there and mark any inconsistent
 	// chains for refresh.
@@ -760,7 +777,10 @@ func (t *NftablesTable) expectedHashesForInsertAppendChain(chainName string) (al
 // table; each entry is the slice of rule hashes for that chain, in order. A rule with no
 // hash comment (e.g. a rule another process added to a chain we hook) is represented by an
 // empty string.
-func (t *NftablesTable) getHashesFromDataplane() map[string][]string {
+//
+// If chainNames is non-nil, it is used directly (e.g. from a prior ListAll call) rather than
+// issuing a separate List("chain") call.
+func (t *NftablesTable) getHashesFromDataplane(chainNames []string) map[string][]string {
 	retries := 3
 	retryDelay := 100 * time.Millisecond
 
@@ -768,7 +788,7 @@ func (t *NftablesTable) getHashesFromDataplane() map[string][]string {
 	// us from spamming a panic into the log when we're being gracefully shut down by a SIGTERM.
 	for {
 		t.onStillAlive()
-		hashes, err := t.attemptToGetHashesFromDataplane()
+		hashes, err := t.attemptToGetHashesFromDataplane(chainNames)
 		if err != nil {
 			countNumListErrors.Inc()
 			var stderr string
@@ -790,7 +810,9 @@ func (t *NftablesTable) getHashesFromDataplane() map[string][]string {
 }
 
 // attemptToGetHashesFromDataplane reads nftables state and extracts our rule hashes.
-func (t *NftablesTable) attemptToGetHashesFromDataplane() (hashes map[string][]string, err error) {
+// If chainNames is non-nil, it is used directly (from a prior ListAll call). If nil,
+// chain names are fetched via a separate List("chain") call.
+func (t *NftablesTable) attemptToGetHashesFromDataplane(chainNames []string) (hashes map[string][]string, err error) {
 	startTime := t.timeNow()
 	defer func() {
 		saveDuration := t.timeNow().Sub(startTime)
@@ -808,18 +830,21 @@ func (t *NftablesTable) attemptToGetHashesFromDataplane() (hashes map[string][]s
 	ctx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
 	defer cancel()
 
-	// List chains separately, as chains may exist without rules.
-	countNumListCalls.Inc()
-	allChains, err := t.nft.List(ctx, "chain")
-	if err != nil {
-		if knftables.IsNotFound(err) {
-			err = nil
-			return
+	if chainNames == nil {
+		// List chains separately, as chains may exist without rules.
+		countNumListCalls.Inc()
+		chainNames, err = t.nft.List(ctx, "chain")
+		if err != nil {
+			if knftables.IsNotFound(err) {
+				err = nil
+				return
+			}
+			countNumListErrors.Inc()
+			return nil, err
 		}
-		countNumListErrors.Inc()
-		return nil, err
 	}
-	for _, chain := range allChains {
+
+	for _, chain := range chainNames {
 		hashes[chain] = []string{}
 	}
 
@@ -1138,13 +1163,16 @@ func (t *NftablesTable) applyUpdates() error {
 		}
 
 		if err := t.runTransaction(tx); err != nil {
-			// Let's just print out the entire ruleset for debugging purposes.
-			cmd := t.newCmd("nft", "list", "ruleset")
+			// Dump our table's state for debugging. We scope this to our
+			// own table rather than using "nft list ruleset" to avoid
+			// parsing objects from other tables that may contain udata
+			// written by a newer nft, which can crash older nft binaries.
+			cmd := t.newCmd("nft", "list", "table", t.name)
 			output, err2 := cmd.Output()
 			if err2 != nil {
-				t.logCxt.WithError(err2).Error("Failed to load nftables ruleset")
+				t.logCxt.WithError(err2).Error("Failed to load nftables table state")
 			} else {
-				t.logCxt.WithField("ruleset", string(output)).Error("Current ruleset after error")
+				t.logCxt.WithField("tableState", string(output)).Error("Current table state after error")
 			}
 
 			t.logCxt.WithError(err).WithField("tx", tx.String()).Error("Failed to run nft transaction")
@@ -1213,7 +1241,7 @@ func (t *NftablesTable) CheckRulesPresent(chain string, rules []generictables.Ru
 	features := t.featureDetector.GetFeatures()
 	hashes := CalculateRuleHashes(chain, rules, features)
 
-	dpHashes := t.getHashesFromDataplane()
+	dpHashes := t.getHashesFromDataplane(nil)
 	dpHashesSet := set.New[string]()
 	for _, h := range dpHashes[chain] {
 		dpHashesSet.Add(h)

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -41,6 +41,11 @@ import (
 const (
 	MaxChainNameLength = knftables.NameLengthMax
 	defaultTimeout     = 30 * time.Second
+
+	// Object type names as returned by knftables' ListAll, used to index its
+	// result map.
+	objectTypeChain = "chain"
+	objectTypeMap   = "map"
 )
 
 var (
@@ -178,6 +183,7 @@ type NftablesTable struct {
 
 	name      string
 	ipVersion uint8
+	family    knftables.Family
 	nft       knftables.Interface
 
 	// When true, the table will not program any rules or chains and insted functions
@@ -416,6 +422,7 @@ func newTable(
 	table := &NftablesTable{
 		IPSetsDataplane:        NewIPSets(ipv, nft, options.OpRecorder),
 		name:                   name,
+		family:                 nftFamily,
 		nft:                    nft,
 		baseChainDefs:          baseChainDefs,
 		render:                 NewNFTRenderer(hashPrefix, ipVersion),
@@ -642,25 +649,29 @@ func (t *NftablesTable) decrefChain(chainName string) {
 }
 
 func (t *NftablesTable) loadDataplaneState() {
-	// Fetch all object names from the dataplane in a single nft invocation.
-	// This replaces separate List("map") and List("chain") calls, halving
-	// the number of nft subprocesses during resync.
-	ctx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
-	defer cancel()
-	allObjects, err := t.nft.ListAll(ctx)
+	// List all of our table's objects in a single nft invocation, giving us the
+	// map and chain names without a separate List call for each type.
+	listCtx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	allObjects, err := t.nft.ListAll(listCtx)
+	cancel()
 	if err != nil {
-		if knftables.IsNotFound(err) {
-			t.logCxt.Debug("Table not found in dataplane, nothing to load.")
-		} else {
-			t.logCxt.WithError(err).Warn("Failed to list all nftables objects")
+		if !knftables.IsNotFound(err) {
+			// A transient list failure shouldn't be treated as an empty table:
+			// that would clear our in-memory view and trigger spurious
+			// reprogramming. Skip this resync and try again on the next one.
+			t.logCxt.WithError(err).Warn("Failed to list nftables objects, skipping resync")
+			return
 		}
-		// Fall through — maps and chains will get empty slices, which is
-		// correct when the table doesn't exist yet.
-		allObjects = map[string][]string{}
+		// Table doesn't exist yet. Carry on with no objects so we program it
+		// from scratch.
+		t.logCxt.Debug("Table not found in dataplane, nothing to load.")
 	}
 
-	// Sync maps using the pre-fetched map names.
-	if err := t.LoadDataplaneState(ctx, allObjects["map"]); err != nil {
+	// Sync maps using the pre-fetched map names. Give the maps resync its own
+	// timeout so a slow one doesn't eat into the chain read below.
+	mapsCtx, cancel := context.WithTimeout(context.Background(), t.contextTimeout)
+	defer cancel()
+	if err := t.LoadDataplaneState(mapsCtx, allObjects[objectTypeMap]); err != nil {
 		t.logCxt.WithError(err).Warn("Failed to load maps state")
 	}
 
@@ -673,7 +684,7 @@ func (t *NftablesTable) loadDataplaneState() {
 
 	t.lastReadTime = t.timeNow()
 
-	dataplaneHashes := t.getHashesFromDataplane(allObjects["chain"])
+	dataplaneHashes := t.getHashesFromDataplane(allObjects[objectTypeChain])
 
 	// Check that the rules we think we've programmed are still there and mark any inconsistent
 	// chains for refresh.
@@ -833,7 +844,7 @@ func (t *NftablesTable) attemptToGetHashesFromDataplane(chainNames []string) (ha
 	if chainNames == nil {
 		// List chains separately, as chains may exist without rules.
 		countNumListCalls.Inc()
-		chainNames, err = t.nft.List(ctx, "chain")
+		chainNames, err = t.nft.List(ctx, objectTypeChain)
 		if err != nil {
 			if knftables.IsNotFound(err) {
 				err = nil
@@ -942,7 +953,7 @@ func (t *NftablesTable) Apply() (rescheduleAfter time.Duration) {
 				continue
 			} else {
 				t.logCxt.WithError(err).Error("Failed to program nftables, loading diags before panic.")
-				cmd := t.newCmd("nft", "list", "table", t.name)
+				cmd := t.newCmd("nft", "list", "table", string(t.family), t.name)
 				output, err2 := cmd.Output()
 				if err2 != nil {
 					t.logCxt.WithError(err2).Error("Failed to load nftables state")
@@ -1167,7 +1178,7 @@ func (t *NftablesTable) applyUpdates() error {
 			// own table rather than using "nft list ruleset" to avoid
 			// parsing objects from other tables that may contain udata
 			// written by a newer nft, which can crash older nft binaries.
-			cmd := t.newCmd("nft", "list", "table", t.name)
+			cmd := t.newCmd("nft", "list", "table", string(t.family), t.name)
 			output, err2 := cmd.Output()
 			if err2 != nil {
 				t.logCxt.WithError(err2).Error("Failed to load nftables table state")
@@ -1241,6 +1252,8 @@ func (t *NftablesTable) CheckRulesPresent(chain string, rules []generictables.Ru
 	features := t.featureDetector.GetFeatures()
 	hashes := CalculateRuleHashes(chain, rules, features)
 
+	// Pass nil so the helper lists chains itself. This is a one-off rule check,
+	// not a full resync where we already have the chain names to hand.
 	dpHashes := t.getHashesFromDataplane(nil)
 	dpHashesSet := set.New[string]()
 	for _, h := range dpHashes[chain] {

--- a/felix/nftables/table_layer.go
+++ b/felix/nftables/table_layer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package nftables
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -183,6 +184,6 @@ func (t *tableLayer) FinishMapUpdates(updates *MapUpdates) {
 	t.maps.FinishMapUpdates(updates)
 }
 
-func (t *tableLayer) LoadDataplaneState() error {
-	return t.maps.LoadDataplaneState()
+func (t *tableLayer) LoadDataplaneState(ctx context.Context, mapNames []string) error {
+	return t.maps.LoadDataplaneState(ctx, mapNames)
 }

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -16,6 +16,7 @@ package nftables_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -176,6 +177,37 @@ var _ = Describe("Table with an empty dataplane", func() {
 		table.Apply()
 		table.Apply()
 		Expect(f.ListCallCount).To(Equal(listCalls))
+	})
+
+	It("should skip the resync when the object listing fails transiently", func() {
+		// Drive to a settled, in-sync state with one programmed rule.
+		table.InsertOrAppendRules("filter-FORWARD", []generictables.Rule{
+			{Match: nftables.Match(), Action: nftables.DropAction{}},
+		})
+		table.Apply()
+		txCount := len(f.transactions)
+		Expect(txCount).To(BeNumerically(">", 0))
+
+		// Force a resync, but make the object listing fail transiently. We bail
+		// out rather than falling back to per-type List calls or treating the
+		// table as empty, so the only list call is the failed ListAll and no
+		// reprogramming transaction is issued.
+		table.InvalidateDataplaneCache("test")
+		listCalls := f.ListCallCount
+		f.ListAllError = errors.New("transient nft failure")
+		table.Apply()
+		Expect(f.ListAllError).To(BeNil(), "expected the resync to consume the injected error")
+		Expect(f.ListCallCount-listCalls).To(Equal(1), "should not fall back to extra List calls after a failed ListAll")
+		Expect(f.transactions).To(HaveLen(txCount), "transient list failure should not trigger reprogramming")
+
+		// Our rule should still be present in the dataplane.
+		rules, err := f.ListRules(context.TODO(), "filter-FORWARD")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rules).To(nftables.ContainRule(knftables.Rule{
+			Chain:   "filter-FORWARD",
+			Rule:    "counter drop",
+			Comment: ptr("cali:DCGauXoHP5A9-AIO;"),
+		}))
 	})
 
 	Describe("after inserting a rule", func() {


### PR DESCRIPTION
Felix's nftables resync reads object names from the dataplane before reconciling. It did this with separate `List("map")` and `List("chain")` calls, each spawning its own `nft` subprocess. This replaces those two with a single `ListAll()` call, halving the per-resync object-name listing from two nft subprocesses to one. `ListAll()` was added in knftables v0.0.21 (already on master) for exactly this: it runs `nft --json --terse list table <family> <table>` once and returns all object names grouped by type.

Also replace the unscoped `nft list ruleset` debug dump (fired on transaction error) with a table-scoped `nft list table` call. The unscoped command parses objects from every kernel nftables table, which can crash older nft binaries when another table contains udata written by a newer nft. See #11750 for details.

Same optimization kube-proxy made in https://github.com/kubernetes/kubernetes/pull/137501.

Benchmarked with the nftables dataplane benchmark (`BenchmarkResync`): ~20% fewer allocations and ~20% less memory churn per resync, consistent across the 100/500/2000-chain scales.

```release-note
None
```
