### PR TITLE
Add tests for allocationBlock, revealing two bugs

### DIFF
--- a/libcalico-go/lib/ipam/ipam_block.go
+++ b/libcalico-go/lib/ipam/ipam_block.go
@@ -230,7 +230,16 @@ func (b allocationBlock) NumFreeAddresses(reservations addrFilter) int {
 // empty returns true if the block has released all of its assignable addresses,
 // and returns false if any assignable addresses are in use.
 func (b allocationBlock) empty() bool {
-	return b.containsOnlyReservedIPs()
+	for _, attrIdx := range b.Allocations {
+		if attrIdx == nil {
+			continue
+		}
+		attrs := b.Attributes[*attrIdx]
+		if attrs.HandleID == nil || strings.ToLower(*attrs.HandleID) != WindowsReservedHandle {
+			return false
+		}
+	}
+	return true
 }
 
 // inUseIPs returns a list of IPs currently allocated in this block in string format.
@@ -246,21 +255,9 @@ func (b allocationBlock) inUseIPs() []string {
 	return ips
 }
 
-// containsOnlyReservedIPs returns true if the block is empty excepted for
-// expected "reserved" IP addresses.
-func (b *allocationBlock) containsOnlyReservedIPs() bool {
-	for _, attrIdx := range b.Allocations {
-		if attrIdx == nil {
-			continue
-		}
-		attrs := b.Attributes[*attrIdx]
-		if attrs.HandleID == nil || strings.ToLower(*attrs.HandleID) != WindowsReservedHandle {
-			return false
-		}
-	}
-	return true
-}
-
+// release tries to release addresses matching the release options, on success, returns
+// slice of IPs that were released, map from handle ID to count of IPs released
+// for that handle.
 func (b *allocationBlock) release(addresses []ReleaseOptions) ([]cnet.IP, map[string]int, error) {
 	// Store return values.
 	unallocated := []cnet.IP{}
@@ -497,22 +494,6 @@ func (b allocationBlock) ipsByHandle(handleID string) []cnet.IP {
 		}
 	}
 	return ips
-}
-
-func (b allocationBlock) attributesForIP(ip cnet.IP) (map[string]string, error) {
-	// Convert to an ordinal.
-	ordinal, err := b.IPToOrdinal(ip)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check if allocated.
-	attrIndex := b.Allocations[ordinal]
-	if attrIndex == nil {
-		log.Debugf("IP %s is not currently assigned in block", ip)
-		return nil, cerrors.ErrorResourceDoesNotExist{Identifier: ip.String(), Err: errors.New("IP is unassigned")}
-	}
-	return b.Attributes[*attrIndex].ActiveOwnerAttrs, nil
 }
 
 // allocationAttributesForIP returns the full AllocationAttribute for the given IP,

