### PR TITLE
OpenStack: delete 'mech_driver' global variable

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -188,14 +188,6 @@ PRIORITY_HIGH = 0
 PRIORITY_LOW = 1
 PRIORITY_RETRY = 2
 
-# This terrible global variable points to the running instance of the
-# Calico Mechanism Driver. This variable relies on the basic assertion that
-# any Neutron process, forked or not, should only ever have *one* Calico
-# Mechanism Driver in it. It's used by our monkeypatch of the
-# security_groups_rule_updated method below to locate the mechanism driver.
-# TODO(nj): Let's not do this anymore. Please?
-mech_driver = None
-
 
 def requires_state(f):
     """requires_state
@@ -340,11 +332,6 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
         # Last resync completion time
         self.last_resync_time = datetime.now()
-
-        # Tell the monkeypatch where we are.
-        global mech_driver
-        assert mech_driver is None
-        mech_driver = self
 
         # Make sure we initialise even if we don't see any API calls.
         eventlet.spawn_after(STARTUP_DELAY_SECS, self._post_fork_init, voting=True)
@@ -745,10 +732,6 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         if not self.db:
             self.db = plugin_dir.get_plugin()
             LOG.info("db = %s" % self.db)
-
-            # Update the reference to ourselves.
-            global mech_driver
-            mech_driver = self
 
     def bind_port(self, context):
         """bind_port

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/lib.py
@@ -343,7 +343,6 @@ class Lib(object):
         self.maxDiff = None
 
         # Create an instance of CalicoMechanismDriver.
-        mech_calico.mech_driver = None
         self.driver = mech_calico.CalicoMechanismDriver()
 
         # Hook the (mock) Neutron database.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_mech_calico.py
@@ -50,13 +50,9 @@ class TestMechanismDriverVoting(lib.Lib, unittest.TestCase):
         self.clientv3.get_prefix.return_value = []
         self.clientv3.watch_prefix.return_value = (iter(()), mock.Mock())
 
-        # Reset the driver
-        mech_calico.mech_driver = None
-
     def tearDown(self):
         # Reset global etcd client.
         etcdv3._client = None
-        mech_calico.mech_driver = None
 
         super(TestMechanismDriverVoting, self).tearDown()
 


### PR DESCRIPTION
We only needed this for a monkey-patching hack that was removed in https://github.com/projectcalico/calico/pull/10926
