### PR TITLE
calicoctl cluster diags: support manifest installs

### DIFF
--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -519,17 +519,22 @@ func collectCalicoRelatedNamespaces(dir string, namespaces set.Typed[string]) {
 	}
 	commands := []common.Cmd{}
 	for ns := range namespaces.All() {
-		filter := ""
+		// Build the base argv as a slice (not a string) because the label
+		// selector contains spaces (e.g. "k8s-app in (...)") which would be
+		// mangled if we let strings.Fields tokenise it.
+		base := []string{"kubectl", "get", "all", "-n", ns}
 		if !isCalicoNamedNamespace(ns) {
-			filter = fmt.Sprintf(" -l '%s'", calicoWorkloadSelector)
+			base = append(base, "-l", calicoWorkloadSelector)
 		}
+		yamlArgs := append(append([]string{}, base...), "-o", "yaml")
+		wideArgs := append(append([]string{}, base...), "-o", "wide")
 		commands = append(commands, common.Cmd{
 			Info:     fmt.Sprintf("Collect all in %s (yaml)", ns),
-			CmdStr:   fmt.Sprintf("kubectl get all -n %s%s -o yaml", ns, filter),
+			CmdArgs:  yamlArgs,
 			FilePath: fmt.Sprintf("%s/%s.yaml", dir, ns),
 		}, common.Cmd{
 			Info:     fmt.Sprintf("Collect all in %s (wide text)", ns),
-			CmdStr:   fmt.Sprintf("kubectl get all -n %s%s -o wide", ns, filter),
+			CmdArgs:  wideArgs,
 			FilePath: fmt.Sprintf("%s/%s.txt", dir, ns),
 		})
 	}

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -175,11 +175,13 @@ func collectDiags(opts *diagOpts) error {
 	// Skip the per-node BPF dumps if the BPF dataplane isn't enabled —
 	// they are slow and on iptables/nftables clusters produce no useful data.
 	bpfEnabled := isBPFEnabled(calicoClient)
+	calicoNamespaces := set.New[string]()
 	if kubeClient != nil {
+		calicoNamespaces = discoverCalicoNamespaces(kubeClient)
 		collectTLSSecrets(kubeClient, dir+"/tls")
-		collectSelectedNodeLogs(kubeClient, dir+"/nodes", dir+"/links", opts, bpfEnabled)
+		collectSelectedNodeLogs(kubeClient, dir+"/nodes", dir+"/links", opts, bpfEnabled, calicoNamespaces)
 	}
-	collectGlobalClusterInformation(dir + "/cluster")
+	collectGlobalClusterInformation(dir+"/cluster", calicoNamespaces)
 	collectUnsupportedAnnotations(tempDir, directoryName)
 	createArchive(tempDir, directoryName, archiveName)
 
@@ -208,7 +210,7 @@ func isBPFEnabled(calicoClient clientv3.Interface) bool {
 	return *fc.Spec.BPFEnabled
 }
 
-func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts, bpfEnabled bool) {
+func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts, bpfEnabled bool, calicoNamespaces set.Typed[string]) {
 	// If --focus-nodes is specified, put those node names at the start of the node list.
 	nodeList := strings.Split(opts.FocusNodes, ",")
 
@@ -239,14 +241,23 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 		return
 	}
 	for _, ns := range nsl.Items {
-		if !strings.Contains(ns.Name, "calico") && !strings.Contains(ns.Name, "tigera") {
+		if !calicoNamespaces.Contains(ns.Name) {
 			continue
 		}
 
 		fmt.Printf("Collecting detailed diags for namespace %v...\n", ns.Name)
 
+		// For namespaces whose name doesn't itself indicate Calico/Tigera (e.g. kube-system
+		// when Calico is installed via manifests), restrict workload listings to known
+		// Calico components plus kube-proxy.  Otherwise we'd pick up every unrelated workload
+		// in kube-system (CSI drivers, kube-proxy variants, etc.).
+		listOpts := v1.ListOptions{}
+		if !isCalicoNamedNamespace(ns.Name) {
+			listOpts.LabelSelector = calicoWorkloadSelector
+		}
+
 		// Iterate through DaemonSets in this namespace.
-		dsl, err := kubeClient.AppsV1().DaemonSets(ns.Name).List(context.TODO(), v1.ListOptions{})
+		dsl, err := kubeClient.AppsV1().DaemonSets(ns.Name).List(context.TODO(), listOpts)
 		if err != nil {
 			fmt.Printf("ERROR listing DaemonSets in namespace %v: %v\n", ns.Name, err)
 			// Continue because deployments or other namespaces might work.
@@ -257,7 +268,7 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 		}
 
 		// Iterate through Deployments in this namespace.
-		dl, err := kubeClient.AppsV1().Deployments(ns.Name).List(context.TODO(), v1.ListOptions{})
+		dl, err := kubeClient.AppsV1().Deployments(ns.Name).List(context.TODO(), listOpts)
 		if err != nil {
 			fmt.Printf("ERROR listing Deployments in namespace %v: %v\n", ns.Name, err)
 			// Continue because other namespaces might work.
@@ -268,7 +279,7 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 		}
 
 		// Iterate through StatefulSets in this namespace.
-		sl, err := kubeClient.AppsV1().StatefulSets(ns.Name).List(context.TODO(), v1.ListOptions{})
+		sl, err := kubeClient.AppsV1().StatefulSets(ns.Name).List(context.TODO(), listOpts)
 		if err != nil {
 			fmt.Printf("ERROR listing StatefulSets in namespace %v: %v\n", ns.Name, err)
 			// Continue because other namespaces might work.
@@ -278,6 +289,60 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			}
 		}
 	}
