### PR TITLE
Drop calico/go-build wrapper around e2e test run

### DIFF
--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -43,32 +43,46 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
 fi
 
 if [[ -n "${E2E_BINARY:-}" ]]; then
-  # Run the e2e binary directly via ginkgo inside calico/go-build.
   echo "[INFO] starting e2e tests..."
   pushd "${HOME}/calico" || exit
-  GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
-  docker run --rm --init --net=host \
-    -e LOCAL_USER_ID="$(id -u)" \
-    -e GOCACHE=/go-cache \
-    -e GOPATH=/go \
-    -e KUBECONFIG=/kubeconfig \
-    -e PRODUCT=${PRODUCT:-calico} \
-    ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
-    -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
-    -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
-    -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
-    -w /go/src/github.com/projectcalico/calico \
-    "calico/go-build:${GO_BUILD_VER}" \
-    make e2e-run \
-      KUBECONFIG=/kubeconfig \
-      E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
-      E2E_OUTPUT_DIR=report \
-      E2E_JUNIT_REPORT=junit.xml \
-    |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
+  if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
+    # Local-build path: run ginkgo inside calico/go-build so the build
+    # toolchain matches the one that produced the binary.
+    GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
+    docker run --rm --init --net=host \
+      -e LOCAL_USER_ID="$(id -u)" \
+      -e GOCACHE=/go-cache \
+      -e GOPATH=/go \
+      -e KUBECONFIG=/kubeconfig \
+      -e PRODUCT=${PRODUCT:-calico} \
+      ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
+      -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
+      -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
+      -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
+      -w /go/src/github.com/projectcalico/calico \
+      "calico/go-build:${GO_BUILD_VER}" \
+      make e2e-run \
+        KUBECONFIG=/kubeconfig \
+        E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
+        E2E_OUTPUT_DIR=report \
+        E2E_JUNIT_REPORT=junit.xml \
+      |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
+  else
+    # Pre-built binary path: the test binary is already on disk and the
+    # Semaphore runner has the Go toolchain ginkgo needs, so we can skip
+    # the calico/go-build pull (~2GB) and run on the host directly.
+    PRODUCT="${PRODUCT:-calico}" \
+      make e2e-run \
+        KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" \
+        E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
+        E2E_OUTPUT_DIR=report \
+        E2E_JUNIT_REPORT=junit.xml \
+      |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
+  fi
 
   # Copy JUnit XML to REPORT_DIR so the epilogue publishes it.
   mkdir -p "${REPORT_DIR}"

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -43,46 +43,25 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
 fi
 
 if [[ -n "${E2E_BINARY:-}" ]]; then
+  # The test binary is already on disk -- either built into
+  # ./e2e/bin/k8s/e2e.test by the local-build branch above (which runs
+  # the build inside calico/go-build via the Makefile) or downloaded
+  # from the hashrelease by the k8s-e2e branch. The Semaphore runner
+  # has the Go toolchain ginkgo needs to drive it, so we run on the
+  # host directly rather than wrapping in calico/go-build (~2GB pull).
   echo "[INFO] starting e2e tests..."
   pushd "${HOME}/calico" || exit
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
-  if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
-    # Local-build path: run ginkgo inside calico/go-build so the build
-    # toolchain matches the one that produced the binary.
-    GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
-    docker run --rm --init --net=host \
-      -e LOCAL_USER_ID="$(id -u)" \
-      -e GOCACHE=/go-cache \
-      -e GOPATH=/go \
-      -e KUBECONFIG=/kubeconfig \
-      -e PRODUCT=${PRODUCT:-calico} \
-      ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
-      -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
-      -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
-      -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
-      -w /go/src/github.com/projectcalico/calico \
-      "calico/go-build:${GO_BUILD_VER}" \
-      make e2e-run \
-        KUBECONFIG=/kubeconfig \
-        E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
-        E2E_OUTPUT_DIR=report \
-        E2E_JUNIT_REPORT=junit.xml \
-      |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
-  else
-    # Pre-built binary path: the test binary is already on disk and the
-    # Semaphore runner has the Go toolchain ginkgo needs, so we can skip
-    # the calico/go-build pull (~2GB) and run on the host directly.
-    PRODUCT="${PRODUCT:-calico}" \
-      make e2e-run \
-        KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" \
-        E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
-        E2E_OUTPUT_DIR=report \
-        E2E_JUNIT_REPORT=junit.xml \
-      |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
-  fi
+  PRODUCT="${PRODUCT:-calico}" \
+    make e2e-run \
+      KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" \
+      E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
+      E2E_OUTPUT_DIR=report \
+      E2E_JUNIT_REPORT=junit.xml \
+    |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
 
   # Copy JUnit XML to REPORT_DIR so the epilogue publishes it.
   mkdir -p "${REPORT_DIR}"

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -43,21 +43,40 @@ elif [[ "${TEST_TYPE}" == "k8s-e2e" ]]; then
 fi
 
 if [[ -n "${E2E_BINARY:-}" ]]; then
-  # The test binary is already on disk -- either built into
-  # ./e2e/bin/k8s/e2e.test by the local-build branch above (which runs
-  # the build inside calico/go-build via the Makefile) or downloaded
-  # from the hashrelease by the k8s-e2e branch. The Semaphore runner
-  # has the Go toolchain ginkgo needs to drive it, so we run on the
-  # host directly rather than wrapping in calico/go-build (~2GB pull).
   echo "[INFO] starting e2e tests..."
   pushd "${HOME}/calico" || exit
