### PR TITLE
[v3.31] Suppress overlapping IP set CIDRs in nftables Auto mode

### DIFF
--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -302,7 +302,6 @@ func NewCalculationGraph(
 	//                   |
 	//               <dataplane>
 	//
-	// nftables interval sets reject overlap; Auto resolves to nftables at runtime.
 	ipsetMemberIndex := labelindex.NewSelectorAndNamedPortIndex(conf.NFTablesMode != "Disabled")
 	ipsetMemberIndex.OnAlive = liveCallback
 	// Wire up the inputs to the IP set member index.

--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -302,7 +302,8 @@ func NewCalculationGraph(
 	//                   |
 	//               <dataplane>
 	//
-	ipsetMemberIndex := labelindex.NewSelectorAndNamedPortIndex(conf.NFTablesMode == "Enabled")
+	// nftables interval sets reject overlap; Auto resolves to nftables at runtime.
+	ipsetMemberIndex := labelindex.NewSelectorAndNamedPortIndex(conf.NFTablesMode != "Disabled")
 	ipsetMemberIndex.OnAlive = liveCallback
 	// Wire up the inputs to the IP set member index.
 	ipsetMemberIndex.RegisterWith(allUpdDispatcher)


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v3.31**: projectcalico/calico#12650
Felix panicked when an nftables HashNet IP set received overlapping CIDRs - for example, a NetworkSet's `192.168.0.0/16` alongside a workload pod's `192.168.82.2/32` selected by the same NetworkPolicy. nftables interval-flagged sets reject contained CIDRs as conflicting intervals, Felix retries, retries fail the same way, and we panic at `felix/nftables/ipsets.go:366`.

The dataplane picks nftables for `NFTablesMode=Auto` whenever kube-proxy is in nftables mode (`useNftables` in `dataplane/linux/int_dataplane.go`), but the calc graph's overlap suppressor only enabled itself when the mode string was literally `"Enabled"`. The suppressor logic in `labelindex/named_port_index.go` was correct, just gated on the wrong predicate.

This change suppresses overlaps for any mode except `Disabled`, which keeps the two predicates in sync. iptables tolerates the dedup harmlessly since a `/16` already matches any contained `/32`.

```release-note
Fixes a Felix panic that could occur when an IP set selector matched both a NetworkSet CIDR and workload IPs contained within it, with nftables as the active dataplane.
```