### PR TITLE
tigera-operator: add NetworkSet RBAC

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -540,12 +540,13 @@ rules:
       - update
       - delete
 {{- end }}
-  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
+  # The operator needs to manage NetworkPolicies, GlobalNetworkPolicies, and NetworkSets via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
       - networkpolicies
       - globalnetworkpolicies
+      - networksets
     verbs:
       - get
       - list

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -517,12 +517,13 @@ rules:
       - list
       - watch
       - delete
-  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
+  # The operator needs to manage NetworkPolicies, GlobalNetworkPolicies, and NetworkSets via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
       - networkpolicies
       - globalnetworkpolicies
+      - networksets
     verbs:
       - get
       - list

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -557,12 +557,13 @@ rules:
       - list
       - watch
       - delete
-  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
+  # The operator needs to manage NetworkPolicies, GlobalNetworkPolicies, and NetworkSets via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
       - networkpolicies
       - globalnetworkpolicies
+      - networksets
     verbs:
       - get
       - list

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -496,12 +496,13 @@ rules:
       - create
       - update
       - delete
-  # The operator needs to manage NetworkPolicies and GlobalNetworkPolicies via the projectcalico.org API group.
+  # The operator needs to manage NetworkPolicies, GlobalNetworkPolicies, and NetworkSets via the projectcalico.org API group.
   - apiGroups:
       - projectcalico.org
     resources:
       - networkpolicies
       - globalnetworkpolicies
+      - networksets
     verbs:
       - get
       - list


### PR DESCRIPTION
Adds RBAC permissions for the tigera-operator to manage v3 NetworkSet resources. The operator needs this to create and reconcile NetworkSets used in webhook ingress policies (see https://github.com/tigera/operator/pull/4695).

**Release note:**
```release-note
None
```