### PR TITLE
Make calico image a tracked prereq for component test targets

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -599,7 +599,7 @@ blocks:
       jobs:
         - name: "CNI Plugin: CI"
           commands:
-            - ../.semaphore/run-and-monitor ci.log make ci
+            - ../.semaphore/run-and-monitor ci.log make ci-no-prereqs
       epilogue:
         always:
           commands:
@@ -1261,11 +1261,11 @@ blocks:
       jobs:
         - name: "kube-controllers: CI"
           commands:
-            - ../.semaphore/run-and-monitor ci.log make ci
+            - ../.semaphore/run-and-monitor ci.log make ci-no-prereqs
         # Run a subset of the kube-controllers CI tests that use the projectcalico.org/v3 API group for CRDs.
         - name: "kube-controllers: CI (projectcalico.org/v3)"
           commands:
-            - ../.semaphore/run-and-monitor ut.log make ut
+            - ../.semaphore/run-and-monitor ut.log make ut-no-prereqs
           env_vars:
             - name: CALICO_API_GROUP
               value: "projectcalico.org/v3"
@@ -1485,13 +1485,13 @@ blocks:
         - name: "Typha: UT and FV tests"
           commands:
             - export TEST_SUITE_PREFIX="calico/base"
-            - ../.semaphore/run-and-monitor make-ci.log make ci
+            - ../.semaphore/run-and-monitor make-ci.log make ci-no-prereqs
         - name: "Typha: FV tests on UBI-minimal"
           commands:
             - 'export TEST_SUITE_PREFIX="UBI-minimal"'
             # Rebuild the combined image with UBI-minimal as CALICO_BASE,
             # then run Typha FV against it.
-            - ../.semaphore/run-and-monitor make-fv-ubi.log bash -c 'make -C ../cmd/calico clean image && make fv'
+            - ../.semaphore/run-and-monitor make-fv-ubi.log bash -c 'make -C ../cmd/calico clean image && make fv-no-prereqs'
           env_vars:
             - name: USE_UBI_AS_CALICO_BASE
               value: '1'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1516,7 +1516,7 @@ blocks:
       jobs:
         - name: "CNI Plugin: CI"
           commands:
-            - ../.semaphore/run-and-monitor ci.log make ci
+            - ../.semaphore/run-and-monitor ci.log make ci-no-prereqs
       epilogue:
         always:
           commands:
@@ -3552,11 +3552,11 @@ blocks:
       jobs:
         - name: "kube-controllers: CI"
           commands:
-            - ../.semaphore/run-and-monitor ci.log make ci
+            - ../.semaphore/run-and-monitor ci.log make ci-no-prereqs
         # Run a subset of the kube-controllers CI tests that use the projectcalico.org/v3 API group for CRDs.
         - name: "kube-controllers: CI (projectcalico.org/v3)"
           commands:
-            - ../.semaphore/run-and-monitor ut.log make ut
+            - ../.semaphore/run-and-monitor ut.log make ut-no-prereqs
           env_vars:
             - name: CALICO_API_GROUP
               value: "projectcalico.org/v3"
@@ -4821,13 +4821,13 @@ blocks:
         - name: "Typha: UT and FV tests"
           commands:
             - export TEST_SUITE_PREFIX="calico/base"
-            - ../.semaphore/run-and-monitor make-ci.log make ci
+            - ../.semaphore/run-and-monitor make-ci.log make ci-no-prereqs
         - name: "Typha: FV tests on UBI-minimal"
           commands:
             - 'export TEST_SUITE_PREFIX="UBI-minimal"'
             # Rebuild the combined image with UBI-minimal as CALICO_BASE,
             # then run Typha FV against it.
-            - ../.semaphore/run-and-monitor make-fv-ubi.log bash -c 'make -C ../cmd/calico clean image && make fv'
+            - ../.semaphore/run-and-monitor make-fv-ubi.log bash -c 'make -C ../cmd/calico clean image && make fv-no-prereqs'
           env_vars:
             - name: USE_UBI_AS_CALICO_BASE
               value: '1'

--- a/.semaphore/semaphore.yml.d/blocks/20-cni-plugin.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-cni-plugin.yml
@@ -15,7 +15,7 @@
     jobs:
       - name: "CNI Plugin: CI"
         commands:
-          - ../.semaphore/run-and-monitor ci.log make ci
+          - ../.semaphore/run-and-monitor ci.log make ci-no-prereqs
     epilogue:
       always:
         commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-kube-controllers.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-kube-controllers.yml
@@ -15,12 +15,12 @@
     jobs:
       - name: "kube-controllers: CI"
         commands:
-          - ../.semaphore/run-and-monitor ci.log make ci
+          - ../.semaphore/run-and-monitor ci.log make ci-no-prereqs
 
       # Run a subset of the kube-controllers CI tests that use the projectcalico.org/v3 API group for CRDs.
       - name: "kube-controllers: CI (projectcalico.org/v3)"
         commands:
-          - ../.semaphore/run-and-monitor ut.log make ut
+          - ../.semaphore/run-and-monitor ut.log make ut-no-prereqs
         env_vars:
           - name: CALICO_API_GROUP
             value: "projectcalico.org/v3"

--- a/.semaphore/semaphore.yml.d/blocks/20-typha.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-typha.yml
@@ -16,13 +16,13 @@
       - name: "Typha: UT and FV tests"
         commands:
           - export TEST_SUITE_PREFIX="calico/base"
-          - ../.semaphore/run-and-monitor make-ci.log make ci
+          - ../.semaphore/run-and-monitor make-ci.log make ci-no-prereqs
       - name: "Typha: FV tests on UBI-minimal"
         commands:
           - 'export TEST_SUITE_PREFIX="UBI-minimal"'
           # Rebuild the combined image with UBI-minimal as CALICO_BASE,
           # then run Typha FV against it.
-          - ../.semaphore/run-and-monitor make-fv-ubi.log bash -c 'make -C ../cmd/calico clean image && make fv'
+          - ../.semaphore/run-and-monitor make-fv-ubi.log bash -c 'make -C ../cmd/calico clean image && make fv-no-prereqs'
         env_vars:
           - name: USE_UBI_AS_CALICO_BASE
             value: '1'

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -229,19 +229,30 @@ pkg/install/install.test: pkg/install/*.go
 			cd /go/src/$(PACKAGE_NAME) && \
 			go test ./pkg/install -c --tags install_test -o ./pkg/install/install.test'
 
-.PHONY: test-install-cni
+.PHONY: test-install-cni test-install-cni-prereqs test-install-cni-no-prereqs
 ## Test the install
 # Uses the combined calico/calico image (loaded from the calico-image prerequisite
-# job in CI, or built locally via `make -C cmd/calico image`). The test invokes
-# `calico component cni install` instead of the legacy `/opt/cni/bin/install`.
-test-install-cni: run-k8s-apiserver pkg/install/install.test
+# job in CI, or built locally via the marker rule in lib.Makefile). The test
+# invokes `calico component cni install` instead of the legacy
+# `/opt/cni/bin/install`. CI invokes the *-no-prereqs target directly so a
+# missing cached image fails loudly rather than triggering a silent rebuild.
+test-install-cni: test-install-cni-prereqs
+	$(MAKE) test-install-cni-no-prereqs
+
+test-install-cni-prereqs: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+
+test-install-cni-no-prereqs: run-k8s-apiserver pkg/install/install.test
 	cd pkg/install && CONTAINER_NAME=calico/calico:latest-$(ARCH) CERTS_PATH=$(CERTS_PATH) ./install.test
 
 ###############################################################################
 # CI/CD
 ###############################################################################
-.PHONY: ci
+.PHONY: ci ci-no-prereqs
 ci: clean mod-download build static-checks ut test-install-cni
+
+# CI entry point: skips the calico image rebuild and runs the full test suite.
+# The image must be preloaded from the GCS cache.
+ci-no-prereqs: mod-download build static-checks ut test-install-cni-no-prereqs
 
 ## Build fv binary for Windows
 $(WINDOWS_BIN)/win-fv.exe: $(WINFV_SRCFILES)

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -319,18 +319,17 @@ fv/fv.test: $(LIBBPF_A) $(SRC_FILES) $(FV_SRC_FILES)
 	fi
 	$(DOCKER_GO_BUILD_CGO) go test ./fv -c -o $@
 
-REMOTE_DEPS=build-calico-image
+# Typha runs from the combined calico image as `component typha` (see
+# FV_TYPHAIMAGE). The marker rule lives in lib.Makefile and recurses into
+# cmd/calico to build the image; in CI the image is preloaded from the
+# calico-image GCS cache and REMOTE_DEPS is set empty to opt out so a
+# broken cache fails loudly instead of silently rebuilding.
+REMOTE_DEPS=$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
 ifeq ($(FV_RACE_DETECTOR_ENABLED),true)
 REMOTE_DEPS+=build-calico-race
 else
 REMOTE_DEPS+=build-calico-cgo
 endif
-
-# Typha runs from the combined calico image as `component typha` (see
-# FV_TYPHAIMAGE). For local FV runs we build the image here; in CI it is
-# preloaded from the calico-image GCS cache.
-build-calico-image:
-	$(MAKE) -C ../cmd/calico image
 
 # FV mounts the combined binary into the felix-test container. The cgo
 # variant supports BPF; the race variant adds -race for the race detector.
@@ -340,7 +339,7 @@ build-calico-cgo:
 build-calico-race:
 	$(MAKE) -C ../cmd/calico build-race
 
-.PHONY: fv fv-prereqs fv-no-build build-calico-image build-calico-cgo build-calico-race
+.PHONY: fv fv-prereqs fv-no-build build-calico-cgo build-calico-race
 
 # Build everything needed to run the FVs but don't actually run them.  The semaphore job runs
 # this target to build everything so that it can be cached and shared between downstream jobs.

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -322,14 +322,17 @@ fv/fv.test: $(LIBBPF_A) $(SRC_FILES) $(FV_SRC_FILES)
 # Typha runs from the combined calico image as `component typha` (see
 # FV_TYPHAIMAGE). The marker rule lives in lib.Makefile and recurses into
 # cmd/calico to build the image; in CI the image is preloaded from the
-# calico-image GCS cache and REMOTE_DEPS is set empty to opt out so a
-# broken cache fails loudly instead of silently rebuilding.
-REMOTE_DEPS=$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+# calico-image GCS cache and CALICO_IMAGE_DEP is cleared to opt out so a
+# broken cache fails loudly instead of silently rebuilding. Callers that
+# supply the image themselves (e.g. typha k8sfv-test) clear CALICO_IMAGE_DEP
+# but keep CALICO_BINARY_DEP so the on-disk FV binary is still produced.
+CALICO_IMAGE_DEP=$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
 ifeq ($(FV_RACE_DETECTOR_ENABLED),true)
-REMOTE_DEPS+=build-calico-race
+CALICO_BINARY_DEP=build-calico-race
 else
-REMOTE_DEPS+=build-calico-cgo
+CALICO_BINARY_DEP=build-calico-cgo
 endif
+REMOTE_DEPS=$(CALICO_IMAGE_DEP) $(CALICO_BINARY_DEP)
 
 # FV mounts the combined binary into the felix-test container. The cgo
 # variant supports BPF; the race variant adds -race for the race detector.

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -84,13 +84,13 @@ bin/gotestsum:
 # cached image fails loudly instead of triggering a silent rebuild.
 test: ut
 
-.PHONY: ut fv ut-prereqs fv-prereqs ut-no-prereqs fv-no-prereqs
+.PHONY: ut fv ut-prereqs ut-no-prereqs
 ut fv: ut-prereqs
 	$(MAKE) ut-no-prereqs
 
-ut-prereqs fv-prereqs: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+ut-prereqs: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
 
-ut-no-prereqs fv-no-prereqs: $(TEST_BINARIES) setup-envtest bin/gotestsum
+ut-no-prereqs: $(TEST_BINARIES) setup-envtest bin/gotestsum
 	KUBE_IMAGE=$(CALICO_BUILD) \
 		   ETCD_IMAGE=$(ETCD_IMAGE) \
 		   CALICO_API_GROUP=$(CALICO_API_GROUP) \

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -79,9 +79,18 @@ bin/gotestsum:
 
 ## Run the unit tests in a container.
 # kube-controllers tests use the combined calico/calico image (loaded from the
-# calico-image prerequisite in CI, or built locally via `make -C cmd/calico image`).
+# calico-image prerequisite in CI, or built locally via the marker rule in
+# lib.Makefile). CI invokes the *-no-prereqs targets directly so a missing
+# cached image fails loudly instead of triggering a silent rebuild.
 test: ut
-ut fv: $(TEST_BINARIES) $(KUBE_CONTROLLER_CONTAINER_CREATED) setup-envtest bin/gotestsum
+
+.PHONY: ut fv ut-prereqs fv-prereqs ut-no-prereqs fv-no-prereqs
+ut fv: ut-prereqs
+	$(MAKE) ut-no-prereqs
+
+ut-prereqs fv-prereqs: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+
+ut-no-prereqs fv-no-prereqs: $(TEST_BINARIES) setup-envtest bin/gotestsum
 	KUBE_IMAGE=$(CALICO_BUILD) \
 		   ETCD_IMAGE=$(ETCD_IMAGE) \
 		   CALICO_API_GROUP=$(CALICO_API_GROUP) \
@@ -105,5 +114,9 @@ ut fv: $(TEST_BINARIES) $(KUBE_CONTROLLER_CONTAINER_CREATED) setup-envtest bin/g
 ###############################################################################
 # CI
 ###############################################################################
-.PHONY: ci
+.PHONY: ci ci-no-prereqs
 ci: clean mod-download static-checks ut
+
+# CI entry point: skips the calico image rebuild and runs static checks plus
+# the unit tests. The image must be preloaded from the GCS cache.
+ci-no-prereqs: mod-download static-checks ut-no-prereqs

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -37,10 +37,15 @@ ut combined.coverprofile: $(SRC_FILES)
 ###############################################################################
 # CI/CD
 ###############################################################################
-.PHONY: ci version
+.PHONY: ci ci-no-prereqs version version-no-prereqs fv fv-no-prereqs k8sfv-test k8sfv-test-no-prereqs
+
 # Uses the combined calico/calico image (loaded from the calico-image prerequisite
-# in CI, or built locally via `make -C cmd/calico image`).
-version:
+# in CI, or built locally via the marker rule in lib.Makefile). CI invokes the
+# *-no-prereqs targets directly so a missing cached image fails loudly rather
+# than triggering a silent rebuild.
+version: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) version-no-prereqs
+
+version-no-prereqs:
 	docker run --rm calico/calico:latest-$(ARCH) version
 
 ci: mod-download version static-checks ut
@@ -48,12 +53,22 @@ ifeq (,$(filter k8sfv-test, $(EXCEPT)))
 	@$(MAKE) k8sfv-test
 endif
 
+# CI entry point: skips the calico image rebuild and runs the full test suite.
+# The image must be preloaded from the GCS cache.
+ci-no-prereqs: mod-download version-no-prereqs static-checks ut
+ifeq (,$(filter k8sfv-test, $(EXCEPT)))
+	@$(MAKE) k8sfv-test-no-prereqs
+endif
+
 fv: k8sfv-test
+fv-no-prereqs: k8sfv-test-no-prereqs
 
 # k8sfv-test runs the combined calico/calico image with `component typha` as the
 # command. The image is loaded from GCS in CI or built locally.
-k8sfv-test:
-	$(MAKE) -C ../felix JUST_A_MINUTE=true USE_TYPHA=true \
+k8sfv-test: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) k8sfv-test-no-prereqs
+
+k8sfv-test-no-prereqs:
+	$(MAKE) -C ../felix REMOTE_DEPS= JUST_A_MINUTE=true USE_TYPHA=true \
 		FV_TYPHAIMAGE=calico/calico:latest-$(ARCH) \
 		FV_TYPHACMD="component typha" \
 		TYPHA_VERSION=latest k8sfv-test

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -43,7 +43,8 @@ ut combined.coverprofile: $(SRC_FILES)
 # in CI, or built locally via the marker rule in lib.Makefile). CI invokes the
 # *-no-prereqs targets directly so a missing cached image fails loudly rather
 # than triggering a silent rebuild.
-version: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) version-no-prereqs
+version: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+	$(MAKE) version-no-prereqs
 
 version-no-prereqs:
 	docker run --rm calico/calico:latest-$(ARCH) version
@@ -65,10 +66,11 @@ fv-no-prereqs: k8sfv-test-no-prereqs
 
 # k8sfv-test runs the combined calico/calico image with `component typha` as the
 # command. The image is loaded from GCS in CI or built locally.
-k8sfv-test: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH) k8sfv-test-no-prereqs
+k8sfv-test: $(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)
+	$(MAKE) k8sfv-test-no-prereqs
 
 k8sfv-test-no-prereqs:
-	$(MAKE) -C ../felix REMOTE_DEPS= JUST_A_MINUTE=true USE_TYPHA=true \
+	$(MAKE) -C ../felix CALICO_IMAGE_DEP= JUST_A_MINUTE=true USE_TYPHA=true \
 		FV_TYPHAIMAGE=calico/calico:latest-$(ARCH) \
 		FV_TYPHACMD="component typha" \
 		TYPHA_VERSION=latest k8sfv-test


### PR DESCRIPTION
kube-controllers, cni-plugin, typha, and felix all docker run the combined calico image during tests, but most of them didn't declare it as a make prereq. On a fresh checkout local dev runs failed because the image hadn't been built yet. kube-controllers in particular referenced an undefined `KUBE_CONTROLLER_CONTAINER_CREATED` variable that expanded to nothing (fallout from the mono-image consolidation in #12225).

Each component now depends on `$(REPO_ROOT)/cmd/calico/.image.created-$(ARCH)` (the marker rule already living in `lib.Makefile`) and provides a `*-no-prereqs` variant that skips the rebuild. CI invokes the no-prereqs variants so a missing cached image fails loudly rather than silently rebuilding. Felix gets the same treatment by swapping its `build-calico-image` PHONY for the marker file in `REMOTE_DEPS`.

Verified with `make -n` on each target: the plain targets (`make fv`, `make k8sfv-test`, etc.) trigger the cmd/calico image build, and the `*-no-prereqs` variants don't.

**Release note:**
```release-note
None
```