--- a/libcalico-go/lib/ipam/ipam_block_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_test.go
@@ -1,0 +1,368 @@
+package ipam
+
+import (
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
+)
+
+type testBlock struct {
+	allocationBlock
+}
+
+func makeTestBlock() *testBlock {
+	_, blockNet, err := cnet.ParseCIDR("100.64.0.0/24")
+	Expect(err).NotTo(HaveOccurred())
+	return &testBlock{allocationBlock: newBlock(*blockNet, nil)}
+}
+
+func (b *testBlock) allocateAttrib(ordinals []int, attrib model.AllocationAttribute) {
+	// Add a new item to Attributes and link all ordinals to it.
+	attrIndex := len(b.Attributes)
+	b.Attributes = append(b.Attributes, attrib)
+	for _, o := range ordinals {
+		b.Allocations[o] = &attrIndex
+	}
+	j := 0
+
+	// Remove all ordinals from Unallocated.
+	for _, o := range b.Unallocated {
+		if !slices.Contains(ordinals, o) {
+			b.Unallocated[j] = o
+			j++
+		}
+	}
+	b.Unallocated = b.Unallocated[:j]
+}
+
+func (b *testBlock) allocate(ordinals []int, handleID string) {
+	b.allocateAttrib(ordinals, model.AllocationAttribute{HandleID: &handleID})
+}
+
+func (b *testBlock) allocatedOrdinals() []int {
+	allocated := []int{}
+	var o int
+	for o = 0; o < b.NumAddresses(); o++ {
+		if b.Allocations[o] != nil {
+			allocated = append(allocated, o)
+		}
+	}
+	return allocated
+}
+
+func (b *testBlock) unallocatedTail(n int) []int {
+	return b.Unallocated[len(b.Unallocated)-n:]
+}
+
+func (b *testBlock) validate() {
+	GinkgoHelper()
+
+	// Check that all non-nil Allocations point to valid attributes.
+	seenAttribs := map[int]struct{}{}
+	seenOrdinals := map[int]struct{}{}
+	var o int
+	for o = 0; o < b.NumAddresses(); o++ {
+		if b.Allocations[o] == nil {
+			continue
+		}
+		attrIdx := *b.Allocations[o]
+		Expect(attrIdx).To(SatisfyAll(BeNumerically(">=", 0), BeNumerically("<", len(b.Attributes))),
+			"Allocations index is within Attributes")
+		if attrIdx >= 0 && attrIdx < len(b.Attributes) {
+			seenAttribs[attrIdx] = struct{}{}
+		}
+		seenOrdinals[o] = struct{}{}
+	}
+
+	// Check that all attributes are pointed to
+	for i := range b.Attributes {
+		Expect(i).To(BeKeyOf(seenAttribs), "Attribute index was seen in Allocations")
+	}
+
+	// Check that all unallocated ordinals are unique and not seen.
+	for i, o := range b.Unallocated {
+		Expect(b.Unallocated[:i]).ToNot(ContainElement(o), "Unallocated element did not already appear in Unallocated")
+		Expect(o).ToNot(BeKeyOf(seenOrdinals), "Unallocated element was not in Allocated")
+	}
+
+	// Check that all addresses are either in Allocated or Unallocated
+	Expect(len(b.Unallocated)+len(seenOrdinals)).To(Equal(b.NumAddresses()), "All addresses are accounted for")
+}
+
+var _ = Describe("Getting summary information about a block", func() {
+	It("identifies an empty block as empty", func() {
+		block := makeTestBlock()
+		Expect(block.empty()).To(Equal(true))
+	})
+
+	It("identifies a block with only IPs reserved for Windows as empty", func() {
+		block := makeTestBlock()
+		block.allocate([]int{255}, WindowsReservedHandle)
+		Expect(block.empty()).To(Equal(true))
+	})
+
+	It("identifies a non-empty block", func() {
+		block := makeTestBlock()
+		block.allocate([]int{32}, "alloc")
+		Expect(block.empty()).To(Equal(false))
+	})
+
+	It("returns no in-use IPs for an empty block", func() {
+		block := makeTestBlock()
+		Expect(block.inUseIPs()).To(HaveLen(0))
+	})
+
+	It("returns all in-use IPs for a non-empty block", func() {
+		block := makeTestBlock()
+		block.allocate([]int{10, 20}, "tens")
+		Expect(block.inUseIPs()).To(HaveLen(2))
+		Expect(block.inUseIPs()).To(ContainElements("100.64.0.10", "100.64.0.20"))
+	})
+
+	It("returns free addresses with no reservations", func() {
+		block := makeTestBlock()
+		block.allocate([]int{10, 20}, "tens")
+		Expect(block.NumFreeAddresses(nilAddrFilter{})).To(Equal(256 - 2))
+	})
+
+	It("returns free addresses with half the block reserved", func() {
+		_, secondHalf, err := cnet.ParseCIDR("100.64.0.128/25")
+		Expect(err).NotTo(HaveOccurred())
+		block := makeTestBlock()
+		block.allocate([]int{10, 20, 210, 220}, "tens")
+		Expect(block.NumFreeAddresses(cidrSliceFilter([]cnet.IPNet{*secondHalf}))).To(Equal(128 - 2))
+	})
+
+	It("returns free addresses entire block reserved", func() {
+		_, wholeBlock, err := cnet.ParseCIDR("100.64.0.128/24")
+		Expect(err).NotTo(HaveOccurred())
+		block := makeTestBlock()
+		block.allocate([]int{10, 20, 210, 220}, "tens")
+		Expect(block.NumFreeAddresses(cidrSliceFilter([]cnet.IPNet{*wholeBlock}))).To(Equal(0))
+	})
+
+	It("correctly returns IPs by handle, whether zero, one, or many", func() {
+		block := makeTestBlock()
+		block.allocate([]int{3}, "singleton")
+		block.allocate([]int{10, 20}, "tens")
+		block.allocate([]int{33}, "thirties")
+		block.allocate([]int{34}, "thirties")
+		Expect(block.ipsByHandle("no-such-handle")).To(HaveLen(0))
+		Expect(block.ipsByHandle("singleton")).To(SatisfyAll(
+			HaveLen(1),
+			ContainElement(*cnet.ParseIP("100.64.0.3")),
+		))
+		Expect(block.ipsByHandle("tens")).To(SatisfyAll(
+			HaveLen(2),
+			ContainElements(*cnet.ParseIP("100.64.0.10"), *cnet.ParseIP("100.64.0.20")),
+		))
+		Expect(block.ipsByHandle("thirties")).To(SatisfyAll(
+			HaveLen(2),
+			ContainElements(*cnet.ParseIP("100.64.0.33"), *cnet.ParseIP("100.64.0.34")),
+		))
+	})
+
+	It("returns an error getting allocationAttributes for an unallocated IP", func() {
+		block := makeTestBlock()
+		ip := cnet.ParseIP("100.64.0.32")
+		Expect(block.allocationAttributesForIP(*ip)).Error().Should(HaveOccurred())
+	})
+
+	It("returns the same attributes for an allocated IP", func() {
+		block := makeTestBlock()
+		ip := cnet.ParseIP("100.64.0.32")
+		block.allocateAttrib([]int{32}, model.AllocationAttribute{
+			HandleID:            new("hand"),
+			ActiveOwnerAttrs:    map[string]string{"is": "active"},
+			AlternateOwnerAttrs: map[string]string{"is": "alternate"},
+		})
+		Expect(block.allocationAttributesForIP(*ip)).To(SatisfyAll(
+			HaveField("HandleID", new("hand")),
+			HaveField("ActiveOwnerAttrs", ConsistOf("active")),
+			HaveField("AlternateOwnerAttrs", ConsistOf("alternate")),
+		))
+	})
+})
+
+var _ = Describe("Releasing IPs", func() {
+	It("deallocates a single IP", func() {
+		block := makeTestBlock()
+		block.allocate([]int{13}, "unlucky")
+
+		unallocated, countByHandle, err := block.release([]ReleaseOptions{{
+			Address: "100.64.0.13",
+			Handle:  "unlucky",
+		}})
+		Expect(err).To(Succeed())
+		Expect(unallocated).To(HaveLen(0))
+		Expect(countByHandle).To(Equal(map[string]int{"unlucky": 1}))
+		Expect(block.allocatedOrdinals()).To(Equal([]int{}), "ordinal no longer Allocated")
+
+		block.validate()
+	})
+
+	It("deallocates one IP leaving its shared attributes behind", func() {
+		block := makeTestBlock()
+		block.allocate([]int{13, 26, 39}, "lucky")
+
+		unallocated, countByHandle, err := block.release([]ReleaseOptions{{
+			Address: "100.64.0.13",
+		}})
+		Expect(err).To(Succeed())
+		Expect(unallocated).To(HaveLen(0))
+		Expect(countByHandle).To(Equal(map[string]int{"lucky": 1}))
+		Expect(block.allocatedOrdinals()).To(SatisfyAll(
+			HaveLen(2),
+			ContainElements(26, 39),
+		), "13 no longer Allocated, but 26, 39 remain")
+
+		block.validate()
+	})
+
+	It("deallocates all IPs with a shared attribute", func() {
+		block := makeTestBlock()
+		block.allocate([]int{13, 26, 39}, "lucky")
+
+		unallocated, _, err := block.release([]ReleaseOptions{
+			{Address: "100.64.0.13"},
+			{Address: "100.64.0.26"},
+			{Address: "100.64.0.39"},
+		})
+		Expect(err).To(Succeed())
+		Expect(unallocated).To(HaveLen(0))
+		// TODO: handle count is incorrect
+		//Expect(countByHandle).To(Equal(map[string]int{"lucky": 3}))
+		Expect(block.allocatedOrdinals()).To(HaveLen(0),
+			"all three IPs no longer Allocated")
+
+		block.validate()
+	})
+
+	It("does nothing when no such IP exists", func() {
+		block := makeTestBlock()
+
+		unallocated, countByHandle, err := block.release([]ReleaseOptions{{
+			Address: "100.64.0.13",
+			Handle:  "unlucky",
+		}})
+		Expect(err).To(Succeed())
+		Expect(unallocated).To(Equal([]cnet.IP{*cnet.ParseIP("100.64.0.13")}))
+		Expect(countByHandle).To(Equal(map[string]int{}))
+
+		block.validate()
+	})
+
+	It("returns an error if the handles do not match", func() {
+		block := makeTestBlock()
+		block.allocate([]int{100}, "newstuff")
+
+		_, _, err := block.release([]ReleaseOptions{{
+			Address: "100.64.0.100",
+			Handle:  "oldstuff",
+		}})
+		Expect(err).ToNot(Succeed())
+
+		block.validate()
+	})
+
+	It("returns an error if the sequence numbers do not match", func() {
+		block := makeTestBlock()
+		block.allocate([]int{13}, "unlucky")
+		block.SequenceNumberForAllocation["13"] = 10
+
+		_, _, err := block.release([]ReleaseOptions{{
+			Address:        "100.64.0.13",
+			Handle:         "unlucky",
+			SequenceNumber: new(uint64(999)),
+		}})
+		Expect(err).ToNot(Succeed())
+
+		block.validate()
+	})
+})
+
+var _ = Describe("Releasing IPs by Handle", func() {
+	It("does nothing when no such handle exists", func() {
+		block := makeTestBlock()
+		released := block.releaseByHandle(ReleaseOptions{
+			Address:        "100.64.0.99",
+			Handle:         "nosuchhandle",
+			SequenceNumber: nil,
+		})
+		Expect(released).To(Equal(0))
+
+		block.validate()
+	})
+
+	It("removes an existing allocation", func() {
+		block := makeTestBlock()
+		block.allocate([]int{15}, "fifteen")
+		block.allocate([]int{20}, "twenty")
+		released := block.releaseByHandle(ReleaseOptions{
+			Address:        "100.64.0.99", // No need for this to match ordinal.
+			Handle:         "fifteen",
+			SequenceNumber: nil,
+		})
+		Expect(released).To(Equal(1))
+		Expect(block.allocatedOrdinals()).To(Equal([]int{20}), "twenty not affected")
+		Expect(block.unallocatedTail(1)).To(ContainElement(15),
+			"Unallocated should have released block at the tail")
+
+		block.validate()
+	})
+
+	It("skips removal if the sequence numbers do not match", func() {
+		Skip("Currently failing: leaks the IP")
+
+		block := makeTestBlock()
+		block.allocate([]int{15}, "fifteen")
+		block.SequenceNumberForAllocation["15"] = 10
+
+		released := block.releaseByHandle(ReleaseOptions{
+			Handle:         "fifteen",
+			SequenceNumber: new(uint64(999)),
+		})
+		Expect(released).To(Equal(0))
+		Expect(block.allocatedOrdinals()).To(Equal([]int{15}), "allocation not affected")
+
+		block.validate()
+	})
+
+	It("removes multiple existing allocations with the same handle and different attributes", func() {
+		block := makeTestBlock()
+		block.allocate([]int{15}, "several")
+		block.allocate([]int{25}, "several")
+		block.allocate([]int{35}, "several")
+		released := block.releaseByHandle(ReleaseOptions{
+			Address:        "100.64.0.99",
+			Handle:         "several",
+			SequenceNumber: nil,
+		})
+		Expect(released).To(Equal(3))
+		Expect(block.allocatedOrdinals()).To(HaveLen(0))
+		Expect(block.unallocatedTail(3)).To(ContainElements(15, 25, 35),
+			"Unallocated should have released blocks at the tail")
+
+		block.validate()
+	})
+
+	It("removes multiple existing allocations with the same handle and attributes", func() {
+		block := makeTestBlock()
+		block.allocate([]int{15, 25, 35}, "several")
+		released := block.releaseByHandle(ReleaseOptions{
+			Address:        "100.64.0.99",
+			Handle:         "several",
+			SequenceNumber: nil,
+		})
+		Expect(released).To(Equal(3))
+		Expect(block.allocatedOrdinals()).To(HaveLen(0))
+		Expect(block.unallocatedTail(3)).To(ContainElements(15, 25, 35),
+			"Unallocated should have released blocks at the tail")
+
+		block.validate()
+	})
+})


### PR DESCRIPTION
This adds a bunch of tests, revealing two bugs:
 - `release` under-counts occurrences of handles
 - `releaseByHandle` leaves the block in an inconsistent state if the sequence number check fails.

This also includes two trivial refactors to `ipam_block.go`, removing an unused function and inlining another to its only callsite.

I will make follow-up PRs to fix those two bugs, so that the fixes can be discussed separately from the tests.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
