### PR TITLE
feat(release): step control flags for hashrelease and release build/publish

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -26,7 +26,7 @@ This section describes how to build a test release using the locally checked out
 Build the release, providing your own registry to use for the images. For example:
 
 ```
-ARCHES=amd64 ./bin/release hashrelease build --skip-validation --build-images --dev-registry <YOUR REGISTRY>
+ARCHS=amd64 ./bin/release hashrelease build --no-validation --images --dev-registry <YOUR REGISTRY>
 ```
 
 This may take some time, but will produce a full set of release images as well as an operator image based on the locally checked out commit. Artifacts can be found

--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -50,7 +50,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				devTagSuffixFlag,
 				operatorBranchFlag,
 				localFlag,
-				validateFlag,
+				validationFlag,
 			},
 			Action: func(_ context.Context, c *cli.Command) error {
 				configureLogging("branch-cut.log")
@@ -62,7 +62,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
-					calico.WithValidate(c.Bool(validateFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
 				)
 
 				m := branch.NewManager(
@@ -72,7 +72,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					branch.WithDevTagIdentifier(c.String(devTagSuffixFlag.Name)),
 					branch.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					branch.WithRepoManager(calicoManager),
-					branch.WithValidate(c.Bool(validateFlag.Name)),
+					branch.WithValidation(c.Bool(validationFlag.Name)),
 					branch.WithPublish(!c.Bool(localFlag.Name)))
 				return m.CutReleaseBranch()
 			},

--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -50,7 +50,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				devTagSuffixFlag,
 				operatorBranchFlag,
 				localFlag,
-				skipValidationFlag,
+				validateFlag,
 			},
 			Action: func(_ context.Context, c *cli.Command) error {
 				configureLogging("branch-cut.log")
@@ -62,7 +62,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					calico.WithValidate(c.Bool(validateFlag.Name)),
 				)
 
 				m := branch.NewManager(
@@ -72,7 +72,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					branch.WithDevTagIdentifier(c.String(devTagSuffixFlag.Name)),
 					branch.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					branch.WithRepoManager(calicoManager),
-					branch.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					branch.WithValidate(c.Bool(validateFlag.Name)),
 					branch.WithPublish(!c.Bool(localFlag.Name)))
 				return m.CutReleaseBranch()
 			},

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -460,12 +460,12 @@ var (
 		f := []cli.Flag{
 			imagesFlag(!hashrelease, envPublishImages),
 			helmChartsFlag(true, envPublishCharts),
-			helmIndexFlag,
 		}
 		if hashrelease {
 			return f
 		}
 		return append(f,
+			helmIndexFlag,
 			gitRefFlag,
 			githubReleaseFlag)
 	}

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -50,44 +50,51 @@ var (
 	}
 
 	// Git flags for interacting with the git repository
-	orgFlag = &cli.StringFlag{
-		Name:    "org",
-		Usage:   "The GitHub organization to use for the release",
-		Sources: cli.EnvVars("ORGANIZATION"),
-		Value:   utils.ProjectCalicoOrg,
+	gitCategory = "Git Repository"
+	orgFlag     = &cli.StringFlag{
+		Name:     "org",
+		Category: gitCategory,
+		Usage:    "The GitHub organization to use for the release",
+		Sources:  cli.EnvVars("ORGANIZATION"),
+		Value:    utils.ProjectCalicoOrg,
 	}
 	repoFlag = &cli.StringFlag{
-		Name:    "repo",
-		Usage:   "The GitHub repository to use for the release",
-		Sources: cli.EnvVars("GIT_REPO"),
-		Value:   utils.CalicoRepoName,
+		Name:     "repo",
+		Category: gitCategory,
+		Usage:    "The GitHub repository to use for the release",
+		Sources:  cli.EnvVars("GIT_REPO"),
+		Value:    utils.CalicoRepoName,
 	}
 	repoRemoteFlag = &cli.StringFlag{
-		Name:    "remote",
-		Usage:   "The remote for the git repository",
-		Sources: cli.EnvVars("GIT_REMOTE"),
-		Value:   utils.DefaultRemote,
+		Name:     "remote",
+		Category: gitCategory,
+		Usage:    "The remote for the git repository",
+		Sources:  cli.EnvVars("GIT_REMOTE"),
+		Value:    utils.DefaultRemote,
 	}
 
 	// Branch/Tag flags are flags used for branch & tag management
 	releaseBranchPrefixFlag = &cli.StringFlag{
-		Name:    "release-branch-prefix",
-		Usage:   "The stardard prefix used to denote release branches",
-		Sources: cli.EnvVars("RELEASE_BRANCH_PREFIX"),
-		Value:   "release",
+		Name:     "release-branch-prefix",
+		Category: gitCategory,
+		Usage:    "The stardard prefix used to denote release branches",
+		Sources:  cli.EnvVars("RELEASE_BRANCH_PREFIX"),
+		Value:    "release",
 	}
 	devTagSuffixFlag = &cli.StringFlag{
-		Name:    "dev-tag-suffix",
-		Usage:   "The suffix used to denote development tags",
-		Sources: cli.EnvVars("DEV_TAG_SUFFIX"),
-		Value:   "0.dev",
+		Name:     "dev-tag-suffix",
+		Category: gitCategory,
+		Usage:    "The suffix used to denote development tags",
+		Sources:  cli.EnvVars("DEV_TAG_SUFFIX"),
+		Value:    "0.dev",
 	}
 	baseBranchFlag = &cli.StringFlag{
-		Name:    "base-branch",
-		Aliases: []string{"base", "main-branch"},
-		Usage:   "The base branch to cut the release branch from",
-		Sources: cli.EnvVars("RELEASE_BRANCH_BASE"),
-		Value:   utils.DefaultBranch,
+		Name:     "base-branch",
+		Category: gitCategory,
+		Aliases:  []string{"base", "main-branch"},
+		Usage:    "The base branch to cut the release branch from",
+		Sources:  cli.EnvVars("RELEASE_BRANCH_BASE"),
+		Value:    utils.DefaultBranch,
 		Action: func(_ context.Context, c *cli.Command, str string) error {
 			if str != utils.DefaultBranch {
 				logrus.Warnf("The new branch will be created from %s which is not the default branch %s", str, utils.DefaultBranch)
@@ -107,36 +114,56 @@ var (
 	}
 )
 
-// Validation flags are flags used to control validation
+// Development flags are flags used to control development behavior of the release process
 var (
+	developmentCategory = "Development"
+
 	skipValidationFlag = &cli.BoolFlag{
-		Name:    "skip-validation",
-		Usage:   "Skip all validation while performing the action",
-		Sources: cli.EnvVars("SKIP_VALIDATION"),
-		Value:   false,
+		Name:     "skip-validation",
+		Category: developmentCategory,
+		Usage:    "Skip all validation while performing the action",
+		Sources:  cli.EnvVars("SKIP_VALIDATION"),
+		Value:    false,
+	}
+	skipBranchCheckFlag = &cli.BoolFlag{
+		Name:     "skip-branch-check",
+		Category: developmentCategory,
+		Usage:    "Skip checking if current branch is a valid branch for release",
+		Sources:  cli.EnvVars("SKIP_BRANCH_CHECK"),
+		Value:    false,
+		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			if c.Bool(skipValidationFlag.Name) && !b {
+				return fmt.Errorf("must skip branch check if %s is set", skipValidationFlag)
+			}
+			return nil
+		},
 	}
 )
 
 // Container image flags are flags used to control container image building and publishing
 var (
-	registryFlag = &cli.StringSliceFlag{
-		Name:    "registry",
-		Usage:   "Override default registries for the release. Repeat for multiple registries.",
-		Sources: cli.EnvVars("REGISTRIES"), // avoid DEV_REGISTRIES as it is already used by the build system (lib.Makefile).
+	containerImageCategory = "Container Image"
+	registryFlag           = &cli.StringSliceFlag{
+		Name:     "registry",
+		Category: containerImageCategory,
+		Usage:    "Override default registries for the release. Repeat for multiple registries.",
+		Sources:  cli.EnvVars("REGISTRIES"), // avoid DEV_REGISTRIES as it is already used by the build system (lib.Makefile).
 	}
 	helmRegistryFlag = &cli.StringSliceFlag{
-		Name:    "helm-registry",
-		Usage:   "Override default OCI-based helm chart registries for the release. Repeat for multiple registries.",
-		Sources: cli.EnvVars("HELM_REGISTRIES"),
+		Name:     "helm-registry",
+		Category: containerImageCategory,
+		Usage:    "Override default OCI-based helm chart registries for the release. Repeat for multiple registries.",
+		Sources:  cli.EnvVars("HELM_REGISTRIES"),
 	}
 
 	archOptions = []string{"amd64", "arm64", "ppc64le", "s390x"}
 	archFlag    = &cli.StringSliceFlag{
-		Name:    "architecture",
-		Aliases: []string{"arch"},
-		Usage:   "The architecture to use for the release. Repeat for multiple architectures.",
-		Sources: cli.EnvVars("ARCHS"), // avoid ARCHES as it is already used by the build system (lib.Makefile).
-		Value:   archOptions,
+		Name:     "architecture",
+		Category: containerImageCategory,
+		Aliases:  []string{"arch"},
+		Usage:    "The architecture to use for the release. Repeat for multiple architectures.",
+		Sources:  cli.EnvVars("ARCHS"), // avoid ARCHES as it is already used by the build system (lib.Makefile).
+		Value:    archOptions,
 		Action: func(_ context.Context, c *cli.Command, values []string) error {
 			for _, arch := range values {
 				if !slices.Contains(archOptions, arch) {
@@ -146,141 +173,99 @@ var (
 			return nil
 		},
 	}
+)
 
-	buildImagesFlag = &cli.BoolFlag{
-		Name:    "build-images",
-		Usage:   "Build container images from the local code",
-		Sources: cli.EnvVars("BUILD_CONTAINER_IMAGES"), // avoid BUILD_IMAGES as it is already used by the build system (lib.Makefile).
-		Value:   true,
-	}
-	buildHashreleaseImagesFlag = &cli.BoolFlag{
-		Name:    buildImagesFlag.Name,
-		Usage:   buildImagesFlag.Usage,
-		Sources: buildImagesFlag.Sources,
-		Value:   false,
-	}
-
-	publishImagesFlag = &cli.BoolFlag{
-		Name:    "publish-images",
-		Usage:   "Publish images to the registry",
-		Sources: cli.EnvVars("PUBLISH_IMAGES"),
-		Value:   true,
-	}
-	publishHashreleaseImagesFlag = &cli.BoolFlag{
-		Name:    publishImagesFlag.Name,
-		Usage:   publishImagesFlag.Usage,
-		Sources: publishImagesFlag.Sources,
-		Value:   false,
-	}
-
-	publishChartsFlag = &cli.BoolFlag{
-		Name:    "publish-charts",
-		Usage:   "Publish Helm charts to the registry",
-		Sources: cli.EnvVars("PUBLISH_CHARTS"),
-		Value:   true,
-	}
+var (
+	cloudCategory  = "Cloud Configuration"
 	awsProfileFlag = &cli.StringFlag{
-		Name:    "aws-profile",
-		Usage:   "The AWS profile to use",
-		Sources: cli.EnvVars("AWS_PROFILE"),
+		Name:     "aws-profile",
+		Category: cloudCategory,
+		Usage:    "The AWS profile to use",
+		Sources:  cli.EnvVars("AWS_PROFILE"),
 	}
 	s3BucketFlag = &cli.StringFlag{
-		Name:    "s3-bucket",
-		Usage:   "The S3 bucket to publish release artifacts to.",
-		Sources: cli.EnvVars("S3_BUCKET"),
-	}
-
-	archiveImagesFlag = &cli.BoolFlag{
-		Name:    "archive-images",
-		Usage:   "Archive images in the release tarball",
-		Sources: cli.EnvVars("ARCHIVE_IMAGES"),
-		Value:   true,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if b && !c.Bool(buildImagesFlag.Name) {
-				return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildImagesFlag.Name)
-			}
-			return nil
-		},
-	}
-	archiveHashreleaseImagesFlag = &cli.BoolFlag{
-		Name:    archiveImagesFlag.Name,
-		Usage:   archiveImagesFlag.Usage,
-		Sources: archiveImagesFlag.Sources,
-		Value:   false,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if b && !c.Bool(buildHashreleaseImagesFlag.Name) {
-				return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildHashreleaseImagesFlag.Name)
-			}
-			return nil
-		},
+		Name:     "s3-bucket",
+		Category: cloudCategory,
+		Usage:    "The S3 bucket to publish release artifacts to.",
+		Sources:  cli.EnvVars("S3_BUCKET"),
 	}
 )
 
 // Operator flags are flags used to interact with Tigera operator repository
 var (
+	operatorCategory   = "Tigera Operator"
 	operatorGitFlags   = []cli.Flag{operatorOrgFlag, operatorRepoFlag}
-	operatorBuildFlags = append(operatorGitFlags,
+	operatorBuildFlags = append(operatorGitFlags, operatorFlag,
 		operatorBranchFlag, operatorReleaseBranchPrefixFlag,
 		operatorRegistryFlag, operatorImageFlag)
 
 	// Operator git flags
 	operatorOrgFlag = &cli.StringFlag{
-		Name:    "operator-org",
-		Usage:   "The GitHub organization to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_ORGANIZATION"),
-		Value:   operator.DefaultOrg,
+		Name:     "operator-org",
+		Category: operatorCategory,
+		Usage:    "The GitHub organization to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_ORGANIZATION"),
+		Value:    operator.DefaultOrg,
 	}
 	operatorRepoFlag = &cli.StringFlag{
-		Name:    "operator-repo",
-		Usage:   "The GitHub repository to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_GIT_REPO"),
-		Value:   operator.DefaultRepoName,
+		Name:     "operator-repo",
+		Category: operatorCategory,
+		Usage:    "The GitHub repository to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_GIT_REPO"),
+		Value:    operator.DefaultRepoName,
 	}
 	// Branch/Tag management flags
 	operatorBranchFlag = &cli.StringFlag{
-		Name:    "operator-branch",
-		Usage:   "The branch to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_BRANCH"),
-		Value:   operator.DefaultBranchName,
+		Name:     "operator-branch",
+		Category: operatorCategory,
+		Usage:    "The branch to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_BRANCH"),
+		Value:    operator.DefaultBranchName,
 	}
 	operatorReleaseBranchPrefixFlag = &cli.StringFlag{
-		Name:    "operator-release-branch-prefix",
-		Usage:   "The stardard prefix used to denote Tigera operator release branches",
-		Sources: cli.EnvVars("OPERATOR_RELEASE_BRANCH_PREFIX"),
-		Value:   operator.DefaultReleaseBranchPrefix,
+		Name:     "operator-release-branch-prefix",
+		Category: operatorCategory,
+		Usage:    "The stardard prefix used to denote Tigera operator release branches",
+		Sources:  cli.EnvVars("OPERATOR_RELEASE_BRANCH_PREFIX"),
+		Value:    operator.DefaultReleaseBranchPrefix,
 	}
 	// Container image flags
 	operatorRegistryFlag = &cli.StringFlag{
-		Name:    "operator-registry",
-		Usage:   "The registry to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_REGISTRY"),
-		Value:   operator.DefaultRegistry,
+		Name:     "operator-registry",
+		Category: operatorCategory,
+		Usage:    "The registry to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_REGISTRY"),
+		Value:    operator.DefaultRegistry,
 	}
 	operatorImageFlag = &cli.StringFlag{
-		Name:    "operator-image",
-		Usage:   "The image name to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_IMAGE"),
-		Value:   operator.DefaultImage,
+		Name:     "operator-image",
+		Category: operatorCategory,
+		Usage:    "The image name to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_IMAGE"),
+		Value:    operator.DefaultImage,
 	}
 
