### PR TITLE
fix(release): register operator git flags on hashrelease publish

### DIFF
--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -227,9 +227,9 @@ var (
 		operatorFlag(envBuildOperator, envReleaseOperator),
 	)
 
-	operatorPublishCommandFlags = []cli.Flag{
+	operatorPublishCommandFlags = append(slices.Clone(operatorGitFlags),
 		operatorFlag(envPublishOperator, envReleaseOperator),
-	}
+	)
 
 	// Operator git flags
 	operatorOrgFlagName = "operator-org"

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -298,6 +298,25 @@ func TestEnvVarPrecedence(t *testing.T) {
 	}
 }
 
+// TestHashreleasePublishFlagsRegisterOperatorGit guards against the regression
+// where the publish subcommand referenced operatorRepoFlag in its action but
+// did not register operatorGitFlags, so c.String("operator-repo") returned ""
+// and the operator dir collapsed to cfg.TmpDir.
+func TestHashreleasePublishFlagsRegisterOperatorGit(t *testing.T) {
+	flags := hashreleasePublishFlags()
+	have := map[string]bool{}
+	for _, f := range flags {
+		for _, n := range f.Names() {
+			have[n] = true
+		}
+	}
+	for _, n := range []string{operatorOrgFlagName, operatorRepoFlagName, operatorBranchFlagName} {
+		if !have[n] {
+			t.Errorf("hashreleasePublishFlags is missing --%s", n)
+		}
+	}
+}
+
 func TestInverseFlagName(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
## Description

The `hashrelease publish` action computes the operator dir as `filepath.Join(cfg.TmpDir, c.String(operatorRepoFlag.Name))` ([release/cmd/hashrelease.go:242](https://github.com/projectcalico/calico/blob/master/release/cmd/hashrelease.go#L242)), but `operatorPublishCommandFlags` only registered the boolean `--operator` flag — the org/repo/branch flags were not registered on the publish subcommand.

With `operator-repo` unregistered, `c.String("operator-repo")` returned `""` at runtime and the publish step ran `make -C release/tmp release-publish` instead of `make -C release/tmp/operator release-publish`, failing with:

```
make[1]: *** No rule to make target 'release-publish'.  Stop.
```

This was the failure mode in [this hashrelease publish job](https://tigera.semaphoreci.com/jobs/f39f33a4-22ae-4eaa-b140-beced8b0b52a). Build worked fine because `operatorBuildCommandFlags` does include `operatorGitFlags`.

## Fix

Append `operatorGitFlags` to `operatorPublishCommandFlags` so `--operator-org`, `--operator-repo`, and `--operator-branch` are registered on the publish subcommand and resolve their metadata.mk-backed defaults — matching the build subcommand.

**Release note:**
```release-note
TBD
```
