### PR TITLE
Skip allocs with seq number conflicts in releaseByHandle

### DIFF
--- a/libcalico-go/lib/ipam/ipam_block.go
+++ b/libcalico-go/lib/ipam/ipam_block.go
@@ -438,6 +438,10 @@ func sanitizeHandle(handleID string) string {
 	return strings.Split(handleID, "\r")[0]
 }
 
+// Release all allocations with the handle in opts.
+//
+// If opts.SequenceNumber is set, and any affected allocations' sequence numbers
+// do not match, those allocations are not released.
 func (b *allocationBlock) releaseByHandle(opts ReleaseOptions) int {
 	handleID := opts.Handle
 	attrIndexes := b.attributeIndexesByHandle(handleID)
@@ -450,23 +454,33 @@ func (b *allocationBlock) releaseByHandle(opts ReleaseOptions) int {
 
 	// There are addresses to release.
 	ordinals := []int{}
+	keepAttrs := make([]bool, len(b.Attributes))
 	var o int
 	for o = 0; o < b.NumAddresses(); o++ {
 		// Only check allocated ordinals.
-		if b.Allocations[o] != nil && intInSlice(*b.Allocations[o], attrIndexes) {
-			if opts.SequenceNumber != nil && *opts.SequenceNumber != b.GetSequenceNumberForOrdinal(o) {
-				f := log.Fields{"opts": opts, "ip": b.OrdinalToIP(o).String()}
-				log.WithFields(f).Warnf("Skipping release of IP with mismatched sequence number")
+		if b.Allocations[o] == nil {
+			continue
+		}
+
+		attrIndex := *b.Allocations[o]
+		if intInSlice(attrIndex, attrIndexes) {
+			if opts.SequenceNumber == nil || *opts.SequenceNumber == b.GetSequenceNumberForOrdinal(o) {
+				// Release this ordinal.
+				ordinals = append(ordinals, o)
 				continue
 			}
-
-			// Release this ordinal.
-			ordinals = append(ordinals, o)
 		}
+		keepAttrs[attrIndex] = true
 	}
 
-	// Clean and reorder attributes.
-	b.deleteAttributes(attrIndexes)
+	// Clean and reorder now-unused attributes.
+	deleteIndexes := make([]int, 0, len(attrIndexes))
+	for _, attrIndex := range attrIndexes {
+		if !keepAttrs[attrIndex] {
+			deleteIndexes = append(deleteIndexes, attrIndex)
+		}
+	}
+	b.deleteAttributes(deleteIndexes)
 
 	// Release the addresses.
 	for _, o := range ordinals {

--- a/libcalico-go/lib/ipam/ipam_block_test.go
+++ b/libcalico-go/lib/ipam/ipam_block_test.go
@@ -315,18 +315,21 @@ var _ = Describe("Releasing IPs by Handle", func() {
 	})
 
 	It("skips removal if the sequence numbers do not match", func() {
-		Skip("Currently failing: leaks the IP")
-
 		block := makeTestBlock()
-		block.allocate([]int{15}, "fifteen")
+		block.allocate([]int{15}, "teens")
+		block.allocate([]int{16}, "teens")
+		block.allocate([]int{17, 18}, "teens")
 		block.SequenceNumberForAllocation["15"] = 10
+		block.SequenceNumberForAllocation["16"] = 10
+		block.SequenceNumberForAllocation["17"] = 999 // not removed
+		block.SequenceNumberForAllocation["18"] = 10
 
 		released := block.releaseByHandle(ReleaseOptions{
-			Handle:         "fifteen",
-			SequenceNumber: new(uint64(999)),
+			Handle:         "teens",
+			SequenceNumber: new(uint64(10)),
 		})
-		Expect(released).To(Equal(0))
-		Expect(block.allocatedOrdinals()).To(Equal([]int{15}), "allocation not affected")
+		Expect(released).To(Equal(3))
+		Expect(block.allocatedOrdinals()).To(Equal([]int{17}), "mismatched allocation not freed")
 
 		block.validate()
 	})


### PR DESCRIPTION
The existing implementation deleted the affected allocations but did not add them to `Deallocated`. Note that no current callers of this method pass a non-nil ReleaseOptions#SequenceNumber, and that this behavior is different from allocationBlock#release, which returns an error if any sequence numbers differ.

Fixes a bug identified in #12508. This is an alternative fix to the [one I proposed initially](https://github.com/projectcalico/calico/compare/master...djmitche:calico:push-xllllxwswqqn?expand=1), based on Slack conversations.

```release-note
IPAM: Fix potential early release of IP attributes.
```