### PR TITLE
Enable external node on in-repo GCP e2e block

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -619,6 +619,8 @@ blocks:
           value: "e2e/config/gcp-bpf.yaml"
         - name: USE_API_SERVER
           value: "false"
+        - name: ENABLE_EXTERNAL_NODE
+          value: "true"
       jobs:
         - name: gcp-kubeadm - e2e local binary
           execution_time_limit:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1049,6 +1049,8 @@ blocks:
           value: "e2e/config/gcp-bpf.yaml"
         - name: USE_API_SERVER
           value: "false"
+        - name: ENABLE_EXTERNAL_NODE
+          value: "true"
       jobs:
         - name: gcp-kubeadm - e2e local binary
           execution_time_limit:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
@@ -34,6 +34,8 @@
         value: "e2e/config/gcp-bpf.yaml"
       - name: USE_API_SERVER
         value: "false"
+      - name: ENABLE_EXTERNAL_NODE
+        value: "true"
     jobs:
       - name: gcp-kubeadm - e2e local binary
         execution_time_limit:

--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -18,7 +18,7 @@ exclude:
     - label: Disruptive
       reason: "breaks cluster state for other parallel tests"
 
-    - label: RunsOnAWS
+    - label: RequiresAWS
       reason: "requires AWS-specific infrastructure (VPC routing layout, etc.)"
 
     - label: RequiresBGPMesh

--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -18,9 +18,6 @@ exclude:
     - label: Disruptive
       reason: "breaks cluster state for other parallel tests"
 
-    - label: ExternalNode
-      reason: "requires a non-cluster node with EXT_IP/EXT_KEY/EXT_USER configured"
-
     - label: RequiresBGPMesh
       reason: "requires BGP routing, but this cluster uses VXLAN"
 

--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -18,6 +18,9 @@ exclude:
     - label: Disruptive
       reason: "breaks cluster state for other parallel tests"
 
+    - label: RunsOnAWS
+      reason: "requires AWS-specific infrastructure (VPC routing layout, etc.)"
+
     - label: RequiresBGPMesh
       reason: "requires BGP routing, but this cluster uses VXLAN"
 

--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -131,14 +131,14 @@ func WithWindows() any {
 	return framework.WithLabel("RunsOnWindows")
 }
 
-// WithAzure marks tests that must run on Azure.
-func WithAzure() any {
-	return framework.WithLabel("RunsOnAzure")
+// RequiresAzure marks tests that can only run on Azure.
+func RequiresAzure() any {
+	return framework.WithLabel("RequiresAzure")
 }
 
-// WithAWS marks tests that must run on AWS.
-func WithAWS() any {
-	return framework.WithLabel("RunsOnAWS")
+// RequiresAWS marks tests that can only run on AWS.
+func RequiresAWS() any {
+	return framework.WithLabel("RequiresAWS")
 }
 
 // WithExternalNode marks tests that require an external node outside of the base cluster,

--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -369,8 +369,15 @@ var _ = describe.CalicoDescribe(
 					}
 				}
 
+				// Target the server's host IP + ports directly. The server pod is host-networked,
+				// so traffic from the external node hits the HEP-protected node on these ports.
+				serverHostIP := hepServer1.Pod().Status.HostIP
+				Expect(serverHostIP).NotTo(BeEmpty(), "server pod must have a host IP")
+				target1 := fmt.Sprintf("http://%s:%d/", serverHostIP, hepPort1)
+				target2 := fmt.Sprintf("http://%s:%d/", serverHostIP, hepPort2)
+
 				// create a networkpolicy that allows all incoming connections.
-				// assert client can ping hep
+				// assert external node can reach the hep.
 				allowIngressPolicy := &v3.GlobalNetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: fmt.Sprintf("%s-allow-all", hepPolicyName),
@@ -394,11 +401,9 @@ var _ = describe.CalicoDescribe(
 					Expect(err).NotTo(HaveOccurred())
 				}()
 
-				By("asserting connections work now from an external node", func() {
-					checker.ResetExpectations()
-					checker.ExpectSuccess(client1, hepServer1.ServiceDomain().Port(hepPort1))
-					checker.ExpectSuccess(client1, hepServer1.ServiceDomain().Port(hepPort2))
-					checker.Execute()
+				By("asserting connections work now from the external node", func() {
+					extClient.TestCanConnect(target1)
+					extClient.TestCanConnect(target2)
 				})
 
 				// We need to enable generic XDP to test XDP in Iptables mode, otherwise the raw table
@@ -475,10 +480,8 @@ var _ = describe.CalicoDescribe(
 				}()
 
 				By(fmt.Sprintf("asserting that none of the ports (tcp %d, %d) are accessible from the external node", hepPort1, hepPort2), func() {
-					checker.ResetExpectations()
-					checker.ExpectFailure(client1, hepServer1.ServiceDomain().Port(hepPort1))
-					checker.ExpectFailure(client1, hepServer1.ServiceDomain().Port(hepPort2))
-					checker.Execute()
+					extClient.TestCannotConnect(target1)
+					extClient.TestCannotConnect(target2)
 				})
 			})
 		})

--- a/e2e/pkg/tests/networking/maglev.go
+++ b/e2e/pkg/tests/networking/maglev.go
@@ -61,7 +61,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithExternalNode(),
 	describe.WithDataplane(describe.BPF),
 	describe.WithSerial(),
-	describe.WithAWS(),
+	describe.RequiresAWS(),
 	"Maglev load balancing tests",
 	func() {
 		var (


### PR DESCRIPTION
Flip `ENABLE_EXTERNAL_NODE=true` on the in-repo GCP kubeadm e2e block so `bz` provisions an external (non-cluster) node alongside the cluster, and drop the matching exclude from `e2e/config/gcp-bpf.yaml` so `ExternalNode`-labeled tests actually run.

`.semaphore/end-to-end/scripts/phases/configure.sh` already handles the env var — it reads `${BZ_LOCAL_DIR}/external_{ip,key}` that `bz` drops during provision and exports `EXT_IP` / `EXT_KEY` / `EXT_USER` for the test runner. Same mechanism calico-private's aws-kubeadm blocks use today.

Unlocks, on this block:
- `e2e/pkg/tests/networking/workload_ingress.go` external-node → NodePort/ClusterIP scenarios
- `e2e/pkg/tests/networking/packet_size.go` external-client context
- `e2e/pkg/tests/hostendpoints/hostendpoints.go` doNotTrack DoS deny policy

`base.yaml`'s `ExternalNode` exclude is left in place — kind configs still genuinely can't have an external node.

`RunsOnAWS` is now excluded on this block too. The Maglev external-node test (`e2e/pkg/tests/networking/maglev.go`) is tagged `[RunsOnAWS]` because its route setup on the external node (`ip route add <svc> via <nodeIP>`) assumes the node IP is on-link, which holds on AWS but not on GCP (where VM interfaces are `/32`). Honor the author's intent and keep it AWS-only.

The `hostendpoints` DoS test had a latent bug: it drove the connection from an in-cluster conncheck pod even though the policy denies traffic sourced from `extClient.IP()`. That would fail the moment it actually ran. Fixed here to drive from the external node directly against the host-networked server's host IP, matching the test description and policy intent.

```release-note
NONE
```
