### PR TITLE
[release 3.32] kube-controllers, goldmane: use default secure debug server (pick 12491)

### DIFF
--- a/goldmane/pkg/daemon/daemon.go
+++ b/goldmane/pkg/daemon/daemon.go
@@ -217,8 +217,7 @@ func Run(ctx context.Context, cfg Config) {
 	defer grpcServer.GracefulStop()
 
 	if cfg.ProfilePort != 0 {
-		// Start a profile server.
-		debugserver.StartDebugPprofServer("0.0.0.0", cfg.ProfilePort)
+		debugserver.StartDebugPprofServer("localhost", cfg.ProfilePort)
 	}
 
 	if cfg.PrometheusPort != 0 {

--- a/kube-controllers/cmd/kube-controllers/fv_test.go
+++ b/kube-controllers/cmd/kube-controllers/fv_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -234,6 +235,20 @@ var _ = Describe("kube-controllers metrics and pprof FV tests", func() {
 		return nil
 	}
 
+	// getFromContainerNS runs an HTTP GET from inside the kube-controllers
+	// network namespace.  This is needed for endpoints that bind to loopback
+	// only (e.g. the pprof debug server), which are not reachable from the host.
+	getFromContainerNS := func(url string) error {
+		cmd := exec.Command("docker", "run", "--rm",
+			"--network=container:"+kubectrls.Name,
+			os.Getenv("KUBE_IMAGE"), "wget", "-q", "-O", "/dev/null", "-T", "2", url)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("wget %q failed: %v: %s", url, err, string(out))
+		}
+		return nil
+	}
+
 	It("should not expose pprof endpoints on the prometheus port", func() {
 		// By checking that prometheus metrics are available on the default port.
 		metricsEndpoint := fmt.Sprintf("http://%s:9094", kubectrls.IP)
@@ -242,9 +257,14 @@ var _ = Describe("kube-controllers metrics and pprof FV tests", func() {
 		// By checking that pprof endpoints are not available on the prometheus port.
 		Expect(get(metricsEndpoint, "/debug/pprof/profile?seconds=1")).NotTo(Succeed())
 
-		// By checking that pprof endpoints are available on the pprof port.
+		// pprof binds to loopback only, so it must be queried from inside the
+		// container's network namespace.
+		Expect(getFromContainerNS("http://127.0.0.1:9095/debug/pprof/profile?seconds=1")).To(Succeed())
+
+		// Confirm that the pprof port is NOT reachable from outside the
+		// container (i.e. not bound to 0.0.0.0).
 		pprofEndpoint := fmt.Sprintf("http://%s:9095", kubectrls.IP)
-		Expect(get(pprofEndpoint, "/debug/pprof/profile?seconds=1")).To(Succeed())
+		Expect(get(pprofEndpoint, "/debug/pprof/profile?seconds=1")).NotTo(Succeed())
 	})
 })
 

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -236,7 +236,7 @@ func main() {
 	}
 
 	if runCfg.DebugProfilePort != 0 {
-		debugserver.StartDebugPprofServer("0.0.0.0", int(runCfg.DebugProfilePort))
+		debugserver.StartDebugPprofServer("localhost", int(runCfg.DebugProfilePort))
 	}
 
 	// Run the controllers. This runs until a config change triggers a restart

--- a/libcalico-go/lib/debugserver/debug_server.go
+++ b/libcalico-go/lib/debugserver/debug_server.go
@@ -25,7 +25,11 @@ import (
 )
 
 func StartDebugPprofServer(host string, port int) {
-	log.Infof("Insecure debug port is enabled on %s:%d.", host, port)
+	if host == "localhost" {
+		log.Infof("pprof debug server enabled on %s:%d. Use kubectl port-forward for remote access.", host, port)
+	} else {
+		log.Warnf("pprof debug server enabled on %s:%d. Endpoints are unauthenticated and expose heap dumps, goroutine stacks, and CPU profiles. Use localhost and kubectl port-forward for safe remote access.", host, port)
+	}
 	_ = httppprof.Profile // Make sure we don't accidentally lose the import.
 	go func() {
 		addr := net.JoinHostPort(host, strconv.Itoa(port))


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

The pprof debug server in kube-controllers and goldmane was binding to `0.0.0.0`, making it reachable from any pod in the cluster when enabled. Hardened to bind `localhost` only, matching felix/typha's existing default. Also upgraded the
 
 "debug port enabled" log line to `Warn` with a clearer message.                                                                                                                                                                                   
   
  Opt-in feature, off by default
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
kube-controllers, goldmane: use default secure pprof server (localhost only). Use `kubectl port-forward` for remote access. 
```
https://github.com/projectcalico/calico/pull/12491