### PR TITLE
Capture pod diagnostics on winfv-felix setup failure

### DIFF
--- a/process/testing/aso/install-aso.sh
+++ b/process/testing/aso/install-aso.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024 Tigera, Inc. All rights reserved.
+# Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ set -o pipefail
 
 : "${ASO_DIR:="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}"
 
+. "${ASO_DIR}/../util/utils.sh"
+
 : "${KIND_CLUSTER_NAME:=kind}"
 : "${KINDEST_NODE_VERSION:=v1.31.0}"
 : "${CERT_MANAGER_VERSION:=v1.14.1}"
@@ -30,6 +32,14 @@ CRD_PATTERN="resources.azure.com/*;containerservice.azure.com/*;compute.azure.co
 : ${CMCTL:=./bin/cmctl}
 : ${ASOCTL:=./bin/asoctl}
 : ${HELM:=./bin/helm}
+
+# On failure, capture describe + logs for every non-Ready pod in the kind cluster
+# so CI has something actionable to look at. Under Semaphore we drop straight into
+# /home/semaphore/fv.log/ (the job's artifact staging dir); otherwise fall back to
+# /tmp for hand runs.
+diag_dir="${DIAG_DIR:-/home/semaphore/fv.log/diagnostics}"
+[[ -d /home/semaphore ]] || diag_dir="/tmp/pod-diagnostics"
+trap 'exit_code=$?; if [ $exit_code -ne 0 ]; then echo ""; echo "========================================"; echo "Script failed! Collecting pod diagnostics..."; echo "========================================"; KUBECTL='"${KUBECTL}"' KUBECONFIG='"${ASO_DIR}"'/kind-kubeconfig collect_pod_diagnostics "'"${diag_dir}"'"; fi; exit $exit_code' EXIT
 
 # Create management cluster
 ${KIND} create cluster --image "kindest/node:${KINDEST_NODE_VERSION}" --name "${KIND_CLUSTER_NAME}" --verbosity 5

--- a/process/testing/aso/install-calico.sh
+++ b/process/testing/aso/install-calico.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+# Copyright (c) 2022-2026 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,12 @@ set -o pipefail
 . ../util/utils.sh
 . ./export-env.sh
 
-# Trap to show pod status on failure for debugging
-trap 'exit_code=$?; if [ $exit_code -ne 0 ]; then echo ""; echo "========================================"; echo "Script failed! Showing pod status for debugging:"; echo "========================================"; ./bin/kubectl get pod -A -o wide --kubeconfig=./kubeconfig 2>/dev/null || true; fi; exit $exit_code' EXIT
+# On failure, capture describe + logs for every non-Ready pod so CI has something
+# actionable to look at. Under Semaphore we drop straight into /home/semaphore/fv.log/
+# (the job's artifact staging dir); otherwise fall back to /tmp for hand runs.
+diag_dir="${DIAG_DIR:-/home/semaphore/fv.log/diagnostics}"
+[[ -d /home/semaphore ]] || diag_dir="/tmp/pod-diagnostics"
+trap 'exit_code=$?; if [ $exit_code -ne 0 ]; then echo ""; echo "========================================"; echo "Script failed! Collecting pod diagnostics..."; echo "========================================"; KUBECTL=./bin/kubectl KUBECONFIG=./kubeconfig collect_pod_diagnostics "'"${diag_dir}"'"; fi; exit $exit_code' EXIT
 
 # Use kubectl with kubeconfig from install-kubeadm.sh
 : "${KUBECTL:=./bin/kubectl}"

--- a/process/testing/util/utils.sh
+++ b/process/testing/util/utils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2025 Tigera, Inc. All rights reserved.
+# Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,6 +61,72 @@ function retry_command() {
   done
   echo "Command '${CMD}' failed after $RETRY attempts"
   return 1
