### PR TITLE
Fix flex volume driver in the consolidated calico image

### DIFF
--- a/cmd/calico/main.go
+++ b/cmd/calico/main.go
@@ -70,6 +70,11 @@ const (
 //     argv[0] and the rest of the args. argv[0] itself is preserved so that
 //     panic traces, log prefixes, and kubectl-plugin detection still see the
 //     original invocation name.
+//   - argv[0] basename of "uds" → Cobra, with "component flexvol" inserted
+//     between argv[0] and the rest of the args. Kubelet invokes the flex
+//     volume driver as "<plugin-dir>/uds <init|mount|unmount> ..."; we
+//     install a copy of the calico binary at that path and rely on this
+//     dispatch to route into the flexvol subcommand.
 //   - Otherwise, CNI_COMMAND in the env dispatches to the CNI plugin, but
 //     only when no subcommand args were passed. This guards against a stray
 //     CNI_COMMAND in a shell environment silently hijacking "calicoctl get
@@ -82,6 +87,9 @@ func dispatch(args []string, cniCommand string) (dispatchMode, []string) {
 		return modeCNIIPAM, args
 	case "calicoctl":
 		rewritten := append([]string{args[0], "ctl"}, args[1:]...)
+		return modeCobra, rewritten
+	case "uds":
+		rewritten := append([]string{args[0], "component", "flexvol"}, args[1:]...)
 		return modeCobra, rewritten
 	default:
 		if len(args) == 1 && cniCommand != "" {

--- a/cmd/calico/main.go
+++ b/cmd/calico/main.go
@@ -71,10 +71,8 @@ const (
 //     panic traces, log prefixes, and kubectl-plugin detection still see the
 //     original invocation name.
 //   - argv[0] basename of "uds" → Cobra, with "component flexvol" inserted
-//     between argv[0] and the rest of the args. Kubelet invokes the flex
-//     volume driver as "<plugin-dir>/uds <init|mount|unmount> ..."; we
-//     install a copy of the calico binary at that path and rely on this
-//     dispatch to route into the flexvol subcommand.
+//     so kubelet's "<plugin-dir>/uds <init|mount|unmount>" calls route
+//     into the flexvol subcommand.
 //   - Otherwise, CNI_COMMAND in the env dispatches to the CNI plugin, but
 //     only when no subcommand args were passed. This guards against a stray
 //     CNI_COMMAND in a shell environment silently hijacking "calicoctl get

--- a/cmd/calico/main_test.go
+++ b/cmd/calico/main_test.go
@@ -49,6 +49,27 @@ func TestDispatch(t *testing.T) {
 			wantArgs:   []string{"/usr/bin/calicoctl", "ctl"},
 		},
 		{
+			name:       "uds basename inserts component flexvol and preserves argv[0]",
+			args:       []string{"/usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds", "mount", "/dest", "{}"},
+			cniCommand: "",
+			wantMode:   modeCobra,
+			wantArgs:   []string{"/usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds", "component", "flexvol", "mount", "/dest", "{}"},
+		},
+		{
+			name:       "uds basename with no args still rewrites (help path)",
+			args:       []string{"/host/driver/uds"},
+			cniCommand: "",
+			wantMode:   modeCobra,
+			wantArgs:   []string{"/host/driver/uds", "component", "flexvol"},
+		},
+		{
+			name:       "uds basename ignores CNI_COMMAND in the env",
+			args:       []string{"/host/driver/uds", "init"},
+			cniCommand: "ADD",
+			wantMode:   modeCobra,
+			wantArgs:   []string{"/host/driver/uds", "component", "flexvol", "init"},
+		},
+		{
 			name:       "calico-ipam basename dispatches to IPAM plugin",
 			args:       []string{"/opt/cni/bin/calico-ipam"},
 			cniCommand: "ADD",

--- a/felix/cmd/calico-bpf/commands/root.go
+++ b/felix/cmd/calico-bpf/commands/root.go
@@ -46,7 +46,16 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig, setLogLevel)
+	// Scope initConfig/setLogLevel to this rootCmd rather than registering
+	// them globally via cobra.OnInitialize. Under the consolidated calico
+	// binary (cmd/calico/main.go) every cobra dispatch shares one global
+	// initializer chain, so a global hook here would also fire for unrelated
+	// subcommands (felix, flexvol, csi, …) and hard-exit them when $HOME is
+	// unset — which is the case when kubelet exec's flex/CSI drivers.
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		initConfig()
+		setLogLevel()
+	}
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/felix/cmd/calico-bpf/commands/root.go
+++ b/felix/cmd/calico-bpf/commands/root.go
@@ -46,12 +46,10 @@ func Execute() {
 }
 
 func init() {
-	// Scope initConfig/setLogLevel to this rootCmd rather than registering
-	// them globally via cobra.OnInitialize. Under the consolidated calico
-	// binary (cmd/calico/main.go) every cobra dispatch shares one global
-	// initializer chain, so a global hook here would also fire for unrelated
-	// subcommands (felix, flexvol, csi, …) and hard-exit them when $HOME is
-	// unset — which is the case when kubelet exec's flex/CSI drivers.
+	// Scope to rootCmd instead of cobra.OnInitialize: the latter is global,
+	// so registering it here would fire initConfig (which exits 1 when
+	// HOME is unset) for every cobra dispatch in the consolidated calico
+	// binary, not just calico-bpf.
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		initConfig()
 		setLogLevel()

--- a/pod2daemon/pkg/flexvol/flexvol.go
+++ b/pod2daemon/pkg/flexvol/flexvol.go
@@ -24,9 +24,11 @@ package flexvol
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/syslog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -126,7 +128,7 @@ var (
 // NewCommand returns the root cobra command for the flexvol driver.
 func NewCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:           "flexvoldrv",
+		Use:           "flexvol",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -192,12 +194,81 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
+	var installTarget string
+	installCmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the flex volume driver onto the host filesystem.",
+		Long: "Install copies the running calico binary to the target path " +
+			"with mode 0550 so kubelet can invoke it as a flex volume driver. " +
+			"The target file is typically '<plugin-dir>/nodeagent~uds/uds'.",
+		RunE: func(c *cobra.Command, args []string) error {
+			if installTarget == "" {
+				return fmt.Errorf("--target is required")
+			}
+			return installDriver(installTarget)
+		},
+	}
+	installCmd.Flags().StringVar(&installTarget, "target", "", "Path on the host where the driver binary is installed (e.g. /host/driver/uds).")
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(mountCmd)
 	rootCmd.AddCommand(unmountCmd)
+	rootCmd.AddCommand(installCmd)
 
 	return rootCmd
+}
+
+// installDriver copies the currently-running binary to target with mode 0550,
+// using a write-tmp-then-rename pattern so a kubelet that's mid-invocation
+// never sees a partially-written file. The source is os.Executable() — which
+// in the consolidated calico image is /usr/bin/calico — and the destination
+// is whatever hostPath the operator mounted (typically
+// /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds).
+// The argv[0] dispatch in cmd/calico/main.go re-routes "uds <args>" calls
+// from kubelet back into this package.
+func installDriver(target string) error {
+	if target == "" {
+		return fmt.Errorf("target is required")
+	}
+	src, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving running binary: %w", err)
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", src, err)
+	}
+	defer in.Close()
+
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, ".uds.*")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Best-effort cleanup if rename never happens.
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		return fmt.Errorf("copying binary: %w", err)
+	}
+	if err := tmp.Chmod(0o550); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, target); err != nil {
+		return fmt.Errorf("renaming %s to %s: %w", tmpPath, target, err)
+	}
+	return nil
 }
 
 // initCommand handles the init command for the driver.