-	skipOperatorFlag = &cli.BoolFlag{
-		Name:    "skip-operator",
-		Usage:   "Skip building and/or publishing the operator",
-		Sources: cli.EnvVars("SKIP_OPERATOR"),
-		Value:   false,
+	operatorFlag = &cli.BoolFlag{
+		Name:     "operator",
+		Category: operatorCategory,
+		Usage:    "Include Tigera operator in the release steps",
+		Sources:  cli.EnvVars("OPERATOR"),
+		Value:    true,
 	}
 )
 
 // External flags are flags used to interact with external services
 var (
 	// CI flags for interacting with CI services (Semaphore)
+	ciCategory  = "CI Environment"
 	ciFlags     = []cli.Flag{ciFlag, ciBaseURLFlag, ciJobIDFlag, ciPipelineIDFlag, ciTokenFlag}
 	semaphoreCI = "semaphore"
 	ciFlag      = &cli.BoolFlag{
-		Name:    "ci",
-		Usage:   "Run in a continuous integration (CI) environment",
-		Sources: cli.EnvVars("CI"),
-		Value:   false,
+		Name:     "ci",
+		Category: ciCategory,
+		Usage:    "Run in a continuous integration (CI) environment",
+		Sources:  cli.EnvVars("CI"),
+		Value:    false,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && (c.String(ciBaseURLFlag.Name) == "" || c.String(ciJobIDFlag.Name) == "") {
 				return fmt.Errorf("CI requires %s and %s flags to be set", ciBaseURLFlag.Name, ciJobIDFlag.Name)
@@ -289,43 +274,51 @@ var (
 		},
 	}
 	ciBaseURLFlag = &cli.StringFlag{
-		Name:    "ci-url",
-		Usage:   fmt.Sprintf("The URL for accesing %s CI", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_ORGANIZATION_URL"),
+		Name:     "ci-url",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The URL for accesing %s CI", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_ORGANIZATION_URL"),
 	}
 	ciJobIDFlag = &cli.StringFlag{
-		Name:    "ci-job-id",
-		Usage:   fmt.Sprintf("The job ID for the %s CI job", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_JOB_ID"),
+		Name:     "ci-job-id",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The job ID for the %s CI job", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_JOB_ID"),
 	}
 	ciPipelineIDFlag = &cli.StringFlag{
-		Name:    "ci-pipeline-id",
-		Usage:   fmt.Sprintf("The pipeline ID for the %s CI pipeline", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_PIPELINE_ID"),
+		Name:     "ci-pipeline-id",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The pipeline ID for the %s CI pipeline", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_PIPELINE_ID"),
 	}
 	ciTokenFlag = &cli.StringFlag{
-		Name:    "ci-token",
-		Usage:   fmt.Sprintf("The token for interacting with %s API", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_API_TOKEN"),
+		Name:     "ci-token",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The token for interacting with %s API", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_API_TOKEN"),
 	}
 
 	// Slack flags for posting messages to Slack
+	slackCategory  = "Slack"
 	slackFlags     = []cli.Flag{slackTokenFlag, slackChannelFlag, notifyFlag}
 	slackTokenFlag = &cli.StringFlag{
-		Name:    "slack-token",
-		Usage:   "The Slack token to use for posting messages",
-		Sources: cli.EnvVars("SLACK_API_TOKEN"),
+		Name:     "slack-token",
+		Category: slackCategory,
+		Usage:    "The Slack token to use for posting messages",
+		Sources:  cli.EnvVars("SLACK_API_TOKEN"),
 	}
 	slackChannelFlag = &cli.StringFlag{
-		Name:    "slack-channel",
-		Usage:   "The Slack channel to post messages",
-		Sources: cli.EnvVars("SLACK_CHANNEL"),
+		Name:     "slack-channel",
+		Category: slackCategory,
+		Usage:    "The Slack channel to post messages",
+		Sources:  cli.EnvVars("SLACK_CHANNEL"),
 	}
 	notifyFlag = &cli.BoolFlag{
-		Name:    "notify",
-		Usage:   "Sending notifications to Slack",
-		Sources: cli.EnvVars("NOTIFY"),
-		Value:   true,
+		Name:     "notify",
+		Category: slackCategory,
+		Usage:    "Sending notifications to Slack",
+		Sources:  cli.EnvVars("NOTIFY"),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			// Check slack configuration
 			if b && (c.String(slackTokenFlag.Name) == "" || c.String(slackChannelFlag.Name) == "") {
@@ -339,31 +332,39 @@ var (
 	}
 
 	// Image scanner flags for interacting with the image scanning service
-	imageScannerAPIFlags = []cli.Flag{
-		imageScannerAPIFlag, imageScannerTokenFlag, imageScannerSelectFlag,
+	imageScannerCategory = "Image Scanning Service"
+	imageScanFlags       = []cli.Flag{
+		skipImageScanFlag,
+		imageScannerAPIFlag,
+		imageScannerTokenFlag,
+		imageScannerSelectFlag,
 	}
 	imageScannerAPIFlag = &cli.StringFlag{
-		Name:    "image-scanner-api",
-		Usage:   "The URL for the Image Scan Service API",
-		Sources: cli.EnvVars("IMAGE_SCANNER_API"),
+		Name:     "image-scanner-api",
+		Category: imageScannerCategory,
+		Usage:    "The URL for the Image Scanning Service API",
+		Sources:  cli.EnvVars("IMAGE_SCANNER_API"),
 	}
 	imageScannerTokenFlag = &cli.StringFlag{
-		Name:    "image-scanner-token",
-		Usage:   "The token for the Image Scan Service API",
-		Sources: cli.EnvVars("IMAGE_SCANNING_TOKEN"),
+		Name:     "image-scanner-token",
+		Category: imageScannerCategory,
+		Usage:    "The token for the Image Scanning Service API",
+		Sources:  cli.EnvVars("IMAGE_SCANNING_TOKEN"),
 	}
 	imageScannerSelectFlag = &cli.StringFlag{
-		Name:    "image-scanner-select",
-		Usage:   "The name of the scanner to use",
-		Sources: cli.EnvVars("IMAGE_SCANNER_SELECT"),
-		Value:   "all",
+		Name:     "image-scanner-select",
+		Category: imageScannerCategory,
+		Usage:    "The name of the scanner to use",
+		Sources:  cli.EnvVars("IMAGE_SCANNER_SELECT"),
+		Value:    "all",
 	}
 	skipImageScanFlagName = "skip-image-scan"
 	skipImageScanFlag     = &cli.BoolFlag{
-		Name:    skipImageScanFlagName,
-		Usage:   "Skip sending the image to the image scan service",
-		Sources: cli.EnvVars("SKIP_IMAGE_SCAN"),
-		Value:   false,
+		Name:     skipImageScanFlagName,
+		Category: imageScannerCategory,
+		Usage:    "Skip sending the image to the image scan service",
+		Sources:  cli.EnvVars("SKIP_IMAGE_SCAN"),
+		Value:    false,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			logrus.WithField(skipImageScanFlagName, b).Info("Image scanning configuration")
 			if !b && !imageScanningAPIConfig(c).Valid() {
@@ -393,61 +394,175 @@ var (
 	}
 )
 
-// Release specific flags.
+// Hashrelease specific flags.
 var (
-	// Publishing flags.
-	publishGitTagFlag = &cli.BoolFlag{
-		Name:    "publish-git-tag",
-		Usage:   "Push the git tag to the remote",
-		Sources: cli.EnvVars("PUBLISH_GIT_TAG"),
-		Value:   true,
+
+	// Hashrelease server configuration flags.
+	hashreleaseServerCategory = "Hashrelease Server"
+	hashreleaseServerFlags    = []cli.Flag{hashreleaseServerBucketFlag}
+	publishHashreleaseFlag    = &cli.BoolFlag{
+		Name:     "publish-to-hashrelease-server",
+		Category: hashreleaseServerCategory,
+		Usage:    "Publish the hashrelease to the hashrelease server",
+		Sources:  cli.EnvVars("PUBLISH_TO_HASHRELEASE_SERVER"),
+		Value:    true,
 	}
-	publishGitHubReleaseFlag = &cli.BoolFlag{
-		Name:    "publish-github-release",
-		Usage:   "Publish the release to GitHub",
-		Sources: cli.EnvVars("PUBLISH_GITHUB_RELEASE"),
-		Value:   true,
+	latestFlag = &cli.BoolFlag{
+		Name:     "latest",
+		Category: hashreleaseServerCategory,
+		Usage:    "Publish the hashrelease as the latest hashrelease",
+		Sources:  cli.EnvVars("LATEST"),
+		Value:    true,
+	}
+	hashreleaseServerBucketFlag = &cli.StringFlag{
+		Name:     "hashrelease-server-bucket",
+		Category: hashreleaseServerCategory,
+		Usage:    "The bucket name for the hashrelease server",
+		Sources:  cli.EnvVars("HASHRELEASE_SERVER_BUCKET"),
+	}
+)
+
+// Step control flags gate logical release steps.
+const (
+	stepControlCategory = "Step Control"
+
+	// Images.
+	imagesFlagName        = "images"
+	envBuildImages        = "BUILD_CONTAINER_IMAGES"
+	envPublishImages      = "PUBLISH_IMAGES"
+	archiveImagesFlagName = "archive-images"
+	envArchiveImages      = "ARCHIVE_IMAGES"
+
+	// Helm Charts.
+	helmChartsFlagName = "helm-charts"
+	envBuildCharts     = "BUILD_CHARTS"
+	envPublishCharts   = "PUBLISH_CHARTS"
+
+	// Windows.
+	windowsArchiveFlagName   = "windows-archive"
+	envBuildWindowsArchive   = "BUILD_WINDOWS_ARCHIVE"
+	envPublishWindowsArchive = "PUBLISH_WINDOWS_ARCHIVE"
+)
+
+var (
+	buildStepFlags = func(hashrelease bool) []cli.Flag {
+		return []cli.Flag{
+			manifestsFlag,
+			ocpBundleFlag,
+			imagesFlag(!hashrelease, envBuildImages),
+			archiveImagesFlag(!hashrelease, envArchiveImages),
+			binariesFlag,
+			helmChartsFlag(true, envBuildCharts),
+			helmIndexFlag,
+			tarballFlag,
+			windowsArchiveFlag(true, envBuildWindowsArchive),
+		}
+	}
+	publishStepFlags = func(hashrelease bool) []cli.Flag {
+		f := buildStepFlags(hashrelease)
+		if hashrelease {
+			return f
+		}
+		return append(f,
+			gitRefFlag,
+			githubReleaseFlag)
+	}
+
+	imagesFlag = func(value bool, envVars ...string) *cli.BoolFlag {
+		return &cli.BoolFlag{
+			Name:     imagesFlagName,
+			Category: stepControlCategory,
+			Usage:    "Include container images in the release step",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+		}
+	}
+	archiveImagesFlag = func(value bool, envVars ...string) *cli.BoolFlag {
+		return &cli.BoolFlag{
+			Name:     archiveImagesFlagName,
+			Category: stepControlCategory,
+			Usage:    "Archive container images in the release tarball",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+			Action: func(_ context.Context, c *cli.Command, b bool) error {
+				if b && !c.Bool(imagesFlagName) {
+					return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", imagesFlagName)
+				}
+				return nil
+			},
+		}
+	}
+	helmChartsFlag = func(value bool, envVars ...string) *cli.BoolFlag {
+		return &cli.BoolFlag{
+			Name:     helmChartsFlagName,
+			Category: stepControlCategory,
+			Usage:    "Include Helm charts in the release step",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+		}
+	}
+	helmIndexFlag = &cli.BoolFlag{
+		Name:     "helm-index",
+		Category: stepControlCategory,
+		Usage:    "Update the Helm chart index",
+		Sources:  cli.EnvVars("RELEASE_HELM_INDEX", "UPDATE_HELM_INDEX"),
+		Value:    true,
+	}
+	binariesFlag = &cli.BoolFlag{
+		Name:     "binaries",
+		Category: stepControlCategory,
+		Usage:    "Include binaries in the release step",
+		Sources:  cli.EnvVars("RELEASE_BINARIES"),
+		Value:    true,
+	}
+	manifestsFlag = &cli.BoolFlag{
+		Name:     "manifests",
+		Category: stepControlCategory,
+		Usage:    "Include manifests in the release step",
+		Sources:  cli.EnvVars("RELEASE_MANIFESTS"),
+		Value:    true,
+	}
+	ocpBundleFlag = &cli.BoolFlag{
+		Name:     "ocp-bundle",
+		Category: stepControlCategory,
+		Usage:    "Include OCP bundle in the release step",
+		Sources:  cli.EnvVars("RELEASE_OCP_BUNDLE"),
+		Value:    true,
+	}
+	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolFlag {
+		return &cli.BoolFlag{
+			Name:     windowsArchiveFlagName,
+			Category: stepControlCategory,
+			Usage:    "Include Windows archive in the release step",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+		}
+	}
+	tarballFlag = &cli.BoolFlag{
+		Name:     "tarball",
+		Category: stepControlCategory,
+		Usage:    "Include the release tarball in the release step",
+		Sources:  cli.EnvVars("RELEASE_TARBALL"),
+		Value:    true,
+	}
+	gitRefFlag = &cli.BoolFlag{
+		Name:     "git-ref",
+		Category: stepControlCategory,
+		Usage:    "Push the git ref(s) to the remote",
+		Sources:  cli.EnvVars("PUBLISH_GIT_TAG", "PUBLISH_GIT_REF"),
+		Value:    true,
+	}
+	githubReleaseFlag = &cli.BoolFlag{
+		Name:     "github-release",
+		Category: stepControlCategory,
+		Usage:    "Publish the GitHub release",
+		Sources:  cli.EnvVars("PUBLISH_GITHUB_RELEASE"),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && c.String(githubTokenFlag.Name) == "" {
 				return fmt.Errorf("GitHub token is required to publish release")
 			}
 			return nil
 		},
-	}
-)
-
-// Hashrelease specific flags.
-var (
-	skipBranchCheckFlag = &cli.BoolFlag{
-		Name:    "skip-branch-check",
-		Usage:   "Skip checking if current branch is a valid branch for release",
-		Sources: cli.EnvVars("SKIP_BRANCH_CHECK"),
-		Value:   false,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if c.Bool(skipValidationFlag.Name) && !b {
-				return fmt.Errorf("must skip branch check if %s is set", skipValidationFlag)
-			}
-			return nil
-		},
-	}
-
-	// Hashrelease server configuration flags.
-	hashreleaseServerFlags = []cli.Flag{hashreleaseServerBucketFlag}
-	publishHashreleaseFlag = &cli.BoolFlag{
-		Name:    "publish-to-hashrelease-server",
-		Usage:   "Publish the hashrelease to the hashrelease server",
-		Sources: cli.EnvVars("PUBLISH_TO_HASHRELEASE_SERVER"),
-		Value:   true,
-	}
-	latestFlag = &cli.BoolFlag{
-		Name:    "latest",
-		Usage:   "Publish the hashrelease as the latest hashrelease",
-		Sources: cli.EnvVars("LATEST"),
-		Value:   true,
-	}
-	hashreleaseServerBucketFlag = &cli.StringFlag{
-		Name:    "hashrelease-server-bucket",
-		Usage:   "The bucket name for the hashrelease server",
-		Sources: cli.EnvVars("HASHRELEASE_SERVER_BUCKET"),
 	}
 )

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -117,25 +117,33 @@ var (
 var (
 	developmentCategory = "Development"
 
-	skipValidationFlag = &cli.BoolFlag{
-		Name:     "skip-validation",
+	validateFlagName = "validation"
+	validateFlag     = &cli.BoolWithInverseFlag{
+		Name:     validateFlagName,
 		Category: developmentCategory,
-		Usage:    "Skip all validation while performing the action",
-		Sources:  cli.EnvVars("SKIP_VALIDATION"),
-		Value:    false,
-	}
-	skipBranchCheckFlag = &cli.BoolFlag{
-		Name:     "skip-branch-check",
-		Category: developmentCategory,
-		Usage:    "Skip checking if current branch is a valid branch for release",
-		Sources:  cli.EnvVars("SKIP_BRANCH_CHECK"),
-		Value:    false,
+		Usage:    "Run validation checks",
+		Sources:  cli.EnvVars("VALIDATION", "RELEASE_VALIDATION"),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if c.Bool(skipValidationFlag.Name) && !b {
-				return fmt.Errorf("must skip branch check if %s is set", skipValidationFlag)
+			if b {
+				return nil
+			}
+			if c.Bool(validateBranchFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(validateBranchFlagName), inverseFlagName(validateFlagName))
+			}
+			if c.Bool(imageScanFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(imageScanFlagName), inverseFlagName(validateFlagName))
 			}
 			return nil
 		},
+	}
+	validateBranchFlagName = "branch-check"
+	validateBranchFlag     = &cli.BoolWithInverseFlag{
+		Name:     validateBranchFlagName,
+		Category: developmentCategory,
+		Usage:    "Check that the current branch is a valid branch for release",
+		Sources:  cli.EnvVars("BRANCH_CHECK", "RELEASE_BRANCH_CHECK"),
+		Value:    true,
 	}
 )
 
@@ -192,11 +200,18 @@ var (
 
 // Operator flags are flags used to interact with Tigera operator repository
 var (
-	operatorCategory   = "Tigera Operator"
-	operatorGitFlags   = []cli.Flag{operatorOrgFlag, operatorRepoFlag}
-	operatorBuildFlags = append(operatorGitFlags, operatorFlag,
-		operatorBranchFlag, operatorReleaseBranchPrefixFlag,
-		operatorRegistryFlag, operatorImageFlag)
+	operatorCategory = "Tigera Operator"
+
+	operatorBuildCommandFlags = []cli.Flag{
+		operatorOrgFlag, operatorRepoFlag, operatorBranchFlag,
+		operatorReleaseBranchPrefixFlag,
+		operatorRegistryFlag, operatorImageFlag,
+		operatorFlag(envBuildOperator, envReleaseOperator),
+	}
+
+	operatorPublishCommandFlags = []cli.Flag{
+		operatorFlag(envPublishOperator, envReleaseOperator),
+	}
 
 	// Operator git flags
 	operatorOrgFlag = &cli.StringFlag{
@@ -244,12 +259,18 @@ var (
 		Value:    operator.DefaultImage,
 	}
 
-	operatorFlag = &cli.BoolFlag{
-		Name:     "operator",
-		Category: operatorCategory,
-		Usage:    "Include Tigera operator in the release steps",
-		Sources:  cli.EnvVars("RELEASE_OPERATOR"),
-		Value:    true,
+	operatorFlagName   = "operator"
+	envBuildOperator   = "BUILD_OPERATOR"
+	envPublishOperator = "PUBLISH_OPERATOR"
+	envReleaseOperator = "RELEASE_OPERATOR"
+	operatorFlag       = func(envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     operatorFlagName,
+			Category: operatorCategory,
+			Usage:    "Include Tigera operator in the release steps",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    true,
+		}
 	}
 )
 
@@ -312,7 +333,7 @@ var (
 		Usage:    "The Slack channel to post messages",
 		Sources:  cli.EnvVars("SLACK_CHANNEL"),
 	}
-	notifyFlag = &cli.BoolFlag{
+	notifyFlag = &cli.BoolWithInverseFlag{
 		Name:     "notify",
 		Category: slackCategory,
 		Usage:    "Sending notifications to Slack",
@@ -333,7 +354,7 @@ var (
 	// Image scanner flags for interacting with the image scanning service
 	imageScannerCategory = "Image Scanning Service"
 	imageScanFlags       = []cli.Flag{
-		skipImageScanFlag,
+		imageScanFlag,
 		imageScannerAPIFlag,
 		imageScannerTokenFlag,
 		imageScannerSelectFlag,
@@ -357,20 +378,19 @@ var (
 		Sources:  cli.EnvVars("IMAGE_SCANNER_SELECT"),
 		Value:    "all",
 	}
-	skipImageScanFlagName = "skip-image-scan"
-	skipImageScanFlag     = &cli.BoolFlag{
-		Name:     skipImageScanFlagName,
+	imageScanFlagName = "image-scan"
+	imageScanFlag     = &cli.BoolWithInverseFlag{
+		Name:     imageScanFlagName,
 		Category: imageScannerCategory,
-		Usage:    "Skip sending the image to the image scan service",
-		Sources:  cli.EnvVars("SKIP_IMAGE_SCAN"),
-		Value:    false,
+		Usage:    "Submit the image to the image scan service",
+		Sources:  cli.EnvVars("RELEASE_IMAGE_SCAN"),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			logrus.WithField(skipImageScanFlagName, b).Info("Image scanning configuration")
-			if !b && !imageScanningAPIConfig(c).Valid() {
+			if b && !imageScanningAPIConfig(c).Valid() {
 				if !c.Bool(ciFlag.Name) {
 					logrus.Warn("Image scanning configuration is incomplete")
 				}
-				return fmt.Errorf("invalid configuration for image scanning. Either set --%s and --%s or set --%s to 'true'", imageScannerAPIFlag.Name, imageScannerTokenFlag.Name, skipImageScanFlagName)
+				return fmt.Errorf("invalid configuration for image scanning. Either set --%s and --%s or set --%s", imageScannerAPIFlag.Name, imageScannerTokenFlag.Name, inverseFlagName(imageScanFlagName))
 			}
 			return nil
 		},
@@ -399,14 +419,14 @@ var (
 	// Hashrelease server configuration flags.
 	hashreleaseServerCategory = "Hashrelease Server"
 	hashreleaseServerFlags    = []cli.Flag{hashreleaseServerBucketFlag}
-	publishHashreleaseFlag    = &cli.BoolFlag{
+	publishHashreleaseFlag    = &cli.BoolWithInverseFlag{
 		Name:     "publish-to-hashrelease-server",
 		Category: hashreleaseServerCategory,
 		Usage:    "Publish the hashrelease to the hashrelease server",
 		Sources:  cli.EnvVars("PUBLISH_TO_HASHRELEASE_SERVER"),
 		Value:    true,
 	}
-	latestFlag = &cli.BoolFlag{
+	latestFlag = &cli.BoolWithInverseFlag{
 		Name:     "latest",
 		Category: hashreleaseServerCategory,
 		Usage:    "Publish the hashrelease as the latest hashrelease",
@@ -426,61 +446,107 @@ const (
 	stepControlCategory = "Step Control"
 
 	// Images.
-	imagesFlagName        = "images"
-	envBuildImages        = "BUILD_CONTAINER_IMAGES"
-	envPublishImages      = "PUBLISH_IMAGES"
-	archiveImagesFlagName = "archive-images"
-	envArchiveImages      = "ARCHIVE_IMAGES"
+	imagesFlagName          = "images"
+	envBuildImages          = "BUILD_CONTAINER_IMAGES"
+	envPublishImages        = "PUBLISH_IMAGES"
+	envReleaseImages        = "RELEASE_IMAGES"
+	archiveImagesFlagName   = "archive-images"
+	envArchiveImages        = "ARCHIVE_IMAGES"
+	envBuildArchiveImages   = "BUILD_IMAGES_ARCHIVE"
+	envReleaseArchiveImages = "RELEASE_IMAGES_ARCHIVE"
 
-	// Helm Charts.
+	// Helm charts.
 	helmChartsFlagName = "helm-charts"
 	envBuildCharts     = "BUILD_CHARTS"
 	envPublishCharts   = "PUBLISH_CHARTS"
+	envReleaseCharts   = "RELEASE_CHARTS"
 
-	// Windows.
-	windowsArchiveFlagName = "windows-archive"
-	envBuildWindowsArchive = "BUILD_WINDOWS_ARCHIVE"
+	// Helm index.
+	helmIndexFlagName   = "helm-index"
+	envHelmIndexLegacy  = "UPDATE_HELM_INDEX"
+	envBuildHelmIndex   = "BUILD_HELM_INDEX"
+	envPublishHelmIndex = "PUBLISH_HELM_INDEX"
+	envReleaseHelmIndex = "RELEASE_HELM_INDEX"
+
+	// Windows archive (build-only).
+	windowsArchiveFlagName   = "windows-archive"
+	envBuildWindowsArchive   = "BUILD_WINDOWS_ARCHIVE"
+	envReleaseWindowsArchive = "RELEASE_WINDOWS_ARCHIVE"
+
+	// Build-only.
+	envBuildManifests     = "BUILD_MANIFESTS"
+	envReleaseManifests   = "RELEASE_MANIFESTS"
+	envBuildOCPBundle     = "BUILD_OCP_BUNDLE"
+	envReleaseOCPBundle   = "RELEASE_OCP_BUNDLE"
+	envBuildBinaries      = "BUILD_BINARIES"
+	envReleaseBinaries    = "RELEASE_BINARIES"
+	envBuildTarball       = "BUILD_TARBALL"
+	envReleaseTarball     = "RELEASE_TARBALL"
+	envBuildE2EBinaries   = "BUILD_E2E_BINARIES"
+	envReleaseE2EBinaries = "RELEASE_E2E_BINARIES"
+	envBuildReleaseNotes  = "BUILD_RELEASE_NOTES"
+	envReleaseNotes       = "RELEASE_NOTES"
+
+	// Publish-only.
+	envPublishGitRefLegacy  = "PUBLISH_GIT_TAG"
+	envPublishGitRef        = "PUBLISH_GIT_REF"
+	envReleaseGitRef        = "RELEASE_GIT_REF"
+	envPublishGithubRelease = "PUBLISH_GITHUB_RELEASE"
+	envReleaseGithubRelease = "RELEASE_GITHUB_RELEASE"
 )
 
 var (
 	buildStepFlags = func(hashrelease bool) []cli.Flag {
-		return []cli.Flag{
+		f := []cli.Flag{
 			manifestsFlag,
 			ocpBundleFlag,
-			imagesFlag(!hashrelease, envBuildImages),
-			archiveImagesFlag(!hashrelease, envArchiveImages),
+			imagesFlag(!hashrelease, envBuildImages, envReleaseImages),
+			archiveImagesFlag(!hashrelease, envArchiveImages, envBuildArchiveImages, envReleaseArchiveImages),
 			binariesFlag,
-			helmChartsFlag(true, envBuildCharts),
-			helmIndexFlag,
+			helmChartsFlag(true, envBuildCharts, envReleaseCharts),
+			helmIndexFlag(envHelmIndexLegacy, envBuildHelmIndex, envReleaseHelmIndex),
 			tarballFlag,
-			windowsArchiveFlag(true, envBuildWindowsArchive),
+			windowsArchiveFlag(true, envBuildWindowsArchive, envReleaseWindowsArchive),
 		}
+		if hashrelease {
+			f = append(f, e2eBinariesFlag, releaseNotesFlag)
+		}
+		return f
 	}
 	publishStepFlags = func(hashrelease bool) []cli.Flag {
 		f := []cli.Flag{
-			imagesFlag(!hashrelease, envPublishImages),
-			helmChartsFlag(true, envPublishCharts),
+			imagesFlag(!hashrelease, envPublishImages, envReleaseImages),
+			helmChartsFlag(true, envPublishCharts, envReleaseCharts),
 		}
 		if hashrelease {
 			return f
 		}
 		return append(f,
-			helmIndexFlag,
+			helmIndexFlag(envHelmIndexLegacy, envPublishHelmIndex, envReleaseHelmIndex),
 			gitRefFlag,
 			githubReleaseFlag)
 	}
 
-	imagesFlag = func(value bool, envVars ...string) *cli.BoolFlag {
-		return &cli.BoolFlag{
+	imagesFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
 			Name:     imagesFlagName,
 			Category: stepControlCategory,
 			Usage:    "Include container images in the release step",
 			Sources:  cli.EnvVars(envVars...),
 			Value:    value,
+			Action: func(_ context.Context, c *cli.Command, b bool) error {
+				if !b && c.Bool(archiveImagesFlagName) {
+					return fmt.Errorf("cannot archive images without building them; use --%s flag to build images", imagesFlagName)
+				}
+				if b && !c.Bool(archiveImagesFlagName) {
+					logrus.Warnf("Images are included but not archived; to include images in the archive set --%s", archiveImagesFlagName)
+				}
+				return nil
+			},
 		}
 	}
-	archiveImagesFlag = func(value bool, envVars ...string) *cli.BoolFlag {
-		return &cli.BoolFlag{
+	archiveImagesFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
 			Name:     archiveImagesFlagName,
 			Category: stepControlCategory,
 			Usage:    "Archive container images in the release tarball",
@@ -488,51 +554,79 @@ var (
 			Value:    value,
 			Action: func(_ context.Context, c *cli.Command, b bool) error {
 				if b && !c.Bool(imagesFlagName) {
-					return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", imagesFlagName)
+					return fmt.Errorf("cannot archive images without building them; use --%s flag to build images", imagesFlagName)
+				}
+				if !b && c.Bool(imagesFlagName) {
+					logrus.Warnf("Images are included but not archived; to include images in the archive set --%s", archiveImagesFlagName)
 				}
 				return nil
 			},
 		}
 	}
-	helmChartsFlag = func(value bool, envVars ...string) *cli.BoolFlag {
-		return &cli.BoolFlag{
+	helmChartsFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
 			Name:     helmChartsFlagName,
 			Category: stepControlCategory,
 			Usage:    "Include Helm charts in the release step",
 			Sources:  cli.EnvVars(envVars...),
 			Value:    value,
+			Action: func(_ context.Context, c *cli.Command, b bool) error {
+				if b {
+					return nil
+				}
+				if c.Bool(helmIndexFlagName) {
+					return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(helmIndexFlagName), inverseFlagName(helmChartsFlagName))
+				}
+				return nil
+			},
 		}
 	}
-	helmIndexFlag = &cli.BoolFlag{
-		Name:     "helm-index",
-		Category: stepControlCategory,
-		Usage:    "Update the Helm chart index",
-		Sources:  cli.EnvVars("RELEASE_HELM_INDEX", "UPDATE_HELM_INDEX"),
-		Value:    true,
+	helmIndexFlag = func(envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     helmIndexFlagName,
+			Category: stepControlCategory,
+			Usage:    "Build/update the Helm chart index",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    true,
+		}
 	}
-	binariesFlag = &cli.BoolFlag{
+	binariesFlag = &cli.BoolWithInverseFlag{
 		Name:     "binaries",
 		Category: stepControlCategory,
 		Usage:    "Include binaries in the release step",
-		Sources:  cli.EnvVars("RELEASE_BINARIES"),
+		Sources:  cli.EnvVars(envBuildBinaries, envReleaseBinaries),
 		Value:    true,
 	}
-	manifestsFlag = &cli.BoolFlag{
+	e2eBinariesFlag = &cli.BoolWithInverseFlag{
+		Name:     "e2e-binaries",
+		Category: stepControlCategory,
+		Usage:    "Build multi-arch e2e test binaries",
+		Sources:  cli.EnvVars(envBuildE2EBinaries, envReleaseE2EBinaries),
+		Value:    true,
+	}
+	releaseNotesFlag = &cli.BoolWithInverseFlag{
+		Name:     "release-notes",
+		Category: stepControlCategory,
+		Usage:    "Generate release notes",
+		Sources:  cli.EnvVars(envBuildReleaseNotes, envReleaseNotes),
+		Value:    true,
+	}
+	manifestsFlag = &cli.BoolWithInverseFlag{
 		Name:     "manifests",
 		Category: stepControlCategory,
 		Usage:    "Include manifests in the release step",
-		Sources:  cli.EnvVars("RELEASE_MANIFESTS"),
+		Sources:  cli.EnvVars(envBuildManifests, envReleaseManifests),
 		Value:    true,
 	}
-	ocpBundleFlag = &cli.BoolFlag{
+	ocpBundleFlag = &cli.BoolWithInverseFlag{
 		Name:     "ocp-bundle",
 		Category: stepControlCategory,
 		Usage:    "Include OCP bundle in the release step",
-		Sources:  cli.EnvVars("RELEASE_OCP_BUNDLE"),
+		Sources:  cli.EnvVars(envBuildOCPBundle, envReleaseOCPBundle),
 		Value:    true,
 	}
-	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolFlag {
-		return &cli.BoolFlag{
+	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
 			Name:     windowsArchiveFlagName,
 			Category: stepControlCategory,
 			Usage:    "Include Windows archive in the release step",
@@ -540,25 +634,25 @@ var (
 			Value:    value,
 		}
 	}
-	tarballFlag = &cli.BoolFlag{
+	tarballFlag = &cli.BoolWithInverseFlag{
 		Name:     "tarball",
 		Category: stepControlCategory,
 		Usage:    "Include the release tarball in the release step",
-		Sources:  cli.EnvVars("RELEASE_TARBALL"),
+		Sources:  cli.EnvVars(envBuildTarball, envReleaseTarball),
 		Value:    true,
 	}
-	gitRefFlag = &cli.BoolFlag{
+	gitRefFlag = &cli.BoolWithInverseFlag{
 		Name:     "git-ref",
 		Category: stepControlCategory,
 		Usage:    "Push the git ref(s) to the remote",
-		Sources:  cli.EnvVars("PUBLISH_GIT_TAG", "PUBLISH_GIT_REF"),
+		Sources:  cli.EnvVars(envPublishGitRefLegacy, envPublishGitRef, envReleaseGitRef),
 		Value:    true,
 	}
-	githubReleaseFlag = &cli.BoolFlag{
+	githubReleaseFlag = &cli.BoolWithInverseFlag{
 		Name:     "github-release",
 		Category: stepControlCategory,
 		Usage:    "Publish the GitHub release",
-		Sources:  cli.EnvVars("PUBLISH_GITHUB_RELEASE"),
+		Sources:  cli.EnvVars(envPublishGithubRelease, envReleaseGithubRelease),
 		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && c.String(githubTokenFlag.Name) == "" {
@@ -568,3 +662,7 @@ var (
 		},
 	}
 )
+
+func inverseFlagName(name string) string {
+	return "no-" + name
+}

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -624,15 +624,6 @@ var (
 		Usage:    "Include manifests in the release step",
 		Sources:  cli.EnvVars(envBuildManifests, envReleaseManifests),
 		Value:    true,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if b {
-				return nil
-			}
-			if hasFlag(c, ocpBundleFlagName) && c.Bool(ocpBundleFlagName) {
-				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(ocpBundleFlagName), inverseFlagName(manifestsFlagName))
-			}
-			return nil
-		},
 	}
 	ocpBundleFlagName = "ocp-bundle"
 	ocpBundleFlag     = &cli.BoolWithInverseFlag{
@@ -641,12 +632,6 @@ var (
 		Usage:    "Include OCP bundle in the release step",
 		Sources:  cli.EnvVars(envBuildOCPBundle, envReleaseOCPBundle),
 		Value:    true,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if b && hasFlag(c, manifestsFlagName) && !c.Bool(manifestsFlagName) {
-				return fmt.Errorf("--%s requires --%s; either drop --%s or also set --%s", ocpBundleFlagName, manifestsFlagName, inverseFlagName(manifestsFlagName), inverseFlagName(ocpBundleFlagName))
-			}
-			return nil
-		},
 	}
 	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
 		return &cli.BoolWithInverseFlag{

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -28,6 +28,20 @@ import (
 
 var globalFlags = append([]cli.Flag{debugFlag}, append(ciFlags, slackFlags...)...)
 
+// Flag categories group flags in --help output.
+const (
+	gitCategory               = "Git Repository"
+	developmentCategory       = "Development"
+	containerImageCategory    = "Container Image"
+	cloudCategory             = "Cloud Configuration"
+	operatorCategory          = "Tigera Operator"
+	ciCategory                = "CI Environment"
+	slackCategory             = "Slack"
+	imageScannerCategory      = "Image Scanning Service"
+	hashreleaseServerCategory = "Hashrelease Server"
+	stepControlCategory       = "Step Control"
+)
+
 // debugFlag is a flag used to enable verbose log output
 var debugFlag = &cli.BoolFlag{
 	Name:        "debug",
@@ -49,8 +63,7 @@ var (
 	}
 
 	// Git flags for interacting with the git repository
-	gitCategory = "Git Repository"
-	orgFlag     = &cli.StringFlag{
+	orgFlag = &cli.StringFlag{
 		Name:     "org",
 		Category: gitCategory,
 		Usage:    "The GitHub organization to use for the release",
@@ -115,11 +128,9 @@ var (
 
 // Development flags are flags used to control development behavior of the release process
 var (
-	developmentCategory = "Development"
-
-	validateFlagName = "validation"
-	validateFlag     = &cli.BoolWithInverseFlag{
-		Name:     validateFlagName,
+	validationFlagName = "validation"
+	validationFlag     = &cli.BoolWithInverseFlag{
+		Name:     validationFlagName,
 		Category: developmentCategory,
 		Usage:    "Run validation checks",
 		Sources:  cli.EnvVars("VALIDATION", "RELEASE_VALIDATION"),
@@ -128,18 +139,20 @@ var (
 			if b {
 				return nil
 			}
-			if c.Bool(validateBranchFlagName) {
-				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(validateBranchFlagName), inverseFlagName(validateFlagName))
+			if c.Bool(branchCheckFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(branchCheckFlagName), inverseFlagName(validationFlagName))
 			}
-			if c.Bool(imageScanFlagName) {
-				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(imageScanFlagName), inverseFlagName(validateFlagName))
+			// image-scan is only registered on publish commands; only enforce the
+			// dependency where the flag actually exists.
+			if hasFlag(c, imageScanFlagName) && c.Bool(imageScanFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(imageScanFlagName), inverseFlagName(validationFlagName))
 			}
 			return nil
 		},
 	}
-	validateBranchFlagName = "branch-check"
-	validateBranchFlag     = &cli.BoolWithInverseFlag{
-		Name:     validateBranchFlagName,
+	branchCheckFlagName = "branch-check"
+	branchCheckFlag     = &cli.BoolWithInverseFlag{
+		Name:     branchCheckFlagName,
 		Category: developmentCategory,
 		Usage:    "Check that the current branch is a valid branch for release",
 		Sources:  cli.EnvVars("BRANCH_CHECK", "RELEASE_BRANCH_CHECK"),
@@ -149,8 +162,7 @@ var (
 
 // Container image flags are flags used to control container image building and publishing
 var (
-	containerImageCategory = "Container Image"
-	registryFlag           = &cli.StringSliceFlag{
+	registryFlag = &cli.StringSliceFlag{
 		Name:     "registry",
 		Category: containerImageCategory,
 		Usage:    "Override default registries for the release. Repeat for multiple registries.",
@@ -183,7 +195,6 @@ var (
 )
 
 var (
-	cloudCategory  = "Cloud Configuration"
 	awsProfileFlag = &cli.StringFlag{
 		Name:     "aws-profile",
 		Category: cloudCategory,
@@ -200,8 +211,6 @@ var (
 
 // Operator flags are flags used to interact with Tigera operator repository
 var (
-	operatorCategory = "Tigera Operator"
-
 	operatorBuildCommandFlags = []cli.Flag{
 		operatorOrgFlag, operatorRepoFlag, operatorBranchFlag,
 		operatorReleaseBranchPrefixFlag,
@@ -277,7 +286,6 @@ var (
 // External flags are flags used to interact with external services
 var (
 	// CI flags for interacting with CI services (Semaphore)
-	ciCategory  = "CI Environment"
 	ciFlags     = []cli.Flag{ciFlag, ciBaseURLFlag, ciJobIDFlag, ciPipelineIDFlag, ciTokenFlag}
 	semaphoreCI = "semaphore"
 	ciFlag      = &cli.BoolFlag{
@@ -319,7 +327,6 @@ var (
 	}
 
 	// Slack flags for posting messages to Slack
-	slackCategory  = "Slack"
 	slackFlags     = []cli.Flag{slackTokenFlag, slackChannelFlag, notifyFlag}
 	slackTokenFlag = &cli.StringFlag{
 		Name:     "slack-token",
@@ -352,8 +359,7 @@ var (
 	}
 
 	// Image scanner flags for interacting with the image scanning service
-	imageScannerCategory = "Image Scanning Service"
-	imageScanFlags       = []cli.Flag{
+	imageScanFlags = []cli.Flag{
 		imageScanFlag,
 		imageScannerAPIFlag,
 		imageScannerTokenFlag,
@@ -386,6 +392,7 @@ var (
 		Sources:  cli.EnvVars("RELEASE_IMAGE_SCAN"),
 		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			logrus.WithField(imageScanFlagName, b).Info("Image scanning configuration")
 			if b && !imageScanningAPIConfig(c).Valid() {
 				if !c.Bool(ciFlag.Name) {
 					logrus.Warn("Image scanning configuration is incomplete")
@@ -417,9 +424,8 @@ var (
 var (
 
 	// Hashrelease server configuration flags.
-	hashreleaseServerCategory = "Hashrelease Server"
-	hashreleaseServerFlags    = []cli.Flag{hashreleaseServerBucketFlag}
-	publishHashreleaseFlag    = &cli.BoolWithInverseFlag{
+	hashreleaseServerFlags = []cli.Flag{hashreleaseServerBucketFlag}
+	publishHashreleaseFlag = &cli.BoolWithInverseFlag{
 		Name:     "publish-to-hashrelease-server",
 		Category: hashreleaseServerCategory,
 		Usage:    "Publish the hashrelease to the hashrelease server",
@@ -443,8 +449,6 @@ var (
 
 // Step control flags gate logical release steps.
 const (
-	stepControlCategory = "Step Control"
-
 	// Images.
 	imagesFlagName          = "images"
 	envBuildImages          = "BUILD_CONTAINER_IMAGES"
@@ -535,11 +539,13 @@ var (
 			Sources:  cli.EnvVars(envVars...),
 			Value:    value,
 			Action: func(_ context.Context, c *cli.Command, b bool) error {
-				if !b && c.Bool(archiveImagesFlagName) {
+				// archive-images is build-only; only enforce the dependency
+				// where the flag is registered. The "images on but not
+				// archived" warning is emitted from archiveImagesFlag.Action
+				// instead so it doesn't fire on publish commands where
+				// archive-images doesn't exist.
+				if hasFlag(c, archiveImagesFlagName) && !b && c.Bool(archiveImagesFlagName) {
 					return fmt.Errorf("cannot archive images without building them; use --%s flag to build images", imagesFlagName)
-				}
-				if b && !c.Bool(archiveImagesFlagName) {
-					logrus.Warnf("Images are included but not archived; to include images in the archive set --%s", archiveImagesFlagName)
 				}
 				return nil
 			},
@@ -611,19 +617,36 @@ var (
 		Sources:  cli.EnvVars(envBuildReleaseNotes, envReleaseNotes),
 		Value:    true,
 	}
-	manifestsFlag = &cli.BoolWithInverseFlag{
-		Name:     "manifests",
+	manifestsFlagName = "manifests"
+	manifestsFlag     = &cli.BoolWithInverseFlag{
+		Name:     manifestsFlagName,
 		Category: stepControlCategory,
 		Usage:    "Include manifests in the release step",
 		Sources:  cli.EnvVars(envBuildManifests, envReleaseManifests),
 		Value:    true,
+		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			if b {
+				return nil
+			}
+			if hasFlag(c, ocpBundleFlagName) && c.Bool(ocpBundleFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(ocpBundleFlagName), inverseFlagName(manifestsFlagName))
+			}
+			return nil
+		},
 	}
-	ocpBundleFlag = &cli.BoolWithInverseFlag{
-		Name:     "ocp-bundle",
+	ocpBundleFlagName = "ocp-bundle"
+	ocpBundleFlag     = &cli.BoolWithInverseFlag{
+		Name:     ocpBundleFlagName,
 		Category: stepControlCategory,
 		Usage:    "Include OCP bundle in the release step",
 		Sources:  cli.EnvVars(envBuildOCPBundle, envReleaseOCPBundle),
 		Value:    true,
+		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			if b && hasFlag(c, manifestsFlagName) && !c.Bool(manifestsFlagName) {
+				return fmt.Errorf("--%s requires --%s; either drop --%s or also set --%s", ocpBundleFlagName, manifestsFlagName, inverseFlagName(manifestsFlagName), inverseFlagName(ocpBundleFlagName))
+			}
+			return nil
+		},
 	}
 	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
 		return &cli.BoolWithInverseFlag{
@@ -665,4 +688,14 @@ var (
 
 func inverseFlagName(name string) string {
 	return "no-" + name
+}
+
+// hasFlag reports whether the command has a flag registered under the given
+// name (or one of its aliases). Used by cross-flag Action callbacks to skip
+// dependency checks against flags that aren't registered on the current
+// command (e.g. image-scan is publish-only).
+func hasFlag(c *cli.Command, name string) bool {
+	return slices.ContainsFunc(c.Flags, func(f cli.Flag) bool {
+		return slices.Contains(f.Names(), name)
+	})
 }

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -40,7 +40,6 @@ var debugFlag = &cli.BoolFlag{
 
 // Product repository flags are flags used to interact with the product repository
 var (
-	gitFlags     = []cli.Flag{orgFlag, repoFlag, repoRemoteFlag}
 	productFlags = []cli.Flag{
 		orgFlag,
 		repoFlag,
@@ -249,7 +248,7 @@ var (
 		Name:     "operator",
 		Category: operatorCategory,
 		Usage:    "Include Tigera operator in the release steps",
-		Sources:  cli.EnvVars("OPERATOR"),
+		Sources:  cli.EnvVars("RELEASE_OPERATOR"),
 		Value:    true,
 	}
 )
@@ -381,7 +380,7 @@ var (
 	githubTokenFlag = &cli.StringFlag{
 		Name:    "github-token",
 		Usage:   "The GitHub token to use when interacting with the GitHub API",
-		Sources: cli.EnvVars("GITHUB_TOKEN"),
+		Sources: cli.EnvVars("GITHUB_TOKEN", "GH_TOKEN"),
 		Action: func(_ context.Context, c *cli.Command, s string) error {
 			if s == "" {
 				if c.Bool(ciFlag.Name) {
@@ -439,9 +438,8 @@ const (
 	envPublishCharts   = "PUBLISH_CHARTS"
 
 	// Windows.
-	windowsArchiveFlagName   = "windows-archive"
-	envBuildWindowsArchive   = "BUILD_WINDOWS_ARCHIVE"
-	envPublishWindowsArchive = "PUBLISH_WINDOWS_ARCHIVE"
+	windowsArchiveFlagName = "windows-archive"
+	envBuildWindowsArchive = "BUILD_WINDOWS_ARCHIVE"
 )
 
 var (
@@ -459,7 +457,11 @@ var (
 		}
 	}
 	publishStepFlags = func(hashrelease bool) []cli.Flag {
-		f := buildStepFlags(hashrelease)
+		f := []cli.Flag{
+			imagesFlag(!hashrelease, envPublishImages),
+			helmChartsFlag(true, envPublishCharts),
+			helmIndexFlag,
+		}
 		if hashrelease {
 			return f
 		}

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -37,36 +37,51 @@ func runFlags(t *testing.T, flags []cli.Flag, args ...string) error {
 	return cmd.Run(context.Background(), append([]string{"test"}, args...))
 }
 
-func TestValidateFlagAction(t *testing.T) {
+// assertRun runs cmd with args and checks the resulting error against wantErr.
+// Empty wantErr means "expect no error". Non-empty wantErr is a substring match.
+func assertRun(t *testing.T, flags []cli.Flag, args []string, wantErr string) {
+	t.Helper()
+	err := runFlags(t, flags, args...)
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", wantErr)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("expected error containing %q, got %q", wantErr, err.Error())
+	}
+}
+
+func TestValidationFlagAction(t *testing.T) {
 	cases := []struct {
 		name    string
 		args    []string
-		wantErr string // substring match; empty means no error
+		wantErr string
 	}{
 		{"defaults pass", nil, ""},
-		{"--no-validate alone errors (default validate-branch=true)", []string{"--no-validate"}, "--no-validate-branch must be set"},
-		{"--no-validate --no-validate-branch but image-scan default true errors", []string{"--no-validate", "--no-validate-branch"}, "--no-image-scan must be set"},
-		{"all three negated passes", []string{"--no-validate", "--no-validate-branch", "--no-image-scan"}, ""},
-		{"--no-validate-branch alone passes (dependent disabled, prerequisite still on)", []string{"--no-validate-branch"}, ""},
+		{"--no-validation alone errors (default branch-check=true)", []string{"--no-validation"}, "--no-branch-check must be set"},
+		{"--no-validation --no-branch-check but image-scan default true errors", []string{"--no-validation", "--no-branch-check"}, "--no-image-scan must be set"},
+		{"all three negated passes", []string{"--no-validation", "--no-branch-check", "--no-image-scan"}, ""},
+		{"--no-branch-check alone passes (dependent disabled, prerequisite still on)", []string{"--no-branch-check"}, ""},
 		{"--no-image-scan alone passes", []string{"--no-image-scan"}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := runFlags(t, []cli.Flag{validateFlag, validateBranchFlag, imageScanFlag}, tc.args...)
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
-			}
+			assertRun(t, []cli.Flag{validationFlag, branchCheckFlag, imageScanFlag}, tc.args, tc.wantErr)
 		})
 	}
+}
+
+// TestValidationFlagActionWithoutImageScan covers the build-side case where
+// imageScanFlag isn't registered. validationFlag.Action must skip the
+// image-scan dependency check rather than misfire.
+func TestValidationFlagActionWithoutImageScan(t *testing.T) {
+	flags := []cli.Flag{validationFlag, branchCheckFlag}
+	assertRun(t, flags, []string{"--no-validation", "--no-branch-check"}, "")
 }
 
 func TestHelmChartsFlagAction(t *testing.T) {
@@ -86,19 +101,7 @@ func TestHelmChartsFlagAction(t *testing.T) {
 				helmChartsFlag(true, "TEST_BUILD_CHARTS"),
 				helmIndexFlag("TEST_BUILD_HELM_INDEX"),
 			}
-			err := runFlags(t, flags, tc.args...)
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
-			}
+			assertRun(t, flags, tc.args, tc.wantErr)
 		})
 	}
 }
@@ -122,19 +125,7 @@ func TestImagesArchiveImagesFlagAction(t *testing.T) {
 					imagesFlag(true, "TEST_BUILD_IMAGES_R"),
 					archiveImagesFlag(true, "TEST_BUILD_ARCHIVE_IMAGES_R"),
 				}
-				err := runFlags(t, flags, tc.args...)
-				if tc.wantErr == "" {
-					if err != nil {
-						t.Fatalf("unexpected error: %v", err)
-					}
-					return
-				}
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
-				}
+				assertRun(t, flags, tc.args, tc.wantErr)
 			})
 		}
 	})
@@ -157,22 +148,116 @@ func TestImagesArchiveImagesFlagAction(t *testing.T) {
 					imagesFlag(false, "TEST_BUILD_IMAGES_H"),
 					archiveImagesFlag(false, "TEST_BUILD_ARCHIVE_IMAGES_H"),
 				}
-				err := runFlags(t, flags, tc.args...)
-				if tc.wantErr == "" {
-					if err != nil {
-						t.Fatalf("unexpected error: %v", err)
-					}
-					return
-				}
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
-				}
+				assertRun(t, flags, tc.args, tc.wantErr)
 			})
 		}
 	})
+
+	// On publish commands archive-images is not registered. images.Action
+	// must skip the archive dependency check rather than misfire.
+	t.Run("publish (no archive-images registered)", func(t *testing.T) {
+		flags := []cli.Flag{imagesFlag(true, "TEST_PUBLISH_IMAGES")}
+		assertRun(t, flags, []string{"--no-images"}, "")
+		assertRun(t, flags, nil, "")
+	})
+}
+
+func TestManifestsOCPBundleFlagAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"defaults pass", nil, ""},
+		{"--no-manifests alone errors (default ocp-bundle=true)", []string{"--no-manifests"}, "--no-ocp-bundle must be set"},
+		{"--no-manifests --no-ocp-bundle passes", []string{"--no-manifests", "--no-ocp-bundle"}, ""},
+		{"--no-ocp-bundle alone passes (dependent disabled)", []string{"--no-ocp-bundle"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRun(t, []cli.Flag{manifestsFlag, ocpBundleFlag}, tc.args, tc.wantErr)
+		})
+	}
+}
+
+// TestEnvVarPrecedence pins down the legacy-alias-wins behaviour. The first
+// env var listed in cli.EnvVars(...) takes precedence; legacy aliases like
+// ARCHIVE_IMAGES, UPDATE_HELM_INDEX, and PUBLISH_GIT_TAG must be listed first
+// in their respective Sources slices so existing CI configs keep winning over
+// the new BUILD_*/PUBLISH_*/RELEASE_* names.
+func TestEnvVarPrecedence(t *testing.T) {
+	cases := []struct {
+		name        string
+		legacyKey   string
+		legacyValue string
+		newKey      string
+		newValue    string
+		flagFn      func() cli.Flag
+		flagName    string
+		want        bool
+	}{
+		{
+			name:        "ARCHIVE_IMAGES wins over BUILD_IMAGES_ARCHIVE",
+			legacyKey:   "ARCHIVE_IMAGES",
+			legacyValue: "false",
+			newKey:      "BUILD_IMAGES_ARCHIVE",
+			newValue:    "true",
+			flagFn: func() cli.Flag {
+				return archiveImagesFlag(true, "ARCHIVE_IMAGES", "BUILD_IMAGES_ARCHIVE")
+			},
+			flagName: archiveImagesFlagName,
+			want:     false,
+		},
+		{
+			name:        "UPDATE_HELM_INDEX wins over BUILD_HELM_INDEX",
+			legacyKey:   "UPDATE_HELM_INDEX",
+			legacyValue: "false",
+			newKey:      "BUILD_HELM_INDEX",
+			newValue:    "true",
+			flagFn: func() cli.Flag {
+				return helmIndexFlag("UPDATE_HELM_INDEX", "BUILD_HELM_INDEX")
+			},
+			flagName: helmIndexFlagName,
+			want:     false,
+		},
+		{
+			name:        "PUBLISH_GIT_TAG wins over PUBLISH_GIT_REF",
+			legacyKey:   "PUBLISH_GIT_TAG",
+			legacyValue: "false",
+			newKey:      "PUBLISH_GIT_REF",
+			newValue:    "true",
+			flagFn: func() cli.Flag {
+				return &cli.BoolWithInverseFlag{
+					Name:    "git-ref",
+					Sources: cli.EnvVars("PUBLISH_GIT_TAG", "PUBLISH_GIT_REF"),
+					Value:   true,
+				}
+			},
+			flagName: "git-ref",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.legacyKey, tc.legacyValue)
+			t.Setenv(tc.newKey, tc.newValue)
+			var got bool
+			cmd := &cli.Command{
+				Name:  "test",
+				Flags: []cli.Flag{tc.flagFn()},
+				Action: func(_ context.Context, c *cli.Command) error {
+					got = c.Bool(tc.flagName)
+					return nil
+				},
+			}
+			if err := cmd.Run(context.Background(), []string{"test"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("env precedence broken: %s=%s vs %s=%s, got %v want %v", tc.legacyKey, tc.legacyValue, tc.newKey, tc.newValue, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestInverseFlagName(t *testing.T) {
@@ -180,7 +265,7 @@ func TestInverseFlagName(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"validate", "no-validate"},
+		{"validation", "no-validation"},
 		{"helm-index", "no-helm-index"},
 		{"", "no-"},
 	}

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -162,20 +162,58 @@ func TestImagesArchiveImagesFlagAction(t *testing.T) {
 	})
 }
 
-func TestManifestsOCPBundleFlagAction(t *testing.T) {
+// Non-hashrelease builds tolerate --no-manifests --ocp-bundle (uses checked-in
+// manifests). Hashrelease enforcement lives in validateHashreleaseBuildFlags.
+func TestManifestsOCPBundleNoFlagAction(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"defaults pass", nil},
+		{"--no-manifests alone passes (no flag-level Action)", []string{"--no-manifests"}},
+		{"--no-manifests --no-ocp-bundle passes", []string{"--no-manifests", "--no-ocp-bundle"}},
+		{"--no-ocp-bundle alone passes", []string{"--no-ocp-bundle"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRun(t, []cli.Flag{manifestsFlag, ocpBundleFlag}, tc.args, "")
+		})
+	}
+}
+
+func TestValidateHashreleaseBuildFlagsOCPManifests(t *testing.T) {
 	cases := []struct {
 		name    string
 		args    []string
 		wantErr string
 	}{
 		{"defaults pass", nil, ""},
-		{"--no-manifests alone errors (default ocp-bundle=true)", []string{"--no-manifests"}, "--no-ocp-bundle must be set"},
+		{"--no-manifests alone errors (ocp-bundle still default true)", []string{"--no-manifests"}, "--ocp-bundle requires --manifests"},
 		{"--no-manifests --no-ocp-bundle passes", []string{"--no-manifests", "--no-ocp-bundle"}, ""},
-		{"--no-ocp-bundle alone passes (dependent disabled)", []string{"--no-ocp-bundle"}, ""},
+		{"--no-ocp-bundle alone passes", []string{"--no-ocp-bundle"}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assertRun(t, []cli.Flag{manifestsFlag, ocpBundleFlag}, tc.args, tc.wantErr)
+			cmd := &cli.Command{
+				Name:  "test",
+				Flags: hashreleaseBuildFlags(),
+				Action: func(_ context.Context, c *cli.Command) error {
+					return validateHashreleaseBuildFlags(c)
+				},
+			}
+			err := cmd.Run(context.Background(), append([]string{"test"}, tc.args...))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
 		})
 	}
 }

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cli "github.com/urfave/cli/v3"
+)
+
+// runFlags builds a *cli.Command with the given flags and runs it with args.
+// The Action is a no-op so any error returned comes from a flag-level Action
+// (cross-flag invariants enforced via flag.Action callbacks).
+func runFlags(t *testing.T, flags []cli.Flag, args ...string) error {
+	t.Helper()
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: flags,
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return nil
+		},
+	}
+	return cmd.Run(context.Background(), append([]string{"test"}, args...))
+}
+
+func TestValidateFlagAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string // substring match; empty means no error
+	}{
+		{"defaults pass", nil, ""},
+		{"--no-validate alone errors (default validate-branch=true)", []string{"--no-validate"}, "--no-validate-branch must be set"},
+		{"--no-validate --no-validate-branch but image-scan default true errors", []string{"--no-validate", "--no-validate-branch"}, "--no-image-scan must be set"},
+		{"all three negated passes", []string{"--no-validate", "--no-validate-branch", "--no-image-scan"}, ""},
+		{"--no-validate-branch alone passes (dependent disabled, prerequisite still on)", []string{"--no-validate-branch"}, ""},
+		{"--no-image-scan alone passes", []string{"--no-image-scan"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runFlags(t, []cli.Flag{validateFlag, validateBranchFlag, imageScanFlag}, tc.args...)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestHelmChartsFlagAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"defaults pass", nil, ""},
+		{"--no-helm-charts alone errors (default helm-index=true)", []string{"--no-helm-charts"}, "--no-helm-index must be set"},
+		{"--no-helm-charts --no-helm-index passes", []string{"--no-helm-charts", "--no-helm-index"}, ""},
+		{"--no-helm-index alone passes (dependent disabled)", []string{"--no-helm-index"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := []cli.Flag{
+				helmChartsFlag(true, "TEST_BUILD_CHARTS"),
+				helmIndexFlag("TEST_BUILD_HELM_INDEX"),
+			}
+			err := runFlags(t, flags, tc.args...)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestImagesArchiveImagesFlagAction(t *testing.T) {
+	// Default-true (release-style) defaults: images=true, archive=true.
+	t.Run("release defaults", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			args    []string
+			wantErr string
+		}{
+			{"defaults pass", nil, ""},
+			{"--no-images alone errors (default archive=true)", []string{"--no-images"}, "cannot archive images without building them"},
+			{"--no-images --no-archive-images passes", []string{"--no-images", "--no-archive-images"}, ""},
+			{"--no-archive-images alone passes (warning only)", []string{"--no-archive-images"}, ""},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				flags := []cli.Flag{
+					imagesFlag(true, "TEST_BUILD_IMAGES_R"),
+					archiveImagesFlag(true, "TEST_BUILD_ARCHIVE_IMAGES_R"),
+				}
+				err := runFlags(t, flags, tc.args...)
+				if tc.wantErr == "" {
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+			})
+		}
+	})
+
+	// Default-false (hashrelease-style) defaults: images=false, archive=false.
+	t.Run("hashrelease defaults", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			args    []string
+			wantErr string
+		}{
+			{"defaults pass", nil, ""},
+			{"--archive-images alone errors (default images=false)", []string{"--archive-images"}, "cannot archive images without building them"},
+			{"--images --archive-images passes", []string{"--images", "--archive-images"}, ""},
+			{"--images alone passes (warning only)", []string{"--images"}, ""},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				flags := []cli.Flag{
+					imagesFlag(false, "TEST_BUILD_IMAGES_H"),
+					archiveImagesFlag(false, "TEST_BUILD_ARCHIVE_IMAGES_H"),
+				}
+				err := runFlags(t, flags, tc.args...)
+				if tc.wantErr == "" {
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+			})
+		}
+	})
+}
+
+func TestInverseFlagName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"validate", "no-validate"},
+		{"helm-index", "no-helm-index"},
+		{"", "no-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := inverseFlagName(tc.in)
+			if got != tc.want {
+				t.Errorf("inverseFlagName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -146,29 +146,30 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				opts := []calico.Option{
+					calico.IsHashRelease(),
+					calico.WithHashrelease(*hashrel, *serverCfg),
+					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithVersion(data.ProductVersion()),
 					calico.WithOperator(c.String(operatorRegistryFlag.Name), c.String(operatorImageFlag.Name), data.OperatorVersion()),
 					calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
-					calico.WithRepoRoot(cfg.RepoRootDir),
-					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
-					calico.IsHashRelease(),
-					calico.WithHashrelease(*hashrel, *serverCfg),
 					calico.WithOutputDir(hashrel.Source),
 					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithImages(c.Bool(imagesFlagName)),
-					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
+					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithManifests(c.Bool(manifestsFlag.Name)),
 					calico.WithBinaries(c.Bool(binariesFlag.Name)),
 					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
+					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
 					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
+					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 				}
 				if len(productRegistriesFromFlag) > 0 {
 					opts = append(opts, calico.WithImageRegistries(productRegistriesFromFlag))
@@ -250,21 +251,21 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				opts := []calico.Option{
-					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.IsHashRelease(),
+					calico.WithHashrelease(*hashrel, *serverCfg),
+					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithVersion(hashrel.ProductVersion),
 					calico.WithOperatorVersion(hashrel.Operator.Version),
+					calico.WithOutputDir(hashrel.Source),
+					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithOutputDir(hashrel.Source),
-					calico.WithHashrelease(*hashrel, *serverCfg),
 					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
+					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts,
@@ -365,7 +366,7 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 
 // hashreleasePublishFlags returns the flags for the hashrelease publish command.
 func hashreleasePublishFlags() []cli.Flag {
-	f := append(gitFlags, publishStepFlags(true)...)
+	f := append(productFlags, publishStepFlags(true)...)
 	f = append(f,
 		registryFlag,
 		helmRegistryFlag,

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -120,8 +120,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithImage(pinned.OperatorCfg.Image),
 					operator.WithRegistry(pinned.OperatorCfg.Registry),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
-					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					operator.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
+					operator.WithValidate(c.Bool(validateFlag.Name)),
+					operator.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
 					operator.WithVersion(data.OperatorVersion()),
 					operator.WithCalicoDirectory(cfg.RepoRootDir),
 					operator.WithCalicoVersion(data.ProductVersion()),
@@ -132,7 +132,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if len(productRegistriesFromFlag) > 0 {
 					operatorOpts = append(operatorOpts, operator.WithProductRegistry(productRegistriesFromFlag[0]))
 				}
-				if c.Bool(operatorFlag.Name) {
+				if c.Bool(operatorFlagName) {
 					o := operator.NewManager(operatorOpts...)
 					if err := o.Build(); err != nil {
 						return err
@@ -167,9 +167,10 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
-					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
+					calico.WithE2EBinaries(c.Bool(e2eBinariesFlag.Name)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
+					calico.WithValidate(c.Bool(validateFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
 				}
 				if len(productRegistriesFromFlag) > 0 {
 					opts = append(opts, calico.WithImageRegistries(productRegistriesFromFlag))
@@ -181,19 +182,21 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 				// For real releases, release notes are generated prior to building the release.
 				// For hash releases, generate a set of release notes and add them to the hashrelease directory.
-				releaseVersion, err := version.DetermineReleaseVersion(version.New(data.ProductVersion()), c.String(devTagSuffixFlag.Name))
-				if err != nil {
-					return fmt.Errorf("failed to determine release version: %v", err)
-				}
-				if c.String(orgFlag.Name) == utils.TigeraOrg {
-					logrus.Warn("Release notes are not supported for Tigera releases, skipping...")
+				if !c.Bool(releaseNotesFlag.Name) {
+					logrus.Info("Skipping release notes generation")
+				} else if c.String(orgFlag.Name) != utils.ProjectCalicoOrg && c.String(repoFlag.Name) != utils.CalicoRepoName {
+					logrus.Warn("Release notes are not supported for non-Calico releases, skipping...")
 				} else {
+					releaseVersion, err := version.DetermineReleaseVersion(version.New(data.ProductVersion()), c.String(devTagSuffixFlag.Name))
+					if err != nil {
+						return fmt.Errorf("failed to determine release version: %v", err)
+					}
 					if _, err := outputs.ReleaseNotes(utils.ProjectCalicoOrg, c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(hashrel.Source, outputs.ReleaseNotesDir), releaseVersion); err != nil {
 						return err
 					}
 				}
 
-				// Adjsut the formatting of the generated outputs to match the legacy hashrelease format.
+				// Adjust the formatting of the generated outputs to match the legacy hashrelease format.
 				return tasks.ReformatHashrelease(hashrel.Source, cfg.TmpDir)
 			},
 		},
@@ -242,9 +245,9 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithVersion(hashrel.Operator.Version),
 					operator.WithCalicoVersion(hashrel.ProductVersion),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
-					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					operator.WithValidate(c.Bool(validateFlag.Name)),
 				)
-				if c.Bool(operatorFlag.Name) {
+				if c.Bool(operatorFlagName) {
 					if err := o.Publish(); err != nil {
 						return err
 					}
@@ -264,7 +267,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					calico.WithValidate(c.Bool(validateFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts,
@@ -272,7 +275,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 						calico.WithImageScanning(false, imagescanner.Config{}), // Disable image scanning if using custom registries.
 					)
 				} else {
-					opts = append(opts, calico.WithImageScanning(!c.Bool(skipImageScanFlag.Name), *imageScanningAPIConfig(c)))
+					opts = append(opts, calico.WithImageScanning(c.Bool(imageScanFlag.Name), *imageScanningAPIConfig(c)))
 				}
 				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir)
 				if err != nil {
@@ -287,7 +290,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					return err
 				}
 
-				if !c.Bool(skipImageScanFlag.Name) {
+				if c.Bool(imageScanFlag.Name) {
 					url, err := imagescanner.RetrieveResultURL(cfg.TmpDir)
 					// Only log error as a warning if the image scan result URL could not be retrieved
 					// as it is not an error that should stop the hashrelease process.
@@ -317,10 +320,10 @@ func hashreleaseBuildFlags() []cli.Flag {
 	f = append(f,
 		registryFlag,
 		archFlag)
-	f = append(f, operatorBuildFlags...)
+	f = append(f, operatorBuildCommandFlags...)
 	f = append(f,
-		skipBranchCheckFlag,
-		skipValidationFlag,
+		validateBranchFlag,
+		validateFlag,
 		githubTokenFlag)
 	return f
 }
@@ -330,13 +333,6 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 	// If using a custom registry for product, ensure operator is also using a custom registry.
 	if len(c.StringSlice(registryFlag.Name)) > 0 && c.String(operatorRegistryFlag.Name) == "" {
 		return fmt.Errorf("%s must be set if %s is set", operatorRegistryFlag, registryFlag)
-	}
-
-	if c.Bool(archiveImagesFlagName) && !c.Bool(imagesFlagName) {
-		return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", imagesFlagName)
-	}
-	if !c.Bool(archiveImagesFlagName) && c.Bool(imagesFlagName) {
-		logrus.Warnf("Images are built but not archived; to archive images set --%s to 'true'", archiveImagesFlagName)
 	}
 
 	// CI conditional checks.
@@ -372,8 +368,9 @@ func hashreleasePublishFlags() []cli.Flag {
 		archFlag,
 		publishHashreleaseFlag,
 		latestFlag,
-		operatorFlag,
-		skipValidationFlag)
+		validateFlag,
+	)
+	f = append(f, operatorPublishCommandFlags...)
 	f = append(f, imageScanFlags...)
 	return f
 }
@@ -397,11 +394,6 @@ func validateHashreleasePublishFlags(c *cli.Command) error {
 				return fmt.Errorf("cannot set hashrelease as latest when building locally, use --%s=false instead", latestFlag.Name)
 			}
 		}
-	}
-
-	// If skipValidationFlag is set, then skipImageScanFlag must also be set.
-	if c.Bool(skipValidationFlag.Name) && !c.Bool(skipImageScanFlag.Name) {
-		return fmt.Errorf("%s must be set if %s is set", skipImageScanFlag, skipValidationFlag)
 	}
 	return nil
 }

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -336,6 +336,12 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		return fmt.Errorf("%s must be set if %s is set", operatorRegistryFlag, registryFlag)
 	}
 
+	// Hashrelease regenerates manifests before building the OCP bundle.
+	if c.Bool(ocpBundleFlagName) && !c.Bool(manifestsFlagName) {
+		return fmt.Errorf("--%s requires --%s on hashrelease builds; either drop --%s or also set --%s",
+			ocpBundleFlagName, manifestsFlagName, inverseFlagName(manifestsFlagName), inverseFlagName(ocpBundleFlagName))
+	}
+
 	// CI conditional checks.
 	if c.Bool(ciFlag.Name) {
 		if !hashreleaseServerConfig(c).Valid() {

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -263,7 +263,6 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
-					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
 					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 				}

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -120,8 +120,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithImage(pinned.OperatorCfg.Image),
 					operator.WithRegistry(pinned.OperatorCfg.Registry),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
-					operator.WithValidate(c.Bool(validateFlag.Name)),
-					operator.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
+					operator.WithValidate(c.Bool(validationFlag.Name)),
+					operator.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 					operator.WithVersion(data.OperatorVersion()),
 					operator.WithCalicoDirectory(cfg.RepoRootDir),
 					operator.WithCalicoVersion(data.ProductVersion()),
@@ -169,8 +169,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
 					calico.WithE2EBinaries(c.Bool(e2eBinariesFlag.Name)),
 					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
-					calico.WithValidate(c.Bool(validateFlag.Name)),
-					calico.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if len(productRegistriesFromFlag) > 0 {
 					opts = append(opts, calico.WithImageRegistries(productRegistriesFromFlag))
@@ -184,7 +184,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				// For hash releases, generate a set of release notes and add them to the hashrelease directory.
 				if !c.Bool(releaseNotesFlag.Name) {
 					logrus.Info("Skipping release notes generation")
-				} else if c.String(orgFlag.Name) != utils.ProjectCalicoOrg && c.String(repoFlag.Name) != utils.CalicoRepoName {
+				} else if c.String(orgFlag.Name) != utils.ProjectCalicoOrg || c.String(repoFlag.Name) != utils.CalicoRepoName {
 					logrus.Warn("Release notes are not supported for non-Calico releases, skipping...")
 				} else {
 					releaseVersion, err := version.DetermineReleaseVersion(version.New(data.ProductVersion()), c.String(devTagSuffixFlag.Name))
@@ -245,7 +245,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithVersion(hashrel.Operator.Version),
 					operator.WithCalicoVersion(hashrel.ProductVersion),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
-					operator.WithValidate(c.Bool(validateFlag.Name)),
+					operator.WithValidate(c.Bool(validationFlag.Name)),
 				)
 				if c.Bool(operatorFlagName) {
 					if err := o.Publish(); err != nil {
@@ -267,7 +267,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
-					calico.WithValidate(c.Bool(validateFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts,
@@ -322,8 +323,8 @@ func hashreleaseBuildFlags() []cli.Flag {
 		archFlag)
 	f = append(f, operatorBuildCommandFlags...)
 	f = append(f,
-		validateBranchFlag,
-		validateFlag,
+		branchCheckFlag,
+		validationFlag,
 		githubTokenFlag)
 	return f
 }
@@ -368,7 +369,8 @@ func hashreleasePublishFlags() []cli.Flag {
 		archFlag,
 		publishHashreleaseFlag,
 		latestFlag,
-		validateFlag,
+		branchCheckFlag,
+		validationFlag,
 	)
 	f = append(f, operatorPublishCommandFlags...)
 	f = append(f, imageScanFlags...)

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -132,7 +132,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if len(productRegistriesFromFlag) > 0 {
 					operatorOpts = append(operatorOpts, operator.WithProductRegistry(productRegistriesFromFlag[0]))
 				}
-				if !c.Bool(skipOperatorFlag.Name) {
+				if c.Bool(operatorFlag.Name) {
 					o := operator.NewManager(operatorOpts...)
 					if err := o.Build(); err != nil {
 						return err
@@ -155,14 +155,20 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithHashrelease(*hashrel, *serverCfg),
 					calico.WithOutputDir(hashrel.Source),
 					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithBuildImages(c.Bool(buildHashreleaseImagesFlag.Name)),
-					calico.WithArchiveImages(c.Bool(archiveHashreleaseImagesFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
 					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithManifests(c.Bool(manifestsFlag.Name)),
+					calico.WithBinaries(c.Bool(binariesFlag.Name)),
+					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
+					calico.WithTarball(c.Bool(tarballFlag.Name)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
 				}
 				if len(productRegistriesFromFlag) > 0 {
 					opts = append(opts, calico.WithImageRegistries(productRegistriesFromFlag))
@@ -237,7 +243,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
 					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
 				)
-				if !c.Bool(skipOperatorFlag.Name) {
+				if c.Bool(operatorFlag.Name) {
 					if err := o.Publish(); err != nil {
 						return err
 					}
@@ -255,8 +261,9 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithOutputDir(hashrel.Source),
 					calico.WithHashrelease(*hashrel, *serverCfg),
-					calico.WithPublishImages(c.Bool(publishHashreleaseImagesFlag.Name)),
-					calico.WithPublishCharts(c.Bool(publishChartsFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
@@ -306,14 +313,12 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 // hashreleaseBuildFlags returns the flags for the hashrelease build command.
 func hashreleaseBuildFlags() []cli.Flag {
-	f := append(productFlags,
+	f := append(productFlags, buildStepFlags(true)...)
+	f = append(f,
 		registryFlag,
-		buildHashreleaseImagesFlag,
-		archiveHashreleaseImagesFlag,
 		archFlag)
 	f = append(f, operatorBuildFlags...)
 	f = append(f,
-		skipOperatorFlag,
 		skipBranchCheckFlag,
 		skipValidationFlag,
 		githubTokenFlag)
@@ -327,11 +332,11 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		return fmt.Errorf("%s must be set if %s is set", operatorRegistryFlag, registryFlag)
 	}
 
-	if c.Bool(archiveHashreleaseImagesFlag.Name) && !c.Bool(buildHashreleaseImagesFlag.Name) {
-		return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildHashreleaseImagesFlag.Name)
+	if c.Bool(archiveImagesFlagName) && !c.Bool(imagesFlagName) {
+		return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", imagesFlagName)
 	}
-	if !c.Bool(archiveHashreleaseImagesFlag.Name) && c.Bool(buildHashreleaseImagesFlag.Name) {
-		logrus.Warnf("Images are built but not archived; to archive images set --%s to 'true'", archiveHashreleaseImagesFlag.Name)
+	if !c.Bool(archiveImagesFlagName) && c.Bool(imagesFlagName) {
+		logrus.Warnf("Images are built but not archived; to archive images set --%s to 'true'", archiveImagesFlagName)
 	}
 
 	// CI conditional checks.
@@ -345,7 +350,7 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		}
 	} else {
 		// If building images, log a warning if no registry is specified.
-		if c.Bool(buildHashreleaseImagesFlag.Name) && len(c.StringSlice(registryFlag.Name)) == 0 {
+		if c.Bool(imagesFlagName) && len(c.StringSlice(registryFlag.Name)) == 0 {
 			logrus.Warn("Building images without specifying a registry will result in images being built with the default registries")
 		}
 
@@ -360,18 +365,16 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 
 // hashreleasePublishFlags returns the flags for the hashrelease publish command.
 func hashreleasePublishFlags() []cli.Flag {
-	f := append(gitFlags,
+	f := append(gitFlags, publishStepFlags(true)...)
+	f = append(f,
 		registryFlag,
 		helmRegistryFlag,
-		publishHashreleaseImagesFlag,
-		publishChartsFlag,
 		archFlag,
 		publishHashreleaseFlag,
 		latestFlag,
-		skipOperatorFlag,
-		skipValidationFlag,
-		skipImageScanFlag)
-	f = append(f, imageScannerAPIFlags...)
+		operatorFlag,
+		skipValidationFlag)
+	f = append(f, imageScanFlags...)
 	return f
 }
 
@@ -429,7 +432,7 @@ func validateCIBuildRequirements(c *cli.Command, repoRootDir string) error {
 	if !c.Bool(ciFlag.Name) {
 		return nil
 	}
-	if c.Bool(buildHashreleaseImagesFlag.Name) {
+	if c.Bool(imagesFlagName) {
 		logrus.Info("Building images in hashrelease, skipping images promotions check...")
 		return nil
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -206,7 +206,7 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 				calico.WithOperatorVersion(operatorVer.FormattedString()),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
-				calico.WithRepoRemote(repoRemoteFlag.Name),
+				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 			}
 			m := calico.NewManager(opts...)
 			if err := m.ReleasePublic(); err != nil {

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -111,8 +111,15 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-					calico.WithBuildImages(c.Bool(buildImagesFlag.Name)),
-					calico.WithArchiveImages(c.Bool(archiveImagesFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithManifests(c.Bool(manifestsFlag.Name)),
+					calico.WithBinaries(c.Bool(binariesFlag.Name)),
+					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
+					calico.WithTarball(c.Bool(tarballFlag.Name)),
+					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
 				}
 				if c.Bool(skipValidationFlag.Name) {
 					opts = append(opts, calico.WithValidate(false))
@@ -147,11 +154,12 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-					calico.WithPublishImages(c.Bool(publishImagesFlag.Name)),
-					calico.WithPublishGitRef(c.Bool(publishGitTagFlag.Name)),
-					calico.WithPublishGithubRelease(c.Bool(publishGitHubReleaseFlag.Name)),
 					calico.WithGithubToken(c.String(githubTokenFlag.Name)),
-					calico.WithPublishCharts(c.Bool(publishChartsFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
+					calico.WithGitRef(c.Bool(gitRefFlag.Name)),
+					calico.WithGithubRelease(c.Bool(githubReleaseFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -283,7 +291,7 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithTmpDir(cfg.TmpDir),
 				calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
 				calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
-				calico.WithPublishGitRef(!c.Bool(localFlag.Name)),
+				calico.WithGitRef(!c.Bool(localFlag.Name)),
 			}
 			r := calico.NewManager(opts...)
 			branch, err := r.PrepareRelease()
@@ -298,11 +306,10 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 
 // releaseBuildFlags returns the flags for release build command.
 func releaseBuildFlags() []cli.Flag {
-	f := append(productFlags,
+	f := append(productFlags, buildStepFlags(false)...)
+	f = append(f,
 		archFlag,
 		registryFlag,
-		buildImagesFlag,
-		archiveImagesFlag,
 		githubTokenFlag,
 		skipValidationFlag)
 	return f
@@ -310,14 +317,11 @@ func releaseBuildFlags() []cli.Flag {
 
 // releasePublishFlags returns the flags for release publish command.
 func releasePublishFlags() []cli.Flag {
-	f := append(productFlags,
+	f := append(productFlags, publishStepFlags(false)...)
+	f = append(f,
 		registryFlag,
 		helmRegistryFlag,
-		publishImagesFlag,
-		publishGitTagFlag,
-		publishGitHubReleaseFlag,
 		githubTokenFlag,
-		publishChartsFlag,
 		awsProfileFlag,
 		s3BucketFlag,
 		skipValidationFlag)

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -102,7 +102,6 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 				// Configure the builder.
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
-					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithVersion(ver.FormattedString()),
 					calico.WithOperatorVersion(operatorVer.FormattedString()),
@@ -121,8 +120,8 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
 					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
-					calico.WithValidate(c.Bool(validateFlag.Name)),
-					calico.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -159,6 +158,8 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
 					calico.WithGitRef(c.Bool(gitRefFlag.Name)),
 					calico.WithGithubRelease(c.Bool(githubReleaseFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -254,8 +255,8 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			operatorRepoFlag,
 			operatorBranchFlag,
 			githubTokenFlag,
-			validateBranchFlag,
-			validateFlag,
+			branchCheckFlag,
+			validationFlag,
 			localFlag,
 		},
 		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
@@ -288,8 +289,8 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 				calico.WithTmpDir(cfg.TmpDir),
-				calico.WithValidate(c.Bool(validateFlag.Name)),
-				calico.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
+				calico.WithValidation(c.Bool(validationFlag.Name)),
+				calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				calico.WithGitRef(!c.Bool(localFlag.Name)),
 			}
 			r := calico.NewManager(opts...)
@@ -310,8 +311,8 @@ func releaseBuildFlags() []cli.Flag {
 		archFlag,
 		registryFlag,
 		githubTokenFlag,
-		validateBranchFlag,
-		validateFlag)
+		branchCheckFlag,
+		validationFlag)
 	return f
 }
 
@@ -323,7 +324,9 @@ func releasePublishFlags() []cli.Flag {
 		helmRegistryFlag,
 		githubTokenFlag,
 		awsProfileFlag,
-		s3BucketFlag)
+		s3BucketFlag,
+		branchCheckFlag,
+		validationFlag)
 	return f
 }
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -102,16 +102,17 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 				// Configure the builder.
 				opts := []calico.Option{
 					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithVersion(ver.FormattedString()),
 					calico.WithOperatorVersion(operatorVer.FormattedString()),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
 					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithManifests(c.Bool(manifestsFlag.Name)),
@@ -120,10 +121,8 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
 					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
-				}
-				if c.Bool(skipValidationFlag.Name) {
-					opts = append(opts, calico.WithValidate(false))
-					opts = append(opts, calico.WithReleaseBranchValidation(false))
+					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -311,6 +310,7 @@ func releaseBuildFlags() []cli.Flag {
 		archFlag,
 		registryFlag,
 		githubTokenFlag,
+		skipBranchCheckFlag,
 		skipValidationFlag)
 	return f
 }
@@ -323,8 +323,7 @@ func releasePublishFlags() []cli.Flag {
 		helmRegistryFlag,
 		githubTokenFlag,
 		awsProfileFlag,
-		s3BucketFlag,
-		skipValidationFlag)
+		s3BucketFlag)
 	return f
 }
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -120,9 +120,9 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
 					calico.WithTarball(c.Bool(tarballFlag.Name)),
 					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
-					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
+					calico.WithValidate(c.Bool(validateFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -156,7 +156,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithGithubToken(c.String(githubTokenFlag.Name)),
 					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
-					calico.WithHelmIndex(c.Bool(helmIndexFlag.Name)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
 					calico.WithGitRef(c.Bool(gitRefFlag.Name)),
 					calico.WithGithubRelease(c.Bool(githubReleaseFlag.Name)),
 				}
@@ -254,8 +254,8 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			operatorRepoFlag,
 			operatorBranchFlag,
 			githubTokenFlag,
-			skipBranchCheckFlag,
-			skipValidationFlag,
+			validateBranchFlag,
+			validateFlag,
 			localFlag,
 		},
 		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
@@ -288,8 +288,8 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 				calico.WithTmpDir(cfg.TmpDir),
-				calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-				calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
+				calico.WithValidate(c.Bool(validateFlag.Name)),
+				calico.WithReleaseBranchValidation(c.Bool(validateBranchFlag.Name)),
 				calico.WithGitRef(!c.Bool(localFlag.Name)),
 			}
 			r := calico.NewManager(opts...)
@@ -310,8 +310,8 @@ func releaseBuildFlags() []cli.Flag {
 		archFlag,
 		registryFlag,
 		githubTokenFlag,
-		skipBranchCheckFlag,
-		skipValidationFlag)
+		validateBranchFlag,
+		validateFlag)
 	return f
 }
 

--- a/release/pkg/manager/branch/options.go
+++ b/release/pkg/manager/branch/options.go
@@ -51,7 +51,7 @@ func WithReleaseBranchPrefix(prefix string) Option {
 	}
 }
 
-func WithValidate(validate bool) Option {
+func WithValidation(validate bool) Option {
 	return func(b *BranchManager) error {
 		b.validate = validate
 		return nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -235,7 +235,7 @@ func (r *CalicoManager) PreBuildValidation() error {
 	if (r.images || r.archiveImages) && len(r.imageRegistries) == 0 {
 		errStack = errors.Join(errStack, fmt.Errorf("no image registries specified"))
 	}
-	if r.ocpBundle && !r.manifests {
+	if r.isHashRelease && r.ocpBundle && !r.manifests {
 		errStack = errors.Join(errStack, fmt.Errorf("cannot build OCP bundle without manifests; set --manifests to 'true'"))
 	}
 	if errStack != nil {
@@ -1063,6 +1063,10 @@ func (r *CalicoManager) uploadDir() string {
 // TODO: We should produce a tar per architecture that we ship.
 // TODO: We should produce windows tars
 func (r *CalicoManager) buildReleaseTar() error {
+	if !r.tarball {
+		logrus.Info("Skipping building release tarball")
+		return nil
+	}
 	baseReleaseOutputDir := filepath.Dir(r.uploadDir())
 	releaseBase := filepath.Join(baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion))
 	releaseTarFilePath := filepath.Join(r.uploadDir(), fmt.Sprintf("release-%s.tgz", r.calicoVersion))
@@ -1379,7 +1383,7 @@ func (r *CalicoManager) publishHelmChart(chart, registry string) error {
 }
 
 func (r *CalicoManager) updateHelmChartIndex() error {
-	if !r.helmCharts {
+	if !r.helmIndex {
 		logrus.Info("Skipping updating helm index")
 		return nil
 	}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -298,35 +298,37 @@ func (r *CalicoManager) Build() error {
 	}
 
 	if r.isHashRelease {
-		// This is a hashrelease.
-		//
-		// Re-generate manifests using the desired versions. This needs to happen
-		// before building the OCP bundle, since the OCP bundle uses the manifests.
-		if err = r.generateManifests(); err != nil {
+		// Regenerate manifests and build the manifest-derived OCP bundle. The defer resets
+		// manifests after downstream consumers (e.g. collectManifests, buildReleaseTar) have
+		// seen the regenerated, pinned manifests.
+		defer r.resetManifests()
+		if err = r.buildManifests(); err != nil {
 			return err
 		}
-		defer r.resetManifests()
 
 		// Real releases call "make release-build", but hashreleases don't.
 		// Instead, we build some of the targets directly. In the future, we should instead align the release
 		// and hashrelease build processes to avoid these separate code paths.
-		env := append(os.Environ(), fmt.Sprintf("VERSION=%s", ver))
-		targets := []string{"release-windows-archive", "dist/install-calico-windows.ps1"}
-		for _, target := range targets {
-			if err = r.makeInDirectoryIgnoreOutput(filepath.Join(r.repoRoot, "node"), target, env...); err != nil {
-				return fmt.Errorf("error building target %s: %s", target, err)
+		if r.windowsArchive {
+			env := append(os.Environ(), fmt.Sprintf("VERSION=%s", ver))
+			targets := []string{"release-windows-archive", "dist/install-calico-windows.ps1"}
+			for _, target := range targets {
+				if err = r.makeInDirectoryIgnoreOutput(filepath.Join(r.repoRoot, "node"), target, env...); err != nil {
+					return fmt.Errorf("error building target %s: %s", target, err)
+				}
 			}
+		} else {
+			logrus.Info("Skipping building windows archive")
 		}
 
 		// Build multi-arch e2e test binaries and copy them into the output directory.
 		if err = r.buildE2EBinaries(); err != nil {
 			return err
 		}
-	}
-
-	// Build an OCP tgz bundle from manifests, used in the docs.
-	if err = r.buildOCPBundle(); err != nil {
-		return err
+	} else {
+		if err = r.buildOCPBundle(); err != nil {
+			return err
+		}
 	}
 
 	// Build and add in the complete release tarball.
@@ -542,6 +544,10 @@ func (r *CalicoManager) resetCharts() {
 }
 
 func (r *CalicoManager) BuildHelm() error {
+	if !r.helmCharts {
+		logrus.Info("Skipping building helm chart and index")
+		return nil
+	}
 	if r.isHashRelease {
 		if err := r.modifyHelmChartsValues(); err != nil {
 			return fmt.Errorf("failed to modify helm chart values: %s", err)
@@ -557,8 +563,10 @@ func (r *CalicoManager) BuildHelm() error {
 	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "chart", env...); err != nil {
 		return fmt.Errorf("failed to build helm chart: %w", err)
 	}
-
-	// Create helm index for the chart.
+	if !r.helmIndex {
+		logrus.Info("Skipping building helm index")
+		return nil
+	}
 	chartURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s", r.githubOrg, r.repo, r.calicoVersion)
 	if r.isHashRelease {
 		chartURL = r.hashrelease.URL()
@@ -634,7 +642,10 @@ func (r *CalicoManager) buildHelmIndex(chartDir, chartURL string) error {
 }
 
 func (r *CalicoManager) buildOCPBundle() error {
-	// Build OpenShift bundle.
+	if !r.ocpBundle {
+		logrus.Info("Skipping building OCP bundle")
+		return nil
+	}
 	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "bin/ocp.tgz"); err != nil {
 		return fmt.Errorf("failed to build OCP bundle: %w", err)
 	}
@@ -1028,8 +1039,16 @@ func (r *CalicoManager) collectOCPBundle() error {
 	return nil
 }
 
-// generateManifests re-generates manifests using the specified calico and operator versions.
-func (r *CalicoManager) generateManifests() error {
+// buildManifests regenerates manifests for pinned calico/operator versions and
+// builds the manifest-derived OCP bundle. Intended for the hashrelease path;
+// regular releases build the OCP bundle directly from the checked-in manifests
+// via buildOCPBundle. The caller must defer resetManifests so downstream
+// consumers (collectManifests, buildReleaseTar) still see the pinned manifests.
+func (r *CalicoManager) buildManifests() error {
+	if !r.manifests {
+		logrus.Info("Skipping regenerating manifests")
+		return nil
+	}
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("PRODUCT_VERSION=%s", r.calicoVersion))
 	env = append(env, fmt.Sprintf("OPERATOR_VERSION=%s", r.operatorVersion))
@@ -1042,10 +1061,13 @@ func (r *CalicoManager) generateManifests() error {
 		logrus.WithError(err).Error("Failed to make manifests")
 		return fmt.Errorf("failed to generate manifests: %w", err)
 	}
-	return nil
+	return r.buildOCPBundle()
 }
 
 func (r *CalicoManager) resetManifests() {
+	if !r.manifests {
+		return
+	}
 	if _, err := r.runner.RunInDir(r.repoRoot, "git", []string{"checkout", "manifests", "test-tools/mocknode/mock-node.yaml"}, nil); err != nil {
 		logrus.WithError(err).Error("Failed to reset manifests")
 	}
@@ -1098,28 +1120,32 @@ func (r *CalicoManager) buildReleaseTar() error {
 	}
 
 	// Add in release binaries that we ship.
-	binDir := filepath.Join(releaseBase, "bin")
-	if err := os.MkdirAll(binDir, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create images dir: %s", err)
-	}
+	if r.binaries {
+		binDir := filepath.Join(releaseBase, "bin")
+		if err := os.MkdirAll(binDir, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create images dir: %s", err)
+		}
 
-	binaries := map[string]string{
-		// Calicoctl binaries.
-		"calicoctl/bin/": filepath.Join(binDir, "calicoctl"),
+		binaries := map[string]string{
+			// Calicoctl binaries.
+			"calicoctl/bin/": filepath.Join(binDir, "calicoctl"),
 
-		// Felix binaries.
-		"felix/bin/calico-bpf": binDir,
-	}
-	// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
-	for src, dst := range binaries {
-		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
-			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+			// Felix binaries.
+			"felix/bin/calico-bpf": binDir,
+		}
+		// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
+		for src, dst := range binaries {
+			if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
+				return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+			}
 		}
 	}
 
 	// Add in manifests directory generated from the docs.
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
-		return fmt.Errorf("failed to copy manifests: %w", err)
+	if r.manifests {
+		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
+			return fmt.Errorf("failed to copy manifests: %w", err)
+		}
 	}
 
 	if _, err := r.runner.RunInDir(r.repoRoot, "tar", []string{"-czvf", releaseTarFilePath, "-C", baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion)}, nil); err != nil {
@@ -1166,6 +1192,10 @@ func (r *CalicoManager) buildE2EBinaries() error {
 }
 
 func (r *CalicoManager) buildBinaries() error {
+	if !r.binaries {
+		logrus.Info("Skipping building binaries")
+		return nil
+	}
 	// calicoctl needs to build unconditionally; everything else is produced
 	// as part of its image release-build target.
 	m := map[string]string{"calicoctl": "build-all"}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -77,6 +77,7 @@ func NewManager(opts ...Option) *CalicoManager {
 		windowsArchive:    true,
 		helmCharts:        true,
 		helmIndex:         true,
+		e2eBinaries:       true,
 		gitRef:            true,
 		githubRelease:     true,
 		imageRegistries:   defaultRegistries,
@@ -209,6 +210,7 @@ type CalicoManager struct {
 	tarball        bool
 	helmCharts     bool
 	helmIndex      bool
+	e2eBinaries    bool
 }
 
 func releaseImages(images []string, version, registry, operatorImage, operatorVersion, operatorRegistry string) []string {
@@ -322,8 +324,12 @@ func (r *CalicoManager) Build() error {
 		}
 
 		// Build multi-arch e2e test binaries and copy them into the output directory.
-		if err = r.buildE2EBinaries(); err != nil {
-			return err
+		if r.e2eBinaries {
+			if err = r.buildE2EBinaries(); err != nil {
+				return err
+			}
+		} else {
+			logrus.Info("Skipping building e2e test binaries")
 		}
 	} else {
 		if err = r.buildOCPBundle(); err != nil {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1419,6 +1419,10 @@ func (r *CalicoManager) publishHelmChart(chart, registry string) error {
 }
 
 func (r *CalicoManager) updateHelmChartIndex() error {
+	if !r.helmCharts {
+		logrus.Info("Skipping updating helm index (charts disabled)")
+		return nil
+	}
 	if !r.helmIndex {
 		logrus.Info("Skipping updating helm index")
 		return nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -68,12 +68,17 @@ func NewManager(opts ...Option) *CalicoManager {
 		productCode:       utils.CalicoProductCode,
 		validate:          true,
 		validateBranch:    true,
-		buildImages:       true,
-		publishImages:     true,
-		publishCharts:     true,
+		manifests:         true,
+		images:            true,
 		archiveImages:     true,
-		publishGitRef:     true,
-		publishGithub:     true,
+		binaries:          true,
+		ocpBundle:         true,
+		tarball:           true,
+		windowsArchive:    true,
+		helmCharts:        true,
+		helmIndex:         true,
+		gitRef:            true,
+		githubRelease:     true,
 		imageRegistries:   defaultRegistries,
 		helmRegistries:    registry.DefaultHelmRegistries,
 		helmRepoURL:       utils.CalicoHelmRepoURL,
@@ -127,9 +132,6 @@ type CalicoManager struct {
 	// isHashRelease is a flag to indicate that we should build a hashrelease.
 	isHashRelease bool
 
-	// buildImages controls whether we should build container images, or use ones already built by CI.
-	buildImages bool
-
 	// archiveImages controls whether we should archive container images in release tarball.
 	archiveImages bool
 
@@ -157,13 +159,11 @@ type CalicoManager struct {
 	// tmpDir is the directory to which we should write temporary files.
 	tmpDir string
 
-	// Fine-tuning configuration for publishing.
-	publishImages bool
-	publishCharts bool
-	publishGitRef bool
-	publishGithub bool
+	gitRef        bool
+	githubRelease bool
 	awsProfile    string
 	s3Bucket      string
+	githubToken   string
 
 	// imageRegistries is the list of imageRegistries to which we should publish images.
 	imageRegistries []string
@@ -200,8 +200,15 @@ type CalicoManager struct {
 	imageScanningConfig imagescanner.Config
 	imageComponents     map[string]registry.Component
 
-	// external configuration.
-	githubToken string
+	// Unified step flags.
+	manifests      bool
+	images         bool
+	binaries       bool
+	ocpBundle      bool
+	windowsArchive bool
+	tarball        bool
+	helmCharts     bool
+	helmIndex      bool
 }
 
 func releaseImages(images []string, version, registry, operatorImage, operatorVersion, operatorRegistry string) []string {
@@ -225,8 +232,11 @@ func (r *CalicoManager) PreBuildValidation() error {
 	if r.operatorVersion == "" {
 		errStack = errors.Join(errStack, fmt.Errorf("no operator version specified"))
 	}
-	if (r.buildImages || r.archiveImages) && len(r.imageRegistries) == 0 {
+	if (r.images || r.archiveImages) && len(r.imageRegistries) == 0 {
 		errStack = errors.Join(errStack, fmt.Errorf("no image registries specified"))
+	}
+	if r.ocpBundle && !r.manifests {
+		errStack = errors.Join(errStack, fmt.Errorf("cannot build OCP bundle without manifests; set --manifests to 'true'"))
 	}
 	if errStack != nil {
 		return errStack
@@ -807,7 +817,7 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 		}
 	}
 
-	if r.publishImages {
+	if r.images {
 		return r.assertImageVersions()
 	} else {
 		if err := r.checkHashreleaseImagesPublished(); err != nil {
@@ -871,10 +881,10 @@ func (r *CalicoManager) publishPrereqs() error {
 	if r.calicoVersion == "" {
 		errStack = errors.Join(errStack, fmt.Errorf("no calico version specified"))
 	}
-	if r.publishImages && len(r.imageRegistries) == 0 {
+	if r.images && len(r.imageRegistries) == 0 {
 		errStack = errors.Join(errStack, fmt.Errorf("no image registries specified"))
 	}
-	if r.publishCharts {
+	if r.helmCharts {
 		if len(r.helmRegistries) == 0 {
 			errStack = errors.Join(errStack, fmt.Errorf("no helm chart registries specified"))
 		}
@@ -922,40 +932,23 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 		return fmt.Errorf("failed to build release metadata file: %s", err)
 	}
 
-	// We attach calicoctl binaries directly to the release as well.
-	files, err := os.ReadDir(filepath.Join(r.repoRoot, "calicoctl", "bin"))
-	if err != nil {
-		return fmt.Errorf("failed to read calicoctl binaries: %w", err)
+	if err := r.collectBinaries(); err != nil {
+		return err
 	}
-	for _, b := range files {
-		if _, err := r.runner.Run("cp", []string{filepath.Join(r.repoRoot, "calicoctl", "bin", b.Name()), uploadDir}, nil); err != nil {
-			return fmt.Errorf("failed to copy calicoctl binary %s: %w", b.Name(), err)
-		}
+	if err := r.collectManifests(); err != nil {
+		return err
 	}
-
-	if r.isHashRelease {
-		// Hashrelease include manifests in a different way, instead of just in the release tarball.
-		if _, err := r.runner.Run("cp", []string{"-r", filepath.Join(r.repoRoot, "manifests"), uploadDir}, nil); err != nil {
-			logrus.WithError(err).Error("Failed to copy manifests to output directory")
-			return fmt.Errorf("failed to copy manifests: %w", err)
-		}
+	if err := r.collectWindowsArchive(); err != nil {
+		return err
 	}
-
-	// Add in the already-built windows zip archive, the Windows install script, ocp bundle, and the helm chart.
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{fmt.Sprintf("node/dist/calico-windows-%s.zip", r.calicoVersion), uploadDir}, nil); err != nil {
-		return fmt.Errorf("failed to copy windows zip archive: %w", err)
-	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"node/dist/install-calico-windows.ps1", uploadDir}, nil); err != nil {
-		return fmt.Errorf("failed to copy windows install script: %w", err)
-	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
-		return fmt.Errorf("failed to copy OCP bundle: %w", err)
+	if err := r.collectOCPBundle(); err != nil {
+		return err
 	}
 
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
 	// sha256sum -c --ignore-missing SHA256SUMS
-	files, err = os.ReadDir(uploadDir)
+	files, err := os.ReadDir(uploadDir)
 	if err != nil {
 		return fmt.Errorf("failed to read upload directory: %w", err)
 	}
@@ -974,6 +967,64 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 		return fmt.Errorf("failed to write SHA256SUMS file: %w", err)
 	}
 
+	return nil
+}
+
+func (r *CalicoManager) collectBinaries() error {
+	if !r.binaries {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	// We attach calicoctl binaries directly to the release as well.
+	files, err := os.ReadDir(filepath.Join(r.repoRoot, "calicoctl", "bin"))
+	if err != nil {
+		return fmt.Errorf("failed to read calicoctl binaries: %w", err)
+	}
+	for _, b := range files {
+		if _, err := r.runner.Run("cp", []string{filepath.Join(r.repoRoot, "calicoctl", "bin", b.Name()), uploadDir}, nil); err != nil {
+			return fmt.Errorf("failed to copy calicoctl binary %s: %w", b.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (r *CalicoManager) collectManifests() error {
+	if !r.manifests {
+		return nil
+	}
+	if r.isHashRelease {
+		uploadDir := r.uploadDir()
+		// Hashrelease include manifests in a different way, instead of just in the release tarball.
+		if _, err := r.runner.Run("cp", []string{"-r", filepath.Join(r.repoRoot, "manifests"), uploadDir}, nil); err != nil {
+			logrus.WithError(err).Error("Failed to copy manifests to output directory")
+			return fmt.Errorf("failed to copy manifests: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *CalicoManager) collectWindowsArchive() error {
+	if !r.windowsArchive {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{fmt.Sprintf("node/dist/calico-windows-%s.zip", r.calicoVersion), uploadDir}, nil); err != nil {
+		return fmt.Errorf("failed to copy windows zip archive: %w", err)
+	}
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"node/dist/install-calico-windows.ps1", uploadDir}, nil); err != nil {
+		return fmt.Errorf("failed to copy windows install script: %w", err)
+	}
+	return nil
+}
+
+func (r *CalicoManager) collectOCPBundle() error {
+	if !r.ocpBundle {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
+		return fmt.Errorf("failed to copy OCP bundle: %w", err)
+	}
 	return nil
 }
 
@@ -1114,7 +1165,7 @@ func (r *CalicoManager) buildBinaries() error {
 	// calicoctl needs to build unconditionally; everything else is produced
 	// as part of its image release-build target.
 	m := map[string]string{"calicoctl": "build-all"}
-	if !r.buildImages {
+	if !r.images {
 		m["felix"] = "release-build"
 	}
 	env := append(os.Environ(),
@@ -1131,7 +1182,7 @@ func (r *CalicoManager) buildBinaries() error {
 }
 
 func (r *CalicoManager) buildContainerImages() error {
-	if !r.buildImages {
+	if !r.images {
 		logrus.Info("Skip building container images")
 		return nil
 	}
@@ -1170,7 +1221,7 @@ func (r *CalicoManager) buildContainerImages() error {
 }
 
 func (r *CalicoManager) publishGitTag() error {
-	if !r.publishGitRef {
+	if !r.gitRef {
 		logrus.Info("Skipping git tag")
 		return nil
 	}
@@ -1182,7 +1233,7 @@ func (r *CalicoManager) publishGitTag() error {
 }
 
 func (r *CalicoManager) publishGithubRelease() error {
-	if !r.publishGithub {
+	if !r.githubRelease {
 		logrus.Info("Skipping github release")
 		return nil
 	}
@@ -1238,7 +1289,7 @@ Additional links:
 }
 
 func (r *CalicoManager) publishContainerImages() error {
-	if !r.publishImages {
+	if !r.images {
 		logrus.Info("Skipping image publish")
 		return nil
 	}
@@ -1285,7 +1336,7 @@ func (r *CalicoManager) publishContainerImages() error {
 }
 
 func (r *CalicoManager) publishHelmCharts() error {
-	if !r.publishCharts {
+	if !r.helmCharts {
 		logrus.Info("Skipping publishing helm charts")
 		return nil
 	}
@@ -1328,7 +1379,7 @@ func (r *CalicoManager) publishHelmChart(chart, registry string) error {
 }
 
 func (r *CalicoManager) updateHelmChartIndex() error {
-	if !r.publishCharts {
+	if !r.helmCharts {
 		logrus.Info("Skipping updating helm index")
 		return nil
 	}
@@ -1398,7 +1449,7 @@ func (r *CalicoManager) determineBranch() (string, error) {
 
 // Uses docker to build a tgz archive of the specified container image.
 func (r *CalicoManager) archiveContainerImage(out, image string) error {
-	if r.isHashRelease && !r.buildImages {
+	if r.isHashRelease && !r.images {
 		if _, err := r.runner.Run("docker", []string{"image", "inspect", image}, nil); err != nil {
 			logrus.WithError(err).WithField("image", image).Error("Image not found locally, will attempt to pull")
 			if _, err := r.runner.Run("docker", []string{"pull", image}, nil); err != nil {
@@ -1629,7 +1680,7 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 
 // pushPrepBranch pushes the prep branch to remote and creates a PR if not in local mode.
 func (r *CalicoManager) pushPrepBranch(baseBranch, prepBranch string) error {
-	if !r.publishGitRef {
+	if !r.gitRef {
 		logrus.WithField("branch", prepBranch).Warn("Local mode: skipping branch push and PR creation")
 		return r.switchToBaseBranch(baseBranch)
 	}
@@ -1710,13 +1761,13 @@ func (r *CalicoManager) prepPrereqs() error {
 			return fmt.Errorf("failed to determine current git branch: %w", err)
 		} else if branch == defaultBranch {
 			return fmt.Errorf("cannot cut release from branch: %s", branch)
-		} else if r.publishGitRef && !strings.HasPrefix(branch, r.releaseBranchPrefix) {
+		} else if r.gitRef && !strings.HasPrefix(branch, r.releaseBranchPrefix) {
 			return fmt.Errorf("current branch is %s, expected to be a release branch with prefix %s. Please switch to the appropriate release branch to cut the release", branch, r.releaseBranchPrefix)
 		}
 	}
 
 	// If publishing, check that we are not on a fork branch. We want to ensure releases are always cut from the main repo
-	if r.publishGitRef {
+	if r.gitRef {
 		owner, err := r.remoteOwner()
 		if err != nil {
 			return err

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -146,6 +146,13 @@ func WithWindowsArchive(enabled bool) Option {
 	}
 }
 
+func WithE2EBinaries(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.e2eBinaries = enabled
+		return nil
+	}
+}
+
 func WithPublishHashrelease(publish bool) Option {
 	return func(r *CalicoManager) error {
 		r.publishHashrelease = publish

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -38,7 +38,7 @@ func IsHashRelease() Option {
 	}
 }
 
-func WithValidate(validate bool) Option {
+func WithValidation(validate bool) Option {
 	return func(r *CalicoManager) error {
 		r.validate = validate
 		return nil

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -111,30 +111,37 @@ func WithS3Bucket(bucket string) Option {
 	}
 }
 
-func WithPublishImages(publish bool) Option {
+func WithHelmIndex(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishImages = publish
+		r.helmIndex = enabled
 		return nil
 	}
 }
 
-func WithPublishCharts(publish bool) Option {
+func WithHelmCharts(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishCharts = publish
+		r.helmCharts = enabled
 		return nil
 	}
 }
 
-func WithPublishGitRef(publish bool) Option {
+func WithGitRef(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishGitRef = publish
+		r.gitRef = enabled
 		return nil
 	}
 }
 
-func WithPublishGithubRelease(publish bool) Option {
+func WithGithubRelease(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishGithub = publish
+		r.githubRelease = enabled
+		return nil
+	}
+}
+
+func WithWindowsArchive(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.windowsArchive = enabled
 		return nil
 	}
 }
@@ -146,9 +153,9 @@ func WithPublishHashrelease(publish bool) Option {
 	}
 }
 
-func WithBuildImages(buildImages bool) Option {
+func WithImages(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.buildImages = buildImages
+		r.images = enabled
 		return nil
 	}
 }
@@ -256,6 +263,34 @@ func WithArchiveImages(archive bool) Option {
 func WithOperatorBranch(branch string) Option {
 	return func(r *CalicoManager) error {
 		r.operatorBranch = branch
+		return nil
+	}
+}
+
+func WithManifests(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.manifests = enabled
+		return nil
+	}
+}
+
+func WithBinaries(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.binaries = enabled
+		return nil
+	}
+}
+
+func WithOCPBundle(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.ocpBundle = enabled
+		return nil
+	}
+}
+
+func WithTarball(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.tarball = enabled
 		return nil
 	}
 }

--- a/release/pkg/manager/calico/options_test.go
+++ b/release/pkg/manager/calico/options_test.go
@@ -15,127 +15,190 @@
 package calico
 
 import (
+	"strings"
 	"testing"
 )
 
-func TestWithImages(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithImages(true)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !m.images {
-		t.Error("expected images=true")
-	}
-	if err := WithImages(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.images {
-		t.Error("expected images=false")
+// requiredOpts returns the bare-minimum opts needed for NewManager to pass
+// its constructor-level required-field checks. Tests layer additional opts
+// on top to exercise specific behaviour.
+func requiredOpts() []Option {
+	return []Option{
+		WithRepoRoot("/tmp"),
+		WithGithubOrg("projectcalico"),
+		WithRepoName("calico"),
+		WithRepoRemote("origin"),
 	}
 }
 
-func TestWithArchiveImages(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithArchiveImages(true)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestNewManagerStepDefaults pins down the all-step-flags-default-to-true
+// contract. CLI gating relies on these defaults being on at the manager
+// layer; flipping a default silently breaks every release without a flag set.
+func TestNewManagerStepDefaults(t *testing.T) {
+	m := NewManager(requiredOpts()...)
+	cases := []struct {
+		name string
+		got  bool
+	}{
+		{"validate", m.validate},
+		{"validateBranch", m.validateBranch},
+		{"images", m.images},
+		{"archiveImages", m.archiveImages},
+		{"manifests", m.manifests},
+		{"binaries", m.binaries},
+		{"ocpBundle", m.ocpBundle},
+		{"tarball", m.tarball},
+		{"windowsArchive", m.windowsArchive},
+		{"helmCharts", m.helmCharts},
+		{"helmIndex", m.helmIndex},
+		{"e2eBinaries", m.e2eBinaries},
+		{"gitRef", m.gitRef},
+		{"githubRelease", m.githubRelease},
 	}
-	if !m.archiveImages {
-		t.Error("expected archiveImages=true")
-	}
-}
-
-func TestWithHelmCharts(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithHelmCharts(true)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !m.helmCharts {
-		t.Error("expected helmCharts=true")
-	}
-	if err := WithHelmCharts(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.helmCharts {
-		t.Error("expected helmCharts=false")
-	}
-}
-
-func TestWithHelmIndex(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithHelmIndex(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.helmIndex {
-		t.Error("expected helmIndex=false")
+	for _, tc := range cases {
+		if !tc.got {
+			t.Errorf("default %s: got false, want true", tc.name)
+		}
 	}
 }
 
-func TestWithManifests(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithManifests(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestPreBuildValidation covers the cross-flag invariants enforced at the
+// manager layer. The test exercises the two non-trivial cases this PR
+// introduces: image-registries required when images/archive-images are on,
+// and ocp-bundle requires manifests on the hashrelease path.
+func TestPreBuildValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		opts      []Option
+		wantErr   string // substring match; empty means "the asserted invariants do not fire"
+		expectErr bool   // true if PreBuildValidation must return non-nil
+	}{
+		{
+			name: "happy path",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+			),
+		},
+		{
+			name: "missing calico version",
+			opts: append(requiredOpts(),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+			),
+			wantErr:   "no calico version specified",
+			expectErr: true,
+		},
+		{
+			name: "missing operator version",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+			),
+			wantErr:   "no operator version specified",
+			expectErr: true,
+		},
+		{
+			name: "images on with no registries errors",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries(nil),
+			),
+			wantErr:   "no image registries specified",
+			expectErr: true,
+		},
+		{
+			name: "images off + archive off skips registry check",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries(nil),
+				WithImages(false),
+				WithArchiveImages(false),
+			),
+		},
+		{
+			name: "archive on with images off still requires registries",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries(nil),
+				WithImages(false),
+			),
+			wantErr:   "no image registries specified",
+			expectErr: true,
+		},
+		{
+			name: "hashrelease ocp-bundle requires manifests",
+			opts: append(requiredOpts(),
+				IsHashRelease(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+				WithManifests(false),
+			),
+			wantErr:   "cannot build OCP bundle without manifests",
+			expectErr: true,
+		},
+		{
+			name: "hashrelease manifests off + ocp-bundle off passes the cross-flag check",
+			opts: append(requiredOpts(),
+				IsHashRelease(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+				WithManifests(false),
+				WithOCPBundle(false),
+			),
+			// PreHashreleaseValidate runs after PreBuildValidation's gates
+			// and may error on its own preconditions; we only assert that
+			// the manifests/ocp-bundle gate above doesn't fire here.
+		},
+		{
+			name: "non-hashrelease build with manifests off is allowed by PreBuildValidation",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+				WithManifests(false),
+			),
+		},
 	}
-	if m.manifests {
-		t.Error("expected manifests=false")
+	// Substrings owned by PreBuildValidation. Errors from downstream
+	// validators (PreHashreleaseValidate / PreReleaseValidate) may surface
+	// when no real repo is wired up; filter on the substrings we care about.
+	guarded := []string{
+		"no calico version specified",
+		"no operator version specified",
+		"no image registries specified",
+		"cannot build OCP bundle without manifests",
 	}
-}
-
-func TestWithBinaries(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithBinaries(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.binaries {
-		t.Error("expected binaries=false")
-	}
-}
-
-func TestWithOCPBundle(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithOCPBundle(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.ocpBundle {
-		t.Error("expected ocpBundle=false")
-	}
-}
-
-func TestWithTarball(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithTarball(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.tarball {
-		t.Error("expected tarball=false")
-	}
-}
-
-func TestWithGitRef(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithGitRef(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.gitRef {
-		t.Error("expected gitRef=false")
-	}
-}
-
-func TestWithGithubRelease(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithGithubRelease(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.githubRelease {
-		t.Error("expected githubRelease=false")
-	}
-}
-
-func TestWithWindowsArchive(t *testing.T) {
-	m := &CalicoManager{}
-	if err := WithWindowsArchive(false)(m); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if m.windowsArchive {
-		t.Error("expected windowsArchive=false")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(tc.opts...)
+			err := m.PreBuildValidation()
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			// Not expecting a guarded-invariant failure. Allow downstream
+			// validator errors to bubble up but fail if any guarded
+			// substring shows up.
+			if err == nil {
+				return
+			}
+			for _, sub := range guarded {
+				if strings.Contains(err.Error(), sub) {
+					t.Fatalf("unexpected guarded-invariant error: %v", err)
+				}
+			}
+		})
 	}
 }

--- a/release/pkg/manager/calico/options_test.go
+++ b/release/pkg/manager/calico/options_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calico
+
+import (
+	"testing"
+)
+
+func TestWithImages(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithImages(true)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.images {
+		t.Error("expected images=true")
+	}
+	if err := WithImages(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.images {
+		t.Error("expected images=false")
+	}
+}
+
+func TestWithArchiveImages(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithArchiveImages(true)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.archiveImages {
+		t.Error("expected archiveImages=true")
+	}
+}
+
+func TestWithHelmCharts(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithHelmCharts(true)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.helmCharts {
+		t.Error("expected helmCharts=true")
+	}
+	if err := WithHelmCharts(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.helmCharts {
+		t.Error("expected helmCharts=false")
+	}
+}
+
+func TestWithHelmIndex(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithHelmIndex(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.helmIndex {
+		t.Error("expected helmIndex=false")
+	}
+}
+
+func TestWithManifests(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithManifests(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.manifests {
+		t.Error("expected manifests=false")
+	}
+}
+
+func TestWithBinaries(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithBinaries(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.binaries {
+		t.Error("expected binaries=false")
+	}
+}
+
+func TestWithOCPBundle(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithOCPBundle(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.ocpBundle {
+		t.Error("expected ocpBundle=false")
+	}
+}
+
+func TestWithTarball(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithTarball(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.tarball {
+		t.Error("expected tarball=false")
+	}
+}
+
+func TestWithGitRef(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithGitRef(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.gitRef {
+		t.Error("expected gitRef=false")
+	}
+}
+
+func TestWithGithubRelease(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithGithubRelease(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.githubRelease {
+		t.Error("expected githubRelease=false")
+	}
+}
+
+func TestWithWindowsArchive(t *testing.T) {
+	m := &CalicoManager{}
+	if err := WithWindowsArchive(false)(m); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.windowsArchive {
+		t.Error("expected windowsArchive=false")
+	}
+}

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -121,8 +121,8 @@ func (o *OperatorManager) Build() error {
 	if err != nil {
 		return err
 	}
-	logFields[fmt.Sprintf("%s_registry", strings.ToLower(defaultProductEnvPrefix))] = o.productRegistry
-	logFields[fmt.Sprintf("%s_image_path", strings.ToLower(defaultProductEnvPrefix))] = o.productRegistry
+	logFields[fmt.Sprintf("%s_registry", strings.ToLower(defaultProductEnvPrefix))] = r
+	logFields[fmt.Sprintf("%s_image_path", strings.ToLower(defaultProductEnvPrefix))] = i
 	env = append(env, fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, r))
 	env = append(env, fmt.Sprintf("%s_IMAGE_PATH=%s", defaultProductEnvPrefix, i))
 	if o.isHashRelease {

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -63,14 +63,14 @@ func ReformatHashrelease(hashreleaseOutputDir, tmpDir string) error {
 	}
 	windowsZip := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("calico-windows-%s.zip", versions.ProductVersion()))
 	windowsZipDst := filepath.Join(windowsDir, fmt.Sprintf("calico-windows-%s.zip", versions.ProductVersion()))
-	if err := utils.CopyFile(windowsZip, windowsZipDst); err != nil {
+	if err := copyIfExists(windowsZip, windowsZipDst); err != nil {
 		return err
 	}
 
 	// Copy the ocp.tgz to manifests/ocp.tgz
 	ocpTarball := filepath.Join(hashreleaseOutputDir, "ocp.tgz")
 	ocpTarballDst := filepath.Join(hashreleaseOutputDir, "manifests", "ocp.tgz")
-	if err := utils.CopyFile(ocpTarball, ocpTarballDst); err != nil {
+	if err := copyIfExists(ocpTarball, ocpTarballDst); err != nil {
 		return err
 	}
 
@@ -82,7 +82,7 @@ func ReformatHashrelease(hashreleaseOutputDir, tmpDir string) error {
 	for _, chart := range utils.AllReleaseCharts() {
 		chartTarball := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s-%s.tgz", chart, versions.HelmChartVersion()))
 		chartTarballDst := filepath.Join(chartsDir, fmt.Sprintf("%s.tgz", chart))
-		if err := utils.CopyFile(chartTarball, chartTarballDst); err != nil {
+		if err := copyIfExists(chartTarball, chartTarballDst); err != nil {
 			return err
 		}
 	}
@@ -90,8 +90,22 @@ func ReformatHashrelease(hashreleaseOutputDir, tmpDir string) error {
 	// Keep copy of the Tigera operator chart without version in name in root dir
 	operatorTarball := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s-%s.tgz", utils.TigeraOperatorChart, versions.HelmChartVersion()))
 	operatorTarballDst := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s.tgz", utils.TigeraOperatorChart))
-	if err := utils.CopyFile(operatorTarball, operatorTarballDst); err != nil {
+	if err := copyIfExists(operatorTarball, operatorTarballDst); err != nil {
 		return err
 	}
 	return nil
+}
+
+// copyIfExists copies src to dst, logging and skipping if src is missing.
+// Missing sources are expected when the caller skipped the step-control flag
+// that would have produced the artifact.
+func copyIfExists(src, dst string) error {
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			logrus.WithField("file", src).Warn("Source missing, skipping reformat copy")
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	return utils.CopyFile(src, dst)
 }


### PR DESCRIPTION
Adds a unified set of step-control flags to `hashrelease build/publish` and `release build/publish` so operators can skip individual build/publish steps (manifests, OCP bundle, helm charts, helm index, binaries, windows archive, images, tarball) from the CLI or via env vars. Every flag is honored at its actual build site in the Manager rather than being validated and ignored, and post-build reformatters tolerate skipped artifacts.

Also tightens flag parity between `hashrelease` and `release` (shared `productFlags`, consistent `BUILD_*`/`PUBLISH_*` and `RELEASE_*` env var prefixes, removal of a dead `--helm-index` on hashrelease publish, and a missing `--skip-branch-check` on `release build`).

Default-on bool flags now use `cli.BoolWithInverseFlag`, so users can write `--no-images` instead of `--images=false`. The development `--skip-*` flags are renamed to positive defaults: `--validation`, `--branch-check`, `--image-scan`; the old `SKIP_*` env vars are dropped. Builders for `images`, `archive-images`, `helm-charts`, `helm-index`, `windows-archive`, and `operator` take per-command env var lists from `buildStepFlags` / `publishStepFlags` so build vs publish can disagree (e.g. `BUILD_CONTAINER_IMAGES` vs `PUBLISH_IMAGES`); legacy aliases like `ARCHIVE_IMAGES`, `UPDATE_HELM_INDEX`, and `PUBLISH_GIT_TAG` are listed first in `Sources` so existing CI configs keep winning precedence. New gates `--e2e-binaries` and `--release-notes` are added to `hashrelease build`. Cross-flag invariants are enforced via flag `Action` callbacks on the prerequisite flag (so they fire when the user toggles only the prerequisite). The duplicate archive-images runtime guard is dropped now that urfave/cli v3.8.0 runs `Action` reliably for env-set flags (urfave/cli#2221). `release/cmd/flags_test.go` covers the cross-flag Actions.

**Release note:**
```release-note
TBD
```