+}
+
+# collect_pod_diagnostics writes describe + logs (current and previous) for every
+# pod whose Ready condition is not True, plus cluster-wide pod/event/node snapshots.
+# Expects KUBECTL and KUBECONFIG in the environment. Safe to call from an EXIT trap;
+# every kubectl invocation tolerates failure so we never mask the original exit code.
+#
+# Args:
+#   $1 - output directory (created if missing). Defaults to /tmp/pod-diagnostics.
+function collect_pod_diagnostics() {
+    local out_dir="${1:-/tmp/pod-diagnostics}"
+    local kubectl="${KUBECTL:-kubectl}"
+
+    mkdir -p "${out_dir}"
+
+    echo ""
+    echo "========================================"
+    echo "Collecting pod diagnostics into ${out_dir}"
+    echo "========================================"
+
+    ${kubectl} get pod -A -o wide > "${out_dir}/pods.txt" 2>&1 || true
+    ${kubectl} get events -A --sort-by=.lastTimestamp > "${out_dir}/events.txt" 2>&1 || true
+    ${kubectl} get nodes -o wide > "${out_dir}/nodes.txt" 2>&1 || true
+
+    local not_ready
+    not_ready=$(${kubectl} get pod -A \
+        -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name} {.status.phase} {range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
+        2>/dev/null \
+        | awk '$2 != "Succeeded" && $3 != "True" { print $1 }' || true)
+
+    if [[ -z "${not_ready}" ]]; then
+        echo "No non-Ready pods found."
+        return 0
+    fi
+
+    echo "Non-Ready pods:"
+    echo "${not_ready}" | sed 's/^/  /'
+    echo ""
+
+    local ns_pod ns pod safe containers c
+    for ns_pod in ${not_ready}; do
+        ns="${ns_pod%%/*}"
+        pod="${ns_pod#*/}"
+        safe="${ns}_${pod}"
+
+        ${kubectl} describe pod "${pod}" -n "${ns}" \
+            > "${out_dir}/${safe}.describe.txt" 2>&1 || true
+
+        containers=$(${kubectl} get pod "${pod}" -n "${ns}" \
+            -o jsonpath='{.spec.initContainers[*].name} {.spec.containers[*].name}' 2>/dev/null || true)
+
+        echo "--- ${ns_pod} ---"
+        for c in ${containers}; do
+            ${kubectl} logs "${pod}" -n "${ns}" -c "${c}" --tail=500 \
+                > "${out_dir}/${safe}.${c}.log" 2>&1 || true
+            ${kubectl} logs "${pod}" -n "${ns}" -c "${c}" --tail=500 --previous \
+                > "${out_dir}/${safe}.${c}.previous.log" 2>&1 || true
+
+            echo "  container ${c} (last 20 lines):"
+            ${kubectl} logs "${pod}" -n "${ns}" -c "${c}" --tail=20 2>&1 \
+                | sed 's/^/    /' || true
+        done
+        echo ""
+    done
+
+    echo "Full diagnostics written to ${out_dir}"
 }
 
 unset -f pause-for-debug

--- a/process/testing/winfv-felix/run-win-fv.sh
+++ b/process/testing/winfv-felix/run-win-fv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025 Tigera, Inc. All rights reserved.
+# Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,8 @@ pushd "${SCRIPT_DIR}"
 FV_TYPE=${FV_TYPE} ./setup-fv.sh | tee setupfv.log; pstat=${PIPESTATUS[0]}
 if [[ $pstat != 0 ]]; then
     EXIT_CODE=$pstat
+    KUBECTL="${ASO_DIR}/bin/kubectl" KUBECONFIG="${ASO_DIR}/kubeconfig" \
+        collect_pod_diagnostics /home/semaphore/fv.log/diagnostics
 fi
 
 # Copy report directory from windows node.


### PR DESCRIPTION
When the winfv-felix setup times out waiting for pods, the existing trap only runs `kubectl get pod -A -o wide` - we know what failed but not why. A recent enterprise run timed out waiting on a Windows pod and there was no describe, no events, and no container logs in the job output to diagnose it from.

Adds a `collect_pod_diagnostics` helper in `process/testing/util/utils.sh` that writes describe + current-container and previous-container logs for every non-Ready pod into `/home/semaphore/fv.log/diagnostics/` (so Semaphore picks it up as a job artifact), with a `/tmp` fallback for hand runs. Wired into the `install-aso.sh` and `install-calico.sh` traps and the `setup-fv.sh` failure path in `run-win-fv.sh`. Also echoes the tail of each non-Ready container's logs straight to stdout so the failure is diagnosable from the job log alone without downloading artifacts.

Port of https://github.com/tigera/calico-private/pull/11644 - the four files touched are byte-identical between OSS and calico-private, and the helper is product-agnostic.

```release-note
None
```