### PR TITLE
Address #12225 review feedback: libbpf guard, comment clarifications, felix FV cache cleanup

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -413,12 +413,21 @@ blocks:
             # and saving the ~30s build step across all Felix jobs.
             - test -f felix/bpf-gpl/libbpf/src/amd64/libbpf.a || make -C felix libbpf
             - LIBBPF_VERSION=$(grep -E '^LIBBPF_VERSION[[:space:]]*=' metadata.mk | cut -d'=' -f2 | tr -d '[:space:]')
+            # Fail loudly if either path is missing. Without this guard, tar would
+            # warn and still exit 0 on a missing path, and every downstream Felix
+            # job would silently regress to cold libbpf builds.
+            - test -d felix/bpf-gpl/libbpf || (echo "ERROR libbpf clone missing at felix/bpf-gpl/libbpf" >&2; exit 1)
+            - test -f "felix/bpf-gpl/.libbpf-${LIBBPF_VERSION}" || (echo "ERROR libbpf version marker felix/bpf-gpl/.libbpf-${LIBBPF_VERSION} missing" >&2; exit 1)
             - tar --use-compress-program="zstd -3" -cf /tmp/libbpf-amd64.tar.zst -C felix/bpf-gpl libbpf ".libbpf-${LIBBPF_VERSION}"
             - gcloud storage cp /tmp/libbpf-amd64.tar.zst "${GCS_WORKFLOW_DIR}/libbpf-amd64.tar.zst"
   - name: "Build: node image"
-    # Builds the node image on top of the combined calico binary. The underlying
-    # Go state lives in the "calico" build cache populated by "Build: calico
-    # image", so this block does not participate in build-cache storage.
+    # Builds the node image on top of the combined calico binary. calico/node is
+    # still the canonical DaemonSet image for OSS users, so it continues to ship
+    # alongside the unified calico image. The underlying Go state lives in the
+    # "calico" build cache populated by "Build: calico image" — only the Docker
+    # stage assembly (copying binaries onto the base image) runs here, not the Go
+    # compile. Kept in prerequisites (rather than 20-node.yml) so consumer blocks
+    # can depend on the shared producer→GCS→consumer upload pattern.
     run:
       when: "true"
     dependencies: []
@@ -435,7 +444,9 @@ blocks:
             - zstd -3 --rm /tmp/node-image.tar
             - gcloud storage cp /tmp/node-image.tar.zst "${GCS_WORKFLOW_DIR}/node-image.tar.zst"
   - name: "Build: whisker image"
-    # Whisker is a TypeScript/React frontend — no Go build cache to populate.
+    # Whisker is a TypeScript/React frontend that won't consolidate into the
+    # calico binary — it ships as its own image indefinitely. No Go build cache
+    # to populate; only produces the image tarball for consumer blocks.
     run:
       when: >-
         true or

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -413,12 +413,21 @@ blocks:
             # and saving the ~30s build step across all Felix jobs.
             - test -f felix/bpf-gpl/libbpf/src/amd64/libbpf.a || make -C felix libbpf
             - LIBBPF_VERSION=$(grep -E '^LIBBPF_VERSION[[:space:]]*=' metadata.mk | cut -d'=' -f2 | tr -d '[:space:]')
+            # Fail loudly if either path is missing. Without this guard, tar would
+            # warn and still exit 0 on a missing path, and every downstream Felix
+            # job would silently regress to cold libbpf builds.
+            - test -d felix/bpf-gpl/libbpf || (echo "ERROR libbpf clone missing at felix/bpf-gpl/libbpf" >&2; exit 1)
+            - test -f "felix/bpf-gpl/.libbpf-${LIBBPF_VERSION}" || (echo "ERROR libbpf version marker felix/bpf-gpl/.libbpf-${LIBBPF_VERSION} missing" >&2; exit 1)
             - tar --use-compress-program="zstd -3" -cf /tmp/libbpf-amd64.tar.zst -C felix/bpf-gpl libbpf ".libbpf-${LIBBPF_VERSION}"
             - gcloud storage cp /tmp/libbpf-amd64.tar.zst "${GCS_WORKFLOW_DIR}/libbpf-amd64.tar.zst"
   - name: "Build: node image"
