### PR TITLE
Fix IPAM GC FV test race on informer cache

### DIFF
--- a/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/kube-controllers/pkg/config"
@@ -41,15 +42,29 @@ import (
 
 var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, ContinueOnFailure, func() {
 	var (
-		etcd      *containers.Container
-		c         client.Interface
-		k8sClient *fake.Clientset
-		stopCh    chan struct{}
-		ips       *testutils.TestBlockAllocator
+		etcd         *containers.Container
+		c            client.Interface
+		k8sClient    *fake.Clientset
+		stopCh       chan struct{}
+		ips          *testutils.TestBlockAllocator
+		nodeInformer cache.SharedIndexInformer
 	)
 
 	const kNodeName = "k8snodename"
 	const cNodeName = "calinodename"
+
+	// waitForK8sNodeInCache blocks until the node informer has observed the given
+	// node. The fake clientset delivers watch events to the informer asynchronously,
+	// so a Create call returns before the store is updated. If the IPAM controller
+	// runs checkAllocations before the node lands in cache, it sees the allocation's
+	// k8s node as missing and marks the IP as a confirmed leak with no grace period.
+	waitForK8sNodeInCache := func(name string) {
+		GinkgoHelper()
+		Eventually(func() bool {
+			_, exists, err := nodeInformer.GetStore().GetByKey(name)
+			return err == nil && exists
+		}, 5*time.Second, 50*time.Millisecond).Should(BeTrue(), "k8s node %q never appeared in informer cache", name)
+	}
 
 	BeforeAll(func() {
 		// Run etcd for the Calico datastore.
@@ -78,7 +93,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		stopCh = make(chan struct{})
 
 		factory := informers.NewSharedInformerFactory(k8sClient, 0)
-		nodeInformer := factory.Core().V1().Nodes().Informer()
+		nodeInformer = factory.Core().V1().Nodes().Informer()
 		podInformer := factory.Core().V1().Pods().Informer()
 
 		dataFeed := utils.NewDataFeed(c, utils.Etcdv3)
@@ -158,6 +173,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: kNodeName}}
 		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		waitForK8sNodeInCache(kNodeName)
 
 		// Create a Calico node with a reference to the K8s node.
 		cn := calicoNode(cNodeName, kNodeName, map[string]string{})
@@ -203,6 +219,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: commonNodeName}}
 		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		waitForK8sNodeInCache(commonNodeName)
 
 		// Create a Calico node without a node reference. Be extra tricky, by naming the calico node the
 		// same name as the Kubernetes node. This makes sure we're really using the orchRef properly.
@@ -265,6 +282,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", Ordered, Continue
 		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: commonNodeName}}
 		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		waitForK8sNodeInCache(commonNodeName)
 
 		// Allocate an IP address on a node that doesn't exist in Calico.
 		handleA := "handleA"


### PR DESCRIPTION
The etcd-mode IPAM GC FV tests intermittently fail the \`Consistently\` check in *should properly garbage collect IP addresses for mismatched node names*, reporting \`Expected 1 IPs with handle handleA, found 0\` a few seconds into what should be a 5-second window (see [this failure](https://tigera.semaphoreci.com/jobs/1e13145c-fdd4-438c-9bb4-f44e5ca97b4c/summary?report_id=d91f3999-23b7-34ec-bcab-c6743b918bb4&test_id=219e32cf-6a96-3042-82f9-7db17c08eed8)).

The test creates a Kubernetes node in the fake clientset and then creates a Calico node plus an allocation in etcd. The Calico etcd syncer can deliver those updates to \`checkAllocations\` before the K8s informer has propagated the node-add into the lister cache. The controller then sees the allocation's Kubernetes node as missing, and since the pod reference is also missing (the test never creates a pod), it skips the grace-period candidacy step and GCs the IP immediately.

Fix is test-side: hoist the node informer into the outer closure and wait for the informer store to observe the node before the test proceeds.

Verified with 20 consecutive passes of the etcd-mode Describe (~9 minutes).

\`\`\`release-note
None
\`\`\`