### PR TITLE
[release 3.32] Fixed a Felix eBPF cleanup race condition (pick 12478)

### DIFF
--- a/felix/bpf/tc/cleanup.go
+++ b/felix/bpf/tc/cleanup.go
@@ -102,8 +102,9 @@ func CleanUpProgramsAndPins() {
 		}
 		link, err := netlink.LinkByIndex(qdisc.Attrs().LinkIndex)
 		if err != nil {
-			log.WithError(err).WithField("iface", link.Attrs().Name).Info(
-				"Failed to remove BPF qdisc from interface, maybe interface is gone?")
+			log.WithError(err).WithField("linkIndex", qdisc.Attrs().LinkIndex).Info(
+				"Failed to look up link for BPF qdisc cleanup; skipping")
+			continue
 		}
 		for _, parent := range []uint32{netlink.HANDLE_MIN_INGRESS, netlink.HANDLE_MIN_EGRESS} {
 			filters, err := netlink.FilterList(link, parent)


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->


**Removes the Nil-Pointer Dereference in Logging**: The previous code attempted to log the interface name using link.Attrs().Name when link was nil (because netlink.LinkByIndex returned an error). The fix safely logs the qdisc.Attrs().LinkIndex instead, which is available and avoids the panic.

**Adds the Missing continue Statement**: By adding continue, the loop now correctly skips over the deleted interface and moves on to the next one. This prevents the code from falling through and passing the nil link to netlink.FilterList(link, parent), which was the second panic trigger mentioned in the report.

Backport: https://github.com/projectcalico/calico/pull/12478

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fixed a Felix eBPF cleanup race condition that could cause a nil-pointer panic when an interface disappeared during TC qdisc cleanup.
```
