### PR TITLE
fix(release): Reduce transient disk usage in hashrelease build

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1108,14 +1108,15 @@ func (r *CalicoManager) buildReleaseTar() error {
 		// Felix binaries.
 		"felix/bin/calico-bpf": binDir,
 	}
+	// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
 	for src, dst := range binaries {
-		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-r", src, dst}, nil); err != nil {
+		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
 			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
 		}
 	}
 
 	// Add in manifests directory generated from the docs.
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-r", "manifests", releaseBase}, nil); err != nil {
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
 		return fmt.Errorf("failed to copy manifests: %w", err)
 	}
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -578,18 +578,22 @@ func (r *CalicoManager) buildHelmIndex(chartDir, chartURL string) error {
 		return fmt.Errorf("download previous helm index from %s: %w", indexURL, err)
 	}
 
-	// Create tmp directory for building index and copy chart there.
+	// Create tmp directory for building index and hard-link charts there.
 	tmpChartsDir := filepath.Join(filepath.Dir(r.uploadDir()), fmt.Sprintf("charts-%s", r.helmChartVersion()))
 	if err := os.MkdirAll(tmpChartsDir, utils.DirPerms); err != nil {
 		return fmt.Errorf("create temp dir for building helm index: %w", err)
 	}
+	defer func() {
+		if err := os.RemoveAll(tmpChartsDir); err != nil {
+			logrus.WithError(err).Warnf("failed to remove helm index staging dir %s", tmpChartsDir)
+		}
+	}()
 
-	// Copy charts to temp dir.
 	for _, chart := range utils.AllReleaseCharts() {
 		srcChart := filepath.Join(chartDir, fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion()))
 		destChart := filepath.Join(tmpChartsDir, fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion()))
-		if err := utils.CopyFile(srcChart, destChart); err != nil {
-			return fmt.Errorf("error copying %s chart to temp dir for building helm index: %w", chart, err)
+		if err := os.Link(srcChart, destChart); err != nil {
+			return fmt.Errorf("linking %s chart to temp dir for building helm index: %w", chart, err)
 		}
 	}
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1065,7 +1065,13 @@ func (r *CalicoManager) uploadDir() string {
 func (r *CalicoManager) buildReleaseTar() error {
 	baseReleaseOutputDir := filepath.Dir(r.uploadDir())
 	releaseBase := filepath.Join(baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion))
-	releaseTarFilePath := filepath.Join(baseReleaseOutputDir, fmt.Sprintf("release-%s.tgz", r.calicoVersion))
+	releaseTarFilePath := filepath.Join(r.uploadDir(), fmt.Sprintf("release-%s.tgz", r.calicoVersion))
+	// Drop the staging tree once tar has consumed it.
+	defer func() {
+		if err := os.RemoveAll(releaseBase); err != nil {
+			logrus.WithError(err).Warnf("failed to remove release staging dir %s", releaseBase)
+		}
+	}()
 
 	if r.archiveImages {
 		imgDir := filepath.Join(releaseBase, "images")
@@ -1120,12 +1126,8 @@ func (r *CalicoManager) buildReleaseTar() error {
 		return fmt.Errorf("failed to copy manifests: %w", err)
 	}
 
-	// tar up the whole thing, and copy it to the target directory
 	if _, err := r.runner.RunInDir(r.repoRoot, "tar", []string{"-czvf", releaseTarFilePath, "-C", baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion)}, nil); err != nil {
 		return fmt.Errorf("failed to create release tar: %w", err)
-	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{releaseTarFilePath, r.uploadDir()}, nil); err != nil {
-		return fmt.Errorf("failed to copy release tar: %w", err)
 	}
 	return nil
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1143,7 +1143,8 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		return fmt.Errorf("failed to build e2e binaries: %w", err)
 	}
 
-	// Copy the built binaries into the hashrelease output directory.
+	// Hard-link the built binaries into the hashrelease output directory
+	// to avoid duplicating ~1 GB of cross-compiled test binaries on disk.
 	e2eOutputDir := filepath.Join(r.uploadDir(), "files", "e2e")
 	if err := os.MkdirAll(e2eOutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create e2e output dir: %w", err)
@@ -1158,13 +1159,10 @@ func (r *CalicoManager) buildE2EBinaries() error {
 		}
 		src := filepath.Join(e2eDir, "bin", "k8s", entry.Name())
 		dst := filepath.Join(e2eOutputDir, entry.Name())
-		if err := utils.CopyFile(src, dst); err != nil {
-			return fmt.Errorf("copying e2e binary %s: %w", entry.Name(), err)
+		if err := os.Link(src, dst); err != nil {
+			return fmt.Errorf("linking e2e binary %s: %w", entry.Name(), err)
 		}
-		if err := os.Chmod(dst, 0o755); err != nil {
-			return fmt.Errorf("setting permissions on e2e binary %s: %w", entry.Name(), err)
-		}
-		logrus.Infof("Copied e2e binary: %s", entry.Name())
+		logrus.Infof("Staged e2e binary: %s", entry.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

OSS master hashrelease runs on Semaphore `f1-standard-4` VMs (~75 GB disk) have been going out-of-disk intermittently. Investigation showed that several stages of the release `Build()` duplicate multi-GB payloads on disk and leave their staging trees behind until process exit — they accumulate while later `Build()` steps run.

This PR eliminates the duplication without changing what gets published, uploaded to GCS, or attached to the hashrelease:

1. **Hard-link calicoctl/cni/felix binaries and manifests into the release-tar staging dir** instead of copying them. `cp -al` preserves the `cni-plugin/bin/<arch>/calico-ipam -> ./calico` symlinks (plain `-rl` would dereference them into duplicated 86 MB binaries per arch).
2. **Hard-link the cross-compiled e2e test binaries into uploadDir** instead of copying them (~200 MB × 4 arches duplicated).
3. **Write the release tar directly into uploadDir** instead of tarring to a sibling and then `cp`-ing it in, and **remove the `release-X.Y.Z/` staging tree via `defer`** once tar has consumed it — the biggest single win, recovering several GB before `collectGithubArtifacts` runs.
4. **Hard-link helm charts into the helm-index staging dir and clean it up via `defer`.** Small in absolute terms (few MB), but follows the same pattern as (3).

All rely on source and destination living on the same filesystem (both under `repoRoot` / `release/_output/`), which is already the case in CI.

## Related issues / PRs

Internal tracking. DE-4120.

The `buildE2EBinaries` step introduced in 3f46a208 (#12506) made the OOD more reliably reproducible but is not the root cause — the release-tar and helm-index staging patterns pre-date it.

## Release Note

```release-note
N/A
```