### PR TITLE
Reduce two Felix FV flakes

### DIFF
--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -516,13 +516,15 @@ func mustInitDatastore(client client.Interface) {
 
 func AssignIP(workload, addr, hostname string, client client.Interface) {
 	// Assign the workload's IP in IPAM, this will trigger calculation of routes.
-	err := client.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-		IP:       cnet.MustParseIP(addr),
-		HandleID: &workload,
-		Attrs: map[string]string{
-			ipam.AttributeNode: hostname,
-		},
-		Hostname: hostname,
-	})
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	// Retry briefly to ride out transient API server errors under CI load.
+	EventuallyWithOffset(1, func() error {
+		return client.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+			IP:       cnet.MustParseIP(addr),
+			HandleID: &workload,
+			Attrs: map[string]string{
+				ipam.AttributeNode: hostname,
+			},
+			Hostname: hostname,
+		})
+	}, "10s", "500ms").ShouldNot(HaveOccurred())
 }

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -420,14 +420,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 								node, err := client.Nodes().Get(context.Background(), felix.Hostname, options.GetOptions{})
 								Expect(err).NotTo(HaveOccurred())
 								return node.Status.WireguardPublicKey
-							}, "5s", "100ms").ShouldNot(BeEmpty())
+							}, "10s", "100ms").ShouldNot(BeEmpty())
 						}
 						if wireguardEnabledV6 {
 							Eventually(func() string {
 								node, err := client.Nodes().Get(context.Background(), felix.Hostname, options.GetOptions{})
 								Expect(err).NotTo(HaveOccurred())
 								return node.Status.WireguardPublicKeyV6
-							}, "5s", "100ms").ShouldNot(BeEmpty())
+							}, "10s", "100ms").ShouldNot(BeEmpty())
 						}
 					}
 				})


### PR DESCRIPTION
Two flakes seen under CI load.

The `WireGuard-Supported ... should contain public-keys` test times out at 5s waiting for `node.Status.WireguardPublicKey` to show up. Bumped to 10s - every other `Eventually` in the surrounding BeforeEach already uses 10s.

`AssignIP` fails the whole test on a single `http: Handler timeout` (usually after an API server 429 storm during BeforeEach setup). Wrapped in a short `Eventually` so it rides out transient errors.

```release-note
None
```