### PR TITLE
Add key-cert-provisioner image to kind-build-images

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1598,7 +1598,8 @@ KIND_IMAGES = $(KIND_OPERATOR_IMAGE) $(KIND_CALICO_IMAGES)
 KIND_IMAGE_MARKERS = \
 	$(REPO_ROOT)/node/.image.created-$(ARCH) \
 	$(REPO_ROOT)/whisker/.image.created-$(ARCH) \
-	$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+	$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) \
+	$(REPO_ROOT)/key-cert-provisioner/.image.created-$(ARCH)
 
 $(REPO_ROOT)/node/.image.created-$(ARCH): $(call local-deps-go-files,node)
 	$(MAKE) -C $(REPO_ROOT)/node image
@@ -1610,6 +1611,10 @@ $(REPO_ROOT)/whisker/.image.created-$(ARCH):
 
 $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH): $(call local-deps-go-files,cmd)
 	$(MAKE) -C $(REPO_ROOT)/cmd/calico image
+
+$(REPO_ROOT)/key-cert-provisioner/.image.created-$(ARCH): $(call local-deps-go-files,key-cert-provisioner)
+	$(MAKE) -C $(REPO_ROOT)/key-cert-provisioner image
+	touch $@
 
 # Operator is built from a separate repo/branch. It only needs
 # calico_versions.yml (a static file with version strings), not the


### PR DESCRIPTION
## Summary

The Calico operator inserts `*-key-cert-provisioner` init containers into several rendered components (calico-apiserver, calico-node, etc.) when certificate management is configured. The image is referenced in the chart CRDs as a supported init-container name, but was missing from `KIND_IMAGE_MARKERS`, so a clean kind bringup left the image unloaded and dependent pods could fail with ImagePullBackOff for `calico/key-cert-provisioner:test-build`.

This adds `key-cert-provisioner` to the list so it is built and tagged alongside the other component images consumed by `kind-deploy`.

## Test plan
- [ ] `make kind-up` from a clean state succeeds without manually building/loading `key-cert-provisioner`.
- [ ] Existing `make e2e-test` runs continue to pass.
- [ ] 
```release-note
Build the key-cert-provisioner image as part of kind-build-images.
```