### PR TITLE
ci: update postrelease tests

### DIFF
--- a/release/pkg/postrelease/github_test.go
+++ b/release/pkg/postrelease/github_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postrelease
 
 import (

--- a/release/pkg/postrelease/github_test.go
+++ b/release/pkg/postrelease/github_test.go
@@ -58,6 +58,8 @@ func TestGitHubRelease(t *testing.T) {
 		expectedAssets := append(calicoctlBinaryList(),
 			metadataFileName,
 			"install-calico-windows.ps1",
+			fmt.Sprintf("crd.projectcalico.org.v1-%s.tgz", releaseVersion),
+			fmt.Sprintf("projectcalico.org.v3-%s.tgz", releaseVersion),
 			fmt.Sprintf("calico-windows-%s.zip", releaseVersion),
 			fmt.Sprintf("release-%s.tgz", releaseVersion),
 			fmt.Sprintf("tigera-operator-%s.tgz", releaseVersion),

--- a/release/pkg/postrelease/helm_test.go
+++ b/release/pkg/postrelease/helm_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postrelease
 
 import (

--- a/release/pkg/postrelease/images_test.go
+++ b/release/pkg/postrelease/images_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postrelease
 
 import (

--- a/release/pkg/postrelease/images_test.go
+++ b/release/pkg/postrelease/images_test.go
@@ -16,8 +16,12 @@ import (
 )
 
 var excludeImageArch = map[string][]string{
-	"envoy-proxy": {"ppc64le", "s390x"},
-	"whisker":     {"ppc64le", "s390x"},
+	"envoy-proxy":       {"ppc64le", "s390x"},
+	"whisker":           {"ppc64le", "s390x"},
+	"istio-pilot":       {"ppc64le", "s390x"},
+	"istio-ztunnel":     {"ppc64le", "s390x"},
+	"istio-proxyv2":     {"ppc64le", "s390x"},
+	"istio-install-cni": {"ppc64le", "s390x"},
 }
 
 func TestImagesPublished(t *testing.T) {

--- a/release/pkg/postrelease/openstack_test.go
+++ b/release/pkg/postrelease/openstack_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postrelease
 
 import (

--- a/release/pkg/postrelease/openstack_test.go
+++ b/release/pkg/postrelease/openstack_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 )
 
 // PackageRevision represents a package with all its various permutations
@@ -33,7 +32,7 @@ func (pr PackageRevision) URL() string {
 // Head fetches and returns the HTTP HEAD response for a given PackageRevision
 func (pr PackageRevision) Head() (*http.Response, error) {
 	client := http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: httpTimeout,
 	}
 	url := pr.URL()
 

--- a/release/pkg/postrelease/openstack_test.go
+++ b/release/pkg/postrelease/openstack_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // PackageRevision represents a package with all its various permutations
@@ -31,9 +32,12 @@ func (pr PackageRevision) URL() string {
 
 // Head fetches and returns the HTTP HEAD response for a given PackageRevision
 func (pr PackageRevision) Head() (*http.Response, error) {
+	client := http.Client{
+		Timeout: 5 * time.Second,
+	}
 	url := pr.URL()
 
-	response, err := http.Head(url)
+	response, err := client.Head(url)
 	if err != nil {
 		return response, fmt.Errorf("could not fetch url: %w", err)
 	}

--- a/release/pkg/postrelease/setup_test.go
+++ b/release/pkg/postrelease/setup_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postrelease
 
 import (

--- a/release/pkg/postrelease/setup_test.go
+++ b/release/pkg/postrelease/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
@@ -18,6 +19,10 @@ var (
 	releaseVersion, operatorVersion, flannelVersion  string
 	githubOrg, githubRepo, githubRemote, githubToken string
 	images                                           string
+	httpTimeout                                      time.Duration
+
+	// The default timeout duration
+	httpDefaultTimeout = 10 * time.Second
 )
 
 func init() {
@@ -29,6 +34,7 @@ func init() {
 	flag.StringVar(&githubRemote, "github-repo-remote", utils.DefaultRemote, "GitHub repository remote")
 	flag.StringVar(&images, "images", "", "List of images to check")
 	flag.StringVar(&githubToken, "github-token", "", "GitHub token")
+	flag.DurationVar(&httpTimeout, "http-timeout", httpDefaultTimeout, "HTTP timeout for checking openstack packages")
 }
 
 func checkVersion(t testing.TB, version string) {


### PR DESCRIPTION
- **Add timeout for openstack postrelease tests (because launchpad is flaky)**
- **Add new v1/v3 CRD bundles**
- **Skip checking for istio ppc64le/s390x images**
