### PR TITLE
[release3.32] Sanitize log output (pick 12604)

### DIFF
--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -161,8 +161,6 @@ func computeNamespaceMatch(
 // matchRequest checks if the request part of the Rule matches the request. It returns true if the
 // Rule matches, false otherwise.
 func matchRequest(rule *proto.Rule, req *requestCache) bool {
-	// Do not log the request object, it may contain sensitive HTTP headers and bodies.
-	log.Debug("Matching request.")
 	return matchHTTP(rule.GetHttpMatch(), req.GetHttpMethod(), req.GetHttpPath())
 }
 

--- a/app-policy/checker/match.go
+++ b/app-policy/checker/match.go
@@ -161,7 +161,8 @@ func computeNamespaceMatch(
 // matchRequest checks if the request part of the Rule matches the request. It returns true if the
 // Rule matches, false otherwise.
 func matchRequest(rule *proto.Rule, req *requestCache) bool {
-	log.WithField("request", req).Debug("Matching request.")
+	// Do not log the request object, it may contain sensitive HTTP headers and bodies.
+	log.Debug("Matching request.")
 	return matchHTTP(rule.GetHttpMatch(), req.GetHttpMethod(), req.GetHttpPath())
 }
 

--- a/app-policy/checker/server.go
+++ b/app-policy/checker/server.go
@@ -86,8 +86,13 @@ func (as *authServer) RegisterGRPCServices(gs *grpc.Server) {
 func (as *authServer) Check(ctx context.Context, req *authz.CheckRequest) (*authz.CheckResponse, error) {
 	hostname, _ := os.Hostname()
 	logCtx := log.WithContext(ctx).WithField("hostname", hostname)
+	// Do not log req.Attributes.String() or req.String(), they contain sensitive HTTP
+	// headers (Authorization, Cookie) and request bodies.
 	if logCtx.Logger.IsLevelEnabled(log.DebugLevel) {
-		logCtx.Debug("Check start: ", req.Attributes.String())
+		logCtx.WithFields(log.Fields{
+			"method": req.GetAttributes().GetRequest().GetHttp().GetMethod(),
+			"path":   req.GetAttributes().GetRequest().GetHttp().GetPath(),
+		}).Debug("Check start")
 	}
 
 	resp := &authz.CheckResponse{Status: &status.Status{Code: INTERNAL}}
@@ -152,11 +157,12 @@ func (as *authServer) Check(ctx context.Context, req *authz.CheckRequest) (*auth
 		}
 	})
 
+	// Do not log the full CheckRequest, it may contain sensitive HTTP headers and bodies.
 	if logCtx.Logger.IsLevelEnabled(log.DebugLevel) {
 		logCtx.WithFields(log.Fields{
 			"code": code.Code(resp.Status.Code),
 			"msg":  resp.Status.Message,
-		}).Debug("Check complete: ", req.String())
+		}).Debug("Check complete")
 	}
 
 	return resp, nil

