### PR TITLE
Fix ARCHES override in istio, envoy-proxy, whisker Makefiles

### DIFF
--- a/istio/Makefile
+++ b/istio/Makefile
@@ -13,8 +13,9 @@ ISTIO_ZTUNNEL_IMAGE ?= istio-ztunnel
 
 BUILD_IMAGES ?= $(ISTIO_CNI_IMAGE) $(ISTIO_PILOT_IMAGE) $(ISTIO_PROXYV2_IMAGE) $(ISTIO_ZTUNNEL_IMAGE)
 
-# Istio artifacts are only supported for amd64 and arm64.
-ARCHES ?= amd64 arm64
+# Only amd64 and arm64 are supported. `=` (not `?=`) so env-provided ARCHES
+# from the release manager doesn't override the allowlist.
+ARCHES = amd64 arm64
 
 # Upstream version (configurable)
 ISTIO_VERSION ?= 1.28.1

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -10,8 +10,9 @@ BUILD_IMAGES ?= $(ENVOY_PROXY_IMAGE)
 # See https://gateway.envoyproxy.io/news/releases/matrix/ for version compatibility.
 ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.37.1-0a0b20ed98
 
-# Envoy proxy artifacts are only supported for amd64 and arm64.
-ARCHES ?= amd64 arm64
+# Only amd64 and arm64 are supported. `=` (not `?=`) so env-provided ARCHES
+# from the release manager doesn't override the allowlist.
+ARCHES = amd64 arm64
 
 ##############################################################################
 # Include lib.Makefile before anything else

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -2,8 +2,9 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/whisker
 IMAGE_BUILD_MARKER = whisker_container-$(ARCH).created
-# Whisker artifacts are only supported for amd64 and arm64.
-ARCHES             ?=amd64 arm64
+# Only amd64 and arm64 are supported. `=` (not `?=`) so env-provided ARCHES
+# from the release manager doesn't override the allowlist.
+ARCHES             = amd64 arm64
 
 # Configure variables used by ci/cd common targets from lib.Makefile.
 BUILD_IMAGES=whisker


### PR DESCRIPTION
PR #12356 switched these from EXCLUDEARCH to ARCHES as an allowlist, but used `?=` which cannot override an env-provided ARCHES.  The release manager passes ARCHES=amd64 arm64 ppc64le s390x via env (see release/pkg/manager/calico/manager.go:1167), which bypasses the `?=` default, causing the hashrelease build to fail trying to build istio-proxyv2:1.28.1 for ppc64le (upstream doesn't publish that platform).

Use `=` instead of `?=` so the hardcoded allowlist wins over env. CLI overrides (`make ARCHES=foo`) still work — they have higher precedence than file-level assignments in GNU Make.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