-    # Builds the node image on top of the combined calico binary. The underlying
-    # Go state lives in the "calico" build cache populated by "Build: calico
-    # image", so this block does not participate in build-cache storage.
+    # Builds the node image on top of the combined calico binary. calico/node is
+    # still the canonical DaemonSet image for OSS users, so it continues to ship
+    # alongside the unified calico image. The underlying Go state lives in the
+    # "calico" build cache populated by "Build: calico image" — only the Docker
+    # stage assembly (copying binaries onto the base image) runs here, not the Go
+    # compile. Kept in prerequisites (rather than 20-node.yml) so consumer blocks
+    # can depend on the shared producer→GCS→consumer upload pattern.
     run:
       when: >-
         change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml',
@@ -673,7 +682,9 @@ blocks:
             - zstd -3 --rm /tmp/node-image.tar
             - gcloud storage cp /tmp/node-image.tar.zst "${GCS_WORKFLOW_DIR}/node-image.tar.zst"
   - name: "Build: whisker image"
-    # Whisker is a TypeScript/React frontend — no Go build cache to populate.
+    # Whisker is a TypeScript/React frontend that won't consolidate into the
+    # calico binary — it ships as its own image indefinitely. No Go build cache
+    # to populate; only produces the image tarball for consumer blocks.
     run:
       when: >-
         false or

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -200,12 +200,21 @@
           # and saving the ~30s build step across all Felix jobs.
           - test -f felix/bpf-gpl/libbpf/src/amd64/libbpf.a || make -C felix libbpf
           - LIBBPF_VERSION=$(grep -E '^LIBBPF_VERSION[[:space:]]*=' metadata.mk | cut -d'=' -f2 | tr -d '[:space:]')
+          # Fail loudly if either path is missing. Without this guard, tar would
+          # warn and still exit 0 on a missing path, and every downstream Felix
+          # job would silently regress to cold libbpf builds.
+          - test -d felix/bpf-gpl/libbpf || (echo "ERROR libbpf clone missing at felix/bpf-gpl/libbpf" >&2; exit 1)
+          - test -f "felix/bpf-gpl/.libbpf-${LIBBPF_VERSION}" || (echo "ERROR libbpf version marker felix/bpf-gpl/.libbpf-${LIBBPF_VERSION} missing" >&2; exit 1)
           - tar --use-compress-program="zstd -3" -cf /tmp/libbpf-amd64.tar.zst -C felix/bpf-gpl libbpf ".libbpf-${LIBBPF_VERSION}"
           - gcloud storage cp /tmp/libbpf-amd64.tar.zst "${GCS_WORKFLOW_DIR}/libbpf-amd64.tar.zst"
 - name: "Build: node image"
-  # Builds the node image on top of the combined calico binary. The underlying
-  # Go state lives in the "calico" build cache populated by "Build: calico
-  # image", so this block does not participate in build-cache storage.
+  # Builds the node image on top of the combined calico binary. calico/node is
+  # still the canonical DaemonSet image for OSS users, so it continues to ship
+  # alongside the unified calico image. The underlying Go state lives in the
+  # "calico" build cache populated by "Build: calico image" — only the Docker
+  # stage assembly (copying binaries onto the base image) runs here, not the Go
+  # compile. Kept in prerequisites (rather than 20-node.yml) so consumer blocks
+  # can depend on the shared producer→GCS→consumer upload pattern.
   run:
     when: "${CHANGE_IN(node)}"
   dependencies: []
@@ -222,7 +231,9 @@
           - zstd -3 --rm /tmp/node-image.tar
           - gcloud storage cp /tmp/node-image.tar.zst "${GCS_WORKFLOW_DIR}/node-image.tar.zst"
 - name: "Build: whisker image"
-  # Whisker is a TypeScript/React frontend — no Go build cache to populate.
+  # Whisker is a TypeScript/React frontend that won't consolidate into the
+  # calico binary — it ships as its own image indefinitely. No Go build cache
+  # to populate; only produces the image tarball for consumer blocks.
   run:
     when: >-
       ${FORCE_RUN} or