--- a/app-policy/checker/server.go
+++ b/app-policy/checker/server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -88,10 +89,16 @@ func (as *authServer) Check(ctx context.Context, req *authz.CheckRequest) (*auth
 	logCtx := log.WithContext(ctx).WithField("hostname", hostname)
 	// Do not log req.Attributes.String() or req.String(), they contain sensitive HTTP
 	// headers (Authorization, Cookie) and request bodies.
+	// Strip query string from the path — Envoy's :path pseudo-header includes it,
+	// and query parameters may carry tokens or credentials.
 	if logCtx.Logger.IsLevelEnabled(log.DebugLevel) {
+		httpPath := req.GetAttributes().GetRequest().GetHttp().GetPath()
+		if i := strings.IndexByte(httpPath, '?'); i >= 0 {
+			httpPath = httpPath[:i]
+		}
 		logCtx.WithFields(log.Fields{
 			"method": req.GetAttributes().GetRequest().GetHttp().GetMethod(),
-			"path":   req.GetAttributes().GetRequest().GetHttp().GetPath(),
+			"path":   httpPath,
 		}).Debug("Check start")
 	}
 

--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -299,8 +299,13 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 				newData, err := json.Marshal(stdinData)
 				if err != nil {
-					// Do not log stdinData, it may contain sensitive credentials (K8sAuthToken, K8sClientKey).
-					logger.WithError(err).Error("Error marshaling CNI stdin data")
+					// Do not log the full stdinData map, it may contain sensitive credentials
+					// (K8sAuthToken, K8sClientKey, K8sCertificateAuthority). Log only the keys.
+					keys := make([]string, 0, len(stdinData))
+					for k := range stdinData {
+						keys = append(keys, k)
+					}
+					logger.WithError(err).WithField("keys", keys).Error("Error marshaling CNI stdin data")
 					return nil, err
 				}
 				args.StdinData = newData

--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -300,7 +300,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 				newData, err := json.Marshal(stdinData)
 				if err != nil {
 					// Do not log stdinData, it may contain sensitive credentials (K8sAuthToken, K8sClientKey).
-				logger.WithError(err).Error("Error marshaling CNI stdin data")
+					logger.WithError(err).Error("Error marshaling CNI stdin data")
 					return nil, err
 				}
 				args.StdinData = newData

--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -299,7 +299,8 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 				newData, err := json.Marshal(stdinData)
 				if err != nil {
-					logger.WithField("stdinData", stdinData).Error("Error Marshaling data")
+					// Do not log stdinData, it may contain sensitive credentials (K8sAuthToken, K8sClientKey).
+				logger.WithError(err).Error("Error marshaling CNI stdin data")
 					return nil, err
 				}
 				args.StdinData = newData
@@ -986,7 +987,8 @@ func NewKubeVirtClient(conf types.NetConf, logger *logrus.Entry) (kubevirt.VirtC
 
 func getK8sNSInfo(client *kubernetes.Clientset, podNamespace string) (annotations map[string]string, err error) {
 	ns, err := client.CoreV1().Namespaces().Get(context.Background(), podNamespace, metav1.GetOptions{})
-	logrus.Debugf("namespace info %+v", ns)
+	// Do not log the full Namespace object, it may contain sensitive data in annotations.
+	logrus.Debugf("namespace info name=%s", podNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -995,7 +997,8 @@ func getK8sNSInfo(client *kubernetes.Clientset, podNamespace string) (annotation
 
 func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []internalapi.WorkloadEndpointPort, profiles []string, generateName, serviceAccount string, err error) {
 	pod, err := client.CoreV1().Pods(string(podNamespace)).Get(context.Background(), podName, metav1.GetOptions{})
-	logrus.Debugf("pod info %+v", pod)
+	// Do not log the full Pod object, it may contain sensitive data in env vars.
+	logrus.Debugf("pod info name=%s namespace=%s", podName, podNamespace)
 	if err != nil {
 		return nil, nil, nil, nil, "", "", err
 	}

--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -299,13 +299,9 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 				newData, err := json.Marshal(stdinData)
 				if err != nil {
-					// Do not log the full stdinData map, it may contain sensitive credentials
-					// (K8sAuthToken, K8sClientKey, K8sCertificateAuthority). Log only the keys.
-					keys := make([]string, 0, len(stdinData))
-					for k := range stdinData {
-						keys = append(keys, k)
-					}
-					logger.WithError(err).WithField("keys", keys).Error("Error marshaling CNI stdin data")
+					// Do not log the stdinData map — it may contain K8sAuthToken,
+					// K8sClientKey, K8sCertificateAuthority.
+					logger.WithError(err).Error("Error marshaling CNI stdin data")
 					return nil, err
 				}
 				args.StdinData = newData
@@ -992,8 +988,8 @@ func NewKubeVirtClient(conf types.NetConf, logger *logrus.Entry) (kubevirt.VirtC
 
 func getK8sNSInfo(client *kubernetes.Clientset, podNamespace string) (annotations map[string]string, err error) {
 	ns, err := client.CoreV1().Namespaces().Get(context.Background(), podNamespace, metav1.GetOptions{})
-	// Do not log the full Namespace object, it may contain sensitive data in annotations.
-	logrus.Debugf("namespace info name=%s", podNamespace)
+	// Do not log the full Namespace object — annotations may carry operator tokens or sensitive state.
+	logrus.WithField("namespace", podNamespace).Debug("Pod namespace")
 	if err != nil {
 		return nil, err
 	}
@@ -1002,8 +998,8 @@ func getK8sNSInfo(client *kubernetes.Clientset, podNamespace string) (annotation
 
 func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []internalapi.WorkloadEndpointPort, profiles []string, generateName, serviceAccount string, err error) {
 	pod, err := client.CoreV1().Pods(string(podNamespace)).Get(context.Background(), podName, metav1.GetOptions{})
-	// Do not log the full Pod object, it may contain sensitive data in env vars.
-	logrus.Debugf("pod info name=%s namespace=%s", podName, podNamespace)
+	// Do not log the full Pod object — env vars may contain literal credentials.
+	logrus.WithFields(logrus.Fields{"name": podName, "namespace": podNamespace}).Debug("Pod info")
 	if err != nil {
 		return nil, nil, nil, nil, "", "", err
 	}

--- a/confd/confd.go
+++ b/confd/confd.go
@@ -26,7 +26,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	log.Infof("Config: %#v", c)
+	// Do not log the full config struct, Typha config contains TLS key/cert file paths.
+	log.Infof("Config: confDir=%s onetime=%t syncOnly=%t typhaAddr=%s typhaTLS=%t",
+		c.ConfDir, c.Onetime, c.SyncOnly, c.Typha.Addr, c.Typha.KeyFile != "")
 
 	// Run confd.
 	run.Run(c)

--- a/confd/confd.go
+++ b/confd/confd.go
@@ -26,9 +26,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	// Do not log the full config struct, Typha config contains TLS key/cert file paths.
-	log.Infof("Config: confDir=%s onetime=%t syncOnly=%t typhaAddr=%s typhaTLS=%t",
-		c.ConfDir, c.Onetime, c.SyncOnly, c.Typha.Addr, c.Typha.KeyFile != "")
+	// Config fields are file paths, flags, and connection params — no inline credentials or key material.
+	log.Infof("Config: %#v", c)
 
 	// Run confd.
 	run.Run(c)

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1824,7 +1824,9 @@ func isValidCommunity(communityValue string) bool {
 // ParseFailed is called from the BGP syncer when an event could not be parsed.
 // We use this purely for logging.
 func (c *client) ParseFailed(rawKey string, rawValue string) {
-	// Do not log rawValue, it may contain sensitive datastore entries (e.g. passwords).
+	// Do not log the raw value — future keys may carry credentials.
+	// The key and length are sufficient to alert; the actual value can be
+	// retrieved directly from the datastore when debugging.
 	log.Errorf("Unable to parse datastore entry Key=%s; ValueLen=%d", rawKey, len(rawValue))
 }
 

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1824,7 +1824,8 @@ func isValidCommunity(communityValue string) bool {
 // ParseFailed is called from the BGP syncer when an event could not be parsed.
 // We use this purely for logging.
 func (c *client) ParseFailed(rawKey string, rawValue string) {
-	log.Errorf("Unable to parse datastore entry Key=%s; Value=%s", rawKey, rawValue)
+	// Do not log rawValue, it may contain sensitive datastore entries (e.g. passwords).
+	log.Errorf("Unable to parse datastore entry Key=%s; ValueLen=%d", rawKey, len(rawValue))
 }
 
 // GetValue gets a single value from the cache

--- a/felix/config/env_var_loader.go
+++ b/felix/config/env_var_loader.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 // LoadConfigFromEnvironment extracts raw config parameters (identified by
@@ -25,37 +27,6 @@ import (
 // An environment entry of "FELIX_FOO=bar" is translated to "foo": "bar".
 func LoadConfigFromEnvironment(environ []string) map[string]string {
 	result := make(map[string]string)
-	// isSensitiveParam checks whether a config parameter name suggests its value
-	// may contain credentials. Matching params have their values redacted in logs.
-	// Note: params ending in "file" (e.g. "etcdkeyfile") are file paths, not secrets.
-	sensitiveSubstrings := []string{
-		"password", "passwd", "passphrase",
-		"token", "bearer",
-		"secret",
-		"credential",
-		"authorization",
-		"cookie",
-		"private",
-	}
-	sensitiveSuffixes := []string{"key", "cert", "kubeconfig", "kubeconfiginline"}
-	isSensitiveParam := func(name string) bool {
-		lower := strings.ToLower(name)
-		// Params ending in "file" or "path" are file paths, not inline secrets.
-		if strings.HasSuffix(lower, "file") || strings.HasSuffix(lower, "path") {
-			return false
-		}
-		for _, sub := range sensitiveSubstrings {
-			if strings.Contains(lower, sub) {
-				return true
-			}
-		}
-		for _, suffix := range sensitiveSuffixes {
-			if strings.HasSuffix(lower, suffix) {
-				return true
-			}
-		}
-		return false
-	}
 	for _, kv := range environ {
 		splits := strings.SplitN(kv, "=", 2)
 		if len(splits) < 2 {
@@ -68,13 +39,10 @@ func LoadConfigFromEnvironment(environ []string) map[string]string {
 		if strings.Index(key, "felix_") == 0 {
 			splits = strings.SplitN(key, "_", 2)
 			paramName := splits[1]
-			// Redact values for env vars that may contain sensitive credentials.
-			if isSensitiveParam(paramName) {
-				log.Infof("Found felix environment variable: %s=<redacted>",
-					paramName)
+			if logutils.IsSensitiveParam(paramName) {
+				log.Infof("Found felix environment variable: %s=<redacted>", paramName)
 			} else {
-				log.Infof("Found felix environment variable: %s=%q",
-					paramName, value)
+				log.Infof("Found felix environment variable: %s=%q", paramName, value)
 			}
 			result[paramName] = value
 		}

--- a/felix/config/env_var_loader.go
+++ b/felix/config/env_var_loader.go
@@ -37,8 +37,9 @@ func LoadConfigFromEnvironment(environ []string) map[string]string {
 		if strings.Index(key, "felix_") == 0 {
 			splits = strings.SplitN(key, "_", 2)
 			paramName := splits[1]
-			log.Infof("Found felix environment variable: %#v=%#v",
-				paramName, value)
+			// Do not log env var values, they may contain sensitive credentials.
+			log.Infof("Found felix environment variable: %s=<set>",
+				paramName)
 			result[paramName] = value
 		}
 	}

--- a/felix/config/env_var_loader.go
+++ b/felix/config/env_var_loader.go
@@ -25,6 +25,37 @@ import (
 // An environment entry of "FELIX_FOO=bar" is translated to "foo": "bar".
 func LoadConfigFromEnvironment(environ []string) map[string]string {
 	result := make(map[string]string)
+	// isSensitiveParam checks whether a config parameter name suggests its value
+	// may contain credentials. Matching params have their values redacted in logs.
+	// Note: params ending in "file" (e.g. "etcdkeyfile") are file paths, not secrets.
+	sensitiveSubstrings := []string{
+		"password", "passwd", "passphrase",
+		"token", "bearer",
+		"secret",
+		"credential",
+		"authorization",
+		"cookie",
+		"private",
+	}
+	sensitiveSuffixes := []string{"key", "cert", "kubeconfig", "kubeconfiginline"}
+	isSensitiveParam := func(name string) bool {
+		lower := strings.ToLower(name)
+		// Params ending in "file" or "path" are file paths, not inline secrets.
+		if strings.HasSuffix(lower, "file") || strings.HasSuffix(lower, "path") {
+			return false
+		}
+		for _, sub := range sensitiveSubstrings {
+			if strings.Contains(lower, sub) {
+				return true
+			}
+		}
+		for _, suffix := range sensitiveSuffixes {
+			if strings.HasSuffix(lower, suffix) {
+				return true
+			}
+		}
+		return false
+	}
 	for _, kv := range environ {
 		splits := strings.SplitN(kv, "=", 2)
 		if len(splits) < 2 {
@@ -37,9 +68,14 @@ func LoadConfigFromEnvironment(environ []string) map[string]string {
 		if strings.Index(key, "felix_") == 0 {
 			splits = strings.SplitN(key, "_", 2)
 			paramName := splits[1]
-			// Do not log env var values, they may contain sensitive credentials.
-			log.Infof("Found felix environment variable: %s=<set>",
-				paramName)
+			// Redact values for env vars that may contain sensitive credentials.
+			if isSensitiveParam(paramName) {
+				log.Infof("Found felix environment variable: %s=<redacted>",
+					paramName)
+			} else {
+				log.Infof("Found felix environment variable: %s=%q",
+					paramName, value)
+			}
 			result[paramName] = value
 		}
 	}

--- a/felix/config/param_types.go
+++ b/felix/config/param_types.go
@@ -653,9 +653,8 @@ func (p *EndpointListParam) Parse(raw string) (result any, err error) {
 		if u.Opaque != "" || u.User != nil || u.Path != "/" ||
 			u.RawPath != "" || u.RawQuery != "" ||
 			u.Fragment != "" {
-			// Do not log the full URL, it may contain credentials in userinfo.
-			log.WithField("url", u.Host).Error(
-				"Unsupported URL part")
+			// Do not log the full URL — it may contain credentials in userinfo.
+			log.WithField("url", u.Host).Error("Unsupported URL part")
 			err = p.parseFailed(raw,
 				"endpoint contained unsupported URL part; "+
 					"expected http(s)://hostname:port only.")

--- a/felix/config/param_types.go
+++ b/felix/config/param_types.go
@@ -653,7 +653,8 @@ func (p *EndpointListParam) Parse(raw string) (result any, err error) {
 		if u.Opaque != "" || u.User != nil || u.Path != "/" ||
 			u.RawPath != "" || u.RawQuery != "" ||
 			u.Fragment != "" {
-			log.WithField("url", fmt.Sprintf("%#v", u)).Error(
+			// Do not log the full URL, it may contain credentials in userinfo.
+			log.WithField("url", u.Host).Error(
 				"Unsupported URL part")
 			err = p.parseFailed(raw,
 				"endpoint contained unsupported URL part; "+

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -1775,12 +1775,14 @@ func (w *Wireguard) getNodeFromKey(key wgtypes.Key) *nodeData {
 
 // applyWireguardConfig applies the wireguard configuration.
 func (w *Wireguard) applyWireguardConfig(wireguardClient netlinkshim.Wireguard, c *wgtypes.Config) error {
-	// Do not log the wgtypes.Config struct, it may contain the WireGuard PrivateKey.
-	w.logCtx.Debug("Apply wireguard config update")
 	if c == nil {
 		// No config to apply.
 		return nil
 	}
+	// Log a sanitized copy — nil out PrivateKey which contains key material.
+	sanitized := *c
+	sanitized.PrivateKey = nil
+	w.logCtx.Debugf("Apply wireguard config update: %#v", &sanitized)
 	return wireguardClient.ConfigureDevice(w.interfaceName, *c)
 }
 

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -1775,7 +1775,8 @@ func (w *Wireguard) getNodeFromKey(key wgtypes.Key) *nodeData {
 
 // applyWireguardConfig applies the wireguard configuration.
 func (w *Wireguard) applyWireguardConfig(wireguardClient netlinkshim.Wireguard, c *wgtypes.Config) error {
-	w.logCtx.Debugf("Apply wireguard config update: %#v", c)
+	// Do not log the wgtypes.Config struct, it may contain the WireGuard PrivateKey.
+	w.logCtx.Debug("Apply wireguard config update")
 	if c == nil {
 		// No config to apply.
 		return nil

--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
@@ -40,6 +39,7 @@ import (
 	"github.com/projectcalico/calico/lib/std/time"
 	"github.com/projectcalico/calico/libcalico-go/lib/debugserver"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 type Config struct {
@@ -122,15 +122,11 @@ func newGRPCServer(cfg *Config) (*grpc.Server, error) {
 }
 
 func Run(ctx context.Context, cfg Config) {
-	// Log a copy with PushURL passed through url.Redacted() as a precaution —
+	// Log a copy with PushURL passed through RedactURL as a precaution —
 	// the default URL has no credentials, but user-supplied values could.
 	sanitized := cfg
 	if sanitized.PushURL != "" {
-		if u, err := url.Parse(sanitized.PushURL); err == nil {
-			sanitized.PushURL = u.Redacted()
-		} else {
-			sanitized.PushURL = "<invalid-url>"
-		}
+		sanitized.PushURL = logutils.RedactURL(sanitized.PushURL)
 	}
 	logrus.WithField("cfg", sanitized).Info("Loaded configuration")
 	defer logrus.Warn("Shutting down")

--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
@@ -121,12 +122,17 @@ func newGRPCServer(cfg *Config) (*grpc.Server, error) {
 }
 
 func Run(ctx context.Context, cfg Config) {
-	// Do not log the full cfg struct, PushURL may contain sensitive credentials.
-	logrus.WithFields(logrus.Fields{
-		"port":       cfg.Port,
-		"logLevel":   cfg.LogLevel,
-		"hasPushURL": cfg.PushURL != "",
-	}).Info("Loaded configuration")
+	// Log a copy with PushURL passed through url.Redacted() as a precaution —
+	// the default URL has no credentials, but user-supplied values could.
+	sanitized := cfg
+	if sanitized.PushURL != "" {
+		if u, err := url.Parse(sanitized.PushURL); err == nil {
+			sanitized.PushURL = u.Redacted()
+		} else {
+			sanitized.PushURL = "<invalid-url>"
+		}
+	}
+	logrus.WithField("cfg", sanitized).Info("Loaded configuration")
 	defer logrus.Warn("Shutting down")
 
 	// Make an initial report that says we're live but not yet ready.

--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -121,7 +121,12 @@ func newGRPCServer(cfg *Config) (*grpc.Server, error) {
 }
 
 func Run(ctx context.Context, cfg Config) {
-	logrus.WithField("cfg", cfg).Info("Loaded configuration")
+	// Do not log the full cfg struct, PushURL may contain sensitive credentials.
+	logrus.WithFields(logrus.Fields{
+		"port":       cfg.Port,
+		"logLevel":   cfg.LogLevel,
+		"hasPushURL": cfg.PushURL != "",
+	}).Info("Loaded configuration")
 	defer logrus.Warn("Shutting down")
 
 	// Make an initial report that says we're live but not yet ready.

--- a/goldmane/pkg/emitter/emitter.go
+++ b/goldmane/pkg/emitter/emitter.go
@@ -329,4 +329,3 @@ func (e *Emitter) loadCachedState() error {
 	e.latestTimestamp = ts
 	return nil
 }
-

--- a/goldmane/pkg/emitter/emitter.go
+++ b/goldmane/pkg/emitter/emitter.go
@@ -88,7 +88,8 @@ func NewEmitter(opts ...Option) *Emitter {
 	if err != nil {
 		logrus.Fatalf("Error creating emitter client: %v", err)
 	}
-	logrus.WithField("url", e.url).Info("Created emitter client.")
+	// Do not log the emitter URL, it may contain sensitive credentials in userinfo or query params.
+	logrus.Info("Created emitter client.")
 
 	if e.kcli == nil {
 		logrus.Warn("No k8s client provided, will not be able to cache state.")
@@ -153,7 +154,8 @@ func (e *Emitter) Run(ctx context.Context) {
 
 		// Emit the bucket.
 		if err := e.emit(bucket); err != nil {
-			logrus.Errorf("Error emitting flows to %s: %v", e.url, err)
+			// Do not log the emitter URL, it may contain sensitive credentials.
+			logrus.Errorf("Error emitting flows: %v", err)
 			e.retry(key)
 			continue
 		}

--- a/goldmane/pkg/emitter/emitter.go
+++ b/goldmane/pkg/emitter/emitter.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -34,6 +33,7 @@ import (
 	"github.com/projectcalico/calico/goldmane/pkg/types"
 	"github.com/projectcalico/calico/lib/std/time"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 var (
@@ -90,7 +90,7 @@ func NewEmitter(opts ...Option) *Emitter {
 		logrus.Fatalf("Error creating emitter client: %v", err)
 	}
 	// Do not log the raw emitter URL — it may contain credentials in userinfo or query params.
-	logrus.WithField("url", redactURL(e.url)).Info("Created emitter client.")
+	logrus.WithField("url", logutils.RedactURL(e.url)).Info("Created emitter client.")
 
 	if e.kcli == nil {
 		logrus.Warn("No k8s client provided, will not be able to cache state.")
@@ -156,7 +156,7 @@ func (e *Emitter) Run(ctx context.Context) {
 		// Emit the bucket.
 		if err := e.emit(bucket); err != nil {
 			// Do not log the raw emitter URL — use redactURL to mask userinfo.
-			logrus.Errorf("Error emitting flows to %s: %v", redactURL(e.url), err)
+			logrus.Errorf("Error emitting flows to %s: %v", logutils.RedactURL(e.url), err)
 			e.retry(key)
 			continue
 		}
@@ -330,13 +330,3 @@ func (e *Emitter) loadCachedState() error {
 	return nil
 }
 
-// redactURL parses a URL string and returns its Redacted() form, which masks
-// any userinfo password.  If the URL cannot be parsed, returns the host or
-// a placeholder.
-func redactURL(raw string) string {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return "<invalid-url>"
-	}
-	return u.Redacted()
-}

--- a/goldmane/pkg/emitter/emitter.go
+++ b/goldmane/pkg/emitter/emitter.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -88,8 +89,8 @@ func NewEmitter(opts ...Option) *Emitter {
 	if err != nil {
 		logrus.Fatalf("Error creating emitter client: %v", err)
 	}
-	// Do not log the emitter URL, it may contain sensitive credentials in userinfo or query params.
-	logrus.Info("Created emitter client.")
+	// Do not log the raw emitter URL — it may contain credentials in userinfo or query params.
+	logrus.WithField("url", redactURL(e.url)).Info("Created emitter client.")
 
 	if e.kcli == nil {
 		logrus.Warn("No k8s client provided, will not be able to cache state.")
@@ -154,8 +155,8 @@ func (e *Emitter) Run(ctx context.Context) {
 
 		// Emit the bucket.
 		if err := e.emit(bucket); err != nil {
-			// Do not log the emitter URL, it may contain sensitive credentials.
-			logrus.Errorf("Error emitting flows: %v", err)
+			// Do not log the raw emitter URL — use redactURL to mask userinfo.
+			logrus.Errorf("Error emitting flows to %s: %v", redactURL(e.url), err)
 			e.retry(key)
 			continue
 		}
@@ -327,4 +328,15 @@ func (e *Emitter) loadCachedState() error {
 	}
 	e.latestTimestamp = ts
 	return nil
+}
+
+// redactURL parses a URL string and returns its Redacted() form, which masks
+// any userinfo password.  If the URL cannot be parsed, returns the host or
+// a placeholder.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	return u.Redacted()
 }

--- a/guardian/cmd/guardian/main.go
+++ b/guardian/cmd/guardian/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -44,11 +45,12 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	// Do not log the full config, it may contain sensitive URL credentials and cert paths.
-	logrus.WithFields(logrus.Fields{
-		"listenPort":    cfg.ListenPort,
-		"healthEnabled": cfg.HealthEnabled,
-	}).Info("Starting Calico Guardian")
+	// Log config with VoltronURL userinfo redacted.
+	sanitized := cfg.Config
+	if u, err := url.Parse(sanitized.VoltronURL); err == nil {
+		sanitized.VoltronURL = u.Redacted()
+	}
+	logrus.Infof("Starting Calico Guardian %s", sanitized.String())
 	daemon.Run(GetShutdownContext(), cfg.Config, cfg.Targets())
 }
 

--- a/guardian/cmd/guardian/main.go
+++ b/guardian/cmd/guardian/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"flag"
-	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/projectcalico/calico/guardian/pkg/config"
 	"github.com/projectcalico/calico/guardian/pkg/daemon"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/calico/pkg/buildinfo"
 )
 
@@ -47,9 +47,7 @@ func main() {
 
 	// Log config with VoltronURL userinfo redacted.
 	sanitized := cfg.Config
-	if u, err := url.Parse(sanitized.VoltronURL); err == nil {
-		sanitized.VoltronURL = u.Redacted()
-	}
+	sanitized.VoltronURL = logutils.RedactURL(sanitized.VoltronURL)
 	logrus.Infof("Starting Calico Guardian %s", sanitized.String())
 	daemon.Run(GetShutdownContext(), cfg.Config, cfg.Targets())
 }

--- a/guardian/cmd/guardian/main.go
+++ b/guardian/cmd/guardian/main.go
@@ -44,7 +44,11 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	logrus.Infof("Starting Calico Guardian %s", cfg.String())
+	// Do not log the full config, it may contain sensitive URL credentials and cert paths.
+	logrus.WithFields(logrus.Fields{
+		"listenPort":    cfg.ListenPort,
+		"healthEnabled": cfg.HealthEnabled,
+	}).Info("Starting Calico Guardian")
 	daemon.Run(GetShutdownContext(), cfg.Config, cfg.Targets())
 }
 

--- a/guardian/pkg/server/proxy.go
+++ b/guardian/pkg/server/proxy.go
@@ -111,8 +111,9 @@ func newTargetHandler(tgt Target) (func(http.ResponseWriter, *http.Request), err
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Do not log the full Target struct, it may contain OAuth tokens and client certs.
-		logCtx := logrus.WithField("dst", tgt.Dest.Host)
+		// Do not log the full Target struct — it contains OAuth tokens and client cert paths.
+		// Use Redacted() on the URL to mask any userinfo credentials.
+		logCtx := logrus.WithField("dst", tgt.Dest.Redacted())
 		if tgt.PathRegexp != nil {
 			if !tgt.PathRegexp.MatchString(r.URL.Path) {
 				http.Error(w, "Not found", 404)
@@ -137,12 +138,13 @@ func newTargetHandler(tgt Target) (func(http.ResponseWriter, *http.Request), err
 			if err != nil {
 				http.Error(w, "Internal Server Error, token read failure", 500)
 				logCtx.Errorf("Loading token failed %s", err)
+				return
 			}
 			tok.SetAuthHeader(r)
 		}
 
-		// Do not log r.RequestURI or the full target URL, they may contain query-string credentials.
-		logCtx.Debugf("Received request %s will proxy to %s", r.URL.Path, tgt.Dest.Host)
+		// Do not log r.RequestURI — it may contain query-string credentials (?access_token=...).
+		logCtx.Debugf("Received request %s will proxy to %s", r.URL.Path, tgt.Dest.Redacted())
 
 		p.ServeHTTP(w, r)
 	}, nil

--- a/guardian/pkg/server/proxy.go
+++ b/guardian/pkg/server/proxy.go
@@ -111,11 +111,12 @@ func newTargetHandler(tgt Target) (func(http.ResponseWriter, *http.Request), err
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		logCtx := logrus.WithField("dst", tgt)
+		// Do not log the full Target struct, it may contain OAuth tokens and client certs.
+		logCtx := logrus.WithField("dst", tgt.Dest.Host)
 		if tgt.PathRegexp != nil {
 			if !tgt.PathRegexp.MatchString(r.URL.Path) {
 				http.Error(w, "Not found", 404)
-				logCtx.Debugf("Received request %s rejected by PathRegexp %q", r.RequestURI, tgt.PathRegexp)
+				logCtx.Debugf("Received request %s rejected by PathRegexp %q", r.URL.Path, tgt.PathRegexp)
 				return
 			}
 			if tgt.PathReplace != nil {
@@ -140,7 +141,8 @@ func newTargetHandler(tgt Target) (func(http.ResponseWriter, *http.Request), err
 			tok.SetAuthHeader(r)
 		}
 
-		logCtx.Debugf("Received request %s will proxy to %s", r.RequestURI, tgt.Dest)
+		// Do not log r.RequestURI or the full target URL, they may contain query-string credentials.
+		logCtx.Debugf("Received request %s will proxy to %s", r.URL.Path, tgt.Dest.Host)
 
 		p.ServeHTTP(w, r)
 	}, nil

--- a/guardian/pkg/server/server.go
+++ b/guardian/pkg/server/server.go
@@ -78,7 +78,11 @@ func New(shutdownCtx context.Context, tunnelCert *tls.Certificate, dialer tunnel
 
 	for _, target := range srv.targets {
 		// Do not log target.Dest directly, it may contain sensitive credentials in URL userinfo.
-		logrus.Infof("Will route traffic to %s for requests matching %s", target.Dest.Host, target.Path)
+		if target.Dest != nil {
+			logrus.Infof("Will route traffic to %s for requests matching %s", target.Dest.Host, target.Path)
+		} else {
+			logrus.Infof("Will route traffic for requests matching %s, but destination is not configured", target.Path)
+		}
 	}
 
 	srv.proxyMux = http.NewServeMux()

--- a/guardian/pkg/server/server.go
+++ b/guardian/pkg/server/server.go
@@ -77,9 +77,9 @@ func New(shutdownCtx context.Context, tunnelCert *tls.Certificate, dialer tunnel
 	}
 
 	for _, target := range srv.targets {
-		// Do not log target.Dest directly, it may contain sensitive credentials in URL userinfo.
+		// Use Redacted() — target.Dest may contain credentials in URL userinfo.
 		if target.Dest != nil {
-			logrus.Infof("Will route traffic to %s for requests matching %s", target.Dest.Host, target.Path)
+			logrus.Infof("Will route traffic to %s for requests matching %s", target.Dest.Redacted(), target.Path)
 		} else {
 			logrus.Infof("Will route traffic for requests matching %s, but destination is not configured", target.Path)
 		}

--- a/guardian/pkg/server/server.go
+++ b/guardian/pkg/server/server.go
@@ -77,7 +77,8 @@ func New(shutdownCtx context.Context, tunnelCert *tls.Certificate, dialer tunnel
 	}
 
 	for _, target := range srv.targets {
-		logrus.Infof("Will route traffic to %s for requests matching %s", target.Dest, target.Path)
+		// Do not log target.Dest directly, it may contain sensitive credentials in URL userinfo.
+		logrus.Infof("Will route traffic to %s for requests matching %s", target.Dest.Host, target.Path)
 	}
 
 	srv.proxyMux = http.NewServeMux()

--- a/guardian/pkg/tunnel/dial.go
+++ b/guardian/pkg/tunnel/dial.go
@@ -125,7 +125,8 @@ func (d *sessionDialer) dialTLS() (net.Conn, error) {
 	dialer := newDialer(d.timeout)
 	if d.httpProxyURL != nil {
 		// mTLS will be negotiated over a TCP connection to the proxy, which performs TCP passthrough to the target.
-		logrus.Infof("Dialing to %s via HTTP proxy at %s", d.addr, d.httpProxyURL)
+		// Do not log the full proxy URL, it may contain credentials in userinfo.
+		logrus.Infof("Dialing to %s via HTTP proxy at %s", d.addr, d.httpProxyURL.Host)
 		var tlsConfig *tls.Config
 		tlsConfig, err = calicoTLS.NewTLSConfig()
 		if err != nil {

--- a/guardian/pkg/tunnel/dial.go
+++ b/guardian/pkg/tunnel/dial.go
@@ -125,8 +125,8 @@ func (d *sessionDialer) dialTLS() (net.Conn, error) {
 	dialer := newDialer(d.timeout)
 	if d.httpProxyURL != nil {
 		// mTLS will be negotiated over a TCP connection to the proxy, which performs TCP passthrough to the target.
-		// Do not log the full proxy URL, it may contain credentials in userinfo.
-		logrus.Infof("Dialing to %s via HTTP proxy at %s", d.addr, d.httpProxyURL.Host)
+		// Do not log the full proxy URL — it may contain credentials in userinfo.
+		logrus.Infof("Dialing to %s via HTTP proxy at %s", d.addr, d.httpProxyURL.Redacted())
 		var tlsConfig *tls.Config
 		tlsConfig, err = calicoTLS.NewTLSConfig()
 		if err != nil {

--- a/libcalico-go/lib/backend/etcd/etcd.go
+++ b/libcalico-go/lib/backend/etcd/etcd.go
@@ -360,7 +360,8 @@ func filterEtcdList(n *etcd.Node, l model.ListInterface) []*model.KVPair {
 			kvs = append(kvs, kv)
 		}
 	}
-	log.Debugf("Returning: %#v", kvs)
+	// Do not log the KVPair values, they may contain sensitive datastore entries.
+	log.Debugf("Returning %d results", len(kvs))
 	return kvs
 }
 

--- a/libcalico-go/lib/backend/etcd/syncer.go
+++ b/libcalico-go/lib/backend/etcd/syncer.go
@@ -541,9 +541,11 @@ func (syn *etcdSyncer) sendUpdate(key string, value string, revision uint64, upd
 
 	parsedValue, err = model.ParseValue(parsedKey, []byte(value))
 	if err != nil {
-		log.Warningf("Failed to parse value for %v: %#v", key, value)
+		// Do not log the raw value, it may contain sensitive datastore entries.
+		log.Warningf("Failed to parse value for %v (len=%d)", key, len(value))
 	}
-	log.Debugf("Parsed value: %#v", parsedValue)
+	// Do not log the parsed value, it may contain sensitive datastore entries.
+	log.Debugf("Parsed value type: %T", parsedValue)
 
 	updates := []api.Update{
 		{

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -156,7 +156,8 @@ func (c *etcdV3Client) Create(ctx context.Context, d *model.KVPair) (*model.KVPa
 	// Take a copy of the key before we default any policy names, we use this key for error returns to return the same name that user provided for create
 	keyCopy := d.Key
 
-	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
+	// Do not log d.Value, it may contain sensitive resource specs.
+	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key, "ttl": d.TTL, "rev": d.Revision})
 	logCxt.Debug("Processing Create request")
 
 	err := defaultPolicyName(d)
@@ -226,7 +227,8 @@ func (c *etcdV3Client) Update(ctx context.Context, d *model.KVPair) (*model.KVPa
 	// Take a copy of the key before we default any policy names, we use this key for error returns to return the same name that user provided for update
 	keyCopy := d.Key
 
-	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
+	// Do not log d.Value, it may contain sensitive resource specs.
+	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key, "ttl": d.TTL, "rev": d.Revision})
 	logCxt.Debug("Processing Update request")
 
 	err := defaultPolicyName(d)
@@ -300,7 +302,8 @@ func (c *etcdV3Client) Update(ctx context.Context, d *model.KVPair) (*model.KVPa
 // It's possible that we will just perform that processing in the clients (e.g. calicoctl),
 // but that is to be decided.
 func (c *etcdV3Client) Apply(ctx context.Context, d *model.KVPair) (*model.KVPair, error) {
-	logCxt := log.WithFields(log.Fields{"etcdKey": d.Key, "value": d.Value, "ttl": d.TTL, "rev": d.Revision})
+	// Do not log d.Value, it may contain sensitive resource specs.
+	logCxt := log.WithFields(log.Fields{"etcdKey": d.Key, "ttl": d.TTL, "rev": d.Revision})
 	logCxt.Debug("Processing Apply request")
 
 	err := defaultPolicyName(d)
@@ -611,7 +614,8 @@ func (c *etcdV3Client) getTTLOption(ctx context.Context, d *model.KVPair) ([]cli
 // getKeyValueStrings returns the etcdv3 etcdKey and serialized value calculated from the
 // KVPair.
 func getKeyValueStrings(d *model.KVPair) (string, string, error) {
-	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key, "value": d.Value})
+	// Do not log d.Value, it may contain sensitive resource specs.
+	logCxt := log.WithFields(log.Fields{"model-etcdKey": d.Key})
 	key, err := model.KeyToDefaultPath(d.Key)
 	if err != nil {
 		logCxt.WithError(err).Error("Failed to convert model-etcdKey to etcdv3 etcdKey")

--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -688,7 +688,8 @@ func restClient(cfg rest.Config, group resources.BackingAPIGroup) (*rest.RESTCli
 
 // Create an entry in the datastore.  This errors if the entry already exists.
 func (c *KubeClient) Create(ctx context.Context, d *model.KVPair) (*model.KVPair, error) {
-	log.Debugf("Performing 'Create' for %+v", d)
+	// Do not log d.Value, it may contain sensitive resource specs (e.g. BGPPassword).
+	log.Debugf("Performing 'Create' for %s", d.Key)
 	client := c.getResourceClientFromKey(d.Key)
 	if client == nil {
 		log.Debug("Attempt to 'Create' using kubernetes backend is not supported.")
@@ -703,7 +704,8 @@ func (c *KubeClient) Create(ctx context.Context, d *model.KVPair) (*model.KVPair
 // Update an existing entry in the datastore.  This errors if the entry does
 // not exist.
 func (c *KubeClient) Update(ctx context.Context, d *model.KVPair) (*model.KVPair, error) {
-	log.Debugf("Performing 'Update' for %+v", d)
+	// Do not log d.Value, it may contain sensitive resource specs (e.g. BGPPassword).
+	log.Debugf("Performing 'Update' for %s", d.Key)
 	client := c.getResourceClientFromKey(d.Key)
 	if client == nil {
 		log.Debug("Attempt to 'Update' using kubernetes backend is not supported.")
@@ -718,7 +720,8 @@ func (c *KubeClient) Update(ctx context.Context, d *model.KVPair) (*model.KVPair
 // UpdateStatus updates the status of an existing entry in the datastore using
 // the status subresource.  This errors if the entry does not exist.
 func (c *KubeClient) UpdateStatus(ctx context.Context, d *model.KVPair) (*model.KVPair, error) {
-	log.Debugf("Performing 'UpdateStatus' for %+v", d)
+	// Do not log d.Value, it may contain sensitive resource specs (e.g. BGPPassword).
+	log.Debugf("Performing 'UpdateStatus' for %s", d.Key)
 	client := c.getResourceClientFromKey(d.Key)
 	if client == nil {
 		log.Debug("Attempt to 'UpdateStatus' using kubernetes backend is not supported.")
@@ -742,10 +745,8 @@ func (c *KubeClient) UpdateStatus(ctx context.Context, d *model.KVPair) (*model.
 // exists.  This is not exposed in the main client - but we keep here for the backend
 // API.
 func (c *KubeClient) Apply(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
-	logContext := log.WithFields(log.Fields{
-		"Key":   kvp.Key,
-		"Value": kvp.Value,
-	})
+	// Do not log kvp.Value, it may contain sensitive resource specs (e.g. BGPPassword).
+	logContext := log.WithField("Key", kvp.Key)
 	logContext.Debug("Apply Kubernetes resource")
 
 	// Attempt to Create and do an Update if the resource already exists.

--- a/libcalico-go/lib/logutils/sensitive.go
+++ b/libcalico-go/lib/logutils/sensitive.go
@@ -57,13 +57,17 @@ func IsSensitiveParam(name string) bool {
 	return false
 }
 
-// RedactURL parses a URL string and returns its Redacted() form, which masks
-// any userinfo password while preserving the scheme, host, port, and path.
+// RedactURL parses a URL string and returns a redacted form that masks any
+// userinfo password while preserving the scheme, host, port, and path.
+// Query strings and fragments are stripped because they may carry credentials
+// (e.g. ?token=, ?X-Amz-Signature=) that url.Redacted() does not handle.
 // If the URL cannot be parsed, it returns "<invalid-url>".
 func RedactURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "<invalid-url>"
 	}
+	u.RawQuery = ""
+	u.Fragment = ""
 	return u.Redacted()
 }

--- a/libcalico-go/lib/logutils/sensitive.go
+++ b/libcalico-go/lib/logutils/sensitive.go
@@ -14,7 +14,10 @@
 
 package logutils
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // sensitiveSubstrings are substrings that, when found in a lowercased
 // config parameter name, indicate the value may contain credentials.
@@ -52,4 +55,15 @@ func IsSensitiveParam(name string) bool {
 		}
 	}
 	return false
+}
+
+// RedactURL parses a URL string and returns its Redacted() form, which masks
+// any userinfo password while preserving the scheme, host, port, and path.
+// If the URL cannot be parsed, it returns "<invalid-url>".
+func RedactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	return u.Redacted()
 }

--- a/libcalico-go/lib/logutils/sensitive.go
+++ b/libcalico-go/lib/logutils/sensitive.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutils
+
+import "strings"
+
+// sensitiveSubstrings are substrings that, when found in a lowercased
+// config parameter name, indicate the value may contain credentials.
+var sensitiveSubstrings = []string{
+	"password", "passwd", "passphrase",
+	"token", "bearer",
+	"secret",
+	"credential",
+	"authorization",
+	"cookie",
+	"private",
+}
+
+// sensitiveSuffixes are suffixes that indicate inline key/cert material
+// (as opposed to file paths like "keyfile" or "certpath").
+var sensitiveSuffixes = []string{"key", "cert", "kubeconfig", "kubeconfiginline"}
+
+// IsSensitiveParam reports whether a configuration parameter name suggests
+// its value may contain credentials or key material.  Parameters whose names
+// end in "file" or "path" are assumed to be file-system paths (not inline
+// secrets) and are excluded.
+func IsSensitiveParam(name string) bool {
+	lower := strings.ToLower(name)
+	if strings.HasSuffix(lower, "file") || strings.HasSuffix(lower, "path") {
+		return false
+	}
+	for _, sub := range sensitiveSubstrings {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	for _, suffix := range sensitiveSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/typha/pkg/config/env_var_loader.go
+++ b/typha/pkg/config/env_var_loader.go
@@ -37,8 +37,9 @@ func LoadConfigFromEnvironment(environ []string) map[string]string {
 		if strings.HasPrefix(key, "typha_") {
 			splits = strings.SplitN(key, "_", 2)
 			paramName := splits[1]
-			log.Infof("Found typha environment variable: %#v=%#v",
-				paramName, value)
+			// Do not log env var values, they may contain sensitive credentials.
+			log.Infof("Found typha environment variable: %s=<set>",
+				paramName)
 			result[paramName] = value
 		}
 	}

--- a/typha/pkg/config/env_var_loader.go
+++ b/typha/pkg/config/env_var_loader.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 // LoadConfigFromEnvironment extracts raw config parameters (identified by
@@ -25,37 +27,6 @@ import (
 // An environment entry of "TYPHA_FOO=bar" is translated to "foo": "bar".
 func LoadConfigFromEnvironment(environ []string) map[string]string {
 	result := make(map[string]string)
-	// isSensitiveParam checks whether a config parameter name suggests its value
-	// may contain credentials. Matching params have their values redacted in logs.
-	// Note: params ending in "file" (e.g. "etcdkeyfile") are file paths, not secrets.
-	sensitiveSubstrings := []string{
-		"password", "passwd", "passphrase",
-		"token", "bearer",
-		"secret",
-		"credential",
-		"authorization",
-		"cookie",
-		"private",
-	}
-	sensitiveSuffixes := []string{"key", "cert", "kubeconfig", "kubeconfiginline"}
-	isSensitiveParam := func(name string) bool {
-		lower := strings.ToLower(name)
-		// Params ending in "file" or "path" are file paths, not inline secrets.
-		if strings.HasSuffix(lower, "file") || strings.HasSuffix(lower, "path") {
-			return false
-		}
-		for _, sub := range sensitiveSubstrings {
-			if strings.Contains(lower, sub) {
-				return true
-			}
-		}
-		for _, suffix := range sensitiveSuffixes {
-			if strings.HasSuffix(lower, suffix) {
-				return true
-			}
-		}
-		return false
-	}
 	for _, kv := range environ {
 		splits := strings.SplitN(kv, "=", 2)
 		if len(splits) < 2 {
@@ -68,13 +39,10 @@ func LoadConfigFromEnvironment(environ []string) map[string]string {
 		if strings.HasPrefix(key, "typha_") {
 			splits = strings.SplitN(key, "_", 2)
 			paramName := splits[1]
-			// Redact values for env vars that may contain sensitive credentials.
-			if isSensitiveParam(paramName) {
-				log.Infof("Found typha environment variable: %s=<redacted>",
-					paramName)
+			if logutils.IsSensitiveParam(paramName) {
+				log.Infof("Found typha environment variable: %s=<redacted>", paramName)
 			} else {
-				log.Infof("Found typha environment variable: %s=%q",
-					paramName, value)
+				log.Infof("Found typha environment variable: %s=%q", paramName, value)
 			}
 			result[paramName] = value
 		}

--- a/typha/pkg/config/env_var_loader.go
+++ b/typha/pkg/config/env_var_loader.go
@@ -25,6 +25,37 @@ import (
 // An environment entry of "TYPHA_FOO=bar" is translated to "foo": "bar".
 func LoadConfigFromEnvironment(environ []string) map[string]string {
 	result := make(map[string]string)
+	// isSensitiveParam checks whether a config parameter name suggests its value
+	// may contain credentials. Matching params have their values redacted in logs.
+	// Note: params ending in "file" (e.g. "etcdkeyfile") are file paths, not secrets.
+	sensitiveSubstrings := []string{
+		"password", "passwd", "passphrase",
+		"token", "bearer",
+		"secret",
+		"credential",
+		"authorization",
+		"cookie",
+		"private",
+	}
+	sensitiveSuffixes := []string{"key", "cert", "kubeconfig", "kubeconfiginline"}
+	isSensitiveParam := func(name string) bool {
+		lower := strings.ToLower(name)
+		// Params ending in "file" or "path" are file paths, not inline secrets.
+		if strings.HasSuffix(lower, "file") || strings.HasSuffix(lower, "path") {
+			return false
+		}
+		for _, sub := range sensitiveSubstrings {
+			if strings.Contains(lower, sub) {
+				return true
+			}
+		}
+		for _, suffix := range sensitiveSuffixes {
+			if strings.HasSuffix(lower, suffix) {
+				return true
+			}
+		}
+		return false
+	}
 	for _, kv := range environ {
 		splits := strings.SplitN(kv, "=", 2)
 		if len(splits) < 2 {
@@ -37,9 +68,14 @@ func LoadConfigFromEnvironment(environ []string) map[string]string {
 		if strings.HasPrefix(key, "typha_") {
 			splits = strings.SplitN(key, "_", 2)
 			paramName := splits[1]
-			// Do not log env var values, they may contain sensitive credentials.
-			log.Infof("Found typha environment variable: %s=<set>",
-				paramName)
+			// Redact values for env vars that may contain sensitive credentials.
+			if isSensitiveParam(paramName) {
+				log.Infof("Found typha environment variable: %s=<redacted>",
+					paramName)
+			} else {
+				log.Infof("Found typha environment variable: %s=%q",
+					paramName, value)
+			}
 			result[paramName] = value
 		}
 	}

--- a/typha/pkg/config/param_types.go
+++ b/typha/pkg/config/param_types.go
@@ -311,7 +311,8 @@ func (p *EndpointListParam) Parse(raw string) (result any, err error) {
 		if u.Opaque != "" || u.User != nil || u.Path != "/" ||
 			u.RawPath != "" || u.RawQuery != "" ||
 			u.Fragment != "" {
-			log.WithField("url", fmt.Sprintf("%#v", u)).Error(
+			// Do not log the full URL, it may contain credentials in userinfo.
+			log.WithField("url", u.Host).Error(
 				"Unsupported URL part")
 			err = p.parseFailed(raw,
 				"endpoint contained unsupported URL part; "+

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -131,6 +131,11 @@ type BreadcrumbProvider interface {
 	CurrentBreadcrumb() *snapcache.Breadcrumb
 }
 
+// Config holds the configuration for the Typha sync server.
+//
+// IMPORTANT: When adding new fields, also update LogFields() below so the
+// field appears in startup logs.  Do NOT add fields that contain credentials,
+// private keys, or other secrets — LogFields() is logged at Info level.
 type Config struct {
 	Host                           string
 	Port                           int

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -160,6 +160,30 @@ type Config struct {
 	DebugLogWrites bool
 }
 
+// LogFields returns a logrus.Fields map with all config values included,
+// but with TLS key/cert file paths redacted.
+func (c Config) LogFields() log.Fields {
+	return log.Fields{
+		"host":                           c.Host,
+		"port":                           c.Port,
+		"maxMessageSize":                 c.MaxMessageSize,
+		"binarySnapshotTimeout":          c.BinarySnapshotTimeout,
+		"maxFallBehind":                  c.MaxFallBehind,
+		"newClientFallBehindGracePeriod": c.NewClientFallBehindGracePeriod,
+		"minBatchingAgeThreshold":        c.MinBatchingAgeThreshold,
+		"pingInterval":                   c.PingInterval,
+		"pongTimeout":                    c.PongTimeout,
+		"handshakeTimeout":               c.HandshakeTimeout,
+		"writeTimeout":                   c.WriteTimeout,
+		"dropInterval":                   c.DropInterval,
+		"shutdownTimeout":                c.ShutdownTimeout,
+		"shutdownMaxDropInterval":        c.ShutdownMaxDropInterval,
+		"maxConns":                       c.MaxConns,
+		"tlsEnabled":                     c.requiringTLS(),
+		"writeBufferSize":                c.WriteBufferSize,
+	}
+}
+
 const (
 	healthName     = "SyncServer"
 	healthInterval = 10 * time.Second
@@ -279,11 +303,7 @@ func (c *Config) requiringTLS() bool {
 
 func New(caches map[syncproto.SyncerType]BreadcrumbProvider, config Config) *Server {
 	config.ApplyDefaults()
-	// Do not log the full config struct, it contains TLS key/cert file paths.
-	log.WithFields(log.Fields{
-		"port":       config.Port,
-		"tlsEnabled": config.KeyFile != "",
-	}).Info("Creating server")
+	log.WithFields(config.LogFields()).Info("Creating server")
 	s := &Server{
 		config:               config,
 		caches:               caches,

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -165,8 +165,10 @@ type Config struct {
 	DebugLogWrites bool
 }
 
-// LogFields returns a logrus.Fields map with all config values included,
-// but with TLS key/cert file paths redacted.
+// LogFields returns a logrus.Fields map with operational config values
+// for logging.  TLS-related fields (KeyFile, CertFile, CAFile, ClientCN,
+// ClientURISAN) and internal fields (HealthAggregator, DebugLogWrites)
+// are omitted; a "tlsEnabled" boolean is included instead.
 func (c Config) LogFields() log.Fields {
 	return log.Fields{
 		"host":                           c.Host,

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -279,7 +279,11 @@ func (c *Config) requiringTLS() bool {
 
 func New(caches map[syncproto.SyncerType]BreadcrumbProvider, config Config) *Server {
 	config.ApplyDefaults()
-	log.WithField("config", config).Info("Creating server")
+	// Do not log the full config struct, it contains TLS key/cert file paths.
+	log.WithFields(log.Fields{
+		"port":       config.Port,
+		"tlsEnabled": config.KeyFile != "",
+	}).Info("Creating server")
 	s := &Server{
 		config:               config,
 		caches:               caches,

--- a/whisker-backend/cmd/app/app.go
+++ b/whisker-backend/cmd/app/app.go
@@ -28,7 +28,11 @@ import (
 )
 
 func Run(ctx context.Context, cfg *config.Config) {
-	logrus.WithField("cfg", cfg.String()).Info("Applying configuration...")
+	// Do not log the full config, it contains TLS key/cert paths.
+	logrus.WithFields(logrus.Fields{
+		"goldmaneHost": cfg.GoldmaneHost,
+		"tlsEnabled":   cfg.TLSKeyPath != "",
+	}).Info("Applying configuration...")
 
 	// Generate credentials for the Goldmane client.
 	creds, err := client.ClientCredentials(cfg.TLSCertPath, cfg.TLSKeyPath, cfg.CACertPath)

--- a/whisker-backend/cmd/app/app.go
+++ b/whisker-backend/cmd/app/app.go
@@ -28,11 +28,8 @@ import (
 )
 
 func Run(ctx context.Context, cfg *config.Config) {
-	// Do not log the full config, it contains TLS key/cert paths.
-	logrus.WithFields(logrus.Fields{
-		"goldmaneHost": cfg.GoldmaneHost,
-		"tlsEnabled":   cfg.TLSKeyPath != "",
-	}).Info("Applying configuration...")
+	// Config fields are file paths and host:port only — no inline credentials or key material.
+	logrus.WithField("cfg", cfg.String()).Info("Applying configuration...")
 
 	// Generate credentials for the Goldmane client.
 	creds, err := client.ClientCredentials(cfg.TLSCertPath, cfg.TLSKeyPath, cfg.CACertPath)

--- a/whisker-backend/pkg/handlers/v1/flows.go
+++ b/whisker-backend/pkg/handlers/v1/flows.go
@@ -18,8 +18,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/projectcalico/calico/goldmane/pkg/client"
 	"github.com/projectcalico/calico/goldmane/proto"
 	"github.com/projectcalico/calico/lib/httpmachinery/pkg/apiutil"
@@ -55,8 +53,9 @@ func (hdlr *flowsHdlr) ListOrStream(ctx apictx.Context, params whiskerv1.ListFlo
 	logger := ctx.Logger()
 	logger.Debug("List flows called.")
 
-	// Do not log filter objects, they may contain user identifiers.
-	logrus.Debug("Applying filters.")
+	// Do not log filter objects or flow objects — they may contain user identifiers and
+	// flow metadata that could be a bulk-exfil vector.
+	logger.Debug("Applying filters.")
 
 	filter := toProtoFilter(params.Filters)
 	if params.Watch {
@@ -85,8 +84,7 @@ func (hdlr *flowsHdlr) ListOrStream(ctx apictx.Context, params whiskerv1.ListFlo
 						break
 					}
 
-					// Do not log full flow objects, they contain flow metadata that can be a bulk-exfil vector.
-					logrus.Debug("Received flow from stream.")
+					logger.Debug("Received flow from stream.")
 					if !yield(protoToFlow(flow.Flow)) {
 						return
 					}

--- a/whisker-backend/pkg/handlers/v1/flows.go
+++ b/whisker-backend/pkg/handlers/v1/flows.go
@@ -55,7 +55,8 @@ func (hdlr *flowsHdlr) ListOrStream(ctx apictx.Context, params whiskerv1.ListFlo
 	logger := ctx.Logger()
 	logger.Debug("List flows called.")
 
-	logrus.WithField("filter", params.Filters).Debug("Applying filters.")
+	// Do not log filter objects, they may contain user identifiers.
+	logrus.Debug("Applying filters.")
 
 	filter := toProtoFilter(params.Filters)
 	if params.Watch {
@@ -84,7 +85,8 @@ func (hdlr *flowsHdlr) ListOrStream(ctx apictx.Context, params whiskerv1.ListFlo
 						break
 					}
 
-					logrus.WithField("flow", flow).Debug("Received flow from stream.")
+					// Do not log full flow objects, they contain flow metadata that can be a bulk-exfil vector.
+					logrus.Debug("Received flow from stream.")
 					if !yield(protoToFlow(flow.Flow)) {
 						return
 					}


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Sanitize log output

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Removed sensitive material (auth tokens, kubeconfig contents, etcd credentials, and inline certificates/keys) from log output. Logs that previously included full client-config or environment-variable dumps now log structured non-secret fields instead.
```
pick https://github.com/projectcalico/calico/pull/12604