### PR TITLE
Add e2e test binary to hashrelease artifacts

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -4,7 +4,13 @@ PACKAGE_NAME=github.com/projectcalico/calico/e2e
 include ../lib.Makefile
 
 SRC_FILES=$(shell find pkg cmd -name '*.go')
+
+###############################################################################
+# Build e2e test binaries
+###############################################################################
+
 build: bin/k8s/e2e.test bin/clusternetworkpolicy/e2e.test $(SRC_FILES)
+
 bin/k8s/e2e.test: $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o $@
@@ -12,6 +18,23 @@ bin/k8s/e2e.test: $(SRC_FILES)
 bin/clusternetworkpolicy/e2e.test: $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/clusternetworkpolicy -c -o $@
+
+# Multi-arch e2e binary targets. Each architecture gets its own binary, built
+# via cross-compilation inside the calico/go-build container.
+bin/k8s/e2e-linux-amd64.test: $(SRC_FILES)
+	mkdir -p bin/k8s
+	$(MAKE) build-e2e-binary ARCH=amd64
+
+bin/k8s/e2e-linux-arm64.test: $(SRC_FILES)
+	mkdir -p bin/k8s
+	$(MAKE) build-e2e-binary ARCH=arm64
+
+.PHONY: build-e2e-binary
+build-e2e-binary:
+	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o bin/k8s/e2e-linux-$(ARCH).test
+
+.PHONY: build-all
+build-all: $(addprefix bin/k8s/e2e-linux-,$(addsuffix .test,$(VALIDARCHES)))
 
 ###############################################################################
 # test images

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -20,18 +20,16 @@ bin/clusternetworkpolicy/e2e.test: $(SRC_FILES)
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/clusternetworkpolicy -c -o $@
 
 # Multi-arch e2e binary targets. Each architecture gets its own binary, built
-# via cross-compilation inside the calico/go-build container.
-bin/k8s/e2e-linux-amd64.test: $(SRC_FILES)
+# via cross-compilation inside the calico/go-build container. Uses a pattern
+# rule so that any arch in VALIDARCHES (including ppc64le, s390x) works.
+# The recursive make sets ARCH so that DOCKER_RUN passes the correct GOARCH.
+bin/k8s/e2e-linux-%.test: $(SRC_FILES)
 	mkdir -p bin/k8s
-	$(MAKE) build-e2e-binary ARCH=amd64
-
-bin/k8s/e2e-linux-arm64.test: $(SRC_FILES)
-	mkdir -p bin/k8s
-	$(MAKE) build-e2e-binary ARCH=arm64
+	$(MAKE) build-e2e-binary ARCH=$* OUTPUT=$@
 
 .PHONY: build-e2e-binary
 build-e2e-binary:
-	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o bin/k8s/e2e-linux-$(ARCH).test
+	$(DOCKER_RUN) $(CALICO_BUILD) go test ./cmd/k8s -c -o $(OUTPUT)
 
 .PHONY: build-all
 build-all: $(addprefix bin/k8s/e2e-linux-,$(addsuffix .test,$(VALIDARCHES)))

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -310,11 +310,11 @@ func (r *CalicoManager) Build() error {
 				return fmt.Errorf("error building target %s: %s", target, err)
 			}
 		}
-	}
 
-	// Build multi-arch e2e test binaries and copy them into the output directory.
-	if err = r.buildE2EBinaries(); err != nil {
-		return err
+		// Build multi-arch e2e test binaries and copy them into the output directory.
+		if err = r.buildE2EBinaries(); err != nil {
+			return err
+		}
 	}
 
 	// Build an OCP tgz bundle from manifests, used in the docs.
@@ -1159,6 +1159,9 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		dst := filepath.Join(e2eOutputDir, entry.Name())
 		if err := utils.CopyFile(src, dst); err != nil {
 			return fmt.Errorf("copying e2e binary %s: %w", entry.Name(), err)
+		}
+		if err := os.Chmod(dst, 0o755); err != nil {
+			return fmt.Errorf("setting permissions on e2e binary %s: %w", entry.Name(), err)
 		}
 		logrus.Infof("Copied e2e binary: %s", entry.Name())
 	}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -310,6 +310,11 @@ func (r *CalicoManager) Build() error {
 				return fmt.Errorf("error building target %s: %s", target, err)
 			}
 		}
+	}
+
+	// Build multi-arch e2e test binaries and copy them into the output directory.
+	if err = r.buildE2EBinaries(); err != nil {
+		return err
 	}
 
 	// Build an OCP tgz bundle from manifests, used in the docs.
@@ -1120,6 +1125,42 @@ func (r *CalicoManager) buildReleaseTar() error {
 	}
 	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{releaseTarFilePath, r.uploadDir()}, nil); err != nil {
 		return fmt.Errorf("failed to copy release tar: %w", err)
+	}
+	return nil
+}
+
+func (r *CalicoManager) buildE2EBinaries() error {
+	logrus.Info("Building multi-arch e2e test binaries")
+	e2eDir := filepath.Join(r.repoRoot, "e2e")
+	env := append(os.Environ(), fmt.Sprintf("VERSION=%s", r.calicoVersion))
+	if len(r.architectures) > 0 {
+		env = append(env, fmt.Sprintf("VALIDARCHES=%s", strings.Join(r.architectures, " ")))
+	}
+	out, err := r.makeInDirectoryWithOutput(e2eDir, "build-all", env...)
+	if err != nil {
+		logrus.Error(out)
+		return fmt.Errorf("failed to build e2e binaries: %w", err)
+	}
+
+	// Copy the built binaries into the hashrelease output directory.
+	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
+	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create e2e output dir: %w", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(e2eDir, "bin", "k8s"))
+	if err != nil {
+		return fmt.Errorf("reading e2e bin directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "e2e-linux-") {
+			continue
+		}
+		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
+		dst := filepath.Join(e2eOutputDir, entry.Name())
+		if err := utils.CopyFile(src, dst); err != nil {
+			return fmt.Errorf("copying e2e binary %s: %w", entry.Name(), err)
+		}
+		logrus.Infof("Copied e2e binary: %s", entry.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
Adds multi-arch e2e test binaries as a hashrelease artifact. The e2e Makefile gets a `build-all` target that cross-compiles a binary per architecture, and the hashrelease build step runs it and copies the results into `files/e2e/` in the output bucket.

This is part 1 of splitting #12351 into stacked PRs - part 2 will update the CI pipeline script to download and run the binary from the hashrelease instead of using `bz tests`.

```release-note
None
```