### PR TITLE
Scope istio ambient selector to pod WorkloadEndpoints

### DIFF
--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -626,6 +626,7 @@ var baseTests = []StateList{
 		istioWithAmbientPod,
 		istioWithMixedPods,
 		istioSelectorEdgeCases,
+		istioWithAmbientNetworkSet,
 	},
 }
 

--- a/felix/calc/istio_calculator.go
+++ b/felix/calc/istio_calculator.go
@@ -31,7 +31,11 @@ import (
 
 const EPCompDataKindIstio = EndpointComputedDataKind("Istio")
 
-var istioSelector = fmt.Sprintf("%s%s == '%s' && %s != '%s' || %s == '%s'",
+// Scope to pod WorkloadEndpoints only — without this, NetworkSets in
+// ambient namespaces would also contribute CIDRs to all-istio-weps.
+var istioSelector = fmt.Sprintf("%s == '%s' && (%s%s == '%s' && %s != '%s' || %s == '%s')",
+	v3.LabelOrchestrator,
+	v3.OrchestratorKubernetes,
 	conversion.NamespaceLabelPrefix,
 	v3.LabelIstioDataplaneMode,
 	v3.LabelIstioDataplaneModeAmbient,

--- a/felix/calc/istio_data_for_test.go
+++ b/felix/calc/istio_data_for_test.go
@@ -62,8 +62,9 @@ var (
 			mustParseNet("fc00:fe10::1/128"),
 		},
 		Labels: uniquelabels.Make(map[string]string{
-			"projectcalico.org/namespace": "istio-ambient",
-			"istio.io/dataplane-mode":     "ambient",
+			"projectcalico.org/namespace":    "istio-ambient",
+			"projectcalico.org/orchestrator": "k8s",
+			"istio.io/dataplane-mode":        "ambient",
 		}),
 		ProfileIDs: []string{"istio-ambient"},
 	}
@@ -85,7 +86,8 @@ var (
 			mustParseNet("fc00:fe10::3/128"),
 		},
 		Labels: uniquelabels.Make(map[string]string{
-			"projectcalico.org/namespace": "istio-none",
+			"projectcalico.org/namespace":    "istio-none",
+			"projectcalico.org/orchestrator": "k8s",
 		}),
 		ProfileIDs: []string{"istio-none"},
 	}
@@ -107,7 +109,8 @@ var (
 			mustParseNet("fc00:fe10::4/128"),
 		},
 		Labels: uniquelabels.Make(map[string]string{
-			"projectcalico.org/namespace": "regular",
+			"projectcalico.org/namespace":    "regular",
+			"projectcalico.org/orchestrator": "k8s",
 		}),
 		ProfileIDs: []string{"regular"},
 	}
@@ -129,8 +132,9 @@ var (
 			mustParseNet("fc00:fe10::5/128"),
 		},
 		Labels: uniquelabels.Make(map[string]string{
-			"projectcalico.org/namespace": "regular",
-			apiv3.LabelIstioDataplaneMode: apiv3.LabelIstioDataplaneModeAmbient,
+			"projectcalico.org/namespace":    "regular",
+			"projectcalico.org/orchestrator": "k8s",
+			apiv3.LabelIstioDataplaneMode:    apiv3.LabelIstioDataplaneModeAmbient,
 		}),
 		ProfileIDs: []string{"regular"},
 	}

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -3589,8 +3589,9 @@ var istioSelectorEdgeCases = istioBaseState.withKVUpdates(
 			mustParseNet("10.10.9.1/32"),
 		},
 		Labels: uniquelabels.Make(map[string]string{
-			"projectcalico.org/namespace": "istio-ambient",
-			v3.LabelIstioDataplaneMode:    v3.LabelIstioDataplaneModeNone, // Explicit none on pod
+			"projectcalico.org/namespace":    "istio-ambient",
+			"projectcalico.org/orchestrator": "k8s",
+			v3.LabelIstioDataplaneMode:       v3.LabelIstioDataplaneModeNone, // Explicit none on pod
 		}),
 		ProfileIDs: []string{"istio-ambient"},
 	}},
@@ -3609,6 +3610,46 @@ var istioSelectorEdgeCases = istioBaseState.withKVUpdates(
 ).withIPSet("all-istio-weps", []string{
 	// Should be EMPTY - this pod should be excluded by both selectors
 }).withName("istio selector edge cases")
