### PR TITLE
Return error channel from PortForward

### DIFF
--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -93,7 +93,7 @@ var _ = describe.CalicoDescribe(
 				stopCh = make(chan time.Time, 1)
 
 				// We read flow logs from whisker-backend, we start port forward so we can query the flows
-				localPort, err := kubectl.PortForward("calico-system", "deployment/whisker", "3002", "", stopCh)
+				localPort, _, err := kubectl.PortForward("calico-system", "deployment/whisker", "3002", "", stopCh)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Build url to get flows from whisker

--- a/e2e/pkg/utils/kubectl.go
+++ b/e2e/pkg/utils/kubectl.go
@@ -36,11 +36,13 @@ func (k *Kubectl) Wait(kind, ns, name, user, condition string, timeout time.Dura
 }
 
 // PortForward starts a kubectl port-forward in the background, allocating a random
-// local port to avoid conflicts when tests run in parallel. It returns the local port.
-func (k *Kubectl) PortForward(ns, pod, remotePort, user string, timeOut chan time.Time) (int, error) {
+// local port to avoid conflicts when tests run in parallel. It returns the local port
+// and a channel that receives an error (or nil) when the port-forward process exits.
+// Callers can select on the channel to detect unexpected port-forward termination.
+func (k *Kubectl) PortForward(ns, pod, remotePort, user string, timeOut chan time.Time) (int, <-chan error, error) {
 	localPort, err := getFreePort()
 	if err != nil {
-		return 0, fmt.Errorf("failed to allocate local port: %w", err)
+		return 0, nil, fmt.Errorf("failed to allocate local port: %w", err)
 	}
 
 	options := []string{"port-forward", pod, fmt.Sprintf("%d:%s", localPort, remotePort)}
@@ -48,13 +50,13 @@ func (k *Kubectl) PortForward(ns, pod, remotePort, user string, timeOut chan tim
 		options = append(options, fmt.Sprintf("--as=%v", user))
 	}
 
+	errCh := make(chan error, 1)
 	go func() {
+		defer close(errCh)
 		_, err := kubectl.NewKubectlCommand(ns, options...).WithTimeout(timeOut).Exec()
-		if err != nil {
-			return
-		}
+		errCh <- err
 	}()
-	return localPort, nil
+	return localPort, errCh, nil
 }
 
 func getFreePort() (int, error) {


### PR DESCRIPTION
The port-forward goroutine in the e2e test helpers previously swallowed errors silently - if the underlying `kubectl port-forward` process died (pod restart, network blip, etc.), callers had no way to know. Tests would just get `connection refused` on the next poll and time out with misleading errors.

`PortForward` now returns a `<-chan error` alongside the port. Callers that don't care can `_` it (like the whisker test does today), but callers that need resilience can select on it to detect failures and restart.

This is the OSS half of a fix for a flaky Linseed port-forward in the enterprise e2e suite. The enterprise side adds a supervisor loop in the Linseed `PortForward()` that watches this channel and auto-restarts.

```release-note
None
```
