### PR TITLE
fix: Introduce dummy interface for LinkAddressManagement to fix RouteSyncDisabled functionality

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr.go
+++ b/felix/dataplane/linux/endpoint_mgr.go
@@ -229,7 +229,7 @@ type endpointManager struct {
 	newLocalBGPPeerIP         string
 	needToCheckLocalBGPPeerIP bool
 
-	linkAddrsMgr *linkaddrs.LinkAddrsManager
+	linkAddrsMgr linkaddrs.Interface
 
 	needToCheckDispatchChains     bool
 	needToCheckEndpointMarkChains bool
@@ -258,7 +258,7 @@ func newEndpointManager(
 	filterMaps nftables.MapsDataplane,
 	bpfEndpointManager hepListener,
 	callbacks *common.Callbacks,
-	linkAddrsMgr *linkaddrs.LinkAddrsManager,
+	linkAddrsMgr linkaddrs.Interface,
 	arpTable Table,
 	arpMaps nftables.MapsDataplane,
 ) *endpointManager {
@@ -300,7 +300,7 @@ func newEndpointManagerWithShims(
 	filterMaps nftables.MapsDataplane,
 	bpfEndpointManager hepListener,
 	callbacks *common.Callbacks,
-	linkAddrsMgr *linkaddrs.LinkAddrsManager,
+	linkAddrsMgr linkaddrs.Interface,
 	arpTable Table,
 	arpMaps nftables.MapsDataplane,
 ) *endpointManager {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -363,7 +363,7 @@ type InternalDataplane struct {
 	vxlanManagerV6      *vxlanManager
 	vxlanFDBs           []*vxlanfdb.VXLANFDB
 
-	linkAddrsManagers []*linkaddrs.LinkAddrsManager
+	linkAddrsManagers []linkaddrs.Interface
 
 	wireguardManager   *wireguardManager
 	wireguardManagerV6 *wireguardManager
@@ -1141,7 +1141,16 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.arpTables = append(dp.arpTables, arpFilterTable)
 	}
 
-	linkAddrsManagerV4 := linkaddrs.New(4, config.RulesConfig.WorkloadIfacePrefixes, featureDetector, config.NetlinkTimeout)
+	var linkAddrsManagerV4 linkaddrs.Interface
+	if !config.RouteSyncDisabled {
+		log.Debug("Route management is enabled. Using default LinkAddrsManager")
+
+		linkAddrsManagerV4 = linkaddrs.New(4, config.RulesConfig.WorkloadIfacePrefixes, featureDetector, config.NetlinkTimeout)
+	} else {
+		log.Info("Route management is disabled, using DummyLinkAddrsManager.")
+		linkAddrsManagerV4 = &linkaddrs.DummyLinkAddrsManager{}
+	}
+
 	dp.linkAddrsManagers = append(dp.linkAddrsManagers, linkAddrsManagerV4)
 
 	epManager := newEndpointManager(
@@ -1354,7 +1363,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			filterMapsV6 = filterTableV6.(nftables.MapsDataplane)
 		}
 
-		linkAddrsManagerV6 := linkaddrs.New(6, config.RulesConfig.WorkloadIfacePrefixes, featureDetector, config.NetlinkTimeout)
+		var linkAddrsManagerV6 linkaddrs.Interface
+		if !config.RouteSyncDisabled {
+			log.Debug("Route management is enabled. Using default LinkAddrsManager")
+			linkAddrsManagerV6 = linkaddrs.New(6, config.RulesConfig.WorkloadIfacePrefixes, featureDetector, config.NetlinkTimeout)
+		} else {
+			log.Info("Route management is disabled, using DummyLinkAddrsManager.")
+			linkAddrsManagerV6 = &linkaddrs.DummyLinkAddrsManager{}
+		}
 		dp.linkAddrsManagers = append(dp.linkAddrsManagers, linkAddrsManagerV6)
 
 		dp.RegisterManager(newEndpointManager(

--- a/felix/linkaddrs/dummy_manager.go
+++ b/felix/linkaddrs/dummy_manager.go
@@ -1,0 +1,27 @@
+package linkaddrs
+
+import (
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/netlinkshim"
+)
+
+type DummyLinkAddrsManager struct {
+}
+
+func (_ *DummyLinkAddrsManager) QueueResync() {
+}
+
+func (_ *DummyLinkAddrsManager) SetLinkLocalAddress(_ string, _ ip.CIDR) error {
+	return nil
+}
+
+func (_ *DummyLinkAddrsManager) RemoveLinkLocalAddress(_ string) {
+}
+
+func (_ *DummyLinkAddrsManager) GetNlHandle() (netlinkshim.Interface, error) {
+	return nil, nil
+}
+
+func (_ *DummyLinkAddrsManager) Apply() error {
+	return nil
+}

--- a/felix/linkaddrs/dummy_manager.go
+++ b/felix/linkaddrs/dummy_manager.go
@@ -8,20 +8,20 @@ import (
 type DummyLinkAddrsManager struct {
 }
 
-func (_ *DummyLinkAddrsManager) QueueResync() {
+func (*DummyLinkAddrsManager) QueueResync() {
 }
 
-func (_ *DummyLinkAddrsManager) SetLinkLocalAddress(_ string, _ ip.CIDR) error {
+func (*DummyLinkAddrsManager) SetLinkLocalAddress(_ string, _ ip.CIDR) error {
 	return nil
 }
 
-func (_ *DummyLinkAddrsManager) RemoveLinkLocalAddress(_ string) {
+func (*DummyLinkAddrsManager) RemoveLinkLocalAddress(_ string) {
 }
 
-func (_ *DummyLinkAddrsManager) GetNlHandle() (netlinkshim.Interface, error) {
+func (*DummyLinkAddrsManager) GetNlHandle() (netlinkshim.Interface, error) {
 	return nil, nil
 }
 
-func (_ *DummyLinkAddrsManager) Apply() error {
+func (*DummyLinkAddrsManager) Apply() error {
 	return nil
 }

--- a/felix/linkaddrs/interface.go
+++ b/felix/linkaddrs/interface.go
@@ -1,0 +1,15 @@
+package linkaddrs
+
+import (
+	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/netlinkshim"
+)
+
+// Interface is the interface provided by the standard linkaddrs module. Made to support multiple implementations (standard and no-op)
+type Interface interface {
+	QueueResync()
+	SetLinkLocalAddress(_ string, _ ip.CIDR) error
+	RemoveLinkLocalAddress(_ string)
+	GetNlHandle() (netlinkshim.Interface, error)
+	Apply() error
+}


### PR DESCRIPTION
# Changes

This PR fixes a regression introduced by #9875 that broke support for "network policy only" mode: `LinkAddrsManager` component alters the kernel route table even if the parameter `RouteSyncDisabled` is set to `true` (see feature #5454). The result is the bug reported in #10648.

I've created an interface for the LinkAddrsManager in order to be able to choose the implementation to be used. In this case, for the network-policy-only mode we are interested in disabling the feature altogether, so `DummyLinkAddrsManager` implements the interface but does basically does nothing.

When the data-plane managers are instantiated, the same `RouteSyncDisabled` flag is used to pick between the real and the dummy implementation of the `LinkAddrsManager`.

I've tested this in our staging environment, as well as a backport of this change into v1.31; and the behavior is as we'd expect: the network policies keep being implemented by calico-node but no routes are modified.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fixed a regression introduced in v3.30 where `RouteSyncDisabled` flag was not being honored by `LinkAddressManager`.
```
