### PR TITLE
Fix parallel libbpf clone race in kind-build-images

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1601,7 +1601,21 @@ KIND_IMAGE_MARKERS = \
 	$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) \
 	$(REPO_ROOT)/key-cert-provisioner/.image.created-$(ARCH)
 
-$(REPO_ROOT)/node/.image.created-$(ARCH): $(call local-deps-go-files,node)
+# Shared libbpf marker. Both node and cmd/calico (and the felix
+# sub-make steps invoked from them) need libbpf, and `kind-build-images`
+# runs the per-image markers under `make -j`. Without a shared prereq,
+# the parallel sub-makes race in felix/bpf-gpl on both the clone (each
+# runs `rm -rf libbpf && git clone`, one fails with "destination path
+# 'libbpf' already exists") and the compile (both write to the same .o
+# paths). Point both image markers at the compiled libbpf.a so Make
+# builds it exactly once, serially, before the parallel image builds
+# start.
+LIBBPF_MARKER = $(REPO_ROOT)/felix/bpf-gpl/libbpf/src/$(ARCH)/libbpf.a
+
+$(LIBBPF_MARKER):
+	$(MAKE) -C $(REPO_ROOT)/felix libbpf
+
+$(REPO_ROOT)/node/.image.created-$(ARCH): $(LIBBPF_MARKER) $(call local-deps-go-files,node)
 	$(MAKE) -C $(REPO_ROOT)/node image
 	touch $@
 
@@ -1609,7 +1623,7 @@ $(REPO_ROOT)/whisker/.image.created-$(ARCH):
 	$(MAKE) -C $(REPO_ROOT)/whisker image
 	touch $@
 
-$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH): $(call local-deps-go-files,cmd)
+$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH): $(LIBBPF_MARKER) $(call local-deps-go-files,cmd)
 	$(MAKE) -C $(REPO_ROOT)/cmd/calico image
 
 $(REPO_ROOT)/key-cert-provisioner/.image.created-$(ARCH): $(call local-deps-go-files,key-cert-provisioner)

--- a/node/.semaphore/cache-test-artifacts
+++ b/node/.semaphore/cache-test-artifacts
@@ -24,7 +24,7 @@ cd ../..
 
 # Copy pre-built images from the workflow cache if available.
 # These were built by the "Build: *" blocks in the Prerequisites stage.
-for img in calico-image.tar.zstd node-image.tar.zstd whisker-image.tar.zstd; do
+for img in calico-image.tar.zst node-image.tar.zst whisker-image.tar.zst; do
   if gcloud storage cp "${GCS_WORKFLOW_DIR}/${img}" "/tmp/${img}" 2>/dev/null; then
     echo "Found pre-built ${img}, including in artifacts."
     gcloud storage cp "/tmp/${img}" "${GCS_WORKFLOW_DIR}/node/fv-artifacts/${img}"

--- a/node/.semaphore/load-test-artifacts
+++ b/node/.semaphore/load-test-artifacts
@@ -24,11 +24,11 @@ REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 
 # Load any pre-built images that were cached by the Prerequisites build blocks.
 for item in calico-image:cmd/calico node-image:node whisker-image:whisker; do
-  tarball="${item%%:*}.tar.zstd"
+  tarball="${item%%:*}.tar.zst"
   marker_dir="${item#*:}"
   if [ -f "/tmp/${tarball}" ]; then
     echo "Loading cached ${tarball}..."
-    zstd -d "/tmp/${tarball}" | docker load
+    zstd -dc "/tmp/${tarball}" | docker load
     mkdir -p "${REPO_ROOT}/${marker_dir}"
     touch "${REPO_ROOT}/${marker_dir}/.image.created-${ARCH}"
     rm -f "/tmp/${tarball}"


### PR DESCRIPTION
Two commits.

Commit 1 (lib.Makefile): both `node` and `cmd/calico` need libbpf, and `kind-build-images` builds the per-image markers in parallel under `make -j`. They race in `felix/bpf-gpl` on the clone (each runs `rm -rf libbpf && git clone`, one fails with "destination path 'libbpf' already exists") and could also race on the libbpf.a compile that follows. Make a shared `\$(LIBBPF_MARKER)` (pointing at the compiled `libbpf.a`) a prereq of both image markers so it gets built once before the fanout.

Commit 2 (node/.semaphore/cache-test-artifacts + load-test-artifacts): two bugs in the cached image load path that masked each other. (a) `cache-test-artifacts` was looking for `*.tar.zstd` upstream but the Build blocks upload `*.tar.zst` (no d) - silently no-op, cached images never reached the test VMs and they rebuilt from source. (b) The decompress pipeline `zstd -d FILE | docker load` relied on zstd writing to stdout, but `zstd -d FILE` writes to `FILE` minus `.zst` by default. docker load got nothing and errored about a missing manifest. Switch to `.tar.zst` consistently and `zstd -dc` to force stdout.

The two are related: hit this on the enterprise cherry-pick where the typo caused VM-side rebuilds, which exposed the libbpf race. The race is reachable in OSS too, it just hasn't tripped here because the `E2E tests (KinD)` block's `load-cached-images` correctly restores and touches both markers, so `kind-build-images` becomes a no-op.

**Release note:**
\`\`\`release-note
NONE
\`\`\`