### PR TITLE
fix(#12253): BPF, check failsafe for DHCP

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -700,6 +700,15 @@ syn_force_policy:
 	if (!dest_rt) {
 		CALI_DEBUG("No route for post DNAT dest " IP_FMT "", debug_ip(ctx->state->post_nat_ip_dst));
 		if (CALI_F_FROM_HEP) {
+			/* Check failsafe for inbound DHCP broadcast (dest 255.255.255.255).
+			 * https://github.com/projectcalico/calico/issues/12253
+			 */
+			if (ctx->state->post_nat_ip_dst == 0xffffffff &&
+			    is_failsafe_in(ctx->state->ip_proto, ctx->state->post_nat_dport, ctx->state->ip_src)) {
+				CALI_DEBUG("Inbound failsafe port: %d. Skip policy (DHCP broadcast).", ctx->state->post_nat_dport);
+				counter_inc(ctx, CALI_REASON_ACCEPTED_BY_FAILSAFE);
+				goto skip_policy;
+			}
 			/* Disable FIB, let the packet go through the host after it is
 			 * policed. It is ingress into the system and we do not know what
 			 * exactly is the packet's destination. It may be a local VM or
@@ -781,6 +790,19 @@ syn_force_policy:
 			}
 			ctx->state->flags |= CALI_ST_CT_NP_REMOTE;
 		}
+	}
+
+	/* Check outbound failsafe for packets with no recognized local source IP.
+	 * Handles DHCP requests where source is 0.0.0.0, which is not in the
+	 * route table as a local host IP so the normal failsafe check is skipped.
+     *
+	 * https://github.com/projectcalico/calico/issues/12253
+	 */
+	if (CALI_F_TO_HEP && !forwarding && ip_void(ctx->state->ip_src) &&
+	    is_failsafe_out(ctx->state->ip_proto, ctx->state->post_nat_dport, ctx->state->post_nat_ip_dst)) {
+		CALI_DEBUG("Outbound failsafe port: %d. Skip policy (void src).", ctx->state->post_nat_dport);
+		counter_inc(ctx, CALI_REASON_ACCEPTED_BY_FAILSAFE);
+		goto skip_policy;
 	}
 
 do_policy:

--- a/felix/bpf/ut/failsafes_test.go
+++ b/felix/bpf/ut/failsafes_test.go
@@ -201,6 +201,36 @@ var failsafeTests = []failsafeTest{
 		Allowed:       false,
 		FromLocalHost: true,
 	},
+	{
+		Description:  "Outbound DHCP request on failsafe port is allowed",
+		Rules:        &denyAllRulesHost,
+		IPHeaderIPv4: &layers.IPv4{
+			Version:  4,
+			IHL:      5,
+			TTL:      64,
+			Flags:    layers.IPv4DontFragment,
+			SrcIP:    net.IPv4(0, 0, 0, 0),
+			DstIP:    fsafeDstIP,
+			Protocol: layers.IPProtocolUDP,
+		},
+		Outbound:     true,
+		Allowed:      true,
+	},
+	{
+		Description:  "Inbound DHCP broadcast response on failsafe port is allowed",
+		Rules:        &denyAllRulesHost,
+		IPHeaderIPv4: &layers.IPv4{
+			Version:  4,
+			IHL:      5,
+			TTL:      64,
+			Flags:    layers.IPv4DontFragment,
+			SrcIP:    srcIP,
+			DstIP:    net.IPv4(255, 255, 255, 255),
+			Protocol: layers.IPProtocolUDP,
+		},
+		Outbound:     false,
+		Allowed:      true,
+	},
 }
 
 func TestFailsafes(t *testing.T) {


### PR DESCRIPTION
When `netplan apply` triggers DHCP renewal, packets use source 0.0.0.0 / dest 255.255.255.255 which are not in the route table as local host IPs. The existing failsafe checks are gated on local host IP recognition, so they are skipped and DHCP is denied by policy.

Add failsafe checks for:
- Outbound: when source IP is void (0.0.0.0)
- Inbound: when dest has no route

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->