### PR TITLE
Exclude Feature:KubeVirt e2e tests from CI

### DIFF
--- a/e2e/config/base.yaml
+++ b/e2e/config/base.yaml
@@ -17,3 +17,6 @@ exclude:
 
     - label: ExternalNode
       reason: "requires a non-cluster node with EXT_IP/EXT_KEY/EXT_USER configured"
+
+    - label: Feature:KubeVirt
+      reason: "e2e infra integration with Banzai not ready, currently run manually"

--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -32,3 +32,6 @@ exclude:
 
     - label: RequiresXtables
       reason: "requires iptables or nftables dataplane, but this cluster uses BPF"
+
+    - label: Feature:KubeVirt
+      reason: "e2e infra integration with Banzai not ready, currently run manually"


### PR DESCRIPTION
## Description

The KubeVirt live-migration e2e tests require infra setup that is not yet integrated with the CI pipeline; they are currently run manually. Add a `Feature:KubeVirt` exclude to the shared (`base.yaml`) and `gcp-bpf.yaml` e2e configs so the tests do not run automatically once the test code lands.

The label comes from `describe.WithFeature("KubeVirt")` in the in-flight KubeVirt tests PR — adding the exclude now means CI stays green when that PR merges.

## Release Note

```release-note
None
```

## Reminders for the reviewer

- [x] Commit messages are descriptive and explain the why
- [x] Tests are updated as appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)