### PR TITLE
Bump nftables to 1.1.4 in node and istio CNI install images

### DIFF
--- a/istio/Dockerfile-install-cni
+++ b/istio/Dockerfile-install-cni
@@ -14,16 +14,72 @@
 
 ARG CALICO_BASE
 
+# nft 1.0.x in AlmaLinux 9 BaseOS segfaults when listing or validating rulesets
+# that contain "udata"-bearing sets created by newer nft (1.1.x+) in the same
+# network namespace (see projectcalico/calico#11750). The fix is upstream
+# nftables commit be737a1, first released in 1.1.4. nftables 1.1.4 in turn
+# requires libnftnl >= 1.3.0, which is also newer than what AlmaLinux 9 ships,
+# so both are built from source below.
+ARG LIBNFTNL_VER=1.3.0
+ARG LIBNFTNL_SHA256=0f4be47a8bb8b77a350ee58cbd4b5fae6260ad486a527706ab15cfe1dd55a3c4
+ARG NFTABLES_VER=1.1.4
+ARG NFTABLES_SHA256=3444f0012af0472399eeae89a758b9c6dc5f311f6c67a48988fa1600fc4bac86
+
 # FIXME(jiawei): iptables-legacy is only available in EPEL 9. We can move to
 # AlmaLinux 10 once we have confirmed that iptables-legacy is no longer required.
 FROM almalinux:9 AS almalinux
 
+ARG LIBNFTNL_VER
+ARG LIBNFTNL_SHA256
+ARG NFTABLES_VER
+ARG NFTABLES_SHA256
+
 RUN dnf upgrade -y && dnf install -y epel-release
 
-RUN dnf install -y \
+RUN dnf --enablerepo=crb install -y \
   iptables-legacy \
   iptables-nft \
