### PR TITLE
Capture VM-side snapshot when batch watchdog fires

### DIFF
--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -222,6 +222,17 @@ for batch in "${batches[@]}"; do
     sleep "$watchdog_seconds"
     echo
     echo "===== WATCHDOG: batch $batch approaching job timeout (${JOB_TIMEOUT_MINUTES}m) ====="
+
+    # Capture a VM-side snapshot before SIGTERM so we have evidence of what
+    # was hung (test process? docker? bpffs umount? leaked BPF objects?).
+    # Wrapped in 'timeout' so a hung VM/SSH cannot extend the kill.
+    snapshot_log="$artifacts_dir/vm-snapshot-$batch_formatted.log"
+    echo "  Capturing pre-kill VM snapshot to $snapshot_log"
+    timeout 60 env VM_NAME="$vm_name" ZONE="$zone" "$my_dir/on-test-vm" \
+        bash "$CALICO_DIR_NAME/.semaphore/vms/vm-snapshot" \
+        > "$snapshot_log" 2>&1 \
+        || echo "  VM snapshot capture failed/timed out (rc=$?)"
+
     echo "  Killing hung batch $batch (pid $pid)"
     kill -TERM "-$pid" 2>/dev/null || true
 

--- a/.semaphore/vms/vm-snapshot
+++ b/.semaphore/vms/vm-snapshot
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Captures VM-side diagnostic state when the batch watchdog fires before
+# SIGTERMing the batch. Best-effort: each section is independent and never
+# aborts the rest of the snapshot.
+
+# Don't 'set -e' - we want best-effort capture.
+export LC_ALL=C
+export PATH=$PATH:/usr/sbin:/sbin
+
+section() {
+  echo
+  echo "===== $* ====="
+}
+
+section "date / kernel / uptime"
+date -u
+uname -a
+uptime
+
+section "load / memory / disk"
+cat /proc/loadavg
+free -m
+df -h
+
+section "mount | grep -E 'bpf|cgroup'"
+mount | grep -E 'bpf|cgroup' || true
+
+section "docker ps -a"
+sudo docker ps -a 2>&1 || true
+
+section "docker info (container-runtime state)"
+sudo docker info 2>&1 | head -80 || true
+
+section "ps auxfww"
+ps auxfww
+
+section "find /sys/fs/bpf (depth<=3)"
+sudo find /sys/fs/bpf -mindepth 1 -maxdepth 3 -printf '%y %p\n' 2>/dev/null | head -300 || true
+
+if command -v bpftool >/dev/null 2>&1; then
+  section "bpftool prog show"
+  sudo bpftool prog show 2>&1 | head -300 || true
+  section "bpftool map show"
+  sudo bpftool map show 2>&1 | head -300 || true
+  section "bpftool link show"
+  sudo bpftool link show 2>&1 | head -200 || true
+fi
+
+section "ip link"
+ip -d link 2>&1 | head -200 || true
+
+# The wrapped batch process pid is written to test.pid by batches.sh.
+# Inspect it and any descendants for kernel-side hang state (wchan + stack).
+if [ -f "$HOME/test.pid" ]; then
+  TEST_PID=$(cat "$HOME/test.pid")
+  section "test wrapper pid=$TEST_PID descendants"
+  if [ -d "/proc/$TEST_PID" ]; then
+    # Walk the process tree under TEST_PID. pgrep -P only gives direct
+    # children, but the test process is typically docker -> bash -> bpf_ut.test
+    # so we recurse manually with ps --ppid.
+    pids=("$TEST_PID")
+    queue=("$TEST_PID")
+    while [ ${#queue[@]} -gt 0 ]; do
+      head=${queue[0]}
+      queue=("${queue[@]:1}")
+      # shellcheck disable=SC2207
+      kids=( $(ps --ppid "$head" -o pid= 2>/dev/null) )
+      for k in "${kids[@]}"; do
+        pids+=("$k")
+        queue+=("$k")
+      done
+    done
+
+    for pid in "${pids[@]}"; do
+      [ -d "/proc/$pid" ] || continue
+      cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
+      state=$(awk '/^State:/{print $2,$3}' "/proc/$pid/status" 2>/dev/null)
+      wchan=$(cat "/proc/$pid/wchan" 2>/dev/null)
+      echo
+      echo "--- pid=$pid state=$state wchan=$wchan"
+      echo "    cmd: $cmd"
+      sudo cat "/proc/$pid/stack" 2>/dev/null | head -30
+    done
+  else
+    echo "/proc/$TEST_PID does not exist (process already gone)"
+  fi
+else
+  section "no \$HOME/test.pid - cannot identify wrapper pid"
+fi
+
+section "dmesg | tail -500"
+sudo dmesg --ctime 2>/dev/null | tail -500 || sudo dmesg | tail -500 || true
+
+section "tail -n 200 \$HOME/test.log"
+tail -n 200 "$HOME/test.log" 2>/dev/null || echo "(no test.log)"
+
+echo
+echo "===== END VM SNAPSHOT ====="


### PR DESCRIPTION
Felix CI batches run on per-batch GCP VMs with a 5-min-before-timeout watchdog. When it fires today, the operator only sees "watchdog killed batch X" with no clue whether the test process, docker, or kernel-side cleanup (bpffs umount, BPF prog/link still attached, leaked maps) was hung. PR #12644 added stderr capture for hangs that emit output, but silent kernel-side hangs leave nothing in the artifact.

This adds a `vm-snapshot` script and invokes it from the watchdog block immediately before SIGTERM. It captures `ps auxfww`, `/proc/<pid>/{status,wchan,stack}` for the wrapper pid (`test.pid` written by `batches.sh`) and all descendants, `mount | grep -E 'bpf|cgroup'`, `find /sys/fs/bpf`, `bpftool prog/map/link show`, `docker ps -a` + `docker info`, `dmesg | tail`, and the tail of `test.log`. Output goes to `artifacts/vm-snapshot-<batch>.log` so it ships with the rest of the batch artifacts via the existing `publish-artifacts` epilogue. Wrapped in `timeout 60` so a hung VM/SSH cannot extend the time before the kill.

Follow-up to #12644: that one catches stderr-emitting hangs; this one catches silent ones.

**Release note:**
```release-note
None
```
