### PR TITLE
[v3.32] deps: ignore non-master/non-release SEMAPHORE_GIT_BRANCH

### DIFF
--- a/hack/cmd/deps/deps.go
+++ b/hack/cmd/deps/deps.go
@@ -818,44 +818,48 @@ func calculateDefaultBranch(semaphoreDir string) (string, error) {
 		return branch, nil
 	}
 
-	if branch := os.Getenv("SEMAPHORE_GIT_BRANCH"); branch != "" {
-		// In CI, this env var is set either to the current branch, if we're
-		// building on a branch, or to the target branch if we're building
-		// a PR.
-		if branch == "master" || strings.HasPrefix(branch, "release-v") {
-			logrus.Infof("Using SEMAPHORE_GIT_BRANCH for default branch: %s", branch)
-			return branch, nil
-		}
-	}
-
-	// Fallback to git.
-	out, err := exec.Command("git", "branch", "--show-current").Output()
-	if err != nil {
-		return "", fmt.Errorf("git branch --show-current failed: %w", err)
-	}
-	branch := strings.TrimSpace(string(out))
-
-	if branch == mainBranchName {
-		logrus.Info("On master branch, using that for default branch.")
-		return branch, nil
-	}
-
-	// Check for release branch.
 	releaseBranchPrefix := os.Getenv("RELEASE_BRANCH_PREFIX")
 	if releaseBranchPrefix == "" {
 		return "", fmt.Errorf("RELEASE_BRANCH_PREFIX not set")
 	}
 	releaseBranchRegexp := regexp.MustCompile(`^` + regexp.QuoteMeta(releaseBranchPrefix) + `-v[\d.-]+$`)
-	if s := releaseBranchRegexp.FindString(branch); s != "" {
-		// Explicitly on a release branch, so use that.
-		logrus.Infof("On release branch %s, using that for default branch.", s)
-		return s, nil
+
+	// In CI, SEMAPHORE_GIT_BRANCH is set either to the current branch, if
+	// we're building on a branch, or to the target branch if we're building
+	// a PR. For stacked PRs (PR2 targets PR1's branch), the target branch
+	// can be a non-master, non-release branch — ignore those and fall
+	// through to detecting the default from the existing semaphore.yml.
+	if branch := os.Getenv("SEMAPHORE_GIT_BRANCH"); branch != "" {
+		if branch == mainBranchName || releaseBranchRegexp.MatchString(branch) {
+			logrus.Infof("Using SEMAPHORE_GIT_BRANCH for default branch: %s", branch)
+			return branch, nil
+		}
+		logrus.Infof("SEMAPHORE_GIT_BRANCH %q is not master or a release branch, ignoring.", branch)
+	} else {
+		// Fallback to git.
+		out, err := exec.Command("git", "branch", "--show-current").Output()
+		if err != nil {
+			return "", fmt.Errorf("git branch --show-current failed: %w", err)
+		}
+		branch := strings.TrimSpace(string(out))
+
+		if branch == mainBranchName {
+			logrus.Info("On master branch, using that for default branch.")
+			return branch, nil
+		}
+
+		if s := releaseBranchRegexp.FindString(branch); s != "" {
+			// Explicitly on a release branch, so use that.
+			logrus.Infof("On release branch %s, using that for default branch.", s)
+			return s, nil
+		}
+		logrus.Infof("Branch %q is not master or a release branch.", branch)
 	}
 
 	// If we're not on a release branch, this is likely to be a PR build,
 	// and the semaphore.yml should have inherited the default from whichever
 	// branch it was based on.  Check there.
-	logrus.Infof("Branch %q is not a release branch, checking semaphore.yml for default branch.", branch)
+	logrus.Infof("Checking semaphore.yml for default branch.")
 	detected, err := detectExistingDefaultBranch(filepath.Join(semaphoreDir, "semaphore.yml"))
 	if err != nil {
 		return "", fmt.Errorf("detect release branch from semaphore yaml: %w", err)


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#12659

For stacked PRs (PR2 targeting PR1's branch), Semaphore sets \`SEMAPHORE_GIT_BRANCH\` to PR1's branch when building PR2. The deps tool was using that value verbatim as the \`default_branch\` in the generated semaphore.yml files, leaving spurious \`default_branch: '<PR1-branch>'\` stanzas in PR2's diff.

This change makes the deps tool only honour \`SEMAPHORE_GIT_BRANCH\` when it points to \`master\` or a release branch. Otherwise, it falls through to the existing logic that detects the default branch from the existing \`semaphore.yml\` (the same fallback that was already used for the local-git case).

