### PR TITLE
Fix server-side apply on BGPConfiguration object lists

### DIFF
--- a/api/config/crd/projectcalico.org_bgpconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_bgpconfigurations.yaml
@@ -82,7 +82,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -204,7 +204,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -230,7 +230,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -246,7 +246,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -273,7 +273,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/api/pkg/apis/projectcalico/v3/bgpconfig.go
+++ b/api/pkg/apis/projectcalico/v3/bgpconfig.go
@@ -85,17 +85,17 @@ type BGPConfigurationSpec struct {
 
 	// ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes Service LoadBalancer IPs.
 	// Kubernetes Service status.LoadBalancer.Ingress IPs will only be advertised if they are within one of these blocks.
-	// +listType=set
+	// +listType=atomic
 	ServiceLoadBalancerIPs []ServiceLoadBalancerIPBlock `json:"serviceLoadBalancerIPs,omitempty" validate:"omitempty,dive" confignamev1:"svc_loadbalancer_ips"`
 
 	// ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
 	// Kubernetes Service ExternalIPs will only be advertised if they are within one of these blocks.
-	// +listType=set
+	// +listType=atomic
 	ServiceExternalIPs []ServiceExternalIPBlock `json:"serviceExternalIPs,omitempty" validate:"omitempty,dive" confignamev1:"svc_external_ips"`
 
 	// ServiceClusterIPs are the CIDR blocks from which service cluster IPs are allocated.
 	// If specified, Calico will advertise these blocks, as well as any cluster IPs within them.
-	// +listType=set
+	// +listType=atomic
 	ServiceClusterIPs []ServiceClusterIPBlock `json:"serviceClusterIPs,omitempty" validate:"omitempty,dive" confignamev1:"svc_cluster_ips"`
 
 	// ServiceLoadBalancerAggregation controls how LoadBalancer service IPs are advertised.
@@ -107,12 +107,12 @@ type BGPConfigurationSpec struct {
 
 	// Communities is a list of BGP community values and their arbitrary names for tagging routes.
 	// +kubebuilder:validation:MaxItems=500
-	// +listType=set
+	// +listType=atomic
 	Communities []Community `json:"communities,omitempty" validate:"omitempty,dive" confignamev1:"communities"`
 
 	// PrefixAdvertisements contains per-prefix advertisement configuration.
 	// +kubebuilder:validation:MaxItems=500
-	// +listType=set
+	// +listType=atomic
 	PrefixAdvertisements []PrefixAdvertisement `json:"prefixAdvertisements,omitempty" validate:"omitempty,dive" confignamev1:"prefix_advertisements"`
 
 	// ListenPort is the port where BGP protocol should listen. Defaults to 179

--- a/api/pkg/client/applyconfiguration_generated/internal/internal.go
+++ b/api/pkg/client/applyconfiguration_generated/internal/internal.go
@@ -87,7 +87,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.Community
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: ignoredInterfaces
       type:
         list:
@@ -126,7 +126,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.PrefixAdvertisement
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: programClusterRoutes
       type:
         scalar: string
@@ -135,13 +135,13 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.ServiceClusterIPBlock
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: serviceExternalIPs
       type:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.ServiceExternalIPBlock
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: serviceLoadBalancerAggregation
       type:
         scalar: string
@@ -150,7 +150,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.ServiceLoadBalancerIPBlock
-          elementRelationship: associative
+          elementRelationship: atomic
 - name: com.github.projectcalico.api.pkg.apis.projectcalico.v3.BGPDaemonStatus
   map:
     fields:

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -695,7 +695,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"serviceLoadBalancerIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -714,7 +714,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"serviceExternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -733,7 +733,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"serviceClusterIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -759,7 +759,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"communities": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -778,7 +778,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"prefixAdvertisements": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
@@ -80,7 +80,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -202,7 +202,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -228,7 +228,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -244,7 +244,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -271,7 +271,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -174,7 +174,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -296,7 +296,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -322,7 +322,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -338,7 +338,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -365,7 +365,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -184,7 +184,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -306,7 +306,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -332,7 +332,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -348,7 +348,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -375,7 +375,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -185,7 +185,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -307,7 +307,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -333,7 +333,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -349,7 +349,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -376,7 +376,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -178,7 +178,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -300,7 +300,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -326,7 +326,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -342,7 +342,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -369,7 +369,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -169,7 +169,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -291,7 +291,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -317,7 +317,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -333,7 +333,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -360,7 +360,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -169,7 +169,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -291,7 +291,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -317,7 +317,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -333,7 +333,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -360,7 +360,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -186,7 +186,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -308,7 +308,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -334,7 +334,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -350,7 +350,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -377,7 +377,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -83,7 +83,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -205,7 +205,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -231,7 +231,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -247,7 +247,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -274,7 +274,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -169,7 +169,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -291,7 +291,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -317,7 +317,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -333,7 +333,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -360,7 +360,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -34722,7 +34722,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -34844,7 +34844,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -34870,7 +34870,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -34886,7 +34886,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -34913,7 +34913,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -34722,7 +34722,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -34844,7 +34844,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -34870,7 +34870,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -34886,7 +34886,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -34913,7 +34913,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -34724,7 +34724,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   description:
                     IgnoredInterfaces indicates the network interfaces that
@@ -34846,7 +34846,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   maxItems: 500
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
                     ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
@@ -34872,7 +34872,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   description: |-
                     ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
@@ -34888,7 +34888,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   description: |-
@@ -34915,7 +34915,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,20 +9,22 @@ include ../lib.Makefile
 .PHONY: ut-validation
 ## Run CRD validation tests against the default K8s version.
 ut-validation: setup-envtest
+	mkdir -p report
 	$(DOCKER_RUN) \
 		-v $$(ls -d $(ENVTEST_DIR)/k8s/*-$(BUILDOS)-$(BUILDARCH) | tail -1):/envtest:ro \
 		-e KUBEBUILDER_ASSETS=/envtest \
 		$(CALICO_BUILD) \
-		go test -count=1 -v ./test/validation/...
+		gotestsum --junitfile test/report/ut-validation.xml -- -count=1 -v ./test/validation/...
 
 .PHONY: ut-validation-min-k8s
 ## Run CRD validation tests against the minimum supported K8s version (1.31).
 ut-validation-min-k8s: setup-envtest-min
+	mkdir -p report
 	$(DOCKER_RUN) \
 		-v $$(ls -d $(ENVTEST_DIR)/k8s/$(ENVTEST_MIN_K8S_MINOR)*-$(BUILDOS)-$(BUILDARCH) | tail -1):/envtest:ro \
 		-e KUBEBUILDER_ASSETS=/envtest \
 		$(CALICO_BUILD) \
-		go test -count=1 -v ./test/validation/...
+		gotestsum --junitfile test/report/ut-validation-min-k8s.xml -- -count=1 -v ./test/validation/...
 
 .PHONY: ci
 ## Run all test/ CI jobs.

--- a/test/validation/serverside_apply_test.go
+++ b/test/validation/serverside_apply_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	"context"
+	"testing"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// expectApplySucceeds asserts that a server-side apply of obj succeeds. This is
+// the same code path used by FluxCD, ArgoCD, and `kubectl apply --server-side`,
+// and exercises the structural-merge-diff schema built from the CRD's listType,
+// listMapKey, and mapType annotations. CRDs that misuse those annotations
+// (e.g. listType=set on a list of objects) fail to build a typed schema and
+// produce errors like "associative list without keys has an element that's a
+// map type", regardless of the spec content.
+func expectApplySucceeds(t *testing.T, obj client.Object) {
+	t.Helper()
+	ctx := context.Background()
+	err := testClient.Patch(ctx, obj, client.Apply,
+		client.FieldOwner("validation-test"),
+		client.ForceOwnership)
+	if err != nil {
+		t.Fatalf("expected server-side apply to succeed but got: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = testClient.Delete(context.Background(), obj)
+	})
+}
+
+// TestBGPConfiguration_ServerSideApply locks in the fix for
+// https://github.com/projectcalico/calico/issues/12700. Each of the object-list
+// fields below was tagged +listType=set in v3.32.0, which is invalid for lists
+// of objects and breaks any server-side-apply client. Apply must succeed for
+// all of them.
+func TestBGPConfiguration_ServerSideApply(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v3.BGPConfigurationSpec
+	}{
+		{
+			name: "serviceLoadBalancerIPs populated",
+			spec: v3.BGPConfigurationSpec{
+				ServiceLoadBalancerIPs: []v3.ServiceLoadBalancerIPBlock{
+					{CIDR: "10.0.0.0/24"},
+					{CIDR: "10.1.0.0/24"},
+				},
+			},
+		},
+		{
+			name: "serviceExternalIPs populated",
+			spec: v3.BGPConfigurationSpec{
+				ServiceExternalIPs: []v3.ServiceExternalIPBlock{
+					{CIDR: "192.168.0.0/24"},
+				},
+			},
+		},
+		{
+			name: "serviceClusterIPs populated",
+			spec: v3.BGPConfigurationSpec{
+				ServiceClusterIPs: []v3.ServiceClusterIPBlock{
+					{CIDR: "172.16.0.0/16"},
+				},
+			},
+		},
+		{
+			name: "communities populated",
+			spec: v3.BGPConfigurationSpec{
+				Communities: []v3.Community{
+					{Name: "my-community", Value: "65001:100"},
+				},
+				PrefixAdvertisements: []v3.PrefixAdvertisement{
+					{CIDR: "10.0.0.0/24", Communities: []string{"my-community"}},
+				},
+			},
+		},
+		{
+			name: "prefixAdvertisements populated",
+			spec: v3.BGPConfigurationSpec{
+				PrefixAdvertisements: []v3.PrefixAdvertisement{
+					{CIDR: "10.0.0.0/24", Communities: []string{"65001:100"}},
+				},
+			},
+		},
+		{
+			name: "all object lists populated together",
+			spec: v3.BGPConfigurationSpec{
+				ServiceLoadBalancerIPs: []v3.ServiceLoadBalancerIPBlock{{CIDR: "10.0.0.0/24"}},
+				ServiceExternalIPs:     []v3.ServiceExternalIPBlock{{CIDR: "192.168.0.0/24"}},
+				ServiceClusterIPs:      []v3.ServiceClusterIPBlock{{CIDR: "172.16.0.0/16"}},
+				Communities:            []v3.Community{{Name: "my-community", Value: "65001:100"}},
+				PrefixAdvertisements: []v3.PrefixAdvertisement{
+					{CIDR: "10.0.0.0/24", Communities: []string{"my-community"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &v3.BGPConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v3.GroupVersionCurrent,
+					Kind:       v3.KindBGPConfiguration,
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: uniqueName("bgpconfig-ssa")},
+				Spec:       tt.spec,
+			}
+			expectApplySucceeds(t, obj)
+		})
+	}
+}


### PR DESCRIPTION
The `serviceLoadBalancerIPs`, `serviceExternalIPs`, `serviceClusterIPs`, `communities`, and `prefixAdvertisements` fields on BGPConfiguration are tagged `+listType=set`, but their elements are objects. Server-side apply only permits `listType=set` on lists of scalars, so any SSA-based tool (FluxCD, `kubectl apply --server-side`, ArgoCD) fails with:

```
failed to convert new object to smd typed: .spec.serviceLoadBalancerIPs: element 0: associative list without keys has an element that's a map type
```

This regressed in v3.32.0 when the `+listType=set` markers were added during the v3 CRD work in #10447. Pre-3.32 CRDs had no list-type annotation, which SSA treats as atomic.

Switching these five fields to `+listType=atomic` restores the pre-3.32 SSA behavior. `IgnoredInterfaces` is `[]string` so its `+listType=set` annotation is correct and is left alone.

## Why atomic and not map

`+listType=map` with `+listMapKey=cidr` (or `name` for communities) would be the more expressive long-term shape — it lets multiple controllers manage different elements of the list independently. I went with `atomic` here because:

- Pre-3.32 CRDs had no `listType` annotation, which SSA treats as atomic. `atomic` is a true restoration of the prior behavior; `map` introduces new SSA semantics that nobody has been running against.
- `listType=map` requires the key field to be required, immutable, and non-empty. The `cidr` field on `ServiceLoadBalancerIPBlock` (and friends) is currently `omitempty` and not required, so converting cleanly would mean tightening the schema — a breaking change on a stable v3 API.
- This needs to cherry-pick to release branches; the smallest behavior-preserving fix is the right shape for a backport.

The `listType=map` conversion is a worthwhile follow-up for master only, alongside making the key fields required.

Fixes https://github.com/projectcalico/calico/issues/12700

```release-note
Fix server-side apply (FluxCD, ArgoCD, `kubectl apply --server-side`) failures on BGPConfiguration resources that set serviceLoadBalancerIPs, serviceExternalIPs, serviceClusterIPs, communities, or prefixAdvertisements.
```
