### PR TITLE
felix/bpf/ut: drain shared ring buffer in BPF UT helpers

### DIFF
--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -708,6 +708,26 @@ func newTestRingBuf(t *testing.T) *ringbuf.RingBuffer {
 	return rb
 }
 
+// ringBufNextWithTimeout reads the next event from rb, failing the test after
+// 5s rather than blocking on epoll indefinitely. Use this instead of rb.Next()
+// directly so a silent BPF-side regression surfaces as a clear timeout instead
+// of a hung test.
+func ringBufNextWithTimeout(t *testing.T, rb *ringbuf.RingBuffer) ringbuf.Event {
+	t.Helper()
+	var (
+		evt ringbuf.Event
+		err error
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		evt, err = rb.Next()
+	}()
+	Eventually(done, "5s").Should(BeClosed(), "timed out waiting for ring buffer event")
+	Expect(err).NotTo(HaveOccurred())
+	return evt
+}
+
 func cleanupMap(m maps.Map) {
 	log.WithField("map", m.GetName()).Info("Cleaning")
 	err := m.Iter(func(_, _ []byte) maps.IteratorAction {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -685,6 +685,21 @@ func initMapsOnce() {
 	})
 }
 
+// newTestRingBuf opens a reader on the shared cali_rb_evnt ring buffer used
+// by all BPF UT programs and drains any events left over from earlier tests,
+// so rb.Next() only observes events produced after this call. The caller is
+// responsible for closing the returned reader.
+//
+// Prefer this helper over calling ringbuf.New directly — the ring buffer map
+// is pinned and shared across tests, so a naked reader can pick up stray
+// records (TYPE_LOST_EVENTS markers, kprobe stats, etc.) and mis-parse them.
+func newTestRingBuf() *ringbuf.RingBuffer {
+	rb, err := ringbuf.New(ringBufMap, rbSize)
+	Expect(err).NotTo(HaveOccurred())
+	rb.Drain()
+	return rb
+}
+
 func cleanupMap(m maps.Map) {
 	log.WithField("map", m.GetName()).Info("Cleaning")
 	err := m.Iter(func(_, _ []byte) maps.IteratorAction {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -667,7 +667,7 @@ func initMapsOnce() {
 		allowSourcesMap = allowsources.Map()
 		allowSourcesMapV6 = allowsources.MapV6()
 
-		ringBufMap = ringbuf.Map("rb_evnt", 1024*1024)
+		ringBufMap = ringbuf.Map("rb_evnt", rbSize)
 		ringBufDropsMap = ringbuf.DropsMap()
 
 		allMaps = []maps.Map{natMap, natBEMap, natMapV6, natBEMapV6, ctMap, ctMapV6, ctCleanupMap, ctCleanupMapV6, rtMap, rtMapV6, ipsMap, ipsMapV6,
@@ -685,18 +685,26 @@ func initMapsOnce() {
 	})
 }
 
+// rbSize is the size in bytes of the shared cali_rb_evnt ring buffer map.
+// Must be a power of two and a multiple of the page size (the kernel ring buffer ABI requirement).
+const rbSize = 1024 * 1024
+
 // newTestRingBuf opens a reader on the shared cali_rb_evnt ring buffer used
 // by all BPF UT programs and drains any events left over from earlier tests,
-// so rb.Next() only observes events produced after this call. The caller is
-// responsible for closing the returned reader.
+// so rb.Next() only observes events produced after this call. The reader is
+// closed automatically at the end of the test via t.Cleanup, even if an
+// assertion fails partway through.
 //
 // Prefer this helper over calling ringbuf.New directly — the ring buffer map
 // is pinned and shared across tests, so a naked reader can pick up stray
 // records (TYPE_LOST_EVENTS markers, kprobe stats, etc.) and mis-parse them.
-func newTestRingBuf() *ringbuf.RingBuffer {
+func newTestRingBuf(t *testing.T) *ringbuf.RingBuffer {
 	rb, err := ringbuf.New(ringBufMap, rbSize)
 	Expect(err).NotTo(HaveOccurred())
-	rb.Drain()
+	t.Cleanup(func() { _ = rb.Close() })
+	if n := rb.Drain(); n > 0 {
+		t.Logf("newTestRingBuf: drained %d stale event(s) from cali_rb_evnt — an earlier test likely left records unread", n)
+	}
 	return rb
 }
 

--- a/felix/bpf/ut/flow_log_events_test.go
+++ b/felix/bpf/ut/flow_log_events_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/felix/bpf/events"
-	"github.com/projectcalico/calico/felix/bpf/ringbuf"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 )
 
@@ -34,8 +33,7 @@ func TestFlowLogV6Events(t *testing.T) {
 	ipv6 := ip6hdr.(*layers.IPv6)
 	udp := l4.(*layers.UDP)
 
-	rb, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb := newTestRingBuf()
 	defer rb.Close()
 
 	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
@@ -54,6 +52,7 @@ func TestFlowLogV6Events(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	e, err := events.ParseEvent(rawEvent)
 	Expect(err).NotTo(HaveOccurred())
+	Expect(e.Type()).To(Equal(events.TypePolicyVerdictV6))
 	evnt := events.ParsePolicyVerdict(e.Data(), true)
 	Expect(evnt.SrcAddr).To(Equal(ipv6.SrcIP))
 	Expect(evnt.DstAddr).To(Equal(ipv6.DstIP))
@@ -71,8 +70,7 @@ func TestFlowLogEvents(t *testing.T) {
 	ipv4 := iphdr.(*layers.IPv4)
 	udp := l4.(*layers.UDP)
 
-	rb, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb := newTestRingBuf()
 	defer rb.Close()
 
 	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
@@ -91,6 +89,7 @@ func TestFlowLogEvents(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	e, err := events.ParseEvent(rawEvent)
 	Expect(err).NotTo(HaveOccurred())
+	Expect(e.Type()).To(Equal(events.TypePolicyVerdict))
 	evnt := events.ParsePolicyVerdict(e.Data(), false)
 	Expect(evnt.SrcAddr).To(Equal(ipv4.SrcIP))
 	Expect(evnt.DstAddr).To(Equal(ipv4.DstIP))
@@ -124,6 +123,7 @@ func TestFlowLogEvents(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	e, err = events.ParseEvent(rawEvent)
 	Expect(err).NotTo(HaveOccurred())
+	Expect(e.Type()).To(Equal(events.TypePolicyVerdict))
 	evnt = events.ParsePolicyVerdict(e.Data(), false)
 	Expect(evnt.SrcAddr).To(Equal(ipv4.SrcIP))
 	Expect(evnt.DstAddr).To(Equal(ipv4.DstIP))

--- a/felix/bpf/ut/flow_log_events_test.go
+++ b/felix/bpf/ut/flow_log_events_test.go
@@ -47,8 +47,7 @@ func TestFlowLogV6Events(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	}, withIPv6(), withFlowLogs())
 
-	rawEvent, err := rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	rawEvent := ringBufNextWithTimeout(t, rb)
 	e, err := events.ParseEvent(rawEvent)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(e.Type()).To(Equal(events.TypePolicyVerdictV6))
@@ -83,8 +82,7 @@ func TestFlowLogEvents(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	}, withFlowLogs())
 
-	rawEvent, err := rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	rawEvent := ringBufNextWithTimeout(t, rb)
 	e, err := events.ParseEvent(rawEvent)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(e.Type()).To(Equal(events.TypePolicyVerdict))
@@ -117,8 +115,7 @@ func TestFlowLogEvents(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	}, withFlowLogs())
 
-	rawEvent, err = rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	rawEvent = ringBufNextWithTimeout(t, rb)
 	e, err = events.ParseEvent(rawEvent)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(e.Type()).To(Equal(events.TypePolicyVerdict))

--- a/felix/bpf/ut/flow_log_events_test.go
+++ b/felix/bpf/ut/flow_log_events_test.go
@@ -33,8 +33,7 @@ func TestFlowLogV6Events(t *testing.T) {
 	ipv6 := ip6hdr.(*layers.IPv6)
 	udp := l4.(*layers.UDP)
 
-	rb := newTestRingBuf()
-	defer rb.Close()
+	rb := newTestRingBuf(t)
 
 	rtKey := routes.NewKeyV6(srcV6CIDR).AsBytes()
 	rtVal := routes.NewValueV6WithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()
@@ -70,8 +69,7 @@ func TestFlowLogEvents(t *testing.T) {
 	ipv4 := iphdr.(*layers.IPv4)
 	udp := l4.(*layers.UDP)
 
-	rb := newTestRingBuf()
-	defer rb.Close()
+	rb := newTestRingBuf(t)
 
 	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
 	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()

--- a/felix/bpf/ut/ringbuf_events_test.go
+++ b/felix/bpf/ut/ringbuf_events_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/projectcalico/calico/felix/bpf/ringbuf"
 )
 
 const (
@@ -42,8 +40,7 @@ func TestRingBufBasic(t *testing.T) {
 	ipv4 := iphdr.(*layers.IPv4)
 	udp := l4.(*layers.UDP)
 
-	rb, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb := newTestRingBuf()
 	defer rb.Close()
 
 	// Send a UDP packet and verify the event.
@@ -98,8 +95,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 	_, _, _, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 
-	rb, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb := newTestRingBuf()
 
 	runBpfUnitTest(t, "ringbuf_events.c", func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
@@ -114,8 +110,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 	// Close the first reader and create a new one on the same map.
 	rb.Close()
 
-	rb2, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb2 := newTestRingBuf()
 	defer rb2.Close()
 
 	// Send another event — the new reader should pick it up.
@@ -145,14 +140,11 @@ func TestRingBufFillup(t *testing.T) {
 	_, _, _, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 
-	rb, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb := newTestRingBuf()
 	defer rb.Close()
 
-	// Drain any leftover events from previous tests and reset the drops map
-	// so we start with a completely clean state.
-	rb.Drain()
-	// Reset the single-entry drops map (struct rb_drops_val = 16 bytes).
+	// Reset the single-entry drops map (struct rb_drops_val = 16 bytes) so
+	// this test's accounting isn't affected by earlier ring-buffer-full tests.
 	k := make([]byte, 4) // key = 0
 	zeroVal := make([]byte, 16)
 	err = ringBufDropsMap.Update(k, zeroVal)
@@ -232,8 +224,7 @@ func TestRingBufMultipleEvents(t *testing.T) {
 	RegisterTestingT(t)
 	hostIP = node1ip
 
-	rb, err := ringbuf.New(ringBufMap, rbSize)
-	Expect(err).NotTo(HaveOccurred())
+	rb := newTestRingBuf()
 	defer rb.Close()
 
 	numEvents := 10

--- a/felix/bpf/ut/ringbuf_events_test.go
+++ b/felix/bpf/ut/ringbuf_events_test.go
@@ -24,12 +24,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// eventSize must match sizeof(struct tuple) in ringbuf_events.c:
-	// event_header(8) + ip_src(4) + ip_dst(4) + port_src(2) + port_dst(2) + proto(1) + _pad(1027)
-	eventSize uint32 = 8 + 4 + 4 + 2 + 2 + 1 + 1027
-	rbSize    int    = 1024 * 1024
-)
+// eventSize must match sizeof(struct tuple) in ringbuf_events.c:
+// event_header(8) + ip_src(4) + ip_dst(4) + port_src(2) + port_dst(2) + proto(1) + _pad(1027)
+const eventSize uint32 = 8 + 4 + 4 + 2 + 2 + 1 + 1027
 
 func TestRingBufBasic(t *testing.T) {
 	RegisterTestingT(t)
@@ -40,8 +37,7 @@ func TestRingBufBasic(t *testing.T) {
 	ipv4 := iphdr.(*layers.IPv4)
 	udp := l4.(*layers.UDP)
 
-	rb := newTestRingBuf()
-	defer rb.Close()
+	rb := newTestRingBuf(t)
 
 	// Send a UDP packet and verify the event.
 	runBpfUnitTest(t, "ringbuf_events.c", func(bpfrun bpfProgRunFn) {
@@ -95,7 +91,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 	_, _, _, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 
-	rb := newTestRingBuf()
+	rb := newTestRingBuf(t)
 
 	runBpfUnitTest(t, "ringbuf_events.c", func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(pktBytes)
@@ -110,8 +106,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 	// Close the first reader and create a new one on the same map.
 	rb.Close()
 
-	rb2 := newTestRingBuf()
-	defer rb2.Close()
+	rb2 := newTestRingBuf(t)
 
 	// Send another event — the new reader should pick it up.
 	runBpfUnitTest(t, "ringbuf_events.c", func(bpfrun bpfProgRunFn) {
@@ -140,8 +135,7 @@ func TestRingBufFillup(t *testing.T) {
 	_, _, _, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 
-	rb := newTestRingBuf()
-	defer rb.Close()
+	rb := newTestRingBuf(t)
 
 	// Reset the single-entry drops map (struct rb_drops_val = 16 bytes) so
 	// this test's accounting isn't affected by earlier ring-buffer-full tests.
@@ -224,8 +218,7 @@ func TestRingBufMultipleEvents(t *testing.T) {
 	RegisterTestingT(t)
 	hostIP = node1ip
 
-	rb := newTestRingBuf()
-	defer rb.Close()
+	rb := newTestRingBuf(t)
 
 	numEvents := 10
 	for range numEvents {

--- a/felix/bpf/ut/ringbuf_events_test.go
+++ b/felix/bpf/ut/ringbuf_events_test.go
@@ -46,8 +46,7 @@ func TestRingBufBasic(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
 
-	eventRaw, err := rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	eventRaw := ringBufNextWithTimeout(t, rb)
 
 	eventHdr := eventHdrFromBytes(eventRaw.Data()[0:8])
 	Expect(eventHdr.typ).To(Equal(uint32(0xdead)))
@@ -71,8 +70,7 @@ func TestRingBufBasic(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
 
-	eventRaw, err = rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	eventRaw = ringBufNextWithTimeout(t, rb)
 	eventHdr = eventHdrFromBytes(eventRaw.Data()[0:8])
 	// The BPF program sets type to 0xdead for all protocols (no special ICMP path anymore).
 	Expect(eventHdr.typ).To(Equal(uint32(0xdead)))
@@ -99,8 +97,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
 
-	eventRaw, err := rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	eventRaw := ringBufNextWithTimeout(t, rb)
 	Expect(len(eventRaw.Data())).To(BeNumerically(">", 0))
 
 	// Close the first reader and create a new one on the same map.
@@ -115,8 +112,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
 
-	eventRaw, err = rb2.Next()
-	Expect(err).NotTo(HaveOccurred())
+	eventRaw = ringBufNextWithTimeout(t, rb2)
 	Expect(len(eventRaw.Data())).To(BeNumerically(">", 0))
 }
 
@@ -195,14 +191,12 @@ func TestRingBufFillup(t *testing.T) {
 	)
 
 	// First: the data event.
-	dataEvent, err := rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	dataEvent := ringBufNextWithTimeout(t, rb)
 	dataHdr := eventHdrFromBytes(dataEvent.Data()[0:8])
 	Expect(dataHdr.typ).To(Equal(uint32(0xdead)))
 
 	// Second: the TYPE_LOST_EVENTS event with exactly 1 drop.
-	lostEvent, err := rb.Next()
-	Expect(err).NotTo(HaveOccurred())
+	lostEvent := ringBufNextWithTimeout(t, rb)
 	lostData := lostEvent.Data()
 	lostHdr := eventHdrFromBytes(lostData[0:8])
 	Expect(lostHdr.typ).To(Equal(uint32(0)), "Expected EVENT_LOST_EVENTS (type 0)")
@@ -233,8 +227,7 @@ func TestRingBufMultipleEvents(t *testing.T) {
 	}
 
 	for range numEvents {
-		eventRaw, err := rb.Next()
-		Expect(err).NotTo(HaveOccurred())
+		eventRaw := ringBufNextWithTimeout(t, rb)
 		Expect(len(eventRaw.Data())).To(BeNumerically(">", 0))
 
 		hdr := eventHdrFromBytes(eventRaw.Data()[0:8])


### PR DESCRIPTION
## Summary

`cali_rb_evnt` is a pinned, shared `BPF_MAP_TYPE_RINGBUF`. Its consumer/producer positions are *kernel state* and persist across `ringbuf.New()` calls, so a reader opened by one test sees any records left unread by an earlier test. `ParsePolicyVerdict` then slices past the end of, e.g., an 84-byte `EVENT_PROTO_STATS` record (emitted by the enterprise \`TestKprobe\`) and panics:

    panic: runtime error: slice bounds out of range [:88] with capacity 76
    github.com/projectcalico/calico/felix/bpf/events.ParsePolicyVerdict
      felix/bpf/events/events.go:268
    github.com/projectcalico/calico/felix/bpf/ut_test.TestFlowLogV6Events
      felix/bpf/ut/flow_log_events_test.go:57

Fix:

- Add a \`newTestRingBuf()\` helper in \`bpf_prog_test.go\` that opens a reader on \`cali_rb_evnt\` and immediately drains any leftover records, so \`rb.Next()\` only returns events produced after the call.
- Convert all six ring-buffer-consuming tests (\`flow_log_events_test.go\`, \`ringbuf_events_test.go\`) to use the helper so future tests get the same protection for free.
- Assert the expected event type in the flow log tests so any future mismatch fails with a clear message rather than panicking inside the parser.

The OSS test suite alone cannot reproduce the panic because only the enterprise fork has kprobe programs that emit stray records into \`cali_rb_evnt\` during earlier tests, but the fix hardens the pattern for everyone.

## Test plan

- [x] \`make ut-bpf FOCUS=TestFlowLog\` — all subtests pass.
- [x] \`make ut-bpf FOCUS=TestRingBuf\` — all subtests pass.
- [x] Confirmed the original panic reproduces on enterprise fork before the fix and no longer reproduces after cherry-picking this change.

**Release note:**
```release-note
None
```