### PR TITLE
Cache node images for CD promotion reuse

### DIFF
--- a/.semaphore/cache-built-image
+++ b/.semaphore/cache-built-image
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Save a locally-built Docker image to the per-workflow GCS cache so that later
+# jobs in the same workflow (e.g. CD promotions) can load it instead of
+# rebuilding from source.
+#
+# Usage: cache-built-image <docker-tag> <gcs-key>
+# Example: cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <docker-tag> <gcs-key>" >&2
+    exit 2
+fi
+
+image=$1
+gcs_key=$2
+
+: "${GCS_WORKFLOW_DIR:?GCS_WORKFLOW_DIR must be set}"
+
+tar_path="/tmp/${gcs_key%.zst}"
+docker save "$image" -o "$tar_path"
+zstd -3 --rm "$tar_path"
+gcloud storage cp "${tar_path}.zst" "${GCS_WORKFLOW_DIR}/${gcs_key}"
+rm -f "${tar_path}.zst"

--- a/.semaphore/cd-load-or-build
+++ b/.semaphore/cd-load-or-build
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Populate local Docker with the per-arch images needed by a component's CD
+# promotion. For each arch, try to load a tarball uploaded to the per-workflow
+# GCS cache by an earlier build block; fall back to rebuilding from source if
+# the cache is empty.
+#
+# On master pushes where the component's build block ran, every arch hits the
+# cache and the promotion skips the rebuild entirely. When the build block was
+# skipped (e.g. CHANGE_IN did not fire) the fallback preserves correctness at
+# the cost of the rebuild — same behavior as before this script existed.
+#
+# Usage: cd-load-or-build <component-dir> <build-image> <arch> [<arch>...] [--fips <arch> [<arch>...]]
+# Example: cd-load-or-build node node amd64 arm64 ppc64le s390x --fips amd64
+#
+# <component-dir> is relative to the repo root (passed to `make -C`).
+# <build-image> is the BUILD_IMAGE tag used by the Makefile (no registry
+# prefix); the cached tarball contains "<build-image>:latest-<arch>" (and
+# "<build-image>:latest-fips-<arch>" for FIPS).
+
+set -euo pipefail
+
+: "${GCS_WORKFLOW_DIR:?GCS_WORKFLOW_DIR must be set}"
+
+if [ "$#" -lt 3 ]; then
+    echo "usage: $0 <component-dir> <build-image> <arch>... [--fips <arch>...]" >&2
+    exit 2
+fi
+
+component=$1
+build_image=$2
+shift 2
+
+arches=()
+fips_arches=()
+in_fips=false
+for arg in "$@"; do
+    if [ "$arg" = "--fips" ]; then
+        in_fips=true
+        continue
+    fi
+    if $in_fips; then
+        fips_arches+=("$arg")
+    else
+        arches+=("$arg")
+    fi
+done
+
+repo_root=$(git rev-parse --show-toplevel)
+
+try_load() {
+    local gcs_key=$1
+    local blob="${GCS_WORKFLOW_DIR}/${gcs_key}"
+    local tmp="/tmp/${gcs_key}"
+    if ! gcloud storage cp "$blob" "$tmp" 2>/dev/null; then
+        echo "Cache miss: ${gcs_key}"
+        return 1
+    fi
+    local tar="${tmp%.zst}"
+    zstd -d --rm "$tmp" -o "$tar"
+    docker load -i "$tar"
+    rm -f "$tar"
+    echo "Loaded ${gcs_key} from workflow cache"
+    return 0
+}
+
+for arch in "${arches[@]}"; do
+    key="cd-${build_image}-${arch}.tar.zst"
+    if ! try_load "$key"; then
+        echo "Rebuilding ${build_image} for ${arch}"
+        make -C "${repo_root}/${component}" image ARCH="$arch"
+    fi
+done
+
+for arch in "${fips_arches[@]}"; do
+    key="cd-${build_image}-fips-${arch}.tar.zst"
+    if ! try_load "$key"; then
+        echo "Rebuilding ${build_image} FIPS for ${arch}"
+        make -C "${repo_root}/${component}" image ARCH="$arch" FIPS=true
+    fi
+done

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -10,9 +10,16 @@ global_job_config:
   env_vars:
     - name: DEV_REGISTRIES
       value: quay.io/calico docker.io/calico
+    - name: GOOGLE_PROJECT
+      value: unique-caldron-775
+    - name: GCS_BUILD_CACHE_BUCKET
+      value: calico-transient-build-artifacts-europe-west3
   secrets:
     - name: docker
     - name: quay-robot-calico+semaphoreci
