### PR TITLE
Add zapDevel value to tigera-operator helm chart

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -67,6 +67,7 @@ spec:
           args:
             # Configure tigera-operator to manage installation of the necessary CRDs.
             - -manage-crds={{ .Values.manageCRDs }}
+            - -zap-devel={{ .Values.zapDevel }}
           volumeMounts:
             - name: var-lib-calico
               readOnly: true

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -113,6 +113,11 @@ certs:
 # needed to run itself and Calico. If disabled, you must manage these resources out-of-band.
 manageCRDs: true
 
+# Whether to run the tigera/operator in zap development logging mode. When true, the operator
+# logs at debug level using a human-readable console encoder and emits stacktraces on warnings.
+# Intended for development and debugging; leave disabled in production.
+zapDevel: false
+
 # Resource requests and limits for the tigera/operator pod.
 resources: {}
 
@@ -144,6 +149,7 @@ podLabels: {}
 
 # Custom DNS configuration for the tigera/operator pod.
 dnsConfig: {}
+
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator

--- a/hack/test/kind/infra/values.yaml
+++ b/hack/test/kind/infra/values.yaml
@@ -148,6 +148,10 @@ defaultFelixConfiguration:
 # CRDs are installed by `make kind-cluster-create` in lib.Makefile ($(KUBECTL) create -f $(REPO_ROOT)/libcalico-go/config/crd;)
 manageCRDs: false
 
+# Enable zap development logging for the tigera/operator in CI so test failures surface debug-level
+# operator logs and stacktraces on warnings.
+zapDevel: true
+
 # Configuration for the tigera operator
 tigeraOperator:
   image: tigera/operator

--- a/manifests/ocp/02-tigera-operator.yaml
+++ b/manifests/ocp/02-tigera-operator.yaml
@@ -39,6 +39,7 @@ spec:
           args:
             # Configure tigera-operator to manage installation of the necessary CRDs.
             - -manage-crds=true
+            - -zap-devel=false
           volumeMounts:
             - name: var-lib-calico
               readOnly: true

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -808,6 +808,7 @@ spec:
           args:
             # Configure tigera-operator to manage installation of the necessary CRDs.
             - -manage-crds=true
+            - -zap-devel=false
           volumeMounts:
             - name: var-lib-calico
               readOnly: true

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -740,6 +740,7 @@ spec:
           args:
             # Configure tigera-operator to manage installation of the necessary CRDs.
             - -manage-crds=true
+            - -zap-devel=false
           volumeMounts:
             - name: var-lib-calico
               readOnly: true


### PR DESCRIPTION
Adds a `zapDevel` value to the tigera-operator helm chart (default `false`) which plumbs through to the operator's `-zap-devel` flag. When true, the operator runs in zap development logging mode: debug-level logs via a human-readable console encoder and stacktraces on warnings. Useful for development and CI debugging.

Also turns it on in the kind CI overlay (`hack/test/kind/infra/values.yaml`) so failing CI runs surface debug-level operator logs.

```release-note
HELM: Added a `zapDevel` value to the tigera-operator chart for enabling development-mode logging on the operator.
```