### PR TITLE
[v3.31] [BPF] Defer kube-proxy construction until first hostIPs

### DIFF
--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -102,7 +102,11 @@ func (kp *KubeProxy) Stop() {
 
 		close(kp.exiting)
 		close(kp.hostIPUpdates)
-		kp.proxy.Stop()
+		if kp.proxy != nil {
+			// kp.proxy is nil if Stop is called before start() has
+			// received its initial host IPs.
+			kp.proxy.Stop()
+		}
 		kp.wg.Wait()
 	})
 }
@@ -137,8 +141,26 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 		return errors.WithMessage(err, "new bpf syncer")
 	}
 
-	kp.proxy.SetHostIPs(hostIPs)
-	kp.proxy.SetSyncer(syncer)
+	if kp.proxy == nil {
+		// First call from start(): construct the proxy with a syncer
+		// that already knows the real host IPs. proxy.New() spins up
+		// the k8s informer goroutines synchronously, so by the time
+		// they sync and trigger an Apply, the syncer's desired state
+		// will include all (realHostIP, nodePort) FE entries.
+		// Constructing the proxy any earlier risks an Apply against a
+		// syncer that lacks real host IPs, which would gut pre-existing
+		// (realHostIP, nodePort) NAT FE entries left by the previous
+		// Felix run and break external NodePort traffic. See #12192.
+		proxy, err := New(kp.k8s, syncer, kp.hostname, kp.opts...)
+		if err != nil {
+			return errors.WithMessage(err, "new proxy")
+		}
+		proxy.SetHostIPs(hostIPs)
+		kp.proxy = proxy
+	} else {
+		kp.proxy.SetHostIPs(hostIPs)
+		kp.proxy.SetSyncer(syncer)
+	}
 
 	log.Infof("kube-proxy v%d node info updated, hostname=%q hostIPs=%+v", kp.ipFamily, kp.hostname, hostIPs)
 
@@ -148,33 +170,27 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 }
 
 func (kp *KubeProxy) start() error {
-	var withLocalNP []net.IP
-	if kp.ipFamily == 4 {
-		withLocalNP = append(withLocalNP, podNPIP)
-	} else {
-		withLocalNP = append(withLocalNP, podNPIPV6)
+	// Block until we have the first batch of host IPs. Only then
+	// construct the proxy, via run(). proxy.New() kicks off the k8s
+	// informer goroutines synchronously; once those sync, they trigger
+	// Apply on the syncer. Constructing the proxy before we have real
+	// host IPs lets that Apply run against a syncer whose desired
+	// state lacks every (realHostIP, nodePort) FE entry, which then
+	// erases pre-existing entries left by the previous Felix run and
+	// breaks external NodePort traffic during the kube-proxy bootstrap
+	// window. See projectcalico/calico#12192.
+	var hostIPs []net.IP
+	select {
+	case ips, ok := <-kp.hostIPUpdates:
+		if !ok {
+			return nil
+		}
+		hostIPs = ips
+	case <-kp.exiting:
+		return nil
 	}
 
-	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt, kp.excludedCIDRs)
-	if err != nil {
-		return errors.WithMessage(err, "new bpf syncer")
-	}
-
-	proxy, err := New(kp.k8s, syncer, kp.hostname, kp.opts...)
-	if err != nil {
-		return errors.WithMessage(err, "new proxy")
-	}
-
-	kp.lock.Lock()
-	kp.proxy = proxy
-	kp.syncer = syncer
-	kp.lock.Unlock()
-
-	// wait for the initial update
-	hostIPs := <-kp.hostIPUpdates
-
-	err = kp.run(hostIPs)
-	if err != nil {
+	if err := kp.run(hostIPs); err != nil {
 		return err
 	}
 
@@ -188,8 +204,7 @@ func (kp *KubeProxy) start() error {
 					log.Error("kube-proxy: hostIPUpdates closed")
 					return
 				}
-				err = kp.run(hostIPs)
-				if err != nil {
+				if err := kp.run(hostIPs); err != nil {
 					log.Panic("kube-proxy failed to resync after host IPs update")
 				}
 			case <-kp.exiting:

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/mock"
+	"github.com/projectcalico/calico/felix/bpf/nat"
 	proxy "github.com/projectcalico/calico/felix/bpf/proxy"
 )
 
@@ -151,5 +152,117 @@ var _ = Describe("BPF kube-proxy", func() {
 				return ip1ok && ip2ok
 			}).Should(BeTrue())
 		})
