### PR TITLE
Remove old and unsed ipv6 support in BPF flag in felix fv

### DIFF
--- a/felix/fv/dscp_test.go
+++ b/felix/fv/dscp_test.go
@@ -59,7 +59,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 		options := infrastructure.DefaultTopologyOptions()
 		options.IPIPMode = apiv3.IPIPModeNever
 		options.EnableIPv6 = true
-		options.BPFEnableIPv6 = true
 		tc, client = infrastructure.StartNNodeTopology(2, options, infra)
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -140,9 +140,6 @@ func (f *Felix) TriggerDelayedStart() {
 
 func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	logrus.Info("Starting felix")
-	ipv6Enabled := fmt.Sprint(options.EnableIPv6)
-	bpfEnableIPv6 := fmt.Sprint(options.BPFEnableIPv6)
-
 	args := infra.GetDockerArgs()
 	args = append(args, "--privileged")
 
@@ -161,8 +158,7 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 		"FELIX_PROMETHEUSMETRICSENABLED": "true",
 		"FELIX_BPFLOGLEVEL":              "debug",
 		"FELIX_USAGEREPORTINGENABLED":    "false",
-		"FELIX_IPV6SUPPORT":              ipv6Enabled,
-		"FELIX_BPFIPV6SUPPORT":           bpfEnableIPv6,
+		"FELIX_IPV6SUPPORT":              fmt.Sprint(options.EnableIPv6),
 		// Disable log dropping, because it can cause flakes in tests that look for particular logs.
 		"FELIX_DEBUGDISABLELOGDROPPING": "true",
 	}

--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -51,15 +51,12 @@ type TopologyOptions struct {
 	FelixDebugFilenameRegex string
 	FelixCoreDumpsEnabled   bool
 	EnableIPv6              bool
-	// Temporary flag to implement and test IPv6 in bpf dataplane.
-	// TODO: Remove it when IPv6 implementation in BPF mode is complete.
-	BPFEnableIPv6     bool
-	ExtraEnvVars      map[string]string
-	ExtraVolumes      map[string]string
-	WithTypha         bool
-	WithFelixTyphaTLS bool
-	TestManagesBPF    bool
-	TyphaLogSeverity  string
+	ExtraEnvVars            map[string]string
+	ExtraVolumes            map[string]string
+	WithTypha               bool
+	WithFelixTyphaTLS       bool
+	TestManagesBPF          bool
+	TyphaLogSeverity        string
 	// In some cases, we rely on BIRD to program IPIP and noEncap routes. VXLAN routes are always programmed by Felix.
 	SimulateBIRDRoutes        bool
 	IPIPMode                  api.IPIPMode
@@ -116,7 +113,6 @@ func DefaultTopologyOptions() TopologyOptions {
 		FelixLogSeverity:      felixLogLevel,
 		FelixCoreDumpsEnabled: true,
 		EnableIPv6:            os.Getenv("FELIX_FV_ENABLE_BPF") != "true",
-		BPFEnableIPv6:         false,
 		ExtraEnvVars:          map[string]string{},
 		ExtraVolumes:          map[string]string{},
 		WithTypha:             false,


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Removing old and unused IPv6 support for BPF in Felix FVs.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
