### PR TITLE
[release 3.32] Add size limit for inbound Typha (pick 12479)

### DIFF
--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -52,6 +52,7 @@ var (
 	ErrReadFailed               = errors.New("failed to read from client")
 	ErrUnexpectedClientMsg      = errors.New("unexpected message from client")
 	ErrUnsupportedClientFeature = errors.New("unsupported client feature")
+	errInboundMessageTooLarge   = errors.New("inbound message too large")
 )
 
 var (
@@ -97,14 +98,21 @@ const (
 	defaultMaxMessageSize                 = 100
 	defaultMaxFallBehind                  = 300 * time.Second
 	defaultNewClientFallBehindGracePeriod = 300 * time.Second
-	defaultBatchingAgeThreshold           = 100 * time.Millisecond
-	defaultPingInterval                   = 10 * time.Second
-	defaultWriteTimeout                   = 120 * time.Second
-	defaultHandshakeTimeout               = 10 * time.Second
-	defaultDropInterval                   = 1 * time.Second
-	defaultShutdownTimeout                = 300 * time.Second
-	defaultMaxConns                       = math.MaxInt32
-	PortRandom                            = -1
+
+	// maxInboundMessageBytes is the maximum number of bytes we'll read from a
+	// client for a single gob message. Client messages (MsgClientHello, MsgPong,
+	// MsgACK, MsgDecoderRestart) are small; 1 MiB is far more than any legitimate
+	// message requires but safely caps memory usage against malformed or
+	// malicious input.
+	maxInboundMessageBytes      int64 = 1 << 20
+	defaultBatchingAgeThreshold       = 100 * time.Millisecond
+	defaultPingInterval               = 10 * time.Second
+	defaultWriteTimeout               = 120 * time.Second
+	defaultHandshakeTimeout           = 10 * time.Second
+	defaultDropInterval               = 1 * time.Second
+	defaultShutdownTimeout            = 300 * time.Second
+	defaultMaxConns                   = math.MaxInt32
+	PortRandom                        = -1
 )
 
 type Server struct {
@@ -847,7 +855,7 @@ func (h *connection) readFromClient(logCxt *log.Entry) {
 		h.shutDownWG.Done()
 		logCxt.Info("Read goroutine finished")
 	}()
-	r := gob.NewDecoder(h.conn)
+	r := gob.NewDecoder(newGobFrameLimitedReader(h.conn, uint64(maxInboundMessageBytes)))
 	for {
 		var envelope syncproto.Envelope
 		err := r.Decode(&envelope)
@@ -870,6 +878,122 @@ func (h *connection) readFromClient(logCxt *log.Entry) {
 		}
 
 	}
+}
+
+// gobFrameLimitedReader wraps a gob stream and enforces a maximum payload size
+// per top-level gob message. It reads the length prefix for the next message,
+// rejects oversized payloads before allocating for them, then serves the exact
+// framed bytes back to gob so the decoder retains its usual stream semantics.
+type gobFrameLimitedReader struct {
+	r      io.Reader
+	br     io.ByteReader
+	limit  uint64
+	frame  []byte
+	offset int
+}
+
+func newGobFrameLimitedReader(r io.Reader, limit uint64) *gobFrameLimitedReader {
+	if br, ok := r.(io.ByteReader); ok {
+		return &gobFrameLimitedReader{
+			r:     r,
+			br:    br,
+			limit: limit,
+		}
+	}
+	buffered := bufio.NewReader(r)
+	return &gobFrameLimitedReader{
+		r:     buffered,
+		br:    buffered,
+		limit: limit,
+	}
+}
+
+func (l *gobFrameLimitedReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if err := l.fillFrame(); err != nil {
+		return 0, err
+	}
+	n := copy(p, l.frame[l.offset:])
+	l.offset += n
+	if l.offset == len(l.frame) {
+		l.frame = nil
+		l.offset = 0
+	}
+	return n, nil
+}
+
+func (l *gobFrameLimitedReader) ReadByte() (byte, error) {
+	if err := l.fillFrame(); err != nil {
+		return 0, err
+	}
+	b := l.frame[l.offset]
+	l.offset++
+	if l.offset == len(l.frame) {
+		l.frame = nil
+		l.offset = 0
+	}
+	return b, nil
+}
+
+func (l *gobFrameLimitedReader) fillFrame() error {
+	if l.offset < len(l.frame) {
+		return nil
+	}
+
+	prefix, nbytes, err := readGobUint(l.br)
+	if err != nil {
+		return err
+	}
+	if nbytes > l.limit {
+		return fmt.Errorf("%w (declared %d bytes, limit %d)", errInboundMessageTooLarge, nbytes, l.limit)
+	}
+
+	l.frame = make([]byte, len(prefix)+int(nbytes))
+	l.offset = 0
+	copy(l.frame, prefix)
+	_, err = io.ReadFull(l.r, l.frame[len(prefix):])
+	if err != nil {
+		l.frame = nil
+		if errors.Is(err, io.EOF) {
+			return io.ErrUnexpectedEOF
+		}
+		return err
+	}
+	return nil
+}
+
+// readGobUint reads a gob-encoded unsigned integer from r and returns both the
+// original encoded bytes and the decoded value.
+func readGobUint(r io.ByteReader) ([]byte, uint64, error) {
+	first, err := r.ReadByte()
+	if err != nil {
+		return nil, 0, err
+	}
+	prefix := []byte{first}
+	if first <= 0x7f {
+		return prefix, uint64(first), nil
+	}
+
+	n := -int(int8(first))
+	if n <= 0 || n > 8 {
+		return nil, 0, errors.New("invalid gob message length prefix")
+	}
+
+	var value uint64
+	for i := 0; i < n; i++ {
+		b, err := r.ReadByte()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, 0, io.ErrUnexpectedEOF
+			}
+			return nil, 0, err
+		}
+		prefix = append(prefix, b)
+		value = (value << 8) | uint64(b)
+	}
+	return prefix, value, nil
 }
 
 // waitForMessage blocks, waiting for a message on the h.readC channel.  It imposes a timeout.

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -893,11 +893,15 @@ type limitedReader struct {
 }
 
 func (l *limitedReader) Read(p []byte) (int, error) {
+	avail := l.limit - l.n
+	if avail <= 0 {
+		return 0, fmt.Errorf("%w (read %d bytes, limit %d)", errInboundMessageTooLarge, l.n, l.limit)
+	}
+	if int64(len(p)) > avail {
+		p = p[:avail]
+	}
 	n, err := l.r.Read(p)
 	l.n += int64(n)
-	if l.n > l.limit {
-		return n, fmt.Errorf("%w (read %d bytes, limit %d)", errInboundMessageTooLarge, l.n, l.limit)
-	}
 	return n, err
 }
 

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -52,7 +52,7 @@ var (
 	ErrReadFailed               = errors.New("failed to read from client")
 	ErrUnexpectedClientMsg      = errors.New("unexpected message from client")
 	ErrUnsupportedClientFeature = errors.New("unsupported client feature")
-	errInboundMessageTooLarge = errors.New("inbound message too large")
+	errInboundMessageTooLarge   = errors.New("inbound message too large")
 )
 
 var (

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -52,7 +52,7 @@ var (
 	ErrReadFailed               = errors.New("failed to read from client")
 	ErrUnexpectedClientMsg      = errors.New("unexpected message from client")
 	ErrUnsupportedClientFeature = errors.New("unsupported client feature")
-	errInboundMessageTooLarge   = errors.New("inbound message too large")
+	errInboundMessageTooLarge = errors.New("inbound message too large")
 )
 
 var (
@@ -855,8 +855,10 @@ func (h *connection) readFromClient(logCxt *log.Entry) {
 		h.shutDownWG.Done()
 		logCxt.Info("Read goroutine finished")
 	}()
-	r := gob.NewDecoder(newGobFrameLimitedReader(h.conn, uint64(maxInboundMessageBytes)))
+	lr := &limitedReader{r: h.conn, limit: maxInboundMessageBytes}
+	r := gob.NewDecoder(lr)
 	for {
+		lr.reset()
 		var envelope syncproto.Envelope
 		err := r.Decode(&envelope)
 		if err != nil {
@@ -880,120 +882,27 @@ func (h *connection) readFromClient(logCxt *log.Entry) {
 	}
 }
 
-// gobFrameLimitedReader wraps a gob stream and enforces a maximum payload size
-// per top-level gob message. It reads the length prefix for the next message,
-// rejects oversized payloads before allocating for them, then serves the exact
-// framed bytes back to gob so the decoder retains its usual stream semantics.
-type gobFrameLimitedReader struct {
-	r      io.Reader
-	br     io.ByteReader
-	limit  uint64
-	frame  []byte
-	offset int
+// limitedReader wraps an io.Reader and tracks the total bytes read since the
+// last call to reset. If the cumulative bytes exceed the limit, Read returns
+// an error. Call reset between gob Decode calls so the limit applies
+// per-message rather than over the whole connection lifetime.
+type limitedReader struct {
+	r     io.Reader
+	limit int64
+	n     int64
 }
 
-func newGobFrameLimitedReader(r io.Reader, limit uint64) *gobFrameLimitedReader {
-	if br, ok := r.(io.ByteReader); ok {
-		return &gobFrameLimitedReader{
-			r:     r,
-			br:    br,
-			limit: limit,
-		}
+func (l *limitedReader) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	l.n += int64(n)
+	if l.n > l.limit {
+		return n, fmt.Errorf("%w (read %d bytes, limit %d)", errInboundMessageTooLarge, l.n, l.limit)
 	}
-	buffered := bufio.NewReader(r)
-	return &gobFrameLimitedReader{
-		r:     buffered,
-		br:    buffered,
-		limit: limit,
-	}
+	return n, err
 }
 
-func (l *gobFrameLimitedReader) Read(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	if err := l.fillFrame(); err != nil {
-		return 0, err
-	}
-	n := copy(p, l.frame[l.offset:])
-	l.offset += n
-	if l.offset == len(l.frame) {
-		l.frame = nil
-		l.offset = 0
-	}
-	return n, nil
-}
-
-func (l *gobFrameLimitedReader) ReadByte() (byte, error) {
-	if err := l.fillFrame(); err != nil {
-		return 0, err
-	}
-	b := l.frame[l.offset]
-	l.offset++
-	if l.offset == len(l.frame) {
-		l.frame = nil
-		l.offset = 0
-	}
-	return b, nil
-}
-
-func (l *gobFrameLimitedReader) fillFrame() error {
-	if l.offset < len(l.frame) {
-		return nil
-	}
-
-	prefix, nbytes, err := readGobUint(l.br)
-	if err != nil {
-		return err
-	}
-	if nbytes > l.limit {
-		return fmt.Errorf("%w (declared %d bytes, limit %d)", errInboundMessageTooLarge, nbytes, l.limit)
-	}
-
-	l.frame = make([]byte, len(prefix)+int(nbytes))
-	l.offset = 0
-	copy(l.frame, prefix)
-	_, err = io.ReadFull(l.r, l.frame[len(prefix):])
-	if err != nil {
-		l.frame = nil
-		if errors.Is(err, io.EOF) {
-			return io.ErrUnexpectedEOF
-		}
-		return err
-	}
-	return nil
-}
-
-// readGobUint reads a gob-encoded unsigned integer from r and returns both the
-// original encoded bytes and the decoded value.
-func readGobUint(r io.ByteReader) ([]byte, uint64, error) {
-	first, err := r.ReadByte()
-	if err != nil {
-		return nil, 0, err
-	}
-	prefix := []byte{first}
-	if first <= 0x7f {
-		return prefix, uint64(first), nil
-	}
-
-	n := -int(int8(first))
-	if n <= 0 || n > 8 {
-		return nil, 0, errors.New("invalid gob message length prefix")
-	}
-
-	var value uint64
-	for i := 0; i < n; i++ {
-		b, err := r.ReadByte()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil, 0, io.ErrUnexpectedEOF
-			}
-			return nil, 0, err
-		}
-		prefix = append(prefix, b)
-		value = (value << 8) | uint64(b)
-	}
-	return prefix, value, nil
+func (l *limitedReader) reset() {
+	l.n = 0
 }
 
 // waitForMessage blocks, waiting for a message on the h.readC channel.  It imposes a timeout.

--- a/typha/pkg/syncserver/sync_server_message_limit_test.go
+++ b/typha/pkg/syncserver/sync_server_message_limit_test.go
@@ -89,10 +89,15 @@ func TestLimitedReaderRejectsOversizedRead(t *testing.T) {
 				t.Fatalf("expected errInboundMessageTooLarge, got %v", err)
 			}
 			break
+		} else if n <= 0 {
+			t.Fatalf("read returned 0 bytes without error, possible infinite loop")
+		}
+		if total > limit {
+			t.Fatalf("read past limit without error: total %d, limit %d", total, limit)
 		}
 	}
-	if total > limit {
-		t.Fatalf("expected reads to be clamped at limit, but read %d bytes (limit %d)", total, limit)
+	if total != limit {
+		t.Fatalf("expected total bytes read to equal limit, got %d (limit %d)", total, limit)
 	}
 }
 
@@ -101,13 +106,21 @@ func TestLimitedReaderResetAllowsNextMessage(t *testing.T) {
 	lr := &limitedReader{r: bytes.NewReader(data), limit: 60}
 
 	buf := make([]byte, 50)
-	if _, err := lr.Read(buf); err != nil {
+	n, err := lr.Read(buf)
+	if err != nil {
 		t.Fatalf("first read should succeed: %v", err)
+	}
+	if n != 50 {
+		t.Fatalf("first read: expected 50 bytes, got %d", n)
 	}
 
 	lr.reset()
 
-	if _, err := lr.Read(buf); err != nil {
+	n, err = lr.Read(buf)
+	if err != nil {
 		t.Fatalf("read after reset should succeed: %v", err)
+	}
+	if n != 50 {
+		t.Fatalf("read after reset: expected 50 bytes, got %d", n)
 	}
 }

--- a/typha/pkg/syncserver/sync_server_message_limit_test.go
+++ b/typha/pkg/syncserver/sync_server_message_limit_test.go
@@ -91,8 +91,8 @@ func TestLimitedReaderRejectsOversizedRead(t *testing.T) {
 			break
 		}
 	}
-	if total <= limit {
-		t.Fatalf("expected to read past limit before error, read %d", total)
+	if total > limit {
+		t.Fatalf("expected reads to be clamped at limit, but read %d bytes (limit %d)", total, limit)
 	}
 }
 

--- a/typha/pkg/syncserver/sync_server_message_limit_test.go
+++ b/typha/pkg/syncserver/sync_server_message_limit_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
-	"io"
 	"reflect"
 	"testing"
 	"time"
@@ -26,7 +25,7 @@ import (
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
 )
 
-func TestGobFrameLimitedReaderPreservesGobStreamState(t *testing.T) {
+func TestLimitedReaderAllowsNormalMessages(t *testing.T) {
 	var stream bytes.Buffer
 	enc := gob.NewEncoder(&stream)
 
@@ -51,9 +50,11 @@ func TestGobFrameLimitedReaderPreservesGobStreamState(t *testing.T) {
 		t.Fatalf("encoding pong: %v", err)
 	}
 
-	dec := gob.NewDecoder(newGobFrameLimitedReader(bytes.NewReader(stream.Bytes()), 1024))
+	lr := &limitedReader{r: bytes.NewReader(stream.Bytes()), limit: 1024}
+	dec := gob.NewDecoder(lr)
 
 	var gotHello syncproto.Envelope
+	lr.reset()
 	if err := dec.Decode(&gotHello); err != nil {
 		t.Fatalf("decoding hello: %v", err)
 	}
@@ -62,6 +63,7 @@ func TestGobFrameLimitedReaderPreservesGobStreamState(t *testing.T) {
 	}
 
 	var gotPong syncproto.Envelope
+	lr.reset()
 	if err := dec.Decode(&gotPong); err != nil {
 		t.Fatalf("decoding pong: %v", err)
 	}
@@ -70,87 +72,42 @@ func TestGobFrameLimitedReaderPreservesGobStreamState(t *testing.T) {
 	}
 }
 
-func TestGobFrameLimitedReaderPreservesGobStreamStateWithBufioPath(t *testing.T) {
-	var stream bytes.Buffer
-	enc := gob.NewEncoder(&stream)
+func TestLimitedReaderRejectsOversizedRead(t *testing.T) {
+	// Create a payload larger than the limit.
+	const limit int64 = 64
+	payload := bytes.Repeat([]byte{0xab}, int(limit*2))
 
-	wantHello := syncproto.Envelope{
-		Message: syncproto.MsgClientHello{
-			Hostname:   "node-a",
-			Info:       "test",
-			Version:    "v3.31.5",
-			SyncerType: syncproto.SyncerTypeFelix,
-		},
-	}
-	wantPong := syncproto.Envelope{
-		Message: syncproto.MsgPong{
-			PingTimestamp: time.Unix(123, 456),
-		},
-	}
+	lr := &limitedReader{r: bytes.NewReader(payload), limit: limit}
 
-	if err := enc.Encode(&wantHello); err != nil {
-		t.Fatalf("encoding hello: %v", err)
+	buf := make([]byte, len(payload))
+	var total int64
+	for {
+		n, err := lr.Read(buf[total:])
+		total += int64(n)
+		if err != nil {
+			if !errors.Is(err, errInboundMessageTooLarge) {
+				t.Fatalf("expected errInboundMessageTooLarge, got %v", err)
+			}
+			break
+		}
 	}
-	if err := enc.Encode(&wantPong); err != nil {
-		t.Fatalf("encoding pong: %v", err)
-	}
-
-	// Wrap in struct{io.Reader} to hide the ReadByte method, forcing the
-	// bufio.NewReader path in newGobFrameLimitedReader — the same path
-	// used in production with net.Conn.
-	dec := gob.NewDecoder(newGobFrameLimitedReader(struct{ io.Reader }{bytes.NewReader(stream.Bytes())}, 1024))
-
-	var gotHello syncproto.Envelope
-	if err := dec.Decode(&gotHello); err != nil {
-		t.Fatalf("decoding hello: %v", err)
-	}
-	if !reflect.DeepEqual(gotHello, wantHello) {
-		t.Fatalf("decoded hello mismatch: got %#v want %#v", gotHello, wantHello)
-	}
-
-	var gotPong syncproto.Envelope
-	if err := dec.Decode(&gotPong); err != nil {
-		t.Fatalf("decoding pong: %v", err)
-	}
-	if !reflect.DeepEqual(gotPong, wantPong) {
-		t.Fatalf("decoded pong mismatch: got %#v want %#v", gotPong, wantPong)
+	if total <= limit {
+		t.Fatalf("expected to read past limit before error, read %d", total)
 	}
 }
 
-func TestGobFrameLimitedReaderRejectsOversizedFrameBeforeReadingPayload(t *testing.T) {
-	const limit = 16
-	payload := bytes.Repeat([]byte{0xab}, 32)
-	prefix := encodeGobUint(limit + 1)
-	source := bytes.NewReader(append(prefix, payload...))
+func TestLimitedReaderResetAllowsNextMessage(t *testing.T) {
+	data := bytes.Repeat([]byte{0x01}, 100)
+	lr := &limitedReader{r: bytes.NewReader(data), limit: 60}
 
-	reader := newGobFrameLimitedReader(source, limit)
-
-	var oneByte [1]byte
-	_, err := reader.Read(oneByte[:])
-	if !errors.Is(err, errInboundMessageTooLarge) {
-		t.Fatalf("expected oversized-frame error, got %v", err)
+	buf := make([]byte, 50)
+	if _, err := lr.Read(buf); err != nil {
+		t.Fatalf("first read should succeed: %v", err)
 	}
 
-	if remaining := source.Len(); remaining != len(payload) {
-		t.Fatalf("expected payload to remain unread, %d bytes remain", remaining)
-	}
-}
+	lr.reset()
 
-func encodeGobUint(value uint64) []byte {
-	if value <= 0x7f {
-		return []byte{byte(value)}
+	if _, err := lr.Read(buf); err != nil {
+		t.Fatalf("read after reset should succeed: %v", err)
 	}
-
-	n := 0
-	for tmp := value; tmp > 0; tmp >>= 8 {
-		n++
-	}
-
-	buf := make([]byte, n+1)
-	buf[0] = byte(-int8(n))
-	for i := n; i > 0; i-- {
-		buf[i] = byte(value)
-		value >>= 8
-	}
-	return buf
 }

--- a/typha/pkg/syncserver/sync_server_message_limit_test.go
+++ b/typha/pkg/syncserver/sync_server_message_limit_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncserver
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/projectcalico/calico/typha/pkg/syncproto"
+)
+
+func TestGobFrameLimitedReaderPreservesGobStreamState(t *testing.T) {
+	var stream bytes.Buffer
+	enc := gob.NewEncoder(&stream)
+
+	wantHello := syncproto.Envelope{
+		Message: syncproto.MsgClientHello{
+			Hostname:   "node-a",
+			Info:       "test",
+			Version:    "v3.31.5",
+			SyncerType: syncproto.SyncerTypeFelix,
+		},
+	}
+	wantPong := syncproto.Envelope{
+		Message: syncproto.MsgPong{
+			PingTimestamp: time.Unix(123, 456),
+		},
+	}
+
+	if err := enc.Encode(&wantHello); err != nil {
+		t.Fatalf("encoding hello: %v", err)
+	}
+	if err := enc.Encode(&wantPong); err != nil {
+		t.Fatalf("encoding pong: %v", err)
+	}
+
+	dec := gob.NewDecoder(newGobFrameLimitedReader(bytes.NewReader(stream.Bytes()), 1024))
+
+	var gotHello syncproto.Envelope
+	if err := dec.Decode(&gotHello); err != nil {
+		t.Fatalf("decoding hello: %v", err)
+	}
+	if !reflect.DeepEqual(gotHello, wantHello) {
+		t.Fatalf("decoded hello mismatch: got %#v want %#v", gotHello, wantHello)
+	}
+
+	var gotPong syncproto.Envelope
+	if err := dec.Decode(&gotPong); err != nil {
+		t.Fatalf("decoding pong: %v", err)
+	}
+	if !reflect.DeepEqual(gotPong, wantPong) {
+		t.Fatalf("decoded pong mismatch: got %#v want %#v", gotPong, wantPong)
+	}
+}
+
+func TestGobFrameLimitedReaderPreservesGobStreamStateWithBufioPath(t *testing.T) {
+	var stream bytes.Buffer
+	enc := gob.NewEncoder(&stream)
+
+	wantHello := syncproto.Envelope{
+		Message: syncproto.MsgClientHello{
+			Hostname:   "node-a",
+			Info:       "test",
+			Version:    "v3.31.5",
+			SyncerType: syncproto.SyncerTypeFelix,
+		},
+	}
+	wantPong := syncproto.Envelope{
+		Message: syncproto.MsgPong{
+			PingTimestamp: time.Unix(123, 456),
+		},
+	}
+
+	if err := enc.Encode(&wantHello); err != nil {
+		t.Fatalf("encoding hello: %v", err)
+	}
+	if err := enc.Encode(&wantPong); err != nil {
+		t.Fatalf("encoding pong: %v", err)
+	}
+
+	// Wrap in struct{io.Reader} to hide the ReadByte method, forcing the
+	// bufio.NewReader path in newGobFrameLimitedReader — the same path
+	// used in production with net.Conn.
+	dec := gob.NewDecoder(newGobFrameLimitedReader(struct{ io.Reader }{bytes.NewReader(stream.Bytes())}, 1024))
+
+	var gotHello syncproto.Envelope
+	if err := dec.Decode(&gotHello); err != nil {
+		t.Fatalf("decoding hello: %v", err)
+	}
+	if !reflect.DeepEqual(gotHello, wantHello) {
+		t.Fatalf("decoded hello mismatch: got %#v want %#v", gotHello, wantHello)
+	}
+
+	var gotPong syncproto.Envelope
+	if err := dec.Decode(&gotPong); err != nil {
+		t.Fatalf("decoding pong: %v", err)
+	}
+	if !reflect.DeepEqual(gotPong, wantPong) {
+		t.Fatalf("decoded pong mismatch: got %#v want %#v", gotPong, wantPong)
+	}
+}
+
+func TestGobFrameLimitedReaderRejectsOversizedFrameBeforeReadingPayload(t *testing.T) {
+	const limit = 16
+	payload := bytes.Repeat([]byte{0xab}, 32)
+	prefix := encodeGobUint(limit + 1)
+	source := bytes.NewReader(append(prefix, payload...))
+
+	reader := newGobFrameLimitedReader(source, limit)
+
+	var oneByte [1]byte
+	_, err := reader.Read(oneByte[:])
+	if !errors.Is(err, errInboundMessageTooLarge) {
+		t.Fatalf("expected oversized-frame error, got %v", err)
+	}
+
+	if remaining := source.Len(); remaining != len(payload) {
+		t.Fatalf("expected payload to remain unread, %d bytes remain", remaining)
+	}
+}
+
+func encodeGobUint(value uint64) []byte {
+	if value <= 0x7f {
+		return []byte{byte(value)}
+	}
+
+	n := 0
+	for tmp := value; tmp > 0; tmp >>= 8 {
+		n++
+	}
+
+	buf := make([]byte, n+1)
+	buf[0] = byte(-int8(n))
+	for i := n; i > 0; i-- {
+		buf[i] = byte(value)
+		value >>= 8
+	}
+	return buf
+}


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

- Add a size limit for inbound Typha client gob frames to prevent oversized messages from consuming excessive memory.
- Reject oversized client frames before reading the payload, reducing Typha’s exposure to DoS from malformed or malicious connections.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Typha now rejects oversized inbound client gob frames before reading them, preventing a potential denial-of-service caused by excessive memory allocation.
```
https://github.com/projectcalico/calico/pull/12479