### PR TITLE
fix(release): wire operator git flags through publish/public, fix manager fallbacks

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -149,7 +149,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithVersion(ver.FormattedString()),
 					calico.WithOperatorVersion(operatorVer.FormattedString()),
-					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
+					calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
@@ -190,14 +190,16 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 }
 
 func releasePublicSubCommands(cfg *Config) *cli.Command {
+	flags := []cli.Flag{
+		orgFlag,
+		repoFlag,
+		repoRemoteFlag,
+	}
+	flags = append(flags, operatorGitFlags...)
 	return &cli.Command{
 		Name:  "public",
 		Usage: "Make a published release available to the public",
-		Flags: []cli.Flag{
-			orgFlag,
-			repoFlag,
-			repoRemoteFlag,
-		},
+		Flags: flags,
 		Action: func(_ context.Context, c *cli.Command) error {
 			configureLogging("release-public.log")
 			ver, operatorVer, err := version.VersionsFromManifests(cfg.RepoRootDir)

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -40,10 +40,10 @@ const (
 )
 
 func Organization() string {
-	return utils.FirstNonEmpty(defaults.OperatorOrganization(), utils.TigeraOrg)
+	return utils.FirstNonEmpty(defaults.OperatorOrganization(), DefaultOrg)
 }
 func Repo() string   { return utils.FirstNonEmpty(defaults.OperatorRepo(), DefaultRepoName) }
-func Branch() string { return utils.FirstNonEmpty(defaults.OperatorBranch(), utils.DefaultBranch) }
+func Branch() string { return utils.FirstNonEmpty(defaults.OperatorBranch(), DefaultBranch) }
 
 var (
 	defaultProductEnvPrefix = "CALICO"


### PR DESCRIPTION
Follow-up to #12665. Three small bugs surfaced by Copilot review on the enterprise cherry-pick of that PR.

## Changes

- **\`release publish\`** registers \`operatorGitFlags\` (\`--operator-org\` / \`--operator-repo\` / \`--operator-branch\`) but the action was still using \`WithOperatorBranch\` and only threading the branch into the manager. Switch to \`WithOperatorGit(org, repo, branch)\` so all three overrides reach the manager.
- **\`release public\`** action calls \`WithOperatorGit(...)\` but the command's \`Flags\` list did not register \`operatorGitFlags\`. As a result, user overrides resolved to empty/defaults and would have broken operator cloning. Add \`operatorGitFlags\` to the public command.
- **\`operator.Organization()\` / \`operator.Branch()\`** in \`release/pkg/manager/operator/manager.go\` fall back to \`utils.TigeraOrg\` / \`utils.DefaultBranch\`. The package already defines local \`DefaultOrg\` and \`DefaultBranch\` constants used as the CLI flag defaults — use those locally instead so the manager and CLI flag defaults can't drift out of sync.

## Testing

- \`go build ./release/...\` clean.
- \`go test\` passes for \`release/cmd\`, \`release/internal/defaults\`, \`release/internal/utils\`, \`release/pkg/manager/calico\`, \`release/pkg/manager/operator\`.

**Release note:**
\`\`\`release-note
TBD
\`\`\`