### PR TITLE
Address post-merge review feedback from PR #11977

### DIFF
--- a/felix/calc/config_batcher.go
+++ b/felix/calc/config_batcher.go
@@ -177,7 +177,11 @@ func (cb *ConfigBatcher) onFelixConfigResourceUpdate(name string, update api.Upd
 			log.WithError(err).WithFields(log.Fields{
 				"name":     name,
 				"selector": selectorStr,
-			}).Warn("Failed to parse nodeSelector on FelixConfiguration, ignoring")
+			}).Warn("Failed to parse nodeSelector on FelixConfiguration, removing selector-scoped config")
+			if _, existed := cb.selectorConfigs[name]; existed {
+				delete(cb.selectorConfigs, name)
+				cb.configDirty = true
+			}
 			return
 		}
 	}

--- a/felix/calc/config_batcher_test.go
+++ b/felix/calc/config_batcher_test.go
@@ -412,6 +412,30 @@ var _ = Describe("ConfigBatcher", func() {
 				Expect(recorder.Updates[0].selector).To(BeEmpty())
 			})
 		})
+
+		Context("when a previously-valid selector is updated to an invalid one", func() {
+			BeforeEach(func() {
+				fc := apiv3.NewFelixConfiguration()
+				fc.Name = "flip-selector"
+				fc.Spec.NodeSelector = stringPtr("role == 'gpu'")
+				enabled := true
+				fc.Spec.BPFEnabled = &enabled
+				sendFelixConfigResource("flip-selector", fc)
+				cb.OnDatamodelStatus(api.InSync)
+
+				// Now update the same resource with an invalid selector.
+				fc2 := apiv3.NewFelixConfiguration()
+				fc2.Name = "flip-selector"
+				fc2.Spec.NodeSelector = stringPtr("invalid @@@ selector")
+				fc2.Spec.BPFEnabled = &enabled
+				sendFelixConfigResource("flip-selector", fc2)
+			})
+			It("should clear the previous selector config", func() {
+				Expect(recorder.Updates).To(HaveLen(2))
+				Expect(recorder.Updates[0].selector).To(HaveKeyWithValue("BPFEnabled", "true"))
+				Expect(recorder.Updates[1].selector).To(BeEmpty())
+			})
+		})
 	})
 })
 

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -997,7 +997,8 @@ func loadConfigFromDatastore(
 
 // loadSelectorScopedFelixConfig lists all FelixConfiguration resources, finds
 // selector-scoped ones (name not "default" and not "node.*"), evaluates their
-// nodeSelector against this node's labels, and merges all matching configs.
+// nodeSelector against this node's labels, and returns the config from the
+// single winning match (the oldest by creation time).
 func loadSelectorScopedFelixConfig(
 	ctx context.Context, client bapi.Client, hostname string,
 ) (map[string]string, error) {

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Test the generic configuration update processor and the concre
 		Kind: apiv3.KindFelixConfiguration,
 		Name: "default",
 	}
-	invalidFelixKey := model.ResourceKey{
+	selectorScopedFelixKey := model.ResourceKey{
 		Kind: apiv3.KindFelixConfiguration,
 		Name: "foobar",
 	}
@@ -182,20 +182,20 @@ var _ = Describe("Test the generic configuration update processor and the concre
 
 		By("Testing selector-scoped name passes through on Process with add/mod")
 		selectorKvps, err := cc.Process(&model.KVPair{
-			Key:   invalidFelixKey,
+			Key:   selectorScopedFelixKey,
 			Value: apiv3.NewFelixConfiguration(),
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(selectorKvps).To(HaveLen(1))
-		Expect(selectorKvps[0].Key).To(Equal(invalidFelixKey))
+		Expect(selectorKvps[0].Key).To(Equal(selectorScopedFelixKey))
 
 		By("Testing selector-scoped name passes through on Process with delete")
 		selectorKvps, err = cc.Process(&model.KVPair{
-			Key: invalidFelixKey,
+			Key: selectorScopedFelixKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(selectorKvps).To(HaveLen(1))
-		Expect(selectorKvps[0].Key).To(Equal(invalidFelixKey))
+		Expect(selectorKvps[0].Key).To(Equal(selectorScopedFelixKey))
 	})
 
 	It("should handle different field types being assigned", func() {

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
@@ -32,7 +32,7 @@ import (
 // FelixValueConverters maps FelixConfigurationSpec field names to their
 // special-case value converter functions. These are needed both by the
 // configUpdateProcessor (for v1 config decomposition) and by
-// ExtractConfigFromFelixSpec (for selector-scoped config extraction).
+// ExtractFelixConfigFields (for selector-scoped config extraction).
 var FelixValueConverters = map[string]ConfigFieldValueToV1ModelValue{
 	"FailsafeInboundHostPorts":  protoPortSliceToString,
 	"FailsafeOutboundHostPorts": protoPortSliceToString,


### PR DESCRIPTION
Follow-up to #11977 addressing review feedback surfaced on the downstream cherry-pick.

## Changes

- **`felix/daemon/daemon.go`**: Fix stale doc comment on `loadSelectorScopedFelixConfig`. The function returns the single winning match (oldest by creation time), not "all matching configs".
- **`libcalico-go/.../felixconfigprocessor.go`**: Fix stale function name in comment (`ExtractConfigFromFelixSpec` → `ExtractFelixConfigFields`).
- **`libcalico-go/.../configurationprocessor_test.go`**: Rename `invalidFelixKey` → `selectorScopedFelixKey` to match its current use as a *valid* selector-scoped FelixConfiguration. The name dates from before the PR started treating these as valid.
- **`felix/calc/config_batcher.go`**: Fix a real bug — when a selector-scoped FelixConfiguration's `nodeSelector` parse fails in `onFelixConfigResourceUpdate`, the handler previously returned without clearing any existing entry for that resource. An update that made a previously-valid selector invalid would leave the old selector/config in place and keep applying it. Now the existing entry is removed and `configDirty` is set so the config is re-evaluated. Added unit test covering the valid-then-invalid transition.

## Release note

```release-note
NONE
```