+	})
+})
+
+// Regression for projectcalico/calico#12192. Felix restart on a node
+// receiving NodePort traffic was breaking new TCP connections for ~500ms
+// — the bootstrap window between kube-proxy starting up and receiving
+// the first hostIPs. In that window, kube-proxy.go:start() used to
+// construct the proxy with a stub Syncer (only podNPIP, no real host
+// IPs). proxy.New() spins up the k8s informer goroutines synchronously;
+// once they sync, an Apply runs against the stub Syncer. The cachingmap
+// computes desired state without any (realHostIP, nodePort) FE entry
+// and erases pre-existing real-host-IP NodePort FE entries left by the
+// previous Felix run. New external TCP connections to the NodePort
+// during the gap miss the FE map, ascend to the host stack with no
+// listener, and get RST by the kernel.
+//
+// The fix defers proxy construction until the first hostIPUpdates has
+// arrived — i.e. until run() is called with real host IPs. This test
+// pre-populates the front map with a real-host-IP NodePort FE entry,
+// starts kube-proxy without firing OnHostIPsUpdate, and asserts the
+// entry survives the bootstrap window.
+var _ = Describe("BPF kube-proxy bootstrap window — regression #12192", func() {
+	realHostIP := net.IPv4(10, 0, 0, 99)
+	const nodePort = uint16(30000)
+
+	var (
+		bpfMaps *bpfmap.IPMaps
+		front   *mockNATMap
+		p       *proxy.KubeProxy
+	)
+
+	BeforeEach(func() {
+		bpfMaps = new(bpfmap.IPMaps)
+		bpfMaps.FrontendMap = newMockNATMap()
+		bpfMaps.BackendMap = newMockNATBackendMap()
+		bpfMaps.AffinityMap = newMockAffinityMap()
+		bpfMaps.CtMap = mock.NewMockMap(conntrack.MapParams)
+		front = bpfMaps.FrontendMap.(*mockNATMap)
+
+		// Marker entry simulating leftover state from the previous
+		// Felix run. Value is not meaningful — only presence matters.
+		markerKey := nat.NewNATKey(realHostIP, nodePort, proxy.ProtoV1ToIntPanic(v1.ProtocolTCP))
+		front.m[markerKey] = nat.NewNATValue(0xdeadbeef, 1, 0, 0)
+	})
+
+	AfterEach(func() {
+		if p != nil {
+			p.Stop()
+		}
+	})
+
+	It("does not erase pre-existing real-host-IP NodePort FE entries during the bootstrap window", func() {
+		testSvc := &v1.Service{
+			TypeMeta:   typeMetaV1("Service"),
+			ObjectMeta: objectMetaV1("regression-12192-svc"),
+			Spec: v1.ServiceSpec{
+				ClusterIP: "10.1.0.1",
+				Type:      v1.ServiceTypeNodePort,
+				Selector:  map[string]string{"app": "test"},
+				Ports: []v1.ServicePort{{
+					Protocol: v1.ProtocolTCP,
+					Port:     1234,
+					NodePort: int32(nodePort),
+				}},
+			},
+		}
+		testSvcEps := &discoveryv1.EndpointSlice{
+			TypeMeta:    typeMetaV1("EndpointSlice"),
+			ObjectMeta:  objectMetaV1("regression-12192-svc"),
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints:   []discoveryv1.Endpoint{{Addresses: []string{"10.1.2.1"}}},
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     ptr.To(int32(1234)),
+				Name:     ptr.To("http"),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}},
+		}
+		k8s := fake.NewClientset(testSvc, testSvcEps)
+
+		markerKey := nat.NewNATKey(realHostIP, nodePort, proxy.ProtoV1ToIntPanic(v1.ProtocolTCP))
+
+		var err error
+		p, err = proxy.StartKubeProxy(k8s, "test-node", bpfMaps, proxy.WithImmediateSync())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Withhold OnHostIPsUpdate to mimic the bootstrap window.
+		// With the buggy code, the proxy is constructed eagerly in
+		// start() with a stub Syncer; informers sync and trigger an
+		// Apply that erases the marker.
+		Consistently(func() bool {
+			front.Lock()
+			defer front.Unlock()
+			_, ok := front.m[markerKey]
+			return ok
+		}, "500ms", "20ms").Should(BeTrue(),
+			"pre-existing (realHostIP, nodePort) FE entry was erased during the kube-proxy bootstrap window")
+
+		// Now release the host-IPs gate. The proxy is constructed
+		// with real host IPs and informers fire their first Apply
+		// against a Syncer whose desired state includes the
+		// (realHostIP, nodePort) FE entry, so the entry stays
+		// (cachingmap updates it in place to the proxy-computed
+		// value).
+		p.OnHostIPsUpdate([]net.IP{realHostIP})
+
+		Eventually(func() bool {
+			front.Lock()
+			defer front.Unlock()
+			_, ok := front.m[markerKey]
+			return ok
+		}, "5s", "50ms").Should(BeTrue(),
+			"after host IPs propagated, real (realHostIP, nodePort) FE entry should remain")
 	})
 })