+}
+
+// calicoWorkloadSelector matches Calico components and kube-proxy.  kube-proxy is
+// included because kube-proxy state is frequently load-bearing when debugging
+// Calico connectivity issues, and its absence from diags bundles on manifest
+// installs has been a recurring gap.
+const calicoWorkloadSelector = "k8s-app in (calico-node,calico-kube-controllers,calico-typha,kube-proxy)"
+
+// isCalicoNamedNamespace returns true if the namespace name itself is a
+// Calico/Tigera namespace (calico-system, tigera-operator, tigera-prometheus,
+// etc.), in which case dumping the whole namespace is appropriate.
+func isCalicoNamedNamespace(name string) bool {
+	return strings.Contains(name, "calico") || strings.Contains(name, "tigera")
+}
+
+// discoverCalicoNamespaces returns the set of namespaces that host Calico
+// components, regardless of whether Calico is operator-managed (calico-system,
+// tigera-operator) or manifest-installed (typically kube-system).
+//
+// The set always includes any namespace whose name contains "calico" or
+// "tigera" (so Tigera Enterprise sub-namespaces are still picked up even when
+// they don't contain a labelled Calico pod), plus any namespace containing a
+// pod with one of the known Calico component labels.
+func discoverCalicoNamespaces(kubeClient kubernetes.Interface) set.Typed[string] {
+	namespaces := set.New[string]()
+
+	nsl, err := kubeClient.CoreV1().Namespaces().List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		fmt.Printf("ERROR listing namespaces while discovering Calico namespaces: %v\n", err)
+	} else {
+		for _, ns := range nsl.Items {
+			if isCalicoNamedNamespace(ns.Name) {
+				namespaces.Add(ns.Name)
+			}
+		}
+	}
+
+	for _, selector := range []string{
+		"k8s-app=calico-node",
+		"k8s-app=calico-kube-controllers",
+		"k8s-app=calico-typha",
+		"k8s-app=tigera-operator",
+	} {
+		pl, err := kubeClient.CoreV1().Pods("").List(context.TODO(), v1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			fmt.Printf("ERROR listing pods with selector %q: %v\n", selector, err)
+			continue
+		}
+		for _, p := range pl.Items {
+			namespaces.Add(p.Namespace)
+		}
+	}
+
+	return namespaces
 }
 
 func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient kubernetes.Interface, nodeList []string, bpfEnabled bool, ns string, selector *v1.LabelSelector) {
@@ -440,31 +505,34 @@ func collectCalicoResource(dir string) {
 	common.ExecAllCmdsWriteToFile(commands)
 }
 
-func collectCalicoSystemNamespace(dir string) {
+// collectCalicoRelatedNamespaces dumps the contents of each namespace that
+// hosts Calico components.  For namespaces whose name itself indicates
+// Calico/Tigera, the entire namespace contents are collected.  For other
+// namespaces (e.g. kube-system on a manifest install) the dump is restricted
+// via label selector to Calico components plus kube-proxy, so we don't pull in
+// unrelated workloads like CSI drivers.
+func collectCalicoRelatedNamespaces(dir string, namespaces set.Typed[string]) {
+	if namespaces.Len() == 0 {
+		// Fall back to the historical behaviour so we still produce something
+		// useful when the kube client wasn't available to run discovery.
+		namespaces = set.From(common.CalicoNamespace, common.TigeraOperatorNamespace)
+	}
 	commands := []common.Cmd{}
-	commands = append(commands, common.Cmd{
-		Info:     fmt.Sprintf("Collect all in %s (yaml)", common.CalicoNamespace),
-		CmdStr:   fmt.Sprintf("kubectl get all -n %s -o yaml", common.CalicoNamespace),
-		FilePath: fmt.Sprintf("%s/calico-system.yaml", dir),
-	}, common.Cmd{
-		Info:     fmt.Sprintf("Collect all in %s (wide text)", common.CalicoNamespace),
-		CmdStr:   fmt.Sprintf("kubectl get all -n %s -o wide", common.CalicoNamespace),
-		FilePath: fmt.Sprintf("%s/calico-system.txt", dir),
-	})
-	common.ExecAllCmdsWriteToFile(commands)
-}
-
-func collectTigeraOperatorNamespace(dir string) {
-	commands := []common.Cmd{}
-	commands = append(commands, common.Cmd{
-		Info:     fmt.Sprintf("Collect all in %s (yaml)", common.TigeraOperatorNamespace),
-		CmdStr:   fmt.Sprintf("kubectl get all -n %s -o yaml", common.TigeraOperatorNamespace),
-		FilePath: fmt.Sprintf("%s/tigera-operator.yaml", dir),
-	}, common.Cmd{
-		Info:     fmt.Sprintf("Collect all in %s (wide text)", common.TigeraOperatorNamespace),
-		CmdStr:   fmt.Sprintf("kubectl get all -n %s -o wide", common.TigeraOperatorNamespace),
-		FilePath: fmt.Sprintf("%s/tigera-operator.txt", dir),
-	})
+	for ns := range namespaces.All() {
+		filter := ""
+		if !isCalicoNamedNamespace(ns) {
+			filter = fmt.Sprintf(" -l '%s'", calicoWorkloadSelector)
+		}
+		commands = append(commands, common.Cmd{
+			Info:     fmt.Sprintf("Collect all in %s (yaml)", ns),
+			CmdStr:   fmt.Sprintf("kubectl get all -n %s%s -o yaml", ns, filter),
+			FilePath: fmt.Sprintf("%s/%s.yaml", dir, ns),
+		}, common.Cmd{
+			Info:     fmt.Sprintf("Collect all in %s (wide text)", ns),
+			CmdStr:   fmt.Sprintf("kubectl get all -n %s%s -o wide", ns, filter),
+			FilePath: fmt.Sprintf("%s/%s.txt", dir, ns),
+		})
+	}
 	common.ExecAllCmdsWriteToFile(commands)
 }
 
@@ -684,7 +752,7 @@ func censorSecret(secret *apiv1.Secret) {
 }
 
 // collectGlobalClusterInformation collects the Kubernetes resource, Calico Resource and Tigera operator details
-func collectGlobalClusterInformation(dir string) {
+func collectGlobalClusterInformation(dir string, calicoNamespaces set.Typed[string]) {
 	fmt.Println("Collecting kubernetes version...")
 	common.ExecAllCmdsWriteToFile([]common.Cmd{
 		{
@@ -695,8 +763,7 @@ func collectGlobalClusterInformation(dir string) {
 	})
 
 	collectCalicoResource(dir + "/crd")
-	collectTigeraOperatorNamespace(dir + "/tigera-operator")
-	collectCalicoSystemNamespace(dir + "/calico-system")
+	collectCalicoRelatedNamespaces(dir+"/namespaces", calicoNamespaces)
 	collectKubernetesResource(dir + "/kubernetes")
 	collectThirdPartyResource(dir + "/third-party")
 }

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
@@ -192,4 +194,52 @@ func cmdStrs(cmds []common.Cmd) []string {
 		out[i] = c.CmdStr
 	}
 	return out
+}
+
+func TestDiscoverCalicoNamespaces(t *testing.T) {
+	RegisterTestingT(t)
+
+	mkNS := func(name string) *apiv1.Namespace {
+		return &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+	mkPod := func(ns, name string, labels map[string]string) *apiv1.Pod {
+		return &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: labels},
+		}
+	}
+
+	// Operator-style cluster: pods in calico-system / tigera-operator, plus
+	// auxiliary tigera namespace with no labelled pods.
+	t.Run("operator install", func(t *testing.T) {
+		RegisterTestingT(t)
+		client := fake.NewSimpleClientset(
+			mkNS("kube-system"),
+			mkNS("default"),
+			mkNS("calico-system"),
+			mkNS("tigera-operator"),
+			mkNS("tigera-prometheus"),
+			mkPod("calico-system", "calico-node-abc", map[string]string{"k8s-app": "calico-node"}),
+			mkPod("calico-system", "calico-kube-controllers-1", map[string]string{"k8s-app": "calico-kube-controllers"}),
+			mkPod("tigera-operator", "tigera-operator-1", map[string]string{"k8s-app": "tigera-operator"}),
+			mkPod("kube-system", "kube-proxy-1", map[string]string{"k8s-app": "kube-proxy"}),
+		)
+		got := discoverCalicoNamespaces(client).Slice()
+		Expect(got).To(ConsistOf("calico-system", "tigera-operator", "tigera-prometheus"))
+	})
+
+	// Manifest install: calico-node lives in kube-system.  Discovery must
+	// surface kube-system even though its name doesn't contain "calico"
+	// or "tigera".
+	t.Run("manifest install", func(t *testing.T) {
+		RegisterTestingT(t)
+		client := fake.NewSimpleClientset(
+			mkNS("kube-system"),
+			mkNS("default"),
+			mkPod("kube-system", "calico-node-xyz", map[string]string{"k8s-app": "calico-node"}),
+			mkPod("kube-system", "calico-kube-controllers-1", map[string]string{"k8s-app": "calico-kube-controllers"}),
+			mkPod("kube-system", "kube-proxy-1", map[string]string{"k8s-app": "kube-proxy"}),
+		)
+		got := discoverCalicoNamespaces(client).Slice()
+		Expect(got).To(ConsistOf("kube-system"))
+	})
 }

--- a/calicoctl/calicoctl/commands/common/cmd.go
+++ b/calicoctl/calicoctl/commands/common/cmd.go
@@ -95,11 +95,26 @@ func KubectlExists() error {
 
 // Cmd is a struct to hold a command to execute, info description to print and a
 // filepath location for where output should be written to.
+//
+// Set exactly one of CmdStr or CmdArgs.  CmdStr is convenient for simple
+// commands whose tokenisation matches whitespace splitting.  Use CmdArgs when
+// any individual argument contains whitespace (e.g. a kubectl label selector
+// like "k8s-app in (a,b,c)") — strings.Fields would otherwise mangle it.
 type Cmd struct {
 	Info     string
 	CmdStr   string
+	CmdArgs  []string
 	FilePath string
 	SymLink  string
+}
+
+// resolved returns the argv to execute and a human-readable rendering for
+// logs, deriving whichever of CmdStr / CmdArgs wasn't supplied.
+func (c Cmd) resolved() (args []string, display string) {
+	if c.CmdArgs != nil {
+		return c.CmdArgs, strings.Join(c.CmdArgs, " ")
+	}
+	return strings.Fields(c.CmdStr), c.CmdStr
 }
 
 // ExecCmdWriteToFile executes the provided command c and outputs the result to a
@@ -119,13 +134,13 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 		return
 	}
 
-	parts := strings.Fields(c.CmdStr)
+	parts, display := c.resolved()
 	logCtx.Debugf("cmd tokens: [%+v]", parts)
 
-	logCtx.Debugf("Executing command: %+v ... ", c.CmdStr)
+	logCtx.Debugf("Executing command: %+v ... ", display)
 	content, err := exec.Command(parts[0], parts[1:]...).CombinedOutput()
 	if err != nil {
-		fmt.Printf("%s Failed to run command: %s\nError: %s\n", logPrefix, c.CmdStr, string(content))
+		fmt.Printf("%s Failed to run command: %s\nError: %s\n", logPrefix, display, string(content))
 	}
 
 	// This is for the commands we want to run but don't want to save the output

--- a/calicoctl/calicoctl/commands/common/cmd_test.go
+++ b/calicoctl/calicoctl/commands/common/cmd_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCmdResolved(t *testing.T) {
+	RegisterTestingT(t)
+
+	// CmdStr path: whitespace-split as before.
+	args, display := Cmd{CmdStr: "kubectl get pods -o yaml"}.resolved()
+	Expect(args).To(Equal([]string{"kubectl", "get", "pods", "-o", "yaml"}))
+	Expect(display).To(Equal("kubectl get pods -o yaml"))
+
+	// CmdArgs path: argv used verbatim so args with embedded whitespace
+	// (e.g. a kubectl label selector) survive intact.
+	cmd := Cmd{CmdArgs: []string{
+		"kubectl", "get", "all", "-n", "kube-system",
+		"-l", "k8s-app in (calico-node,kube-proxy)",
+		"-o", "yaml",
+	}}
+	args, display = cmd.resolved()
+	Expect(args).To(Equal(cmd.CmdArgs))
+	Expect(args[6]).To(Equal("k8s-app in (calico-node,kube-proxy)"))
+	Expect(display).To(ContainSubstring("k8s-app in (calico-node,kube-proxy)"))
+}


### PR DESCRIPTION
`calicoctl cluster diags` previously filtered namespaces by name (substring match on `calico`/`tigera`) and hard-coded the namespace dumps to `calico-system` and `tigera-operator`. Manifest-based installs put `calico-node`, `calico-kube-controllers`, and `calico-typha` in `kube-system`, so the resulting bundle contained no per-pod logs, describes, or calico-node dataplane diagnostics for those clusters — the most useful data was missing.

This PR discovers Calico namespaces by listing pods with the known component labels (`k8s-app=calico-node`, `calico-kube-controllers`, `calico-typha`, `tigera-operator`) cluster-wide, unioned with any namespace whose name contains `calico`/`tigera` (so Tigera Enterprise sub-namespaces are still picked up).

For namespaces whose name doesn't itself indicate Calico (e.g. `kube-system`), workload listings and the namespace dump are restricted via label selector to Calico components plus `kube-proxy`, so the bundle doesn't pull in every unrelated `kube-system` workload. `kube-proxy` is included deliberately — its state is frequently load-bearing when debugging Calico connectivity issues and has been a recurring gap in diags bundles.

The output path for namespace dumps moves from `cluster/calico-system/` and `cluster/tigera-operator/` to `cluster/namespaces/<ns>.yaml|.txt` so additional discovered namespaces (kube-system, tigera-prometheus, etc.) sit alongside each other.

**Test plan**

- [x] `go test ./calicoctl/calicoctl/commands/cluster/...` — added `TestDiscoverCalicoNamespaces` covering both operator and manifest installs via the client-go fake.
- [ ] Run against a real manifest-installed kind cluster: confirm `nodes/<node>/kube-system/calico-node-*.log` and `cluster/namespaces/kube-system.yaml` exist, and the kube-system dump is restricted to Calico components and kube-proxy.
- [ ] Run against an operator-installed cluster (regression): confirm `cluster/namespaces/calico-system.yaml` and `cluster/namespaces/tigera-operator.yaml` are populated as before.

**Release note:**
```release-note
calicoctl cluster diags now supports manifest-based Calico installs (where Calico components run in kube-system) in addition to operator-based installs. The bundle also captures kube-proxy state.
```