### PR TITLE
felix/.semaphore: capture stderr in batch test.log

### DIFF
--- a/felix/.semaphore/batches.sh
+++ b/felix/.semaphore/batches.sh
@@ -65,7 +65,11 @@ run_batch() {
   #   a retry loop.
   # - nohup swallows the return code of the process so we use a 'bash -c'
   #   wrapper to capture it in a file.
-  VM_NAME="$vm_name" ${remote_exec} "nohup bash -c 'echo \$\$ > test.pid; $cmd_quot > test.log; echo \$? > test.rc' < /dev/null >& /dev/null & while [ ! -e test.log ]; do sleep 1; done"
+  # - We merge stderr into test.log (2>&1) so that any error emitted by make,
+  #   docker, or the wrapped test command after the test binary exits (e.g.
+  #   docker --rm cleanup hangs) is captured in the artifact rather than
+  #   silently discarded by the outer '>& /dev/null'.
+  VM_NAME="$vm_name" ${remote_exec} "nohup bash -c 'echo \$\$ > test.pid; $cmd_quot > test.log 2>&1; echo \$? > test.rc' < /dev/null >& /dev/null & while [ ! -e test.log ]; do sleep 1; done"
   echo "RUNNER: Started batch '$batch' on VM '$vm_name', monitoring log..." >> "$log_file"
 
   # Subshell to limit scope of trap.


### PR DESCRIPTION
Merge stderr into `test.log` (`2>&1`) inside the `nohup` wrapper that runs the remote test command, so anything emitted by `make`/`docker`/cleanup after the test binary exits (e.g. a hang in `docker run --rm` tearing down a privileged container) lands in the uploaded artifact.

Previously the outer `nohup ... >& /dev/null` swallowed stderr because the inner `> test.log` only redirected stdout, leaving the orchestrator with no diagnostic clue when `test.rc` never appeared and the watchdog killed the batch.

**Release note:**
```release-note
TBD
```
