### PR TITLE
Add Felix FV test for RouteSyncDisabled=true

### DIFF
--- a/felix/fv/route_sync_disabled_test.go
+++ b/felix/fv/route_sync_disabled_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var _ = infrastructure.DatastoreDescribe(
-	"Network policy only mode (RouteSyncDisabled=true) tests",
+	"_BPF-SAFE_ Network policy only mode (RouteSyncDisabled=true) tests",
 	[]apiconfig.DatastoreType{apiconfig.EtcdV3},
 	func(getInfra infrastructure.InfraFactory) {
 		var (
@@ -42,22 +42,29 @@ var _ = infrastructure.DatastoreDescribe(
 			probeWl      *workload.Workload
 		)
 
+		const (
+			probeV4 = "10.65.0.10"
+			probeV6 = "dead:beef::10"
+			wlV4    = "10.65.0.2"
+			wlV6    = "dead:beef::2"
+			peerV4  = "169.254.0.179"
+			peerV6  = "fe80::179"
+		)
+
 		BeforeEach(func() {
 			infra = getInfra()
 
 			opts := infrastructure.DefaultTopologyOptions()
-			// Default topology uses IPIPModeAlways; turn off all encap so Felix
-			// would otherwise program plain workload routes directly on veths.
+			// Dual-stack: exercise both v4 and v6 paths.
 			opts.IPIPMode = api.IPIPModeNever
-			opts.VXLANMode = api.VXLANModeNever
-			opts.EnableIPv6 = false
+			opts.EnableIPv6 = true
 
 			// Set RouteSyncDisabled=true in the initial FelixConfiguration so
 			// Felix picks it up on startup — RouteSyncDisabled requires a Felix
 			// restart to take effect.
-			routeSyncDisabled := true
 			felixConfig := api.NewFelixConfiguration()
 			felixConfig.Name = "default"
+			routeSyncDisabled := true
 			felixConfig.Spec.RouteSyncDisabled = &routeSyncDisabled
 			opts.InitialFelixConfiguration = felixConfig
 
@@ -81,17 +88,51 @@ var _ = infrastructure.DatastoreDescribe(
 			// Felix only renders policy chains for policies that select at
 			// least one local endpoint, so we need a workload on the node
 			// before we can assert that the policy has been programmed.
-			probeWl = workload.Run(tc.Felixes[0], "probe", "default", "10.65.0.10", "8088", "tcp")
+			probeWl = workload.Run(tc.Felixes[0], "probe", "default", probeV4, "8088", "tcp",
+				workload.WithIPv6Address(probeV6))
 			probeWl.ConfigureInInfra(infra)
+
+			if BPFMode() {
+				// In BPF mode, policy lives in BPF programs attached to the
+				// workload's veth; wait for those to come up before asserting.
+				ensureAllNodesBPFProgramsAttached(tc.Felixes)
+			}
 
 			By("Verifying the default-allow policy is programmed in the dataplane")
 			Eventually(policyProgrammedOn(tc.Felixes[0], probeWl.InterfaceName, "default-allow"), "30s", "500ms").
 				Should(BeTrue(), "Felix should program the default-allow policy even when RouteSyncDisabled is true")
 		})
 
-		It("should not assign IPv4 addresses to workload endpoints", func() {
-			By("Creating a local workload")
-			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
+		// assertNoRouteEntry asserts that no route entry exists in any routing
+		// table for the given address on the given interface. Felix should not
+		// program routes at all when RouteSyncDisabled is true; this includes
+		// the side-channel entries that the kernel would install if Felix
+		// assigned an address to the veth via LinkAddrsManager.
+		assertNoRouteEntry := func(iface string, addrs ...string) {
+			for _, addr := range addrs {
+				flag := "-4"
+				if strings.Contains(addr, ":") {
+					flag = "-6"
+				}
+				query := func() string {
+					out, _ := tc.Felixes[0].ExecOutput(
+						"ip", flag, "route", "show", "table", "all", addr, "dev", iface)
+					return out
+				}
+				Eventually(query, "5s", "500ms").Should(BeEmpty(),
+					"Felix should not program a route for %s on %s when RouteSyncDisabled is true",
+					addr, iface)
+				Consistently(query, "3s", "500ms").Should(BeEmpty(),
+					"Felix should not program a route for %s on %s when RouteSyncDisabled is true",
+					addr, iface)
+			}
+		}
+
+		It("should not program routes for workload endpoint addresses", func() {
+			By("Creating a dual-stack local workload")
+			wl := workload.Run(tc.Felixes[0], "w0", "default", wlV4, "8088", "tcp",
+				workload.WithIPv6Address(wlV6))
+			defer wl.Stop()
 			wl.ConfigureInInfra(infra)
 
 			By("Waiting for the workload's veth to exist on the host")
@@ -100,33 +141,34 @@ var _ = infrastructure.DatastoreDescribe(
 				return out
 			}, "30s").Should(ContainSubstring(wl.InterfaceName))
 
-			By("Verifying no IPv4 address is assigned to the workload interface")
-			// With RouteSyncDisabled=true, Felix should not touch the workload
-			// veth beyond what's required for policy. The host side of the veth
-			// should have no IPv4 addresses attached.
-			Consistently(func() string {
-				out, _ := tc.Felixes[0].ExecOutput("ip", "-4", "addr", "show", "dev", wl.InterfaceName)
-				return out
-			}, "5s", "500ms").ShouldNot(ContainSubstring("inet "),
-				"Felix should not assign any IPv4 address to the workload interface when RouteSyncDisabled is true")
+			By("Verifying no routes are programmed for the workload IPs")
+			// With RouteSyncDisabled=true, Felix's endpoint manager writes
+			// workload routes into a DummyTable; no /32 or /128 entry should
+			// appear in any kernel routing table.
+			assertNoRouteEntry(wl.InterfaceName, wlV4+"/32", wlV6+"/128")
 		})
 
-		It("should not assign link-local peer addresses to the workload interface", func() {
+		It("should not program routes for link-local peer addresses", func() {
 			// When a workload is selected as a local BGP peer, the endpoint
-			// manager calls LinkAddrsManager.SetLinkLocalAddress, which issues
-			// netlink AddrAdd on the workload's veth. That peer address is only
-			// useful when Felix is also programming routes, but not when RouteSyncDisabled is true.
+			// manager would normally call LinkAddrsManager.SetLinkLocalAddress,
+			// which issues netlink AddrAdd on the workload's veth. The kernel
+			// then populates the local routing table with entries for the
+			// assigned address. With RouteSyncDisabled=true the link-address
+			// manager must be inert, so no such local-table entries should
+			// appear.
 			By("Creating a workload labelled for local BGP peering")
-			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
+			wl := workload.Run(tc.Felixes[0], "w0", "default", wlV4, "8088", "tcp",
+				workload.WithIPv6Address(wlV6))
 			wl.WorkloadEndpoint.Labels["role"] = "bgp-peer"
 			wl.ConfigureInInfra(infra)
 
-			By("Configuring the local workload peering IP")
+			By("Configuring the local workload peering IPs (v4 + v6)")
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			bgpCfg := api.NewBGPConfiguration()
 			bgpCfg.Name = "default"
-			bgpCfg.Spec.LocalWorkloadPeeringIPV4 = "169.254.0.179"
+			bgpCfg.Spec.LocalWorkloadPeeringIPV4 = peerV4
+			bgpCfg.Spec.LocalWorkloadPeeringIPV6 = peerV6
 			_, err := calicoClient.BGPConfigurations().Create(ctx, bgpCfg, options.SetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -146,16 +188,12 @@ var _ = infrastructure.DatastoreDescribe(
 				return out
 			}, "30s").Should(ContainSubstring(wl.InterfaceName))
 
-			By("Verifying that the link-local peer address is not assigned to the workload interface")
-			// Expected to fail today: LinkAddrsManager runs unconditionally and
-			// will assign 169.254.0.179/32 to the veth, even though routes to
-			// make it useful are suppressed by RouteSyncDisabled.
-			Consistently(func() string {
-				out, _ := tc.Felixes[0].ExecOutput("ip", "-4", "addr", "show", "dev", wl.InterfaceName)
-				return out
-			}, "5s", "500ms").ShouldNot(ContainSubstring("inet "),
-				"Felix should not assign the link-local peer address to the workload interface "+
-					"when RouteSyncDisabled is true")
+			By("Verifying no routes are programmed for the workload IPs or the peer IPs")
+			assertNoRouteEntry(
+				wl.InterfaceName,
+				wlV4+"/32", wlV6+"/128",
+				peerV4+"/32", peerV6+"/128",
+			)
 		})
 	},
 )
@@ -164,8 +202,8 @@ var _ = infrastructure.DatastoreDescribe(
 // is programmed on the given workload interface. In BPF mode it inspects the
 // per-interface BPF policy dump for the canonical
 // "Policy: GlobalNetworkPolicy <name>" marker — the tool's "all" pseudo-iface
-// cannot be used here because the debug JSON is keyed by real interface name
-// and the command silently produces no output when the file is missing. In
+// cannot be used because the debug JSON is keyed by real interface name and
+// the command silently produces no output when the file is missing. In
 // iptables/nftables mode, policy chain names embed the policy name, so a
 // ruleset grep is sufficient.
 func policyProgrammedOn(felix *infrastructure.Felix, ifaceName, policyName string) func() bool {

--- a/felix/fv/route_sync_disabled_test.go
+++ b/felix/fv/route_sync_disabled_test.go
@@ -115,8 +115,9 @@ var _ = infrastructure.DatastoreDescribe(
 					flag = "-6"
 				}
 				query := func() string {
-					out, _ := tc.Felixes[0].ExecOutput(
+					out, err := tc.Felixes[0].ExecOutput(
 						"ip", flag, "route", "show", "table", "all", addr, "dev", iface)
+					Expect(err).NotTo(HaveOccurred())
 					return out
 				}
 				Eventually(query, "5s", "500ms").Should(BeEmpty(),

--- a/felix/fv/route_sync_disabled_test.go
+++ b/felix/fv/route_sync_disabled_test.go
@@ -85,30 +85,13 @@ var _ = infrastructure.DatastoreDescribe(
 			probeWl.ConfigureInInfra(infra)
 
 			By("Verifying the default-allow policy is programmed in the dataplane")
-			Eventually(policyProgrammedOn(tc.Felixes[0], "default-allow"), "30s", "500ms").
+			Eventually(policyProgrammedOn(tc.Felixes[0], probeWl.InterfaceName, "default-allow"), "30s", "500ms").
 				Should(BeTrue(), "Felix should program the default-allow policy even when RouteSyncDisabled is true")
-		})
-
-		AfterEach(func() {
-			if CurrentSpecReport().Failed() {
-				for _, felix := range tc.Felixes {
-					felix.Exec("ip", "r")
-					felix.Exec("ip", "a")
-				}
-				infra.DumpErrorData()
-			}
-			if probeWl != nil {
-				probeWl.Stop()
-				probeWl = nil
-			}
-			tc.Stop()
-			infra.Stop()
 		})
 
 		It("should not assign IPv4 addresses to workload endpoints", func() {
 			By("Creating a local workload")
 			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
-			defer wl.Stop()
 			wl.ConfigureInInfra(infra)
 
 			By("Waiting for the workload's veth to exist on the host")
@@ -132,13 +115,9 @@ var _ = infrastructure.DatastoreDescribe(
 			// When a workload is selected as a local BGP peer, the endpoint
 			// manager calls LinkAddrsManager.SetLinkLocalAddress, which issues
 			// netlink AddrAdd on the workload's veth. That peer address is only
-			// useful when Felix is also programming routes, so assigning it
-			// while RouteSyncDisabled is true is a known bug: the link-address
-			// manager should be inert (or the endpoint manager should skip the
-			// peer-IP path) when route sync is disabled.
+			// useful when Felix is also programming routes, but not when RouteSyncDisabled is true.
 			By("Creating a workload labelled for local BGP peering")
 			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
-			defer wl.Stop()
 			wl.WorkloadEndpoint.Labels["role"] = "bgp-peer"
 			wl.ConfigureInInfra(infra)
 
@@ -182,23 +161,32 @@ var _ = infrastructure.DatastoreDescribe(
 )
 
 // policyProgrammedOn returns a function that reports whether the given policy
-// name appears in the felix container's programmed rules (iptables, nftables,
-// or BPF depending on mode).
-func policyProgrammedOn(felix *infrastructure.Felix, policyName string) func() bool {
+// is programmed on the given workload interface. In BPF mode it inspects the
+// per-interface BPF policy dump for the canonical
+// "Policy: GlobalNetworkPolicy <name>" marker — the tool's "all" pseudo-iface
+// cannot be used here because the debug JSON is keyed by real interface name
+// and the command silently produces no output when the file is missing. In
+// iptables/nftables mode, policy chain names embed the policy name, so a
+// ruleset grep is sufficient.
+func policyProgrammedOn(felix *infrastructure.Felix, ifaceName, policyName string) func() bool {
 	return func() bool {
-		var cmd []string
-		switch {
-		case BPFMode():
-			// In BPF mode, policies are attached per-interface; probing all
-			// programs on the node is enough for this smoke check.
-			out, err := felix.ExecOutput("calico-bpf", "policy", "dump", "all", "all", "--asm")
-			if err != nil {
-				return false
+		if BPFMode() {
+			marker := "Policy: GlobalNetworkPolicy " + policyName
+			for _, hook := range []string{"ingress", "egress"} {
+				out, err := felix.ExecOutput("calico-bpf", "policy", "dump", ifaceName, hook)
+				if err != nil {
+					continue
+				}
+				if strings.Contains(out, marker) {
+					return true
+				}
 			}
-			return strings.Contains(out, policyName)
-		case NFTMode():
+			return false
+		}
+		var cmd []string
+		if NFTMode() {
 			cmd = []string{"nft", "list", "ruleset"}
-		default:
+		} else {
 			cmd = []string{"iptables-save", "-t", "filter"}
 		}
 		out, err := felix.ExecOutput(cmd...)

--- a/felix/fv/route_sync_disabled_test.go
+++ b/felix/fv/route_sync_disabled_test.go
@@ -16,6 +16,7 @@ package fv_test
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,13 +32,14 @@ import (
 )
 
 var _ = infrastructure.DatastoreDescribe(
-	"pepper Network policy only mode (RouteSyncDisabled=true) tests",
+	"Network policy only mode (RouteSyncDisabled=true) tests",
 	[]apiconfig.DatastoreType{apiconfig.EtcdV3},
 	func(getInfra infrastructure.InfraFactory) {
 		var (
 			infra        infrastructure.DatastoreInfra
 			tc           infrastructure.TopologyContainers
 			calicoClient client.Interface
+			probeWl      *workload.Workload
 		)
 
 		BeforeEach(func() {
@@ -60,6 +62,31 @@ var _ = infrastructure.DatastoreDescribe(
 			opts.InitialFelixConfiguration = felixConfig
 
 			tc, calicoClient = infrastructure.StartSingleNodeTopology(opts, infra)
+
+			By("Installing a default-allow GlobalNetworkPolicy")
+			// In network-policy-only mode we still expect Felix to program
+			// policy. Install an allow-all policy and verify that Felix has
+			// rendered it before running the rest of the test.
+			policy := api.NewGlobalNetworkPolicy()
+			policy.Name = "default-allow"
+			policy.Spec.Selector = "all()"
+			policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+			policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_, err := calicoClient.GlobalNetworkPolicies().Create(ctx, policy, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a probe workload so the policy becomes active")
+			// Felix only renders policy chains for policies that select at
+			// least one local endpoint, so we need a workload on the node
+			// before we can assert that the policy has been programmed.
+			probeWl = workload.Run(tc.Felixes[0], "probe", "default", "10.65.0.10", "8088", "tcp")
+			probeWl.ConfigureInInfra(infra)
+
+			By("Verifying the default-allow policy is programmed in the dataplane")
+			Eventually(policyProgrammedOn(tc.Felixes[0], "default-allow"), "30s", "500ms").
+				Should(BeTrue(), "Felix should program the default-allow policy even when RouteSyncDisabled is true")
 		})
 
 		AfterEach(func() {
@@ -70,11 +97,15 @@ var _ = infrastructure.DatastoreDescribe(
 				}
 				infra.DumpErrorData()
 			}
+			if probeWl != nil {
+				probeWl.Stop()
+				probeWl = nil
+			}
 			tc.Stop()
 			infra.Stop()
 		})
 
-		It("should not program routes to workload endpoints", func() {
+		It("should not assign IPv4 addresses to workload endpoints", func() {
 			By("Creating a local workload")
 			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
 			defer wl.Stop()
@@ -86,15 +117,15 @@ var _ = infrastructure.DatastoreDescribe(
 				return out
 			}, "30s").Should(ContainSubstring(wl.InterfaceName))
 
-			By("Verifying no workload-interface route is programmed in the main table")
-			// With RouteSyncDisabled=true, Felix's route table is a DummyTable,
-			// so the endpoint manager's SetRoutes calls for the workload are
-			// no-ops. The workload's veth should have no routes via it.
+			By("Verifying no IPv4 address is assigned to the workload interface")
+			// With RouteSyncDisabled=true, Felix should not touch the workload
+			// veth beyond what's required for policy. The host side of the veth
+			// should have no IPv4 addresses attached.
 			Consistently(func() string {
-				out, _ := tc.Felixes[0].ExecOutput("ip", "route", "show", "dev", wl.InterfaceName)
+				out, _ := tc.Felixes[0].ExecOutput("ip", "-4", "addr", "show", "dev", wl.InterfaceName)
 				return out
-			}, "5s", "500ms").Should(BeEmpty(),
-				"Felix should not program any route via the workload interface when RouteSyncDisabled is true")
+			}, "5s", "500ms").ShouldNot(ContainSubstring("inet "),
+				"Felix should not assign any IPv4 address to the workload interface when RouteSyncDisabled is true")
 		})
 
 		It("should not assign link-local peer addresses to the workload interface", func() {
@@ -143,9 +174,37 @@ var _ = infrastructure.DatastoreDescribe(
 			Consistently(func() string {
 				out, _ := tc.Felixes[0].ExecOutput("ip", "-4", "addr", "show", "dev", wl.InterfaceName)
 				return out
-			}, "15s", "500ms").ShouldNot(ContainSubstring("169.254.0.179"),
+			}, "5s", "500ms").ShouldNot(ContainSubstring("inet "),
 				"Felix should not assign the link-local peer address to the workload interface "+
 					"when RouteSyncDisabled is true")
 		})
 	},
 )
+
+// policyProgrammedOn returns a function that reports whether the given policy
+// name appears in the felix container's programmed rules (iptables, nftables,
+// or BPF depending on mode).
+func policyProgrammedOn(felix *infrastructure.Felix, policyName string) func() bool {
+	return func() bool {
+		var cmd []string
+		switch {
+		case BPFMode():
+			// In BPF mode, policies are attached per-interface; probing all
+			// programs on the node is enough for this smoke check.
+			out, err := felix.ExecOutput("calico-bpf", "policy", "dump", "all", "all", "--asm")
+			if err != nil {
+				return false
+			}
+			return strings.Contains(out, policyName)
+		case NFTMode():
+			cmd = []string{"nft", "list", "ruleset"}
+		default:
+			cmd = []string{"iptables-save", "-t", "filter"}
+		}
+		out, err := felix.ExecOutput(cmd...)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(out, policyName)
+	}
+}

--- a/felix/fv/route_sync_disabled_test.go
+++ b/felix/fv/route_sync_disabled_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/api/pkg/lib/numorstring"
+
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+var _ = infrastructure.DatastoreDescribe(
+	"pepper Network policy only mode (RouteSyncDisabled=true) tests",
+	[]apiconfig.DatastoreType{apiconfig.EtcdV3},
+	func(getInfra infrastructure.InfraFactory) {
+		var (
+			infra        infrastructure.DatastoreInfra
+			tc           infrastructure.TopologyContainers
+			calicoClient client.Interface
+		)
+
+		BeforeEach(func() {
+			infra = getInfra()
+
+			opts := infrastructure.DefaultTopologyOptions()
+			// Default topology uses IPIPModeAlways; turn off all encap so Felix
+			// would otherwise program plain workload routes directly on veths.
+			opts.IPIPMode = api.IPIPModeNever
+			opts.VXLANMode = api.VXLANModeNever
+			opts.EnableIPv6 = false
+
+			// Set RouteSyncDisabled=true in the initial FelixConfiguration so
+			// Felix picks it up on startup — RouteSyncDisabled requires a Felix
+			// restart to take effect.
+			routeSyncDisabled := true
+			felixConfig := api.NewFelixConfiguration()
+			felixConfig.Name = "default"
+			felixConfig.Spec.RouteSyncDisabled = &routeSyncDisabled
+			opts.InitialFelixConfiguration = felixConfig
+
+			tc, calicoClient = infrastructure.StartSingleNodeTopology(opts, infra)
+		})
+
+		AfterEach(func() {
+			if CurrentSpecReport().Failed() {
+				for _, felix := range tc.Felixes {
+					felix.Exec("ip", "r")
+					felix.Exec("ip", "a")
+				}
+				infra.DumpErrorData()
+			}
+			tc.Stop()
+			infra.Stop()
+		})
+
+		It("should not program routes to workload endpoints", func() {
+			By("Creating a local workload")
+			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
+			defer wl.Stop()
+			wl.ConfigureInInfra(infra)
+
+			By("Waiting for the workload's veth to exist on the host")
+			Eventually(func() string {
+				out, _ := tc.Felixes[0].ExecOutput("ip", "link", "show", wl.InterfaceName)
+				return out
+			}, "30s").Should(ContainSubstring(wl.InterfaceName))
+
+			By("Verifying no workload-interface route is programmed in the main table")
+			// With RouteSyncDisabled=true, Felix's route table is a DummyTable,
+			// so the endpoint manager's SetRoutes calls for the workload are
+			// no-ops. The workload's veth should have no routes via it.
+			Consistently(func() string {
+				out, _ := tc.Felixes[0].ExecOutput("ip", "route", "show", "dev", wl.InterfaceName)
+				return out
+			}, "5s", "500ms").Should(BeEmpty(),
+				"Felix should not program any route via the workload interface when RouteSyncDisabled is true")
+		})
+
+		It("should not assign link-local peer addresses to the workload interface", func() {
+			// When a workload is selected as a local BGP peer, the endpoint
+			// manager calls LinkAddrsManager.SetLinkLocalAddress, which issues
+			// netlink AddrAdd on the workload's veth. That peer address is only
+			// useful when Felix is also programming routes, so assigning it
+			// while RouteSyncDisabled is true is a known bug: the link-address
+			// manager should be inert (or the endpoint manager should skip the
+			// peer-IP path) when route sync is disabled.
+			By("Creating a workload labelled for local BGP peering")
+			wl := workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8088", "tcp")
+			defer wl.Stop()
+			wl.WorkloadEndpoint.Labels["role"] = "bgp-peer"
+			wl.ConfigureInInfra(infra)
+
+			By("Configuring the local workload peering IP")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			bgpCfg := api.NewBGPConfiguration()
+			bgpCfg.Name = "default"
+			bgpCfg.Spec.LocalWorkloadPeeringIPV4 = "169.254.0.179"
+			_, err := calicoClient.BGPConfigurations().Create(ctx, bgpCfg, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a BGPPeer that selects the workload")
+			asn, err := numorstring.ASNumberFromString("65401")
+			Expect(err).NotTo(HaveOccurred())
+			peer := api.NewBGPPeer()
+			peer.Name = "local-wl-peer"
+			peer.Spec.LocalWorkloadSelector = "role == 'bgp-peer'"
+			peer.Spec.ASNumber = asn
+			_, err = calicoClient.BGPPeers().Create(ctx, peer, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the workload's veth to exist on the host")
+			Eventually(func() string {
+				out, _ := tc.Felixes[0].ExecOutput("ip", "link", "show", wl.InterfaceName)
+				return out
+			}, "30s").Should(ContainSubstring(wl.InterfaceName))
+
+			By("Verifying that the link-local peer address is not assigned to the workload interface")
+			// Expected to fail today: LinkAddrsManager runs unconditionally and
+			// will assign 169.254.0.179/32 to the veth, even though routes to
+			// make it useful are suppressed by RouteSyncDisabled.
+			Consistently(func() string {
+				out, _ := tc.Felixes[0].ExecOutput("ip", "-4", "addr", "show", "dev", wl.InterfaceName)
+				return out
+			}, "15s", "500ms").ShouldNot(ContainSubstring("169.254.0.179"),
+				"Felix should not assign the link-local peer address to the workload interface "+
+					"when RouteSyncDisabled is true")
+		})
+	},
+)


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Adding test coverage for network policy only mode (RouteSyncDisabled=true in FelixConfiguration) to not regress in future.

Related to:
- Bug: https://github.com/projectcalico/calico/issues/10648
- Fix: https://github.com/projectcalico/calico/pull/12489

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
