### PR TITLE
kube-controllers: stop migration controller's os.Exit from masking FV failures

### DIFF
--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -94,6 +94,12 @@ type ControllerConfig struct {
 	// WaitingPollInterval controls how frequently the controller re-checks
 	// conflicts during WaitingForConflictResolution. Defaults to 10s.
 	WaitingPollInterval time.Duration
+
+	// RestartFunc is invoked once the migration reaches Complete in manifest
+	// mode so kube-controllers can re-exec and pick up the v3 API group.
+	// Defaults to os.Exit(0); tests override this with a no-op so the test
+	// binary isn't killed mid-run.
+	RestartFunc func()
 }
 
 // NewController creates a new migration controller. It watches for DatastoreMigration CRs
@@ -104,6 +110,10 @@ func NewController(cfg ControllerConfig) controller.Controller {
 	if pollInterval == 0 {
 		pollInterval = defaultWaitingPollInterval
 	}
+	restartFunc := cfg.RestartFunc
+	if restartFunc == nil {
+		restartFunc = func() { os.Exit(0) }
+	}
 	m := &migrationController{
 		ctx:                 cfg.Ctx,
 		k8sClient:           cfg.K8sClient,
@@ -113,6 +123,7 @@ func NewController(cfg ControllerConfig) controller.Controller {
 		apiregClient:        cfg.APIRegClient,
 		migrators:           cfg.Migrators,
 		waitingPollInterval: pollInterval,
+		restartFunc:         restartFunc,
 	}
 	return controller.NewDeferredCRDController(
 		"datastoremigrations.migration.projectcalico.org",
@@ -147,6 +158,7 @@ type migrationController struct {
 	apiregClient        apiregv1client.ApiregistrationV1Interface
 	migrators           []migrators.ResourceMigrator
 	waitingPollInterval time.Duration
+	restartFunc         func()
 	queue               workqueue.TypedRateLimitingInterface[string]
 
 	// operatorManaged is true if the cluster is managed by the Tigera operator,
@@ -681,7 +693,7 @@ func (m *migrationController) handleConverged(logCtx *logrus.Entry, dm *Datastor
 	// cleanup first.
 	if !m.operatorManaged && dm.DeletionTimestamp == nil {
 		logCtx.Info("Migration complete, restarting kube-controllers to pick up v3 API group")
-		os.Exit(0)
+		m.restartFunc()
 	}
 	return nil
 }

--- a/kube-controllers/pkg/controllers/migration/controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/controller_fv_test.go
@@ -158,6 +158,7 @@ func TestLifecycle_Mainline(t *testing.T) {
 		APIRegClient:  fakeAPIReg.ApiregistrationV1(),
 		CRDClient:     fvCRDClient,
 		Migrators:     NewMigrators(bc, fvRTClient),
+		RestartFunc:   func() {},
 	})
 	go ctrl.Run(stop)
 

--- a/kube-controllers/pkg/controllers/migration/utils_fv_test.go
+++ b/kube-controllers/pkg/controllers/migration/utils_fv_test.go
@@ -140,6 +140,7 @@ func startController(
 		CRDClient:           fvCRDClient,
 		Migrators:           NewMigrators(bc, fvRTClient),
 		WaitingPollInterval: 500 * time.Millisecond,
+		RestartFunc:         func() {},
 	})
 
 	stop := make(chan struct{})

--- a/kube-controllers/run-uts
+++ b/kube-controllers/run-uts
@@ -53,4 +53,16 @@ for PKG in "$@"; do
 	fi
 done
 
+# Defense-in-depth: if a test binary exits 0 but the JUnit XML records a
+# failure or error (e.g. because an os.Exit() call inside the test killed
+# the binary mid-run), the pipe exit code above won't catch it. Scan the
+# published XMLs and fail the run if any failures or errors were recorded.
+for xml in report/*.xml; do
+	[ -f "$xml" ] || continue
+	if grep -qE '<(failure|error)(\s|>|/>)' "$xml"; then
+		echo "FAIL: detected failures/errors in ${xml}"
+		((RC++))
+	fi
+done
+
 exit ${RC}


### PR DESCRIPTION
When the migration controller reaches Complete in manifest mode, it calls `os.Exit(0)` so kube-controllers re-execs and picks up the v3 API group. In the migration FV tests, that kills the test binary mid-run — `TestLifecycle_Mainline` produces a `FAIL ... (-1.00s) unknown` record, but the binary still exits 0. `run-uts` pipes through `gotestsum --raw-command -- go tool test2json`, which follows the binary's exit code, so the pipe succeeds and the job is reported as passed even though the test failed.

Seen on master at https://tigera.semaphoreci.com/jobs/c5fc91bd-dd7c-46d4-99be-9e91065b052d.

Fix: make the restart injectable via `ControllerConfig.RestartFunc`, defaulting to `os.Exit(0)`. The FV helper and `TestLifecycle_Mainline` pass a no-op so the `Eventually` waiting for `phase=Complete` can actually observe the state. Production caller in `pkg/kubecontrollers/run.go` leaves it unset, so real kube-controllers keeps restarting as before.

Also harden `run-uts`: after the test loop, scan the published JUnit XMLs for `<failure>`/`<error>` elements and bump `RC`. Defense-in-depth against any future test that exits 0 while a JUnit record shows a failure.