### PR TITLE
Wait for CRDs to be Established in kube-controllers FV ApplyCRDs

### DIFF
--- a/kube-controllers/tests/testutils/utils.go
+++ b/kube-controllers/tests/testutils/utils.go
@@ -108,13 +108,13 @@ func ApplyCRDs(apiserver *containers.Container) {
 	// see a NoKindMatchError from the controller-runtime RESTMapper. Wait for all
 	// CRDs to report Established before returning.
 	waitEstablished := func() error {
-		out, err := apiserver.ExecOutput("kubectl", "wait", "--for=condition=Established", "--all", "crds", "--timeout=30s")
+		out, err := apiserver.ExecOutput("kubectl", "wait", "--for=condition=Established", "--all", "crds", "--timeout=5s")
 		if err != nil {
 			return fmt.Errorf("%s: %s", err, out)
 		}
 		return nil
 	}
-	EventuallyWithOffset(1, waitEstablished, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	EventuallyWithOffset(1, waitEstablished, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
 func RunK8sApiserver(etcdIp string) *containers.Container {

--- a/kube-controllers/tests/testutils/utils.go
+++ b/kube-controllers/tests/testutils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017,2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2019,2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,6 +101,20 @@ func ApplyCRDs(apiserver *containers.Container) {
 		return nil
 	}
 	EventuallyWithOffset(1, apply, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+	// kubectl apply returns as soon as the API server accepts each CRD object, but
+	// the apiserver needs additional time to register the CRD's API in discovery.
+	// Tests that hit the new CRD immediately race against that registration and can
+	// see a NoKindMatchError from the controller-runtime RESTMapper. Wait for all
+	// CRDs to report Established before returning.
+	waitEstablished := func() error {
+		out, err := apiserver.ExecOutput("kubectl", "wait", "--for=condition=Established", "--all", "crds", "--timeout=30s")
+		if err != nil {
+			return fmt.Errorf("%s: %s", err, out)
+		}
+		return nil
+	}
+	EventuallyWithOffset(1, waitEstablished, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
 func RunK8sApiserver(etcdIp string) *containers.Container {


### PR DESCRIPTION
The `policy name migration tests (kdd mode)` have been flaking with `no matches for kind "StagedNetworkPolicy" in version "crd.projectcalico.org/v1"`. The same race affects every kdd-mode test that uses `testutils.ApplyCRDs`.

`kubectl apply -f /crds/` returns as soon as the apiserver accepts each CRD object, but discovery registration happens asynchronously. The controller-runtime `crdClient` is constructed before `ApplyCRDs` runs, so when a test immediately calls `Create` on the new resource, its RESTMapper races the apiserver and returns `NoKindMatchError`.

Wait for all CRDs to report `Established` before `ApplyCRDs` returns. Same approach as in https://github.com/projectcalico/calico/pull/12225, pulled out as a targeted fix.

```release-note
None
```