### PR TITLE
[release-v3.32] Cherry-pick release tooling improvements (#12585, #12615, #12665, #12680, #12682)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ pod2daemon/node-driver-registrar/
 
 /* Created by libcalico-go UTs */
 ut-tmp-dir
+
+# Build-time copy of metadata.mk for the release CLI's embedded defaults.
+release/internal/defaults/metadata.mk

--- a/Makefile
+++ b/Makefile
@@ -229,12 +229,12 @@ e2e-run-cnp-test:
 ###############################################################################
 .PHONY: release release-publish create-release-branch release-test build-openstack publish-openstack release-notes
 # Build the release tool.
-release/bin/release: $(shell find ./release -type f -name '*.go')
+release/bin/release: $(shell find ./release -type f -name '*.go') metadata.mk
 	$(MAKE) -C release
 
 # Prepare for a release (update version references, charts, manifests).
 release-prep: release/bin/release bin/gh
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release prep
+	@release/bin/release release prep
 
 # Install ghr for publishing to github.
 bin/ghr:
@@ -249,14 +249,14 @@ bin/gh:
 
 # Build a release.
 release: release/bin/release
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release build
+	@release/bin/release release build
 
 # Publish an already built release.
 release-publish: release/bin/release bin/ghr bin/helm
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release publish
+	@release/bin/release release publish
 
 release-public: bin/gh release/bin/release
-	@OPERATOR_BRANCH=$(OPERATOR_BRANCH) release/bin/release release public
+	@release/bin/release release public
 
 # Create a release branch.
 create-release-branch: release/bin/release

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -482,7 +482,6 @@ define update_calico_base_pin
 		fi'
 endef
 
-GIT_REMOTE?=origin
 API_BRANCH?=$(PIN_BRANCH)
 API_REPO?=github.com/projectcalico/calico/api
 BASE_API_REPO?=github.com/projectcalico/calico/api

--- a/metadata.mk
+++ b/metadata.mk
@@ -27,6 +27,7 @@ KIND_VERSION=v0.31.0
 # differently for a forked repo.
 ORGANIZATION  ?= projectcalico
 GIT_REPO      ?= calico
+GIT_REMOTE    ?= origin
 
 RELEASE_BRANCH_PREFIX ?=release
 DEV_TAG_SUFFIX        ?= 0.dev

--- a/release/Makefile
+++ b/release/Makefile
@@ -4,26 +4,26 @@ PACKAGE_NAME = github.com/projectcalico/calico/release
 
 include ../lib.Makefile
 
-export ORGANIZATION
-export GIT_REPO
-export RELEASE_BRANCH_PREFIX
-export DEV_TAG_SUFFIX
-export DEV_REGISTRIES
-export OPERATOR_ORGANIZATION
-export OPERATOR_GIT_REPO
-export OPERATOR_BRANCH
-
 .PHONY: build
 build: bin/release
 
 clean:
 	@rm -rf ./bin ./output ./_output ./report ./tmp
+	@rm -f ./internal/defaults/metadata.mk
 	@find ../ -name '*release*.log' -delete
 	@find . -name '*.received.*' -delete
 
-bin/release: $(shell find . -name "*.go" -or -name "*.gotmpl")
-	@mkdir -p bin && \
-	$(call build_binary, ./cmd, bin/release)
+# Stage metadata.mk next to embed.go so go:embed (which requires paths relative to the source file) can pick it up.
+# Embedding also makes the binary self-contained across invocation dirs (root Makefile vs release/).
+internal/defaults/metadata.mk: ../metadata.mk
+	@cp ../metadata.mk $@
+
+bin/release: $(shell find . -name "*.go" -or -name "*.gotmpl") internal/defaults/metadata.mk
+	@mkdir -p bin
+	@$(DOCKER_RUN) \
+		-e CGO_ENABLED=0 \
+		$(CALICO_BUILD) \
+		sh -c '$(GIT_CONFIG_SSH) go build -o bin/release -v -buildvcs=false -tags with_embed -ldflags "$(LDFLAGS)" ./cmd'
 
 POSTRELEASE_TEST_PACKAGE		:= $(PACKAGE_NAME)/pkg/postrelease
 UNIT_TEST_PACKAGES	:= $(shell go list ./... | grep -v $(POSTRELEASE_TEST_PACKAGE))

--- a/release/README.md
+++ b/release/README.md
@@ -26,7 +26,7 @@ This section describes how to build a test release using the locally checked out
 Build the release, providing your own registry to use for the images. For example:
 
 ```
-ARCHES=amd64 ./bin/release hashrelease build --skip-validation --build-images --dev-registry <YOUR REGISTRY>
+ARCHS=amd64 ./bin/release hashrelease build --no-validation --images --dev-registry <YOUR REGISTRY>
 ```
 
 This may take some time, but will produce a full set of release images as well as an operator image based on the locally checked out commit. Artifacts can be found

--- a/release/cmd/branch.go
+++ b/release/cmd/branch.go
@@ -50,7 +50,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 				devTagSuffixFlag,
 				operatorBranchFlag,
 				localFlag,
-				skipValidationFlag,
+				validationFlag,
 			},
 			Action: func(_ context.Context, c *cli.Command) error {
 				configureLogging("branch-cut.log")
@@ -62,7 +62,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
 				)
 
 				m := branch.NewManager(
@@ -72,7 +72,7 @@ func branchSubCommands(cfg *Config) []*cli.Command {
 					branch.WithDevTagIdentifier(c.String(devTagSuffixFlag.Name)),
 					branch.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					branch.WithRepoManager(calicoManager),
-					branch.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					branch.WithValidation(c.Bool(validationFlag.Name)),
 					branch.WithPublish(!c.Bool(localFlag.Name)))
 				return m.CutReleaseBranch()
 			},

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -519,10 +519,10 @@ var (
 			imagesFlag(!hashrelease, envBuildImages, envReleaseImages),
 			archiveImagesFlag(!hashrelease, envArchiveImages, envBuildArchiveImages, envReleaseArchiveImages),
 			binariesFlag,
-			helmChartsFlag(true, envBuildCharts, envReleaseCharts),
+			helmChartsFlag(envBuildCharts, envReleaseCharts),
 			helmIndexFlag(envHelmIndexLegacy, envBuildHelmIndex, envReleaseHelmIndex),
 			tarballFlag,
-			windowsArchiveFlag(true, envBuildWindowsArchive, envReleaseWindowsArchive),
+			windowsArchiveFlag(envBuildWindowsArchive, envReleaseWindowsArchive),
 		}
 		if hashrelease {
 			f = append(f, e2eBinariesFlag, releaseNotesFlag)
@@ -532,7 +532,7 @@ var (
 	publishStepFlags = func(hashrelease bool) []cli.Flag {
 		f := []cli.Flag{
 			imagesFlag(!hashrelease, envPublishImages, envReleaseImages),
-			helmChartsFlag(true, envPublishCharts, envReleaseCharts),
+			helmChartsFlag(envPublishCharts, envReleaseCharts),
 		}
 		if hashrelease {
 			return f
@@ -581,13 +581,13 @@ var (
 			},
 		}
 	}
-	helmChartsFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+	helmChartsFlag = func(envVars ...string) *cli.BoolWithInverseFlag {
 		return &cli.BoolWithInverseFlag{
 			Name:     helmChartsFlagName,
 			Category: stepControlCategory,
 			Usage:    "Include Helm charts in the release step",
 			Sources:  cli.EnvVars(envVars...),
-			Value:    value,
+			Value:    true,
 			Action: func(_ context.Context, c *cli.Command, b bool) error {
 				if b {
 					return nil
@@ -629,29 +629,27 @@ var (
 		Sources:  cli.EnvVars(envBuildReleaseNotes, envReleaseNotes),
 		Value:    true,
 	}
-	manifestsFlagName = "manifests"
-	manifestsFlag     = &cli.BoolWithInverseFlag{
-		Name:     manifestsFlagName,
+	manifestsFlag = &cli.BoolWithInverseFlag{
+		Name:     "manifests",
 		Category: stepControlCategory,
 		Usage:    "Include manifests in the release step",
 		Sources:  cli.EnvVars(envBuildManifests, envReleaseManifests),
 		Value:    true,
 	}
-	ocpBundleFlagName = "ocp-bundle"
-	ocpBundleFlag     = &cli.BoolWithInverseFlag{
-		Name:     ocpBundleFlagName,
+	ocpBundleFlag = &cli.BoolWithInverseFlag{
+		Name:     "ocp-bundle",
 		Category: stepControlCategory,
 		Usage:    "Include OCP bundle in the release step",
 		Sources:  cli.EnvVars(envBuildOCPBundle, envReleaseOCPBundle),
 		Value:    true,
 	}
-	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+	windowsArchiveFlag = func(envVars ...string) *cli.BoolWithInverseFlag {
 		return &cli.BoolWithInverseFlag{
 			Name:     windowsArchiveFlagName,
 			Category: stepControlCategory,
 			Usage:    "Include Windows archive in the release step",
 			Sources:  cli.EnvVars(envVars...),
-			Value:    value,
+			Value:    true,
 		}
 	}
 	tarballFlag = &cli.BoolWithInverseFlag{

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
 
+	"github.com/projectcalico/calico/release/internal/defaults"
 	"github.com/projectcalico/calico/release/internal/utils"
 	"github.com/projectcalico/calico/release/pkg/manager/operator"
 )
@@ -63,42 +64,47 @@ var (
 	}
 
 	// Git flags for interacting with the git repository
-	orgFlag = &cli.StringFlag{
-		Name:     "org",
+	orgFlagName = "org"
+	orgFlag     = &cli.StringFlag{
+		Name:     orgFlagName,
 		Category: gitCategory,
 		Usage:    "The GitHub organization to use for the release",
-		Sources:  cli.EnvVars("ORGANIZATION"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("ORGANIZATION"), defaults.MK(defaults.KeyOrganization)),
 		Value:    utils.ProjectCalicoOrg,
 	}
-	repoFlag = &cli.StringFlag{
-		Name:     "repo",
+	repoFlagName = "repo"
+	repoFlag     = &cli.StringFlag{
+		Name:     repoFlagName,
 		Category: gitCategory,
 		Usage:    "The GitHub repository to use for the release",
-		Sources:  cli.EnvVars("GIT_REPO"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("GIT_REPO"), defaults.MK(defaults.KeyGitRepo)),
 		Value:    utils.CalicoRepoName,
 	}
-	repoRemoteFlag = &cli.StringFlag{
-		Name:     "remote",
+	repoRemoteFlagName = "remote"
+	repoRemoteFlag     = &cli.StringFlag{
+		Name:     repoRemoteFlagName,
 		Category: gitCategory,
 		Usage:    "The remote for the git repository",
-		Sources:  cli.EnvVars("GIT_REMOTE"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("GIT_REMOTE"), defaults.MK(defaults.KeyGitRemote)),
 		Value:    utils.DefaultRemote,
 	}
 
 	// Branch/Tag flags are flags used for branch & tag management
-	releaseBranchPrefixFlag = &cli.StringFlag{
-		Name:     "release-branch-prefix",
+	releaseBranchPrefixFlagName = "release-branch-prefix"
+	releaseBranchPrefixFlag     = &cli.StringFlag{
+		Name:     releaseBranchPrefixFlagName,
 		Category: gitCategory,
 		Usage:    "The stardard prefix used to denote release branches",
-		Sources:  cli.EnvVars("RELEASE_BRANCH_PREFIX"),
-		Value:    "release",
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("RELEASE_BRANCH_PREFIX"), defaults.MK(defaults.KeyReleaseBranchPrefix)),
+		Value:    utils.DefaultReleaseBranchPrefix,
 	}
-	devTagSuffixFlag = &cli.StringFlag{
-		Name:     "dev-tag-suffix",
+	devTagSuffixFlagName = "dev-tag-suffix"
+	devTagSuffixFlag     = &cli.StringFlag{
+		Name:     devTagSuffixFlagName,
 		Category: gitCategory,
 		Usage:    "The suffix used to denote development tags",
-		Sources:  cli.EnvVars("DEV_TAG_SUFFIX"),
-		Value:    "0.dev",
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("DEV_TAG_SUFFIX"), defaults.MK(defaults.KeyDevTagSuffix)),
+		Value:    utils.DefaultDevTagSuffix,
 	}
 	baseBranchFlag = &cli.StringFlag{
 		Name:     "base-branch",
@@ -211,39 +217,45 @@ var (
 
 // Operator flags are flags used to interact with Tigera operator repository
 var (
-	operatorBuildCommandFlags = []cli.Flag{
-		operatorOrgFlag, operatorRepoFlag, operatorBranchFlag,
+	// operatorGitFlags resolve the operator's org/repo/branch. Required on any
+	// command that calls calico.WithOperatorGit or operator.Clone.
+	operatorGitFlags = []cli.Flag{operatorOrgFlag, operatorRepoFlag, operatorBranchFlag}
+
+	operatorBuildCommandFlags = append(slices.Clone(operatorGitFlags),
 		operatorReleaseBranchPrefixFlag,
 		operatorRegistryFlag, operatorImageFlag,
 		operatorFlag(envBuildOperator, envReleaseOperator),
-	}
+	)
 
 	operatorPublishCommandFlags = []cli.Flag{
 		operatorFlag(envPublishOperator, envReleaseOperator),
 	}
 
 	// Operator git flags
-	operatorOrgFlag = &cli.StringFlag{
-		Name:     "operator-org",
+	operatorOrgFlagName = "operator-org"
+	operatorOrgFlag     = &cli.StringFlag{
+		Name:     operatorOrgFlagName,
 		Category: operatorCategory,
 		Usage:    "The GitHub organization to use for Tigera operator release",
-		Sources:  cli.EnvVars("OPERATOR_ORGANIZATION"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("OPERATOR_ORGANIZATION"), defaults.MK(defaults.KeyOperatorOrganization)),
 		Value:    operator.DefaultOrg,
 	}
-	operatorRepoFlag = &cli.StringFlag{
-		Name:     "operator-repo",
+	operatorRepoFlagName = "operator-repo"
+	operatorRepoFlag     = &cli.StringFlag{
+		Name:     operatorRepoFlagName,
 		Category: operatorCategory,
 		Usage:    "The GitHub repository to use for Tigera operator release",
-		Sources:  cli.EnvVars("OPERATOR_GIT_REPO"),
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("OPERATOR_GIT_REPO"), defaults.MK(defaults.KeyOperatorGitRepo)),
 		Value:    operator.DefaultRepoName,
 	}
 	// Branch/Tag management flags
-	operatorBranchFlag = &cli.StringFlag{
-		Name:     "operator-branch",
+	operatorBranchFlagName = "operator-branch"
+	operatorBranchFlag     = &cli.StringFlag{
+		Name:     operatorBranchFlagName,
 		Category: operatorCategory,
 		Usage:    "The branch to use for Tigera operator release",
-		Sources:  cli.EnvVars("OPERATOR_BRANCH"),
-		Value:    operator.DefaultBranchName,
+		Sources:  cli.NewValueSourceChain(cli.EnvVar("OPERATOR_BRANCH"), defaults.MK(defaults.KeyOperatorBranch)),
+		Value:    operator.DefaultBranch,
 	}
 	operatorReleaseBranchPrefixFlag = &cli.StringFlag{
 		Name:     "operator-release-branch-prefix",

--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -28,6 +28,20 @@ import (
 
 var globalFlags = append([]cli.Flag{debugFlag}, append(ciFlags, slackFlags...)...)
 
+// Flag categories group flags in --help output.
+const (
+	gitCategory               = "Git Repository"
+	developmentCategory       = "Development"
+	containerImageCategory    = "Container Image"
+	cloudCategory             = "Cloud Configuration"
+	operatorCategory          = "Tigera Operator"
+	ciCategory                = "CI Environment"
+	slackCategory             = "Slack"
+	imageScannerCategory      = "Image Scanning Service"
+	hashreleaseServerCategory = "Hashrelease Server"
+	stepControlCategory       = "Step Control"
+)
+
 // debugFlag is a flag used to enable verbose log output
 var debugFlag = &cli.BoolFlag{
 	Name:        "debug",
@@ -40,7 +54,6 @@ var debugFlag = &cli.BoolFlag{
 
 // Product repository flags are flags used to interact with the product repository
 var (
-	gitFlags     = []cli.Flag{orgFlag, repoFlag, repoRemoteFlag}
 	productFlags = []cli.Flag{
 		orgFlag,
 		repoFlag,
@@ -51,43 +64,49 @@ var (
 
 	// Git flags for interacting with the git repository
 	orgFlag = &cli.StringFlag{
-		Name:    "org",
-		Usage:   "The GitHub organization to use for the release",
-		Sources: cli.EnvVars("ORGANIZATION"),
-		Value:   utils.ProjectCalicoOrg,
+		Name:     "org",
+		Category: gitCategory,
+		Usage:    "The GitHub organization to use for the release",
+		Sources:  cli.EnvVars("ORGANIZATION"),
+		Value:    utils.ProjectCalicoOrg,
 	}
 	repoFlag = &cli.StringFlag{
-		Name:    "repo",
-		Usage:   "The GitHub repository to use for the release",
-		Sources: cli.EnvVars("GIT_REPO"),
-		Value:   utils.CalicoRepoName,
+		Name:     "repo",
+		Category: gitCategory,
+		Usage:    "The GitHub repository to use for the release",
+		Sources:  cli.EnvVars("GIT_REPO"),
+		Value:    utils.CalicoRepoName,
 	}
 	repoRemoteFlag = &cli.StringFlag{
-		Name:    "remote",
-		Usage:   "The remote for the git repository",
-		Sources: cli.EnvVars("GIT_REMOTE"),
-		Value:   utils.DefaultRemote,
+		Name:     "remote",
+		Category: gitCategory,
+		Usage:    "The remote for the git repository",
+		Sources:  cli.EnvVars("GIT_REMOTE"),
+		Value:    utils.DefaultRemote,
 	}
 
 	// Branch/Tag flags are flags used for branch & tag management
 	releaseBranchPrefixFlag = &cli.StringFlag{
-		Name:    "release-branch-prefix",
-		Usage:   "The stardard prefix used to denote release branches",
-		Sources: cli.EnvVars("RELEASE_BRANCH_PREFIX"),
-		Value:   "release",
+		Name:     "release-branch-prefix",
+		Category: gitCategory,
+		Usage:    "The stardard prefix used to denote release branches",
+		Sources:  cli.EnvVars("RELEASE_BRANCH_PREFIX"),
+		Value:    "release",
 	}
 	devTagSuffixFlag = &cli.StringFlag{
-		Name:    "dev-tag-suffix",
-		Usage:   "The suffix used to denote development tags",
-		Sources: cli.EnvVars("DEV_TAG_SUFFIX"),
-		Value:   "0.dev",
+		Name:     "dev-tag-suffix",
+		Category: gitCategory,
+		Usage:    "The suffix used to denote development tags",
+		Sources:  cli.EnvVars("DEV_TAG_SUFFIX"),
+		Value:    "0.dev",
 	}
 	baseBranchFlag = &cli.StringFlag{
-		Name:    "base-branch",
-		Aliases: []string{"base", "main-branch"},
-		Usage:   "The base branch to cut the release branch from",
-		Sources: cli.EnvVars("RELEASE_BRANCH_BASE"),
-		Value:   utils.DefaultBranch,
+		Name:     "base-branch",
+		Category: gitCategory,
+		Aliases:  []string{"base", "main-branch"},
+		Usage:    "The base branch to cut the release branch from",
+		Sources:  cli.EnvVars("RELEASE_BRANCH_BASE"),
+		Value:    utils.DefaultBranch,
 		Action: func(_ context.Context, c *cli.Command, str string) error {
 			if str != utils.DefaultBranch {
 				logrus.Warnf("The new branch will be created from %s which is not the default branch %s", str, utils.DefaultBranch)
@@ -107,36 +126,63 @@ var (
 	}
 )
 
-// Validation flags are flags used to control validation
+// Development flags are flags used to control development behavior of the release process
 var (
-	skipValidationFlag = &cli.BoolFlag{
-		Name:    "skip-validation",
-		Usage:   "Skip all validation while performing the action",
-		Sources: cli.EnvVars("SKIP_VALIDATION"),
-		Value:   false,
+	validationFlagName = "validation"
+	validationFlag     = &cli.BoolWithInverseFlag{
+		Name:     validationFlagName,
+		Category: developmentCategory,
+		Usage:    "Run validation checks",
+		Sources:  cli.EnvVars("VALIDATION", "RELEASE_VALIDATION"),
+		Value:    true,
+		Action: func(_ context.Context, c *cli.Command, b bool) error {
+			if b {
+				return nil
+			}
+			if c.Bool(branchCheckFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(branchCheckFlagName), inverseFlagName(validationFlagName))
+			}
+			// image-scan is only registered on publish commands; only enforce the
+			// dependency where the flag actually exists.
+			if hasFlag(c, imageScanFlagName) && c.Bool(imageScanFlagName) {
+				return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(imageScanFlagName), inverseFlagName(validationFlagName))
+			}
+			return nil
+		},
+	}
+	branchCheckFlagName = "branch-check"
+	branchCheckFlag     = &cli.BoolWithInverseFlag{
+		Name:     branchCheckFlagName,
+		Category: developmentCategory,
+		Usage:    "Check that the current branch is a valid branch for release",
+		Sources:  cli.EnvVars("BRANCH_CHECK", "RELEASE_BRANCH_CHECK"),
+		Value:    true,
 	}
 )
 
 // Container image flags are flags used to control container image building and publishing
 var (
 	registryFlag = &cli.StringSliceFlag{
-		Name:    "registry",
-		Usage:   "Override default registries for the release. Repeat for multiple registries.",
-		Sources: cli.EnvVars("REGISTRIES"), // avoid DEV_REGISTRIES as it is already used by the build system (lib.Makefile).
+		Name:     "registry",
+		Category: containerImageCategory,
+		Usage:    "Override default registries for the release. Repeat for multiple registries.",
+		Sources:  cli.EnvVars("REGISTRIES"), // avoid DEV_REGISTRIES as it is already used by the build system (lib.Makefile).
 	}
 	helmRegistryFlag = &cli.StringSliceFlag{
-		Name:    "helm-registry",
-		Usage:   "Override default OCI-based helm chart registries for the release. Repeat for multiple registries.",
-		Sources: cli.EnvVars("HELM_REGISTRIES"),
+		Name:     "helm-registry",
+		Category: containerImageCategory,
+		Usage:    "Override default OCI-based helm chart registries for the release. Repeat for multiple registries.",
+		Sources:  cli.EnvVars("HELM_REGISTRIES"),
 	}
 
 	archOptions = []string{"amd64", "arm64", "ppc64le", "s390x"}
 	archFlag    = &cli.StringSliceFlag{
-		Name:    "architecture",
-		Aliases: []string{"arch"},
-		Usage:   "The architecture to use for the release. Repeat for multiple architectures.",
-		Sources: cli.EnvVars("ARCHS"), // avoid ARCHES as it is already used by the build system (lib.Makefile).
-		Value:   archOptions,
+		Name:     "architecture",
+		Category: containerImageCategory,
+		Aliases:  []string{"arch"},
+		Usage:    "The architecture to use for the release. Repeat for multiple architectures.",
+		Sources:  cli.EnvVars("ARCHS"), // avoid ARCHES as it is already used by the build system (lib.Makefile).
+		Value:    archOptions,
 		Action: func(_ context.Context, c *cli.Command, values []string) error {
 			for _, arch := range values {
 				if !slices.Contains(archOptions, arch) {
@@ -146,128 +192,94 @@ var (
 			return nil
 		},
 	}
+)
 
-	buildImagesFlag = &cli.BoolFlag{
-		Name:    "build-images",
-		Usage:   "Build container images from the local code",
-		Sources: cli.EnvVars("BUILD_CONTAINER_IMAGES"), // avoid BUILD_IMAGES as it is already used by the build system (lib.Makefile).
-		Value:   true,
-	}
-	buildHashreleaseImagesFlag = &cli.BoolFlag{
-		Name:    buildImagesFlag.Name,
-		Usage:   buildImagesFlag.Usage,
-		Sources: buildImagesFlag.Sources,
-		Value:   false,
-	}
-
-	publishImagesFlag = &cli.BoolFlag{
-		Name:    "publish-images",
-		Usage:   "Publish images to the registry",
-		Sources: cli.EnvVars("PUBLISH_IMAGES"),
-		Value:   true,
-	}
-	publishHashreleaseImagesFlag = &cli.BoolFlag{
-		Name:    publishImagesFlag.Name,
-		Usage:   publishImagesFlag.Usage,
-		Sources: publishImagesFlag.Sources,
-		Value:   false,
-	}
-
-	publishChartsFlag = &cli.BoolFlag{
-		Name:    "publish-charts",
-		Usage:   "Publish Helm charts to the registry",
-		Sources: cli.EnvVars("PUBLISH_CHARTS"),
-		Value:   true,
-	}
+var (
 	awsProfileFlag = &cli.StringFlag{
-		Name:    "aws-profile",
-		Usage:   "The AWS profile to use",
-		Sources: cli.EnvVars("AWS_PROFILE"),
+		Name:     "aws-profile",
+		Category: cloudCategory,
+		Usage:    "The AWS profile to use",
+		Sources:  cli.EnvVars("AWS_PROFILE"),
 	}
 	s3BucketFlag = &cli.StringFlag{
-		Name:    "s3-bucket",
-		Usage:   "The S3 bucket to publish release artifacts to.",
-		Sources: cli.EnvVars("S3_BUCKET"),
-	}
-
-	archiveImagesFlag = &cli.BoolFlag{
-		Name:    "archive-images",
-		Usage:   "Archive images in the release tarball",
-		Sources: cli.EnvVars("ARCHIVE_IMAGES"),
-		Value:   true,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if b && !c.Bool(buildImagesFlag.Name) {
-				return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildImagesFlag.Name)
-			}
-			return nil
-		},
-	}
-	archiveHashreleaseImagesFlag = &cli.BoolFlag{
-		Name:    archiveImagesFlag.Name,
-		Usage:   archiveImagesFlag.Usage,
-		Sources: archiveImagesFlag.Sources,
-		Value:   false,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if b && !c.Bool(buildHashreleaseImagesFlag.Name) {
-				return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildHashreleaseImagesFlag.Name)
-			}
-			return nil
-		},
+		Name:     "s3-bucket",
+		Category: cloudCategory,
+		Usage:    "The S3 bucket to publish release artifacts to.",
+		Sources:  cli.EnvVars("S3_BUCKET"),
 	}
 )
 
 // Operator flags are flags used to interact with Tigera operator repository
 var (
-	operatorGitFlags   = []cli.Flag{operatorOrgFlag, operatorRepoFlag}
-	operatorBuildFlags = append(operatorGitFlags,
-		operatorBranchFlag, operatorReleaseBranchPrefixFlag,
-		operatorRegistryFlag, operatorImageFlag)
+	operatorBuildCommandFlags = []cli.Flag{
+		operatorOrgFlag, operatorRepoFlag, operatorBranchFlag,
+		operatorReleaseBranchPrefixFlag,
+		operatorRegistryFlag, operatorImageFlag,
+		operatorFlag(envBuildOperator, envReleaseOperator),
+	}
+
+	operatorPublishCommandFlags = []cli.Flag{
+		operatorFlag(envPublishOperator, envReleaseOperator),
+	}
 
 	// Operator git flags
 	operatorOrgFlag = &cli.StringFlag{
-		Name:    "operator-org",
-		Usage:   "The GitHub organization to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_ORGANIZATION"),
-		Value:   operator.DefaultOrg,
+		Name:     "operator-org",
+		Category: operatorCategory,
+		Usage:    "The GitHub organization to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_ORGANIZATION"),
+		Value:    operator.DefaultOrg,
 	}
 	operatorRepoFlag = &cli.StringFlag{
-		Name:    "operator-repo",
-		Usage:   "The GitHub repository to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_GIT_REPO"),
-		Value:   operator.DefaultRepoName,
+		Name:     "operator-repo",
+		Category: operatorCategory,
+		Usage:    "The GitHub repository to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_GIT_REPO"),
+		Value:    operator.DefaultRepoName,
 	}
 	// Branch/Tag management flags
 	operatorBranchFlag = &cli.StringFlag{
-		Name:    "operator-branch",
-		Usage:   "The branch to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_BRANCH"),
-		Value:   operator.DefaultBranchName,
+		Name:     "operator-branch",
+		Category: operatorCategory,
+		Usage:    "The branch to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_BRANCH"),
+		Value:    operator.DefaultBranchName,
 	}
 	operatorReleaseBranchPrefixFlag = &cli.StringFlag{
-		Name:    "operator-release-branch-prefix",
-		Usage:   "The stardard prefix used to denote Tigera operator release branches",
-		Sources: cli.EnvVars("OPERATOR_RELEASE_BRANCH_PREFIX"),
-		Value:   operator.DefaultReleaseBranchPrefix,
+		Name:     "operator-release-branch-prefix",
+		Category: operatorCategory,
+		Usage:    "The stardard prefix used to denote Tigera operator release branches",
+		Sources:  cli.EnvVars("OPERATOR_RELEASE_BRANCH_PREFIX"),
+		Value:    operator.DefaultReleaseBranchPrefix,
 	}
 	// Container image flags
 	operatorRegistryFlag = &cli.StringFlag{
-		Name:    "operator-registry",
-		Usage:   "The registry to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_REGISTRY"),
-		Value:   operator.DefaultRegistry,
+		Name:     "operator-registry",
+		Category: operatorCategory,
+		Usage:    "The registry to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_REGISTRY"),
+		Value:    operator.DefaultRegistry,
 	}
 	operatorImageFlag = &cli.StringFlag{
-		Name:    "operator-image",
-		Usage:   "The image name to use for Tigera operator release",
-		Sources: cli.EnvVars("OPERATOR_IMAGE"),
-		Value:   operator.DefaultImage,
+		Name:     "operator-image",
+		Category: operatorCategory,
+		Usage:    "The image name to use for Tigera operator release",
+		Sources:  cli.EnvVars("OPERATOR_IMAGE"),
+		Value:    operator.DefaultImage,
 	}
 
-	skipOperatorFlag = &cli.BoolFlag{
-		Name:    "skip-operator",
-		Usage:   "Skip building and/or publishing the operator",
-		Sources: cli.EnvVars("SKIP_OPERATOR"),
-		Value:   false,
+	operatorFlagName   = "operator"
+	envBuildOperator   = "BUILD_OPERATOR"
+	envPublishOperator = "PUBLISH_OPERATOR"
+	envReleaseOperator = "RELEASE_OPERATOR"
+	operatorFlag       = func(envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     operatorFlagName,
+			Category: operatorCategory,
+			Usage:    "Include Tigera operator in the release steps",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    true,
+		}
 	}
 )
 
@@ -277,10 +289,11 @@ var (
 	ciFlags     = []cli.Flag{ciFlag, ciBaseURLFlag, ciJobIDFlag, ciPipelineIDFlag, ciTokenFlag}
 	semaphoreCI = "semaphore"
 	ciFlag      = &cli.BoolFlag{
-		Name:    "ci",
-		Usage:   "Run in a continuous integration (CI) environment",
-		Sources: cli.EnvVars("CI"),
-		Value:   false,
+		Name:     "ci",
+		Category: ciCategory,
+		Usage:    "Run in a continuous integration (CI) environment",
+		Sources:  cli.EnvVars("CI"),
+		Value:    false,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && (c.String(ciBaseURLFlag.Name) == "" || c.String(ciJobIDFlag.Name) == "") {
 				return fmt.Errorf("CI requires %s and %s flags to be set", ciBaseURLFlag.Name, ciJobIDFlag.Name)
@@ -289,43 +302,50 @@ var (
 		},
 	}
 	ciBaseURLFlag = &cli.StringFlag{
-		Name:    "ci-url",
-		Usage:   fmt.Sprintf("The URL for accesing %s CI", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_ORGANIZATION_URL"),
+		Name:     "ci-url",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The URL for accesing %s CI", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_ORGANIZATION_URL"),
 	}
 	ciJobIDFlag = &cli.StringFlag{
-		Name:    "ci-job-id",
-		Usage:   fmt.Sprintf("The job ID for the %s CI job", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_JOB_ID"),
+		Name:     "ci-job-id",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The job ID for the %s CI job", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_JOB_ID"),
 	}
 	ciPipelineIDFlag = &cli.StringFlag{
-		Name:    "ci-pipeline-id",
-		Usage:   fmt.Sprintf("The pipeline ID for the %s CI pipeline", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_PIPELINE_ID"),
+		Name:     "ci-pipeline-id",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The pipeline ID for the %s CI pipeline", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_PIPELINE_ID"),
 	}
 	ciTokenFlag = &cli.StringFlag{
-		Name:    "ci-token",
-		Usage:   fmt.Sprintf("The token for interacting with %s API", semaphoreCI),
-		Sources: cli.EnvVars("SEMAPHORE_API_TOKEN"),
+		Name:     "ci-token",
+		Category: ciCategory,
+		Usage:    fmt.Sprintf("The token for interacting with %s API", semaphoreCI),
+		Sources:  cli.EnvVars("SEMAPHORE_API_TOKEN"),
 	}
 
 	// Slack flags for posting messages to Slack
 	slackFlags     = []cli.Flag{slackTokenFlag, slackChannelFlag, notifyFlag}
 	slackTokenFlag = &cli.StringFlag{
-		Name:    "slack-token",
-		Usage:   "The Slack token to use for posting messages",
-		Sources: cli.EnvVars("SLACK_API_TOKEN"),
+		Name:     "slack-token",
+		Category: slackCategory,
+		Usage:    "The Slack token to use for posting messages",
+		Sources:  cli.EnvVars("SLACK_API_TOKEN"),
 	}
 	slackChannelFlag = &cli.StringFlag{
-		Name:    "slack-channel",
-		Usage:   "The Slack channel to post messages",
-		Sources: cli.EnvVars("SLACK_CHANNEL"),
+		Name:     "slack-channel",
+		Category: slackCategory,
+		Usage:    "The Slack channel to post messages",
+		Sources:  cli.EnvVars("SLACK_CHANNEL"),
 	}
-	notifyFlag = &cli.BoolFlag{
-		Name:    "notify",
-		Usage:   "Sending notifications to Slack",
-		Sources: cli.EnvVars("NOTIFY"),
-		Value:   true,
+	notifyFlag = &cli.BoolWithInverseFlag{
+		Name:     "notify",
+		Category: slackCategory,
+		Usage:    "Sending notifications to Slack",
+		Sources:  cli.EnvVars("NOTIFY"),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			// Check slack configuration
 			if b && (c.String(slackTokenFlag.Name) == "" || c.String(slackChannelFlag.Name) == "") {
@@ -339,38 +359,45 @@ var (
 	}
 
 	// Image scanner flags for interacting with the image scanning service
-	imageScannerAPIFlags = []cli.Flag{
-		imageScannerAPIFlag, imageScannerTokenFlag, imageScannerSelectFlag,
+	imageScanFlags = []cli.Flag{
+		imageScanFlag,
+		imageScannerAPIFlag,
+		imageScannerTokenFlag,
+		imageScannerSelectFlag,
 	}
 	imageScannerAPIFlag = &cli.StringFlag{
-		Name:    "image-scanner-api",
-		Usage:   "The URL for the Image Scan Service API",
-		Sources: cli.EnvVars("IMAGE_SCANNER_API"),
+		Name:     "image-scanner-api",
+		Category: imageScannerCategory,
+		Usage:    "The URL for the Image Scanning Service API",
+		Sources:  cli.EnvVars("IMAGE_SCANNER_API"),
 	}
 	imageScannerTokenFlag = &cli.StringFlag{
-		Name:    "image-scanner-token",
-		Usage:   "The token for the Image Scan Service API",
-		Sources: cli.EnvVars("IMAGE_SCANNING_TOKEN"),
+		Name:     "image-scanner-token",
+		Category: imageScannerCategory,
+		Usage:    "The token for the Image Scanning Service API",
+		Sources:  cli.EnvVars("IMAGE_SCANNING_TOKEN"),
 	}
 	imageScannerSelectFlag = &cli.StringFlag{
-		Name:    "image-scanner-select",
-		Usage:   "The name of the scanner to use",
-		Sources: cli.EnvVars("IMAGE_SCANNER_SELECT"),
-		Value:   "all",
+		Name:     "image-scanner-select",
+		Category: imageScannerCategory,
+		Usage:    "The name of the scanner to use",
+		Sources:  cli.EnvVars("IMAGE_SCANNER_SELECT"),
+		Value:    "all",
 	}
-	skipImageScanFlagName = "skip-image-scan"
-	skipImageScanFlag     = &cli.BoolFlag{
-		Name:    skipImageScanFlagName,
-		Usage:   "Skip sending the image to the image scan service",
-		Sources: cli.EnvVars("SKIP_IMAGE_SCAN"),
-		Value:   false,
+	imageScanFlagName = "image-scan"
+	imageScanFlag     = &cli.BoolWithInverseFlag{
+		Name:     imageScanFlagName,
+		Category: imageScannerCategory,
+		Usage:    "Submit the image to the image scan service",
+		Sources:  cli.EnvVars("RELEASE_IMAGE_SCAN"),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			logrus.WithField(skipImageScanFlagName, b).Info("Image scanning configuration")
-			if !b && !imageScanningAPIConfig(c).Valid() {
+			logrus.WithField(imageScanFlagName, b).Info("Image scanning configuration")
+			if b && !imageScanningAPIConfig(c).Valid() {
 				if !c.Bool(ciFlag.Name) {
 					logrus.Warn("Image scanning configuration is incomplete")
 				}
-				return fmt.Errorf("invalid configuration for image scanning. Either set --%s and --%s or set --%s to 'true'", imageScannerAPIFlag.Name, imageScannerTokenFlag.Name, skipImageScanFlagName)
+				return fmt.Errorf("invalid configuration for image scanning. Either set --%s and --%s or set --%s", imageScannerAPIFlag.Name, imageScannerTokenFlag.Name, inverseFlagName(imageScanFlagName))
 			}
 			return nil
 		},
@@ -380,7 +407,7 @@ var (
 	githubTokenFlag = &cli.StringFlag{
 		Name:    "github-token",
 		Usage:   "The GitHub token to use when interacting with the GitHub API",
-		Sources: cli.EnvVars("GITHUB_TOKEN"),
+		Sources: cli.EnvVars("GITHUB_TOKEN", "GH_TOKEN"),
 		Action: func(_ context.Context, c *cli.Command, s string) error {
 			if s == "" {
 				if c.Bool(ciFlag.Name) {
@@ -393,20 +420,248 @@ var (
 	}
 )
 
-// Release specific flags.
+// Hashrelease specific flags.
 var (
-	// Publishing flags.
-	publishGitTagFlag = &cli.BoolFlag{
-		Name:    "publish-git-tag",
-		Usage:   "Push the git tag to the remote",
-		Sources: cli.EnvVars("PUBLISH_GIT_TAG"),
-		Value:   true,
+
+	// Hashrelease server configuration flags.
+	hashreleaseServerFlags = []cli.Flag{hashreleaseServerBucketFlag}
+	publishHashreleaseFlag = &cli.BoolWithInverseFlag{
+		Name:     "publish-to-hashrelease-server",
+		Category: hashreleaseServerCategory,
+		Usage:    "Publish the hashrelease to the hashrelease server",
+		Sources:  cli.EnvVars("PUBLISH_TO_HASHRELEASE_SERVER"),
+		Value:    true,
 	}
-	publishGitHubReleaseFlag = &cli.BoolFlag{
-		Name:    "publish-github-release",
-		Usage:   "Publish the release to GitHub",
-		Sources: cli.EnvVars("PUBLISH_GITHUB_RELEASE"),
-		Value:   true,
+	latestFlag = &cli.BoolWithInverseFlag{
+		Name:     "latest",
+		Category: hashreleaseServerCategory,
+		Usage:    "Publish the hashrelease as the latest hashrelease",
+		Sources:  cli.EnvVars("LATEST"),
+		Value:    true,
+	}
+	hashreleaseServerBucketFlag = &cli.StringFlag{
+		Name:     "hashrelease-server-bucket",
+		Category: hashreleaseServerCategory,
+		Usage:    "The bucket name for the hashrelease server",
+		Sources:  cli.EnvVars("HASHRELEASE_SERVER_BUCKET"),
+	}
+)
+
+// Step control flags gate logical release steps.
+const (
+	// Images.
+	imagesFlagName          = "images"
+	envBuildImages          = "BUILD_CONTAINER_IMAGES"
+	envPublishImages        = "PUBLISH_IMAGES"
+	envReleaseImages        = "RELEASE_IMAGES"
+	archiveImagesFlagName   = "archive-images"
+	envArchiveImages        = "ARCHIVE_IMAGES"
+	envBuildArchiveImages   = "BUILD_IMAGES_ARCHIVE"
+	envReleaseArchiveImages = "RELEASE_IMAGES_ARCHIVE"
+
+	// Helm charts.
+	helmChartsFlagName = "helm-charts"
+	envBuildCharts     = "BUILD_CHARTS"
+	envPublishCharts   = "PUBLISH_CHARTS"
+	envReleaseCharts   = "RELEASE_CHARTS"
+
+	// Helm index.
+	helmIndexFlagName   = "helm-index"
+	envHelmIndexLegacy  = "UPDATE_HELM_INDEX"
+	envBuildHelmIndex   = "BUILD_HELM_INDEX"
+	envPublishHelmIndex = "PUBLISH_HELM_INDEX"
+	envReleaseHelmIndex = "RELEASE_HELM_INDEX"
+
+	// Windows archive (build-only).
+	windowsArchiveFlagName   = "windows-archive"
+	envBuildWindowsArchive   = "BUILD_WINDOWS_ARCHIVE"
+	envReleaseWindowsArchive = "RELEASE_WINDOWS_ARCHIVE"
+
+	// Build-only.
+	envBuildManifests     = "BUILD_MANIFESTS"
+	envReleaseManifests   = "RELEASE_MANIFESTS"
+	envBuildOCPBundle     = "BUILD_OCP_BUNDLE"
+	envReleaseOCPBundle   = "RELEASE_OCP_BUNDLE"
+	envBuildBinaries      = "BUILD_BINARIES"
+	envReleaseBinaries    = "RELEASE_BINARIES"
+	envBuildTarball       = "BUILD_TARBALL"
+	envReleaseTarball     = "RELEASE_TARBALL"
+	envBuildE2EBinaries   = "BUILD_E2E_BINARIES"
+	envReleaseE2EBinaries = "RELEASE_E2E_BINARIES"
+	envBuildReleaseNotes  = "BUILD_RELEASE_NOTES"
+	envReleaseNotes       = "RELEASE_NOTES"
+
+	// Publish-only.
+	envPublishGitRefLegacy  = "PUBLISH_GIT_TAG"
+	envPublishGitRef        = "PUBLISH_GIT_REF"
+	envReleaseGitRef        = "RELEASE_GIT_REF"
+	envPublishGithubRelease = "PUBLISH_GITHUB_RELEASE"
+	envReleaseGithubRelease = "RELEASE_GITHUB_RELEASE"
+)
+
+var (
+	buildStepFlags = func(hashrelease bool) []cli.Flag {
+		f := []cli.Flag{
+			manifestsFlag,
+			ocpBundleFlag,
+			imagesFlag(!hashrelease, envBuildImages, envReleaseImages),
+			archiveImagesFlag(!hashrelease, envArchiveImages, envBuildArchiveImages, envReleaseArchiveImages),
+			binariesFlag,
+			helmChartsFlag(true, envBuildCharts, envReleaseCharts),
+			helmIndexFlag(envHelmIndexLegacy, envBuildHelmIndex, envReleaseHelmIndex),
+			tarballFlag,
+			windowsArchiveFlag(true, envBuildWindowsArchive, envReleaseWindowsArchive),
+		}
+		if hashrelease {
+			f = append(f, e2eBinariesFlag, releaseNotesFlag)
+		}
+		return f
+	}
+	publishStepFlags = func(hashrelease bool) []cli.Flag {
+		f := []cli.Flag{
+			imagesFlag(!hashrelease, envPublishImages, envReleaseImages),
+			helmChartsFlag(true, envPublishCharts, envReleaseCharts),
+		}
+		if hashrelease {
+			return f
+		}
+		return append(f,
+			helmIndexFlag(envHelmIndexLegacy, envPublishHelmIndex, envReleaseHelmIndex),
+			gitRefFlag,
+			githubReleaseFlag)
+	}
+
+	imagesFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     imagesFlagName,
+			Category: stepControlCategory,
+			Usage:    "Include container images in the release step",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+			Action: func(_ context.Context, c *cli.Command, b bool) error {
+				// archive-images is build-only; only enforce the dependency
+				// where the flag is registered. The "images on but not
+				// archived" warning is emitted from archiveImagesFlag.Action
+				// instead so it doesn't fire on publish commands where
+				// archive-images doesn't exist.
+				if hasFlag(c, archiveImagesFlagName) && !b && c.Bool(archiveImagesFlagName) {
+					return fmt.Errorf("cannot archive images without building them; use --%s flag to build images", imagesFlagName)
+				}
+				return nil
+			},
+		}
+	}
+	archiveImagesFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     archiveImagesFlagName,
+			Category: stepControlCategory,
+			Usage:    "Archive container images in the release tarball",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+			Action: func(_ context.Context, c *cli.Command, b bool) error {
+				if b && !c.Bool(imagesFlagName) {
+					return fmt.Errorf("cannot archive images without building them; use --%s flag to build images", imagesFlagName)
+				}
+				if !b && c.Bool(imagesFlagName) {
+					logrus.Warnf("Images are included but not archived; to include images in the archive set --%s", archiveImagesFlagName)
+				}
+				return nil
+			},
+		}
+	}
+	helmChartsFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     helmChartsFlagName,
+			Category: stepControlCategory,
+			Usage:    "Include Helm charts in the release step",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+			Action: func(_ context.Context, c *cli.Command, b bool) error {
+				if b {
+					return nil
+				}
+				if c.Bool(helmIndexFlagName) {
+					return fmt.Errorf("--%s must be set when --%s is set", inverseFlagName(helmIndexFlagName), inverseFlagName(helmChartsFlagName))
+				}
+				return nil
+			},
+		}
+	}
+	helmIndexFlag = func(envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     helmIndexFlagName,
+			Category: stepControlCategory,
+			Usage:    "Build/update the Helm chart index",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    true,
+		}
+	}
+	binariesFlag = &cli.BoolWithInverseFlag{
+		Name:     "binaries",
+		Category: stepControlCategory,
+		Usage:    "Include binaries in the release step",
+		Sources:  cli.EnvVars(envBuildBinaries, envReleaseBinaries),
+		Value:    true,
+	}
+	e2eBinariesFlag = &cli.BoolWithInverseFlag{
+		Name:     "e2e-binaries",
+		Category: stepControlCategory,
+		Usage:    "Build multi-arch e2e test binaries",
+		Sources:  cli.EnvVars(envBuildE2EBinaries, envReleaseE2EBinaries),
+		Value:    true,
+	}
+	releaseNotesFlag = &cli.BoolWithInverseFlag{
+		Name:     "release-notes",
+		Category: stepControlCategory,
+		Usage:    "Generate release notes",
+		Sources:  cli.EnvVars(envBuildReleaseNotes, envReleaseNotes),
+		Value:    true,
+	}
+	manifestsFlagName = "manifests"
+	manifestsFlag     = &cli.BoolWithInverseFlag{
+		Name:     manifestsFlagName,
+		Category: stepControlCategory,
+		Usage:    "Include manifests in the release step",
+		Sources:  cli.EnvVars(envBuildManifests, envReleaseManifests),
+		Value:    true,
+	}
+	ocpBundleFlagName = "ocp-bundle"
+	ocpBundleFlag     = &cli.BoolWithInverseFlag{
+		Name:     ocpBundleFlagName,
+		Category: stepControlCategory,
+		Usage:    "Include OCP bundle in the release step",
+		Sources:  cli.EnvVars(envBuildOCPBundle, envReleaseOCPBundle),
+		Value:    true,
+	}
+	windowsArchiveFlag = func(value bool, envVars ...string) *cli.BoolWithInverseFlag {
+		return &cli.BoolWithInverseFlag{
+			Name:     windowsArchiveFlagName,
+			Category: stepControlCategory,
+			Usage:    "Include Windows archive in the release step",
+			Sources:  cli.EnvVars(envVars...),
+			Value:    value,
+		}
+	}
+	tarballFlag = &cli.BoolWithInverseFlag{
+		Name:     "tarball",
+		Category: stepControlCategory,
+		Usage:    "Include the release tarball in the release step",
+		Sources:  cli.EnvVars(envBuildTarball, envReleaseTarball),
+		Value:    true,
+	}
+	gitRefFlag = &cli.BoolWithInverseFlag{
+		Name:     "git-ref",
+		Category: stepControlCategory,
+		Usage:    "Push the git ref(s) to the remote",
+		Sources:  cli.EnvVars(envPublishGitRefLegacy, envPublishGitRef, envReleaseGitRef),
+		Value:    true,
+	}
+	githubReleaseFlag = &cli.BoolWithInverseFlag{
+		Name:     "github-release",
+		Category: stepControlCategory,
+		Usage:    "Publish the GitHub release",
+		Sources:  cli.EnvVars(envPublishGithubRelease, envReleaseGithubRelease),
+		Value:    true,
 		Action: func(_ context.Context, c *cli.Command, b bool) error {
 			if b && c.String(githubTokenFlag.Name) == "" {
 				return fmt.Errorf("GitHub token is required to publish release")
@@ -416,38 +671,16 @@ var (
 	}
 )
 
-// Hashrelease specific flags.
-var (
-	skipBranchCheckFlag = &cli.BoolFlag{
-		Name:    "skip-branch-check",
-		Usage:   "Skip checking if current branch is a valid branch for release",
-		Sources: cli.EnvVars("SKIP_BRANCH_CHECK"),
-		Value:   false,
-		Action: func(_ context.Context, c *cli.Command, b bool) error {
-			if c.Bool(skipValidationFlag.Name) && !b {
-				return fmt.Errorf("must skip branch check if %s is set", skipValidationFlag)
-			}
-			return nil
-		},
-	}
+func inverseFlagName(name string) string {
+	return "no-" + name
+}
 
-	// Hashrelease server configuration flags.
-	hashreleaseServerFlags = []cli.Flag{hashreleaseServerBucketFlag}
-	publishHashreleaseFlag = &cli.BoolFlag{
-		Name:    "publish-to-hashrelease-server",
-		Usage:   "Publish the hashrelease to the hashrelease server",
-		Sources: cli.EnvVars("PUBLISH_TO_HASHRELEASE_SERVER"),
-		Value:   true,
-	}
-	latestFlag = &cli.BoolFlag{
-		Name:    "latest",
-		Usage:   "Publish the hashrelease as the latest hashrelease",
-		Sources: cli.EnvVars("LATEST"),
-		Value:   true,
-	}
-	hashreleaseServerBucketFlag = &cli.StringFlag{
-		Name:    "hashrelease-server-bucket",
-		Usage:   "The bucket name for the hashrelease server",
-		Sources: cli.EnvVars("HASHRELEASE_SERVER_BUCKET"),
-	}
-)
+// hasFlag reports whether the command has a flag registered under the given
+// name (or one of its aliases). Used by cross-flag Action callbacks to skip
+// dependency checks against flags that aren't registered on the current
+// command (e.g. image-scan is publish-only).
+func hasFlag(c *cli.Command, name string) bool {
+	return slices.ContainsFunc(c.Flags, func(f cli.Flag) bool {
+		return slices.Contains(f.Names(), name)
+	})
+}

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cli "github.com/urfave/cli/v3"
+)
+
+// runFlags builds a *cli.Command with the given flags and runs it with args.
+// The Action is a no-op so any error returned comes from a flag-level Action
+// (cross-flag invariants enforced via flag.Action callbacks).
+func runFlags(t *testing.T, flags []cli.Flag, args ...string) error {
+	t.Helper()
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: flags,
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return nil
+		},
+	}
+	return cmd.Run(context.Background(), append([]string{"test"}, args...))
+}
+
+// assertRun runs cmd with args and checks the resulting error against wantErr.
+// Empty wantErr means "expect no error". Non-empty wantErr is a substring match.
+func assertRun(t *testing.T, flags []cli.Flag, args []string, wantErr string) {
+	t.Helper()
+	err := runFlags(t, flags, args...)
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", wantErr)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("expected error containing %q, got %q", wantErr, err.Error())
+	}
+}
+
+func TestValidationFlagAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"defaults pass", nil, ""},
+		{"--no-validation alone errors (default branch-check=true)", []string{"--no-validation"}, "--no-branch-check must be set"},
+		{"--no-validation --no-branch-check but image-scan default true errors", []string{"--no-validation", "--no-branch-check"}, "--no-image-scan must be set"},
+		{"all three negated passes", []string{"--no-validation", "--no-branch-check", "--no-image-scan"}, ""},
+		{"--no-branch-check alone passes (dependent disabled, prerequisite still on)", []string{"--no-branch-check"}, ""},
+		{"--no-image-scan alone passes", []string{"--no-image-scan"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRun(t, []cli.Flag{validationFlag, branchCheckFlag, imageScanFlag}, tc.args, tc.wantErr)
+		})
+	}
+}
+
+// TestValidationFlagActionWithoutImageScan covers the build-side case where
+// imageScanFlag isn't registered. validationFlag.Action must skip the
+// image-scan dependency check rather than misfire.
+func TestValidationFlagActionWithoutImageScan(t *testing.T) {
+	flags := []cli.Flag{validationFlag, branchCheckFlag}
+	assertRun(t, flags, []string{"--no-validation", "--no-branch-check"}, "")
+}
+
+func TestHelmChartsFlagAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"defaults pass", nil, ""},
+		{"--no-helm-charts alone errors (default helm-index=true)", []string{"--no-helm-charts"}, "--no-helm-index must be set"},
+		{"--no-helm-charts --no-helm-index passes", []string{"--no-helm-charts", "--no-helm-index"}, ""},
+		{"--no-helm-index alone passes (dependent disabled)", []string{"--no-helm-index"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := []cli.Flag{
+				helmChartsFlag(true, "TEST_BUILD_CHARTS"),
+				helmIndexFlag("TEST_BUILD_HELM_INDEX"),
+			}
+			assertRun(t, flags, tc.args, tc.wantErr)
+		})
+	}
+}
+
+func TestImagesArchiveImagesFlagAction(t *testing.T) {
+	// Default-true (release-style) defaults: images=true, archive=true.
+	t.Run("release defaults", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			args    []string
+			wantErr string
+		}{
+			{"defaults pass", nil, ""},
+			{"--no-images alone errors (default archive=true)", []string{"--no-images"}, "cannot archive images without building them"},
+			{"--no-images --no-archive-images passes", []string{"--no-images", "--no-archive-images"}, ""},
+			{"--no-archive-images alone passes (warning only)", []string{"--no-archive-images"}, ""},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				flags := []cli.Flag{
+					imagesFlag(true, "TEST_BUILD_IMAGES_R"),
+					archiveImagesFlag(true, "TEST_BUILD_ARCHIVE_IMAGES_R"),
+				}
+				assertRun(t, flags, tc.args, tc.wantErr)
+			})
+		}
+	})
+
+	// Default-false (hashrelease-style) defaults: images=false, archive=false.
+	t.Run("hashrelease defaults", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			args    []string
+			wantErr string
+		}{
+			{"defaults pass", nil, ""},
+			{"--archive-images alone errors (default images=false)", []string{"--archive-images"}, "cannot archive images without building them"},
+			{"--images --archive-images passes", []string{"--images", "--archive-images"}, ""},
+			{"--images alone passes (warning only)", []string{"--images"}, ""},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				flags := []cli.Flag{
+					imagesFlag(false, "TEST_BUILD_IMAGES_H"),
+					archiveImagesFlag(false, "TEST_BUILD_ARCHIVE_IMAGES_H"),
+				}
+				assertRun(t, flags, tc.args, tc.wantErr)
+			})
+		}
+	})
+
+	// On publish commands archive-images is not registered. images.Action
+	// must skip the archive dependency check rather than misfire.
+	t.Run("publish (no archive-images registered)", func(t *testing.T) {
+		flags := []cli.Flag{imagesFlag(true, "TEST_PUBLISH_IMAGES")}
+		assertRun(t, flags, []string{"--no-images"}, "")
+		assertRun(t, flags, nil, "")
+	})
+}
+
+// Non-hashrelease builds tolerate --no-manifests --ocp-bundle (uses checked-in
+// manifests). Hashrelease enforcement lives in validateHashreleaseBuildFlags.
+func TestManifestsOCPBundleNoFlagAction(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"defaults pass", nil},
+		{"--no-manifests alone passes (no flag-level Action)", []string{"--no-manifests"}},
+		{"--no-manifests --no-ocp-bundle passes", []string{"--no-manifests", "--no-ocp-bundle"}},
+		{"--no-ocp-bundle alone passes", []string{"--no-ocp-bundle"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRun(t, []cli.Flag{manifestsFlag, ocpBundleFlag}, tc.args, "")
+		})
+	}
+}
+
+func TestValidateHashreleaseBuildFlagsOCPManifests(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"defaults pass", nil, ""},
+		{"--no-manifests alone errors (ocp-bundle still default true)", []string{"--no-manifests"}, "--ocp-bundle requires --manifests"},
+		{"--no-manifests --no-ocp-bundle passes", []string{"--no-manifests", "--no-ocp-bundle"}, ""},
+		{"--no-ocp-bundle alone passes", []string{"--no-ocp-bundle"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cli.Command{
+				Name:  "test",
+				Flags: hashreleaseBuildFlags(),
+				Action: func(_ context.Context, c *cli.Command) error {
+					return validateHashreleaseBuildFlags(c)
+				},
+			}
+			err := cmd.Run(context.Background(), append([]string{"test"}, tc.args...))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+// TestEnvVarPrecedence pins down the legacy-alias-wins behaviour. The first
+// env var listed in cli.EnvVars(...) takes precedence; legacy aliases like
+// ARCHIVE_IMAGES, UPDATE_HELM_INDEX, and PUBLISH_GIT_TAG must be listed first
+// in their respective Sources slices so existing CI configs keep winning over
+// the new BUILD_*/PUBLISH_*/RELEASE_* names.
+func TestEnvVarPrecedence(t *testing.T) {
+	cases := []struct {
+		name        string
+		legacyKey   string
+		legacyValue string
+		newKey      string
+		newValue    string
+		flagFn      func() cli.Flag
+		flagName    string
+		want        bool
+	}{
+		{
+			name:        "ARCHIVE_IMAGES wins over BUILD_IMAGES_ARCHIVE",
+			legacyKey:   "ARCHIVE_IMAGES",
+			legacyValue: "false",
+			newKey:      "BUILD_IMAGES_ARCHIVE",
+			newValue:    "true",
+			flagFn: func() cli.Flag {
+				return archiveImagesFlag(true, "ARCHIVE_IMAGES", "BUILD_IMAGES_ARCHIVE")
+			},
+			flagName: archiveImagesFlagName,
+			want:     false,
+		},
+		{
+			name:        "UPDATE_HELM_INDEX wins over BUILD_HELM_INDEX",
+			legacyKey:   "UPDATE_HELM_INDEX",
+			legacyValue: "false",
+			newKey:      "BUILD_HELM_INDEX",
+			newValue:    "true",
+			flagFn: func() cli.Flag {
+				return helmIndexFlag("UPDATE_HELM_INDEX", "BUILD_HELM_INDEX")
+			},
+			flagName: helmIndexFlagName,
+			want:     false,
+		},
+		{
+			name:        "PUBLISH_GIT_TAG wins over PUBLISH_GIT_REF",
+			legacyKey:   "PUBLISH_GIT_TAG",
+			legacyValue: "false",
+			newKey:      "PUBLISH_GIT_REF",
+			newValue:    "true",
+			flagFn: func() cli.Flag {
+				return &cli.BoolWithInverseFlag{
+					Name:    "git-ref",
+					Sources: cli.EnvVars("PUBLISH_GIT_TAG", "PUBLISH_GIT_REF"),
+					Value:   true,
+				}
+			},
+			flagName: "git-ref",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.legacyKey, tc.legacyValue)
+			t.Setenv(tc.newKey, tc.newValue)
+			var got bool
+			cmd := &cli.Command{
+				Name:  "test",
+				Flags: []cli.Flag{tc.flagFn()},
+				Action: func(_ context.Context, c *cli.Command) error {
+					got = c.Bool(tc.flagName)
+					return nil
+				},
+			}
+			if err := cmd.Run(context.Background(), []string{"test"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("env precedence broken: %s=%s vs %s=%s, got %v want %v", tc.legacyKey, tc.legacyValue, tc.newKey, tc.newValue, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInverseFlagName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"validation", "no-validation"},
+		{"helm-index", "no-helm-index"},
+		{"", "no-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := inverseFlagName(tc.in)
+			if got != tc.want {
+				t.Errorf("inverseFlagName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -98,7 +98,7 @@ func TestHelmChartsFlagAction(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			flags := []cli.Flag{
-				helmChartsFlag(true, "TEST_BUILD_CHARTS"),
+				helmChartsFlag("TEST_BUILD_CHARTS"),
 				helmIndexFlag("TEST_BUILD_HELM_INDEX"),
 			}
 			assertRun(t, flags, tc.args, tc.wantErr)

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -120,8 +120,8 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithImage(pinned.OperatorCfg.Image),
 					operator.WithRegistry(pinned.OperatorCfg.Registry),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
-					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					operator.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
+					operator.WithValidate(c.Bool(validationFlag.Name)),
+					operator.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 					operator.WithVersion(data.OperatorVersion()),
 					operator.WithCalicoDirectory(cfg.RepoRootDir),
 					operator.WithCalicoVersion(data.ProductVersion()),
@@ -132,7 +132,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				if len(productRegistriesFromFlag) > 0 {
 					operatorOpts = append(operatorOpts, operator.WithProductRegistry(productRegistriesFromFlag[0]))
 				}
-				if !c.Bool(skipOperatorFlag.Name) {
+				if c.Bool(operatorFlagName) {
 					o := operator.NewManager(operatorOpts...)
 					if err := o.Build(); err != nil {
 						return err
@@ -146,23 +146,31 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				opts := []calico.Option{
+					calico.IsHashRelease(),
+					calico.WithHashrelease(*hashrel, *serverCfg),
+					calico.WithRepoRoot(cfg.RepoRootDir),
+					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithVersion(data.ProductVersion()),
 					calico.WithOperator(c.String(operatorRegistryFlag.Name), c.String(operatorImageFlag.Name), data.OperatorVersion()),
 					calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
-					calico.WithRepoRoot(cfg.RepoRootDir),
-					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
-					calico.IsHashRelease(),
-					calico.WithHashrelease(*hashrel, *serverCfg),
 					calico.WithOutputDir(hashrel.Source),
 					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithBuildImages(c.Bool(buildHashreleaseImagesFlag.Name)),
-					calico.WithArchiveImages(c.Bool(archiveHashreleaseImagesFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
 					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
+					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithManifests(c.Bool(manifestsFlag.Name)),
+					calico.WithBinaries(c.Bool(binariesFlag.Name)),
+					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
+					calico.WithTarball(c.Bool(tarballFlag.Name)),
+					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
+					calico.WithE2EBinaries(c.Bool(e2eBinariesFlag.Name)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if len(productRegistriesFromFlag) > 0 {
 					opts = append(opts, calico.WithImageRegistries(productRegistriesFromFlag))
@@ -174,19 +182,21 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 				// For real releases, release notes are generated prior to building the release.
 				// For hash releases, generate a set of release notes and add them to the hashrelease directory.
-				releaseVersion, err := version.DetermineReleaseVersion(version.New(data.ProductVersion()), c.String(devTagSuffixFlag.Name))
-				if err != nil {
-					return fmt.Errorf("failed to determine release version: %v", err)
-				}
-				if c.String(orgFlag.Name) == utils.TigeraOrg {
-					logrus.Warn("Release notes are not supported for Tigera releases, skipping...")
+				if !c.Bool(releaseNotesFlag.Name) {
+					logrus.Info("Skipping release notes generation")
+				} else if c.String(orgFlag.Name) != utils.ProjectCalicoOrg || c.String(repoFlag.Name) != utils.CalicoRepoName {
+					logrus.Warn("Release notes are not supported for non-Calico releases, skipping...")
 				} else {
+					releaseVersion, err := version.DetermineReleaseVersion(version.New(data.ProductVersion()), c.String(devTagSuffixFlag.Name))
+					if err != nil {
+						return fmt.Errorf("failed to determine release version: %v", err)
+					}
 					if _, err := outputs.ReleaseNotes(utils.ProjectCalicoOrg, c.String(githubTokenFlag.Name), cfg.RepoRootDir, filepath.Join(hashrel.Source, outputs.ReleaseNotesDir), releaseVersion); err != nil {
 						return err
 					}
 				}
 
-				// Adjsut the formatting of the generated outputs to match the legacy hashrelease format.
+				// Adjust the formatting of the generated outputs to match the legacy hashrelease format.
 				return tasks.ReformatHashrelease(hashrel.Source, cfg.TmpDir)
 			},
 		},
@@ -235,29 +245,30 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					operator.WithVersion(hashrel.Operator.Version),
 					operator.WithCalicoVersion(hashrel.ProductVersion),
 					operator.WithArchitectures(c.StringSlice(archFlag.Name)),
-					operator.WithValidate(!c.Bool(skipValidationFlag.Name)),
+					operator.WithValidate(c.Bool(validationFlag.Name)),
 				)
-				if !c.Bool(skipOperatorFlag.Name) {
+				if c.Bool(operatorFlagName) {
 					if err := o.Publish(); err != nil {
 						return err
 					}
 				}
 
 				opts := []calico.Option{
-					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.IsHashRelease(),
+					calico.WithHashrelease(*hashrel, *serverCfg),
+					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithVersion(hashrel.ProductVersion),
 					calico.WithOperatorVersion(hashrel.Operator.Version),
+					calico.WithOutputDir(hashrel.Source),
+					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-					calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithOutputDir(hashrel.Source),
-					calico.WithHashrelease(*hashrel, *serverCfg),
-					calico.WithPublishImages(c.Bool(publishHashreleaseImagesFlag.Name)),
-					calico.WithPublishCharts(c.Bool(publishChartsFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
 					calico.WithPublishHashrelease(c.Bool(publishHashreleaseFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts,
@@ -265,7 +276,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 						calico.WithImageScanning(false, imagescanner.Config{}), // Disable image scanning if using custom registries.
 					)
 				} else {
-					opts = append(opts, calico.WithImageScanning(!c.Bool(skipImageScanFlag.Name), *imageScanningAPIConfig(c)))
+					opts = append(opts, calico.WithImageScanning(c.Bool(imageScanFlag.Name), *imageScanningAPIConfig(c)))
 				}
 				components, err := pinnedversion.RetrieveImageComponents(cfg.TmpDir)
 				if err != nil {
@@ -280,7 +291,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 					return err
 				}
 
-				if !c.Bool(skipImageScanFlag.Name) {
+				if c.Bool(imageScanFlag.Name) {
 					url, err := imagescanner.RetrieveResultURL(cfg.TmpDir)
 					// Only log error as a warning if the image scan result URL could not be retrieved
 					// as it is not an error that should stop the hashrelease process.
@@ -306,16 +317,14 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 // hashreleaseBuildFlags returns the flags for the hashrelease build command.
 func hashreleaseBuildFlags() []cli.Flag {
-	f := append(productFlags,
-		registryFlag,
-		buildHashreleaseImagesFlag,
-		archiveHashreleaseImagesFlag,
-		archFlag)
-	f = append(f, operatorBuildFlags...)
+	f := append(productFlags, buildStepFlags(true)...)
 	f = append(f,
-		skipOperatorFlag,
-		skipBranchCheckFlag,
-		skipValidationFlag,
+		registryFlag,
+		archFlag)
+	f = append(f, operatorBuildCommandFlags...)
+	f = append(f,
+		branchCheckFlag,
+		validationFlag,
 		githubTokenFlag)
 	return f
 }
@@ -327,11 +336,10 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		return fmt.Errorf("%s must be set if %s is set", operatorRegistryFlag, registryFlag)
 	}
 
-	if c.Bool(archiveHashreleaseImagesFlag.Name) && !c.Bool(buildHashreleaseImagesFlag.Name) {
-		return fmt.Errorf("cannot archive images without building them; set --%s to 'true'", buildHashreleaseImagesFlag.Name)
-	}
-	if !c.Bool(archiveHashreleaseImagesFlag.Name) && c.Bool(buildHashreleaseImagesFlag.Name) {
-		logrus.Warnf("Images are built but not archived; to archive images set --%s to 'true'", archiveHashreleaseImagesFlag.Name)
+	// Hashrelease regenerates manifests before building the OCP bundle.
+	if c.Bool(ocpBundleFlagName) && !c.Bool(manifestsFlagName) {
+		return fmt.Errorf("--%s requires --%s on hashrelease builds; either drop --%s or also set --%s",
+			ocpBundleFlagName, manifestsFlagName, inverseFlagName(manifestsFlagName), inverseFlagName(ocpBundleFlagName))
 	}
 
 	// CI conditional checks.
@@ -345,7 +353,7 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 		}
 	} else {
 		// If building images, log a warning if no registry is specified.
-		if c.Bool(buildHashreleaseImagesFlag.Name) && len(c.StringSlice(registryFlag.Name)) == 0 {
+		if c.Bool(imagesFlagName) && len(c.StringSlice(registryFlag.Name)) == 0 {
 			logrus.Warn("Building images without specifying a registry will result in images being built with the default registries")
 		}
 
@@ -360,18 +368,18 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 
 // hashreleasePublishFlags returns the flags for the hashrelease publish command.
 func hashreleasePublishFlags() []cli.Flag {
-	f := append(gitFlags,
+	f := append(productFlags, publishStepFlags(true)...)
+	f = append(f,
 		registryFlag,
 		helmRegistryFlag,
-		publishHashreleaseImagesFlag,
-		publishChartsFlag,
 		archFlag,
 		publishHashreleaseFlag,
 		latestFlag,
-		skipOperatorFlag,
-		skipValidationFlag,
-		skipImageScanFlag)
-	f = append(f, imageScannerAPIFlags...)
+		branchCheckFlag,
+		validationFlag,
+	)
+	f = append(f, operatorPublishCommandFlags...)
+	f = append(f, imageScanFlags...)
 	return f
 }
 
@@ -394,11 +402,6 @@ func validateHashreleasePublishFlags(c *cli.Command) error {
 				return fmt.Errorf("cannot set hashrelease as latest when building locally, use --%s=false instead", latestFlag.Name)
 			}
 		}
-	}
-
-	// If skipValidationFlag is set, then skipImageScanFlag must also be set.
-	if c.Bool(skipValidationFlag.Name) && !c.Bool(skipImageScanFlag.Name) {
-		return fmt.Errorf("%s must be set if %s is set", skipImageScanFlag, skipValidationFlag)
 	}
 	return nil
 }
@@ -429,7 +432,7 @@ func validateCIBuildRequirements(c *cli.Command, repoRootDir string) error {
 	if !c.Bool(ciFlag.Name) {
 		return nil
 	}
-	if c.Bool(buildHashreleaseImagesFlag.Name) {
+	if c.Bool(imagesFlagName) {
 		logrus.Info("Building images in hashrelease, skipping images promotions check...")
 		return nil
 	}

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v3"
@@ -72,7 +73,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				}
 
 				// Clone the operator repository.
-				operatorDir := filepath.Join(cfg.TmpDir, operator.DefaultRepoName)
+				operatorDir := filepath.Join(cfg.TmpDir, c.String(operatorRepoFlag.Name))
 				err := operator.Clone(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name), operatorDir)
 				if err != nil {
 					return fmt.Errorf("failed to clone operator repository: %v", err)
@@ -238,7 +239,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 				// Push the operator hashrelease first before validaion
 				// This is because validation checks all images exists and sends to Image Scan Service
 				o := operator.NewManager(
-					operator.WithOperatorDirectory(filepath.Join(cfg.TmpDir, operator.DefaultRepoName)),
+					operator.WithOperatorDirectory(filepath.Join(cfg.TmpDir, c.String(operatorRepoFlag.Name))),
 					operator.IsHashRelease(),
 					operator.WithImage(hashrel.Operator.Image),
 					operator.WithRegistry(hashrel.Operator.Registry),
@@ -317,7 +318,7 @@ func hashreleaseSubCommands(cfg *Config) []*cli.Command {
 
 // hashreleaseBuildFlags returns the flags for the hashrelease build command.
 func hashreleaseBuildFlags() []cli.Flag {
-	f := append(productFlags, buildStepFlags(true)...)
+	f := append(slices.Clone(productFlags), buildStepFlags(true)...)
 	f = append(f,
 		registryFlag,
 		archFlag)
@@ -368,7 +369,7 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 
 // hashreleasePublishFlags returns the flags for the hashrelease publish command.
 func hashreleasePublishFlags() []cli.Flag {
-	f := append(productFlags, publishStepFlags(true)...)
+	f := append(slices.Clone(productFlags), publishStepFlags(true)...)
 	f = append(f,
 		registryFlag,
 		helmRegistryFlag,

--- a/release/cmd/hashrelease.go
+++ b/release/cmd/hashrelease.go
@@ -338,9 +338,9 @@ func validateHashreleaseBuildFlags(c *cli.Command) error {
 	}
 
 	// Hashrelease regenerates manifests before building the OCP bundle.
-	if c.Bool(ocpBundleFlagName) && !c.Bool(manifestsFlagName) {
+	if c.Bool(ocpBundleFlag.Name) && !c.Bool(manifestsFlag.Name) {
 		return fmt.Errorf("--%s requires --%s on hashrelease builds; either drop --%s or also set --%s",
-			ocpBundleFlagName, manifestsFlagName, inverseFlagName(manifestsFlagName), inverseFlagName(ocpBundleFlagName))
+			ocpBundleFlag.Name, manifestsFlag.Name, inverseFlagName(manifestsFlag.Name), inverseFlagName(ocpBundleFlag.Name))
 	}
 
 	// CI conditional checks.

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -105,7 +106,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 					calico.WithVersion(ver.FormattedString()),
 					calico.WithOperatorVersion(operatorVer.FormattedString()),
-					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
+					calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
@@ -207,6 +208,7 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 				calico.WithRepoRoot(cfg.RepoRootDir),
 				calico.WithVersion(ver.FormattedString()),
 				calico.WithOperatorVersion(operatorVer.FormattedString()),
+				calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
@@ -227,7 +229,7 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 
 func determineOperatorReleaseVersion(c *cli.Command, tmpDir string) (string, error) {
 	// Clone the operator repository to determine the operator version.
-	operatorDir := filepath.Join(tmpDir, operator.DefaultRepoName)
+	operatorDir := filepath.Join(tmpDir, c.String(operatorRepoFlag.Name))
 	if err := operator.Clone(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name), operatorDir); err != nil {
 		return "", fmt.Errorf("clone operator repository: %w", err)
 	}
@@ -244,23 +246,17 @@ func determineOperatorReleaseVersion(c *cli.Command, tmpDir string) (string, err
 }
 
 func releasePrepCommand(cfg *Config) *cli.Command {
+	flags := append(slices.Clone(productFlags), operatorGitFlags...)
+	flags = append(flags,
+		githubTokenFlag,
+		branchCheckFlag,
+		validationFlag,
+		localFlag,
+	)
 	return &cli.Command{
 		Name:  "prep",
 		Usage: "Prepare for a Calico release",
-		Flags: []cli.Flag{
-			orgFlag,
-			repoFlag,
-			repoRemoteFlag,
-			releaseBranchPrefixFlag,
-			devTagSuffixFlag,
-			operatorOrgFlag,
-			operatorRepoFlag,
-			operatorBranchFlag,
-			githubTokenFlag,
-			branchCheckFlag,
-			validationFlag,
-			localFlag,
-		},
+		Flags: flags,
 		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
 			// Determine the versions to use for the release.
 			ver, err := version.DetermineReleaseVersion(version.GitVersion(), c.String(devTagSuffixFlag.Name))
@@ -287,6 +283,7 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithReleaseBranchPrefix(c.String(releaseBranchPrefixFlag.Name)),
 				calico.WithVersion(ver.FormattedString()),
 				calico.WithOperatorVersion(operatorVer),
+				calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
@@ -308,20 +305,21 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 
 // releaseBuildFlags returns the flags for release build command.
 func releaseBuildFlags() []cli.Flag {
-	f := append(productFlags, buildStepFlags(false)...)
+	f := append(slices.Clone(productFlags), buildStepFlags(false)...)
 	f = append(f,
-		archFlag,
 		registryFlag,
-		githubTokenFlag,
+		archFlag)
+	f = append(f, operatorGitFlags...)
+	f = append(f,
 		branchCheckFlag,
 		validationFlag,
-		operatorBranchFlag)
+		githubTokenFlag)
 	return f
 }
 
 // releasePublishFlags returns the flags for release publish command.
 func releasePublishFlags() []cli.Flag {
-	f := append(productFlags, publishStepFlags(false)...)
+	f := append(slices.Clone(productFlags), publishStepFlags(false)...)
 	f = append(f,
 		registryFlag,
 		helmRegistryFlag,
@@ -330,7 +328,8 @@ func releasePublishFlags() []cli.Flag {
 		s3BucketFlag,
 		branchCheckFlag,
 		validationFlag,
-		operatorBranchFlag)
+	)
+	f = append(f, operatorGitFlags...)
 	return f
 }
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -108,16 +108,21 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithTmpDir(cfg.TmpDir),
-					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-					calico.WithBuildImages(c.Bool(buildImagesFlag.Name)),
-					calico.WithArchiveImages(c.Bool(archiveImagesFlag.Name)),
-				}
-				if c.Bool(skipValidationFlag.Name) {
-					opts = append(opts, calico.WithValidate(false))
-					opts = append(opts, calico.WithReleaseBranchValidation(false))
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithArchitectures(c.StringSlice(archFlag.Name)),
+					calico.WithArchiveImages(c.Bool(archiveImagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithManifests(c.Bool(manifestsFlag.Name)),
+					calico.WithBinaries(c.Bool(binariesFlag.Name)),
+					calico.WithOCPBundle(c.Bool(ocpBundleFlag.Name)),
+					calico.WithTarball(c.Bool(tarballFlag.Name)),
+					calico.WithWindowsArchive(c.Bool(windowsArchiveFlagName)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -149,11 +154,14 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
 					calico.WithRepoName(c.String(repoFlag.Name)),
 					calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
-					calico.WithPublishImages(c.Bool(publishImagesFlag.Name)),
-					calico.WithPublishGitRef(c.Bool(publishGitTagFlag.Name)),
-					calico.WithPublishGithubRelease(c.Bool(publishGitHubReleaseFlag.Name)),
 					calico.WithGithubToken(c.String(githubTokenFlag.Name)),
-					calico.WithPublishCharts(c.Bool(publishChartsFlag.Name)),
+					calico.WithImages(c.Bool(imagesFlagName)),
+					calico.WithHelmCharts(c.Bool(helmChartsFlagName)),
+					calico.WithHelmIndex(c.Bool(helmIndexFlagName)),
+					calico.WithGitRef(c.Bool(gitRefFlag.Name)),
+					calico.WithGithubRelease(c.Bool(githubReleaseFlag.Name)),
+					calico.WithValidation(c.Bool(validationFlag.Name)),
+					calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
 				}
 				if reg := c.StringSlice(registryFlag.Name); len(reg) > 0 {
 					opts = append(opts, calico.WithImageRegistries(reg))
@@ -201,7 +209,7 @@ func releasePublicSubCommands(cfg *Config) *cli.Command {
 				calico.WithOperatorVersion(operatorVer.FormattedString()),
 				calico.WithGithubOrg(c.String(orgFlag.Name)),
 				calico.WithRepoName(c.String(repoFlag.Name)),
-				calico.WithRepoRemote(repoRemoteFlag.Name),
+				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 			}
 			m := calico.NewManager(opts...)
 			if err := m.ReleasePublic(); err != nil {
@@ -249,8 +257,8 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 			operatorRepoFlag,
 			operatorBranchFlag,
 			githubTokenFlag,
-			skipBranchCheckFlag,
-			skipValidationFlag,
+			branchCheckFlag,
+			validationFlag,
 			localFlag,
 		},
 		Action: withLogging(withSummary(cfg, "release-prep", func(_ context.Context, c *cli.Command) (string, map[string]any, error) {
@@ -283,9 +291,9 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 				calico.WithRepoName(c.String(repoFlag.Name)),
 				calico.WithRepoRemote(c.String(repoRemoteFlag.Name)),
 				calico.WithTmpDir(cfg.TmpDir),
-				calico.WithValidate(!c.Bool(skipValidationFlag.Name)),
-				calico.WithReleaseBranchValidation(!c.Bool(skipBranchCheckFlag.Name)),
-				calico.WithPublishGitRef(!c.Bool(localFlag.Name)),
+				calico.WithValidation(c.Bool(validationFlag.Name)),
+				calico.WithReleaseBranchValidation(c.Bool(branchCheckFlag.Name)),
+				calico.WithGitRef(!c.Bool(localFlag.Name)),
 			}
 			r := calico.NewManager(opts...)
 			branch, err := r.PrepareRelease()
@@ -300,30 +308,28 @@ func releasePrepCommand(cfg *Config) *cli.Command {
 
 // releaseBuildFlags returns the flags for release build command.
 func releaseBuildFlags() []cli.Flag {
-	f := append(productFlags,
+	f := append(productFlags, buildStepFlags(false)...)
+	f = append(f,
 		archFlag,
 		registryFlag,
-		buildImagesFlag,
-		archiveImagesFlag,
 		githubTokenFlag,
-		skipValidationFlag,
+		branchCheckFlag,
+		validationFlag,
 		operatorBranchFlag)
 	return f
 }
 
 // releasePublishFlags returns the flags for release publish command.
 func releasePublishFlags() []cli.Flag {
-	f := append(productFlags,
+	f := append(productFlags, publishStepFlags(false)...)
+	f = append(f,
 		registryFlag,
 		helmRegistryFlag,
-		publishImagesFlag,
-		publishGitTagFlag,
-		publishGitHubReleaseFlag,
 		githubTokenFlag,
-		publishChartsFlag,
 		awsProfileFlag,
 		s3BucketFlag,
-		skipValidationFlag,
+		branchCheckFlag,
+		validationFlag,
 		operatorBranchFlag)
 	return f
 }

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -149,7 +149,7 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 					calico.WithRepoRoot(cfg.RepoRootDir),
 					calico.WithVersion(ver.FormattedString()),
 					calico.WithOperatorVersion(operatorVer.FormattedString()),
-					calico.WithOperatorBranch(c.String(operatorBranchFlag.Name)),
+					calico.WithOperatorGit(c.String(operatorOrgFlag.Name), c.String(operatorRepoFlag.Name), c.String(operatorBranchFlag.Name)),
 					calico.WithOutputDir(releaseOutputDir(cfg.RepoRootDir, ver.FormattedString())),
 					calico.WithTmpDir(cfg.TmpDir),
 					calico.WithGithubOrg(c.String(orgFlag.Name)),
@@ -190,14 +190,16 @@ func releaseSubCommands(cfg *Config) []*cli.Command {
 }
 
 func releasePublicSubCommands(cfg *Config) *cli.Command {
+	flags := []cli.Flag{
+		orgFlag,
+		repoFlag,
+		repoRemoteFlag,
+	}
+	flags = append(flags, operatorGitFlags...)
 	return &cli.Command{
 		Name:  "public",
 		Usage: "Make a published release available to the public",
-		Flags: []cli.Flag{
-			orgFlag,
-			repoFlag,
-			repoRemoteFlag,
-		},
+		Flags: flags,
 		Action: func(_ context.Context, c *cli.Command) error {
 			configureLogging("release-public.log")
 			ver, operatorVer, err := version.VersionsFromManifests(cfg.RepoRootDir)

--- a/release/deps.txt
+++ b/release/deps.txt
@@ -90,6 +90,7 @@ local:libcalico-go/lib/logutils
 local:release/cmd
 local:release/internal/ci
 local:release/internal/command
+local:release/internal/defaults
 local:release/internal/hashreleaseserver
 local:release/internal/imagescanner
 local:release/internal/outputs

--- a/release/internal/defaults/embed.go
+++ b/release/internal/defaults/embed.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build with_embed
+
+package defaults
+
+import _ "embed"
+
+// metadata.mk is copied here by release/Makefile before build as
+// embedded paths must be relative to the source file.
+//
+//go:embed metadata.mk
+var embeddedMetadata []byte

--- a/release/internal/defaults/metadata.go
+++ b/release/internal/defaults/metadata.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package defaults exposes flag-default values sourced from the repo's
+// build metadata. Values resolve once per process via sync.OnceValue.
+//
+// Constant names match metadata.mk variable names verbatim. Unknown keys
+// resolve to empty, so additional keys are added by adding a constant and
+// a metadata.mk entry.
+package defaults
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/release/internal/command"
+)
+
+// driverPrefix snapshots the variables defined before metadata.mk is
+// included; driverSuffix prints only those introduced by the include.
+const (
+	driverPrefix = "VARS_OLD := $(.VARIABLES)\n"
+	driverSuffix = "\n_defaults_print:\n" +
+		"\t@$(foreach v,$(filter-out $(VARS_OLD) VARS_OLD,$(.VARIABLES)),$(info $(v) = $($(v))))\n"
+)
+
+// driverLine matches a `KEY = VALUE` line emitted by the driver's $(info).
+var driverLine = regexp.MustCompile(`^([A-Z_][A-Z0-9_]*)\s*=\s*(.*)$`)
+
+const (
+	KeyOrganization         = "ORGANIZATION"
+	KeyGitRepo              = "GIT_REPO"
+	KeyGitRemote            = "GIT_REMOTE"
+	KeyReleaseBranchPrefix  = "RELEASE_BRANCH_PREFIX"
+	KeyDevTagSuffix         = "DEV_TAG_SUFFIX"
+	KeyOperatorBranch       = "OPERATOR_BRANCH"
+	KeyOperatorOrganization = "OPERATOR_ORGANIZATION"
+	KeyOperatorGitRepo      = "OPERATOR_GIT_REPO"
+)
+
+var load = sync.OnceValue(readMetadata)
+
+func readMetadata() map[string]string {
+	if len(embeddedMetadata) > 0 {
+		m, err := parseMetadata(embeddedMetadata)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to parse embedded metadata.mk; release flag defaults will be empty")
+			return map[string]string{}
+		}
+		return m
+	}
+	root, err := command.GitDir()
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to locate git root for metadata.mk; release flag defaults will be empty")
+		return map[string]string{}
+	}
+	data, err := os.ReadFile(filepath.Join(root, "metadata.mk"))
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to read metadata.mk; release flag defaults will be empty")
+		return map[string]string{}
+	}
+	m, err := parseMetadata(data)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to parse metadata.mk; release flag defaults will be empty")
+		return map[string]string{}
+	}
+	return m
+}
+
+// parseMetadata wraps data with a driver makefile and runs make on it via
+// stdin, so make resolves $(...) references and ?= precedence naturally.
+// The driver prints only the variables introduced by the included data.
+func parseMetadata(data []byte) (map[string]string, error) {
+	var stdin bytes.Buffer
+	stdin.WriteString(driverPrefix)
+	stdin.Write(data)
+	stdin.WriteString(driverSuffix)
+
+	cmd := exec.Command("make", "--quiet", "-f", "-", "_defaults_print")
+	cmd.Stdin = &stdin
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("make: %w: %s", err, out)
+	}
+	return parseDriverOutput(string(out))
+}
+
+// parseDriverOutput reads the driver's $(info) output (one `KEY = VALUE` per
+// line) and returns the assignments.
+func parseDriverOutput(out string) (map[string]string, error) {
+	m := map[string]string{}
+	scanner := bufio.NewScanner(bytes.NewBufferString(out))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		match := driverLine.FindStringSubmatch(scanner.Text())
+		if match == nil {
+			continue
+		}
+		m[match[1]] = strings.TrimSpace(match[2])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning driver output: %w", err)
+	}
+	return m, nil
+}
+
+func get(key string) string { return load()[key] }
+
+func Organization() string         { return get(KeyOrganization) }
+func Repo() string                 { return get(KeyGitRepo) }
+func Remote() string               { return get(KeyGitRemote) }
+func ReleaseBranchPrefix() string  { return get(KeyReleaseBranchPrefix) }
+func DevTagSuffix() string         { return get(KeyDevTagSuffix) }
+func OperatorBranch() string       { return get(KeyOperatorBranch) }
+func OperatorOrganization() string { return get(KeyOperatorOrganization) }
+func OperatorRepo() string         { return get(KeyOperatorGitRepo) }

--- a/release/internal/defaults/metadata_test.go
+++ b/release/internal/defaults/metadata_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// setValues replaces the cached loader with one that returns v. Tests defer
+// resetValues to ensure state does not leak between cases.
+func setValues(v map[string]string) {
+	load = sync.OnceValue(func() map[string]string { return v })
+}
+
+func resetValues() {
+	load = sync.OnceValue(readMetadata)
+}
+
+func TestParseMetadata(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "metadata.mk"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	m, err := parseMetadata(data)
+	if err != nil {
+		t.Fatalf("parseMetadata: %v", err)
+	}
+	cases := map[string]string{
+		KeyOrganization:         "testorg",
+		KeyGitRepo:              "testrepo",
+		KeyGitRemote:            "testremote",
+		KeyReleaseBranchPrefix:  "testprefix",
+		KeyDevTagSuffix:         "testsuffix",
+		KeyOperatorBranch:       "test-operator-branch",
+		KeyOperatorOrganization: "testopsorg",
+		KeyOperatorGitRepo:      "testopsrepo",
+	}
+	for k, want := range cases {
+		if got := m[k]; got != want {
+			t.Errorf("key %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestParseMetadataIgnoresPreExistingVars(t *testing.T) {
+	m, err := parseMetadata([]byte("ORGANIZATION ?= newvalue\n"))
+	if err != nil {
+		t.Fatalf("parseMetadata: %v", err)
+	}
+	if got := m[KeyOrganization]; got != "newvalue" {
+		t.Errorf("ORGANIZATION: got %q, want %q", got, "newvalue")
+	}
+	for _, k := range []string{"VARS_OLD", "MAKEFLAGS", "SHELL", ".VARIABLES"} {
+		if _, ok := m[k]; ok {
+			t.Errorf("%s should not appear in parsed output", k)
+		}
+	}
+}
+
+func TestAccessorsWithInjectedValues(t *testing.T) {
+	t.Cleanup(resetValues)
+	setValues(map[string]string{
+		KeyOrganization:         "o",
+		KeyGitRepo:              "r",
+		KeyGitRemote:            "rem",
+		KeyReleaseBranchPrefix:  "rp",
+		KeyDevTagSuffix:         "ds",
+		KeyOperatorBranch:       "ob",
+		KeyOperatorOrganization: "oo",
+		KeyOperatorGitRepo:      "orepo",
+	})
+	if got := Organization(); got != "o" {
+		t.Errorf("Organization: got %q, want %q", got, "o")
+	}
+	if got := Repo(); got != "r" {
+		t.Errorf("Repo: got %q, want %q", got, "r")
+	}
+	if got := Remote(); got != "rem" {
+		t.Errorf("Remote: got %q, want %q", got, "rem")
+	}
+	if got := ReleaseBranchPrefix(); got != "rp" {
+		t.Errorf("ReleaseBranchPrefix: got %q, want %q", got, "rp")
+	}
+	if got := DevTagSuffix(); got != "ds" {
+		t.Errorf("DevTagSuffix: got %q, want %q", got, "ds")
+	}
+	if got := OperatorBranch(); got != "ob" {
+		t.Errorf("OperatorBranch: got %q, want %q", got, "ob")
+	}
+	if got := OperatorOrganization(); got != "oo" {
+		t.Errorf("OperatorOrganization: got %q, want %q", got, "oo")
+	}
+	if got := OperatorRepo(); got != "orepo" {
+		t.Errorf("OperatorRepo: got %q, want %q", got, "orepo")
+	}
+}
+
+func TestAccessorsEmptyWhenUnset(t *testing.T) {
+	t.Cleanup(resetValues)
+	setValues(map[string]string{})
+	if got := Organization(); got != "" {
+		t.Errorf("Organization with empty map: got %q, want empty", got)
+	}
+}

--- a/release/internal/defaults/noembed.go
+++ b/release/internal/defaults/noembed.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !with_embed
+
+package defaults
+
+// Stub for builds without -tags with_embed (e.g. go run, go test) where the metadata.mk copy hasn't been staged.
+// readMetadata falls back to reading the root metadata.mk via gitDir.
+var embeddedMetadata []byte

--- a/release/internal/defaults/source.go
+++ b/release/internal/defaults/source.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"fmt"
+
+	cli "github.com/urfave/cli/v3"
+)
+
+// MK returns a cli.ValueSource that resolves key from the embedded
+// metadata.mk. Unknown keys and load/parse failures (already logged by
+// readMetadata) yield (_, false), so the surrounding chain falls through
+// to the next source.
+func MK(key string) cli.ValueSource {
+	return &mkSource{key: key}
+}
+
+type mkSource struct{ key string }
+
+func (s *mkSource) Lookup() (string, bool) {
+	v, ok := load()[s.key]
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
+}
+
+func (s *mkSource) String() string   { return fmt.Sprintf("metadata.mk:%s", s.key) }
+func (s *mkSource) GoString() string { return fmt.Sprintf("defaults.MK(%q)", s.key) }

--- a/release/internal/defaults/source_test.go
+++ b/release/internal/defaults/source_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import "testing"
+
+func TestMKLookup(t *testing.T) {
+	t.Cleanup(resetValues)
+	setValues(map[string]string{
+		KeyOrganization: "myorg",
+		KeyGitRepo:      "",
+	})
+	cases := []struct {
+		key     string
+		wantVal string
+		wantOK  bool
+	}{
+		{KeyOrganization, "myorg", true},
+		{KeyGitRepo, "", false},    // empty value falls through
+		{"UNKNOWN_KEY", "", false}, // missing key falls through
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			v, ok := MK(tc.key).Lookup()
+			if v != tc.wantVal || ok != tc.wantOK {
+				t.Errorf("MK(%q).Lookup() = (%q, %v), want (%q, %v)", tc.key, v, ok, tc.wantVal, tc.wantOK)
+			}
+		})
+	}
+}

--- a/release/internal/defaults/testdata/metadata.mk
+++ b/release/internal/defaults/testdata/metadata.mk
@@ -1,0 +1,10 @@
+ORGANIZATION  ?= testorg
+GIT_REPO      ?= testrepo
+GIT_REMOTE    ?= testremote
+
+RELEASE_BRANCH_PREFIX ?= testprefix
+DEV_TAG_SUFFIX        ?= testsuffix
+
+OPERATOR_BRANCH       ?= test-operator-branch
+OPERATOR_ORGANIZATION ?= testopsorg
+OPERATOR_GIT_REPO     := testopsrepo

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/defaults"
 )
 
 const (
@@ -66,7 +67,31 @@ const (
 
 	// CalicoHelmRepoURL is the URL for the Calico Helm charts.
 	CalicoHelmRepoURL = "https://docs.tigera.io/calico/charts"
+
+	// ReleaseBranchPrefix is the prefix for release branches.
+	DefaultReleaseBranchPrefix = "release"
+
+	// DevTagSuffix is the suffix for dev tags.
+	DefaultDevTagSuffix = "0.dev"
 )
+
+func Organization() string { return FirstNonEmpty(defaults.Organization(), ProjectCalicoOrg) }
+func Repo() string         { return FirstNonEmpty(defaults.Repo(), CalicoRepoName) }
+func Remote() string       { return FirstNonEmpty(defaults.Remote(), DefaultRemote) }
+func ReleaseBranchPrefix() string {
+	return FirstNonEmpty(defaults.ReleaseBranchPrefix(), DefaultReleaseBranchPrefix)
+}
+func DevTagSuffix() string { return FirstNonEmpty(defaults.DevTagSuffix(), DefaultDevTagSuffix) }
+
+// FirstNonEmpty returns the first non-empty string from values, or "".
+func FirstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 // AllReleaseCharts returns a list of all Helm charts to be released.
 func AllReleaseCharts() []string {

--- a/release/pkg/manager/branch/options.go
+++ b/release/pkg/manager/branch/options.go
@@ -51,7 +51,7 @@ func WithReleaseBranchPrefix(prefix string) Option {
 	}
 }
 
-func WithValidate(validate bool) Option {
+func WithValidation(validate bool) Option {
 	return func(b *BranchManager) error {
 		b.validate = validate
 		return nil

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -578,18 +578,22 @@ func (r *CalicoManager) buildHelmIndex(chartDir, chartURL string) error {
 		return fmt.Errorf("download previous helm index from %s: %w", indexURL, err)
 	}
 
-	// Create tmp directory for building index and copy chart there.
+	// Create tmp directory for building index and hard-link charts there.
 	tmpChartsDir := filepath.Join(filepath.Dir(r.uploadDir()), fmt.Sprintf("charts-%s", r.helmChartVersion()))
 	if err := os.MkdirAll(tmpChartsDir, utils.DirPerms); err != nil {
 		return fmt.Errorf("create temp dir for building helm index: %w", err)
 	}
+	defer func() {
+		if err := os.RemoveAll(tmpChartsDir); err != nil {
+			logrus.WithError(err).Warnf("failed to remove helm index staging dir %s", tmpChartsDir)
+		}
+	}()
 
-	// Copy charts to temp dir.
 	for _, chart := range utils.AllReleaseCharts() {
 		srcChart := filepath.Join(chartDir, fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion()))
 		destChart := filepath.Join(tmpChartsDir, fmt.Sprintf("%s-%s.tgz", chart, r.helmChartVersion()))
-		if err := utils.CopyFile(srcChart, destChart); err != nil {
-			return fmt.Errorf("error copying %s chart to temp dir for building helm index: %w", chart, err)
+		if err := os.Link(srcChart, destChart); err != nil {
+			return fmt.Errorf("linking %s chart to temp dir for building helm index: %w", chart, err)
 		}
 	}
 
@@ -1065,7 +1069,13 @@ func (r *CalicoManager) uploadDir() string {
 func (r *CalicoManager) buildReleaseTar() error {
 	baseReleaseOutputDir := filepath.Dir(r.uploadDir())
 	releaseBase := filepath.Join(baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion))
-	releaseTarFilePath := filepath.Join(baseReleaseOutputDir, fmt.Sprintf("release-%s.tgz", r.calicoVersion))
+	releaseTarFilePath := filepath.Join(r.uploadDir(), fmt.Sprintf("release-%s.tgz", r.calicoVersion))
+	// Drop the staging tree once tar has consumed it.
+	defer func() {
+		if err := os.RemoveAll(releaseBase); err != nil {
+			logrus.WithError(err).Warnf("failed to remove release staging dir %s", releaseBase)
+		}
+	}()
 
 	if r.archiveImages {
 		imgDir := filepath.Join(releaseBase, "images")
@@ -1108,23 +1118,20 @@ func (r *CalicoManager) buildReleaseTar() error {
 		// Felix binaries.
 		"felix/bin/calico-bpf": binDir,
 	}
+	// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
 	for src, dst := range binaries {
-		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-r", src, dst}, nil); err != nil {
+		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
 			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
 		}
 	}
 
 	// Add in manifests directory generated from the docs.
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-r", "manifests", releaseBase}, nil); err != nil {
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
 		return fmt.Errorf("failed to copy manifests: %w", err)
 	}
 
-	// tar up the whole thing, and copy it to the target directory
 	if _, err := r.runner.RunInDir(r.repoRoot, "tar", []string{"-czvf", releaseTarFilePath, "-C", baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion)}, nil); err != nil {
 		return fmt.Errorf("failed to create release tar: %w", err)
-	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{releaseTarFilePath, r.uploadDir()}, nil); err != nil {
-		return fmt.Errorf("failed to copy release tar: %w", err)
 	}
 	return nil
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -88,9 +88,9 @@ func NewManager(opts ...Option) *CalicoManager {
 		helmRepoURL:       utils.CalicoHelmRepoURL,
 		operatorRegistry:  operator.DefaultRegistry,
 		operatorImage:     operator.DefaultImage,
-		operatorGithubOrg: operator.DefaultOrg,
-		operatorRepo:      operator.DefaultRepoName,
-		operatorBranch:    operator.DefaultBranchName,
+		operatorGithubOrg: operator.Organization(),
+		operatorRepo:      operator.Repo(),
+		operatorBranch:    operator.Branch(),
 	}
 
 	// Run through provided options.
@@ -1740,7 +1740,12 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 	if err := r.modifyHelmChartsValues(); err != nil {
 		return fmt.Errorf("failed to update chart versions: %w", err)
 	}
-	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "generate"); err != nil {
+	env := append(os.Environ(),
+		fmt.Sprintf("OPERATOR_ORGANIZATION=%s", r.operatorGithubOrg),
+		fmt.Sprintf("OPERATOR_GIT_REPO=%s", r.operatorRepo),
+		fmt.Sprintf("OPERATOR_BRANCH=%s", r.operatorBranch),
+	)
+	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "generate", env...); err != nil {
 		return fmt.Errorf("failed to run make generate: %w", err)
 	}
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -71,12 +71,18 @@ func NewManager(opts ...Option) *CalicoManager {
 		productCode:       utils.CalicoProductCode,
 		validate:          true,
 		validateBranch:    true,
-		buildImages:       true,
-		publishImages:     true,
-		publishCharts:     true,
+		manifests:         true,
+		images:            true,
 		archiveImages:     true,
-		publishGitRef:     true,
-		publishGithub:     true,
+		binaries:          true,
+		ocpBundle:         true,
+		tarball:           true,
+		windowsArchive:    true,
+		helmCharts:        true,
+		helmIndex:         true,
+		e2eBinaries:       true,
+		gitRef:            true,
+		githubRelease:     true,
 		imageRegistries:   defaultRegistries,
 		helmRegistries:    registry.DefaultHelmRegistries,
 		helmRepoURL:       utils.CalicoHelmRepoURL,
@@ -130,9 +136,6 @@ type CalicoManager struct {
 	// isHashRelease is a flag to indicate that we should build a hashrelease.
 	isHashRelease bool
 
-	// buildImages controls whether we should build container images, or use ones already built by CI.
-	buildImages bool
-
 	// archiveImages controls whether we should archive container images in release tarball.
 	archiveImages bool
 
@@ -160,13 +163,11 @@ type CalicoManager struct {
 	// tmpDir is the directory to which we should write temporary files.
 	tmpDir string
 
-	// Fine-tuning configuration for publishing.
-	publishImages bool
-	publishCharts bool
-	publishGitRef bool
-	publishGithub bool
+	gitRef        bool
+	githubRelease bool
 	awsProfile    string
 	s3Bucket      string
+	githubToken   string
 
 	// imageRegistries is the list of imageRegistries to which we should publish images.
 	imageRegistries []string
@@ -203,8 +204,16 @@ type CalicoManager struct {
 	imageScanningConfig imagescanner.Config
 	imageComponents     map[string]registry.Component
 
-	// external configuration.
-	githubToken string
+	// Unified step flags.
+	manifests      bool
+	images         bool
+	binaries       bool
+	ocpBundle      bool
+	windowsArchive bool
+	tarball        bool
+	helmCharts     bool
+	helmIndex      bool
+	e2eBinaries    bool
 }
 
 func releaseImages(images []string, version, registry, operatorImage, operatorVersion, operatorRegistry string) []string {
@@ -228,8 +237,11 @@ func (r *CalicoManager) PreBuildValidation() error {
 	if r.operatorVersion == "" {
 		errStack = errors.Join(errStack, fmt.Errorf("no operator version specified"))
 	}
-	if (r.buildImages || r.archiveImages) && len(r.imageRegistries) == 0 {
+	if (r.images || r.archiveImages) && len(r.imageRegistries) == 0 {
 		errStack = errors.Join(errStack, fmt.Errorf("no image registries specified"))
+	}
+	if r.isHashRelease && r.ocpBundle && !r.manifests {
+		errStack = errors.Join(errStack, fmt.Errorf("cannot build OCP bundle without manifests; set --manifests to 'true'"))
 	}
 	if errStack != nil {
 		return errStack
@@ -296,30 +308,32 @@ func (r *CalicoManager) Build() error {
 	}
 
 	if r.isHashRelease {
-		// This is a hashrelease.
-		//
-		// Re-generate manifests using the desired versions. This needs to happen
-		// before building the OCP bundle, since the OCP bundle uses the manifests.
-		if err = r.generateManifests(); err != nil {
+		// Regenerate manifests and build the manifest-derived OCP bundle. The defer resets
+		// manifests after downstream consumers (e.g. collectManifests, buildReleaseTar) have
+		// seen the regenerated, pinned manifests.
+		defer r.resetManifests()
+		if err = r.buildManifests(); err != nil {
 			return err
 		}
-		defer r.resetManifests()
 
 		// Real releases call "make release-build", but hashreleases don't.
 		// Instead, we build some of the targets directly. In the future, we should instead align the release
 		// and hashrelease build processes to avoid these separate code paths.
-		env := append(os.Environ(), fmt.Sprintf("VERSION=%s", ver))
-		targets := []string{"release-windows-archive", "dist/install-calico-windows.ps1"}
-		for _, target := range targets {
-			if err = r.makeInDirectoryIgnoreOutput(filepath.Join(r.repoRoot, "node"), target, env...); err != nil {
-				return fmt.Errorf("error building target %s: %s", target, err)
+		if r.windowsArchive {
+			env := append(os.Environ(), fmt.Sprintf("VERSION=%s", ver))
+			targets := []string{"release-windows-archive", "dist/install-calico-windows.ps1"}
+			for _, target := range targets {
+				if err = r.makeInDirectoryIgnoreOutput(filepath.Join(r.repoRoot, "node"), target, env...); err != nil {
+					return fmt.Errorf("error building target %s: %s", target, err)
+				}
 			}
+		} else {
+			logrus.Info("Skipping building windows archive")
 		}
-	}
-
-	// Build an OCP tgz bundle from manifests, used in the docs.
-	if err = r.buildOCPBundle(); err != nil {
-		return err
+	} else {
+		if err = r.buildOCPBundle(); err != nil {
+			return err
+		}
 	}
 
 	// Build and add in the complete release tarball.
@@ -535,6 +549,10 @@ func (r *CalicoManager) resetCharts() {
 }
 
 func (r *CalicoManager) BuildHelm() error {
+	if !r.helmCharts {
+		logrus.Info("Skipping building helm chart and index")
+		return nil
+	}
 	if r.isHashRelease {
 		if err := r.modifyHelmChartsValues(); err != nil {
 			return fmt.Errorf("failed to modify helm chart values: %s", err)
@@ -550,8 +568,10 @@ func (r *CalicoManager) BuildHelm() error {
 	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "chart", env...); err != nil {
 		return fmt.Errorf("failed to build helm chart: %w", err)
 	}
-
-	// Create helm index for the chart.
+	if !r.helmIndex {
+		logrus.Info("Skipping building helm index")
+		return nil
+	}
 	chartURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s", r.githubOrg, r.repo, r.calicoVersion)
 	if r.isHashRelease {
 		chartURL = r.hashrelease.URL()
@@ -627,7 +647,10 @@ func (r *CalicoManager) buildHelmIndex(chartDir, chartURL string) error {
 }
 
 func (r *CalicoManager) buildOCPBundle() error {
-	// Build OpenShift bundle.
+	if !r.ocpBundle {
+		logrus.Info("Skipping building OCP bundle")
+		return nil
+	}
 	if err := r.makeInDirectoryIgnoreOutput(r.repoRoot, "bin/ocp.tgz"); err != nil {
 		return fmt.Errorf("failed to build OCP bundle: %w", err)
 	}
@@ -810,7 +833,7 @@ func (r *CalicoManager) hashreleasePrereqs() error {
 		}
 	}
 
-	if r.publishImages {
+	if r.images {
 		return r.assertImageVersions()
 	} else {
 		if err := r.checkHashreleaseImagesPublished(); err != nil {
@@ -926,10 +949,10 @@ func (r *CalicoManager) publishPrereqs() error {
 	if r.calicoVersion == "" {
 		errStack = errors.Join(errStack, fmt.Errorf("no calico version specified"))
 	}
-	if r.publishImages && len(r.imageRegistries) == 0 {
+	if r.images && len(r.imageRegistries) == 0 {
 		errStack = errors.Join(errStack, fmt.Errorf("no image registries specified"))
 	}
-	if r.publishCharts {
+	if r.helmCharts {
 		if len(r.helmRegistries) == 0 {
 			errStack = errors.Join(errStack, fmt.Errorf("no helm chart registries specified"))
 		}
@@ -977,40 +1000,23 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 		return fmt.Errorf("failed to build release metadata file: %s", err)
 	}
 
-	// We attach calicoctl binaries directly to the release as well.
-	files, err := os.ReadDir(filepath.Join(r.repoRoot, "calicoctl", "bin"))
-	if err != nil {
-		return fmt.Errorf("failed to read calicoctl binaries: %w", err)
+	if err := r.collectBinaries(); err != nil {
+		return err
 	}
-	for _, b := range files {
-		if _, err := r.runner.Run("cp", []string{filepath.Join(r.repoRoot, "calicoctl", "bin", b.Name()), uploadDir}, nil); err != nil {
-			return fmt.Errorf("failed to copy calicoctl binary %s: %w", b.Name(), err)
-		}
+	if err := r.collectManifests(); err != nil {
+		return err
 	}
-
-	if r.isHashRelease {
-		// Hashrelease include manifests in a different way, instead of just in the release tarball.
-		if _, err := r.runner.Run("cp", []string{"-r", filepath.Join(r.repoRoot, "manifests"), uploadDir}, nil); err != nil {
-			logrus.WithError(err).Error("Failed to copy manifests to output directory")
-			return fmt.Errorf("failed to copy manifests: %w", err)
-		}
+	if err := r.collectWindowsArchive(); err != nil {
+		return err
 	}
-
-	// Add in the already-built windows zip archive, the Windows install script, ocp bundle, and the helm chart.
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{fmt.Sprintf("node/dist/calico-windows-%s.zip", r.calicoVersion), uploadDir}, nil); err != nil {
-		return fmt.Errorf("failed to copy windows zip archive: %w", err)
-	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"node/dist/install-calico-windows.ps1", uploadDir}, nil); err != nil {
-		return fmt.Errorf("failed to copy windows install script: %w", err)
-	}
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
-		return fmt.Errorf("failed to copy OCP bundle: %w", err)
+	if err := r.collectOCPBundle(); err != nil {
+		return err
 	}
 
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
 	// sha256sum -c --ignore-missing SHA256SUMS
-	files, err = os.ReadDir(uploadDir)
+	files, err := os.ReadDir(uploadDir)
 	if err != nil {
 		return fmt.Errorf("failed to read upload directory: %w", err)
 	}
@@ -1032,8 +1038,74 @@ func (r *CalicoManager) collectGithubArtifacts() error {
 	return nil
 }
 
-// generateManifests re-generates manifests using the specified calico and operator versions.
-func (r *CalicoManager) generateManifests() error {
+func (r *CalicoManager) collectBinaries() error {
+	if !r.binaries {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	// We attach calicoctl binaries directly to the release as well.
+	files, err := os.ReadDir(filepath.Join(r.repoRoot, "calicoctl", "bin"))
+	if err != nil {
+		return fmt.Errorf("failed to read calicoctl binaries: %w", err)
+	}
+	for _, b := range files {
+		if _, err := r.runner.Run("cp", []string{filepath.Join(r.repoRoot, "calicoctl", "bin", b.Name()), uploadDir}, nil); err != nil {
+			return fmt.Errorf("failed to copy calicoctl binary %s: %w", b.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (r *CalicoManager) collectManifests() error {
+	if !r.manifests {
+		return nil
+	}
+	if r.isHashRelease {
+		uploadDir := r.uploadDir()
+		// Hashrelease include manifests in a different way, instead of just in the release tarball.
+		if _, err := r.runner.Run("cp", []string{"-r", filepath.Join(r.repoRoot, "manifests"), uploadDir}, nil); err != nil {
+			logrus.WithError(err).Error("Failed to copy manifests to output directory")
+			return fmt.Errorf("failed to copy manifests: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *CalicoManager) collectWindowsArchive() error {
+	if !r.windowsArchive {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{fmt.Sprintf("node/dist/calico-windows-%s.zip", r.calicoVersion), uploadDir}, nil); err != nil {
+		return fmt.Errorf("failed to copy windows zip archive: %w", err)
+	}
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"node/dist/install-calico-windows.ps1", uploadDir}, nil); err != nil {
+		return fmt.Errorf("failed to copy windows install script: %w", err)
+	}
+	return nil
+}
+
+func (r *CalicoManager) collectOCPBundle() error {
+	if !r.ocpBundle {
+		return nil
+	}
+	uploadDir := r.uploadDir()
+	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"bin/ocp.tgz", uploadDir}, nil); err != nil {
+		return fmt.Errorf("failed to copy OCP bundle: %w", err)
+	}
+	return nil
+}
+
+// buildManifests regenerates manifests for pinned calico/operator versions and
+// builds the manifest-derived OCP bundle. Intended for the hashrelease path;
+// regular releases build the OCP bundle directly from the checked-in manifests
+// via buildOCPBundle. The caller must defer resetManifests so downstream
+// consumers (collectManifests, buildReleaseTar) still see the pinned manifests.
+func (r *CalicoManager) buildManifests() error {
+	if !r.manifests {
+		logrus.Info("Skipping regenerating manifests")
+		return nil
+	}
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("PRODUCT_VERSION=%s", r.calicoVersion))
 	env = append(env, fmt.Sprintf("OPERATOR_VERSION=%s", r.operatorVersion))
@@ -1046,10 +1118,13 @@ func (r *CalicoManager) generateManifests() error {
 		logrus.WithError(err).Error("Failed to make manifests")
 		return fmt.Errorf("failed to generate manifests: %w", err)
 	}
-	return nil
+	return r.buildOCPBundle()
 }
 
 func (r *CalicoManager) resetManifests() {
+	if !r.manifests {
+		return
+	}
 	if _, err := r.runner.RunInDir(r.repoRoot, "git", []string{"checkout", "manifests", "test-tools/mocknode/mock-node.yaml"}, nil); err != nil {
 		logrus.WithError(err).Error("Failed to reset manifests")
 	}
@@ -1067,6 +1142,10 @@ func (r *CalicoManager) uploadDir() string {
 // TODO: We should produce a tar per architecture that we ship.
 // TODO: We should produce windows tars
 func (r *CalicoManager) buildReleaseTar() error {
+	if !r.tarball {
+		logrus.Info("Skipping building release tarball")
+		return nil
+	}
 	baseReleaseOutputDir := filepath.Dir(r.uploadDir())
 	releaseBase := filepath.Join(baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion))
 	releaseTarFilePath := filepath.Join(r.uploadDir(), fmt.Sprintf("release-%s.tgz", r.calicoVersion))
@@ -1103,31 +1182,35 @@ func (r *CalicoManager) buildReleaseTar() error {
 	}
 
 	// Add in release binaries that we ship.
-	binDir := filepath.Join(releaseBase, "bin")
-	if err := os.MkdirAll(binDir, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create images dir: %s", err)
-	}
+	if r.binaries {
+		binDir := filepath.Join(releaseBase, "bin")
+		if err := os.MkdirAll(binDir, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create images dir: %s", err)
+		}
 
-	binaries := map[string]string{
-		// CNI plugin binaries
-		"cni-plugin/bin/": filepath.Join(binDir, "cni"),
+		binaries := map[string]string{
+			// CNI plugin binaries
+			"cni-plugin/bin/": filepath.Join(binDir, "cni"),
 
-		// Calicoctl binaries.
-		"calicoctl/bin/": filepath.Join(binDir, "calicoctl"),
+			// Calicoctl binaries.
+			"calicoctl/bin/": filepath.Join(binDir, "calicoctl"),
 
-		// Felix binaries.
-		"felix/bin/calico-bpf": binDir,
-	}
-	// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
-	for src, dst := range binaries {
-		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
-			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+			// Felix binaries.
+			"felix/bin/calico-bpf": binDir,
+		}
+		// -al (archive + hard-link) keeps staging disk usage flat and preserves symlinks
+		for src, dst := range binaries {
+			if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", src, dst}, nil); err != nil {
+				return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+			}
 		}
 	}
 
 	// Add in manifests directory generated from the docs.
-	if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
-		return fmt.Errorf("failed to copy manifests: %w", err)
+	if r.manifests {
+		if _, err := r.runner.RunInDir(r.repoRoot, "cp", []string{"-al", "manifests", releaseBase}, nil); err != nil {
+			return fmt.Errorf("failed to copy manifests: %w", err)
+		}
 	}
 
 	if _, err := r.runner.RunInDir(r.repoRoot, "tar", []string{"-czvf", releaseTarFilePath, "-C", baseReleaseOutputDir, fmt.Sprintf("release-%s", r.calicoVersion)}, nil); err != nil {
@@ -1137,15 +1220,16 @@ func (r *CalicoManager) buildReleaseTar() error {
 }
 
 func (r *CalicoManager) buildBinaries() error {
-	// Skip building binaries if we are building images
-	// binaries are built as part of "release-build" target.
-	if r.buildImages {
+	if !r.binaries {
+		logrus.Info("Skipping building binaries")
 		return nil
 	}
-	m := map[string]string{
-		"calicoctl":  "build-all",
-		"cni-plugin": "build-all",
-		"felix":      "release-build",
+	// calicoctl needs to build unconditionally; everything else is produced
+	// as part of its image release-build target.
+	m := map[string]string{"calicoctl": "build-all"}
+	if !r.images {
+		m["cni-plugin"] = "build-all"
+		m["felix"] = "release-build"
 	}
 	env := append(os.Environ(),
 		fmt.Sprintf("VERSION=%s", r.calicoVersion),
@@ -1161,7 +1245,7 @@ func (r *CalicoManager) buildBinaries() error {
 }
 
 func (r *CalicoManager) buildContainerImages() error {
-	if !r.buildImages {
+	if !r.images {
 		logrus.Info("Skip building container images")
 		return nil
 	}
@@ -1201,7 +1285,7 @@ func (r *CalicoManager) buildContainerImages() error {
 }
 
 func (r *CalicoManager) publishGitTag() error {
-	if !r.publishGitRef {
+	if !r.gitRef {
 		logrus.Info("Skipping git tag")
 		return nil
 	}
@@ -1213,7 +1297,7 @@ func (r *CalicoManager) publishGitTag() error {
 }
 
 func (r *CalicoManager) publishGithubRelease() error {
-	if !r.publishGithub {
+	if !r.githubRelease {
 		logrus.Info("Skipping github release")
 		return nil
 	}
@@ -1269,7 +1353,7 @@ Additional links:
 }
 
 func (r *CalicoManager) publishContainerImages() error {
-	if !r.publishImages {
+	if !r.images {
 		logrus.Info("Skipping image publish")
 		return nil
 	}
@@ -1327,7 +1411,7 @@ func (r *CalicoManager) publishContainerImages() error {
 }
 
 func (r *CalicoManager) publishHelmCharts() error {
-	if !r.publishCharts {
+	if !r.helmCharts {
 		logrus.Info("Skipping publishing helm charts")
 		return nil
 	}
@@ -1370,7 +1454,11 @@ func (r *CalicoManager) publishHelmChart(chart, registry string) error {
 }
 
 func (r *CalicoManager) updateHelmChartIndex() error {
-	if !r.publishCharts {
+	if !r.helmCharts {
+		logrus.Info("Skipping updating helm index (charts disabled)")
+		return nil
+	}
+	if !r.helmIndex {
 		logrus.Info("Skipping updating helm index")
 		return nil
 	}
@@ -1440,7 +1528,7 @@ func (r *CalicoManager) determineBranch() (string, error) {
 
 // Uses docker to build a tgz archive of the specified container image.
 func (r *CalicoManager) archiveContainerImage(out, image string) error {
-	if r.isHashRelease && !r.buildImages {
+	if r.isHashRelease && !r.images {
 		if _, err := r.runner.Run("docker", []string{"image", "inspect", image}, nil); err != nil {
 			logrus.WithError(err).WithField("image", image).Error("Image not found locally, will attempt to pull")
 			if _, err := r.runner.Run("docker", []string{"pull", image}, nil); err != nil {
@@ -1671,7 +1759,7 @@ func (r *CalicoManager) updateAndCommitPrep() error {
 
 // pushPrepBranch pushes the prep branch to remote and creates a PR if not in local mode.
 func (r *CalicoManager) pushPrepBranch(baseBranch, prepBranch string) error {
-	if !r.publishGitRef {
+	if !r.gitRef {
 		logrus.WithField("branch", prepBranch).Warn("Local mode: skipping branch push and PR creation")
 		return r.switchToBaseBranch(baseBranch)
 	}
@@ -1752,13 +1840,13 @@ func (r *CalicoManager) prepPrereqs() error {
 			return fmt.Errorf("failed to determine current git branch: %w", err)
 		} else if branch == defaultBranch {
 			return fmt.Errorf("cannot cut release from branch: %s", branch)
-		} else if r.publishGitRef && !strings.HasPrefix(branch, r.releaseBranchPrefix) {
+		} else if r.gitRef && !strings.HasPrefix(branch, r.releaseBranchPrefix) {
 			return fmt.Errorf("current branch is %s, expected to be a release branch with prefix %s. Please switch to the appropriate release branch to cut the release", branch, r.releaseBranchPrefix)
 		}
 	}
 
 	// If publishing, check that we are not on a fork branch. We want to ensure releases are always cut from the main repo
-	if r.publishGitRef {
+	if r.gitRef {
 		owner, err := r.remoteOwner()
 		if err != nil {
 			return err

--- a/release/pkg/manager/calico/options.go
+++ b/release/pkg/manager/calico/options.go
@@ -38,7 +38,7 @@ func IsHashRelease() Option {
 	}
 }
 
-func WithValidate(validate bool) Option {
+func WithValidation(validate bool) Option {
 	return func(r *CalicoManager) error {
 		r.validate = validate
 		return nil
@@ -111,30 +111,44 @@ func WithS3Bucket(bucket string) Option {
 	}
 }
 
-func WithPublishImages(publish bool) Option {
+func WithHelmIndex(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishImages = publish
+		r.helmIndex = enabled
 		return nil
 	}
 }
 
-func WithPublishCharts(publish bool) Option {
+func WithHelmCharts(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishCharts = publish
+		r.helmCharts = enabled
 		return nil
 	}
 }
 
-func WithPublishGitRef(publish bool) Option {
+func WithGitRef(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishGitRef = publish
+		r.gitRef = enabled
 		return nil
 	}
 }
 
-func WithPublishGithubRelease(publish bool) Option {
+func WithGithubRelease(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.publishGithub = publish
+		r.githubRelease = enabled
+		return nil
+	}
+}
+
+func WithWindowsArchive(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.windowsArchive = enabled
+		return nil
+	}
+}
+
+func WithE2EBinaries(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.e2eBinaries = enabled
 		return nil
 	}
 }
@@ -146,9 +160,9 @@ func WithPublishHashrelease(publish bool) Option {
 	}
 }
 
-func WithBuildImages(buildImages bool) Option {
+func WithImages(enabled bool) Option {
 	return func(r *CalicoManager) error {
-		r.buildImages = buildImages
+		r.images = enabled
 		return nil
 	}
 }
@@ -256,6 +270,34 @@ func WithArchiveImages(archive bool) Option {
 func WithOperatorBranch(branch string) Option {
 	return func(r *CalicoManager) error {
 		r.operatorBranch = branch
+		return nil
+	}
+}
+
+func WithManifests(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.manifests = enabled
+		return nil
+	}
+}
+
+func WithBinaries(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.binaries = enabled
+		return nil
+	}
+}
+
+func WithOCPBundle(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.ocpBundle = enabled
+		return nil
+	}
+}
+
+func WithTarball(enabled bool) Option {
+	return func(r *CalicoManager) error {
+		r.tarball = enabled
 		return nil
 	}
 }

--- a/release/pkg/manager/calico/options_test.go
+++ b/release/pkg/manager/calico/options_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calico
+
+import (
+	"strings"
+	"testing"
+)
+
+// requiredOpts returns the bare-minimum opts needed for NewManager to pass
+// its constructor-level required-field checks. Tests layer additional opts
+// on top to exercise specific behaviour.
+func requiredOpts() []Option {
+	return []Option{
+		WithRepoRoot("/tmp"),
+		WithGithubOrg("projectcalico"),
+		WithRepoName("calico"),
+		WithRepoRemote("origin"),
+	}
+}
+
+// TestNewManagerStepDefaults pins down the all-step-flags-default-to-true
+// contract. CLI gating relies on these defaults being on at the manager
+// layer; flipping a default silently breaks every release without a flag set.
+func TestNewManagerStepDefaults(t *testing.T) {
+	m := NewManager(requiredOpts()...)
+	cases := []struct {
+		name string
+		got  bool
+	}{
+		{"validate", m.validate},
+		{"validateBranch", m.validateBranch},
+		{"images", m.images},
+		{"archiveImages", m.archiveImages},
+		{"manifests", m.manifests},
+		{"binaries", m.binaries},
+		{"ocpBundle", m.ocpBundle},
+		{"tarball", m.tarball},
+		{"windowsArchive", m.windowsArchive},
+		{"helmCharts", m.helmCharts},
+		{"helmIndex", m.helmIndex},
+		{"e2eBinaries", m.e2eBinaries},
+		{"gitRef", m.gitRef},
+		{"githubRelease", m.githubRelease},
+	}
+	for _, tc := range cases {
+		if !tc.got {
+			t.Errorf("default %s: got false, want true", tc.name)
+		}
+	}
+}
+
+// TestPreBuildValidation covers the cross-flag invariants enforced at the
+// manager layer. The test exercises the two non-trivial cases this PR
+// introduces: image-registries required when images/archive-images are on,
+// and ocp-bundle requires manifests on the hashrelease path.
+func TestPreBuildValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		opts      []Option
+		wantErr   string // substring match; empty means "the asserted invariants do not fire"
+		expectErr bool   // true if PreBuildValidation must return non-nil
+	}{
+		{
+			name: "happy path",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+			),
+		},
+		{
+			name: "missing calico version",
+			opts: append(requiredOpts(),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+			),
+			wantErr:   "no calico version specified",
+			expectErr: true,
+		},
+		{
+			name: "missing operator version",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+			),
+			wantErr:   "no operator version specified",
+			expectErr: true,
+		},
+		{
+			name: "images on with no registries errors",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries(nil),
+			),
+			wantErr:   "no image registries specified",
+			expectErr: true,
+		},
+		{
+			name: "images off + archive off skips registry check",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries(nil),
+				WithImages(false),
+				WithArchiveImages(false),
+			),
+		},
+		{
+			name: "archive on with images off still requires registries",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries(nil),
+				WithImages(false),
+			),
+			wantErr:   "no image registries specified",
+			expectErr: true,
+		},
+		{
+			name: "hashrelease ocp-bundle requires manifests",
+			opts: append(requiredOpts(),
+				IsHashRelease(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+				WithManifests(false),
+			),
+			wantErr:   "cannot build OCP bundle without manifests",
+			expectErr: true,
+		},
+		{
+			name: "hashrelease manifests off + ocp-bundle off passes the cross-flag check",
+			opts: append(requiredOpts(),
+				IsHashRelease(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+				WithManifests(false),
+				WithOCPBundle(false),
+			),
+			// PreHashreleaseValidate runs after PreBuildValidation's gates
+			// and may error on its own preconditions; we only assert that
+			// the manifests/ocp-bundle gate above doesn't fire here.
+		},
+		{
+			name: "non-hashrelease build with manifests off is allowed by PreBuildValidation",
+			opts: append(requiredOpts(),
+				WithVersion("v3.99.0"),
+				WithOperatorVersion("v9.99.0"),
+				WithImageRegistries([]string{"example.com/calico"}),
+				WithManifests(false),
+			),
+		},
+	}
+	// Substrings owned by PreBuildValidation. Errors from downstream
+	// validators (PreHashreleaseValidate / PreReleaseValidate) may surface
+	// when no real repo is wired up; filter on the substrings we care about.
+	guarded := []string{
+		"no calico version specified",
+		"no operator version specified",
+		"no image registries specified",
+		"cannot build OCP bundle without manifests",
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(tc.opts...)
+			err := m.PreBuildValidation()
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			// Not expecting a guarded-invariant failure. Allow downstream
+			// validator errors to bubble up but fail if any guarded
+			// substring shows up.
+			if err == nil {
+				return
+			}
+			for _, sub := range guarded {
+				if strings.Contains(err.Error(), sub) {
+					t.Fatalf("unexpected guarded-invariant error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -40,10 +40,10 @@ const (
 )
 
 func Organization() string {
-	return utils.FirstNonEmpty(defaults.OperatorOrganization(), utils.TigeraOrg)
+	return utils.FirstNonEmpty(defaults.OperatorOrganization(), DefaultOrg)
 }
 func Repo() string   { return utils.FirstNonEmpty(defaults.OperatorRepo(), DefaultRepoName) }
-func Branch() string { return utils.FirstNonEmpty(defaults.OperatorBranch(), utils.DefaultBranch) }
+func Branch() string { return utils.FirstNonEmpty(defaults.OperatorBranch(), DefaultBranch) }
 
 var (
 	defaultProductEnvPrefix = "CALICO"

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/release/internal/command"
+	"github.com/projectcalico/calico/release/internal/defaults"
 	"github.com/projectcalico/calico/release/internal/registry"
 	"github.com/projectcalico/calico/release/internal/utils"
 )
@@ -32,11 +33,17 @@ const (
 	DefaultImage               = registry.TigeraOperatorImage
 	DefaultOrg                 = utils.TigeraOrg
 	DefaultRepoName            = "operator"
-	DefaultBranchName          = utils.DefaultBranch
 	DefaultReleaseBranchPrefix = "release"
+	DefaultBranch              = "master"
 	DefaultDevTagSuffix        = "0.dev"
 	DefaultRegistry            = "quay.io"
 )
+
+func Organization() string {
+	return utils.FirstNonEmpty(defaults.OperatorOrganization(), utils.TigeraOrg)
+}
+func Repo() string   { return utils.FirstNonEmpty(defaults.OperatorRepo(), DefaultRepoName) }
+func Branch() string { return utils.FirstNonEmpty(defaults.OperatorBranch(), utils.DefaultBranch) }
 
 var (
 	defaultProductEnvPrefix = "CALICO"

--- a/release/pkg/manager/operator/manager.go
+++ b/release/pkg/manager/operator/manager.go
@@ -121,8 +121,8 @@ func (o *OperatorManager) Build() error {
 	if err != nil {
 		return err
 	}
-	logFields[fmt.Sprintf("%s_registry", strings.ToLower(defaultProductEnvPrefix))] = o.productRegistry
-	logFields[fmt.Sprintf("%s_image_path", strings.ToLower(defaultProductEnvPrefix))] = o.productRegistry
+	logFields[fmt.Sprintf("%s_registry", strings.ToLower(defaultProductEnvPrefix))] = r
+	logFields[fmt.Sprintf("%s_image_path", strings.ToLower(defaultProductEnvPrefix))] = i
 	env = append(env, fmt.Sprintf("%s_REGISTRY=%s", defaultProductEnvPrefix, r))
 	env = append(env, fmt.Sprintf("%s_IMAGE_PATH=%s", defaultProductEnvPrefix, i))
 	if o.isHashRelease {

--- a/release/pkg/tasks/hashrelease.go
+++ b/release/pkg/tasks/hashrelease.go
@@ -63,14 +63,14 @@ func ReformatHashrelease(hashreleaseOutputDir, tmpDir string) error {
 	}
 	windowsZip := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("calico-windows-%s.zip", versions.ProductVersion()))
 	windowsZipDst := filepath.Join(windowsDir, fmt.Sprintf("calico-windows-%s.zip", versions.ProductVersion()))
-	if err := utils.CopyFile(windowsZip, windowsZipDst); err != nil {
+	if err := copyIfExists(windowsZip, windowsZipDst); err != nil {
 		return err
 	}
 
 	// Copy the ocp.tgz to manifests/ocp.tgz
 	ocpTarball := filepath.Join(hashreleaseOutputDir, "ocp.tgz")
 	ocpTarballDst := filepath.Join(hashreleaseOutputDir, "manifests", "ocp.tgz")
-	if err := utils.CopyFile(ocpTarball, ocpTarballDst); err != nil {
+	if err := copyIfExists(ocpTarball, ocpTarballDst); err != nil {
 		return err
 	}
 
@@ -82,7 +82,7 @@ func ReformatHashrelease(hashreleaseOutputDir, tmpDir string) error {
 	for _, chart := range utils.AllReleaseCharts() {
 		chartTarball := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s-%s.tgz", chart, versions.HelmChartVersion()))
 		chartTarballDst := filepath.Join(chartsDir, fmt.Sprintf("%s.tgz", chart))
-		if err := utils.CopyFile(chartTarball, chartTarballDst); err != nil {
+		if err := copyIfExists(chartTarball, chartTarballDst); err != nil {
 			return err
 		}
 	}
@@ -90,8 +90,22 @@ func ReformatHashrelease(hashreleaseOutputDir, tmpDir string) error {
 	// Keep copy of the Tigera operator chart without version in name in root dir
 	operatorTarball := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s-%s.tgz", utils.TigeraOperatorChart, versions.HelmChartVersion()))
 	operatorTarballDst := filepath.Join(hashreleaseOutputDir, fmt.Sprintf("%s.tgz", utils.TigeraOperatorChart))
-	if err := utils.CopyFile(operatorTarball, operatorTarballDst); err != nil {
+	if err := copyIfExists(operatorTarball, operatorTarballDst); err != nil {
 		return err
 	}
 	return nil
+}
+
+// copyIfExists copies src to dst, logging and skipping if src is missing.
+// Missing sources are expected when the caller skipped the step-control flag
+// that would have produced the artifact.
+func copyIfExists(src, dst string) error {
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			logrus.WithField("file", src).Warn("Source missing, skipping reformat copy")
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	return utils.CopyFile(src, dst)
 }


### PR DESCRIPTION
Cherry-picks five release tooling PRs from master to release-v3.32:

- #12585 — Reduce transient disk usage in hashrelease build
- #12615 — Step control flags for hashrelease and release build/publish
- #12665 — Source CLI flag defaults from metadata.mk (the original ask; needs #12615 to apply cleanly)
- #12680 — Wire operator git flags through publish/public, fix manager fallbacks (follow-up to #12665, fixes the issue Copilot flagged on the initial revision of this PR)
- #12682 — Drop dead value param from helm/windows flags

## Conflict resolution notes

- **#12585**: dropped the `buildE2EBinaries` hard-link change. That function was added in #12506 (e2e test binary support) which has not been cherry-picked to release-v3.32, so the change has nothing to apply against. The remaining three improvements (release-tar staging, helm-index staging, cni/calicoctl/felix hard-links) all apply.
- **#12615**: dropped the new `buildE2EBinaries` invocation in `Build()` for the same reason. In `buildBinaries`, kept `cni-plugin: build-all` in the unconditional-build map; release-v3.32 still ships cni-plugin as its own image (PR #12225 binary/image consolidation is not on this branch), so it follows the same `!r.images` gate as felix. Preserved explicit `operatorBranchFlag` registration on `release build`/`release publish` since #12665 had not yet folded it into `operatorGitFlags`.
- **#12665**: dropped the explicit `operatorBranchFlag` carried over from #12615 — it is now part of `operatorGitFlags` after this PR.
- **#12680**: applied cleanly.
- **#12682**: applied cleanly.

## Verification

- `go build ./...` clean in `release/`
- `go vet ./...` clean
- Unit tests pass: `./cmd`, `./internal/defaults`, `./pkg/manager/calico`, `./pkg/manager/operator`
- `make fix-changed` produced no changes

**Release note:**
```release-note
TBD
```