### PR TITLE
confd: let UPDATE_EXPECTED_DATA create missing golden files

### DIFF
--- a/confd/tests/helpers_test.go
+++ b/confd/tests/helpers_test.go
@@ -838,9 +838,21 @@ func compareOutput(t *testing.T, outputDir, goldenDir string) {
 
 		expectedPath := filepath.Join("compiled_templates", goldenDir, f)
 		want, err := os.ReadFile(expectedPath)
-		require.NoError(t, err, "reading golden file %s", expectedPath)
-
 		gotNorm := normalizeBlankLines(string(got))
+		if err != nil {
+			if updateGoldenFiles && os.IsNotExist(err) {
+				t.Logf("creating golden file %s", expectedPath)
+				if err := os.MkdirAll(filepath.Dir(expectedPath), 0755); err != nil {
+					t.Fatalf("failed to create golden dir for %s: %v", expectedPath, err)
+				}
+				if err := os.WriteFile(expectedPath, []byte(gotNorm), 0644); err != nil {
+					t.Fatalf("failed to create golden file %s: %v", expectedPath, err)
+				}
+				continue
+			}
+			require.NoError(t, err, "reading golden file %s", expectedPath)
+		}
+
 		wantNorm := normalizeBlankLines(string(want))
 		if gotNorm != wantNorm {
 			if updateGoldenFiles {
@@ -1085,6 +1097,11 @@ func (d *confdDaemon) expectOutput(goldenDir string) {
 			expectedPath := filepath.Join("compiled_templates", goldenDir, f)
 			want, err := os.ReadFile(expectedPath)
 			if err != nil {
+				if updateGoldenFiles && os.IsNotExist(err) {
+					allMatch = false
+					lastMismatch = fmt.Sprintf("%s missing, will create", expectedPath)
+					break
+				}
 				d.t.Fatalf("reading golden file %s: %v", expectedPath, err)
 			}
 
@@ -1122,6 +1139,9 @@ func (d *confdDaemon) updateGoldenFiles(goldenDir string, files []string) {
 		}
 		expectedPath := filepath.Join("compiled_templates", goldenDir, f)
 		d.t.Logf("updating golden file %s", expectedPath)
+		if err := os.MkdirAll(filepath.Dir(expectedPath), 0755); err != nil {
+			d.t.Fatalf("failed to create golden dir for %s: %v", expectedPath, err)
+		}
 		if err := os.WriteFile(expectedPath, []byte(normalizeBlankLines(string(got))), 0644); err != nil {
 			d.t.Fatalf("failed to update golden file %s: %v", expectedPath, err)
 		}


### PR DESCRIPTION
Both \`compareOutput\` and \`expectOutput\` in \`confd/tests/helpers_test.go\` call \`t.Fatalf\` the moment a golden file doesn't exist on disk, so the \`UPDATE_EXPECTED_DATA=true\` path only ever refreshes goldens that are already there. Anyone adding a new confd FV test still has to check in empty placeholder files for all six BIRD configs by hand before the harness will fill them — easy to miss, and not what the README suggests the flag does.

This change treats a missing golden under \`UPDATE_EXPECTED_DATA\` as a mismatch (so the existing write path runs), and \`MkdirAll\`s the parent so a brand-new golden directory works on first run.

No behavior change when \`UPDATE_EXPECTED_DATA\` is unset.

\`\`\`release-note
None
\`\`\`