+    # Needed for cd-load-or-build to read per-arch image tarballs from the
+    # workflow's GCS cache, populated by the main pipeline's build blocks.
+    - name: google-service-account-for-gce
   prologue:
     commands:
       - checkout
@@ -23,6 +30,13 @@ global_job_config:
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
       - ssh-add ~/.ssh/id_rsa
+      # Mirror the GCS setup from 02-global_job_config.yml so cd-load-or-build
+      # can pull image tarballs written earlier in this workflow.
+      - export GCS_WORKFLOW_DIR=gs://$GCS_BUILD_CACHE_BUCKET/workflow/${SEMAPHORE_WORKFLOW_ID}
+      - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
+      - gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS" || true
+      - gcloud config set project ${GOOGLE_PROJECT} || true
+      - sudo apt-get install -y zstd || true
 blocks:
   - name: Publish node images and multi-arch manifests
     dependencies: []

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -434,6 +434,11 @@ blocks:
             - docker save calico/node:latest-amd64 -o /tmp/node-image.tar
             - zstd -3 --rm /tmp/node-image.tar
             - gcloud storage cp /tmp/node-image.tar.zst "${GCS_WORKFLOW_DIR}/node-image.tar.zst"
+            # Also cache the image under the CD blob key (bare "node:latest-amd64"
+            # tag) so the publish pipeline's cd-load-or-build can skip the amd64
+            # rebuild. The tarball above carries "calico/node:latest-amd64", which
+            # is what load-cached-images expects for downstream tests.
+            - ../.semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
   - name: "Build: whisker image"
     # Whisker is a TypeScript/React frontend — no Go build cache to populate.
     run:
@@ -1369,6 +1374,11 @@ blocks:
                 - s390x
           commands:
             - ../.semaphore/run-and-monitor image-$ARCH.log make image ARCH=$ARCH
+            # Cache the freshly-built image so the CD promotion pipeline can load
+            # it via .semaphore/cd-load-or-build instead of rebuilding from
+            # source. Only one tag is produced per arch here; FIPS and amd64 are
+            # produced by the "Build: node image" block in 10-prerequisites.yml.
+            - ../.semaphore/cache-built-image node:latest-$ARCH cd-node-$ARCH.tar.zst
         - name: "Node: build Windows archive"
           commands:
             - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -438,7 +438,7 @@ blocks:
             # tag) so the publish pipeline's cd-load-or-build can skip the amd64
             # rebuild. The tarball above carries "calico/node:latest-amd64", which
             # is what load-cached-images expects for downstream tests.
-            - ../.semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
+            - .semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
   - name: "Build: whisker image"
     # Whisker is a TypeScript/React frontend — no Go build cache to populate.
     run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -676,7 +676,7 @@ blocks:
             # tag) so the publish pipeline's cd-load-or-build can skip the amd64
             # rebuild. The tarball above carries "calico/node:latest-amd64", which
             # is what load-cached-images expects for downstream tests.
-            - ../.semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
+            - .semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
   - name: "Build: whisker image"
     # Whisker is a TypeScript/React frontend — no Go build cache to populate.
     run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -672,6 +672,11 @@ blocks:
             - docker save calico/node:latest-amd64 -o /tmp/node-image.tar
             - zstd -3 --rm /tmp/node-image.tar
             - gcloud storage cp /tmp/node-image.tar.zst "${GCS_WORKFLOW_DIR}/node-image.tar.zst"
+            # Also cache the image under the CD blob key (bare "node:latest-amd64"
+            # tag) so the publish pipeline's cd-load-or-build can skip the amd64
+            # rebuild. The tarball above carries "calico/node:latest-amd64", which
+            # is what load-cached-images expects for downstream tests.
+            - ../.semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
   - name: "Build: whisker image"
     # Whisker is a TypeScript/React frontend — no Go build cache to populate.
     run:
@@ -4168,6 +4173,11 @@ blocks:
                 - s390x
           commands:
             - ../.semaphore/run-and-monitor image-$ARCH.log make image ARCH=$ARCH
+            # Cache the freshly-built image so the CD promotion pipeline can load
+            # it via .semaphore/cd-load-or-build instead of rebuilding from
+            # source. Only one tag is produced per arch here; FIPS and amd64 are
+            # produced by the "Build: node image" block in 10-prerequisites.yml.
+            - ../.semaphore/cache-built-image node:latest-$ARCH cd-node-$ARCH.tar.zst
         - name: "Node: build Windows archive"
           commands:
             - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -225,7 +225,7 @@
           # tag) so the publish pipeline's cd-load-or-build can skip the amd64
           # rebuild. The tarball above carries "calico/node:latest-amd64", which
           # is what load-cached-images expects for downstream tests.
