### PR TITLE
Fix status_file_watcher CI

### DIFF
--- a/libcalico-go/lib/epstatusfile/status_file_watcher.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher.go
@@ -244,7 +244,7 @@ func (w *FileWatcher) scanDirectory() {
 		if !exists {
 			log.WithField("file", path).Debug("New file detected")
 			w.callbacks.OnFileCreation(path)
-		} else if oldInfo.ModTime() != info.ModTime() || oldInfo.Size() != info.Size() {
+		} else if !oldInfo.ModTime().Equal(info.ModTime()) || oldInfo.Size() != info.Size() {
 			log.WithField("file", path).Debug("File modified")
 			w.callbacks.OnFileUpdate(path)
 		}

--- a/libcalico-go/lib/epstatusfile/status_file_watcher.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher.go
@@ -244,7 +244,7 @@ func (w *FileWatcher) scanDirectory() {
 		if !exists {
 			log.WithField("file", path).Debug("New file detected")
 			w.callbacks.OnFileCreation(path)
-		} else if oldInfo.ModTime() != info.ModTime() {
+		} else if oldInfo.ModTime() != info.ModTime() || oldInfo.Size() != info.Size() {
 			log.WithField("file", path).Debug("File modified")
 			w.callbacks.OnFileUpdate(path)
 		}

--- a/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Workload endpoint status file watcher test", func() {
 		clearDir(statusDir)
 		fsnotifyActivity = new(activityReporter)
 		fsnotifyErr = new(fsnotifyError)
-		w = NewFileWatcherWithShim(statusDir, 10*time.Second, fsnotifyErr.newFsnotifyWatcherShim, fsnotifyActivity)
+		w = NewFileWatcherWithShim(statusDir, 1*time.Second, fsnotifyErr.newFsnotifyWatcherShim, fsnotifyActivity)
 		r = newEventRecorder()
 		w.SetCallbacks(Callbacks{
 			OnFileCreation: r.OnFileCreate,


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

● Summary                                                                                                                                                                     
                                                                                                                                                                            
  - Fix flaky "should receive events when fsnotify fails" test in epstatusfile caused by mtime granularity in CI                                                              
  - Add file size comparison to scanDirectory() so polling detects updates even when two writes land within the same filesystem timestamp second                              
  - Reduce test poll interval from 10s to 1s so the 15s Eventually timeout gets multiple polling attempts instead of just one   

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
