### PR TITLE
Cherry-pick e2e go-build wrapper fixes to release-v3.32

### DIFF
--- a/.semaphore/end-to-end/scripts/body_standard.sh
+++ b/.semaphore/end-to-end/scripts/body_standard.sh
@@ -91,11 +91,11 @@ else
 
     if [[ -n "$RUN_LOCAL_TESTS" ]]; then
       echo "[INFO] starting e2e testing from local binary..."
-      pushd ${HOME}/calico
-      make -C e2e build |& tee >(gzip --stdout > ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz)
+      pushd "${HOME}/calico"
+      make -C e2e build |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
       GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
       docker run --rm --init --net=host \
-        -e LOCAL_USER_ID=$(id -u) \
+        -e LOCAL_USER_ID="$(id -u)" \
         -e GOCACHE=/go-cache \
         -e GOPATH=/go \
         -e KUBECONFIG=/kubeconfig \
@@ -109,12 +109,12 @@ else
         -e ENCAPSULATION_TYPE \
         -e WINDOWS_OS \
         -e USE_VENDORED_CNI \
-        -v $(pwd):/go/src/github.com/projectcalico/calico:rw \
-        -v $(pwd)/.go-pkg-cache:/go-cache:rw \
-        -v ${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro \
+        -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
+        -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
+        -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
         -w /go/src/github.com/projectcalico/calico \
-        calico/go-build:${GO_BUILD_VER} \
-        go run github.com/onsi/ginkgo/v2/ginkgo -procs=${E2E_PROCS:-4} ./e2e/bin/k8s/e2e.test -- ${K8S_E2E_FLAGS} |& tee -a >(gzip --stdout > ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz)
+        "calico/go-build:${GO_BUILD_VER}" \
+        go run github.com/onsi/ginkgo/v2/ginkgo -procs="${E2E_PROCS:-4}" ./e2e/bin/k8s/e2e.test -- "${K8S_E2E_FLAGS}" |& tee -a >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
       popd
     else
       echo "[INFO] starting bz testing..."

--- a/.semaphore/end-to-end/scripts/body_standard.sh
+++ b/.semaphore/end-to-end/scripts/body_standard.sh
@@ -94,6 +94,8 @@ else
       pushd "${HOME}/calico"
       make -C e2e build |& tee >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
       GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
+      # Disable shellcheck double quote validation for ${K8S_E2E_FLAGS} as this var can contain multiple args and should be word split
+      #shellcheck disable=SC2086
       docker run --rm --init --net=host \
         -e LOCAL_USER_ID="$(id -u)" \
         -e GOCACHE=/go-cache \
@@ -114,7 +116,7 @@ else
         -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
         -w /go/src/github.com/projectcalico/calico \
         "calico/go-build:${GO_BUILD_VER}" \
-        go run github.com/onsi/ginkgo/v2/ginkgo -procs="${E2E_PROCS:-4}" ./e2e/bin/k8s/e2e.test -- "${K8S_E2E_FLAGS}" |& tee -a >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
+        go run github.com/onsi/ginkgo/v2/ginkgo -procs="${E2E_PROCS:-4}" ./e2e/bin/k8s/e2e.test -- ${K8S_E2E_FLAGS} |& tee -a >(gzip --stdout > "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz")
       popd
     else
       echo "[INFO] starting bz testing..."

--- a/.semaphore/end-to-end/scripts/body_standard.sh
+++ b/.semaphore/end-to-end/scripts/body_standard.sh
@@ -93,7 +93,28 @@ else
       echo "[INFO] starting e2e testing from local binary..."
       pushd ${HOME}/calico
       make -C e2e build |& tee >(gzip --stdout > ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz)
-      KUBECONFIG=${BZ_LOCAL_DIR}/kubeconfig PRODUCT=calico go run github.com/onsi/ginkgo/v2/ginkgo -procs=${E2E_PROCS:-4} ./e2e/bin/k8s/e2e.test -- ${K8S_E2E_FLAGS} |& tee -a >(gzip --stdout > ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz)
+      GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ${HOME}/calico-private/metadata.mk | cut -d= -f2)
+      docker run --rm --init --net=host \
+        -e LOCAL_USER_ID=$(id -u) \
+        -e GOCACHE=/go-cache \
+        -e GOPATH=/go \
+        -e KUBECONFIG=/kubeconfig \
+        -e PRODUCT=calico \
+        -e CREATE_WINDOWS_NODES \
+        -e FUNCTIONAL_AREA \
+        -e INSTALLER \
+        -e PROVISIONER \
+        -e K8S_VERSION \
+        -e DATAPLANE \
+        -e ENCAPSULATION_TYPE \
+        -e WINDOWS_OS \
+        -e USE_VENDORED_CNI \
+        -v ${HOME}/calico-private:/go/src/github.com/projectcalico/calico:rw \
+        -v ${HOME}/calico-private/.go-pkg-cache:/go-cache:rw \
+        -v ${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro \
+        -w /go/src/github.com/projectcalico/calico \
+        calico/go-build:${GO_BUILD_VER} \
+        go run github.com/onsi/ginkgo/v2/ginkgo -procs=${E2E_PROCS:-4} ./e2e/bin/k8s/e2e.test -- ${K8S_E2E_FLAGS} |& tee -a >(gzip --stdout > ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz)
       popd
     else
       echo "[INFO] starting bz testing..."

--- a/.semaphore/end-to-end/scripts/body_standard.sh
+++ b/.semaphore/end-to-end/scripts/body_standard.sh
@@ -93,7 +93,7 @@ else
       echo "[INFO] starting e2e testing from local binary..."
       pushd ${HOME}/calico
       make -C e2e build |& tee >(gzip --stdout > ${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log.gz)
-      GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ${HOME}/calico-private/metadata.mk | cut -d= -f2)
+      GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
       docker run --rm --init --net=host \
         -e LOCAL_USER_ID=$(id -u) \
         -e GOCACHE=/go-cache \
@@ -109,8 +109,8 @@ else
         -e ENCAPSULATION_TYPE \
         -e WINDOWS_OS \
         -e USE_VENDORED_CNI \
-        -v ${HOME}/calico-private:/go/src/github.com/projectcalico/calico:rw \
-        -v ${HOME}/calico-private/.go-pkg-cache:/go-cache:rw \
+        -v $(pwd):/go/src/github.com/projectcalico/calico:rw \
+        -v $(pwd)/.go-pkg-cache:/go-cache:rw \
         -v ${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro \
         -w /go/src/github.com/projectcalico/calico \
         calico/go-build:${GO_BUILD_VER} \


### PR DESCRIPTION
Cherry-pick of four commits from master that fix `go: command not found` errors in `release-v3.32` e2e CI jobs. Without these, `body_standard.sh` calls `go run .../ginkgo ...` directly on the Semaphore host, which has no Go installed - the fix wraps the invocation in `docker run calico/go-build`.

Originally landed in #12097 and #12248.

```release-note
None
```