### PR TITLE
fix(release): source CLI flag defaults from metadata.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ pod2daemon/node-driver-registrar/
 ut-tmp-dir
 
 .remember
+
+# Build-time copy of metadata.mk for the release CLI's embedded defaults.
+release/internal/defaults/metadata.mk

--- a/Makefile
+++ b/Makefile
@@ -280,12 +280,12 @@ e2e-run-cnp:
 ###############################################################################
 .PHONY: release release-publish create-release-branch release-test build-openstack publish-openstack release-notes
 # Build the release tool.
-release/bin/release: $(shell find ./release -type f -name '*.go')
+release/bin/release: $(shell find ./release -type f -name '*.go') metadata.mk
 	$(MAKE) -C release
 
 # Prepare for a release (update version references, charts, manifests).
 release-prep: release/bin/release bin/gh
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release prep
+	@release/bin/release release prep
 
 # Install ghr for publishing to github.
 bin/ghr:
@@ -301,14 +301,14 @@ bin/gh:
 
 # Build a release.
 release: release/bin/release
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release build
+	@release/bin/release release build
 
 # Publish an already built release.
 release-publish: release/bin/release bin/ghr bin/helm
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release publish
+	@release/bin/release release publish
 
 release-public: bin/gh release/bin/release
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release public
+	@release/bin/release release public
 
 # Create a release branch.
 create-release-branch: release/bin/release

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -507,7 +507,6 @@ define update_calico_base_pin
 		fi'
 endef
 
-GIT_REMOTE?=origin
 API_BRANCH?=$(PIN_BRANCH)
 API_REPO?=github.com/projectcalico/calico/api
 BASE_API_REPO?=github.com/projectcalico/calico/api

--- a/metadata.mk
+++ b/metadata.mk
@@ -26,6 +26,7 @@ KIND_VERSION=v0.31.0
 # differently for a forked repo.
 ORGANIZATION  ?= projectcalico
 GIT_REPO      ?= calico
+GIT_REMOTE    ?= origin
 
 RELEASE_BRANCH_PREFIX ?=release
 DEV_TAG_SUFFIX        ?= 0.dev

--- a/release/Makefile
+++ b/release/Makefile
@@ -4,26 +4,26 @@ PACKAGE_NAME = github.com/projectcalico/calico/release
 
 include ../lib.Makefile
 
-export ORGANIZATION
-export GIT_REPO
-export RELEASE_BRANCH_PREFIX
-export DEV_TAG_SUFFIX
-export DEV_REGISTRIES
-export OPERATOR_ORGANIZATION
-export OPERATOR_GIT_REPO
-export OPERATOR_BRANCH
-
 .PHONY: build
 build: bin/release
 
 clean:
 	@rm -rf ./bin ./output ./_output ./report ./tmp
+	@rm -f ./internal/defaults/metadata.mk
 	@find ../ -name '*release*.log' -delete
 	@find . -name '*.received.*' -delete
 