--- a/pod2daemon/pkg/flexvol/flexvol.go
+++ b/pod2daemon/pkg/flexvol/flexvol.go
@@ -237,7 +237,7 @@ func installDriver(target string) error {
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", src, err)
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	dir := filepath.Dir(target)
 	tmp, err := os.CreateTemp(dir, ".uds.*")
@@ -251,11 +251,11 @@ func installDriver(target string) error {
 	}()
 
 	if _, err := io.Copy(tmp, in); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("copying binary: %w", err)
 	}
 	if err := tmp.Chmod(0o550); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("chmod temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {

--- a/pod2daemon/pkg/flexvol/flexvol.go
+++ b/pod2daemon/pkg/flexvol/flexvol.go
@@ -198,13 +198,11 @@ func NewCommand() *cobra.Command {
 	installCmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the flex volume driver onto the host filesystem.",
-		Long: "Install copies the running calico binary to the target path " +
-			"with mode 0550 so kubelet can invoke it as a flex volume driver. " +
-			"The target file is typically '<plugin-dir>/nodeagent~uds/uds'.",
+		Long: "Install copies the running binary to --target with mode 0550. " +
+			"The basename must be 'uds' since kubelet calls the driver as " +
+			"<plugin-dir>/uds and the argv[0] dispatch only matches that name. " +
+			"Must run as root - the target dir is typically owned by root.",
 		RunE: func(c *cobra.Command, args []string) error {
-			if installTarget == "" {
-				return fmt.Errorf("--target is required")
-			}
 			return installDriver(installTarget)
 		},
 	}
@@ -219,17 +217,16 @@ func NewCommand() *cobra.Command {
 	return rootCmd
 }
 
-// installDriver copies the currently-running binary to target with mode 0550,
-// using a write-tmp-then-rename pattern so a kubelet that's mid-invocation
-// never sees a partially-written file. The source is os.Executable() — which
-// in the consolidated calico image is /usr/bin/calico — and the destination
-// is whatever hostPath the operator mounted (typically
-// /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds).
-// The argv[0] dispatch in cmd/calico/main.go re-routes "uds <args>" calls
-// from kubelet back into this package.
+// installDriver copies the running binary to target with mode 0550. Uses
+// write-tmp-then-rename so a kubelet mid-invocation never sees a partial
+// file. Target basename must be "uds" - the argv[0] dispatch in
+// cmd/calico/main.go only routes that name back into this package.
 func installDriver(target string) error {
 	if target == "" {
 		return fmt.Errorf("target is required")
+	}
+	if base := filepath.Base(target); base != "uds" {
+		return fmt.Errorf("target basename must be \"uds\", got %q", base)
 	}
 	src, err := os.Executable()
 	if err != nil {

--- a/pod2daemon/pkg/flexvol/flexvol.go
+++ b/pod2daemon/pkg/flexvol/flexvol.go
@@ -237,7 +237,11 @@ func installDriver(target string) error {
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", src, err)
 	}
-	defer func() { _ = in.Close() }()
+	defer func() {
+		if err := in.Close(); err != nil {
+			logError("installDriver", target, fmt.Sprintf("failed to close source file %s: %s\n", src, err.Error()), syslogOnlyTrue)
+		}
+	}()
 
 	dir := filepath.Dir(target)
 	tmp, err := os.CreateTemp(dir, ".uds.*")
@@ -246,16 +250,21 @@ func installDriver(target string) error {
 	}
 	tmpPath := tmp.Name()
 	defer func() {
-		// Best-effort cleanup if rename never happens.
-		_ = os.Remove(tmpPath)
+		if err := os.Remove(tmpPath); err != nil {
+			logError("installDriver", target, fmt.Sprintf("failed to remove temp file %s: %s\n", tmpPath, err.Error()), syslogOnlyTrue)
+		}
 	}()
 
 	if _, err := io.Copy(tmp, in); err != nil {
-		_ = tmp.Close()
+		if err := tmp.Close(); err != nil {
+			logError("installDriver", target, fmt.Sprintf("failed to close temp file %s: %s\n", tmpPath, err.Error()), syslogOnlyTrue)
+		}
 		return fmt.Errorf("copying binary: %w", err)
 	}
 	if err := tmp.Chmod(0o550); err != nil {
-		_ = tmp.Close()
+		if err := tmp.Close(); err != nil {
+			logError("installDriver", target, fmt.Sprintf("failed to close temp file %s: %s\n", tmpPath, err.Error()), syslogOnlyTrue)
+		}
 		return fmt.Errorf("chmod temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
@@ -305,7 +314,7 @@ func checkValidMountOpts(opts string) (*creds.Credentials, string, bool) {
 func doMount(destinationDir string, ninputs *creds.Credentials, workloadPath string) error {
 	inp := strings.Join([]string{destinationDir, workloadPath}, "|")
 	newDir := configuration.NodeAgentWorkloadHomeDir + "/" + workloadPath
-	err := os.MkdirAll(newDir, 0777)
+	err := os.MkdirAll(newDir, 0o777)
 	if err != nil {
 		logError("doMount", inp, fmt.Sprintf("failed to create directory %s\n", newDir), syslogOnlyTrue)
 		return err
@@ -321,7 +330,7 @@ func doMount(destinationDir string, ninputs *creds.Credentials, workloadPath str
 	}
 
 	newDestinationDir := destinationDir + "/nodeagent"
-	err = os.MkdirAll(newDestinationDir, 0777)
+	err = os.MkdirAll(newDestinationDir, 0o777)
 	if err != nil {
 		cmd := exec.Command("/bin/umount", destinationDir)
 		e := cmd.Run()
@@ -479,8 +488,8 @@ func logToSys(caller, inp, opts string) {
 
 // addCredentialFile is used to create a credential file when a workload with the flex-volume volume mounted is created.
 func addCredentialFile(ninputs *creds.Credentials) error {
-	//Make the directory and then write the ninputs as json to it.
-	err := os.MkdirAll(configuration.NodeAgentCredentialsHomeDir, 0755)
+	// Make the directory and then write the ninputs as json to it.
+	err := os.MkdirAll(configuration.NodeAgentCredentialsHomeDir, 0o755)
 	if err != nil {
 		return err
 	}
@@ -492,7 +501,7 @@ func addCredentialFile(ninputs *creds.Credentials) error {
 	}
 
 	credsFileTmp := strings.Join([]string{configuration.NodeAgentManagementHomeDir, ninputs.UID + ".json"}, "/")
-	_ = os.WriteFile(credsFileTmp, attrs, 0644)
+	_ = os.WriteFile(credsFileTmp, attrs, 0o644)
 
 	// Move it to the right location now.
 	credsFile := strings.Join([]string{configuration.NodeAgentCredentialsHomeDir, ninputs.UID + ".json"}, "/")
@@ -528,7 +537,7 @@ func initConfiguration() {
 		return
 	}
 
-	//fill in if missing configurations
+	// fill in if missing configurations
 	if len(config.NodeAgentManagementHomeDir) == 0 {
 		config.NodeAgentManagementHomeDir = NODEAGENT_HOME
 	}

--- a/pod2daemon/pkg/flexvol/flexvol_test.go
+++ b/pod2daemon/pkg/flexvol/flexvol_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flexvol
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallDriverCopiesRunningBinary(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "uds")
+
+	if err := installDriver(dst); err != nil {
+		t.Fatalf("installDriver: %v", err)
+	}
+
+	// Source is whatever runs the test (the test binary). We assert the
+	// destination is byte-identical so the symlink-by-argv[0] dispatch in
+	// cmd/calico/main.go gets the same binary kubelet would have called
+	// directly.
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	srcBytes, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read src: %v", err)
+	}
+	dstBytes, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(srcBytes, dstBytes) {
+		t.Fatalf("dst (%d bytes) does not match src (%d bytes)", len(dstBytes), len(srcBytes))
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o550 {
+		t.Errorf("dst permissions = %#o, want 0550", mode)
+	}
+}
+
+func TestInstallDriverRequiresTarget(t *testing.T) {
+	if err := installDriver(""); err == nil {
+		t.Fatal("expected error when target is empty")
+	}
+}
+
+func TestInstallDriverOverwritesExistingFile(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "uds")
+	if err := os.WriteFile(dst, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+
+	if err := installDriver(dst); err != nil {
+		t.Fatalf("installDriver: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if bytes.Equal(got, []byte("stale")) {
+		t.Fatal("install did not overwrite existing file")
+	}
+}

--- a/pod2daemon/pkg/flexvol/flexvol_test.go
+++ b/pod2daemon/pkg/flexvol/flexvol_test.go
@@ -28,10 +28,8 @@ func TestInstallDriverCopiesRunningBinary(t *testing.T) {
 		t.Fatalf("installDriver: %v", err)
 	}
 
-	// Source is whatever runs the test (the test binary). We assert the
-	// destination is byte-identical so the symlink-by-argv[0] dispatch in
-	// cmd/calico/main.go gets the same binary kubelet would have called
-	// directly.
+	// Destination must be byte-identical to the source so argv[0]
+	// dispatch routes kubelet's "uds <args>" into the same binary.
 	src, err := os.Executable()
 	if err != nil {
 		t.Fatalf("os.Executable: %v", err)
@@ -60,6 +58,13 @@ func TestInstallDriverCopiesRunningBinary(t *testing.T) {
 func TestInstallDriverRequiresTarget(t *testing.T) {
 	if err := installDriver(""); err == nil {
 		t.Fatal("expected error when target is empty")
+	}
+}
+
+func TestInstallDriverRejectsNonUdsBasename(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "policysync")
+	if err := installDriver(dst); err == nil {
+		t.Fatal("expected error when target basename is not \"uds\"")
 	}
 }
 


### PR DESCRIPTION
Egress gateway and dikastes pods using `flexVolume.driver: nodeagent/uds` get stuck in `ContainerCreating` with `FailedMount: no volume plugin matched` on the consolidated image (#12225). Two bugs:

1. The flexvol cobra command is registered as `flexvoldrv`, so `calico component flexvol` (what the operator invokes from the calico-node DaemonSet flex-volume init container) falls through to help text. Renamed to `flexvol`.

2. The old `pod2daemon-flexvol` image had `flexvol.sh` as entrypoint that copied the driver onto the kubelet plugin dir. That step disappeared in the consolidation. Added `calico component flexvol install --target <path>` that copies the running binary at mode 0550 using a write-tmp-then-rename. Operator invokes this from the init container.

Plus an argv[0] dispatch case for `uds` in `cmd/calico/main.go`, since kubelet calls the installed driver as `<plugin-dir>/uds <init|mount|unmount>`. Same pattern as the existing `calicoctl` case.

Separate bug fix in the first commit: `felix/cmd/calico-bpf/commands/root.go` was registering `initConfig` and `setLogLevel` globally via `cobra.OnInitialize` in a package `init()`. In the consolidated binary that fires for every cobra subcommand, including kubelet flex/CSI driver execs where `HOME` is unset and `initConfig` calls `os.UserHomeDir(); os.Exit(1)`. Scoped to the calico-bpf rootCmd via `PersistentPreRun`.

Verified on a kind cluster: installed the new driver, then a pod using `nodeagent/uds` went from `ContainerCreating` to `Running 1/1`.

Operator-side change to invoke `install --target` is a follow-up against tigera/operator.

```release-note
Fixes flex volume driver registration in the consolidated calico image, which was rendering as a no-op so pods using the nodeagent/uds flex volume driver (egress gateway, application-layer policy) could not mount their policysync volume.
```
