### PR TITLE
Assert correct error type in k8s policy conversion (#12490)

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/kubeclusternetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubeclusternetworkpolicy.go
@@ -99,13 +99,9 @@ func (c *clusterNetworkPolicyClient) List(ctx context.Context, list model.ListIn
 		// Silently ignore rule conversion errors. We don't expect any conversion errors
 		// since the data given to us here is validated by the Kubernetes API. The conversion
 		// code ignores any rules that it cannot parse, and we will pass the valid ones to Felix.
-		var e *cerrors.ErrorClusterNetworkPolicyConversion
+		var e cerrors.ErrorClusterNetworkPolicyConversion
 		if err != nil && !errors.As(err, &e) {
 			return nil, err
-		}
-		// Skip malformed policies that returned a nil-Value tombstone KVPair.
-		if kvp == nil || kvp.Value == nil {
-			return nil, nil
 		}
 		return []*model.KVPair{kvp}, nil
 	}

--- a/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
@@ -102,7 +102,7 @@ func (c *networkPolicyClient) List(ctx context.Context, list model.ListInterface
 		// Silently ignore rule conversion errors. We don't expect any conversion errors
 		// since the data given to us here is validated by the Kubernetes API. The conversion
 		// code ignores any rules that it cannot parse, and we will pass the valid ones to Felix.
-		var e *cerrors.ErrorPolicyConversion
+		var e cerrors.ErrorPolicyConversion
 		if err != nil && !errors.As(err, &e) {
 			return nil, err
 		}


### PR DESCRIPTION
Assert correct error type in k8s network policy conversions. We check for a reference to an error type, while `GetError` return the error type itself. Identified here https://github.com/projectcalico/calico/pull/12486#discussion_r3088119331

https://github.com/projectcalico/calico/blob/5da11896abd7b78beb649d8db9f3b4e9aa598e5d/libcalico-go/lib/errors/errors.go#L294-L299

https://github.com/projectcalico/calico/blob/5da11896abd7b78beb649d8db9f3b4e9aa598e5d/libcalico-go/lib/errors/errors.go#L401-L407

Pick of https://github.com/projectcalico/calico/pull/12490

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
