### PR TITLE
release: add hashrelease preflight image-existence check

### DIFF
--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -116,7 +116,13 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				// check if the component images that the operator will reference have been published.
 				// If they haven't, there's no point in proceeding to build this operator or this hashrelease.
 				if c.Bool(validationFlag.Name) && !c.Bool(imagesFlagName) {
-					if published, err := componentImagesPublished(cfg, data.ProductVersion(), data.OperatorVersion(), productRegistriesFromFlag); err != nil {
+					published, err := componentImagesPublished(
+						cfg,
+						data.ProductVersion(), data.OperatorVersion(),
+						productRegistriesFromFlag,
+						c.String(orgFlag.Name), c.String(repoFlag.Name), c.String(repoRemoteFlag.Name),
+					)
+					if err != nil {
 						return fmt.Errorf("failed to check if component images are published: %v", err)
 					} else if !published {
 						return fmt.Errorf("required component images have not been published; aborting hashrelease build")
@@ -466,6 +472,7 @@ func componentImagesPublished(
 	cfg *Config,
 	productVersion, operatorVersion string,
 	productRegistries []string,
+	githubOrg, repoName, repoRemote string,
 ) (bool, error) {
 	components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, false)
 	if err != nil {
@@ -479,6 +486,9 @@ func componentImagesPublished(
 		calico.WithOperatorVersion(operatorVersion),
 		calico.WithTmpDir(cfg.TmpDir),
 		calico.WithComponents(components),
+		calico.WithGithubOrg(githubOrg),
+		calico.WithRepoName(repoName),
+		calico.WithRepoRemote(repoRemote),
 	}
 	if len(productRegistries) > 0 {
 		opts = append(opts, calico.WithImageRegistries(productRegistries))

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -112,14 +112,14 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 				productRegistriesFromFlag := c.StringSlice(registryFlag.Name)
 
-				// PREFLIGHT: gate per-component image existence before Phase 1 builds anything.
-				// Excludes the operator (which will be pushed by operator.Publish in Phase 2).
-				// Honors --no-validation (skip when validation disabled), and --images
-				// (skip when the user is building product images locally — registry-side
-				// probe doesn't make sense in that developer mode).
+				// If validation is enabled (and the user isn't building product images locally),
+				// check if the component images that the operator will reference have been published.
+				// If they haven't, there's no point in proceeding to build this operator or this hashrelease.
 				if c.Bool(validationFlag.Name) && !c.Bool(imagesFlagName) {
-					if err := runPreflightImageCheck(cfg, data.ProductVersion(), data.OperatorVersion(), productRegistriesFromFlag); err != nil {
-						return err
+					if published, err := componentImagesPublished(cfg, data.ProductVersion(), data.OperatorVersion(), productRegistriesFromFlag); err != nil {
+						return fmt.Errorf("failed to check if component images are published: %v", err)
+					} else if !published {
+						return fmt.Errorf("required component images have not been published; aborting hashrelease build")
 					}
 				}
 
@@ -289,7 +289,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				} else {
 					opts = append(opts, calico.WithImageScanning(c.Bool(imageScanFlag.Name), *imageScanningAPIConfig(c)))
 				}
-				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, true /* includeOperator */)
+				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, true)
 				if err != nil {
 					return fmt.Errorf("failed to retrieve images for hashrelease: %w", err)
 				}
@@ -460,23 +460,16 @@ func validateCIBuildRequirements(c *cli.Command, repoRootDir string) error {
 	return nil
 }
 
-// runPreflightImageCheck verifies that all required per-component images
-// already exist in their registries, before Phase 1's expensive build work begins.
-// The operator image is intentionally excluded — it's pushed later by
-// operator.Publish() in Phase 2.
-//
-// On failure, this returns an error that the build action propagates as its exit
-// status; no Phase 1 build artifacts are produced and no operator image is pushed.
-// On success, ~12 seconds are added to the build action's runtime; on failure,
-// ~30 minutes of doomed Phase 1 build work is avoided.
-func runPreflightImageCheck(
+// componentImagesPublished verifies that the component images the operator
+// will reference have been published.
+func componentImagesPublished(
 	cfg *Config,
 	productVersion, operatorVersion string,
 	productRegistries []string,
-) error {
-	components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, false /* includeOperator */)
+) (bool, error) {
+	components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, false)
 	if err != nil {
-		return fmt.Errorf("preflight: retrieve components: %w", err)
+		return false, fmt.Errorf("retrieve components: %w", err)
 	}
 
 	opts := []calico.Option{
@@ -490,12 +483,6 @@ func runPreflightImageCheck(
 	if len(productRegistries) > 0 {
 		opts = append(opts, calico.WithImageRegistries(productRegistries))
 	}
-	pre := calico.NewManager(opts...)
-
-	logrus.Info("Running preflight image existence check")
-	if err := pre.CheckImagesPublished(); err != nil {
-		return fmt.Errorf("preflight image check failed: %w", err)
-	}
-	logrus.Info("Preflight image check passed; continuing with hashrelease build")
-	return nil
+	mgr := calico.NewManager(opts...)
+	return mgr.CheckHashreleaseImagesPublished()
 }

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -112,6 +112,17 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 				productRegistriesFromFlag := c.StringSlice(registryFlag.Name)
 
+				// PREFLIGHT: gate per-component image existence before Phase 1 builds anything.
+				// Excludes the operator (which will be pushed by operator.Publish in Phase 2).
+				// Honors --no-validation (skip when validation disabled), and --images
+				// (skip when the user is building product images locally — registry-side
+				// probe doesn't make sense in that developer mode).
+				if c.Bool(validationFlag.Name) && !c.Bool(imagesFlagName) {
+					if err := runPreflightImageCheck(cfg, data.ProductVersion(), data.OperatorVersion(), productRegistriesFromFlag); err != nil {
+						return err
+					}
+				}
+
 				// Build the operator
 				operatorOpts := []operator.Option{
 					operator.WithOperatorDirectory(operatorDir),
@@ -278,7 +289,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				} else {
 					opts = append(opts, calico.WithImageScanning(c.Bool(imageScanFlag.Name), *imageScanningAPIConfig(c)))
 				}
-				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir)
+				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, true /* includeOperator */)
 				if err != nil {
 					return fmt.Errorf("failed to retrieve images for hashrelease: %w", err)
 				}
@@ -446,5 +457,45 @@ func validateCIBuildRequirements(c *cli.Command, repoRootDir string) error {
 	if !promotionsDone {
 		return errors.New("images promotions are not done, wait for all images promotions to pass before publishing the hashrelease")
 	}
+	return nil
+}
+
+// runPreflightImageCheck verifies that all required per-component images
+// already exist in their registries, before Phase 1's expensive build work begins.
+// The operator image is intentionally excluded — it's pushed later by
+// operator.Publish() in Phase 2.
+//
+// On failure, this returns an error that the build action propagates as its exit
+// status; no Phase 1 build artifacts are produced and no operator image is pushed.
+// On success, ~12 seconds are added to the build action's runtime; on failure,
+// ~30 minutes of doomed Phase 1 build work is avoided.
+func runPreflightImageCheck(
+	cfg *Config,
+	productVersion, operatorVersion string,
+	productRegistries []string,
+) error {
+	components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir, false /* includeOperator */)
+	if err != nil {
+		return fmt.Errorf("preflight: retrieve components: %w", err)
+	}
+
+	opts := []calico.Option{
+		calico.WithRepoRoot(cfg.RepoRootDir),
+		calico.IsHashRelease(),
+		calico.WithVersion(productVersion),
+		calico.WithOperatorVersion(operatorVersion),
+		calico.WithTmpDir(cfg.TmpDir),
+		calico.WithComponents(components),
+	}
+	if len(productRegistries) > 0 {
+		opts = append(opts, calico.WithImageRegistries(productRegistries))
+	}
+	pre := calico.NewManager(opts...)
+
+	logrus.Info("Running preflight image existence check")
+	if err := pre.CheckImagesPublished(); err != nil {
+		return fmt.Errorf("preflight image check failed: %w", err)
+	}
+	logrus.Info("Preflight image check passed; continuing with hashrelease build")
 	return nil
 }

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -123,7 +123,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 						c.String(orgFlag.Name), c.String(repoFlag.Name), c.String(repoRemoteFlag.Name),
 					)
 					if err != nil {
-						return fmt.Errorf("failed to check if component images are published: %v", err)
+						return fmt.Errorf("failed to check if component images are published: %w", err)
 					} else if !published {
 						return fmt.Errorf("required component images have not been published; aborting hashrelease build")
 					}

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -272,7 +272,7 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 }
 
 // RetrieveImageComponents retrieves the images from Calico components in the pinned version file that produce images.
