### PR TITLE
Fix incorrect handle counting

### DIFF
--- a/libcalico-go/lib/ipam/ipam_block.go
+++ b/libcalico-go/lib/ipam/ipam_block.go
@@ -343,14 +343,7 @@ func (b *allocationBlock) release(addresses []ReleaseOptions) ([]cnet.IP, map[st
 		// exists.
 		log.Debugf("Looking up attribute with index %d", *attrIdx)
 		if handleID != "" {
-			log.Debugf("HandleID is %s", handleID)
-			handleCount := 0
-			if count, ok := countByHandle[handleID]; !ok {
-				handleCount = count
-			}
-			log.Debugf("Handle ref count is %d, incrementing", handleCount)
-			handleCount += 1
-			countByHandle[handleID] = handleCount
+			countByHandle[handleID] = countByHandle[handleID] + 1
 			log.Debugf("countByHandle %v", countByHandle)
 		}
 	}

--- a/libcalico-go/lib/ipam/ipam_block_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_test.go
@@ -227,15 +227,14 @@ var _ = Describe("Releasing IPs", func() {
 		block := makeTestBlock()
 		block.allocate([]int{13, 26, 39}, "lucky")
 
-		unallocated, _, err := block.release([]ReleaseOptions{
+		unallocated, countByHandle, err := block.release([]ReleaseOptions{
 			{Address: "100.64.0.13"},
 			{Address: "100.64.0.26"},
 			{Address: "100.64.0.39"},
 		})
 		Expect(err).To(Succeed())
 		Expect(unallocated).To(HaveLen(0))
-		// TODO: handle count is incorrect
-		//Expect(countByHandle).To(Equal(map[string]int{"lucky": 3}))
+		Expect(countByHandle).To(Equal(map[string]int{"lucky": 3}))
 		Expect(block.allocatedOrdinals()).To(HaveLen(0),
 			"all three IPs no longer Allocated")
 


### PR DESCRIPTION
Map indexing returns `found` not `ok`, with the opposite boolean sense. But indexing also returns the zero value when the map key does not exist, which happens to be useful here.

Fixes a bug identified in #12508.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fix incorrect IPAM handle counting on release. 
```
