### PR TITLE
Rename HostMetadataV4V6* messages to HostMetadata ones

### DIFF
--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -35,7 +35,7 @@ type KubeProxy struct {
 	proxy  ProxyFrontend
 	syncer DPSyncer
 
-	// pendingHostMetadataUpdates contains HostMetadataV4V6Update and HostMetadataV4V6Removes
+	// pendingHostMetadataUpdates contains HostMetadataUpdate and HostMetadataRemoves
 	// that we're batching up to send. Only accessed from the int-dataplane goroutine.
 	// Keyed by hostname (node name).
 	pendingHostMetadataUpdates map[string]any
@@ -124,14 +124,14 @@ func (kp *KubeProxy) Stop() {
 	})
 }
 
-func (kp *KubeProxy) setProxyHostMetadata(hostMetadata map[string]*proto.HostMetadataV4V6Update) {
+func (kp *KubeProxy) setProxyHostMetadata(hostMetadata map[string]*proto.HostMetadataUpdate) {
 	kp.lock.Lock()
 	defer kp.lock.Unlock()
 
 	kp.proxy.SetHostMetadata(hostMetadata, true)
 }
 
-func (kp *KubeProxy) run(hostIPs []net.IP, hostMetadata map[string]*proto.HostMetadataV4V6Update) error {
+func (kp *KubeProxy) run(hostIPs []net.IP, hostMetadata map[string]*proto.HostMetadataUpdate) error {
 
 	ips := make([]net.IP, 0, len(hostIPs))
 	for _, ip := range hostIPs {
@@ -199,12 +199,12 @@ func (kp *KubeProxy) start() error {
 	// Wait for the initial update.
 	hostIPs := <-kp.hostIPUpdates
 
-	hostMetadata := make(map[string]*proto.HostMetadataV4V6Update)
+	hostMetadata := make(map[string]*proto.HostMetadataUpdate)
 	// Block until we go in-sync and get the first batch of hostmetadata
 	// updates, to avoid a flap after a Felix restart. In practice, this
 	// recv should happen very soon after receiving the host IPs above.
 	hostMetadataUpdates := <-kp.hostMetadataUpdates
-	mergeHostMetadataV4V6Updates(hostMetadata, hostMetadataUpdates)
+	mergeHostMetadataUpdates(hostMetadata, hostMetadataUpdates)
 
 	err = kp.run(hostIPs, hostMetadata)
 	if err != nil {
@@ -230,7 +230,7 @@ func (kp *KubeProxy) start() error {
 					log.Error("kube-proxy: hostMetadataUpdates closed")
 					return
 				}
-				mergeHostMetadataV4V6Updates(hostMetadata, hostMetadataUpdates)
+				mergeHostMetadataUpdates(hostMetadata, hostMetadataUpdates)
 				kp.setProxyHostMetadata(hostMetadata)
 
 			case <-kp.exiting:
@@ -266,10 +266,10 @@ func (kp *KubeProxy) OnHostIPsUpdate(IPs []net.IP) {
 func (kp *KubeProxy) OnUpdate(msg any) {
 	hostname := ""
 	switch update := msg.(type) {
-	case *proto.HostMetadataV4V6Update:
+	case *proto.HostMetadataUpdate:
 		hostname = update.Hostname
 		log.WithField("msg", update).Debugf("kube-proxy OnUpdate: host metadata update")
-	case *proto.HostMetadataV4V6Remove:
+	case *proto.HostMetadataRemove:
 		hostname = update.Hostname
 		log.WithField("msg", update).Debugf("kube-proxy OnUpdate: host metadata remove")
 	default:
@@ -295,7 +295,7 @@ func (kp *KubeProxy) CompleteDeferredWork() error {
 	}
 
 	// Drain any pre-existing msg first and merge.
-	updates := kp.pollHostMetadataV4V6UpdatesNonBlocking()
+	updates := kp.pollHostMetadataUpdatesNonBlocking()
 	if updates == nil {
 		updates = make(map[string]any)
 	}
@@ -317,9 +317,9 @@ func (kp *KubeProxy) CompleteDeferredWork() error {
 	return nil
 }
 
-// pollHostMetadataV4V6UpdatesNonBlocking tries to read a pending host metadata update on the update channel.
+// pollHostMetadataUpdatesNonBlocking tries to read a pending host metadata update on the update channel.
 // Returns nil immediately, if nothing can be received from the updates channel.
-func (kp *KubeProxy) pollHostMetadataV4V6UpdatesNonBlocking() map[string]any {
+func (kp *KubeProxy) pollHostMetadataUpdatesNonBlocking() map[string]any {
 	select {
 	case upd := <-kp.hostMetadataUpdates:
 		return upd
@@ -328,20 +328,20 @@ func (kp *KubeProxy) pollHostMetadataV4V6UpdatesNonBlocking() map[string]any {
 	}
 }
 
-// mergeHostMetadataV4V6Updates merges the existing host metadata updates with the latest updates:
+// mergeHostMetadataUpdates merges the existing host metadata updates with the latest updates:
 // - A 'remove' in latest deletes the corresponding key in 'existing'.
 // - An 'update' in latest overwrites the corresponding key in 'existing'.
 // - If 'latest' is nil, does nothing. 'existing' must be non-nil.
-func mergeHostMetadataV4V6Updates(existing map[string]*proto.HostMetadataV4V6Update, latest map[string]any) {
+func mergeHostMetadataUpdates(existing map[string]*proto.HostMetadataUpdate, latest map[string]any) {
 	if latest == nil {
 		return
 	}
 
 	for k, v := range latest {
 		switch update := v.(type) {
-		case *proto.HostMetadataV4V6Update:
+		case *proto.HostMetadataUpdate:
 			existing[k] = update
-		case *proto.HostMetadataV4V6Remove:
+		case *proto.HostMetadataRemove:
 			delete(existing, k)
 		}
 	}

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ type KubeProxy struct {
 	proxy  ProxyFrontend
 	syncer DPSyncer
 
-	// pendingHostMetadataUpdates contains HostMetadataUpdate and HostMetadataRemoves
+	// pendingHostMetadataUpdates contains HostMetadataUpdate and HostMetadataRemove messages
 	// that we're batching up to send. Only accessed from the int-dataplane goroutine.
 	// Keyed by hostname (node name).
 	pendingHostMetadataUpdates map[string]any

--- a/felix/bpf/proxy/kube-proxy_internal_test.go
+++ b/felix/bpf/proxy/kube-proxy_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf/proxy/kube-proxy_internal_test.go
+++ b/felix/bpf/proxy/kube-proxy_internal_test.go
@@ -77,18 +77,18 @@ func (s *mockSyncer) ConntrackDestIsService(ip net.IP, port uint16, proto uint8)
 	return true
 }
 
-func TestMergeHostMetadataV4V6Updates(t *testing.T) {
+func TestMergeHostMetadataUpdates(t *testing.T) {
 	RegisterTestingT(t)
-	existing := map[string]*proto.HostMetadataV4V6Update{
+	existing := map[string]*proto.HostMetadataUpdate{
 		"host1": {Hostname: "host1", Ipv4Addr: "1.1.1.1"},
 		"host2": {Hostname: "host2", Ipv4Addr: "2.2.2.2"},
 	}
 	latest := map[string]any{
-		"host1": &proto.HostMetadataV4V6Remove{Hostname: "host1"},
-		"host2": &proto.HostMetadataV4V6Update{Hostname: "host2", Ipv4Addr: "5.5.5.5"},
-		"host3": &proto.HostMetadataV4V6Update{Hostname: "host3", Ipv4Addr: "3.3.3.3"},
+		"host1": &proto.HostMetadataRemove{Hostname: "host1"},
+		"host2": &proto.HostMetadataUpdate{Hostname: "host2", Ipv4Addr: "5.5.5.5"},
+		"host3": &proto.HostMetadataUpdate{Hostname: "host3", Ipv4Addr: "3.3.3.3"},
 	}
-	mergeHostMetadataV4V6Updates(existing, latest)
+	mergeHostMetadataUpdates(existing, latest)
 
 	Expect(existing).To(HaveLen(2), "Expected host1 to be removed and host3 to be added")
 	Expect(existing).NotTo(HaveKey("host1"))
@@ -106,25 +106,25 @@ func TestOnUpdateBatchesHostMetadataUpdates(t *testing.T) {
 		pendingHostMetadataUpdates: make(map[string]any),
 	}
 
-	update := &proto.HostMetadataV4V6Update{
+	update := &proto.HostMetadataUpdate{
 		Hostname: "hn1",
 		Ipv4Addr: "1.2.3.4",
 		Labels:   map[string]string{"label1": "label1val"},
 	}
 	kp.OnUpdate(update)
 
-	update2 := &proto.HostMetadataV4V6Update{
+	update2 := &proto.HostMetadataUpdate{
 		Hostname: "hn2",
 		Ipv4Addr: "2.2.2.2",
 		Labels:   map[string]string{"label2": "label2val"},
 	}
 	kp.OnUpdate(update2)
 
-	Consistently(kp.pollHostMetadataV4V6UpdatesNonBlocking(), 100*time.Millisecond).Should(BeNil(), "No updates should have been sent before CompleteDeferredWork")
+	Consistently(kp.pollHostMetadataUpdatesNonBlocking(), 100*time.Millisecond).Should(BeNil(), "No updates should have been sent before CompleteDeferredWork")
 
 	Expect(kp.CompleteDeferredWork()).To(Succeed(), "CompleteDeferredWork should succeed")
 	// Read the queued update from the channel.
-	Expect(kp.pollHostMetadataV4V6UpdatesNonBlocking()).To(Equal(map[string]any{
+	Expect(kp.pollHostMetadataUpdatesNonBlocking()).To(Equal(map[string]any{
 		"hn1": update,
 		"hn2": update2,
 	}))
@@ -140,25 +140,25 @@ func TestCompleteDeferredWorkSendsEmptyUpdateOnce(t *testing.T) {
 	// First call with no pending updates should still send an empty map
 	// to signal the KP loop to start.
 	Expect(kp.CompleteDeferredWork()).To(Succeed())
-	msg := kp.pollHostMetadataV4V6UpdatesNonBlocking()
+	msg := kp.pollHostMetadataUpdatesNonBlocking()
 	Expect(msg).NotTo(BeNil(), "First call should send an empty update to unblock the KP loop")
 	Expect(msg).To(BeEmpty(), "The update should be an empty map")
 
 	// Second call with no pending updates should be a no-op.
 	Expect(kp.CompleteDeferredWork()).To(Succeed())
-	Expect(kp.pollHostMetadataV4V6UpdatesNonBlocking()).To(BeNil(),
+	Expect(kp.pollHostMetadataUpdatesNonBlocking()).To(BeNil(),
 		"Second call with no pending updates should not send anything")
 
 	// Sending a real update should still work after we're in sync.
-	kp.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "host1", Ipv4Addr: "1.1.1.1"})
+	kp.OnUpdate(&proto.HostMetadataUpdate{Hostname: "host1", Ipv4Addr: "1.1.1.1"})
 	Expect(kp.CompleteDeferredWork()).To(Succeed())
-	msg = kp.pollHostMetadataV4V6UpdatesNonBlocking()
+	msg = kp.pollHostMetadataUpdatesNonBlocking()
 	Expect(msg).To(HaveLen(1))
 	Expect(msg).To(HaveKey("host1"))
 
 	// And after that, no-op again with no pending updates.
 	Expect(kp.CompleteDeferredWork()).To(Succeed())
-	Expect(kp.pollHostMetadataV4V6UpdatesNonBlocking()).To(BeNil(),
+	Expect(kp.pollHostMetadataUpdatesNonBlocking()).To(BeNil(),
 		"Should not send when in sync and no pending updates")
 }
 
@@ -169,15 +169,15 @@ func TestOnUpdateRemoveOverwritesPendingUpdate(t *testing.T) {
 		pendingHostMetadataUpdates: make(map[string]any),
 	}
 
-	update1 := &proto.HostMetadataV4V6Update{
+	update1 := &proto.HostMetadataUpdate{
 		Hostname: "hn1",
 		Ipv4Addr: "1.2.3.4",
 	}
-	update2 := &proto.HostMetadataV4V6Update{
+	update2 := &proto.HostMetadataUpdate{
 		Hostname: "hn2",
 		Ipv4Addr: "1.2.3.4",
 	}
-	update1Remove := &proto.HostMetadataV4V6Remove{Hostname: "hn1"}
+	update1Remove := &proto.HostMetadataRemove{Hostname: "hn1"}
 
 	// Queue an update, then an immediate remove for the same hostname.
 	kp.OnUpdate(update1)
@@ -186,7 +186,7 @@ func TestOnUpdateRemoveOverwritesPendingUpdate(t *testing.T) {
 
 	Expect(kp.CompleteDeferredWork()).To(Succeed(), "CompleteDeferredWork should succeed")
 
-	Expect(kp.pollHostMetadataV4V6UpdatesNonBlocking()).To(Equal(map[string]any{
+	Expect(kp.pollHostMetadataUpdatesNonBlocking()).To(Equal(map[string]any{
 		"hn1": update1Remove,
 		"hn2": update2,
 	}))

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -89,7 +89,7 @@ var _ = Describe("BPF kube-proxy", func() {
 		k8s := fake.NewClientset(testSvc, testSvcEps)
 		p, _ = proxy.StartKubeProxy(k8s, "test-node", maps, proxy.WithImmediateSync(), proxy.WithMaglevLUTSize(maglevLUTSize))
 		// Unblock start(), which blocks on the initial host metadata update.
-		p.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "dummy"})
+		p.OnUpdate(&proto.HostMetadataUpdate{Hostname: "dummy"})
 		Expect(p.CompleteDeferredWork()).To(Succeed())
 	})
 

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -251,7 +251,7 @@ var _ = Describe("BPF kube-proxy bootstrap window — regression #12192", func()
 		// In the bootstrap window with the buggy code, the proxy is
 		// already constructed and informers are syncing — they'll
 		// trigger an Apply on the stub Syncer that erases the marker.
-		p.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "test-node"})
+		p.OnUpdate(&proto.HostMetadataUpdate{Hostname: "test-node"})
 		Expect(p.CompleteDeferredWork()).To(Succeed())
 
 		// The marker must survive the bootstrap window. With

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -60,7 +60,7 @@ type ProxyFrontend interface {
 	Proxy
 	SetSyncer(DPSyncer)
 	SetHostIPs([]net.IP)
-	SetHostMetadata(updates map[string]*proto.HostMetadataV4V6Update, requestResync bool)
+	SetHostMetadata(updates map[string]*proto.HostMetadataUpdate, requestResync bool)
 }
 
 // DPSyncerState groups the information passed to the DPSyncer's Apply
@@ -98,7 +98,7 @@ type proxy struct {
 	svcMap k8sp.ServicePortMap
 	epsMap k8sp.EndpointsMap
 
-	hostMetadataByHostname map[string]*proto.HostMetadataV4V6Update
+	hostMetadataByHostname map[string]*proto.HostMetadataUpdate
 
 	dpSyncer  DPSyncer
 	syncerLck sync.Mutex
@@ -152,7 +152,7 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 		svcMap:   make(k8sp.ServicePortMap),
 		epsMap:   make(k8sp.EndpointsMap),
 
-		hostMetadataByHostname: make(map[string]*proto.HostMetadataV4V6Update),
+		hostMetadataByHostname: make(map[string]*proto.HostMetadataUpdate),
 
 		recorder: new(loggerRecorder),
 
@@ -398,7 +398,7 @@ func (p *proxy) SetHostIPs(hostIPs []net.IP) {
 		npa, p.healthzServer)
 }
 
-func (p *proxy) SetHostMetadata(updates map[string]*proto.HostMetadataV4V6Update, requestResync bool) {
+func (p *proxy) SetHostMetadata(updates map[string]*proto.HostMetadataUpdate, requestResync bool) {
 	p.runnerLck.Lock()
 	defer p.runnerLck.Unlock()
 

--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf/proxy/service_type_change_test.go
+++ b/felix/bpf/proxy/service_type_change_test.go
@@ -103,7 +103,7 @@ var _ = Describe("BPF service type change", func() {
 	BeforeEach(func() {
 		p, _ = proxy.StartKubeProxy(k8s, "test-node", bpfMaps, proxy.WithImmediateSync(), proxy.WithMaglevLUTSize(maglevLUTSize))
 		// Unblock start(), which blocks on the initial host metadata update.
-		p.OnUpdate(&felixproto.HostMetadataV4V6Update{Hostname: "dummy"})
+		p.OnUpdate(&felixproto.HostMetadataUpdate{Hostname: "dummy"})
 		Expect(p.CompleteDeferredWork()).To(Succeed())
 		p.OnHostIPsUpdate([]net.IP{initIP})
 	})

--- a/felix/bpf/proxy/service_type_change_test.go
+++ b/felix/bpf/proxy/service_type_change_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -157,7 +157,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 		}
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1.2.3.4"))
-		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		err = bpfEpMgr.CompleteDeferredWork()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -215,7 +215,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		if ipv6Enabled {
 			// IPv6 address update
 			bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1::4"))
-			bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv6Addr: "1::4"})
+			bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv6Addr: "1::4"})
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -672,7 +672,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(attached2).To(Equal(attached))
 
-		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep2", ifacemonitor.StateUp, workload2.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep2", "1.6.6.1"))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep2", ifacemonitor.StateUp, host2.Attrs().Index))
@@ -756,7 +756,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(pmIng).To(HaveLen(0))
 		Expect(pmEgr).To(HaveLen(0))
 
-		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep2", ifacemonitor.StateUp, workload2.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep2", "1.6.6.1"))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep2", ifacemonitor.StateUp, host2.Attrs().Index))
@@ -817,7 +817,7 @@ func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
 	workload1 := createVethName("workloadep1")
 	defer deleteLink(workload1)
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep1", ifacemonitor.StateUp, workload1.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep1", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -998,7 +998,7 @@ func TestRepeatedAttach(t *testing.T) {
 		regexp.MustCompile("^workloadep[123]"),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep1", ifacemonitor.StateUp, iface.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep1", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1148,7 +1148,7 @@ func TestAttachInterfaceRecreate(t *testing.T) {
 		}
 	}()
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1242,7 +1242,7 @@ func TestAttachTcx(t *testing.T) {
 	workload0 := createVethName("workloadep0")
 	defer deleteLink(workload0)
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1282,7 +1282,7 @@ func TestAttachTcx(t *testing.T) {
 		regexp.MustCompile("^workloadep[0123]"),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1311,7 +1311,7 @@ func TestAttachTcx(t *testing.T) {
 		regexp.MustCompile("^workloadep[0123]"),
 	)
 	Expect(err).NotTo(HaveOccurred())
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1374,7 +1374,7 @@ func TestAttachNetkit(t *testing.T) {
 	workload0 := createNetkitName("workloadep0")
 	defer deleteLink(workload0)
 
-	bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep0", "1.6.6.6"))
 	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
@@ -1455,7 +1455,7 @@ func TestLogFilters(t *testing.T) {
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep1", ifacemonitor.StateUp, host1.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1.2.3.4"))
-		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		err = bpfEpMgr.CompleteDeferredWork()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1485,7 +1485,7 @@ func TestLogFilters(t *testing.T) {
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("hostep1", ifacemonitor.StateUp, host1.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep0", ifacemonitor.StateUp, workload0.Attrs().Index))
 		bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("hostep1", "1.2.3.4"))
-		bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+		bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
 		err = bpfEpMgr.CompleteDeferredWork()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -812,12 +812,12 @@ func expectCorrectDataplaneState(mockDataplane *mock.MockDataplane, state State)
 	Expect(mockDataplane.ActiveWireguardV6Endpoints()).To(Equal(state.ExpectedWireguardV6Endpoints),
 		"Active IPv6 Wireguard Endpoints were incorrect after moving to state: %v",
 		state.Name)
-	for key, protoHostMetadataV4V6 := range mockDataplane.ActiveHostMetadataV4V6() {
-		Expect(googleproto.Equal(protoHostMetadataV4V6, state.ExpectedHostMetadataV4V6[key])).To(BeTrue(),
+	for key, protoHostMetadata := range mockDataplane.ActiveHostMetadata() {
+		Expect(googleproto.Equal(protoHostMetadata, state.ExpectedHostMetadata[key])).To(BeTrue(),
 			"Active Host MetadataV4V6 were incorrect after moving to state: %v",
 			state.Name)
 	}
-	Expect(mockDataplane.ActiveHostMetadataV4V6()).To(Equal(state.ExpectedHostMetadataV4V6),
+	Expect(mockDataplane.ActiveHostMetadata()).To(Equal(state.ExpectedHostMetadata),
 		"Active Host MetadataV4V6 were incorrect after moving to state: %v",
 		state.Name)
 	// Comparing stringified versions of the routes here so that, on failure, we get much more readable output.

--- a/felix/calc/calc_graph_test.go
+++ b/felix/calc/calc_graph_test.go
@@ -69,8 +69,8 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 		switch messageReceived.(type) {
 		case *proto.IPAMPoolUpdate:
 			Expect(googleproto.Equal(messageReceived.(*proto.IPAMPoolUpdate), expUpdate.(*proto.IPAMPoolUpdate))).To(BeTrue())
-		case *proto.HostMetadataV4V6Update:
-			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataV4V6Update), expUpdate.(*proto.HostMetadataV4V6Update))).To(BeTrue())
+		case *proto.HostMetadataUpdate:
+			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataUpdate), expUpdate.(*proto.HostMetadataUpdate))).To(BeTrue())
 		case *proto.GlobalBGPConfigUpdate:
 			Expect(googleproto.Equal(messageReceived.(*proto.GlobalBGPConfigUpdate), expUpdate.(*proto.GlobalBGPConfigUpdate))).To(BeTrue())
 		case *proto.WireguardEndpointUpdate:
@@ -95,8 +95,8 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 		switch messageReceived.(type) {
 		case *proto.IPAMPoolRemove:
 			Expect(googleproto.Equal(messageReceived.(*proto.IPAMPoolRemove), expRemove.(*proto.IPAMPoolRemove))).To(BeTrue())
-		case *proto.HostMetadataV4V6Remove:
-			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataV4V6Remove), expRemove.(*proto.HostMetadataV4V6Remove))).To(BeTrue())
+		case *proto.HostMetadataRemove:
+			Expect(googleproto.Equal(messageReceived.(*proto.HostMetadataRemove), expRemove.(*proto.HostMetadataRemove))).To(BeTrue())
 		case *proto.GlobalBGPConfigUpdate:
 			Expect(googleproto.Equal(messageReceived.(*proto.GlobalBGPConfigUpdate), expRemove.(*proto.GlobalBGPConfigUpdate))).To(BeTrue())
 		case *proto.WireguardEndpointRemove:
@@ -141,11 +141,11 @@ var _ = DescribeTable("Calculation graph pass-through tests",
 	Entry("HostIP",
 		model.HostIPKey{Hostname: "foo"},
 		&testIP,
-		&proto.HostMetadataV4V6Update{
+		&proto.HostMetadataUpdate{
 			Hostname: "foo",
 			Ipv4Addr: "10.0.0.1/32",
 		},
-		&proto.HostMetadataV4V6Remove{
+		&proto.HostMetadataRemove{
 			Hostname: "foo",
 		}),
 	Entry("Global BGPConfiguration",
@@ -263,7 +263,7 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 		})
 		eb.Flush()
 		Expect(messagesReceived).To(HaveLen(1))
-		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
+		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
 			Hostname: "foo",
 			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
@@ -286,11 +286,11 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 		})
 		eb.Flush()
 		Expect(messagesReceived).To(HaveLen(2))
-		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
+		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
 			Hostname: "foo",
 			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
-		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
+		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
 			Hostname: "foo",
 			Ipv4Addr: "10.0.0.2/32",
 		})).To(BeTrue())
@@ -320,14 +320,14 @@ var _ = Describe("Host IP duplicate squashing test", func() {
 		})
 		eb.Flush()
 		Expect(messagesReceived).To(HaveLen(3))
-		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
+		Expect(googleproto.Equal(messagesReceived[0].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
 			Hostname: "foo",
 			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())
-		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataV4V6Remove), &proto.HostMetadataV4V6Remove{
+		Expect(googleproto.Equal(messagesReceived[1].(*proto.HostMetadataRemove), &proto.HostMetadataRemove{
 			Hostname: "foo",
 		})).To(BeTrue())
-		Expect(googleproto.Equal(messagesReceived[2].(*proto.HostMetadataV4V6Update), &proto.HostMetadataV4V6Update{
+		Expect(googleproto.Equal(messagesReceived[2].(*proto.HostMetadataUpdate), &proto.HostMetadataUpdate{
 			Hostname: "foo",
 			Ipv4Addr: "10.0.0.1/32",
 		})).To(BeTrue())

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -622,7 +622,7 @@ func (buf *EventSequencer) OnHostMetadataUpdate(hostname string, info *HostInfo)
 
 func (buf *EventSequencer) flushHostUpdates() {
 	for hostname, hostInfo := range buf.pendingHostMetadataUpdates {
-		buf.Callback(&proto.HostMetadataV4V6Update{
+		buf.Callback(&proto.HostMetadataUpdate{
 			Hostname: hostname,
 			Ipv4Addr: hostInfo.ip4Addr,
 			Ipv6Addr: hostInfo.ip6Addr,
@@ -644,7 +644,7 @@ func (buf *EventSequencer) OnHostMetadataRemove(hostname string) {
 
 func (buf *EventSequencer) flushHostDeletes() {
 	for item := range buf.pendingHostMetadataDeletes.All() {
-		buf.Callback(&proto.HostMetadataV4V6Remove{
+		buf.Callback(&proto.HostMetadataRemove{
 			Hostname: item,
 		})
 		buf.sentHosts.Discard(item)

--- a/felix/calc/state_test.go
+++ b/felix/calc/state_test.go
@@ -50,7 +50,7 @@ type State struct {
 	ExpectedEndpointPolicyOrder          map[string][]mock.TierInfo
 	ExpectedUntrackedEndpointPolicyOrder map[string][]mock.TierInfo
 	ExpectedPreDNATEndpointPolicyOrder   map[string][]mock.TierInfo
-	ExpectedHostMetadataV4V6             map[string]*proto.HostMetadataV4V6Update
+	ExpectedHostMetadata                 map[string]*proto.HostMetadataUpdate
 	ExpectedEndpointComputedData         map[string]map[calc.EndpointComputedDataKind]calc.EndpointComputedData
 	ExpectedLiveMigrationRoles           map[string]proto.LiveMigrationRole
 	ExpectedNumberOfALPPolicies          int
@@ -81,7 +81,7 @@ func NewState() State {
 		ExpectedEndpointPolicyOrder:          make(map[string][]mock.TierInfo),
 		ExpectedUntrackedEndpointPolicyOrder: make(map[string][]mock.TierInfo),
 		ExpectedPreDNATEndpointPolicyOrder:   make(map[string][]mock.TierInfo),
-		ExpectedHostMetadataV4V6:             make(map[string]*proto.HostMetadataV4V6Update),
+		ExpectedHostMetadata:                 make(map[string]*proto.HostMetadataUpdate),
 		ExpectedEndpointComputedData:         make(map[string]map[calc.EndpointComputedDataKind]calc.EndpointComputedData),
 		ExpectedLiveMigrationRoles:           make(map[string]proto.LiveMigrationRole),
 		ExpectedNumberOfPolicies:             -1,
@@ -100,7 +100,7 @@ func (s State) Copy() State {
 	maps.Copy(cpy.ExpectedEndpointPolicyOrder, s.ExpectedEndpointPolicyOrder)
 	maps.Copy(cpy.ExpectedUntrackedEndpointPolicyOrder, s.ExpectedUntrackedEndpointPolicyOrder)
 	maps.Copy(cpy.ExpectedPreDNATEndpointPolicyOrder, s.ExpectedPreDNATEndpointPolicyOrder)
-	maps.Copy(cpy.ExpectedHostMetadataV4V6, s.ExpectedHostMetadataV4V6)
+	maps.Copy(cpy.ExpectedHostMetadata, s.ExpectedHostMetadata)
 	maps.Copy(cpy.ExpectedEndpointComputedData, s.ExpectedEndpointComputedData)
 	maps.Copy(cpy.ExpectedLiveMigrationRoles, s.ExpectedLiveMigrationRoles)
 
@@ -258,11 +258,11 @@ func (s State) withRoutes(routes ...types.RouteUpdate) (newState State) {
 	return newState
 }
 
-func (s State) withHostMetadataV4V6(hostMetas ...*proto.HostMetadataV4V6Update) (newState State) {
+func (s State) withHostMetadata(hostMetas ...*proto.HostMetadataUpdate) (newState State) {
 	newState = s.Copy()
-	newState.ExpectedHostMetadataV4V6 = make(map[string]*proto.HostMetadataV4V6Update)
+	newState.ExpectedHostMetadata = make(map[string]*proto.HostMetadataUpdate)
 	for _, v := range hostMetas {
-		newState.ExpectedHostMetadataV4V6[v.Hostname] = v
+		newState.ExpectedHostMetadata[v.Hostname] = v
 	}
 	return newState
 }

--- a/felix/calc/state_test.go
+++ b/felix/calc/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -1639,8 +1639,8 @@ var vxlanWithWEPIPs = empty.withKVUpdates(
 	routeUpdateRemoteHost2,
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname2,
 		Ipv4Addr: remoteHost2IP.String() + "/32",
 	},
@@ -1694,12 +1694,12 @@ var vxlanWithWEPIPsAndWEPDuplicate = vxlanWithWEPIPsAndWEP.withKVUpdates(
 		DstNodeIp:   remoteHostIP.String(),
 		NatOutgoing: true,
 	},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname2,
 		Ipv4Addr: remoteHost2IP.String() + "/32",
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -1721,8 +1721,8 @@ var vxlanWithBlock = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
-).withRoutes(vxlanWithBlockRoutes...).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withRoutes(vxlanWithBlockRoutes...).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -1750,12 +1750,12 @@ var (
 // As vxlanWithBlock but with a host sharing the same IP.  No route update because we tie-break on host name.
 var vxlanWithBlockDupNodeIP = vxlanWithBlock.withKVUpdates(
 	KVPair{Key: remoteHost2IPKey, Value: &remoteHostIP},
-).withName("VXLAN with dup node IP").withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withName("VXLAN with dup node IP").withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname2,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -1763,8 +1763,8 @@ var vxlanWithBlockDupNodeIP = vxlanWithBlock.withKVUpdates(
 
 var vxlanWithDupNodeIPRemoved = vxlanWithBlockDupNodeIP.withKVUpdates(
 	KVPair{Key: remoteHostIPKey, Value: nil},
-).withName("VXLAN with dup node IP removed").withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withName("VXLAN with dup node IP removed").withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname2,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -1800,8 +1800,8 @@ var vxlanWithBlockNodeRes = vxlanWithBlock.withKVUpdates(
 			IPv4Address: remoteHostIP.String() + "/24",
 		}},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/24",
 	},
@@ -1882,12 +1882,12 @@ var vxlanWithBlockAndBorrows = vxlanWithBlock.withKVUpdates(
 		NatOutgoing: true,
 		Borrowed:    true,
 	},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname2,
 		Ipv4Addr: remoteHost2IP.String() + "/32",
 	},
@@ -1935,8 +1935,8 @@ var vxlanWithBlockAndDifferentNodeIP = vxlanWithBlock.withKVUpdates(
 		DstNodeIp:   remoteHost2IP.String(),
 		NatOutgoing: true,
 	},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHost2IP.String() + "/32",
 	},
@@ -2025,12 +2025,12 @@ var vxlanLocalBlockWithBorrows = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIP.String() + "/32",
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -2114,12 +2114,12 @@ var vxlanLocalBlockWithBorrowsNodeRes = vxlanLocalBlockWithBorrows.withKVUpdates
 			IPv4Address: localHostIPWithPrefix,
 		}},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIPWithPrefix,
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIPWithPrefix,
 	},
@@ -2180,11 +2180,11 @@ var vxlanLocalBlockWithBorrowsDifferentSubnetNodeRes = vxlanLocalBlockWithBorrow
 			IPv4Address: localHostIP.String() + "/32",
 		}},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIP.String() + "/32",
 	},
@@ -2223,8 +2223,8 @@ var vxlanLocalBlockWithBorrowsDifferentSubnetNodeRes = vxlanLocalBlockWithBorrow
 // vxlanWithBlockAndBorrows but missing the VTEP information for the first host.
 var vxlanWithBlockAndBorrowsAndMissingFirstVTEP = vxlanWithBlockAndBorrows.withKVUpdates(
 	KVPair{Key: remoteHostIPKey, Value: nil},
-).withName("VXLAN borrow missing VTEP").withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withName("VXLAN borrow missing VTEP").withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname2,
 		Ipv4Addr: remoteHost2IP.String() + "/32",
 	},
@@ -2293,7 +2293,7 @@ var vxlanBlockDelete = vxlanWithBlock.withKVUpdates(
 
 var vxlanHostIPDelete = vxlanWithBlock.withKVUpdates(
 	KVPair{Key: remoteHostIPKey, Value: nil},
-).withName("VXLAN host IP removed").withHostMetadataV4V6().withRoutes(
+).withName("VXLAN host IP removed").withHostMetadata().withRoutes(
 	routeUpdateIPPoolVXLAN,
 	// Host removed but keep the route without the node IP.
 	types.RouteUpdate{
@@ -2338,8 +2338,8 @@ var vxlanSlash32 = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -2362,8 +2362,8 @@ var vxlanSlash32NoBlock = empty.withKVUpdates(
 	routeUpdateRemoteHost,
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true, VxlanEnabledV6: false},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -2391,8 +2391,8 @@ var vxlanSlash32NoPool = empty.withKVUpdates(
 		DstNodeName: remoteHostname,
 		DstNodeIp:   remoteHostIP.String(),
 	},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/32",
 	},
@@ -2421,8 +2421,8 @@ var vxlanV6WithBlock = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	&proto.Encapsulation{IpipEnabled: false, VxlanEnabled: false, VxlanEnabledV6: true},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv6Addr: remoteHostIPv6.String() + "/96",
 	},
@@ -2465,7 +2465,7 @@ var vxlanV6NodeResIPDelete = vxlanV6WithBlock.withKVUpdates(
 		},
 		Spec: internalapi.NodeSpec{BGP: &internalapi.NodeBGPSpec{}},
 	}},
-).withHostMetadataV4V6().withName("VXLAN IPv6 Node Resource IP removed").withRoutes(
+).withHostMetadata().withName("VXLAN IPv6 Node Resource IP removed").withRoutes(
 	routeUpdateV6IPPoolVXLAN,
 	types.RouteUpdate{
 		Types:       proto.RouteType_REMOTE_WORKLOAD,
@@ -2483,8 +2483,8 @@ var vxlanV6NodeResBGPDelete = vxlanV6WithBlock.withKVUpdates(
 		},
 		Spec: internalapi.NodeSpec{BGP: nil},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 	},
 ).withName("VXLAN IPv6 Node Resource BGP removed").withRoutes(
@@ -2500,7 +2500,7 @@ var vxlanV6NodeResBGPDelete = vxlanV6WithBlock.withKVUpdates(
 
 var vxlanV6NodeResDelete = vxlanV6WithBlock.withKVUpdates(
 	KVPair{Key: remoteNodeResKey, Value: nil},
-).withHostMetadataV4V6().withName("VXLAN IPv6 Node Resource removed").withRoutes(
+).withHostMetadata().withName("VXLAN IPv6 Node Resource removed").withRoutes(
 	routeUpdateV6IPPoolVXLAN,
 	types.RouteUpdate{
 		Types:       proto.RouteType_REMOTE_WORKLOAD,
@@ -2544,8 +2544,8 @@ var vxlanV4V6WithBlock = empty.withKVUpdates(
 			IPv6Address: remoteHostIPv6.String() + "/96",
 		}},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/24",
 		Ipv6Addr: remoteHostIPv6.String() + "/96",
@@ -2613,8 +2613,8 @@ var vxlanV4V6NodeResIPv4Delete = vxlanV4V6WithBlock.withKVUpdates(
 			IPv6Address: remoteHostIPv6.String() + "/96",
 		}},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv6Addr: remoteHostIPv6.String() + "/96",
 	},
@@ -2649,8 +2649,8 @@ var vxlanV4V6NodeResIPv6Delete = vxlanV4V6WithBlock.withKVUpdates(
 			IPv4Address: remoteHostIP.String() + "/24",
 		}},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/24",
 	},
@@ -2681,8 +2681,8 @@ var vxlanV4V6NodeResBGPDelete = vxlanV4V6WithBlock.withKVUpdates(
 		},
 		Spec: internalapi.NodeSpec{BGP: nil},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 	},
 ).withName("VXLAN IPv4+IPv6 Node Resource BGP removed").withRoutes(
@@ -2708,7 +2708,7 @@ var vxlanV4V6NodeResBGPDelete = vxlanV4V6WithBlock.withKVUpdates(
 
 var vxlanV4V6NodeResDelete = vxlanV4V6WithBlock.withKVUpdates(
 	KVPair{Key: remoteNodeResKey, Value: nil},
-).withHostMetadataV4V6().withName("VXLAN IPv4+IPv6 Node Resource removed").withRoutes(
+).withHostMetadata().withName("VXLAN IPv4+IPv6 Node Resource removed").withRoutes(
 	routeUpdateIPPoolVXLAN,
 	// Host removed but keep the route without the node IP.
 	types.RouteUpdate{
@@ -2869,12 +2869,12 @@ var nodesWithMoreIPs = vxlanWithBlock.withKVUpdates(
 			},
 		},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIPWithPrefix,
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIPWithPrefix,
 	},
@@ -2932,12 +2932,12 @@ var nodesWithMoreIPsAndDuplicates = nodesWithMoreIPs.withKVUpdates(
 			},
 		},
 	},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIPWithPrefix,
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIPWithPrefix,
 	},
@@ -2968,12 +2968,12 @@ var nodesWithDifferentAddressTypes = nodesWithMoreIPs.withKVUpdates(
 			},
 		},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{ // from nodesWithMoreIPs
+).withHostMetadata(
+	&proto.HostMetadataUpdate{ // from nodesWithMoreIPs
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIPWithPrefix,
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIPWithPrefix,
 	},
@@ -3026,12 +3026,12 @@ var nodesWithMoreIPsDeleted = vxlanWithBlock.withKVUpdates(
 			},
 		},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIPWithPrefix,
 	},
-	&proto.HostMetadataV4V6Update{
+	&proto.HostMetadataUpdate{
 		Hostname: localHostname,
 		Ipv4Addr: localHostIPWithPrefix,
 	},
@@ -3211,8 +3211,8 @@ var wireguardV4 = empty.withKVUpdates(
 			TunnelType:  &proto.TunnelType{Wireguard: true},
 		},
 	}...,
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteHostname,
 		Ipv4Addr: remoteHostIP.String() + "/24",
 	},
@@ -3251,8 +3251,8 @@ var wireguardV6 = empty.withKVUpdates(
 			WireguardPublicKeyV6: wgPublicKey2.String(),
 		},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteNodeResKey.Name,
 		Ipv6Addr: remoteHostIPv6.String() + "/96",
 	},
@@ -3309,8 +3309,8 @@ var wireguardV4V6 = empty.withKVUpdates(
 			WireguardPublicKeyV6: wgPublicKey2.String(),
 		},
 	}},
-).withHostMetadataV4V6(
-	&proto.HostMetadataV4V6Update{
+).withHostMetadata(
+	&proto.HostMetadataUpdate{
 		Hostname: remoteNodeResKey.Name,
 		Ipv4Addr: remoteHostIP.String() + "/24",
 		Ipv6Addr: remoteHostIPv6.String() + "/96",

--- a/felix/dataplane/external/ext_dataplane.go
+++ b/felix/dataplane/external/ext_dataplane.go
@@ -202,10 +202,10 @@ func WrapPayloadWithEnvelope(msg any, seqNo uint64) (*proto.ToDataplane, error) 
 		envelope.Payload = &proto.ToDataplane_WorkloadEndpointUpdate{WorkloadEndpointUpdate: msg}
 	case *proto.WorkloadEndpointRemove:
 		envelope.Payload = &proto.ToDataplane_WorkloadEndpointRemove{WorkloadEndpointRemove: msg}
-	case *proto.HostMetadataV4V6Update:
-		envelope.Payload = &proto.ToDataplane_HostMetadataV4V6Update{HostMetadataV4V6Update: msg}
-	case *proto.HostMetadataV4V6Remove:
-		envelope.Payload = &proto.ToDataplane_HostMetadataV4V6Remove{HostMetadataV4V6Remove: msg}
+	case *proto.HostMetadataUpdate:
+		envelope.Payload = &proto.ToDataplane_HostMetadataUpdate{HostMetadataUpdate: msg}
+	case *proto.HostMetadataRemove:
+		envelope.Payload = &proto.ToDataplane_HostMetadataRemove{HostMetadataRemove: msg}
 	case *proto.IPAMPoolUpdate:
 		envelope.Payload = &proto.ToDataplane_IpamPoolUpdate{IpamPoolUpdate: msg}
 	case *proto.IPAMPoolRemove:

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -943,16 +943,16 @@ func (m *bpfEndpointManager) OnUpdate(msg any) {
 	case *proto.ActiveProfileRemove:
 		m.onProfileRemove(msg)
 
-	case *proto.HostMetadataV4V6Update:
+	case *proto.HostMetadataUpdate:
 		if msg.Hostname != m.hostname {
 			break
 		}
 		if m.v4 != nil {
-			logrus.WithField("HostMetadataV4V6Update", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
+			logrus.WithField("HostMetadataUpdate", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
 			m.updateHostIP(msg.Ipv4Addr, 4)
 		}
 		if m.v6 != nil {
-			logrus.WithField("HostMetadataV4V6Update", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
+			logrus.WithField("HostMetadataUpdate", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
 			m.updateHostIP(msg.Ipv6Addr, 6)
 		}
 	case *proto.ServiceUpdate:

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -662,7 +662,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 
 	genHostMetadataUpdate := func(ip string) func() {
 		return func() {
-			bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+			bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{
 				Hostname: "uthost",
 				Ipv4Addr: ip,
 			})
@@ -673,7 +673,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 
 	genHostMetadataV6Update := func(ip string) func() {
 		return func() {
-			bpfEpMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+			bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{
 				Hostname: "uthost",
 				Ipv6Addr: ip,
 			})

--- a/felix/dataplane/linux/ipip_mgr.go
+++ b/felix/dataplane/linux/ipip_mgr.go
@@ -122,7 +122,7 @@ func newIPIPManagerWithShims(
 
 func (m *ipipManager) OnUpdate(protoBufMsg any) {
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataV4V6Update:
+	case *proto.HostMetadataUpdate:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host update/create")
 		if msg.Hostname == m.hostname {
 			m.routeMgr.updateParentIfaceAddr(msg.Ipv4Addr)
@@ -136,7 +136,7 @@ func (m *ipipManager) OnUpdate(protoBufMsg any) {
 			m.activeHostnameToIP[msg.Hostname] = msg.Ipv4Addr
 		}
 		m.maybeUpdateRoutes()
-	case *proto.HostMetadataV4V6Remove:
+	case *proto.HostMetadataRemove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
 		if msg.Hostname == m.hostname {
 			m.routeMgr.updateParentIfaceAddr("")

--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -73,7 +73,7 @@ var _ = Describe("IPIPManager", func() {
 	})
 
 	It("should configure tunnel properly", func() {
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
@@ -133,11 +133,11 @@ var _ = Describe("IPIPManager", func() {
 	})
 
 	It("successfully adds a route to the noEncap interface", func() {
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -215,7 +215,7 @@ var _ = Describe("IPIPManager", func() {
 		go ipipMgr.keepIPIPDeviceInSync(ctx, 1400, false, 1*time.Second, dataDeviceC)
 
 		By("Sending another node's route.")
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "10.0.0.2",
 		})
@@ -235,7 +235,7 @@ var _ = Describe("IPIPManager", func() {
 		Expect(rt.currentRoutes[dataplanedefs.IPIPIfaceName]).To(HaveLen(1))
 
 		By("Sending another local node update.")
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
@@ -260,11 +260,11 @@ var _ = Describe("IPIPManager", func() {
 
 	It("should program routes for remote endpoints with borrowed IP addresses", func() {
 		By("Sending host updates")
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -307,11 +307,11 @@ var _ = Describe("IPIPManager", func() {
 	})
 
 	It("should only program black hole routes for local endpoints", func() {
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -368,11 +368,11 @@ var _ = Describe("IPIPManager", func() {
 
 	It("should program routes for remote tunnel endpoint", func() {
 		By("Sending host updates")
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		ipipMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		ipipMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})

--- a/felix/dataplane/linux/ipset_hosts_mgr.go
+++ b/felix/dataplane/linux/ipset_hosts_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/dataplane/linux/ipset_hosts_mgr.go
+++ b/felix/dataplane/linux/ipset_hosts_mgr.go
@@ -71,7 +71,7 @@ func newHostsIPSetManager(
 
 func (m *hostsIPSetManager) OnUpdate(protoBufMsg any) {
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataV4V6Update:
+	case *proto.HostMetadataUpdate:
 		if (m.ipVersion == 4 && msg.Ipv4Addr == "") || (m.ipVersion == 6 && msg.Ipv6Addr == "") {
 			// Skip since the update is for a mismatched IP version
 			m.logCtx.WithField("msg", msg).Debug("Skipping mismatched IP version update")
@@ -87,7 +87,7 @@ func (m *hostsIPSetManager) OnUpdate(protoBufMsg any) {
 		parts := strings.Split(addr, "/")
 		m.activeHostnameToIP[msg.Hostname] = parts[0]
 		m.ipSetDirty = true
-	case *proto.HostMetadataV4V6Remove:
+	case *proto.HostMetadataRemove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
 		delete(m.activeHostnameToIP, msg.Hostname)
 		m.ipSetDirty = true

--- a/felix/dataplane/linux/ipset_hosts_mgr_test.go
+++ b/felix/dataplane/linux/ipset_hosts_mgr_test.go
@@ -61,7 +61,7 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(ipSets.AddOrReplaceCalled).To(BeTrue())
 
 		By("adding host1")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host1",
 			Ipv4Addr: "10.0.0.1",
 		})
@@ -70,7 +70,7 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", externalCIDR)))
 
 		By("adding host2")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host2",
 			Ipv4Addr: "10.0.0.2",
 		})
@@ -79,7 +79,7 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2", externalCIDR)))
 
 		By("testing tolerance for duplicate ip")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host3",
 			Ipv4Addr: "10.0.0.2",
 		})
@@ -88,7 +88,7 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2", externalCIDR)))
 
 		By("removing the duplicate ip should keep the ip")
-		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+		manager.OnUpdate(&proto.HostMetadataRemove{
 			Hostname: "host3",
 		})
 		err = manager.CompleteDeferredWork()
@@ -96,7 +96,7 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", "10.0.0.2", externalCIDR)))
 
 		By("removing the initial copy of ip")
-		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+		manager.OnUpdate(&proto.HostMetadataRemove{
 			Hostname: "host2",
 		})
 		err = manager.CompleteDeferredWork()
@@ -104,11 +104,11 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", externalCIDR)))
 
 		By("adding/removing a duplicate IP in one batch")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host2",
 			Ipv4Addr: "10.0.0.1",
 		})
-		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+		manager.OnUpdate(&proto.HostMetadataRemove{
 			Hostname: "host2",
 		})
 		err = manager.CompleteDeferredWork()
@@ -116,7 +116,7 @@ var _ = Describe("IPSet all-hosts manager", func() {
 		Expect(allHostsSet()).To(Equal(set.From("10.0.0.1", externalCIDR)))
 
 		By("changing ip of host1")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host1",
 			Ipv4Addr: "10.0.0.2",
 		})
@@ -170,7 +170,7 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(ipSets.AddOrReplaceCalled).To(BeTrue())
 
 		By("adding host1")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host1",
 			Ipv6Addr: "dead:beef::1",
 		})
@@ -181,7 +181,7 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(allHostsSet()).To(Equal(set.From("dead:beef::1")))
 
 		By("adding host2")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host2",
 			Ipv6Addr: "dead:beef::2",
 		})
@@ -190,7 +190,7 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(allHostsSet()).To(Equal(set.From("dead:beef::1", "dead:beef::2")))
 
 		By("testing tolerance for duplicate ip")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host3",
 			Ipv6Addr: "dead:beef::2",
 		})
@@ -199,7 +199,7 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(allHostsSet()).To(Equal(set.From("dead:beef::1", "dead:beef::2")))
 
 		By("removing the duplicate ip should keep the ip")
-		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+		manager.OnUpdate(&proto.HostMetadataRemove{
 			Hostname: "host3",
 		})
 		err = manager.CompleteDeferredWork()
@@ -207,7 +207,7 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(allHostsSet()).To(Equal(set.From("dead:beef::1", "dead:beef::2")))
 
 		By("removing the initial copy of ip")
-		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+		manager.OnUpdate(&proto.HostMetadataRemove{
 			Hostname: "host2",
 		})
 		err = manager.CompleteDeferredWork()
@@ -215,11 +215,11 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(allHostsSet()).To(Equal(set.From("dead:beef::1")))
 
 		By("adding/removing a duplicate IP in one batch")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host2",
 			Ipv6Addr: "dead:beef::1",
 		})
-		manager.OnUpdate(&proto.HostMetadataV4V6Remove{
+		manager.OnUpdate(&proto.HostMetadataRemove{
 			Hostname: "host2",
 		})
 		err = manager.CompleteDeferredWork()
@@ -227,7 +227,7 @@ var _ = Describe("IPSet all-hosts manager - IPv6", func() {
 		Expect(allHostsSet()).To(Equal(set.From("dead:beef::1")))
 
 		By("changing ip of host1")
-		manager.OnUpdate(&proto.HostMetadataV4V6Update{
+		manager.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "host1",
 			Ipv6Addr: "dead:beef::2",
 		})

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Masquerade manager", func() {
 		})
 		It("an unrelated update shouldn't trigger work", func() {
 			natTable.UpdateCalled = false
-			masqMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+			masqMgr.OnUpdate(&proto.HostMetadataUpdate{
 				Hostname: "foo",
 				Ipv4Addr: "10.0.0.17",
 			})

--- a/felix/dataplane/linux/noencap_mgr.go
+++ b/felix/dataplane/linux/noencap_mgr.go
@@ -91,7 +91,7 @@ func newNoEncapManagerWithSims(
 
 func (m *noEncapManager) OnUpdate(protoBufMsg any) {
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataV4V6Update:
+	case *proto.HostMetadataUpdate:
 		if msg.Hostname != m.hostname {
 			break
 		}
@@ -106,11 +106,11 @@ func (m *noEncapManager) OnUpdate(protoBufMsg any) {
 			m.logCtx.WithFields(logrus.Fields{
 				"hostname":  msg.Hostname,
 				"ipVersion": m.ipVersion,
-			}).Debug("Ignoring HostMetadataV4V6Update with no address for this IP version")
+			}).Debug("Ignoring HostMetadataUpdate with no address for this IP version")
 			return
 		}
 		m.routesNeedUpdate(addrStr)
-	case *proto.HostMetadataV4V6Remove:
+	case *proto.HostMetadataRemove:
 		m.logCtx.WithField("hostname", msg.Hostname).Debug("Host removed")
 		if msg.Hostname == m.hostname {
 			m.routesNeedUpdate("")

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -76,11 +76,11 @@ var _ = Describe("NoEncap Manager", func() {
 	})
 
 	It("successfully adds a route to the noEncap interface", func() {
-		noencapMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv4Addr: "172.0.0.2",
 		})
-		noencapMgr.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgr.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv4Addr: "172.0.2.2",
 		})
@@ -162,11 +162,11 @@ var _ = Describe("NoEncap Manager", func() {
 	})
 
 	It("successfully adds a IPv6 route to the noEncap interface", func() {
-		noencapMgrV6.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgrV6.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node1",
 			Ipv6Addr: "fc00:10:96::2",
 		})
-		noencapMgrV6.OnUpdate(&proto.HostMetadataV4V6Update{
+		noencapMgrV6.OnUpdate(&proto.HostMetadataUpdate{
 			Hostname: "node2",
 			Ipv6Addr: "fc00:10:10::1",
 		})

--- a/felix/dataplane/linux/wireguard_mgr.go
+++ b/felix/dataplane/linux/wireguard_mgr.go
@@ -63,8 +63,8 @@ func (m *wireguardManager) OnUpdate(protoBufMsg any) {
 	logCtx := logrus.WithField("ipVersion", m.ipVersion)
 	logCtx.WithField("msg", protoBufMsg).Debug("Received message")
 	switch msg := protoBufMsg.(type) {
-	case *proto.HostMetadataV4V6Update:
-		logCtx.WithField("msg", msg).Debug("HostMetadataV4V6Update update")
+	case *proto.HostMetadataUpdate:
+		logCtx.WithField("msg", msg).Debug("HostMetadataUpdate update")
 		var addrStr string
 		if m.ipVersion == 4 {
 			addrStr = msg.Ipv4Addr
@@ -75,7 +75,7 @@ func (m *wireguardManager) OnUpdate(protoBufMsg any) {
 			logCtx.WithFields(logrus.Fields{
 				"hostname":  msg.Hostname,
 				"ipVersion": m.ipVersion,
-			}).Debug("Ignoring HostMetadataV4V6Update with no address for this IP version")
+			}).Debug("Ignoring HostMetadataUpdate with no address for this IP version")
 			return
 		}
 		addr := ip.FromIPOrCIDRString(addrStr)
@@ -84,12 +84,12 @@ func (m *wireguardManager) OnUpdate(protoBufMsg any) {
 				"hostname":  msg.Hostname,
 				"address":   addrStr,
 				"ipVersion": m.ipVersion,
-			}).Warn("Ignoring HostMetadataV4V6Update with invalid or mismatched address for this IP version")
+			}).Warn("Ignoring HostMetadataUpdate with invalid or mismatched address for this IP version")
 			return
 		}
 		m.wireguardRouteTable.EndpointUpdate(msg.Hostname, addr)
-	case *proto.HostMetadataV4V6Remove:
-		logCtx.WithField("msg", msg).Debug("HostMetadataV4V6Remove update")
+	case *proto.HostMetadataRemove:
+		logCtx.WithField("msg", msg).Debug("HostMetadataRemove update")
 		m.wireguardRouteTable.EndpointRemove(msg.Hostname)
 	case *proto.RouteUpdate:
 		logCtx.WithField("msg", msg).Debug("RouteUpdate update")

--- a/felix/dataplane/mock/mock_dataplane.go
+++ b/felix/dataplane/mock/mock_dataplane.go
@@ -45,7 +45,7 @@ type MockDataplane struct {
 	activeVTEPs                    map[string]types.VXLANTunnelEndpointUpdate
 	activeWireguardEndpoints       map[string]types.WireguardEndpointUpdate
 	activeWireguardV6Endpoints     map[string]types.WireguardEndpointV6Update
-	activeHostMetadataV4V6         map[string]*proto.HostMetadataV4V6Update
+	activeHostMetadata             map[string]*proto.HostMetadataUpdate
 	activeRoutes                   set.Set[types.RouteUpdate]
 	endpointToPolicyOrder          map[string][]TierInfo
 	endpointToUntrackedPolicyOrder map[string][]TierInfo
@@ -159,12 +159,12 @@ func (d *MockDataplane) ActiveWireguardV6Endpoints() set.Set[types.WireguardEndp
 	return cp
 }
 
-func (d *MockDataplane) ActiveHostMetadataV4V6() map[string]*proto.HostMetadataV4V6Update {
+func (d *MockDataplane) ActiveHostMetadata() map[string]*proto.HostMetadataUpdate {
 	d.Lock()
 	defer d.Unlock()
 
-	cp := make(map[string]*proto.HostMetadataV4V6Update)
-	for _, v := range d.activeHostMetadataV4V6 {
+	cp := make(map[string]*proto.HostMetadataUpdate)
+	for _, v := range d.activeHostMetadata {
 		cp[v.Hostname] = v
 	}
 
@@ -287,7 +287,7 @@ func NewMockDataplane() *MockDataplane {
 		activeVTEPs:                    make(map[string]types.VXLANTunnelEndpointUpdate),
 		activeWireguardEndpoints:       make(map[string]types.WireguardEndpointUpdate),
 		activeWireguardV6Endpoints:     make(map[string]types.WireguardEndpointV6Update),
-		activeHostMetadataV4V6:         make(map[string]*proto.HostMetadataV4V6Update),
+		activeHostMetadata:             make(map[string]*proto.HostMetadataUpdate),
 		endpointToPolicyOrder:          make(map[string][]TierInfo),
 		endpointToUntrackedPolicyOrder: make(map[string][]TierInfo),
 		endpointToPreDNATPolicyOrder:   make(map[string][]TierInfo),
@@ -515,11 +515,11 @@ func (d *MockDataplane) OnEvent(event any) {
 		delete(d.activeWireguardV6Endpoints, event.Hostname)
 	case *proto.Encapsulation:
 		d.encapsulation = event
-	case *proto.HostMetadataV4V6Update:
-		d.activeHostMetadataV4V6[event.Hostname] = event
-	case *proto.HostMetadataV4V6Remove:
-		Expect(d.activeHostMetadataV4V6).To(HaveKey(event.Hostname), "delete for unknown HostmetadataV4V6")
-		delete(d.activeHostMetadataV4V6, event.Hostname)
+	case *proto.HostMetadataUpdate:
+		d.activeHostMetadata[event.Hostname] = event
+	case *proto.HostMetadataRemove:
+		Expect(d.activeHostMetadata).To(HaveKey(event.Hostname), "delete for unknown Hostmetadata")
+		delete(d.activeHostMetadata, event.Hostname)
 	}
 }
 

--- a/felix/dataplane/mock/mock_dataplane.go
+++ b/felix/dataplane/mock/mock_dataplane.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -518,7 +518,7 @@ func (d *MockDataplane) OnEvent(event any) {
 	case *proto.HostMetadataUpdate:
 		d.activeHostMetadata[event.Hostname] = event
 	case *proto.HostMetadataRemove:
-		Expect(d.activeHostMetadata).To(HaveKey(event.Hostname), "delete for unknown Hostmetadata")
+		Expect(d.activeHostMetadata).To(HaveKey(event.Hostname), "delete for unknown HostMetadata")
 		delete(d.activeHostMetadata, event.Hostname)
 	}
 }

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -1027,12 +1027,12 @@ type ToDataplane_ConfigUpdate struct {
 
 type ToDataplane_HostMetadataUpdate struct {
 	// HostMetadataUpdate is sent when a host is added or updated.
-	HostMetadataUpdate *HostMetadataUpdate `protobuf:"bytes,37,opt,name=host_metadata_update,json=hostMetadataUpdate,proto3,oneof"`
+	HostMetadataUpdate *HostMetadataUpdate `protobuf:"bytes,14,opt,name=host_metadata_update,json=hostMetadataUpdate,proto3,oneof"`
 }
 
 type ToDataplane_HostMetadataRemove struct {
 	// HostIPRemove is sent when a host is removed.
-	HostMetadataRemove *HostMetadataRemove `protobuf:"bytes,38,opt,name=host_metadata_remove,json=hostMetadataRemove,proto3,oneof"`
+	HostMetadataRemove *HostMetadataRemove `protobuf:"bytes,18,opt,name=host_metadata_remove,json=hostMetadataRemove,proto3,oneof"`
 }
 
 type ToDataplane_IpamPoolUpdate struct {
@@ -6226,7 +6226,7 @@ var File_felixbackend_proto protoreflect.FileDescriptor
 const file_felixbackend_proto_rawDesc = "" +
 	"\n" +
 	"\x12felixbackend.proto\x12\x05felix\"\r\n" +
-	"\vSyncRequest\"\xab\x14\n" +
+	"\vSyncRequest\"\xdb\x14\n" +
 	"\vToDataplane\x12'\n" +
 	"\x0fsequence_number\x18\x0f \x01(\x04R\x0esequenceNumber\x12(\n" +
 	"\ain_sync\x18\x01 \x01(\v2\r.felix.InSyncH\x00R\x06inSync\x127\n" +
@@ -6243,8 +6243,8 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x18workload_endpoint_update\x18\v \x01(\v2\x1d.felix.WorkloadEndpointUpdateH\x00R\x16workloadEndpointUpdate\x12Y\n" +
 	"\x18workload_endpoint_remove\x18\f \x01(\v2\x1d.felix.WorkloadEndpointRemoveH\x00R\x16workloadEndpointRemove\x12:\n" +
 	"\rconfig_update\x18\r \x01(\v2\x13.felix.ConfigUpdateH\x00R\fconfigUpdate\x12M\n" +
-	"\x14host_metadata_update\x18% \x01(\v2\x19.felix.HostMetadataUpdateH\x00R\x12hostMetadataUpdate\x12M\n" +
-	"\x14host_metadata_remove\x18& \x01(\v2\x19.felix.HostMetadataRemoveH\x00R\x12hostMetadataRemove\x12A\n" +
+	"\x14host_metadata_update\x18\x0e \x01(\v2\x19.felix.HostMetadataUpdateH\x00R\x12hostMetadataUpdate\x12M\n" +
+	"\x14host_metadata_remove\x18\x12 \x01(\v2\x19.felix.HostMetadataRemoveH\x00R\x12hostMetadataRemove\x12A\n" +
 	"\x10ipam_pool_update\x18\x10 \x01(\v2\x15.felix.IPAMPoolUpdateH\x00R\x0eipamPoolUpdate\x12A\n" +
 	"\x10ipam_pool_remove\x18\x11 \x01(\v2\x15.felix.IPAMPoolRemoveH\x00R\x0eipamPoolRemove\x12S\n" +
 	"\x16service_account_update\x18\x13 \x01(\v2\x1b.felix.ServiceAccountUpdateH\x00R\x14serviceAccountUpdate\x12S\n" +
@@ -6265,7 +6265,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x0eservice_remove\x18  \x01(\v2\x14.felix.ServiceRemoveH\x00R\rserviceRemove\x12c\n" +
 	"\x1cwireguard_endpoint_v6_update\x18! \x01(\v2 .felix.WireguardEndpointV6UpdateH\x00R\x19wireguardEndpointV6Update\x12c\n" +
 	"\x1cwireguard_endpoint_v6_remove\x18\" \x01(\v2 .felix.WireguardEndpointV6RemoveH\x00R\x19wireguardEndpointV6RemoveB\t\n" +
-	"\apayloadJ\x04\b\x0e\x10\x0fJ\x04\b\x12\x10\x13J\x04\b#\x10$J\x04\b$\x10%R\x14HostMetadataV6UpdateR\x14HostMetadataV6Remove\"\xd3\x05\n" +
+	"\apayloadJ\x04\b#\x10$J\x04\b$\x10%J\x04\b%\x10&J\x04\b&\x10'R\x14HostMetadataV6UpdateR\x14HostMetadataV6RemoveR\x16HostMetadataV4V6UpdateR\x16HostMetadataV4V6Remove\"\xd3\x05\n" +
 	"\rFromDataplane\x12'\n" +
 	"\x0fsequence_number\x18\b \x01(\x04R\x0esequenceNumber\x12P\n" +
 	"\x15process_status_update\x18\x03 \x01(\v2\x1a.felix.ProcessStatusUpdateH\x00R\x13processStatusUpdate\x12`\n" +

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -581,8 +581,8 @@ type ToDataplane struct {
 	//	*ToDataplane_WorkloadEndpointUpdate
 	//	*ToDataplane_WorkloadEndpointRemove
 	//	*ToDataplane_ConfigUpdate
-	//	*ToDataplane_HostMetadataV4V6Update
-	//	*ToDataplane_HostMetadataV4V6Remove
+	//	*ToDataplane_HostMetadataUpdate
+	//	*ToDataplane_HostMetadataRemove
 	//	*ToDataplane_IpamPoolUpdate
 	//	*ToDataplane_IpamPoolRemove
 	//	*ToDataplane_ServiceAccountUpdate
@@ -767,19 +767,19 @@ func (x *ToDataplane) GetConfigUpdate() *ConfigUpdate {
 	return nil
 }
 
-func (x *ToDataplane) GetHostMetadataV4V6Update() *HostMetadataV4V6Update {
+func (x *ToDataplane) GetHostMetadataUpdate() *HostMetadataUpdate {
 	if x != nil {
-		if x, ok := x.Payload.(*ToDataplane_HostMetadataV4V6Update); ok {
-			return x.HostMetadataV4V6Update
+		if x, ok := x.Payload.(*ToDataplane_HostMetadataUpdate); ok {
+			return x.HostMetadataUpdate
 		}
 	}
 	return nil
 }
 
-func (x *ToDataplane) GetHostMetadataV4V6Remove() *HostMetadataV4V6Remove {
+func (x *ToDataplane) GetHostMetadataRemove() *HostMetadataRemove {
 	if x != nil {
-		if x, ok := x.Payload.(*ToDataplane_HostMetadataV4V6Remove); ok {
-			return x.HostMetadataV4V6Remove
+		if x, ok := x.Payload.(*ToDataplane_HostMetadataRemove); ok {
+			return x.HostMetadataRemove
 		}
 	}
 	return nil
@@ -1025,14 +1025,14 @@ type ToDataplane_ConfigUpdate struct {
 	ConfigUpdate *ConfigUpdate `protobuf:"bytes,13,opt,name=config_update,json=configUpdate,proto3,oneof"`
 }
 
-type ToDataplane_HostMetadataV4V6Update struct {
-	// HostMetadataV4V6Update is sent when a host is added or updated.
-	HostMetadataV4V6Update *HostMetadataV4V6Update `protobuf:"bytes,37,opt,name=host_metadata_v4v6_update,json=hostMetadataV4v6Update,proto3,oneof"`
+type ToDataplane_HostMetadataUpdate struct {
+	// HostMetadataUpdate is sent when a host is added or updated.
+	HostMetadataUpdate *HostMetadataUpdate `protobuf:"bytes,37,opt,name=host_metadata_update,json=hostMetadataUpdate,proto3,oneof"`
 }
 
-type ToDataplane_HostMetadataV4V6Remove struct {
+type ToDataplane_HostMetadataRemove struct {
 	// HostIPRemove is sent when a host is removed.
-	HostMetadataV4V6Remove *HostMetadataV4V6Remove `protobuf:"bytes,38,opt,name=host_metadata_v4v6_remove,json=hostMetadataV4v6Remove,proto3,oneof"`
+	HostMetadataRemove *HostMetadataRemove `protobuf:"bytes,38,opt,name=host_metadata_remove,json=hostMetadataRemove,proto3,oneof"`
 }
 
 type ToDataplane_IpamPoolUpdate struct {
@@ -1148,9 +1148,9 @@ func (*ToDataplane_WorkloadEndpointRemove) isToDataplane_Payload() {}
 
 func (*ToDataplane_ConfigUpdate) isToDataplane_Payload() {}
 
-func (*ToDataplane_HostMetadataV4V6Update) isToDataplane_Payload() {}
+func (*ToDataplane_HostMetadataUpdate) isToDataplane_Payload() {}
 
-func (*ToDataplane_HostMetadataV4V6Remove) isToDataplane_Payload() {}
+func (*ToDataplane_HostMetadataRemove) isToDataplane_Payload() {}
 
 func (*ToDataplane_IpamPoolUpdate) isToDataplane_Payload() {}
 
@@ -4290,7 +4290,7 @@ func (*DataplaneInSync) Descriptor() ([]byte, []int) {
 	return file_felixbackend_proto_rawDescGZIP(), []int{45}
 }
 
-type HostMetadataV4V6Update struct {
+type HostMetadataUpdate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Hostname      string                 `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
 	Ipv4Addr      string                 `protobuf:"bytes,2,opt,name=ipv4_addr,json=ipv4Addr,proto3" json:"ipv4_addr,omitempty"`
@@ -4301,20 +4301,20 @@ type HostMetadataV4V6Update struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *HostMetadataV4V6Update) Reset() {
-	*x = HostMetadataV4V6Update{}
+func (x *HostMetadataUpdate) Reset() {
+	*x = HostMetadataUpdate{}
 	mi := &file_felixbackend_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *HostMetadataV4V6Update) String() string {
+func (x *HostMetadataUpdate) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*HostMetadataV4V6Update) ProtoMessage() {}
+func (*HostMetadataUpdate) ProtoMessage() {}
 
-func (x *HostMetadataV4V6Update) ProtoReflect() protoreflect.Message {
+func (x *HostMetadataUpdate) ProtoReflect() protoreflect.Message {
 	mi := &file_felixbackend_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -4326,47 +4326,47 @@ func (x *HostMetadataV4V6Update) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use HostMetadataV4V6Update.ProtoReflect.Descriptor instead.
-func (*HostMetadataV4V6Update) Descriptor() ([]byte, []int) {
+// Deprecated: Use HostMetadataUpdate.ProtoReflect.Descriptor instead.
+func (*HostMetadataUpdate) Descriptor() ([]byte, []int) {
 	return file_felixbackend_proto_rawDescGZIP(), []int{46}
 }
 
-func (x *HostMetadataV4V6Update) GetHostname() string {
+func (x *HostMetadataUpdate) GetHostname() string {
 	if x != nil {
 		return x.Hostname
 	}
 	return ""
 }
 
-func (x *HostMetadataV4V6Update) GetIpv4Addr() string {
+func (x *HostMetadataUpdate) GetIpv4Addr() string {
 	if x != nil {
 		return x.Ipv4Addr
 	}
 	return ""
 }
 
-func (x *HostMetadataV4V6Update) GetIpv6Addr() string {
+func (x *HostMetadataUpdate) GetIpv6Addr() string {
 	if x != nil {
 		return x.Ipv6Addr
 	}
 	return ""
 }
 
-func (x *HostMetadataV4V6Update) GetAsnumber() string {
+func (x *HostMetadataUpdate) GetAsnumber() string {
 	if x != nil {
 		return x.Asnumber
 	}
 	return ""
 }
 
-func (x *HostMetadataV4V6Update) GetLabels() map[string]string {
+func (x *HostMetadataUpdate) GetLabels() map[string]string {
 	if x != nil {
 		return x.Labels
 	}
 	return nil
 }
 
-type HostMetadataV4V6Remove struct {
+type HostMetadataRemove struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Hostname      string                 `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
 	Ipv4Addr      string                 `protobuf:"bytes,2,opt,name=ipv4_addr,json=ipv4Addr,proto3" json:"ipv4_addr,omitempty"`
@@ -4374,20 +4374,20 @@ type HostMetadataV4V6Remove struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *HostMetadataV4V6Remove) Reset() {
-	*x = HostMetadataV4V6Remove{}
+func (x *HostMetadataRemove) Reset() {
+	*x = HostMetadataRemove{}
 	mi := &file_felixbackend_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *HostMetadataV4V6Remove) String() string {
+func (x *HostMetadataRemove) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*HostMetadataV4V6Remove) ProtoMessage() {}
+func (*HostMetadataRemove) ProtoMessage() {}
 
-func (x *HostMetadataV4V6Remove) ProtoReflect() protoreflect.Message {
+func (x *HostMetadataRemove) ProtoReflect() protoreflect.Message {
 	mi := &file_felixbackend_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -4399,19 +4399,19 @@ func (x *HostMetadataV4V6Remove) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use HostMetadataV4V6Remove.ProtoReflect.Descriptor instead.
-func (*HostMetadataV4V6Remove) Descriptor() ([]byte, []int) {
+// Deprecated: Use HostMetadataRemove.ProtoReflect.Descriptor instead.
+func (*HostMetadataRemove) Descriptor() ([]byte, []int) {
 	return file_felixbackend_proto_rawDescGZIP(), []int{47}
 }
 
-func (x *HostMetadataV4V6Remove) GetHostname() string {
+func (x *HostMetadataRemove) GetHostname() string {
 	if x != nil {
 		return x.Hostname
 	}
 	return ""
 }
 
-func (x *HostMetadataV4V6Remove) GetIpv4Addr() string {
+func (x *HostMetadataRemove) GetIpv4Addr() string {
 	if x != nil {
 		return x.Ipv4Addr
 	}
@@ -6226,7 +6226,7 @@ var File_felixbackend_proto protoreflect.FileDescriptor
 const file_felixbackend_proto_rawDesc = "" +
 	"\n" +
 	"\x12felixbackend.proto\x12\x05felix\"\r\n" +
-	"\vSyncRequest\"\xed\x14\n" +
+	"\vSyncRequest\"\xab\x14\n" +
 	"\vToDataplane\x12'\n" +
 	"\x0fsequence_number\x18\x0f \x01(\x04R\x0esequenceNumber\x12(\n" +
 	"\ain_sync\x18\x01 \x01(\v2\r.felix.InSyncH\x00R\x06inSync\x127\n" +
@@ -6242,9 +6242,9 @@ const file_felixbackend_proto_rawDesc = "" +
 	" \x01(\v2\x19.felix.HostEndpointRemoveH\x00R\x12hostEndpointRemove\x12Y\n" +
 	"\x18workload_endpoint_update\x18\v \x01(\v2\x1d.felix.WorkloadEndpointUpdateH\x00R\x16workloadEndpointUpdate\x12Y\n" +
 	"\x18workload_endpoint_remove\x18\f \x01(\v2\x1d.felix.WorkloadEndpointRemoveH\x00R\x16workloadEndpointRemove\x12:\n" +
-	"\rconfig_update\x18\r \x01(\v2\x13.felix.ConfigUpdateH\x00R\fconfigUpdate\x12Z\n" +
-	"\x19host_metadata_v4v6_update\x18% \x01(\v2\x1d.felix.HostMetadataV4V6UpdateH\x00R\x16hostMetadataV4v6Update\x12Z\n" +
-	"\x19host_metadata_v4v6_remove\x18& \x01(\v2\x1d.felix.HostMetadataV4V6RemoveH\x00R\x16hostMetadataV4v6Remove\x12A\n" +
+	"\rconfig_update\x18\r \x01(\v2\x13.felix.ConfigUpdateH\x00R\fconfigUpdate\x12M\n" +
+	"\x14host_metadata_update\x18% \x01(\v2\x19.felix.HostMetadataUpdateH\x00R\x12hostMetadataUpdate\x12M\n" +
+	"\x14host_metadata_remove\x18& \x01(\v2\x19.felix.HostMetadataRemoveH\x00R\x12hostMetadataRemove\x12A\n" +
 	"\x10ipam_pool_update\x18\x10 \x01(\v2\x15.felix.IPAMPoolUpdateH\x00R\x0eipamPoolUpdate\x12A\n" +
 	"\x10ipam_pool_remove\x18\x11 \x01(\v2\x15.felix.IPAMPoolRemoveH\x00R\x0eipamPoolRemove\x12S\n" +
 	"\x16service_account_update\x18\x13 \x01(\v2\x1b.felix.ServiceAccountUpdateH\x00R\x14serviceAccountUpdate\x12S\n" +
@@ -6265,7 +6265,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x0eservice_remove\x18  \x01(\v2\x14.felix.ServiceRemoveH\x00R\rserviceRemove\x12c\n" +
 	"\x1cwireguard_endpoint_v6_update\x18! \x01(\v2 .felix.WireguardEndpointV6UpdateH\x00R\x19wireguardEndpointV6Update\x12c\n" +
 	"\x1cwireguard_endpoint_v6_remove\x18\" \x01(\v2 .felix.WireguardEndpointV6RemoveH\x00R\x19wireguardEndpointV6RemoveB\t\n" +
-	"\apayloadJ\x04\b\x0e\x10\x0fJ\x04\b\x12\x10\x13J\x04\b#\x10$J\x04\b$\x10%R\x12HostMetadataUpdateR\x12HostMetadataRemoveR\x14HostMetadataV6UpdateR\x14HostMetadataV6Remove\"\xd3\x05\n" +
+	"\apayloadJ\x04\b\x0e\x10\x0fJ\x04\b\x12\x10\x13J\x04\b#\x10$J\x04\b$\x10%R\x14HostMetadataV6UpdateR\x14HostMetadataV6Remove\"\xd3\x05\n" +
 	"\rFromDataplane\x12'\n" +
 	"\x0fsequence_number\x18\b \x01(\x04R\x0esequenceNumber\x12P\n" +
 	"\x15process_status_update\x18\x03 \x01(\v2\x1a.felix.ProcessStatusUpdateH\x00R\x13processStatusUpdate\x12`\n" +
@@ -6520,17 +6520,17 @@ const file_felixbackend_proto_rawDesc = "" +
 	"public_key\x18\x01 \x01(\tR\tpublicKey\x12/\n" +
 	"\n" +
 	"ip_version\x18\x02 \x01(\x0e2\x10.felix.IPVersionR\tipVersion\"\x11\n" +
-	"\x0fDataplaneInSync\"\x88\x02\n" +
-	"\x16HostMetadataV4V6Update\x12\x1a\n" +
+	"\x0fDataplaneInSync\"\x80\x02\n" +
+	"\x12HostMetadataUpdate\x12\x1a\n" +
 	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
 	"\tipv4_addr\x18\x02 \x01(\tR\bipv4Addr\x12\x1b\n" +
 	"\tipv6_addr\x18\x03 \x01(\tR\bipv6Addr\x12\x1a\n" +
-	"\basnumber\x18\x04 \x01(\tR\basnumber\x12A\n" +
-	"\x06labels\x18\x05 \x03(\v2).felix.HostMetadataV4V6Update.LabelsEntryR\x06labels\x1a9\n" +
+	"\basnumber\x18\x04 \x01(\tR\basnumber\x12=\n" +
+	"\x06labels\x18\x05 \x03(\v2%.felix.HostMetadataUpdate.LabelsEntryR\x06labels\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"Q\n" +
-	"\x16HostMetadataV4V6Remove\x12\x1a\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"M\n" +
+	"\x12HostMetadataRemove\x12\x1a\n" +
 	"\bhostname\x18\x01 \x01(\tR\bhostname\x12\x1b\n" +
 	"\tipv4_addr\x18\x02 \x01(\tR\bipv4Addr\"E\n" +
 	"\x0eIPAMPoolUpdate\x12\x0e\n" +
@@ -6784,8 +6784,8 @@ var file_felixbackend_proto_goTypes = []any{
 	(*WorkloadEndpointStatusRemove)(nil), // 53: felix.WorkloadEndpointStatusRemove
 	(*WireguardStatusUpdate)(nil),        // 54: felix.WireguardStatusUpdate
 	(*DataplaneInSync)(nil),              // 55: felix.DataplaneInSync
-	(*HostMetadataV4V6Update)(nil),       // 56: felix.HostMetadataV4V6Update
-	(*HostMetadataV4V6Remove)(nil),       // 57: felix.HostMetadataV4V6Remove
+	(*HostMetadataUpdate)(nil),           // 56: felix.HostMetadataUpdate
+	(*HostMetadataRemove)(nil),           // 57: felix.HostMetadataRemove
 	(*IPAMPoolUpdate)(nil),               // 58: felix.IPAMPoolUpdate
 	(*IPAMPoolRemove)(nil),               // 59: felix.IPAMPoolRemove
 	(*IPAMPool)(nil),                     // 60: felix.IPAMPool
@@ -6819,7 +6819,7 @@ var file_felixbackend_proto_goTypes = []any{
 	(*HTTPMatch_PathMatch)(nil),          // 88: felix.HTTPMatch.PathMatch
 	nil,                                  // 89: felix.RuleMetadata.AnnotationsEntry
 	nil,                                  // 90: felix.WorkloadEndpoint.AnnotationsEntry
-	nil,                                  // 91: felix.HostMetadataV4V6Update.LabelsEntry
+	nil,                                  // 91: felix.HostMetadataUpdate.LabelsEntry
 	nil,                                  // 92: felix.ServiceAccountUpdate.LabelsEntry
 	nil,                                  // 93: felix.NamespaceUpdate.LabelsEntry
 }
@@ -6837,8 +6837,8 @@ var file_felixbackend_proto_depIdxs = []int32{
 	35,  // 10: felix.ToDataplane.workload_endpoint_update:type_name -> felix.WorkloadEndpointUpdate
 	41,  // 11: felix.ToDataplane.workload_endpoint_remove:type_name -> felix.WorkloadEndpointRemove
 	13,  // 12: felix.ToDataplane.config_update:type_name -> felix.ConfigUpdate
-	56,  // 13: felix.ToDataplane.host_metadata_v4v6_update:type_name -> felix.HostMetadataV4V6Update
-	57,  // 14: felix.ToDataplane.host_metadata_v4v6_remove:type_name -> felix.HostMetadataV4V6Remove
+	56,  // 13: felix.ToDataplane.host_metadata_update:type_name -> felix.HostMetadataUpdate
+	57,  // 14: felix.ToDataplane.host_metadata_remove:type_name -> felix.HostMetadataRemove
 	58,  // 15: felix.ToDataplane.ipam_pool_update:type_name -> felix.IPAMPoolUpdate
 	59,  // 16: felix.ToDataplane.ipam_pool_remove:type_name -> felix.IPAMPoolRemove
 	62,  // 17: felix.ToDataplane.service_account_update:type_name -> felix.ServiceAccountUpdate
@@ -6923,7 +6923,7 @@ var file_felixbackend_proto_depIdxs = []int32{
 	37,  // 96: felix.WorkloadEndpointStatusUpdate.endpoint:type_name -> felix.WorkloadEndpoint
 	34,  // 97: felix.WorkloadEndpointStatusRemove.id:type_name -> felix.WorkloadEndpointID
 	0,   // 98: felix.WireguardStatusUpdate.ip_version:type_name -> felix.IPVersion
-	91,  // 99: felix.HostMetadataV4V6Update.labels:type_name -> felix.HostMetadataV4V6Update.LabelsEntry
+	91,  // 99: felix.HostMetadataUpdate.labels:type_name -> felix.HostMetadataUpdate.LabelsEntry
 	60,  // 100: felix.IPAMPoolUpdate.pool:type_name -> felix.IPAMPool
 	64,  // 101: felix.ServiceAccountUpdate.id:type_name -> felix.ServiceAccountID
 	92,  // 102: felix.ServiceAccountUpdate.labels:type_name -> felix.ServiceAccountUpdate.LabelsEntry
@@ -6977,8 +6977,8 @@ func file_felixbackend_proto_init() {
 		(*ToDataplane_WorkloadEndpointUpdate)(nil),
 		(*ToDataplane_WorkloadEndpointRemove)(nil),
 		(*ToDataplane_ConfigUpdate)(nil),
-		(*ToDataplane_HostMetadataV4V6Update)(nil),
-		(*ToDataplane_HostMetadataV4V6Remove)(nil),
+		(*ToDataplane_HostMetadataUpdate)(nil),
+		(*ToDataplane_HostMetadataRemove)(nil),
 		(*ToDataplane_IpamPoolUpdate)(nil),
 		(*ToDataplane_IpamPoolRemove)(nil),
 		(*ToDataplane_ServiceAccountUpdate)(nil),

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -1031,7 +1031,7 @@ type ToDataplane_HostMetadataUpdate struct {
 }
 
 type ToDataplane_HostMetadataRemove struct {
-	// HostIPRemove is sent when a host is removed.
+	// HostMetadataRemove is sent when a host is removed.
 	HostMetadataRemove *HostMetadataRemove `protobuf:"bytes,18,opt,name=host_metadata_remove,json=hostMetadataRemove,proto3,oneof"`
 }
 

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -84,10 +84,10 @@ message ToDataplane {
     // ConfigUpdate is sent at start of day or when the config changes.
     ConfigUpdate config_update = 13;
 
-    // HostMetadataV4V6Update is sent when a host is added or updated.
-    HostMetadataV4V6Update host_metadata_v4v6_update = 37;
+    // HostMetadataUpdate is sent when a host is added or updated.
+    HostMetadataUpdate host_metadata_update = 37;
     // HostIPRemove is sent when a host is removed.
-    HostMetadataV4V6Remove host_metadata_v4v6_remove = 38;
+    HostMetadataRemove host_metadata_remove = 38;
 
     // IPAMPoolUpdate is sent when an IPAM pool is added/updated.
     IPAMPoolUpdate ipam_pool_update = 16;
@@ -132,8 +132,8 @@ message ToDataplane {
     // WireguardEndpointV6Remove is sent to undo IPv6 wireguard on the host.
     WireguardEndpointV6Remove wireguard_endpoint_v6_remove = 34;
   }
-  // Deprecated fields related to host information. Removed in favor of HostMetadataV4V6* messages.
-  reserved "HostMetadataUpdate", "HostMetadataRemove", "HostMetadataV6Update", "HostMetadataV6Remove";
+  // Deprecated fields related to host information. Replaced by host_metadata_update and host_metadata_remove.
+  reserved "HostMetadataV6Update", "HostMetadataV6Remove";
   reserved 14, 18, 35, 36;
 }
 
@@ -533,7 +533,7 @@ message WireguardStatusUpdate {
 message DataplaneInSync {
 }
 
-message HostMetadataV4V6Update {
+message HostMetadataUpdate {
   string hostname = 1;
   string ipv4_addr = 2;
   string ipv6_addr = 3;
@@ -541,7 +541,7 @@ message HostMetadataV4V6Update {
   map<string, string> labels = 5;
 }
 
-message HostMetadataV4V6Remove {
+message HostMetadataRemove {
   string hostname = 1;
   string ipv4_addr = 2;
 }

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -86,7 +86,7 @@ message ToDataplane {
 
     // HostMetadataUpdate is sent when a host is added or updated.
     HostMetadataUpdate host_metadata_update = 14;
-    // HostIPRemove is sent when a host is removed.
+    // HostMetadataRemove is sent when a host is removed.
     HostMetadataRemove host_metadata_remove = 18;
 
     // IPAMPoolUpdate is sent when an IPAM pool is added/updated.

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -85,9 +85,9 @@ message ToDataplane {
     ConfigUpdate config_update = 13;
 
     // HostMetadataUpdate is sent when a host is added or updated.
-    HostMetadataUpdate host_metadata_update = 37;
+    HostMetadataUpdate host_metadata_update = 14;
     // HostIPRemove is sent when a host is removed.
-    HostMetadataRemove host_metadata_remove = 38;
+    HostMetadataRemove host_metadata_remove = 18;
 
     // IPAMPoolUpdate is sent when an IPAM pool is added/updated.
     IPAMPoolUpdate ipam_pool_update = 16;
@@ -132,9 +132,9 @@ message ToDataplane {
     // WireguardEndpointV6Remove is sent to undo IPv6 wireguard on the host.
     WireguardEndpointV6Remove wireguard_endpoint_v6_remove = 34;
   }
-  // Deprecated fields related to host information. Replaced by host_metadata_update and host_metadata_remove.
-  reserved "HostMetadataV6Update", "HostMetadataV6Remove";
-  reserved 14, 18, 35, 36;
+  // Deprecated fields related to host information. Replaced by HostMetadataUpdate and HostMetadataRemove.
+  reserved "HostMetadataV6Update", "HostMetadataV6Remove", "HostMetadataV4V6Update", "HostMetadataV4V6Remove";
+  reserved 35, 36, 37, 38;
 }
 
 message FromDataplane {


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Following on deprecating `HostMetadata*` and `HostMetadaV6*` protobuf messages in favor of `HostMetadataV4V6` ones, since they include all necessary host information, in the previous PR: https://github.com/projectcalico/calico/pull/11284

This PR removes `V4V6` from `HostMetadavaV4V6*` messages, for sake of simplicity, effectively to `HostMetadata` ones.

`HostMetadavaV4V6*` messages were added initially in this PR: https://github.com/projectcalico/calico/pull/7042

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Renaming HostMetadaV4V6Update and HosMetadataV4V6Remove Felix internal protobuf messages to HostMetadataUpdate and HostMetadataRemove respectively.
```
