### PR TITLE
fix(ci): free up disk space for (hash)release runs

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -29,6 +29,7 @@ global_job_config:
 
   prologue:
     commands:
+      - sudo rm -rf ~/.phpbrew ~/.kerl ~/.sbt ~/.nvm ~/.npm ~/.kiex /usr/local/golang/ /usr/lib/jvm /opt/* /opt/az
       - chmod 0600 ~/.keys/*
       - ssh-add ~/.keys/*
       # Checkout the code and unshallow it.

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -21,6 +21,7 @@ blocks:
         - name: openstack-signing-publishing
       prologue:
         commands:
+          - sudo rm -rf ~/.phpbrew ~/.kerl ~/.sbt ~/.nvm ~/.npm ~/.kiex /usr/local/golang/ /usr/lib/jvm /opt/* /opt/az
           # Load the github access secrets.  First fix the permissions.
           - chmod 0600 /home/semaphore/.keys/git_ssh_rsa
           - ssh-add /home/semaphore/.keys/git_ssh_rsa


### PR DESCRIPTION
Followup to #12585 as the hashrelease CI pipeline still failed due to disk space.
This cleans up existing files in `f1-standard-4`

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
N/A
```
