### PR TITLE
LB ipam wait for full allocation block context

### DIFF
--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -422,6 +422,21 @@ func (c *loadBalancerController) ensureDatastoreUpgraded() error {
 // - Updates the controllers internal state tracking of which IP addresses are allocated.
 // - Updates the IP addresses in the Service Status to match the IPAM DB.
 func (c *loadBalancerController) syncService(svcKey serviceKey) {
+	if c.syncStatus != bapi.InSync {
+		// Defer service sync until the syncer has replayed all existing IPAM blocks
+		// into allocationTracker. Otherwise a service event observed during the cold-start
+		// window would see an empty tracker and allocate a fresh IP alongside the historical
+		// one that arrives later, leaving the service with more IPs than its IPFamilyPolicy
+		// permits. Events received pre-InSync are picked up by syncIPAM, which is kicked
+		// once the syncer reaches InSync.
+		log.WithFields(log.Fields{
+			"status":    c.syncStatus,
+			"namespace": svcKey.namespace,
+			"name":      svcKey.name,
+		}).Debug("Syncer not yet InSync; deferring service sync")
+		return
+	}
+
 	if len(c.ipPools) == 0 {
 		if _, ok := c.allocationTracker.ipsByService[svcKey]; ok {
 			// Last LoadBalancer IPPool was deleted, and we have previously assigned IPs to this service. We need to release the IPs now and update the service status

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -972,6 +972,11 @@ func poolContains(ipAddr string, cidrs []cnet.IPNet) bool {
 		return false
 	}
 	ip := net.ParseIP(ipAddr)
+	if ip == nil {
+		// Invalid IP address, cannot be in any pool
+		log.Warnf("Invalid IP address encountered in IPAM allocation tracker: %q (treating as not in any pool)", ipAddr)
+		return false
+	}
 	for _, cidr := range cidrs {
 		if cidr.Contains(ip) {
 			return true

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -538,4 +538,40 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cli.IPAMUpgradeCallCount()).To(Equal(2))
 	})
+
+	It("should handle invalid IP addresses in allocation tracker without panicking", func() {
+		svcKey, err := serviceKeyFromService(&svc)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Add an invalid IP address to the allocation tracker
+		c.allocationTracker.assignAddressToService(*svcKey, "invalid-ip-address")
+
+		// Create a service with pool annotations to trigger the problematic code path
+		svc.Annotations = map[string]string{
+			annotationIPv4Pools: "[\"10.0.0.0/24\"]",
+		}
+
+		// Add a valid IP pool to the controller
+		ipv4Pool := apiv3.IPPool{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pool",
+			},
+			Spec: apiv3.IPPoolSpec{
+				CIDR:        "10.0.0.0/24",
+				AllowedUses: []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseLoadBalancer},
+			},
+		}
+		c.ipPools["test-pool"] = ipv4Pool
+
+		// Create the service in the fake client
+		_, err = c.clientSet.CoreV1().Services(svc.Namespace).Create(context.Background(), &svc, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// This should not panic even with invalid IP in allocation tracker
+		// The syncService method should handle invalid IPs gracefully
+		Expect(func() {
+			c.syncService(*svcKey)
+		}).ToNot(Panic())
+	})
 })

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectcalico/calico/kube-controllers/pkg/config"
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/node"
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/utils"
+	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -543,6 +544,9 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		svcKey, err := serviceKeyFromService(&svc)
 		Expect(err).ToNot(HaveOccurred())
 
+		// syncService is guarded on the syncer being InSync; mark it so the body runs.
+		c.syncStatus = bapi.InSync
+
 		// Add an invalid IP address to the allocation tracker
 		c.allocationTracker.assignAddressToService(*svcKey, "invalid-ip-address")
 
@@ -573,5 +577,56 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		Expect(func() {
 			c.syncService(*svcKey)
 		}).ToNot(Panic())