-// When includeOperator is true, the Tigera operator and its init image are also added to the returned map.
+// When includeOperator is true, the Tigera operator is also added to the returned map.
 func RetrieveImageComponents(outputDir string, includeOperator bool) (map[string]registry.Component, error) {
 	pinnedVersion, err := retrievePinnedVersion(outputDir)
 	if err != nil {

--- a/release/internal/pinnedversion/pinnedversion.go
+++ b/release/internal/pinnedversion/pinnedversion.go
@@ -272,13 +272,13 @@ func LoadHashrelease(repoRootDir, outputDir, hashreleaseSrcBaseDir string, lates
 }
 
 // RetrieveImageComponents retrieves the images from Calico components in the pinned version file that produce images.
-// It also adds the Tigera operator and its init image to the returned map.
-func RetrieveImageComponents(outputDir string) (map[string]registry.Component, error) {
+// When includeOperator is true, the Tigera operator and its init image are also added to the returned map.
+func RetrieveImageComponents(outputDir string, includeOperator bool) (map[string]registry.Component, error) {
 	pinnedVersion, err := retrievePinnedVersion(outputDir)
 	if err != nil {
 		return nil, err
 	}
-	return pinnedVersion.ImageComponents(true), nil
+	return pinnedVersion.ImageComponents(includeOperator), nil
 }
 
 func RetrieveVersions(outputDir string) (version.Versions, error) {

--- a/release/internal/registry/image.go
+++ b/release/internal/registry/image.go
@@ -15,11 +15,14 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
 const TigeraOperatorImage = "tigera/operator"
@@ -32,6 +35,12 @@ func CheckImage(image string) (bool, error) {
 
 	_, err = remote.Head(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
+		// HTTP 404 is the canonical "manifest not present at this tag" response;
+		// treat it as a clean "image not published" verdict rather than a probe failure.
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to get image descriptor for %s: %w", image, err)
 	}
 	return true, nil

--- a/release/internal/registry/image.go
+++ b/release/internal/registry/image.go
@@ -35,13 +35,19 @@ func CheckImage(image string) (bool, error) {
 
 	_, err = remote.Head(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		// HTTP 404 is the canonical "manifest not present at this tag" response;
-		// treat it as a clean "image not published" verdict rather than a probe failure.
-		var terr *transport.Error
-		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+		if imageNotFound(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to get image descriptor for %s: %w", image, err)
 	}
 	return true, nil
+}
+
+// imageNotFound reports whether err represents an HTTP 404 from the registry —
+// the canonical "manifest not present at this tag" response in the OCI Registry
+// v2 API, which we treat as a clean "image not published" verdict rather than a
+// probe failure.
+func imageNotFound(err error) bool {
+	var terr *transport.Error
+	return errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound
 }

--- a/release/internal/registry/image_test.go
+++ b/release/internal/registry/image_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+func TestImageNotFound(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "404 transport.Error",
+			err:  &transport.Error{StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "404 wrapped in fmt.Errorf",
+			err:  fmt.Errorf("checking image: %w", &transport.Error{StatusCode: http.StatusNotFound}),
+			want: true,
+		},
+		{
+			name: "401 transport.Error",
+			err:  &transport.Error{StatusCode: http.StatusUnauthorized},
+			want: false,
+		},
+		{
+			name: "500 transport.Error",
+			err:  &transport.Error{StatusCode: http.StatusInternalServerError},
+			want: false,
+		},
+		{
+			name: "non-transport error",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+		{
+			name: "wrapped non-transport error",
+			err:  fmt.Errorf("probe: %w", io.ErrUnexpectedEOF),
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imageNotFound(tc.err); got != tc.want {
+				t.Errorf("imageNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/release/internal/registry/image_test.go
+++ b/release/internal/registry/image_test.go
@@ -17,8 +17,9 @@ package registry
 import (
 	"errors"
 	"fmt"
-	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -56,14 +57,32 @@ func TestImageNotFound(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-transport error",
-			err:  errors.New("dial tcp: connection refused"),
+			// Mirrors the real shape remote.Head produces when the registry's
+			// WWW-Authenticate realm can't be reached (auth-dance DNS failure).
+			name: "url.Error (auth-dance network failure)",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://invalid.example.test/?service=x",
+				Err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("lookup invalid.example.test: no such host")},
+			},
 			want: false,
 		},
 		{
-			name: "wrapped non-transport error",
-			err:  fmt.Errorf("probe: %w", io.ErrUnexpectedEOF),
+			// Mirrors the real shape remote.Head produces when the manifest
+			// response is missing required headers — plain fmt.Errorf with no
+			// wrapped transport.Error in the chain.
+			name: "*errors.errorString (protocol issue)",
+			err:  fmt.Errorf("HEAD http://example.test/v2/foo/manifests/v1: response did not include Content-Type header"),
 			want: false,
+		},
+		{
+			// Mirrors the real shape remote.Head produces when both an HTTPS
+			// and HTTP attempt fail (transport.multierrs is unexported, but
+			// errors.Join uses the same Unwrap() []error pattern that
+			// errors.As walks).
+			name: "joined multi-error wrapping *transport.Error{404}",
+			err:  errors.Join(errors.New("https attempt failed"), &transport.Error{StatusCode: http.StatusNotFound}),
+			want: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -786,25 +786,14 @@ func (r *CalicoManager) componentImages() map[string]string {
 	return components
 }
 
-// CheckImagesPublished is the exported entry point for running the gate
-// (checkHashreleaseImagesPublished) without going through the surrounding
-// publishPrereqs validation chain. It is intended for use as a preflight
-// gate in hashrelease build, where we want to validate component image
-// existence before Phase 1's expensive build work begins. The existing
-// publishPrereqs path remains the canonical entry point at Phase 2 publish
-// time.
-func (r *CalicoManager) CheckImagesPublished() error {
-	return r.checkHashreleaseImagesPublished()
-}
-
-// checkHashreleaseImagesPublished checks that the images required for the hashrelease exist in the specified registries.
-func (r *CalicoManager) checkHashreleaseImagesPublished() error {
+// CheckHashreleaseImagesPublished checks that the images required for the hashrelease exist in the specified registries.
+func (r *CalicoManager) CheckHashreleaseImagesPublished() (bool, error) {
 	logrus.Info("Checking images required for hashrelease have already been published")
 	componentImages := r.componentImages()
 	numOfComponents := len(componentImages)
 	if numOfComponents == 0 {
 		logrus.Error("No images to check")
-		return fmt.Errorf("no images to check")
+		return false, fmt.Errorf("no images to check")
 	}
 
 	resultsCh := make(chan imageExistsResult, numOfComponents)
@@ -831,10 +820,14 @@ func (r *CalicoManager) checkHashreleaseImagesPublished() error {
 			missingImages = append(missingImages, result.image)
 		}
 	}
-	if len(missingImages) > 0 {
-		return errors.Join(fmt.Errorf("the following images required for hashrelease have not been published: %s", strings.Join(missingImages, ", ")), resultsErr)
+	if resultsErr != nil {
+		return false, resultsErr
 	}
-	return resultsErr
+	if len(missingImages) > 0 {
+		logrus.Errorf("the following images required for hashrelease have not been published: %s", strings.Join(missingImages, ", "))
+		return false, nil
+	}
+	return true, nil
 }
 
 // Check that the environment has the necessary prereqs for publishing hashrelease
@@ -848,8 +841,12 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 	if r.images {
 		return r.assertImageVersions()
 	} else {
-		if err := r.checkHashreleaseImagesPublished(); err != nil {
+		published, err := r.CheckHashreleaseImagesPublished()
+		if err != nil {
 			return err
+		}
+		if !published {
+			return fmt.Errorf("required component images have not been published")
 		}
 		logrus.Info("All images required for hashrelease have been published")
 	}

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -786,6 +786,17 @@ func (r *CalicoManager) componentImages() map[string]string {
 	return components
 }
 
+// CheckImagesPublished is the exported entry point for running the gate
+// (checkHashreleaseImagesPublished) without going through the surrounding
+// publishPrereqs validation chain. It is intended for use as a preflight
+// gate in hashrelease build, where we want to validate component image
+// existence before Phase 1's expensive build work begins. The existing
+// publishPrereqs path remains the canonical entry point at Phase 2 publish
+// time.
+func (r *CalicoManager) CheckImagesPublished() error {
+	return r.checkHashreleaseImagesPublished()
+}
+
 // checkHashreleaseImagesPublished checks that the images required for the hashrelease exist in the specified registries.
 func (r *CalicoManager) checkHashreleaseImagesPublished() error {
 	logrus.Info("Checking images required for hashrelease have already been published")


### PR DESCRIPTION
## Issue

When an upstream component image isn't yet published, the hashrelease build still runs to completion before failing — ~30 min of CI time spent on artifacts we already know won't ship, plus an operator image tag pushed and left orphaned at the registry.

## Why it exists

The check that detects missing component images — `checkHashreleaseImagesPublished` — runs only at publish time, inside `publishPrereqs`. By then the build is already done.

## Solution

Run the same check at the start of the build, immediately after the existing `HashreleasePublished` idempotency check. Exclude the operator from the set — it isn't pushed until publish.

## Derivation

The check function already exists; we export it as `CheckHashreleaseImagesPublished` and call it from the build action right after `HashreleasePublished`. All its inputs are in scope by then: the pinned-version file has been generated and registries are bound from flags. We parameterize `RetrieveImageComponents` with `includeOperator bool` so the preflight call can exclude the operator. The check now returns `(bool, error)` to mirror `HashreleasePublished` and distinguish a missing image from a probe failure.

## How we know it works

- The check is the same function publish already relies on — anything publish would catch, preflight catches earlier.
- Preflight is read-only — no disk writes, docker calls, registry pushes, or GCS writes.
- `--no-validation` skips preflight, matching publish's existing behavior. `--images` (developer mode where component images are built locally) also skips, since a registry-side probe isn't meaningful in that mode.
- Unit tests pass; manual integration test on a doomed sha pending.
