### PR TITLE
Return tombstone KVPair for malformed ClusterNetworkPolicy instead of error (#12464)

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/clusternetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/conversion/clusternetworkpolicy.go
@@ -36,9 +36,12 @@ func (c converter) K8sClusterNetworkPolicyToCalico(kcnp *clusternetpol.ClusterNe
 	// Pull out important fields.
 	tier, err := clusterNetworkPolicyTier(kcnp)
 	if err != nil {
+		// Log and return a nil-Value KVPair rather than an error. Returning an error here
+		// would surface as a WatchError in the KDD watch converter, terminating and resyncing
+		// the watch — which loops indefinitely if the same malformed policy keeps reappearing.
 		logrus.WithError(err).WithField("policy", kcnp.Name).
-			Error("Failed to parse cluster network policy tier.")
-		return nil, err
+			Warn("Skipping malformed cluster network policy: failed to parse tier.")
+		return clusterNetworkPolicyTombstone(kcnp), nil
 	}
 
 	order := float64(kcnp.Spec.Priority)
@@ -54,7 +57,9 @@ func (c converter) K8sClusterNetworkPolicyToCalico(kcnp *clusternetpol.ClusterNe
 		nsSelector = k8sSelectorToCalico(&kcnp.Spec.Subject.Pods.NamespaceSelector, SelectorNamespace)
 		podSelector = k8sSelectorToCalico(&kcnp.Spec.Subject.Pods.PodSelector, SelectorPod)
 	} else {
-		return nil, fmt.Errorf("no subject selector specified in cluster network policy %s", kcnp.Name)
+		logrus.WithField("policy", kcnp.Name).
+			Warn("Skipping malformed cluster network policy: no subject selector specified.")
+		return clusterNetworkPolicyTombstone(kcnp), nil
 	}
 
 	// Generate the ingress rules list.
@@ -151,6 +156,19 @@ func clusterNetworkPolicyTier(kcnp *clusternetpol.ClusterNetworkPolicy) (string,
 		return names.KubeBaselineTierName, nil
 	default:
 		return "", fmt.Errorf("invalid cluster network policy tier %s", kcnp.Spec.Tier)
+	}
+}
+
+// clusterNetworkPolicyTombstone returns a KVPair with the correct Key and Revision
+// but a nil Value, which signals downstream consumers to remove any previously-cached
+// version of this policy.
+func clusterNetworkPolicyTombstone(kcnp *clusternetpol.ClusterNetworkPolicy) *model.KVPair {
+	return &model.KVPair{
+		Key: model.ResourceKey{
+			Name: kcnp.Name,
+			Kind: model.KindKubernetesClusterNetworkPolicy,
+		},
+		Revision: kcnp.ResourceVersion,
 	}
 }
 

--- a/libcalico-go/lib/backend/k8s/conversion/clusternetworkpolicy_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/clusternetworkpolicy_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clusternetpol "sigs.k8s.io/network-policy-api/apis/v1alpha2"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 )
 
@@ -2277,6 +2278,60 @@ var _ = Describe("Test ClusterNetworkPolicy conversion - Baseline tier", func() 
 				Action: "Deny", // The invalid rule is replaced with a deny-all rule.
 			},
 		))
+	})
+})
+
+var _ = Describe("Test ClusterNetworkPolicy conversion - malformed policies", func() {
+	It("should return a tombstone KVPair for an invalid tier", func() {
+		cnp := clusternetpol.ClusterNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "bad-tier-policy",
+				ResourceVersion: "1234",
+			},
+			Spec: clusternetpol.ClusterNetworkPolicySpec{
+				Priority: 100,
+				Tier:     "InvalidTier",
+				Subject: clusternetpol.ClusterNetworkPolicySubject{
+					Namespaces: &metav1.LabelSelector{},
+				},
+			},
+		}
+
+		c := NewConverter()
+		kvp, err := c.K8sClusterNetworkPolicyToCalico(&cnp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvp).NotTo(BeNil())
+		Expect(kvp.Value).To(BeNil(), "tombstone KVPair should have nil Value")
+		Expect(kvp.Key).To(Equal(model.ResourceKey{
+			Name: "bad-tier-policy",
+			Kind: model.KindKubernetesClusterNetworkPolicy,
+		}))
+		Expect(kvp.Revision).To(Equal("1234"))
+	})
+
+	It("should return a tombstone KVPair when no subject selector is specified", func() {
+		cnp := clusternetpol.ClusterNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "no-subject-policy",
+				ResourceVersion: "5678",
+			},
+			Spec: clusternetpol.ClusterNetworkPolicySpec{
+				Priority: 100,
+				Tier:     clusternetpol.AdminTier,
+				Subject:  clusternetpol.ClusterNetworkPolicySubject{},
+			},
+		}
+
+		c := NewConverter()
+		kvp, err := c.K8sClusterNetworkPolicyToCalico(&cnp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvp).NotTo(BeNil())
+		Expect(kvp.Value).To(BeNil(), "tombstone KVPair should have nil Value")
+		Expect(kvp.Key).To(Equal(model.ResourceKey{
+			Name: "no-subject-policy",
+			Kind: model.KindKubernetesClusterNetworkPolicy,
+		}))
+		Expect(kvp.Revision).To(Equal("5678"))
 	})
 })
 

--- a/libcalico-go/lib/backend/k8s/resources/kubeclusternetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubeclusternetworkpolicy.go
@@ -103,6 +103,10 @@ func (c *clusterNetworkPolicyClient) List(ctx context.Context, list model.ListIn
 		if err != nil && !errors.As(err, &e) {
 			return nil, err
 		}
+		// Skip malformed policies that returned a nil-Value tombstone KVPair.
+		if kvp == nil || kvp.Value == nil {
+			return nil, nil
+		}
 		return []*model.KVPair{kvp}, nil
 	}
 	return pagedList(ctx, logContext, revision, list, convertFunc, listFunc)


### PR DESCRIPTION
Previously, K8sClusterNetworkPolicyToCalico returned hard errors for invalid tiers and missing subject selectors. These errors surfaced as WatchError in the KDD watch converter, terminating and resyncing the watch stream. If the same malformed policy kept reappearing, this caused an infinite resync loop.

Instead, log a warning and return a KVPair with the correct Key/Revision but nil Value (a tombstone). This keeps the watch stream healthy and signals downstream consumers to remove any previously-cached version of the policy. Also add a nil-Value guard in the list path's convertFunc.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Pick of https://github.com/projectcalico/calico/pull/12464

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
