### PR TITLE
Bump knftables to v0.0.21 to fix nft segfault

### DIFF
--- a/app-policy/deps.txt
+++ b/app-policy/deps.txt
@@ -119,7 +119,7 @@ kubevirt.io/api v1.8.0-alpha.0
 kubevirt.io/containerized-data-importer-api v1.63.1
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.19
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.8-0.20260217173220-6bb86defe1a7
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0

--- a/cni-plugin/deps.txt
+++ b/cni-plugin/deps.txt
@@ -115,7 +115,7 @@ kubevirt.io/api v1.8.0-alpha.0
 kubevirt.io/containerized-data-importer-api v1.63.1
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.19
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.8-0.20260217173220-6bb86defe1a7
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0

--- a/felix/deps.txt
+++ b/felix/deps.txt
@@ -163,7 +163,7 @@ kubevirt.io/containerized-data-importer-api v1.63.1
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 modernc.org/memory v1.11.0
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.19
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.8-0.20260217173220-6bb86defe1a7
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0

--- a/felix/nftables/fake_test.go
+++ b/felix/nftables/fake_test.go
@@ -127,6 +127,13 @@ func (f *fakeNFT) Check(ctx context.Context, tx *knftables.Transaction) error {
 	return f.fake.Check(ctx, tx)
 }
 
+// ListAll returns a map containing the names of all objects in the table,
+// grouped by object type.
+func (f *fakeNFT) ListAll(ctx context.Context) (map[string][]string, error) {
+	f.preList()
+	return f.fake.ListAll(ctx)
+}
+
 // List returns a list of the names of the objects of objectType ("chain", "set",
 // or "map") in the table. If there are no such objects, this will return an empty
 // list and no error.

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1182,13 +1182,16 @@ func (t *NftablesTable) applyUpdates() error {
 		}
 
 		if err := t.runTransaction(tx); err != nil {
-			// Let's just print out the entire ruleset for debugging purposes.
-			cmd := t.newCmd("nft", "list", "ruleset")
+			// Dump our table's state for debugging. We scope this to our
+			// own table rather than using "nft list ruleset" to avoid
+			// parsing objects from other tables that may contain udata
+			// written by a newer nft, which can crash older nft binaries.
+			cmd := t.newCmd("nft", "list", "table", t.name)
 			output, err2 := cmd.Output()
 			if err2 != nil {
-				t.logCxt.WithError(err2).Error("Failed to load nftables ruleset")
+				t.logCxt.WithError(err2).Error("Failed to load nftables table state")
 			} else {
-				t.logCxt.WithField("ruleset", string(output)).Error("Current ruleset after error")
+				t.logCxt.WithField("tableState", string(output)).Error("Current table state after error")
 			}
 
 			t.logCxt.WithError(err).WithField("tx", tx.String()).Error("Failed to run nft transaction")

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	modernc.org/memory v1.11.0
 	sigs.k8s.io/controller-runtime v0.22.3
 	sigs.k8s.io/kind v0.30.0
-	sigs.k8s.io/knftables v0.0.19
+	sigs.k8s.io/knftables v0.0.21
 	sigs.k8s.io/network-policy-api v0.1.8-0.20260217173220-6bb86defe1a7
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1465,8 +1465,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.30.0 h1:2Xi1KFEfSMm0XDcvKnUt15ZfgRPCT0OnCBbpgh8DztY=
 sigs.k8s.io/kind v0.30.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
-sigs.k8s.io/knftables v0.0.19 h1:0orK0+tYhY575F5X9uJGu80t+aVQ/hJj48I3fz3TBk8=
-sigs.k8s.io/knftables v0.0.19/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
+sigs.k8s.io/knftables v0.0.21 h1:mby+JtzhJH1Ucnq++ZJaM+ViQBY5JzIyX4bSCP8K5YQ=
+sigs.k8s.io/knftables v0.0.21/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
 sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
 sigs.k8s.io/kustomize/kyaml v0.20.1 h1:PCMnA2mrVbRP3NIB6v9kYCAc38uvFLVs8j/CD567A78=

--- a/kube-controllers/deps.txt
+++ b/kube-controllers/deps.txt
@@ -134,7 +134,7 @@ kubevirt.io/containerized-data-importer-api v1.63.1
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 sigs.k8s.io/controller-runtime v0.22.3
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.19
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.8-0.20260217173220-6bb86defe1a7
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0

--- a/node/calico_test/Dockerfile
+++ b/node/calico_test/Dockerfile
@@ -38,12 +38,11 @@ FROM docker:25
 ARG ETCD_VERSION
 ARG TARGETARCH
 
-# Update apk repositories first
-RUN apk update
-
 # Running STs in this container requires that it has all dependencies installed
 # for executing the tests. Install these dependencies:
-RUN apk add --no-cache \
+# The upgrade ensures base image packages (e.g. libexpat) stay ABI-compatible
+# with newly installed packages (e.g. python3's pyexpat).
+RUN apk upgrade --no-cache && apk add --no-cache \
     curl \
     gcc \
     ip6tables \

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -162,7 +162,7 @@ kubevirt.io/containerized-data-importer-api v1.63.1
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 modernc.org/memory v1.11.0
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-sigs.k8s.io/knftables v0.0.19
+sigs.k8s.io/knftables v0.0.21
 sigs.k8s.io/network-policy-api v0.1.8-0.20260217173220-6bb86defe1a7
 sigs.k8s.io/randfill v1.0.0
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0


### PR DESCRIPTION
knftables v0.0.19 used unscoped `nft list sets/maps` which traverses all kernel nftables tables. On systems where the host nft creates objects with udata, this crashes the older nft binary in the calico-node container. v0.0.20+ scopes `List()` to `nft list table <family> <table>`, avoiding the crash. This is the same fix kube-proxy applied in https://github.com/kubernetes/kubernetes/pull/137501.

Also adds the `ListAll` method to the test fake to satisfy the expanded `knftables.Interface` in v0.0.21.

Fixes https://github.com/projectcalico/calico/issues/11750

```release-note
Fix nftables segfault on systems with newer nft versions (Debian Trixie, Fedora 42+) by bumping knftables to v0.0.21.
```