### PR TITLE
Fix incorrect comment on IPAM release behavour.

### DIFF
--- a/libcalico-go/lib/ipam/ipam_block.go
+++ b/libcalico-go/lib/ipam/ipam_block.go
@@ -255,9 +255,9 @@ func (b allocationBlock) inUseIPs() []string {
 	return ips
 }
 
-// release tries to release addresses matching the release options, on success, returns
-// slice of IPs that were released, map from handle ID to count of IPs released
-// for that handle.
+// release tries to release addresses matching the release options, on success,
+// returns slice of IPs that were *skipped* due to not being allocated and a
+// map from handle ID to count of IPs released for that handle.
 func (b *allocationBlock) release(addresses []ReleaseOptions) ([]cnet.IP, map[string]int, error) {
 	// Store return values.
 	unallocated := []cnet.IP{}


### PR DESCRIPTION
Fix incorrect comment on IPAM release behavour.

`release()` returns the IPs that were skipped, not the IPs that were released.