### PR TITLE
Fix flaky BPF fragmented UDP from external client test

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1850,6 +1850,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							allowIngressFromExtClient.Spec.Selector = allowIngressFromExtClientSelector
 							allowIngressFromExtClient = createPolicy(allowIngressFromExtClient)
 
+							externalClient.Exec("ip", "route", "add", w[0][0].IP, "via", felixIP(0))
+
+							// Wait for the ext-client allow policy to be applied in the BPF datapath.
+							cc.ResetExpectations()
+							cc.ExpectSome(externalClient, w[0][0])
+							cc.CheckConnectivity()
+
 							tcpdump1 := tc.Felixes[0].AttachTCPDump("eth0")
 							tcpdump1.SetLogEnabled(true)
 							tcpdump1.AddMatcher("udp-frags", regexp.MustCompile(
@@ -1863,8 +1870,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								fmt.Sprintf("%s.* > %s.*", externalClient.IP, w[0][0].IP)))
 							tcpdump0.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP)
 							defer tcpdump1.Stop()
-
-							externalClient.Exec("ip", "route", "add", w[0][0].IP, "via", felixIP(0))
 
 							// Send a packet with large payload without the DNF flag
 							// 16,000 bytes is the typical limit on the size of a

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1869,7 +1869,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							tcpdump0.AddMatcher("udp-pod-frags", regexp.MustCompile(
 								fmt.Sprintf("%s.* > %s.*", externalClient.IP, w[0][0].IP)))
 							tcpdump0.Start(infra, "-vvv", "src", "host", externalClient.IP, "and", "dst", "host", w[0][0].IP)
-							defer tcpdump1.Stop()
+							defer tcpdump0.Stop()
 
 							// Send a packet with large payload without the DNF flag
 							// 16,000 bytes is the typical limit on the size of a


### PR DESCRIPTION
## Summary
- The BPF FV test "should handle fragmented UDP from external client" flakes because it creates a GlobalNetworkPolicy allowing ingress from the external client and immediately sends fragmented UDP via pktgen, without waiting for Felix to compile the updated BPF policy program.
- When the BPF policy update hasn't propagated yet, all fragments are denied by the old deny-all policy.
- Fix: add a connectivity check (`cc.ExpectSome`) after creating the policy to gate on it being applied in the BPF datapath before sending fragmented traffic. This is the standard pattern used elsewhere in the BPF FV tests.

## Test plan
- [x] Verified fix compiles (`go vet`)
- [x] Run the specific test repeatedly on Ubuntu 24.04 to confirm the flake is resolved

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)