+
+// Regression: NetworkSets in an ambient namespace inherit pcns.* labels via
+// their kns.<ns> profile. Without scoping the istio selector to pod WEPs,
+// a NetworkSet's CIDR (e.g. an apiserver IP) leaks into all-istio-weps.
+// The IPSet should contain only the ambient WEP, not the NetworkSet CIDR.
+var istioWithAmbientNetworkSet = istioBaseState.withKVUpdates(
+	KVPair{Key: ResourceKey{Name: "istio-ambient", Kind: v3.KindProfile}, Value: namespaceToProfile(&istioNamespaceAmbient)},
+	KVPair{Key: istioWepAmbientKey, Value: &istioWepAmbient},
+	KVPair{Key: NetworkSetKey{Name: "istio-ambient/apiserver-netset"}, Value: &NetworkSet{
+		Nets: []calinet.IPNet{
+			mustParseNet("192.168.99.99/32"),
+		},
+		Labels: uniquelabels.Make(map[string]string{
+			"projectcalico.org/namespace": "istio-ambient",
+		}),
+		ProfileIDs: []string{"istio-ambient"},
+	}},
+).withEndpoint(
+	"orch/istio-wep-ambient/ep1",
+	[]mock.TierInfo{},
+).withActiveProfiles(
+	types.ProfileID{Name: "istio-ambient"},
+).withRoutes(
+	types.RouteUpdate{
+		Types:         proto.RouteType_LOCAL_WORKLOAD,
+		Dst:           "10.10.1.1/32",
+		DstNodeName:   localHostname,
+		LocalWorkload: true,
+	},
+	types.RouteUpdate{
+		Types:         proto.RouteType_LOCAL_WORKLOAD,
+		Dst:           "fc00:fe10::1/128",
+		DstNodeName:   localHostname,
+		LocalWorkload: true,
+	},
+).withIPSet("all-istio-weps", []string{
+	// 192.168.99.99/32 (NetworkSet) must NOT appear here.
+	"10.10.1.1/32",
+	"fc00:fe10::1/128",
+}).withName("istio with ambient namespace networkset")
 
 type StateList []State
 


### PR DESCRIPTION
When a Kubernetes namespace is labelled `istio.io/dataplane-mode=ambient`, NetworkSets in that namespace inherit `pcns.istio.io/dataplane-mode=ambient` via their `kns.<ns>` profile. The istio calculator's selector is registered with `SelectorAndNamedPortIndex`, which has no endpoint-kind filter, so any matching resource — WEP, HEP, or NetworkSet — contributes its CIDRs to `all-istio-weps`. The result: NetworkSet CIDRs (e.g. an apiserver IP carried by a NetworkSet in `default`) leak into `cali40all-istio-weps` and break ambient pod connectivity, including kubelet readiness probes.

The selector is scoped to pod WorkloadEndpoints by AND'ing `projectcalico.org/orchestrator == 'k8s'` onto the front, matching the same idiom Calico already uses in `k8sSelectorToCalico` to exclude HostEndpoints from k8s pod selectors. NetworkSets and HostEndpoints don't carry that label, so they no longer match.

## Reproduction (from the ticket)

1. Deploy ambient mode and label `default` with `istio.io/dataplane-mode=ambient`.
2. Schedule an ambient-mode pod with a readiness probe on a control-plane node.
3. Observe the readiness probe failing.
4. `ipset list cali40all-istio-weps` on the control-plane node — the apiserver IP is in the set, despite not being a workload.

After this fix, the apiserver IP no longer appears in `cali40all-istio-weps` and the readiness probe succeeds.

## Tests

- Added a regression state `istio with ambient namespace networkset` to `felix/calc/states_for_test.go` exercising a NetworkSet in an ambient namespace. The NetworkSet's CIDR (`192.168.99.99/32`) must not appear in `all-istio-weps`.
- Verified the new state fails against the un-fixed selector and passes with the fix.
- Existing istio test fixtures updated to stamp `projectcalico.org/orchestrator=k8s` on WEPs, matching what `PodToWorkloadEndpoint` always emits in production.
- Full `./felix/calc/...` suite is green.

**Release note:**
```release-note
Fix Istio ambient mode incorrectly adding NetworkSet CIDRs (e.g. the apiserver IP) to the all-istio-weps IPSet when a namespace is labelled istio.io/dataplane-mode=ambient, which broke readiness probes on ambient pods.
```
