### PR TITLE
node, calicoctl: don't write .pyc files from pytest containers

### DIFF
--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -119,6 +119,7 @@ st: bin/calicoctl-linux-$(ARCH) version-helper
 	#   - This also provides access to calicoctl and the docker client
 	docker run --net=host --privileged \
 		   -e MY_IP=$(LOCAL_IP_ENV) \
+		   -e PYTHONDONTWRITEBYTECODE=1 \
 		   --rm -t \
 		   -v $(CERTS_PATH):/home/user/certs \
 		   -v $(CURDIR):/code \

--- a/node/Makefile
+++ b/node/Makefile
@@ -391,6 +391,7 @@ kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG)
 	    -v $(KUBECTL):/bin/kubectl \
 	    -v $(REPO_ROOT)/cmd/calico/bin/calico-$(ARCH):/usr/local/bin/calico \
 	    -e ROUTER_IMAGE=$(BIRD_IMAGE) \
+	    -e PYTHONDONTWRITEBYTECODE=1 \
 	    --privileged \
 	    --net host \
 	${TEST_CONTAINER_NAME} \


### PR DESCRIPTION
The node `kind-k8st-run-test` and calicoctl `st` Makefile targets bind-mount the source tree into a privileged container and run `pytest` as root. CPython writes `__pycache__/*.pyc` files alongside the imported modules, which means they land on the host as root-owned files. The unprivileged user running `make clean` later can't delete them, and `node/Makefile`'s existing `find . -name '*.pyc' -exec rm -f {} +` cleanup fails with permission errors.

Set `PYTHONDONTWRITEBYTECODE=1` in both containers so the cache files don't get written in the first place. Bytecode caching saves milliseconds of import time, but k8st / st runs take minutes end-to-end and the container is `--rm`'d after each run anyway, so the savings are noise.

Leaving the `find -name '*.pyc'` line in `node/Makefile`'s clean target as-is for one cycle to handle stragglers from prior runs.

```release-note
None
```
