### PR TITLE
Drop csi-node-driver-registrar from kind calico_versions.yml

### DIFF
--- a/hack/test/kind/infra/calico_versions.yml
+++ b/hack/test/kind/infra/calico_versions.yml
@@ -12,8 +12,6 @@ components:
     version: test-build
   calico:
     version: test-build
-  csi-node-driver-registrar:
-    version: test-build
   whisker:
     version: test-build
   envoy-gateway:


### PR DESCRIPTION
The OSS image consolidation in #12225 folded `csi-node-driver-registrar` into the combined `calico/calico` image, and tigera/operator master removed the `gen-versions` `defaultImages` mapping for it. The Enterprise counterpart cleanup landed in tigera/calico-private#11732, but the OSS port was missed: this entry is the last stale component reference still listed in `hack/test/kind/infra/calico_versions.yml`.

Currently it breaks every PR's `make kind-up` (the `.stamp.operator` step) with:

```
image not specified and no default image available for component "csi-node-driver-registrar".
Either fill in the 'image' field or update this code with a defaultImage.
make[2]: *** [lib.Makefile:1634: .../.stamp.operator] Error 1
```

Drop the entry so the `gen-versions` step matches the post-consolidation reality and unblocks OSS CI.

**Release note:**
```release-note
None
```