### PR TITLE
Make deps file calculation more robust.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ DEP_FILES=$(patsubst %, %/deps.txt, $(GO_DIRS))
 gen-deps-files:
 	$(MAKE) -j$$(nproc) $(DEP_FILES)
 
-$(DEP_FILES): go.mod go.sum $(shell ./hack/list-go-sources.sh files) Makefile hack/cmd/deps/*
+$(DEP_FILES): go.mod go.sum $(shell ./hack/list-go-sources.sh files) Makefile ./hack/list-go-sources.sh hack/cmd/deps/*
 	@{ \
 	  echo "!!! GENERATED FILE, DO NOT EDIT !!!" && \
 	  echo "Run 'make gen-deps-files' to regenerate." && \

--- a/hack/list-go-sources.sh
+++ b/hack/list-go-sources.sh
@@ -37,7 +37,7 @@ list_dirs() {
   for d in */; do
     d=${d%/}
     excluded "$d" && continue
-    if find "$d" -name '*.go' -print -quit 2>/dev/null | read -r _; then
+    if find "$d" -type f -name '*.go' -print -quit 2>/dev/null | read -r _; then
       echo "$d"
     fi
   done


### PR DESCRIPTION
Couple of tweaks from enterprise merge code review:

- Make deps.txt depend on the list script.
- Only print files, avoid confusion with foo.go directory.