### PR DESCRIPTION
## Description

Cherry-pick of #12667 to `release-v3.31`. Felix restart on a node receiving NodePort traffic was breaking new TCP connections for ~500 ms — the bootstrap window between kube-proxy starting up and receiving the first hostIPs.

### Root cause

In that window, `kube-proxy.go:start()` constructed the proxy with a stub `Syncer` (only `podNPIP`, no real host IPs). `proxy.New()` spins up the k8s informer goroutines synchronously; once they sync, an Apply runs against the stub Syncer. The cachingmap computes desired state without any `(realHostIP, nodePort)` FE entry and erases pre-existing real-host-IP NodePort FE entries left by the previous Felix run.

New external TCP connections to the NodePort during the gap miss the FE map, ascend to the host stack with no listener, and get RST by the kernel. The wildcard FE entry does **not** cover external→HEP NodePort traffic (`nat_lookup.h:60-71` returns NULL on `CALI_F_FROM_HEP` without `from_tun`), so it provides no safety net.

### Fix

Defer proxy construction until the first `hostIPUpdates` has arrived, then construct the `Syncer` (with real host IPs) and the proxy in one shot via `run()`. The `KubeProxy.Conntrack*` callbacks already nil-check `kp.syncer`, so in-flight conntrack scans during the wait remain safe.

#### Deviation from master

Master uses an explicit "host-metadata in-sync" gate (added in #11817) that doesn't exist on this branch, so the cherry-pick gates only on the first `hostIPUpdate`. That fully fixes the stub-Syncer case (the reported bug). A residual race remains for multi-host-IP nodes if `hostIPUpdates` fires with a partial set before the iface monitor's initial resync completes; the master fix's metadata gate closes that gap and is not present here.

### Test

New regression test in `kube-proxy_test.go` pre-populates the front map with a real-host-IP NodePort FE entry, starts kube-proxy without firing `OnHostIPsUpdate` (mimicking the bootstrap window), and asserts via `Consistently` over 500 ms that the entry survives. The test fails on the unfixed 3.31 code (`Consistently` trips at ~125 ms) and passes with the fix.

End-to-end validated on a 3.31 BPF cluster with an external probe VM hitting a NodePort service while node-0's calico-node was restarted 5x:

| | New conns OK | New conns FAIL | Failure windows |
|---|---|---|---|
| **fixed (this PR)** | 10 378 | **0** | — |
| stock v3.31.5 | 6 133 | **87** | 5–6 windows, 259–730 ms each, 7–21 fails per window |

Long-lived connections survived in both runs (conntrack covers established flows).

## Related issues/PRs

Closes #12192. Cherry-pick of #12667.

## Release Note

```release-note
ebpf - Fix transient NodePort connection failures when Felix restarts on a node receiving external NodePort traffic.
```

## Reminder for the reviewer

- [x] `release-note-required`
- [x] `docs-not-required` (no user-facing config change; bug fix)