-          - ../.semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
+          - .semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
 - name: "Build: whisker image"
   # Whisker is a TypeScript/React frontend — no Go build cache to populate.
   run:

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -221,6 +221,11 @@
           - docker save calico/node:latest-amd64 -o /tmp/node-image.tar
           - zstd -3 --rm /tmp/node-image.tar
           - gcloud storage cp /tmp/node-image.tar.zst "${GCS_WORKFLOW_DIR}/node-image.tar.zst"
+          # Also cache the image under the CD blob key (bare "node:latest-amd64"
+          # tag) so the publish pipeline's cd-load-or-build can skip the amd64
+          # rebuild. The tarball above carries "calico/node:latest-amd64", which
+          # is what load-cached-images expects for downstream tests.
+          - ../.semaphore/cache-built-image node:latest-amd64 cd-node-amd64.tar.zst
 - name: "Build: whisker image"
   # Whisker is a TypeScript/React frontend — no Go build cache to populate.
   run:

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -55,6 +55,11 @@
               - s390x
         commands:
           - ../.semaphore/run-and-monitor image-$ARCH.log make image ARCH=$ARCH
+          # Cache the freshly-built image so the CD promotion pipeline can load
+          # it via .semaphore/cd-load-or-build instead of rebuilding from
+          # source. Only one tag is produced per arch here; FIPS and amd64 are
+          # produced by the "Build: node image" block in 10-prerequisites.yml.
+          - ../.semaphore/cache-built-image node:latest-$ARCH cd-node-$ARCH.tar.zst
       - name: "Node: build Windows archive"
         commands:
           - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive

--- a/node/Makefile
+++ b/node/Makefile
@@ -403,8 +403,13 @@ kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG)
 .PHONY: ci
 ci: static-checks ut image image-windows
 
-## Deploys images to registry
-cd: image-all cd-common
+## Deploys images to registry. Pulls per-arch images from the workflow GCS cache
+## populated by the build blocks in the main pipeline; any cache miss falls back
+## to rebuilding that arch from source.
+cd: cd-load-or-build cd-common
+
+cd-load-or-build:
+	$(REPO_ROOT)/.semaphore/cd-load-or-build node $(NODE_IMAGE) $(VALIDARCHES) --fips amd64
 
 ###############################################################################
 # Release


### PR DESCRIPTION
The node publish pipeline runs `make -C node cd`, which depends on `image-all` and rebuilds libbpf plus the calico binary for every arch and FIPS variant inside the promotion job - about 40 minutes per master merge on `Linux multi-arch`. Meanwhile the main pipeline's `Build: node image` and `Node: multi-arch build` blocks already produced the same images minutes earlier and threw them away.

This wires up a per-workflow GCS cache for the images:

- `.semaphore/cache-built-image` - producer side. `docker save` + zstd + `gcloud storage cp` to `${GCS_WORKFLOW_DIR}/cd-<build-image>-<arch>.tar.zst`. Called from the main pipeline's build blocks right after each `make image` run.
- `.semaphore/cd-load-or-build` - consumer side. For each arch, tries to load the tarball from GCS and `docker load` it; on miss, runs `make image ARCH=<arch>` as a fallback. Handles FIPS via a `--fips <arch>` tail arg.
- `node/Makefile`: swaps `cd: image-all cd-common` for `cd: cd-load-or-build cd-common`, with a one-line recipe calling the script. No inline shell in the Makefile.
- `.semaphore/push-images/node.yml`: adds the `google-service-account-for-gce` secret, `GOOGLE_PROJECT` / `GCS_BUILD_CACHE_BUCKET` env vars, and the gcloud auth prologue so the promotion can read `${GCS_WORKFLOW_DIR}`.

Fallback behavior preserves correctness on any master run - if `CHANGE_IN(node)` didn't fire in the main pipeline, the build blocks never ran, the cache is empty, and the script rebuilds from source the same as today.

Scoped to `node` as a proof of concept. If the numbers look good on a master run, same pattern should apply to istio (~34m rebuild), envoy (~17m), openstack packages (~13m), whisker, and mocknode.

## Known follow-ups

- FIPS amd64 is not currently produced by any main-pipeline block, so the promotion will cache-miss and rebuild it (~5m). Adding a FIPS build to `Build: node image` would push the main critical path out 3-5m - left for a follow-up once we can measure.
- `release-windows` in the same publish pipeline is untouched; different build flow.

```release-note
None
```