### PR TITLE
fix(e2e): build libbpf for amd64 multi-arch e2e binary target

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -23,18 +23,17 @@ SRC_FILES=$(shell find pkg cmd -name '*.go')
 
 build: bin/k8s/e2e.test bin/clusternetworkpolicy/e2e.test $(SRC_FILES)
 
-bin/k8s/e2e.test: $(LIBBPF_A) $(SRC_FILES)
-	mkdir -p bin
-	$(DOCKER_RUN_CGO) $(CALICO_BUILD) go test ./cmd/k8s -c -o $@
+bin/k8s/e2e.test: bin/k8s/e2e-linux-$(ARCH).test
+	mv $< $@
 
 bin/clusternetworkpolicy/e2e.test: $(LIBBPF_A) $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN_CGO) $(CALICO_BUILD) go test ./cmd/clusternetworkpolicy -c -o $@
 
-# Multi-arch e2e binary targets. Each architecture gets its own binary, built
-# via cross-compilation inside the calico/go-build container. Uses a pattern
-# rule so that any arch in VALIDARCHES (including ppc64le, s390x) works.
-# The recursive make sets ARCH so that DOCKER_RUN passes the correct GOARCH.
+bin/k8s/e2e-linux-amd64.test: $(LIBBPF_A) $(SRC_FILES)
+	mkdir -p bin/k8s
+	$(DOCKER_RUN_CGO) $(CALICO_BUILD) go test ./cmd/k8s -c -o $@
+
 bin/k8s/e2e-linux-%.test: $(SRC_FILES)
 	mkdir -p bin/k8s
 	$(MAKE) build-e2e-binary ARCH=$* OUTPUT=$@


### PR DESCRIPTION
The multi-arch pattern rule `bin/k8s/e2e-linux-%.test` (added in #12506) dropped the `$(LIBBPF_A)` prereq and `DOCKER_RUN_CGO` wiring. Only amd64 needs them — other arches have CGO off and compile the `//go:build !cgo` stub. amd64 fails to link on a clean tree with `undefined reference to libbpf_strerror_r`.

Add an explicit `bin/k8s/e2e-linux-amd64.test` rule (CGO + libbpf) and have `bin/k8s/e2e.test` rename it for local use (`mv`, not `ln`).

**Release note:**
```release-note
None
```