--- a/.semaphore/vms/vm-bootstrap.sh
+++ b/.semaphore/vms/vm-bootstrap.sh
@@ -66,7 +66,7 @@ elif [ "$ubuntu_codename" = "plucky" ]; then
 fi
 
 retry apt-get update -y
-retry apt-get install -y --no-install-recommends git docker-ce"${docker_version}" docker-ce-cli"${docker_version}" docker-buildx-plugin"${buildx_version}" containerd.io make iproute2 wireguard
+retry apt-get install -y --no-install-recommends git docker-ce"${docker_version}" docker-ce-cli"${docker_version}" docker-buildx-plugin"${buildx_version}" containerd.io make iproute2 wireguard zstd
 usermod -a -G docker ubuntu
 
 # The IPIP module is loaded on demand, but pre-loading it prevents flakes in

--- a/felix/.semaphore/cache-test-artifacts
+++ b/felix/.semaphore/cache-test-artifacts
@@ -22,9 +22,14 @@ set -x
 
 artifact push job bin &
 docker save -o /tmp/calico-felix-test.tar calico/felix-test:latest-amd64
-# The combined calico image provides Typha (via `component typha`) and other
-# components used by the FVs.
-docker save -o /tmp/calico-image.tar calico/calico:latest-amd64
+
+# The combined calico image (which provides Typha and other components used by
+# the FVs) is already published to ${GCS_WORKFLOW_DIR}/calico-image.tar.zst by
+# the "Build: calico image" prerequisite block. Server-side copy it into this
+# component's fv-artifacts directory so the test VM sees it alongside the
+# working copy and felix-test image.
+gcloud storage cp "${GCS_WORKFLOW_DIR}/calico-image.tar.zst" "${GCS_WORKFLOW_DIR}/felix/fv-artifacts/calico-image.tar.zst"
+
 cd ../..
 
 # Future work: Split UT and FV artifacts so we can be even more selective.
@@ -35,5 +40,5 @@ tar -czf /tmp/working-copy.tgz \
   --exclude=calico/typha/docker-image/bin \
   --exclude=artifacts \
   ${CALICO_DIR_NAME}
-gcloud storage cp /tmp/working-copy.tgz /tmp/calico-felix-test.tar /tmp/calico-image.tar "${GCS_WORKFLOW_DIR}/felix/fv-artifacts/"
+gcloud storage cp /tmp/working-copy.tgz /tmp/calico-felix-test.tar "${GCS_WORKFLOW_DIR}/felix/fv-artifacts/"
 wait

--- a/felix/.semaphore/load-test-artifacts
+++ b/felix/.semaphore/load-test-artifacts
@@ -20,5 +20,5 @@
 set -ex
 
 docker load -i /tmp/calico-felix-test.tar
-docker load -i /tmp/calico-image.tar
+zstd -d --stdout /tmp/calico-image.tar.zst | docker load
 docker tag calico/felix-test:latest-amd64 felix-test:latest-amd64


### PR DESCRIPTION
Follow-up cleanup for review comments on https://github.com/projectcalico/calico/pull/12225.

- **libbpf guard**: `tar -c` silently ignores missing paths, so a mis-parsed `LIBBPF_VERSION` or renamed marker would regress every Felix job to cold libbpf builds with no error surfaced. Adds `test -d` / `test -f` guards before the tar so a broken cache fails loudly.
- **Prereq block comments**: clarify why the node and whisker image builds live in the prerequisites block. Node is still the canonical DaemonSet image for OSS users; whisker is a TS/React frontend that won't consolidate into the calico binary. Both stay in prereqs so consumer blocks can depend on the shared producer→GCS→consumer upload pattern.
- **Felix FV artifact cleanup**: `felix/.semaphore/cache-test-artifacts` was re-saving `calico/calico` even though the \"Build: calico image\" prereq already publishes the compressed tarball. Server-side copy the pre-built `.tar.zst` into `felix/fv-artifacts/` instead and decompress on the test VM. Install `zstd` in `vm-bootstrap.sh` so the load step works on fresh VMs.

```release-note
None
```