### PR TITLE
ci: restore cni-plugin Windows image publishing promotion

### DIFF
--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -24,15 +24,12 @@ global_job_config:
       - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
       - ssh-add ~/.ssh/id_rsa
 blocks:
-  - name: Publish cni-plugin images and multi-arch manifests
+  - name: Publish cni-plugin images
     dependencies: []
     skip:
       when: "branch !~ '.+'"
     task:
       jobs:
-        - name: Linux multi-arch
-          commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin cd push-manifests-with-tag CONFIRM=true; fi
         - name: Windows
           commands:
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin release-windows CONFIRM=true; fi

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -171,6 +171,10 @@ promotions:
     pipeline_file: push-images/node.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  - name: Push cni-plugin images
+    pipeline_file: push-images/cni-plugin.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
     auto_promote:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -171,6 +171,10 @@ promotions:
     pipeline_file: push-images/node.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  - name: Push cni-plugin images
+    pipeline_file: push-images/cni-plugin.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
     auto_promote:

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -43,6 +43,10 @@ promotions:
     pipeline_file: push-images/node.yml
     auto_promote:
       when: "branch =~ 'master|release-.*'"
+  - name: Push cni-plugin images
+    pipeline_file: push-images/cni-plugin.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
     auto_promote:


### PR DESCRIPTION
The `Push cni-plugin images` promotion was dropped in #12225, but `cni-plugin` still produces `calico/cni-windows`. Without the promotion that image is no longer published on master, so hashrelease publishes 404 on the pre-publish image check.

Fix: Re-add the promotion; drop the Linux multi-arch job from `push-images/cni-plugin.yml`.
**Release note:**
```release-note
TBD
```