-  nftables
+  nftables \
+  # Build deps for nftables / libnftnl source builds.
+  curl \
+  gcc \
+  make \
+  autoconf \
+  automake \
+  bison \
+  flex \
+  gmp-devel \
+  jansson-devel \
+  libmnl-devel \
+  libtool \
+  pkgconfig \
+  xz
+
+# Build libnftnl from source. Required by nftables ${NFTABLES_VER}, which needs
+# libnftnl >= 1.3.0; AlmaLinux 9 only ships 1.2.6.
+RUN curl -sSfL --retry 5 -o /tmp/libnftnl.tar.xz \
+        https://netfilter.org/projects/libnftnl/files/libnftnl-${LIBNFTNL_VER}.tar.xz && \
+    echo "${LIBNFTNL_SHA256}  /tmp/libnftnl.tar.xz" | sha256sum -c - && \
+    tar xJ -C /root -f /tmp/libnftnl.tar.xz && rm -f /tmp/libnftnl.tar.xz && \
+    cd /root/libnftnl-${LIBNFTNL_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j"$(nproc)" && \
+    make install
+
+# Build nftables from source, overlaying the BaseOS package's nft binary and
+# libnftables shared library.
+RUN curl -sSfL --retry 5 -o /tmp/nftables.tar.xz \
+        https://netfilter.org/projects/nftables/files/nftables-${NFTABLES_VER}.tar.xz && \
+    echo "${NFTABLES_SHA256}  /tmp/nftables.tar.xz" | sha256sum -c - && \
+    tar xJ -C /root -f /tmp/nftables.tar.xz && rm -f /tmp/nftables.tar.xz && \
+    cd /root/nftables-${NFTABLES_VER} && \
+    # --with-json: knftables (used by Felix) parses nft JSON output;
+    # --without-cli: we never invoke the interactive shell (`nft -i`) and
+    #                 dropping it removes the editline build dep.
+    ./configure --prefix=/usr --libdir=/usr/lib64 --sbindir=/usr/sbin \
+                --disable-man-doc --with-json --without-cli && \
+    make -j"$(nproc)" && \
+    make install
 
 # Create symlinks to xtables-legacy-multi
 RUN set -eux; \

--- a/istio/Dockerfile-install-cni
+++ b/istio/Dockerfile-install-cni
@@ -40,8 +40,9 @@ RUN dnf --enablerepo=crb install -y \
   iptables-legacy \
   iptables-nft \
   nftables \
-  # Build deps for nftables / libnftnl source builds.
-  curl \
+  # Build deps for nftables / libnftnl source builds. curl-minimal is
+  # preinstalled in the AlmaLinux 9 base image, so don't pull in `curl`
+  # here — it conflicts with curl-minimal.
   gcc \
   make \
   autoconf \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,26 +18,51 @@ ARG UBI_IMAGE
 
 ARG RUNIT_VER=2.1.2
 
+# nft 1.0.x in UBI 9 / AlmaLinux 9 BaseOS segfaults when listing or validating
+# rulesets that contain "udata"-bearing sets created by newer nft (1.1.x+) in
+# the same network namespace. The fix is upstream nftables commit be737a1,
+# first released in 1.1.4. nftables 1.1.4 in turn requires libnftnl >= 1.3.0,
+# which is also newer than what AlmaLinux 9 ships, so both are built from
+# source below.
+ARG LIBNFTNL_VER=1.3.0
+ARG LIBNFTNL_SHA256=0f4be47a8bb8b77a350ee58cbd4b5fae6260ad486a527706ab15cfe1dd55a3c4
+ARG NFTABLES_VER=1.1.4
+ARG NFTABLES_SHA256=3444f0012af0472399eeae89a758b9c6dc5f311f6c67a48988fa1600fc4bac86
+
 FROM ${BPFTOOL_IMAGE} AS bpftool
 
 FROM ${BIRD_IMAGE} AS bird
 
-# Use this build stage to install iptables-legacy and build runit binaries.
-# We need to build runit because there aren't any rpms for it in AlmaLinux or ubi repositories.
+# Use this build stage to install iptables-legacy, build runit binaries, and
+# build a recent nftables (with libnftnl) from source.
 FROM almalinux:9 AS almalinux
 
 ARG RUNIT_VER
+ARG LIBNFTNL_VER
+ARG LIBNFTNL_SHA256
+ARG NFTABLES_VER
+ARG NFTABLES_SHA256
 
 RUN dnf upgrade -y && dnf install -y epel-release
 
 RUN dnf --enablerepo=crb install -y \
     iptables-legacy \
-    # Needed for building runit
+    # Needed for building runit and nftables
     gcc \
     glibc-static \
-    patch
-
-RUN dnf clean all
+    make \
+    patch \
+    # Build deps for nftables / libnftnl
+    autoconf \
+    automake \
+    bison \
+    flex \
+    gmp-devel \
+    jansson-devel \
+    libmnl-devel \
+    libtool \
+    pkgconfig \
+    xz
 
 # Copy the patch that adjusts svlogd log file permissions from 0744 to 0644.
 # This file is used in the next step to apply the patch during the build process.
@@ -50,6 +75,47 @@ RUN curl -sSfL --retry 5 -o /tmp/runit.tar.gz https://ftp.debian.org/debian/pool
     cd /root/admin/runit-${RUNIT_VER} && \
     patch -p1 < /svlogd_use_0644_permission_instead_of_0744.patch && \
     package/compile
+
+# Build libnftnl from source. Required by nftables ${NFTABLES_VER}, which needs
+# libnftnl >= 1.3.0; AlmaLinux 9 only ships 1.2.6.
+RUN curl -sSfL --retry 5 -o /tmp/libnftnl.tar.xz \
+        https://netfilter.org/projects/libnftnl/files/libnftnl-${LIBNFTNL_VER}.tar.xz && \
+    echo "${LIBNFTNL_SHA256}  /tmp/libnftnl.tar.xz" | sha256sum -c - && \
+    tar xJ -C /root -f /tmp/libnftnl.tar.xz && rm -f /tmp/libnftnl.tar.xz && \
+    cd /root/libnftnl-${LIBNFTNL_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j"$(nproc)" && \
+    make install
+
+# Build nftables from source. We ship this in place of the BaseOS nftables
+# package because UBI/AlmaLinux nftables (<= 1.0.x) crashes on udata-bearing
+# sets created by newer nft binaries in the same network namespace.
+# Install into a clean DESTDIR so the runtime image only picks up the bits we
+# actually want to overlay onto the BaseOS install.
+RUN curl -sSfL --retry 5 -o /tmp/nftables.tar.xz \
+        https://netfilter.org/projects/nftables/files/nftables-${NFTABLES_VER}.tar.xz && \
+    echo "${NFTABLES_SHA256}  /tmp/nftables.tar.xz" | sha256sum -c - && \
+    tar xJ -C /root -f /tmp/nftables.tar.xz && rm -f /tmp/nftables.tar.xz && \
+    cd /root/nftables-${NFTABLES_VER} && \
+    # --with-json: knftables (used by Felix) parses nft JSON output;
+    # --without-cli: we never invoke the interactive shell (`nft -i`) and
+    #                 dropping it removes the editline build dep.
+    ./configure --prefix=/usr --libdir=/usr/lib64 --sbindir=/usr/sbin \
+                --disable-man-doc --with-json --without-cli && \
+    make -j"$(nproc)" && \
+    make install DESTDIR=/nft-install && \
+    # Strip headers, pkg-config, static archives, and libtool .la files; we
+    # only want the runtime binary and shared libraries in the final image.
+    rm -rf /nft-install/usr/include \
+           /nft-install/usr/lib64/pkgconfig \
+           /nft-install/usr/lib64/*.la \
+           /nft-install/usr/lib64/*.a \
+           /nft-install/usr/share && \
+    # Stage libnftnl runtime libs alongside the nftables artifacts so a single
+    # COPY in the runtime image overlays both.
+    cp -a /usr/lib64/libnftnl.so* /nft-install/usr/lib64/
+
+RUN dnf clean all
 
 FROM ${UBI_IMAGE} AS ubi
 
@@ -102,6 +168,14 @@ COPY --from=almalinux /root/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 COPY --from=almalinux /usr/sbin/xtables-legacy-multi /usr/sbin/xtables-legacy-multi
 COPY --from=almalinux /lib64/libip4tc.so.2 /lib64/libip4tc.so.2
 COPY --from=almalinux /lib64/libip6tc.so.2 /lib64/libip6tc.so.2
+
+# Overlay the nft binary and libnftables / libnftnl shared libraries built
+# from source in the almalinux stage. This replaces the BaseOS nftables
+# (1.0.x), which segfaults on udata-bearing sets created by newer nft
+# binaries in the same network namespace (see projectcalico/calico#11750).
+# The microdnf install of nftables above remains so its runtime deps
+# (jansson, gmp, readline, ...) are still present.
+COPY --from=almalinux /nft-install/ /
 
 # Set symbolic links for iptables-legacy binaries
 RUN set -eux; \


### PR DESCRIPTION
The nftables binary shipped in UBI 9 / AlmaLinux 9 BaseOS (1.0.x) segfaults when it has to list or validate a ruleset that contains udata-bearing sets created by newer nft (1.1.x+) in the same network namespace. Reports of this in calico/node show up as repeated dataplane resync failures and core dumps that fill node disks. The relevant upstream fix is in nftables 1.1.4.

This builds libnftnl 1.3.0 and nftables 1.1.4 from source in the existing almalinux build stage and overlays them on top of the BaseOS install in both `node/Dockerfile` and `istio/Dockerfile-install-cni`. We keep the BaseOS `nftables` package install in the runtime stage so its transitive runtime deps (jansson, gmp, libmnl, ...) stay satisfied.

The earlier knftables bump in #12472 fixed the list-side path (it scopes list calls to our own table), but transactional writes via `nft -f -` and `nft --check -f -` still walk full kernel state internally and trip the same parser bug — that's what this PR addresses.

Fixes #11750

```release-note
Fixes nft binary segfaults in calico/node and the Istio CNI install image when newer nftables (>= 1.1.x) is in use elsewhere on the host.
```