### PR TITLE
fix(aso): wait for containerd installation before proceeding in setup-node.sh

### DIFF
--- a/process/testing/aso/linux/setup-node.sh
+++ b/process/testing/aso/linux/setup-node.sh
@@ -28,27 +28,23 @@ SYSCTL
 
 sudo sysctl --system || true # ignore errors from unrelated sysctl params in the base image
 
-# Wait for containerd to be installed (the VM extension may still be running)
-echo "Waiting for containerd to be installed..."
-for i in $(seq 1 30); do
-  if command -v containerd &> /dev/null; then
-    break
+# Wait for containerd to be fully configured (the VM extension may still be running)
+echo "Waiting for containerd to be installed and configured..."
+for i in $(seq 1 31); do
+  if command -v containerd &> /dev/null && [ -f /etc/containerd/config.toml ]; then
+    if ! command -v systemctl &> /dev/null || systemctl is-active --quiet containerd; then
+      break
+    fi
   fi
-  if [ "$i" -eq 30 ]; then
-    echo "ERROR: containerd is not installed after 5 minutes!"
-    echo "Please ensure the VM extension in vmss-linux.yaml has installed containerd."
+  if [ "$i" -eq 31 ]; then
+    echo "ERROR: containerd is not installed after 5 minutes"
+    echo "Please ensure the VM extension in vmss-linux.yaml has installed containerd, created /etc/containerd/config.toml, and started the containerd service."
     exit 1
   fi
   sleep 10
 done
 
 echo "Containerd found: $(containerd --version)"
-
-# Verify containerd configuration
-if [ ! -f /etc/containerd/config.toml ]; then
-  echo "ERROR: containerd config file /etc/containerd/config.toml not found!"
-  exit 1
-fi
 
 # Verify systemd cgroup is enabled
 if ! grep -q "SystemdCgroup = true" /etc/containerd/config.toml; then

--- a/process/testing/aso/linux/setup-node.sh
+++ b/process/testing/aso/linux/setup-node.sh
@@ -28,13 +28,19 @@ SYSCTL
 
 sudo sysctl --system || true # ignore errors from unrelated sysctl params in the base image
 
-# Verify containerd is installed
-echo "Verifying containerd..."
-if ! command -v containerd &> /dev/null; then
-  echo "ERROR: containerd is not installed!"
-  echo "Please ensure the VM extension in vmss-linux.yaml has installed containerd."
-  exit 1
-fi
+# Wait for containerd to be installed (the VM extension may still be running)
+echo "Waiting for containerd to be installed..."
+for i in $(seq 1 30); do
+  if command -v containerd &> /dev/null; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "ERROR: containerd is not installed after 5 minutes!"
+    echo "Please ensure the VM extension in vmss-linux.yaml has installed containerd."
+    exit 1
+  fi
+  sleep 10
+done
 
 echo "Containerd found: $(containerd --version)"
 

--- a/process/testing/aso/linux/setup-node.sh
+++ b/process/testing/aso/linux/setup-node.sh
@@ -31,14 +31,12 @@ sudo sysctl --system || true # ignore errors from unrelated sysctl params in the
 # Wait for containerd to be fully configured (the VM extension may still be running)
 echo "Waiting for containerd to be installed and configured..."
 for i in $(seq 1 31); do
-  if command -v containerd &> /dev/null && [ -f /etc/containerd/config.toml ]; then
-    if ! command -v systemctl &> /dev/null || systemctl is-active --quiet containerd; then
-      break
-    fi
+  if command -v containerd &> /dev/null && [ -f /etc/containerd/config.toml ] && systemctl is-active --quiet containerd; then
+    break
   fi
   if [ "$i" -eq 31 ]; then
-    echo "ERROR: containerd is not installed after 5 minutes"
-    echo "Please ensure the VM extension in vmss-linux.yaml has installed containerd, created /etc/containerd/config.toml, and started the containerd service."
+    echo "ERROR: containerd was not ready after 5 minutes"
+    echo "Please ensure the VM extension in vmss-linux.yaml has installed containerd, created /etc/containerd/config.toml and started the containerd service."
     exit 1
   fi
   sleep 10


### PR DESCRIPTION
The CustomScript VM extension that installs containerd may still be running when setup-node.sh starts over SSH. Retry for up to 5 minutes instead of failing immediately.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
