### PR TITLE
Parallelize istio image-all builds

### DIFF
--- a/istio/Makefile
+++ b/istio/Makefile
@@ -33,9 +33,14 @@ include ../lib.Makefile
 ISTIO_DOWNLOADED = .istio.downloaded
 ZTUNNEL_DOWNLOADED = .ztunnel.downloaded
 
-.PHONY: init-istio-source init-ztunnel-source
+.PHONY: init-istio-source init-ztunnel-source init-sources
 init-istio-source: $(ISTIO_DOWNLOADED)
 init-ztunnel-source: $(ZTUNNEL_DOWNLOADED)
+
+# init-sources is a barrier: all upstream sources must be downloaded and
+# patched before any per-arch image build runs. Without it, parallel sub-makes
+# race on creating the shared stamp files.
+init-sources: $(ISTIO_DOWNLOADED) $(ZTUNNEL_DOWNLOADED)
 
 $(ISTIO_DOWNLOADED):
 	mkdir -p istio
@@ -89,9 +94,21 @@ ISTIO_PILOT_IMAGE_CREATED = .istio-pilot.created-$(ARCH)
 ISTIO_PROXYV2_IMAGE_CREATED = .istio-proxyv2.created-$(ARCH)
 ISTIO_ZTUNNEL_IMAGE_CREATED = .istio-ztunnel.created-$(ARCH)
 
-# Build images for all architectures
+# Build images for all architectures.
+#
+# Sources are downloaded once via the init-sources barrier, then per-arch
+# sub-makes run in parallel; each sub-image-% sub-make also builds its four
+# istio images concurrently via the inherited jobserver.
+#
+# DOCKER_RUN in lib.Makefile is :=-expanded (so GOARCH is baked at include
+# time), which is why per-arch parallelism has to be a sub-make per arch
+# rather than a flat target matrix in a single process.
+ISTIO_PARALLEL_JOBS ?= 4
+
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all:
+	$(MAKE) init-sources
+	$(MAKE) -j$(ISTIO_PARALLEL_JOBS) $(addprefix sub-image-,$(VALIDARCHES))
 
 sub-image-%:
 	$(MAKE) image ARCH=$*


### PR DESCRIPTION
The istio block of a hashrelease takes ~39 minutes today, the single biggest phase in the build. Most of that is the four istio images (install-cni, pilot, proxyv2, ztunnel) building one at a time, twice (amd64 and arm64), with no concurrency between them.

This restructures the istio Makefile so:

- `init-sources` is an explicit barrier - upstream istio + ztunnel sources are downloaded and patched once, before any per-arch sub-make starts. Without the barrier, parallel sub-makes would race on creating the shared `.istio.downloaded` / `.ztunnel.downloaded` stamp files.
- `image-all` then dispatches per-arch sub-makes in parallel under `-j$(ISTIO_PARALLEL_JOBS)` (default 4).
- Within each per-arch sub-make, `image: $(BUILD_IMAGES)` already lets the four istio images build concurrently via the inherited jobserver.

Net effect: up to 4 concurrent (image × arch) builds instead of 8 serial ones. Bounded at 4 to leave headroom for QEMU emulation memory pressure on arm64. Expected to cut the istio block roughly in half, with the long pole becoming arm64 ztunnel under QEMU.

One note for reviewers on why this isn't a flatter `make` graph: `DOCKER_RUN` in `lib.Makefile` is `:=`-expanded, which bakes `GOARCH` at include time. That's why per-arch parallelism keeps the recursive sub-make-per-arch shape rather than flattening to a single static-pattern matrix in one process.

Validation so far: `make -n image-all` parses cleanly and produces the expected per-arch recipes; concurrent stamp creation is safely guarded by the barrier. Will verify wall-clock with the next hashrelease run.

```release-note
None
```