+	})
+
+	// Service event observed before the syncer has replayed historical
+	// IPAM blocks into allocationTracker must not trigger an IP allocation. Otherwise
+	// a freshly allocated IP and a later-arriving historical IP both land in the
+	// tracker and the service's status ends up with more IPs than its IPFamilyPolicy allows.
+	It("should defer syncService until InSync and pick up work once the syncer catches up", func() {
+		svcKey, err := serviceKeyFromService(&svc)
+		Expect(err).ToNot(HaveOccurred())
+
+		ipv4Pool := apiv3.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
+			Spec: apiv3.IPPoolSpec{
+				CIDR:        "10.0.0.0/24",
+				AllowedUses: []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseLoadBalancer},
+			},
+		}
+		c.ipPools["test-pool"] = ipv4Pool
+
+		created, err := c.clientSet.CoreV1().Services(svc.Namespace).Create(context.Background(), &svc, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(created.Status.LoadBalancer.Ingress).To(BeEmpty())
+		// serviceLister reads from the informer's indexer; seed it directly so tests
+		// don't race the informer's watch.
+		Expect(c.serviceInformer.GetIndexer().Add(created)).To(Succeed())
+
+		// Phase 1: pre-InSync. The guard must short-circuit so no allocation or status
+		// write happens on a service event observed before the syncer has replayed IPAM.
+		Expect(c.syncStatus).ToNot(Equal(bapi.InSync))
+
+		c.syncService(*svcKey)
+
+		Expect(c.allocationTracker.ipsByService[*svcKey]).To(BeEmpty())
+		fetched, err := c.clientSet.CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetched.Status.LoadBalancer.Ingress).To(BeEmpty())
+
+		// Phase 2: syncer reaches InSync. handleBlockUpdate has by now populated the
+		// tracker with the service's historical IP, so syncService should observe the
+		// existing allocation, skip assignment, and write the IP to the service status.
+		c.allocationTracker.assignAddressToService(*svcKey, "10.0.0.4")
+		c.syncStatus = bapi.InSync
+
+		c.syncService(*svcKey)
+
+		Expect(c.allocationTracker.ipsByService[*svcKey]).To(HaveLen(1))
+		Expect(c.allocationTracker.ipsByService[*svcKey]).To(HaveKey("10.0.0.4"))
+		fetched, err = c.clientSet.CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetched.Status.LoadBalancer.Ingress).To(HaveLen(1))
+		Expect(fetched.Status.LoadBalancer.Ingress[0].IP).To(Equal("10.0.0.4"))
 	})
 })

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller_ut_test.go
@@ -587,11 +587,13 @@ var _ = Describe("LoadBalancer controller UTs", func() {
 		svcKey, err := serviceKeyFromService(&svc)
 		Expect(err).ToNot(HaveOccurred())
 
+		automatic := apiv3.Automatic
 		ipv4Pool := apiv3.IPPool{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
 			Spec: apiv3.IPPoolSpec{
-				CIDR:        "10.0.0.0/24",
-				AllowedUses: []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseLoadBalancer},
+				CIDR:           "10.0.0.0/24",
+				AllowedUses:    []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseLoadBalancer},
+				AssignmentMode: &automatic,
 			},
 		}
 		c.ipPools["test-pool"] = ipv4Pool


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Fixes a cold-start race where SingleStack LoadBalancer services could end up with multiple IPv4 addresses. On kube-controllers pod restart, the informer can deliver a Service event to syncService before the Calico syncer has replayed historical IPAM blocks into allocationTracker. With the tracker empty, needsIPsAssigned returns true and assignIP allocates a fresh IP. Shortly after, handleBlockUpdate replays the service's existing historical IP into the tracker. The tracker now holds two IPs; assignIP short-circuits on re-entry because a same-family IP is present, no release path fires, and updateServiceStatus writes both IPs to Status.LoadBalancer.Ingress.

Fixes https://github.com/projectcalico/calico/issues/12503

Pick of https://github.com/projectcalico/calico/pull/12567
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fix LoadBalancer IPAM race on kube-controllers startup that could assign multiple addresses to a Service.
```