+
+  # Pick a runtime image. The local-build path already pulled
+  # calico/go-build to compile the binary, so reusing it for the run
+  # step is free. The hashrelease path didn't compile anything, so
+  # there's no reason to drag in the build toolchain -- use the
+  # official golang image (debian-bookworm base, glibc-compatible
+  # with the binary, ~800MB vs ~2GB).
+  if [[ -n "${RUN_LOCAL_TESTS:-}" ]]; then
+    GO_BUILD_VER=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2)
+    RUN_IMAGE="calico/go-build:${GO_BUILD_VER}"
+  else
+    GO_VERSION=$(grep '^GO_BUILD_VER=' ./metadata.mk | cut -d= -f2 | cut -d- -f1)
+    RUN_IMAGE="golang:${GO_VERSION}-bookworm"
+  fi
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
-  PRODUCT="${PRODUCT:-calico}" \
+  docker run --rm --init --net=host \
+    -e LOCAL_USER_ID="$(id -u)" \
+    -e GOCACHE=/go-cache \
+    -e GOPATH=/go \
+    -e KUBECONFIG=/kubeconfig \
+    -e PRODUCT=${PRODUCT:-calico} \
+    ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
+    -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
+    -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
+    -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \
+    -w /go/src/github.com/projectcalico/calico \
+    "${RUN_IMAGE}" \
     make e2e-run \
-      KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" \
+      KUBECONFIG=/kubeconfig \
       E2E_TEST_CONFIG="${E2E_TEST_CONFIG}" \
       E2E_OUTPUT_DIR=report \
       E2E_JUNIT_REPORT=junit.xml \

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -683,7 +683,7 @@ blocks:
   - name: "E2E tests on GCP kubeadm (local binary)"
     run:
       when: >-
-        true or change_in(['/e2e/**'],
+        true or change_in(['/e2e/**', '/.semaphore/end-to-end/'],
         {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
     dependencies:
       - Prerequisites

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -683,7 +683,7 @@ blocks:
   - name: "E2E tests on GCP kubeadm (local binary)"
     run:
       when: >-
-        true or change_in(['/e2e/**', '/.semaphore/end-to-end/'],
+        true or change_in(['/e2e/**', '/.semaphore/end-to-end/scripts/'],
         {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
     dependencies:
       - Prerequisites

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1735,7 +1735,7 @@ blocks:
   - name: "E2E tests on GCP kubeadm (local binary)"
     run:
       when: >-
-        false or change_in(['/e2e/**'],
+        false or change_in(['/e2e/**', '/.semaphore/end-to-end/'],
         {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
     dependencies:
       - Prerequisites

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1735,7 +1735,7 @@ blocks:
   - name: "E2E tests on GCP kubeadm (local binary)"
     run:
       when: >-
-        false or change_in(['/e2e/**', '/.semaphore/end-to-end/'],
+        false or change_in(['/e2e/**', '/.semaphore/end-to-end/scripts/'],
         {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
     dependencies:
       - Prerequisites

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
@@ -1,6 +1,6 @@
 - name: "E2E tests on GCP kubeadm (local binary)"
   run:
-    when: "${FORCE_RUN} or change_in(['/e2e/**', '/.semaphore/end-to-end/'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "${FORCE_RUN} or change_in(['/e2e/**', '/.semaphore/end-to-end/scripts/'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
@@ -1,6 +1,6 @@
 - name: "E2E tests on GCP kubeadm (local binary)"
   run:
-    when: "${FORCE_RUN} or change_in(['/e2e/**'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+    when: "${FORCE_RUN} or change_in(['/e2e/**', '/.semaphore/end-to-end/'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - Prerequisites
   task:


### PR DESCRIPTION
The e2e test phase script wraps `make e2e-run` in `calico/go-build` (~2GB pull every job) on both the local-build and hashrelease paths. The build toolchain is overkill for the run step — `make e2e-run` only needs Go to drive ginkgo against an already-existing `e2e.test` binary. Pick the runtime image based on the path:

- **Local-build path**: keep `calico/go-build`. The Makefile just pulled it to compile the binary (`e2e/Makefile:30-43`), so reusing it for the run step is free.
- **Hashrelease path**: switch to `golang:${GO_VERSION}-bookworm`. The path didn't compile anything, so there's no reason to drag in the LLVM/BPF toolchain. The official Go image is debian-bookworm-based, glibc-compatible with the binary, and runs ~800MB instead of ~2GB. `GO_VERSION` is parsed from `GO_BUILD_VER` in `metadata.mk` so the pin tracks the rest of the toolchain.

Also widens the change-detection filter on the GCP e2e block to fire on `.semaphore/end-to-end/` changes, so this PR (and future runner-script changes) actually exercises the GCP e2e job.

The binary is CGO=1 with libbpf (likely static)/libelf/libz/libc dynamically linked. `golang:bookworm` carries libc6/libelf1/zlib1g, so dynamic linkage and glibc symbol versions should resolve cleanly. CI will tell us if not.

```release-note
None
```
