### PR TITLE
[BPF] Explicitly detach tcx/netkit links during cleanup

### DIFF
--- a/felix/bpf/tc/cleanup.go
+++ b/felix/bpf/tc/cleanup.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path"
 	"slices"
 	"strings"
 
@@ -26,10 +27,12 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
+	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
-// CleanUpProgramsAndPins makes a best effort to remove all our TC BPF programs.
+// CleanUpProgramsAndPins makes a best effort to remove all of our BPF programs
+// and pinned state, covering legacy TC (clsact), TCX, and netkit attachments.
 func CleanUpProgramsAndPins() {
 	log.Debug("Trying to clean up any left-over BPF state from a previous run.")
 	bpftool := exec.Command("bpftool", "map", "list", "--json")
@@ -128,8 +131,46 @@ func CleanUpProgramsAndPins() {
 			}
 		}
 	}
-	// Remove all tcx and netkit pins
-	os.RemoveAll(bpfdefs.TcxPinDir)
-	os.RemoveAll(bpfdefs.NetkitPinDir)
+	// Detach and unpin any tcx and netkit links.  Removing the pin alone is
+	// usually enough — once the last reference goes away the kernel detaches —
+	// but explicitly calling Detach() makes the cleanup synchronous so the
+	// program is gone from the interface by the time we return.
+	detachAndRemoveLinkPins(bpfdefs.TcxPinDir)
+	detachAndRemoveLinkPins(bpfdefs.NetkitPinDir)
 	bpf.CleanUpCalicoPins(bpfdefs.DefaultBPFfsPath)
+}
+
+func detachAndRemoveLinkPins(pinDir string) {
+	entries, err := os.ReadDir(pinDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.WithError(err).WithField("dir", pinDir).Info("Failed to list link pin dir for cleanup")
+		}
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		pinPath := path.Join(pinDir, e.Name())
+		link, err := libbpf.OpenLink(pinPath)
+		if err != nil {
+			log.WithError(err).WithField("pin", pinPath).Info(
+				"Failed to open link pin; falling back to pin removal only")
+		} else {
+			if err := link.Detach(); err != nil {
+				log.WithError(err).WithField("pin", pinPath).Info(
+					"Failed to detach link; pin removal will let the kernel reap it")
+			}
+			if err := link.Close(); err != nil {
+				log.WithError(err).WithField("pin", pinPath).Debug("Failed to close link handle")
+			}
+		}
+		if err := os.Remove(pinPath); err != nil && !os.IsNotExist(err) {
+			log.WithError(err).WithField("pin", pinPath).Info("Failed to remove link pin")
+		}
+	}
+	if err := os.Remove(pinDir); err != nil && !os.IsNotExist(err) {
+		log.WithError(err).WithField("dir", pinDir).Debug("Failed to remove link pin dir")
+	}
 }


### PR DESCRIPTION
The cleanup path used by `calico-bpf cleanup` and by Felix when leaving BPF mode would remove the entire `/sys/fs/bpf/tcx` and `/sys/fs/bpf/netkit` directories with `os.RemoveAll`, relying on the kernel to auto-detach each `bpf_link` once its last reference went away. That's fine in the common case but is not synchronous and is not guaranteed if any other handle still references the link.

This change opens each pinned link, calls `Detach()` to actively detach the program from the interface, closes the FD, and only then unlinks the pin file. The detach step makes cleanup deterministic so the program is gone by the time the function returns. Each step logs and continues so a single bad pin doesn't abort the rest.

The legacy TC (clsact) cleanup path is unchanged.

**Release note:**
```release-note
TBD
```