### PR TITLE
[release 3.32] Remove sensitive info from logs (pick 12535)

### DIFF
--- a/calicoctl/calicoctl/commands/clientmgr/client.go
+++ b/calicoctl/calicoctl/commands/clientmgr/client.go
@@ -37,7 +37,20 @@ func NewClient(cf string) (client.Interface, error) {
 		log.Info("Error loading config")
 		return nil, err
 	}
-	log.Infof("Loaded client config: %#v", cfg.Spec)
+	// Do not log cfg.Spec directly (e.g. %#v / %+v / %v).
+	// It embeds K8sAPIToken, KubeconfigInline, EtcdPassword, EtcdKey, and EtcdCert.
+	log.WithFields(log.Fields{
+		"datastoreType":       cfg.Spec.DatastoreType,
+		"etcdEndpoints":       cfg.Spec.EtcdEndpoints,
+		"k8sAPIEndpoint":      cfg.Spec.K8sAPIEndpoint,
+		"kubeconfig":          cfg.Spec.Kubeconfig,
+		"kubeconfigInlineSet": cfg.Spec.KubeconfigInline != "",
+		"etcdUsernameSet":     cfg.Spec.EtcdUsername != "",
+		"etcdPasswordSet":     cfg.Spec.EtcdPassword != "",
+		"etcdKeyInlineSet":    cfg.Spec.EtcdKey != "",
+		"etcdCertInlineSet":   cfg.Spec.EtcdCert != "",
+		"k8sAPITokenSet":      cfg.Spec.K8sAPIToken != "",
+	}).Info("Loaded client config")
 	return NewClientFromConfig(cfg)
 }
 


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
`calicoctl` no longer logs raw client config on startup, which previously included `K8sAPIToken`, inline kubeconfig, `EtcdPassword`, and inline etcd key/cert material. The replacement log entry reports only non-sensitive fields and boolean "set" indicators for each credential.
```

https://github.com/projectcalico/calico/pull/12535