### PR TITLE
Handle BGPConfiguration fields directly, not via confd "cache"

### DIFF
--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -169,9 +169,9 @@ func (c *client) populateNodeConfig(config *types.BirdBGPConfig, ipVersion int) 
 	}
 
 	// Process bind mode and listen address
-	bindMode, err := c.getNodeOrGlobalValue(NodeName, "bind_mode")
+
 	// Set listen address if bind mode is NodeIP and we have a node IP
-	if err == nil && bindMode == "NodeIP" {
+	if getBindMode(c.globalBGPConfig) == v3.BindModeNodeIP {
 		if ipVersion == 6 && config.NodeIPv6 != "" {
 			config.ListenAddress = config.NodeIPv6
 		} else if ipVersion == 4 && config.NodeIP != "" {

--- a/confd/pkg/backends/calico/bgp_processor.go
+++ b/confd/pkg/backends/calico/bgp_processor.go
@@ -39,6 +39,10 @@ type bgpConfigCache struct {
 	revision uint64
 }
 
+type processorContext struct {
+	globalBGPConfig *v3.BGPConfiguration
+}
+
 // GetBirdBGPConfig processes raw datastore data into a clean BGP configuration structure
 // ipVersion should be 4 for IPv4 or 6 for IPv6
 func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
@@ -55,6 +59,8 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 
 	logc.Debug("BGP config cache miss or expired, processing new configuration")
 
+	pc := c.getBGPProcessorContext()
+
 	config := &types.BirdBGPConfig{
 		NodeName:    NodeName,
 		Peers:       make([]types.BirdBGPPeer, 0),
@@ -63,7 +69,7 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 	}
 
 	// Get basic node configuration
-	if err := c.populateNodeConfig(config, ipVersion); err != nil {
+	if err := c.populateNodeConfig(pc, config, ipVersion); err != nil {
 		logc.WithError(err).Warn("Failed to populate node configuration")
 		return nil, err
 	}
@@ -89,7 +95,7 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 	logc.Debugf("Processed community rules: found %d rules", len(config.Communities))
 
 	// Process ippools.
-	if err := c.processIPPools(config, ipVersion); err != nil {
+	if err := c.processIPPools(pc, config, ipVersion); err != nil {
 		logc.WithError(err).Warn("Failed to process ippools")
 		return nil, err
 	}
@@ -111,8 +117,14 @@ func (c *client) GetBirdBGPConfig(ipVersion int) (*types.BirdBGPConfig, error) {
 	return config, nil
 }
 
+func (c *client) getBGPProcessorContext() *processorContext {
+	return &processorContext{
+		globalBGPConfig: c.getBGPConfig(),
+	}
+}
+
 // populateNodeConfig fills in basic node configuration
-func (c *client) populateNodeConfig(config *types.BirdBGPConfig, ipVersion int) error {
+func (c *client) populateNodeConfig(pc *processorContext, config *types.BirdBGPConfig, ipVersion int) error {
 	// Get node IPv4 address
 	nodeIPv4Key := fmt.Sprintf("/calico/bgp/v1/host/%s/ip_addr_v4", NodeName)
 	if nodeIP, err := c.GetValue(nodeIPv4Key); err == nil {
@@ -171,7 +183,7 @@ func (c *client) populateNodeConfig(config *types.BirdBGPConfig, ipVersion int) 
 	// Process bind mode and listen address
 
 	// Set listen address if bind mode is NodeIP and we have a node IP
-	if getBindMode(c.globalBGPConfig) == v3.BindModeNodeIP {
+	if getBindMode(pc.globalBGPConfig) == v3.BindModeNodeIP {
 		if ipVersion == 6 && config.NodeIPv6 != "" {
 			config.ListenAddress = config.NodeIPv6
 		} else if ipVersion == 4 && config.NodeIP != "" {
@@ -205,7 +217,7 @@ func (c *client) populateNodeConfig(config *types.BirdBGPConfig, ipVersion int) 
 	}
 
 	// Set NormalRoutePriority from BGPConfiguration (default 1024).
-	config.NormalRoutePriority = getNormalRoutePriority(ipVersion, c.globalBGPConfig)
+	config.NormalRoutePriority = getNormalRoutePriority(ipVersion, pc.globalBGPConfig)
 
 	config.SetMetricForBGPRoutes = []string{
 		"  if (defined(source) && (source = RTS_BGP) && !defined(krt_metric)) then {",
@@ -856,7 +868,7 @@ func (c *client) processCommunityRules(config *types.BirdBGPConfig, ipVersion in
 	return nil
 }
 
-func (c *client) processIPPools(config *types.BirdBGPConfig, ipVersion int) error {
+func (c *client) processIPPools(pc *processorContext, config *types.BirdBGPConfig, ipVersion int) error {
 	poolKey := fmt.Sprintf("/calico/v1/ipam/v%d/pool", ipVersion)
 	logCtx := log.WithFields(map[string]any{
 		"ipVersion": ipVersion,
@@ -881,8 +893,8 @@ func (c *client) processIPPools(config *types.BirdBGPConfig, ipVersion int) erro
 	}
 
 	programClusterRoutes := true // Default is Enabled when ProgramClusterRoutes is unset in BGPConfiguration.
-	if c.globalBGPConfig != nil && c.globalBGPConfig.Spec.ProgramClusterRoutes != nil &&
-		*c.globalBGPConfig.Spec.ProgramClusterRoutes == "Disabled" {
+	if pc.globalBGPConfig != nil && pc.globalBGPConfig.Spec.ProgramClusterRoutes != nil &&
+		*pc.globalBGPConfig.Spec.ProgramClusterRoutes == "Disabled" {
 		programClusterRoutes = false
 		logCtx.Debug("Programming cluster routes is disabled.")
 	} else {

--- a/confd/pkg/backends/calico/bgp_processor_test.go
+++ b/confd/pkg/backends/calico/bgp_processor_test.go
@@ -41,7 +41,7 @@ func newTestClient(cache, peeringCache map[string]string) *client {
 		configCache:  make(map[int]*bgpConfigCache),
 	}
 	c.globalBGPConfig = v3.NewBGPConfiguration()
-	c.globalBGPConfig.ObjectMeta.Name = "default"
+	c.globalBGPConfig.Name = "default"
 	return c
 }
 

--- a/confd/pkg/backends/calico/bgp_processor_test.go
+++ b/confd/pkg/backends/calico/bgp_processor_test.go
@@ -222,7 +222,7 @@ func TestPopulateNodeConfig_BasicIPv4(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "10.0.0.1", config.NodeIP)
@@ -248,7 +248,7 @@ func TestPopulateNodeConfig_BasicIPv6(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 6)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 6)
 	require.NoError(t, err)
 
 	assert.Equal(t, "10.0.0.1", config.NodeIP)
@@ -276,7 +276,7 @@ func TestPopulateNodeConfig_NodeSpecificAS(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Node-specific AS should take precedence
@@ -301,7 +301,7 @@ func TestPopulateNodeConfig_RouterIDHash(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Router ID should be hash-generated, not the node IP
@@ -328,7 +328,7 @@ func TestPopulateNodeConfig_RouterIDHashIPv6(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 6)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 6)
 	require.NoError(t, err)
 
 	// Router ID should be hash-generated
@@ -353,7 +353,7 @@ func TestPopulateNodeConfig_ExplicitRouterID(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Router ID should be the explicit value
@@ -378,7 +378,7 @@ func TestPopulateNodeConfig_LogLevelDebug(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "debug", config.LogLevel)
@@ -403,7 +403,7 @@ func TestPopulateNodeConfig_LogLevelInfo(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "info", config.LogLevel)
@@ -428,7 +428,7 @@ func TestPopulateNodeConfig_LogLevelNone(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "none", config.LogLevel)
@@ -454,7 +454,7 @@ func TestPopulateNodeConfig_NodeSpecificLogLevel(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "debug", config.LogLevel)
@@ -479,7 +479,7 @@ func TestPopulateNodeConfig_BindModeNodeIP_IPv4(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "10.0.0.1", config.ListenAddress)
@@ -504,7 +504,7 @@ func TestPopulateNodeConfig_BindModeNodeIP_IPv6(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 6)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 6)
 	require.NoError(t, err)
 
 	// IPv6 should use IPv6 address for listen
@@ -529,7 +529,7 @@ func TestPopulateNodeConfig_ListenPort(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1790", config.ListenPort)
@@ -554,7 +554,7 @@ func TestPopulateNodeConfig_NodeSpecificListenPort(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	assert.Equal(t, "1791", config.ListenPort)
@@ -577,7 +577,7 @@ func TestPopulateNodeConfig_IgnoredInterfaces_Default(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Default pattern
@@ -602,7 +602,7 @@ func TestPopulateNodeConfig_IgnoredInterfaces_Custom(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Custom interfaces plus standard exclusions
@@ -632,37 +632,13 @@ func TestPopulateNodeConfig_NodeSpecificIgnoredInterfaces(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Node-specific interface should be present
 	assert.Contains(t, config.DirectInterfaces, `-"node-if"`)
 	// Global interface should NOT be present
 	assert.NotContains(t, config.DirectInterfaces, `-"global-if"`)
-}
-
-func TestPopulateNodeConfig_NodeSpecificBindMode(t *testing.T) {
-	originalNodeName := NodeName
-	NodeName = "test-node"
-	defer func() { NodeName = originalNodeName }()
-
-	_ = os.Unsetenv("CALICO_ROUTER_ID")
-
-	cache := map[string]string{
-		"/calico/bgp/v1/host/test-node/ip_addr_v4": "10.0.0.1",
-		"/calico/bgp/v1/global/as_num":             "64512",
-	}
-
-	c := newTestClient(cache, nil)
-	c.globalBGPConfig.Spec.BindMode = ptr.To(v3.BindModeNodeIP)
-	config := &types.BirdBGPConfig{
-		NodeName: NodeName,
-	}
-
-	err := c.populateNodeConfig(config, 4)
-	require.NoError(t, err)
-
-	assert.Equal(t, "10.0.0.1", config.ListenAddress)
 }
 
 func TestPopulateNodeConfig_NoBindMode(t *testing.T) {
@@ -682,7 +658,7 @@ func TestPopulateNodeConfig_NoBindMode(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// ListenAddress should be empty when bind_mode is not NodeIP
@@ -707,7 +683,7 @@ func TestPopulateNodeConfig_DefaultLogLevel(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Default debug mode when no log level is set
@@ -729,7 +705,7 @@ func TestPopulateNodeConfig_NormalRoutePriority_Default(t *testing.T) {
 	c := newTestClient(cache, nil)
 
 	config := &types.BirdBGPConfig{}
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	// Default should be 1024
@@ -758,7 +734,7 @@ func TestPopulateNodeConfig_NormalRoutePriority_FromBGPConfig(t *testing.T) {
 	}
 
 	config := &types.BirdBGPConfig{}
-	err := c.populateNodeConfig(config, 4)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 	assert.Equal(t, 500, config.NormalRoutePriority)
 }
@@ -787,7 +763,7 @@ func TestPopulateNodeConfig_NormalRoutePriority_IPv6(t *testing.T) {
 	}
 
 	config := &types.BirdBGPConfig{}
-	err := c.populateNodeConfig(config, 6)
+	err := c.populateNodeConfig(c.getBGPProcessorContext(), config, 6)
 	require.NoError(t, err)
 	assert.Equal(t, 800, config.NormalRoutePriority)
 }

--- a/confd/pkg/backends/calico/bgp_processor_test.go
+++ b/confd/pkg/backends/calico/bgp_processor_test.go
@@ -25,6 +25,7 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	"github.com/projectcalico/calico/confd/pkg/backends/types"
 	"github.com/projectcalico/calico/confd/pkg/resource/template"
@@ -39,6 +40,8 @@ func newTestClient(cache, peeringCache map[string]string) *client {
 		peeringCache: peeringCache,
 		configCache:  make(map[int]*bgpConfigCache),
 	}
+	c.globalBGPConfig = v3.NewBGPConfiguration()
+	c.globalBGPConfig.ObjectMeta.Name = "default"
 	return c
 }
 
@@ -468,10 +471,10 @@ func TestPopulateNodeConfig_BindModeNodeIP_IPv4(t *testing.T) {
 	cache := map[string]string{
 		"/calico/bgp/v1/host/test-node/ip_addr_v4": "10.0.0.1",
 		"/calico/bgp/v1/global/as_num":             "64512",
-		"/calico/bgp/v1/global/bind_mode":          "NodeIP",
 	}
 
 	c := newTestClient(cache, nil)
+	c.globalBGPConfig.Spec.BindMode = ptr.To(v3.BindModeNodeIP)
 	config := &types.BirdBGPConfig{
 		NodeName: NodeName,
 	}
@@ -493,10 +496,10 @@ func TestPopulateNodeConfig_BindModeNodeIP_IPv6(t *testing.T) {
 		"/calico/bgp/v1/host/test-node/ip_addr_v4": "10.0.0.1",
 		"/calico/bgp/v1/host/test-node/ip_addr_v6": "fd00::1",
 		"/calico/bgp/v1/global/as_num":             "64512",
-		"/calico/bgp/v1/global/bind_mode":          "NodeIP",
 	}
 
 	c := newTestClient(cache, nil)
+	c.globalBGPConfig.Spec.BindMode = ptr.To(v3.BindModeNodeIP)
 	config := &types.BirdBGPConfig{
 		NodeName: NodeName,
 	}
@@ -648,10 +651,10 @@ func TestPopulateNodeConfig_NodeSpecificBindMode(t *testing.T) {
 	cache := map[string]string{
 		"/calico/bgp/v1/host/test-node/ip_addr_v4": "10.0.0.1",
 		"/calico/bgp/v1/global/as_num":             "64512",
-		"/calico/bgp/v1/host/test-node/bind_mode":  "NodeIP", // Node-specific
 	}
 
 	c := newTestClient(cache, nil)
+	c.globalBGPConfig.Spec.BindMode = ptr.To(v3.BindModeNodeIP)
 	config := &types.BirdBGPConfig{
 		NodeName: NodeName,
 	}
@@ -672,7 +675,6 @@ func TestPopulateNodeConfig_NoBindMode(t *testing.T) {
 	cache := map[string]string{
 		"/calico/bgp/v1/host/test-node/ip_addr_v4": "10.0.0.1",
 		"/calico/bgp/v1/global/as_num":             "64512",
-		// No bind_mode set
 	}
 
 	c := newTestClient(cache, nil)

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1231,7 +1231,6 @@ func (c *client) updateBGPConfigCache(resName string, v3res *apiv3.BGPConfigurat
 	if resName == globalConfigName {
 		c.getPrefixAdvertisementsKVPair(v3res, model.GlobalBGPConfigKey{})
 		c.getListenPortKVPair(v3res, model.GlobalBGPConfigKey{}, updatePeersV1, updateReasons)
-		c.getBindModeKVPair(v3res, model.GlobalBGPConfigKey{}, updatePeersV1, updateReasons)
 		c.getASNumberKVPair(v3res, model.GlobalBGPConfigKey{}, updatePeersV1, updateReasons)
 		c.getServiceExternalIPsKVPair(v3res, model.GlobalBGPConfigKey{}, svcAdvertisement)
 		c.getServiceClusterIPsKVPair(v3res, model.GlobalBGPConfigKey{}, svcAdvertisement)
@@ -1251,11 +1250,16 @@ func (c *client) updateBGPConfigCache(resName string, v3res *apiv3.BGPConfigurat
 			c.serviceLoadBalancerAggregation = apiv3.ServiceLoadBalancerAggregationEnabled
 		}
 
-		// Check if normal route priority is changing.
+		// Check for changes in BGPConfiguration fields that impact GetBirdBGPConfig.  Note,
+		// the following changes do not affect the _set_ of BGP peers, so do not require
+		// setting updatePeersV1 and updateReasons.
 		if getNormalRoutePriority(4, v3res) != getNormalRoutePriority(4, c.globalBGPConfig) {
 			c.keyUpdated("/calico/bgpconfig")
 		}
 		if getNormalRoutePriority(6, v3res) != getNormalRoutePriority(6, c.globalBGPConfig) {
+			c.keyUpdated("/calico/bgpconfig")
+		}
+		if getBindMode(v3res) != getBindMode(c.globalBGPConfig) {
 			c.keyUpdated("/calico/bgpconfig")
 		}
 
@@ -1382,16 +1386,12 @@ func (c *client) getListenPortKVPair(v3res *apiv3.BGPConfiguration, key any, upd
 	*updatePeersV1 = true
 }
 
-func (c *client) getBindModeKVPair(v3res *apiv3.BGPConfiguration, key any, updatePeersV1 *bool, updateReasons *[]string) {
-	bindMode := getBGPConfigKey("bind_mode", key)
+func getBindMode(v3res *apiv3.BGPConfiguration) (bindMode apiv3.BindMode) {
+	bindMode = apiv3.BindModeNone
 	if v3res != nil && v3res.Spec.BindMode != nil {
-		*updateReasons = append(*updateReasons, "bindMode updated.")
-		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(bindMode, string(*v3res.Spec.BindMode)))
-	} else {
-		*updateReasons = append(*updateReasons, "bindMode deleted.")
-		c.updateCache(api.UpdateTypeKVDeleted, getKVPair(bindMode))
+		bindMode = *v3res.Spec.BindMode
 	}
-	*updatePeersV1 = true
+	return
 }
 
 func (c *client) getASNumberKVPair(v3res *apiv3.BGPConfiguration, key any, updatePeersV1 *bool, updateReasons *[]string) {

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1885,6 +1885,13 @@ func (c *client) GetValues(keys []string) (map[string]string, error) {
 	return values, nil
 }
 
+func (c *client) getBGPConfig() *apiv3.BGPConfiguration {
+	c.waitForSync.Wait()
+	c.cacheLock.Lock()
+	defer c.cacheLock.Unlock()
+	return c.globalBGPConfig
+}
+
 // WatchPrefix is called from confd.  It blocks waiting for updates to the data which have any
 // of the requested set of prefixes.
 //

--- a/confd/pkg/backends/calico/ippools_test.go
+++ b/confd/pkg/backends/calico/ippools_test.go
@@ -124,7 +124,7 @@ func Test_processIPPoolsV4(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.processIPPools(config, 4)
+	err := c.processIPPools(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	if !reflect.DeepEqual(config.KernelFilterForIPPools, forKernelStatements) {
@@ -177,7 +177,7 @@ func Test_processIPPoolsV4_NoLocalSubnet(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.processIPPools(config, 4)
+	err := c.processIPPools(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	if config.KernelFilterForIPPools != nil {
@@ -246,7 +246,7 @@ func Test_processIPPoolsV6(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.processIPPools(config, 6)
+	err := c.processIPPools(c.getBGPProcessorContext(), config, 6)
 	require.NoError(t, err)
 
 	expected := filterExpectedStatements(forKernelStatements, "reject")
@@ -324,7 +324,7 @@ func Test_processIPPoolsV4_FelixProgramsClusterRoutes(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.processIPPools(config, 4)
+	err := c.processIPPools(c.getBGPProcessorContext(), config, 4)
 	require.NoError(t, err)
 
 	if !reflect.DeepEqual(config.KernelFilterForIPPools, forKernelStatements) {
@@ -400,7 +400,7 @@ func Test_processIPPoolsV6_FelixProgramsClusterRoutes(t *testing.T) {
 		NodeName: NodeName,
 	}
 
-	err := c.processIPPools(config, 6)
+	err := c.processIPPools(c.getBGPProcessorContext(), config, 6)
 	require.NoError(t, err)
 
 	expected := filterExpectedStatements(forKernelStatements, "reject")


### PR DESCRIPTION
I'd like eventually to remove all translations to the "v2" / "model" / legacy etcd paths, as well as all use of the confd "cache", and emit BIRD config based directly on our v3 resources.

This PR is one step in that direction, for the BGPConfiguration fields that we honour in the "default" (aka global) BGPConfiguration but not in a per-node BGPConfiguration.

(If this looks good for the BindMode field, I'll expand to other such fields.)