### PR TITLE
fix(e2e): guard bpf.go with cgo build tag and correct stub Fail import

### DIFF
--- a/e2e/pkg/utils/bpf.go
+++ b/e2e/pkg/utils/bpf.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cgo
+
 package utils
 
 import (

--- a/e2e/pkg/utils/bpf_stub.go
+++ b/e2e/pkg/utils/bpf_stub.go
@@ -1,4 +1,16 @@
 // Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //go:build !cgo
 
@@ -7,7 +19,7 @@ package utils
 import (
 	"fmt"
 
-	"github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -15,6 +27,6 @@ import (
 )
 
 func DumpBPFNATServiceBackends(cs kubernetes.Interface, nodeName string, serviceIP string, servicePort int, proto corev1.Protocol) (set.Set[string], error) {
-	gomega.Fail("DumpBPFNATServiceBackends requires CGO (libbpf) but it is not enabled")
+	ginkgo.Fail("DumpBPFNATServiceBackends requires CGO (libbpf) but it is not enabled")
 	return nil, fmt.Errorf("DumpBPFNATServiceBackends requires CGO (libbpf) but it is not enabled")
 }


### PR DESCRIPTION
The `bpf.go` / `bpf_stub.go` pair in `e2e/pkg/utils` is intended to be mutually exclusive: `bpf.go` pulls in `felix/bpf/maps` which requires CGO, and `bpf_stub.go` has ``//go:build !cgo``. `bpf.go` was missing the complementary build tag, so cross-compile builds (e.g., ``release hashrelease-build`` for arm64/ppc64le/s390x where CGO defaults to off) pulled in both files and failed with a duplicate ``DumpBPFNATServiceBackends`` declaration.

The stub also called ``gomega.Fail``, which is not an exported symbol of ``onsi/gomega`` (it is a method on ``internalGomega``). Replace with ``ginkgo.Fail``, matching the ginkgo import used elsewhere in the package tree.

### Reproduction (before fix)
```
make -C release hashrelease-build
…
pkg/utils/bpf_stub.go:17:6: DumpBPFNATServiceBackends redeclared in this block
	pkg/utils/bpf.go:36:6: other declaration of DumpBPFNATServiceBackends
pkg/utils/bpf_stub.go:18:9: undefined: gomega.Fail
```

### Verification
- ``make -C e2e build-e2e-binary ARCH=arm64 OUTPUT=/tmp/e2e-arm64.test`` — compiles cleanly (previously failed).
- ``go vet ./pkg/utils/`` with ``CGO_ENABLED=0 GOARCH=arm64`` — clean.
- Also confirmed the stub and primary file no longer collide on any CGO on/off combination.

Introduced by #12477 which landed earlier today.

**Release note:**
```release-note
None
```