### PR TITLE
release: always produce calicoctl binaries to fix hashrelease packaging

### DIFF
--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1114,15 +1114,13 @@ func (r *CalicoManager) buildE2EBinaries() error {
 }
 
 func (r *CalicoManager) buildBinaries() error {
-	// Skip building binaries if we are building images
-	// binaries are built as part of "release-build" target.
-	if r.buildImages {
-		return nil
-	}
-	m := map[string]string{
-		"calicoctl":  "build-all",
-		"cni-plugin": "build-all",
-		"felix":      "release-build",
+	// calicoctl is no longer produced as a side effect of an image build after
+	// the consolidation in #12225, so build it unconditionally. cni-plugin and
+	// felix binaries are built as part of their image release-build targets.
+	m := map[string]string{"calicoctl": "build-all"}
+	if !r.buildImages {
+		m["cni-plugin"] = "build-all"
+		m["felix"] = "release-build"
 	}
 	env := append(os.Environ(),
 		fmt.Sprintf("VERSION=%s", r.calicoVersion),


### PR DESCRIPTION
The hashrelease packaging step copies \`calicoctl/bin/\` into the staged release output and currently fails with:

\`\`\`
failed to copy calicoctl/bin/ to .../bin/calicoctl: exit status 1: cp: cannot stat 'calicoctl/bin/': No such file or directory
\`\`\`

\`buildBinaries\` returns early when \`buildImages=true\`, on the assumption that the calicoctl binaries fall out of the calicoctl image build. After the calico binary consolidation in https://github.com/projectcalico/calico/pull/12225 the calicoctl image was removed, so nothing produces those binaries on the hashrelease path.

Build calicoctl unconditionally; cni-plugin and felix stay on the existing \`!buildImages\` branch since their binaries are still produced by their image release-build targets.

Targeted minimal fix to unblock master. A broader cleanup (including consolidating calicoctl into the cmd/calico binary) is in https://github.com/projectcalico/calico/pull/12624.

\`\`\`release-note
NONE
\`\`\`