### PR TITLE
fix(windows): add -s -w linker flags to Windows binary build functions

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -214,7 +214,7 @@ define build_windows_binary
 		-e GOARCH=amd64 \
 		-e GOOS=windows \
 		$(CALICO_BUILD) \
-		sh -c '$(GIT_CONFIG_SSH) go build -o $(2) -v -buildvcs=false -ldflags "$(LDFLAGS)" $(1)'
+		sh -c '$(GIT_CONFIG_SSH) go build -o $(2) -v -buildvcs=false -ldflags "$(LDFLAGS) -s -w" $(1)'
 endef
 
 # Images used in build / test across multiple directories.


### PR DESCRIPTION
Restore stripped/no-DWARF linker flags to build_cgo_windows_binary and build_windows_binary in lib.Makefile, consistent with all other build functions. Also reduces binary size significantly.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