-bin/release: $(shell find . -name "*.go" -or -name "*.gotmpl")
-	@mkdir -p bin && \
-	$(call build_binary, ./cmd, bin/release)
+# Stage metadata.mk next to embed.go so go:embed (which requires paths relative to the source file) can pick it up.
+# Embedding also makes the binary self-contained across invocation dirs (root Makefile vs release/).
+internal/defaults/metadata.mk: ../metadata.mk
+	@cp ../metadata.mk $@
+
+bin/release: $(shell find . -name "*.go" -or -name "*.gotmpl") internal/defaults/metadata.mk
+	@mkdir -p bin
+	@$(DOCKER_RUN) \
+		-e CGO_ENABLED=0 \
+		$(CALICO_BUILD) \
+		sh -c '$(GIT_CONFIG_SSH) go build -o bin/release -v -buildvcs=false -tags with_embed -ldflags "$(LDFLAGS)" ./cmd'
 
 POSTRELEASE_TEST_PACKAGE		:= $(PACKAGE_NAME)/pkg/postrelease
 UNIT_TEST_PACKAGES	:= $(shell go list ./... | grep -v $(POSTRELEASE_TEST_PACKAGE))

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -217,6 +217,10 @@ var (
 
 // Operator flags are flags used to interact with Tigera operator repository
 var (
+	// operatorGitFlags resolve the operator's org/repo/branch. Required on any
+	// command that calls calico.WithOperatorGit or operator.Clone.
+	operatorGitFlags = []cli.Flag{operatorOrgFlag, operatorRepoFlag, operatorBranchFlag}
+
 	operatorBuildCommandFlags = []cli.Flag{
 		operatorOrgFlag, operatorRepoFlag, operatorBranchFlag,
 		operatorReleaseBranchPrefixFlag,

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
 
+	"github.com/projectcalico/calico/release/internal/defaults"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
@@ -63,42 +64,47 @@ var (
 	}
 
 	// Git flags for interacting with the git repository
-	orgFlag = &cli.StringFlag{
-		Name:     "org",
+	orgFlagName = "org"
+	orgFlag     = &cli.StringFlag{
+		Name:     orgFlagName,
 		Category: gitCategory,
 		Usage:    "The GitHub organization to use for the release",
-		Sources:  cli.EnvVars("ORGANIZATION"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("ORGANIZATION"), defaults.MK(defaults.KeyOrganization)),
 		Value:    utils.ProjectCalicoOrg,
 	}
-	repoFlag = &cli.StringFlag{
-		Name:     "repo",
+	repoFlagName = "repo"
+	repoFlag     = &cli.StringFlag{
+		Name:     repoFlagName,
 		Category: gitCategory,
 		Usage:    "The GitHub repository to use for the release",
-		Sources:  cli.EnvVars("GIT_REPO"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("GIT_REPO"), defaults.MK(defaults.KeyGitRepo)),
 		Value:    utils.CalicoRepoName,
 	}
-	repoRemoteFlag = &cli.StringFlag{
-		Name:     "remote",
+	repoRemoteFlagName = "remote"
+	repoRemoteFlag     = &cli.StringFlag{
+		Name:     repoRemoteFlagName,
 		Category: gitCategory,
 		Usage:    "The remote for the git repository",
-		Sources:  cli.EnvVars("GIT_REMOTE"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("GIT_REMOTE"), defaults.MK(defaults.KeyGitRemote)),
 		Value:    utils.DefaultRemote,
 	}
 
 	// Branch/Tag flags are flags used for branch & tag management
-	releaseBranchPrefixFlag = &cli.StringFlag{
-		Name:     "release-branch-prefix",
+	releaseBranchPrefixFlagName = "release-branch-prefix"
+	releaseBranchPrefixFlag     = &cli.StringFlag{
+		Name:     releaseBranchPrefixFlagName,
 		Category: gitCategory,
 		Usage:    "The stardard prefix used to denote release branches",
-		Sources:  cli.EnvVars("RELEASE_BRANCH_PREFIX"),
-		Value:    "release",
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("RELEASE_BRANCH_PREFIX"), defaults.MK(defaults.KeyReleaseBranchPrefix)),
+		Value:    utils.DefaultReleaseBranchPrefix,
 	}
-	devTagSuffixFlag = &cli.StringFlag{
-		Name:     "dev-tag-suffix",
+	devTagSuffixFlagName = "dev-tag-suffix"
+	devTagSuffixFlag     = &cli.StringFlag{
+		Name:     devTagSuffixFlagName,
 		Category: gitCategory,
 		Usage:    "The suffix used to denote development tags",
-		Sources:  cli.EnvVars("DEV_TAG_SUFFIX"),
-		Value:    "0.dev",
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("DEV_TAG_SUFFIX"), defaults.MK(defaults.KeyDevTagSuffix)),
+		Value:    utils.DefaultDevTagSuffix,
 	}
 	baseBranchFlag = &cli.StringFlag{
 		Name:     "base-branch",
@@ -223,27 +229,30 @@ var (
 	}
 
 	// Operator git flags
-	operatorOrgFlag = &cli.StringFlag{
-		Name:     "operator-org",
+	operatorOrgFlagName = "operator-org"
+	operatorOrgFlag     = &cli.StringFlag{
+		Name:     operatorOrgFlagName,
 		Category: operatorCategory,
 		Usage:    "The GitHub organization to use for Tigera operator release",
-		Sources:  cli.EnvVars("OPERATOR_ORGANIZATION"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("OPERATOR_ORGANIZATION"), defaults.MK(defaults.KeyOperatorOrganization)),
 		Value:    operator.DefaultOrg,
 	}
-	operatorRepoFlag = &cli.StringFlag{
-		Name:     "operator-repo",
+	operatorRepoFlagName = "operator-repo"
+	operatorRepoFlag     = &cli.StringFlag{
+		Name:     operatorRepoFlagName,
 		Category: operatorCategory,
 		Usage:    "The GitHub repository to use for Tigera operator release",
-		Sources:  cli.EnvVars("OPERATOR_GIT_REPO"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("OPERATOR_GIT_REPO"), defaults.MK(defaults.KeyOperatorGitRepo)),
 		Value:    operator.DefaultRepoName,
 	}
 	// Branch/Tag management flags
-	operatorBranchFlag = &cli.StringFlag{
-		Name:     "operator-branch",
+	operatorBranchFlagName = "operator-branch"
+	operatorBranchFlag     = &cli.StringFlag{
+		Name:     operatorBranchFlagName,
 		Category: operatorCategory,
 		Usage:    "The branch to use for Tigera operator release",
-		Sources:  cli.EnvVars("OPERATOR_BRANCH"),
-		Value:    operator.DefaultBranchName,
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("OPERATOR_BRANCH"), defaults.MK(defaults.KeyOperatorBranch)),
+		Value:    operator.DefaultBranch,
 	}
 	operatorReleaseBranchPrefixFlag = &cli.StringFlag{
 		Name:     "operator-release-branch-prefix",
@@ -684,3 +693,4 @@ func hasFlag(c *cli.Command, name string) bool {
 		return slices.Contains(f.Names(), name)
 	})
 }
+

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -221,12 +221,11 @@ var (
 	// command that calls calico.WithOperatorGit or operator.Clone.
 	operatorGitFlags = []cli.Flag{operatorOrgFlag, operatorRepoFlag, operatorBranchFlag}
 
-	operatorBuildCommandFlags = []cli.Flag{
-		operatorOrgFlag, operatorRepoFlag, operatorBranchFlag,
+	operatorBuildCommandFlags = append(slices.Clone(operatorGitFlags),
 		operatorReleaseBranchPrefixFlag,
 		operatorRegistryFlag, operatorImageFlag,
 		operatorFlag(envBuildOperator, envReleaseOperator),
-	}
+	)
 
 	operatorPublishCommandFlags = []cli.Flag{
 		operatorFlag(envPublishOperator, envReleaseOperator),
@@ -697,4 +696,3 @@ func hasFlag(c *cli.Command, name string) bool {
 		return slices.Contains(f.Names(), name)
 	})
 }
-

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
@@ -317,7 +318,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 // hashreleaseBuildFlags returns the flags for the hashrelease build command.
 func hashreleaseBuildFlags() []cli.Flag {
-	f := append(productFlags, buildStepFlags(true)...)
+	f := append(slices.Clone(productFlags), buildStepFlags(true)...)
 	f = append(f,
 		registryFlag,
 		archFlag)
@@ -368,7 +369,7 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 
 // hashreleasePublishFlags returns the flags for the hashrelease publish command.
 func hashreleasePublishFlags() []cli.Flag {
-	f := append(productFlags, publishStepFlags(true)...)
+	f := append(slices.Clone(productFlags), publishStepFlags(true)...)
 	f = append(f,
 		registryFlag,
 		helmRegistryFlag,

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -72,7 +72,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				// Clone the operator repository.
-				operatorDir := filepath.Join(cfg.TmpDir, operator.DefaultRepoName)
+				operatorDir := filepath.Join(cfg.TmpDir, c.String(operatorRepoFlag.Name))
 				err := operator.Clone(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name), operatorDir)
 				if err != nil {
 					return fmt.Errorf("failed to clone operator repository: %v", err)
@@ -238,7 +238,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				// Push the operator hashrelease first before validaion
 				// This is because validation checks all images exists and sends to Image Scan Service
 				o := operator.NewManager(
-					operator.WithOperatorDirectory(filepath.Join(cfg.TmpDir, operator.DefaultRepoName)),
+					operator.WithOperatorDirectory(filepath.Join(cfg.TmpDir, c.String(operatorRepoFlag.Name))),
 					operator.IsHashRelease(),
 					operator.WithImage(hashrel.Operator.Image),
 					operator.WithRegistry(hashrel.Operator.Registry),

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -246,23 +246,17 @@ func determineOperatorReleaseVersion(c *cli.Command, tmpDir string) (string, err
 }
 
 func releasePrepCommand(cfg *Config) *cli.Command {
+	flags := append(slices.Clone(productFlags), operatorGitFlags...)
+	flags = append(flags,
+		githubTokenFlag,
+		branchCheckFlag,
+		validationFlag,
+		localFlag,
+	)
 	return &cli.Command{
 		Name:  "prep",
 		Usage: "Prepare for a Calico release",
-		Flags: []cli.Flag{
-			orgFlag,
-			repoFlag,
-			repoRemoteFlag,
-			releaseBranchPrefixFlag,
-			devTagSuffixFlag,
-			operatorOrgFlag,
-			operatorRepoFlag,
-			operatorBranchFlag,
-			githubTokenFlag,
-			branchCheckFlag,
-			validationFlag,
-			localFlag,
-		},
+		Flags: flags,
 		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
 			// Determine the versions to use for the release.
 			ver, err := version.DetermineReleaseVersion(version.GitVersion(), c.String(devTagSuffixFlag.Name))

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -227,7 +227,7 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 
 func determineOperatorReleaseVersion(c *cli.Command, tmpDir string) (string, error) {
 	// Clone the operator repository to determine the operator version.
-	operatorDir := filepath.Join(tmpDir, operator.DefaultRepoName)
+	operatorDir := filepath.Join(tmpDir, c.String(operatorRepoFlag.Name))
 	if err := operator.Clone(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name), operatorDir); err != nil {
 		return "", fmt.Errorf("clone operator repository: %w", err)
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -105,7 +106,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithVersion(ver.FormattedString()),
 					calico.WithOperatorVersion(operatorVer.FormattedString()),
-					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
+					calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
@@ -207,6 +208,7 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 				calico.WithRepoRoot(cfg.RepoRootDir),
 				calico.WithVersion(ver.FormattedString()),
 				calico.WithOperatorVersion(operatorVer.FormattedString()),
+				calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
@@ -287,6 +289,7 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 				calico.WithVersion(ver.FormattedString()),
 				calico.WithOperatorVersion(operatorVer),
+				calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
@@ -308,21 +311,21 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 
 // releaseBuildFlags returns the flags for release build command.
 func releaseBuildFlags() []cli.Flag {
-	f := append(productFlags, buildStepFlags(false)...)
+	f := append(slices.Clone(productFlags), buildStepFlags(false)...)
 	f = append(f,
-		archFlag,
 		registryFlag,
-		githubTokenFlag,
+		archFlag)
+	f = append(f, operatorGitFlags...)
+	f = append(f,
 		branchCheckFlag,
 		validationFlag,
-		operatorBranchFlag,
-	)
+		githubTokenFlag)
 	return f
 }
 
 // releasePublishFlags returns the flags for release publish command.
 func releasePublishFlags() []cli.Flag {
-	f := append(productFlags, publishStepFlags(false)...)
+	f := append(slices.Clone(productFlags), publishStepFlags(false)...)
 	f = append(f,
 		registryFlag,
 		helmRegistryFlag,
@@ -331,8 +334,8 @@ func releasePublishFlags() []cli.Flag {
 		s3BucketFlag,
 		branchCheckFlag,
 		validationFlag,
-		operatorBranchFlag,
 	)
+	f = append(f, operatorGitFlags...)
 	return f
 }
 

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -88,6 +88,7 @@ local:libcalico-go/lib/logutils
 local:release/cmd
 local:release/internal/ci
 local:release/internal/command
+local:release/internal/defaults
 local:release/internal/hashreleaseserver
 local:release/internal/imagescanner
 local:release/internal/outputs

--- a/release/internal/defaults/embed.go
+++ b/release/internal/defaults/embed.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build with_embed
+
+package defaults
+
+import _ "embed"
+
+// metadata.mk is copied here by release/Makefile before build as
+// embedded paths must be relative to the source file.
+//
+//go:embed metadata.mk
+var embeddedMetadata []byte

--- a/release/internal/defaults/metadata.go
+++ b/release/internal/defaults/metadata.go
@@ -14,6 +14,10 @@
 
 // Package defaults exposes flag-default values sourced from the repo's
 // build metadata. Values resolve once per process via sync.OnceValue.
+//
+// Constant names match metadata.mk variable names verbatim. Unknown keys
+// resolve to empty, so additional keys are added by adding a constant and
+// a metadata.mk entry.
 package defaults
 
 import (

--- a/release/internal/defaults/metadata.go
+++ b/release/internal/defaults/metadata.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package defaults exposes flag-default values sourced from the repo's
+// build metadata. Values resolve once per process via sync.OnceValue.
+package defaults
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/release/internal/command"
+)
+
+// makeAssignment matches a make variable assignment line. `!=` is excluded
+// on purpose — shell output has no business being a flag default.
+var makeAssignment = regexp.MustCompile(`^([A-Z_][A-Z0-9_]*)\s*(?:\?|:{1,3}|\+)?=\s*(.*)$`)
+
+const (
+	KeyOrganization         = "ORGANIZATION"
+	KeyGitRepo              = "GIT_REPO"
+	KeyGitRemote            = "GIT_REMOTE"
+	KeyReleaseBranchPrefix  = "RELEASE_BRANCH_PREFIX"
+	KeyDevTagSuffix         = "DEV_TAG_SUFFIX"
+	KeyOperatorBranch       = "OPERATOR_BRANCH"
+	KeyOperatorOrganization = "OPERATOR_ORGANIZATION"
+	KeyOperatorGitRepo      = "OPERATOR_GIT_REPO"
+)
+
+var load = sync.OnceValue(readMetadata)
+
+func readMetadata() map[string]string {
+	if len(embeddedMetadata) > 0 {
+		m, err := parseMetadata(embeddedMetadata)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to parse embedded metadata.mk; release flag defaults will be empty")
+			return map[string]string{}
+		}
+		return m
+	}
+	root, err := command.GitDir()
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to locate git root for metadata.mk; release flag defaults will be empty")
+		return map[string]string{}
+	}
+	data, err := os.ReadFile(filepath.Join(root, "metadata.mk"))
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to read metadata.mk; release flag defaults will be empty")
+		return map[string]string{}
+	}
+	m, err := parseMetadata(data)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to parse metadata.mk; release flag defaults will be empty")
+		return map[string]string{}
+	}
+	return m
+}
+
+func parseMetadata(data []byte) (map[string]string, error) {
+	tmp, err := os.CreateTemp("", "metadata-*.mk")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return nil, err
+	}
+	if _, err := tmp.Write([]byte("\n_defaults_noop:\n")); err != nil {
+		tmp.Close()
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, err
+	}
+	out, err := command.Make([]string{"-f", tmp.Name(), "-pn", "_defaults_noop"}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseMakeDatabase(out)
+}
+
+// parseMakeDatabase reads the output of `make -pn` and returns variable
+// assignments. Make's database dump emits lines like `KEY = VALUE` for every
+// resolved variable; we only retain the keys we care about.
+func parseMakeDatabase(out string) (map[string]string, error) {
+	wanted := map[string]struct{}{
+		KeyOrganization:         {},
+		KeyGitRepo:              {},
+		KeyGitRemote:            {},
+		KeyReleaseBranchPrefix:  {},
+		KeyDevTagSuffix:         {},
+		KeyOperatorBranch:       {},
+		KeyOperatorOrganization: {},
+		KeyOperatorGitRepo:      {},
+	}
+	m := map[string]string{}
+	scanner := bufio.NewScanner(bytes.NewBufferString(out))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || line[0] == '#' || line[0] == '\t' {
+			continue
+		}
+		match := makeAssignment.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		key := match[1]
+		if _, ok := wanted[key]; !ok {
+			continue
+		}
+		m[key] = strings.TrimSpace(match[2])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning make database: %w", err)
+	}
+	return m, nil
+}
+
+func get(key string) string { return load()[key] }
+
+func Organization() string         { return get(KeyOrganization) }
+func Repo() string                 { return get(KeyGitRepo) }
+func Remote() string               { return get(KeyGitRemote) }
+func ReleaseBranchPrefix() string  { return get(KeyReleaseBranchPrefix) }
+func DevTagSuffix() string         { return get(KeyDevTagSuffix) }
+func OperatorBranch() string       { return get(KeyOperatorBranch) }
+func OperatorOrganization() string { return get(KeyOperatorOrganization) }
+func OperatorRepo() string         { return get(KeyOperatorGitRepo) }

--- a/release/internal/defaults/metadata.go
+++ b/release/internal/defaults/metadata.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -31,9 +32,16 @@ import (
 	"github.com/projectcalico/calico/release/internal/command"
 )
 
-// makeAssignment matches a make variable assignment line. `!=` is excluded
-// on purpose — shell output has no business being a flag default.
-var makeAssignment = regexp.MustCompile(`^([A-Z_][A-Z0-9_]*)\s*(?:\?|:{1,3}|\+)?=\s*(.*)$`)
+// driverPrefix snapshots the variables defined before metadata.mk is
+// included; driverSuffix prints only those introduced by the include.
+const (
+	driverPrefix = "VARS_OLD := $(.VARIABLES)\n"
+	driverSuffix = "\n_defaults_print:\n" +
+		"\t@$(foreach v,$(filter-out $(VARS_OLD) VARS_OLD,$(.VARIABLES)),$(info $(v) = $($(v))))\n"
+)
+
+// driverLine matches a `KEY = VALUE` line emitted by the driver's $(info).
+var driverLine = regexp.MustCompile(`^([A-Z_][A-Z0-9_]*)\s*=\s*(.*)$`)
 
 const (
 	KeyOrganization         = "ORGANIZATION"
@@ -75,64 +83,39 @@ func readMetadata() map[string]string {
 	return m
 }
 
+// parseMetadata wraps data with a driver makefile and runs make on it via
+// stdin, so make resolves $(...) references and ?= precedence naturally.
+// The driver prints only the variables introduced by the included data.
 func parseMetadata(data []byte) (map[string]string, error) {
-	tmp, err := os.CreateTemp("", "metadata-*.mk")
+	var stdin bytes.Buffer
+	stdin.WriteString(driverPrefix)
+	stdin.Write(data)
+	stdin.WriteString(driverSuffix)
+
+	cmd := exec.Command("make", "--quiet", "-f", "-", "_defaults_print")
+	cmd.Stdin = &stdin
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("make: %w: %s", err, out)
 	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return nil, err
-	}
-	if _, err := tmp.Write([]byte("\n_defaults_noop:\n")); err != nil {
-		tmp.Close()
-		return nil, err
-	}
-	if err := tmp.Close(); err != nil {
-		return nil, err
-	}
-	out, err := command.Make([]string{"-f", tmp.Name(), "-pn", "_defaults_noop"}, nil)
-	if err != nil {
-		return nil, err
-	}
-	return parseMakeDatabase(out)
+	return parseDriverOutput(string(out))
 }
 
-// parseMakeDatabase reads the output of `make -pn` and returns variable
-// assignments. Make's database dump emits lines like `KEY = VALUE` for every
-// resolved variable; we only retain the keys we care about.
-func parseMakeDatabase(out string) (map[string]string, error) {
-	wanted := map[string]struct{}{
-		KeyOrganization:         {},
-		KeyGitRepo:              {},
-		KeyGitRemote:            {},
-		KeyReleaseBranchPrefix:  {},
-		KeyDevTagSuffix:         {},
-		KeyOperatorBranch:       {},
-		KeyOperatorOrganization: {},
-		KeyOperatorGitRepo:      {},
-	}
+// parseDriverOutput reads the driver's $(info) output (one `KEY = VALUE` per
+// line) and returns the assignments.
+func parseDriverOutput(out string) (map[string]string, error) {
 	m := map[string]string{}
 	scanner := bufio.NewScanner(bytes.NewBufferString(out))
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" || line[0] == '#' || line[0] == '\t' {
-			continue
-		}
-		match := makeAssignment.FindStringSubmatch(line)
+		match := driverLine.FindStringSubmatch(scanner.Text())
 		if match == nil {
 			continue
 		}
-		key := match[1]
-		if _, ok := wanted[key]; !ok {
-			continue
-		}
-		m[key] = strings.TrimSpace(match[2])
+		m[match[1]] = strings.TrimSpace(match[2])
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scanning make database: %w", err)
+		return nil, fmt.Errorf("scanning driver output: %w", err)
 	}
 	return m, nil
 }

--- a/release/internal/defaults/metadata_test.go
+++ b/release/internal/defaults/metadata_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// setValues replaces the cached loader with one that returns v. Tests defer
+// resetValues to ensure state does not leak between cases.
+func setValues(v map[string]string) {
+	load = sync.OnceValue(func() map[string]string { return v })
+}
+
+func resetValues() {
+	load = sync.OnceValue(readMetadata)
+}
+
+func TestParseMetadata(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "metadata.mk"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	m, err := parseMetadata(data)
+	if err != nil {
+		t.Fatalf("parseMetadata: %v", err)
+	}
+	cases := map[string]string{
+		KeyOrganization:         "testorg",
+		KeyGitRepo:              "testrepo",
+		KeyGitRemote:            "testremote",
+		KeyReleaseBranchPrefix:  "testprefix",
+		KeyDevTagSuffix:         "testsuffix",
+		KeyOperatorBranch:       "test-operator-branch",
+		KeyOperatorOrganization: "testopsorg",
+		KeyOperatorGitRepo:      "testopsrepo",
+	}
+	for k, want := range cases {
+		if got := m[k]; got != want {
+			t.Errorf("key %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestAccessorsWithInjectedValues(t *testing.T) {
+	t.Cleanup(resetValues)
+	setValues(map[string]string{
+		KeyOrganization:         "o",
+		KeyGitRepo:              "r",
+		KeyGitRemote:            "rem",
+		KeyReleaseBranchPrefix:  "rp",
+		KeyDevTagSuffix:         "ds",
+		KeyOperatorBranch:       "ob",
+		KeyOperatorOrganization: "oo",
+		KeyOperatorGitRepo:      "orepo",
+	})
+	if got := Organization(); got != "o" {
+		t.Errorf("Organization: got %q, want %q", got, "o")
+	}
+	if got := Repo(); got != "r" {
+		t.Errorf("Repo: got %q, want %q", got, "r")
+	}
+	if got := Remote(); got != "rem" {
+		t.Errorf("Remote: got %q, want %q", got, "rem")
+	}
+	if got := ReleaseBranchPrefix(); got != "rp" {
+		t.Errorf("ReleaseBranchPrefix: got %q, want %q", got, "rp")
+	}
+	if got := DevTagSuffix(); got != "ds" {
+		t.Errorf("DevTagSuffix: got %q, want %q", got, "ds")
+	}
+	if got := OperatorBranch(); got != "ob" {
+		t.Errorf("OperatorBranch: got %q, want %q", got, "ob")
+	}
+	if got := OperatorOrganization(); got != "oo" {
+		t.Errorf("OperatorOrganization: got %q, want %q", got, "oo")
+	}
+	if got := OperatorRepo(); got != "orepo" {
+		t.Errorf("OperatorRepo: got %q, want %q", got, "orepo")
+	}
+}
+
+func TestAccessorsEmptyWhenUnset(t *testing.T) {
+	t.Cleanup(resetValues)
+	setValues(map[string]string{})
+	if got := Organization(); got != "" {
+		t.Errorf("Organization with empty map: got %q, want empty", got)
+	}
+}

--- a/release/internal/defaults/metadata_test.go
+++ b/release/internal/defaults/metadata_test.go
@@ -57,6 +57,21 @@ func TestParseMetadata(t *testing.T) {
 	}
 }
 
+func TestParseMetadataIgnoresPreExistingVars(t *testing.T) {
+	m, err := parseMetadata([]byte("ORGANIZATION ?= newvalue\n"))
+	if err != nil {
+		t.Fatalf("parseMetadata: %v", err)
+	}
+	if got := m[KeyOrganization]; got != "newvalue" {
+		t.Errorf("ORGANIZATION: got %q, want %q", got, "newvalue")
+	}
+	for _, k := range []string{"VARS_OLD", "MAKEFLAGS", "SHELL", ".VARIABLES"} {
+		if _, ok := m[k]; ok {
+			t.Errorf("%s should not appear in parsed output", k)
+		}
+	}
+}
+
 func TestAccessorsWithInjectedValues(t *testing.T) {
 	t.Cleanup(resetValues)
 	setValues(map[string]string{

--- a/release/internal/defaults/noembed.go
+++ b/release/internal/defaults/noembed.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !with_embed
+
+package defaults
+
+// Stub for builds without -tags with_embed (e.g. go run, go test) where the metadata.mk copy hasn't been staged.
+// readMetadata falls back to reading the root metadata.mk via gitDir.
+var embeddedMetadata []byte

--- a/release/internal/defaults/source.go
+++ b/release/internal/defaults/source.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"fmt"
+
+	cli "github.com/urfave/cli/v3"
+)
+
+// MK returns a cli.ValueSource that resolves key from the embedded
+// metadata.mk. Unknown keys and load/parse failures (already logged by
+// readMetadata) yield (_, false), so the surrounding chain falls through
+// to the next source.
+func MK(key string) cli.ValueSource {
+	return &mkSource{key: key}
+}
+
+type mkSource struct{ key string }
+
+func (s *mkSource) Lookup() (string, bool) {
+	v, ok := load()[s.key]
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
+}
+
+func (s *mkSource) String() string   { return fmt.Sprintf("metadata.mk:%s", s.key) }
+func (s *mkSource) GoString() string { return fmt.Sprintf("defaults.MK(%q)", s.key) }

--- a/release/internal/defaults/source_test.go
+++ b/release/internal/defaults/source_test.go
@@ -28,7 +28,7 @@ func TestMKLookup(t *testing.T) {
 		wantOK  bool
 	}{
 		{KeyOrganization, "myorg", true},
-		{KeyGitRepo, "", false},   // empty value falls through
+		{KeyGitRepo, "", false},    // empty value falls through
 		{"UNKNOWN_KEY", "", false}, // missing key falls through
 	}
 	for _, tc := range cases {

--- a/release/internal/defaults/source_test.go
+++ b/release/internal/defaults/source_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import "testing"
+
+func TestMKLookup(t *testing.T) {
+	t.Cleanup(resetValues)
+	setValues(map[string]string{
+		KeyOrganization: "myorg",
+		KeyGitRepo:      "",
+	})
+	cases := []struct {
+		key     string
+		wantVal string
+		wantOK  bool
+	}{
+		{KeyOrganization, "myorg", true},
+		{KeyGitRepo, "", false},   // empty value falls through
+		{"UNKNOWN_KEY", "", false}, // missing key falls through
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			v, ok := MK(tc.key).Lookup()
+			if v != tc.wantVal || ok != tc.wantOK {
+				t.Errorf("MK(%q).Lookup() = (%q, %v), want (%q, %v)", tc.key, v, ok, tc.wantVal, tc.wantOK)
+			}
+		})
+	}
+}

--- a/release/internal/defaults/testdata/metadata.mk
+++ b/release/internal/defaults/testdata/metadata.mk
@@ -1,0 +1,10 @@
+ORGANIZATION  ?= testorg
+GIT_REPO      ?= testrepo
+GIT_REMOTE    ?= testremote
+
+RELEASE_BRANCH_PREFIX ?= testprefix
+DEV_TAG_SUFFIX        ?= testsuffix
+
+OPERATOR_BRANCH       ?= test-operator-branch
+OPERATOR_ORGANIZATION ?= testopsorg
+OPERATOR_GIT_REPO     := testopsrepo

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -75,11 +75,13 @@ const (
 	DefaultDevTagSuffix = "0.dev"
 )
 
-func Organization() string        { return FirstNonEmpty(defaults.Organization(), ProjectCalicoOrg) }
-func Repo() string                { return FirstNonEmpty(defaults.Repo(), CalicoRepoName) }
-func Remote() string              { return FirstNonEmpty(defaults.Remote(), DefaultRemote) }
-func ReleaseBranchPrefix() string { return FirstNonEmpty(defaults.ReleaseBranchPrefix(), DefaultReleaseBranchPrefix) }
-func DevTagSuffix() string        { return FirstNonEmpty(defaults.DevTagSuffix(), DefaultDevTagSuffix) }
+func Organization() string { return FirstNonEmpty(defaults.Organization(), ProjectCalicoOrg) }
+func Repo() string         { return FirstNonEmpty(defaults.Repo(), CalicoRepoName) }
+func Remote() string       { return FirstNonEmpty(defaults.Remote(), DefaultRemote) }
+func ReleaseBranchPrefix() string {
+	return FirstNonEmpty(defaults.ReleaseBranchPrefix(), DefaultReleaseBranchPrefix)
+}
+func DevTagSuffix() string { return FirstNonEmpty(defaults.DevTagSuffix(), DefaultDevTagSuffix) }
 
 // FirstNonEmpty returns the first non-empty string from values, or "".
 func FirstNonEmpty(values ...string) string {

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/defaults"
 )
 
 const (
@@ -66,7 +67,29 @@ const (
 
 	// CalicoHelmRepoURL is the URL for the Calico Helm charts.
 	CalicoHelmRepoURL = "https://docs.tigera.io/calico/charts"
+
+	// ReleaseBranchPrefix is the prefix for release branches.
+	DefaultReleaseBranchPrefix = "release"
+
+	// DevTagSuffix is the suffix for dev tags.
+	DefaultDevTagSuffix = "0.dev"
 )
+
+func Organization() string        { return FirstNonEmpty(defaults.Organization(), ProjectCalicoOrg) }
+func Repo() string                { return FirstNonEmpty(defaults.Repo(), CalicoRepoName) }
+func Remote() string              { return FirstNonEmpty(defaults.Remote(), DefaultRemote) }
+func ReleaseBranchPrefix() string { return FirstNonEmpty(defaults.ReleaseBranchPrefix(), DefaultReleaseBranchPrefix) }
+func DevTagSuffix() string        { return FirstNonEmpty(defaults.DevTagSuffix(), DefaultDevTagSuffix) }
+
+// FirstNonEmpty returns the first non-empty string from values, or "".
+func FirstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 // AllReleaseCharts returns a list of all Helm charts to be released.
 func AllReleaseCharts() []string {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1710,7 +1710,12 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 	if err := r.modifyHelmChartsValues(); err != nil {
 		return fmt.Errorf("failed to update chart versions: %w", err)
 	}
-	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "generate"); err != nil {
+	env := append(os.Environ(),
+		fmt.Sprintf("OPERATOR_ORGANIZATION=%s", r.operatorGithubOrg),
+		fmt.Sprintf("OPERATOR_GIT_REPO=%s", r.operatorRepo),
+		fmt.Sprintf("OPERATOR_BRANCH=%s", r.operatorBranch),
+	)
+	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "generate", env...); err != nil {
 		return fmt.Errorf("failed to run make generate: %w", err)
 	}
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -85,9 +85,9 @@ func NewManager(opts ...Option) *CalicoManager {
 		helmRepoURL:       utils.CalicoHelmRepoURL,
 		operatorRegistry:  operator.DefaultRegistry,
 		operatorImage:     operator.DefaultImage,
-		operatorGithubOrg: operator.DefaultOrg,
-		operatorRepo:      operator.DefaultRepoName,
-		operatorBranch:    operator.DefaultBranchName,
+		operatorGithubOrg: operator.Organization(),
+		operatorRepo:      operator.Repo(),
+		operatorBranch:    operator.Branch(),
 	}
 
 	// Run through provided options.

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/defaults"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
@@ -32,11 +33,17 @@ const (
 	DefaultImage               = registry.TigeraOperatorImage
 	DefaultOrg                 = utils.TigeraOrg
 	DefaultRepoName            = "operator"
-	DefaultBranchName          = utils.DefaultBranch
 	DefaultReleaseBranchPrefix = "release"
+	DefaultBranch              = "master"
 	DefaultDevTagSuffix        = "0.dev"
 	DefaultRegistry            = "quay.io"
 )
+
+func Organization() string {
+	return utils.FirstNonEmpty(defaults.OperatorOrganization(), utils.TigeraOrg)
+}
+func Repo() string   { return utils.FirstNonEmpty(defaults.OperatorRepo(), DefaultRepoName) }
+func Branch() string { return utils.FirstNonEmpty(defaults.OperatorBranch(), utils.DefaultBranch) }
 
 var (
 	defaultProductEnvPrefix = "CALICO"


### PR DESCRIPTION
On a `release-vX.Y` branch, `--operator-branch` and other metadata.mk-derived flags ignored the file and silently used `master`. Flag defaults now source from metadata.mk.

## Changes

- New `release/internal/defaults` package reads metadata.mk via an embedded copy (`-tags with_embed`), with a `<gitDir>/metadata.mk` runtime fallback for `go run` / `go test`.
- Eight git/operator string flags resolve via `cli.NewValueSourceChain(cli.EnvVar(...), defaults.MK(...))` with hardcoded constants as final fallback.
- `release build`, `release publish`, `release public`, and `release prep` thread `--operator-org/-repo/-branch` through `calico.WithOperatorGit(...)`. `release build` and `release publish` now register all three operator git flags (only `--operator-branch` was registered before).
- `GIT_REMOTE` moves to `metadata.mk`. Root `Makefile` drops the now-obsolete `OPERATOR_BRANCH=` env passthroughs.

## Follow-up

The package surface is shaped to be stable across the metadata.mk → `defaults.yaml` migration tracked in #12420:

- Constant names (`KeyOperatorBranch`, `KeyGitRemote`, …) match the source-file variable names verbatim.
- The parser accepts any `VAR ?= value` line; unknown keys passed to `defaults.MK(...)` resolve to empty so callers can probe additional keys without panicking. Adding a key is "add a constant + a metadata.mk entry"; no parser changes required.
- When metadata moves to `defaults.yaml`, swap `defaults.MK(...)` for [urfave/cli-altsrc](https://github.com/urfave/cli-altsrc) YAML sources at flag sites, and swap the parser from `make -pn` to `yaml.Unmarshal`. Constant names and accessor signatures stay the same, so flag sites and non-flag callers don't change.

**Release note:**
```release-note
TBD
```
