### PR TITLE
[BPF] Re-wire SetTriggerFn on syncer swap in proxy.SetSyncer

### DIFF
--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -365,6 +365,12 @@ func (p *proxy) SetSyncer(s DPSyncer) {
 	p.syncerLck.Lock()
 	p.dpSyncer.Stop()
 	p.dpSyncer = s
+	// Re-wire the trigger so that the new syncer's expand-NodePort fixup
+	// goroutine can schedule a dataplane Apply when previously-missed
+	// route lookups resolve. proxy.New() does this for the initial syncer;
+	// without it here, swapping in a fresh syncer (e.g. on a host-IP
+	// change) would silently lose that wakeup path.
+	s.SetTriggerFn(p.runner.Run)
 	p.syncerLck.Unlock()
 
 	p.forceSyncDP()

--- a/felix/bpf/proxy/proxy_test.go
+++ b/felix/bpf/proxy/proxy_test.go
@@ -69,6 +69,50 @@ var _ = Describe("BPF Proxy", func() {
 		})
 	})
 
+	It("should re-arm the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap", func() {
+		// expand-NodePort fixup (used for ExternalTrafficPolicy=Local
+		// NodePort services with remote endpoints) parks unresolved
+		// route lookups on a goroutine that calls back into the proxy
+		// via syncer.triggerFn() once the missing route arrives. proxy.New()
+		// wires that callback on the initial syncer; SetSyncer must do the
+		// same when swapping a fresh syncer in (e.g. on a host-IP change),
+		// otherwise local-policy NodePort traffic to backends that landed
+		// after the swap is silently never applied to the dataplane.
+		k8s := fake.NewClientset()
+		syncStop = make(chan struct{})
+
+		first := newMockSyncer(syncStop)
+		p, err := proxy.New(k8s, first, "testnode", proxy.WithImmediateSync())
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			close(syncStop)
+			p.Stop()
+		}()
+
+		// Drain the initial sync.
+		first.checkState(func(proxy.DPSyncerState) {})
+
+		// SetSyncer calls forceSyncDP synchronously, which calls Apply on
+		// the new syncer; that blocks until checkState drains it. Run
+		// SetSyncer in a goroutine so the test can drain in parallel.
+		second := newMockSyncer(syncStop)
+		go p.SetSyncer(second)
+
+		// Drain the forceSyncDP triggered by SetSyncer.
+		second.checkState(func(proxy.DPSyncerState) {})
+
+		// SetSyncer must have wired the fixup callback on the new syncer
+		// before any of its background goroutines could fire.
+		Expect(second.triggerFn).NotTo(BeNil(), "SetSyncer must wire the fixup callback on the new syncer")
+
+		// Simulate the fixup goroutine resolving a missed route by
+		// invoking the callback the syncer was handed. The proxy must
+		// schedule another Apply.
+		second.triggerFn()
+		second.checkState(func(proxy.DPSyncerState) {})
+	})
+
 	testSvc := &v1.Service{
 		TypeMeta:   typeMetaV1("Service"),
 		ObjectMeta: objectMetaV1("testService"),
@@ -645,12 +689,14 @@ var _ = Describe("BPF Proxy", func() {
 
 type mockSyncer struct {
 	syncerConntrackAPIDummy
-	out  chan proxy.DPSyncerState
-	in   chan error
-	stop chan struct{}
+	out       chan proxy.DPSyncerState
+	in        chan error
+	stop      chan struct{}
+	triggerFn func()
 }
 
 func (s *mockSyncer) SetTriggerFn(f func()) {
+	s.triggerFn = f
 }
 
 func newMockSyncer(stop chan struct{}) *mockSyncer {


### PR DESCRIPTION
## Description

`proxy.New()` wires the syncer's expand-NodePort fixup callback to the proxy's runner via `dp.SetTriggerFn(p.runner.Run)` (proxy.go:180). `proxy.SetSyncer()` swaps in a fresh syncer (e.g. on a host-IP change inside `KubeProxy.run()`) but did **not** re-wire that callback.

### Effect

The expand-NodePort fixup goroutine handles `ExternalTrafficPolicy=Local` NodePort services with backends on remote nodes whose routes were not yet programmed when the syncer first computed dataplane state. It re-runs `expandNodePorts` on each route-table change and, when a previously-missed route now resolves, calls `s.triggerFn()` to schedule an Apply (syncer.go:1216).

After any host-IP change, the new syncer that `KubeProxy.run()` hands to `SetSyncer` had `triggerFn = nil`, so the fixup's resolution was silently lost until some unrelated service/endpoint update piggybacked an Apply. In a quiet cluster, NodePort entries to backends on certain remote nodes could remain stale for an arbitrary period.

### Origin

The asymmetry is pre-existing — `kp.run()` always created a fresh syncer and called `SetSyncer` on it before #12667. But #12667 made it visible in the diff: the *first* call now also goes through this path's logical sibling (`proxy.New()`, which does set the trigger), making the missing wiring on `SetSyncer` plain to read. Caught on the v3.31 backport review (#12693).

### Fix

Have `proxy.SetSyncer` call `s.SetTriggerFn(p.runner.Run)` on the new syncer, under the same lock as the dpSyncer swap, mirroring what `proxy.New()` does for the initial syncer.

### Test

New regression test `should re-arm the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap` in `proxy_test.go` swaps a syncer via `SetSyncer`, verifies the new syncer received a non-nil trigger callback, and confirms invoking it schedules an Apply.

The test fails on master before this change with:
```
SetSyncer must wire the fixup callback on the new syncer
Expected <func()>: nil not to be nil
```

## Related issues/PRs

Follow-up to #12667. Surfaced during v3.31 backport review (#12693, comment thread on `kube-proxy.go:161`).

## Release Note

```release-note
ebpf - Fix kube-proxy losing the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap, which could cause stale NAT entries on remote backends.
```

## Reminder for the reviewer

- [x] `release-note-required`
- [x] `docs-not-required` (no user-facing config change; bug fix)
- [x] `cherry-pick-candidate` (bug fix; should be backported alongside #12693 / #12694)