### PR TITLE
Fix: start-of-day syncer could apply state without host IPs (broke NP frontends)

### DIFF
--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -161,6 +161,11 @@ func (kp *KubeProxy) run(hostIPs []net.IP, hostMetadata map[string]*proto.HostMe
 		return errors.WithMessage(err, "new bpf syncer")
 	}
 
+	kp.proxy, err = New(kp.k8s, syncer, kp.hostname, kp.opts...)
+	if err != nil {
+		return errors.WithMessage(err, "new proxy")
+	}
+
 	kp.proxy.SetHostIPs(hostIPs)
 	// Don't bother invoking a resync within SetHostMetadata; we will be syncing a fresh syncer right after.
 	kp.proxy.SetHostMetadata(hostMetadata, false)
@@ -174,28 +179,6 @@ func (kp *KubeProxy) run(hostIPs []net.IP, hostMetadata map[string]*proto.HostMe
 }
 
 func (kp *KubeProxy) start() error {
-	var withLocalNP []net.IP
-	if kp.ipFamily == 4 {
-		withLocalNP = append(withLocalNP, podNPIP)
-	} else {
-		withLocalNP = append(withLocalNP, podNPIPV6)
-	}
-
-	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.MaglevMap, kp.affinityMap, kp.rt, kp.excludedCIDRs, kp.maglevLUTSize)
-	if err != nil {
-		return errors.WithMessage(err, "new bpf syncer")
-	}
-
-	proxy, err := New(kp.k8s, syncer, kp.hostname, kp.opts...)
-	if err != nil {
-		return errors.WithMessage(err, "new proxy")
-	}
-
-	kp.lock.Lock()
-	kp.proxy = proxy
-	kp.syncer = syncer
-	kp.lock.Unlock()
-
 	// Wait for the initial update.
 	hostIPs := <-kp.hostIPUpdates
 
@@ -206,7 +189,7 @@ func (kp *KubeProxy) start() error {
 	hostMetadataUpdates := <-kp.hostMetadataUpdates
 	mergeHostMetadataV4V6Updates(hostMetadata, hostMetadataUpdates)
 
-	err = kp.run(hostIPs, hostMetadata)
+	err := kp.run(hostIPs, hostMetadata)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This was a latent bug which now seems to be exposed (v3.31 and later).

CT cleaner races with syncer to acquire a lock at start of day which, if CT cleaner acquired it, would block syncer from applying bad state at start of day for 10's of seconds. In 3.31 and later, it loses this race, and syncer applies its state before hostIPs are recv'd from Felix. This means the state it applies is missing NP frontend entries.

**Release note:**
```release-note
Fix a latent bug in eBPF proxy which led to ingress traffic for NodePorts getting temporarily refused during calico-node restart.
```
