### PR TITLE
fix(aso/windows): harden ASO setup scripts for non-interactive Azure VM environments

### DIFF
--- a/process/testing/aso/infra/templates/vmss-linux.yaml
+++ b/process/testing/aso/infra/templates/vmss-linux.yaml
@@ -63,20 +63,20 @@ spec:
   settings:
     commandToExecute: |
       /bin/bash -c '
-      set -e
+      set -eu -o pipefail
       echo "Installing containerd..."
 
       # Update package list
-      apt-get update
+      apt-get -o DPkg::Lock::Timeout=60 update
 
       # Install prerequisites
-      apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
+      apt-get -o DPkg::Lock::Timeout=60 install -y apt-transport-https ca-certificates curl gnupg lsb-release
 
       # Install containerd from the Docker repo
-      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --no-tty --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-      apt-get update
-      apt-get install -y containerd.io
+      apt-get -o DPkg::Lock::Timeout=60 update
+      apt-get -o DPkg::Lock::Timeout=60 install -y containerd.io
 
       # Configure containerd for Kubernetes
       mkdir -p /etc/containerd

--- a/process/testing/aso/linux/setup-node.sh
+++ b/process/testing/aso/linux/setup-node.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eu -o pipefail
 
 echo "=== Setting up Kubernetes prerequisites ==="
 
@@ -26,7 +26,7 @@ net.bridge.bridge-nf-call-ip6tables = 1
 net.ipv4.ip_forward                 = 1
 SYSCTL
 
-sudo sysctl --system
+sudo sysctl --system || true # ignore errors from unrelated sysctl params in the base image
 
 # Verify containerd is installed
 echo "Verifying containerd..."
@@ -66,18 +66,18 @@ KUBE_VERSION=${1:-"v1.33.7"}
 KUBE_MAJOR_MINOR=$(echo "${KUBE_VERSION}" | cut -d'.' -f1,2)
 echo "Installing kubeadm, kubelet, and kubectl ${KUBE_VERSION}..."
 echo "Using repository version: ${KUBE_MAJOR_MINOR}"
-sudo apt-get update
+sudo apt-get -o DPkg::Lock::Timeout=60 update
 sudo apt-get -o DPkg::Lock::Timeout=60 install -y apt-transport-https ca-certificates curl gpg
 
 # Create keyrings directory
 sudo mkdir -p /etc/apt/keyrings
 
 # Add Kubernetes apt repository
-curl -fsSL "https://pkgs.k8s.io/core:/stable:/${KUBE_MAJOR_MINOR}/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL "https://pkgs.k8s.io/core:/stable:/${KUBE_MAJOR_MINOR}/deb/Release.key" | sudo gpg --batch --yes --no-tty --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_MAJOR_MINOR}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # Install Kubernetes components
-sudo apt-get update
+sudo apt-get -o DPkg::Lock::Timeout=60 update
 sudo apt-get -o DPkg::Lock::Timeout=60 install -y kubelet kubeadm kubectl
 sudo apt-mark hold kubelet kubeadm kubectl
 

--- a/process/testing/aso/vmss.sh
+++ b/process/testing/aso/vmss.sh
@@ -671,6 +671,17 @@ function delete_rg() {
   # Verify required environment variables
   : "${AZURE_RESOURCE_GROUP:?Environment variable empty or not defined.}"
 
+  # Verify az CLI is installed and authenticated
+  if ! command -v az >/dev/null 2>&1; then
+    log_error "Azure CLI ('az') is not installed or not available in PATH."
+    return 1
+  fi
+  local az_error
+  if ! az_error="$(az account show 2>&1)"; then
+    log_error "Unable to use Azure CLI account context: ${az_error}. Running 'az login' may be needed."
+    return 1
+  fi
+
   # Check if resource group exists
   log_info "Checking if resource group '${AZURE_RESOURCE_GROUP}' exists..."
   if ! az group show --name "${AZURE_RESOURCE_GROUP}" &>/dev/null; then


### PR DESCRIPTION
- Add --batch --yes --no-tty to gpg --dearmor calls to prevent TTY
  prompts that fail in CustomScript extensions
- Use apt-get -o DPkg::Lock::Timeout=60 to handle apt lock contention
  from background unattended-upgrades on fresh Azure VMs
- Use set -eu -o pipefail for stricter error handling in containerd
  extension script and setup-node.sh
- Verify az CLI is installed and authenticated before attempting
  resource group deletion to avoid silently treating auth errors
  as "resource group not found"
- Tolerate sysctl errors from Azure base image on setup-node.sh.
  The Azure Ubuntu image ships sysctl configs referencing network
  interfaces not yet present, which is harmless but now fatal under
  set -eu -o pipefail.


<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
