### PR TITLE
Wait for VirtualNetworksSubnet before creating VMs in ASO test setup

### DIFF
--- a/process/testing/aso/vmss.sh
+++ b/process/testing/aso/vmss.sh
@@ -141,6 +141,13 @@ EOF
     return 1
   fi
 
+  # NICs reference subnet-aso directly; ASO does not retry NIC creation if
+  # the subnet hasn't reconciled in Azure yet, so gate on the subnet too.
+  if ! wait_for_aso_resource "virtualnetworkssubnet" "subnet-aso" "aso" "300s"; then
+    log_error "Failed to create Subnet"
+    return 1
+  fi
+
   # Step 3: Secrets
   log_info "Creating secrets..."
   ${KUBECTL} apply -f ${ASO_DIR}/infra/manifests/password.yaml

--- a/process/testing/aso/vmss.sh
+++ b/process/testing/aso/vmss.sh
@@ -148,6 +148,12 @@ EOF
     return 1
   fi
 
+  # NICs also reference aso-sg; same race class as the subnet.
+  if ! wait_for_aso_resource "networksecuritygroup" "aso-sg" "aso" "300s"; then
+    log_error "Failed to create Network Security Group"
+    return 1
+  fi
+
   # Step 3: Secrets
   log_info "Creating secrets..."
   ${KUBECTL} apply -f ${ASO_DIR}/infra/manifests/password.yaml
@@ -206,11 +212,12 @@ function wait_for_aso_resource() {
 
   log_info "Waiting for $resource_type/$resource_name in namespace $namespace (timeout: $timeout)..."
 
-  # First, wait for the resource to exist (up to 60 seconds)
+  # First, wait for the resource to exist (up to 120 seconds — controller restarts
+  # or webhook backpressure occasionally push past 60s).
   local wait_count=0
   while ! ${KUBECTL} get "$resource_type/$resource_name" -n "$namespace" >/dev/null 2>&1; do
-    if [[ $wait_count -ge 60 ]]; then
-      log_fail "$resource_type/$resource_name does not exist after 60 seconds"
+    if [[ $wait_count -ge 120 ]]; then
+      log_fail "$resource_type/$resource_name does not exist after 120 seconds"
       return 1
     fi
     log_info "Waiting for $resource_type/$resource_name to be created... (${wait_count}s)"
@@ -247,6 +254,17 @@ function get_and_export_node_ips() {
     log_info "Ensuring ${vm_name} is ready with ASO v2 status check..."
     if ! wait_for_aso_resource "virtualmachine" "${vm_name}" "aso" "480s"; then
       log_error "${vm_name} did not become ready in time"
+      return 1
+    fi
+
+    # The VirtualMachine Ready condition does NOT propagate NIC/PIP failures,
+    # so we must explicitly wait on those before reading their status fields.
+    if ! wait_for_aso_resource "networkinterface" "${nic_name}" "aso" "300s"; then
+      log_error "${nic_name} did not become ready"
+      return 1
+    fi
+    if ! wait_for_aso_resource "publicipaddress" "${pip_name}" "aso" "300s"; then
+      log_error "${pip_name} did not become ready"
       return 1
     fi
 
@@ -288,6 +306,16 @@ function get_and_export_node_ips() {
     log_info "Ensuring ${vm_name} is ready with ASO v2 status check..."
     if ! wait_for_aso_resource "virtualmachine" "${vm_name}" "aso" "480s"; then
       log_error "${vm_name} did not become ready in time"
+      return 1
+    fi
+
+    # See note above: VM Ready does not imply NIC/PIP Ready.
+    if ! wait_for_aso_resource "networkinterface" "${nic_name}" "aso" "300s"; then
+      log_error "${nic_name} did not become ready"
+      return 1
+    fi
+    if ! wait_for_aso_resource "publicipaddress" "${pip_name}" "aso" "300s"; then
+      log_error "${pip_name} did not become ready"
       return 1
     fi
 


### PR DESCRIPTION
The Windows CNI plugin test pipeline was failing during ASO v2 cluster bring-up: `nic-linux-1` ended in `InvalidResourceReference` because the subnet it bound to had not yet reconciled in Azure.

`process/testing/aso/vmss.sh` (`apply_azure_crds`) was waiting for `virtualnetwork/vnet-aso` to be Ready and then immediately applying the VM/NIC manifests. ASO models the subnet as a separate child CR (`virtualnetworkssubnet/subnet-aso`, defined alongside the vnet in `infra/templates/vnet.yaml`), and that resource was not waited on. When the NIC reconcile lost the race against the subnet's first reconcile, ASO did not retry the NIC creation, which then masked downstream: ASO still reported the dependent `virtualmachine` as Ready, but IP retrieval returned empty strings, and the SSH retry loop ran for 15 minutes against `aso@` with no host before failing.

This change adds a wait on `virtualnetworkssubnet/subnet-aso` between the existing vnet wait and the VM/NIC apply, using the existing `wait_for_aso_resource` helper.

**Testing:** `bash -n` clean; end-to-end verification is via the Windows CNI plugin CI job.