### PR TITLE
Use kubebuilder markers for numorstring int-or-string types

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -63,7 +63,7 @@ build: gen-files examples
 .PHONY: gen-files
 gen-files .generate_files: lint-cache-dir clean-generated
 	# Generate CRDs
-	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) controller-gen crd:allowDangerousTypes=true,crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false paths=./pkg/apis/... output:crd:dir=config/crd/'
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0 crd:allowDangerousTypes=true,crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false paths=./pkg/apis/... output:crd:dir=config/crd/'
 	# Remove the first yaml separator line.
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'find ./config/crd -name "*.yaml" | xargs sed -i 1d'
 	# Run prettier to fix indentation

--- a/api/config/crd/projectcalico.org_felixconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_felixconfigurations.yaml
@@ -436,9 +436,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -447,6 +444,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -940,10 +938,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -1052,13 +1048,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-

--- a/api/config/crd/projectcalico.org_globalnetworkpolicies.yaml
+++ b/api/config/crd/projectcalico.org_globalnetworkpolicies.yaml
@@ -129,10 +129,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -152,10 +150,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -371,18 +367,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -391,6 +382,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -438,10 +430,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -461,10 +451,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -685,10 +673,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -708,10 +694,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -927,18 +911,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -947,6 +926,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -994,10 +974,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -1017,10 +995,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/api/config/crd/projectcalico.org_hostendpoints.yaml
+++ b/api/config/crd/projectcalico.org_hostendpoints.yaml
@@ -103,10 +103,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name

--- a/api/config/crd/projectcalico.org_networkpolicies.yaml
+++ b/api/config/crd/projectcalico.org_networkpolicies.yaml
@@ -114,10 +114,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -137,10 +135,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -356,18 +352,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -376,6 +367,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -423,10 +415,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -446,10 +436,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -670,10 +658,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -693,10 +679,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -912,18 +896,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -932,6 +911,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -979,10 +959,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -1002,10 +980,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/api/config/crd/projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/api/config/crd/projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -126,10 +126,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -149,10 +147,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -368,18 +364,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -388,6 +379,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -435,10 +427,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -458,10 +448,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -682,10 +670,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -705,10 +691,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -924,18 +908,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -944,6 +923,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -991,10 +971,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -1014,10 +992,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/api/config/crd/projectcalico.org_stagednetworkpolicies.yaml
+++ b/api/config/crd/projectcalico.org_stagednetworkpolicies.yaml
@@ -117,10 +117,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -140,10 +138,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -359,18 +355,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -379,6 +370,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -426,10 +418,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -449,10 +439,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -673,10 +661,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -696,10 +682,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -915,18 +899,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -935,6 +914,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -982,10 +962,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -1005,10 +983,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/api/pkg/lib/numorstring/port.go
+++ b/api/pkg/lib/numorstring/port.go
@@ -28,6 +28,10 @@ import (
 //   - For a port range, set MinPort and MaxPort to the (inclusive) port numbers.  Set
 //     PortName to "".
 //   - For a single port, set MinPort = MaxPort and PortName = "".
+//
+// +kubebuilder:validation:Type=string
+// +kubebuilder:validation:XIntOrString
+// +kubebuilder:validation:Pattern=`^.*`
 type Port struct {
 	MinPort  uint16 `json:"minPort,omitempty"`
 	MaxPort  uint16 `json:"maxPort,omitempty"`

--- a/api/pkg/lib/numorstring/protocol.go
+++ b/api/pkg/lib/numorstring/protocol.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,9 @@ var (
 	}
 )
 
+// +kubebuilder:validation:Type=integer
+// +kubebuilder:validation:XIntOrString
+// +kubebuilder:validation:Pattern=`^.*`
 type Protocol Uint8OrString
 
 // ProtocolFromInt creates a Protocol struct from an integer value.

--- a/api/pkg/lib/numorstring/uint8orstring.go
+++ b/api/pkg/lib/numorstring/uint8orstring.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@ import (
 // JSON or YAML marshalling and unmarshalling, it produces or consumes the
 // inner type.  This allows you to have, for example, a JSON field that can
 // accept a name or number.
+//
+// +kubebuilder:validation:Type=integer
+// +kubebuilder:validation:XIntOrString
+// +kubebuilder:validation:Pattern=`^.*`
 type Uint8OrString struct {
 	Type   NumOrStringType `json:"type"`
 	NumVal uint8           `json:"numVal"`

--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -48,7 +48,7 @@ gen-files: gen-crds
 gen-crds:
 	rm -rf config/crd
 	# Generate CRDs
-	$(DOCKER_GO_BUILD) sh -c '$(GIT_CONFIG_SSH) controller-gen crd:allowDangerousTypes=true,crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false paths=./lib/apis/... output:crd:dir=config/crd/'
+	$(DOCKER_GO_BUILD) sh -c '$(GIT_CONFIG_SSH) go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0 crd:allowDangerousTypes=true,crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false paths=./lib/apis/... output:crd:dir=config/crd/'
 	rm -f config/crd/_.yaml
 	rm -f config/crd/_nodes.yaml
 	# Remove the first yaml separator line.

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -437,9 +437,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -448,6 +445,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -941,10 +939,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -1053,13 +1049,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-

--- a/libcalico-go/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -116,10 +116,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -139,10 +137,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -358,18 +354,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -378,6 +369,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -425,10 +417,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -448,10 +438,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -672,10 +660,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -695,10 +681,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -914,18 +898,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -934,6 +913,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -981,10 +961,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -1004,10 +982,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/libcalico-go/config/crd/crd.projectcalico.org_hostendpoints.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_hostendpoints.yaml
@@ -89,10 +89,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name

--- a/libcalico-go/config/crd/crd.projectcalico.org_networkpolicies.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_networkpolicies.yaml
@@ -104,10 +104,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -127,10 +125,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -346,18 +342,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -366,6 +357,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -413,10 +405,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -436,10 +426,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -660,10 +648,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -683,10 +669,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -902,18 +886,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -922,6 +901,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -969,10 +949,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -992,10 +970,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/libcalico-go/config/crd/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -116,10 +116,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -139,10 +137,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -358,18 +354,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -378,6 +369,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -425,10 +417,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -448,10 +438,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -672,10 +660,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -695,10 +681,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -914,18 +898,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -934,6 +913,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -981,10 +961,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -1004,10 +982,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/libcalico-go/config/crd/crd.projectcalico.org_stagednetworkpolicies.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_stagednetworkpolicies.yaml
@@ -104,10 +104,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -127,10 +125,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -346,18 +342,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -366,6 +357,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -413,10 +405,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -436,10 +426,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -660,10 +648,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -683,10 +669,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -902,18 +886,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -922,6 +901,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -969,10 +949,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -992,10 +970,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -2462,9 +2462,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2473,6 +2470,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2966,10 +2964,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3078,13 +3074,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3613,10 +3607,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3636,10 +3628,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3855,18 +3845,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3875,6 +3860,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3922,10 +3908,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3945,10 +3929,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4169,10 +4151,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4192,10 +4172,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4411,18 +4389,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4431,6 +4404,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4478,10 +4452,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4501,10 +4473,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4947,10 +4917,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6174,10 +6142,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6197,10 +6163,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6416,18 +6380,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6436,6 +6395,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6483,10 +6443,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6506,10 +6464,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6730,10 +6686,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6753,10 +6707,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6972,18 +6924,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6992,6 +6939,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7039,10 +6987,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7062,10 +7008,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7496,10 +7440,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7519,10 +7461,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7738,18 +7678,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7758,6 +7693,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7805,10 +7741,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7828,10 +7762,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8052,10 +7984,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8075,10 +8005,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8294,18 +8222,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8314,6 +8237,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8361,10 +8285,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8384,10 +8306,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9328,10 +9248,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9351,10 +9269,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9570,18 +9486,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9590,6 +9501,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9637,10 +9549,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9660,10 +9570,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9884,10 +9792,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9907,10 +9813,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10126,18 +10030,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10146,6 +10045,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10193,10 +10093,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10216,10 +10114,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -2472,9 +2472,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2483,6 +2480,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2976,10 +2974,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3088,13 +3084,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3623,10 +3617,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3646,10 +3638,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3865,18 +3855,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3885,6 +3870,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3932,10 +3918,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3955,10 +3939,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4179,10 +4161,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4202,10 +4182,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4421,18 +4399,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4441,6 +4414,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4488,10 +4462,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4511,10 +4483,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4957,10 +4927,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6184,10 +6152,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6207,10 +6173,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6426,18 +6390,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6446,6 +6405,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6493,10 +6453,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6516,10 +6474,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6740,10 +6696,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6763,10 +6717,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6982,18 +6934,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7002,6 +6949,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7049,10 +6997,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7072,10 +7018,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7506,10 +7450,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7529,10 +7471,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7748,18 +7688,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7768,6 +7703,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7815,10 +7751,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7838,10 +7772,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8062,10 +7994,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8085,10 +8015,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8304,18 +8232,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8324,6 +8247,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8371,10 +8295,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8394,10 +8316,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9338,10 +9258,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9361,10 +9279,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9580,18 +9496,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9600,6 +9511,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9647,10 +9559,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9670,10 +9580,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9894,10 +9802,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9917,10 +9823,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10136,18 +10040,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10156,6 +10055,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10203,10 +10103,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10226,10 +10124,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -2473,9 +2473,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2484,6 +2481,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2977,10 +2975,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3089,13 +3085,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3624,10 +3618,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3647,10 +3639,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3866,18 +3856,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3886,6 +3871,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3933,10 +3919,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3956,10 +3940,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4180,10 +4162,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4203,10 +4183,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4422,18 +4400,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4442,6 +4415,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4489,10 +4463,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4512,10 +4484,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4958,10 +4928,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6185,10 +6153,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6208,10 +6174,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6427,18 +6391,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6447,6 +6406,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6494,10 +6454,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6517,10 +6475,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6741,10 +6697,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6764,10 +6718,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6983,18 +6935,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7003,6 +6950,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7050,10 +6998,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7073,10 +7019,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7507,10 +7451,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7530,10 +7472,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7749,18 +7689,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7769,6 +7704,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7816,10 +7752,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7839,10 +7773,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8063,10 +7995,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8086,10 +8016,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8305,18 +8233,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8325,6 +8248,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8372,10 +8296,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8395,10 +8317,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9339,10 +9259,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9362,10 +9280,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9581,18 +9497,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9601,6 +9512,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9648,10 +9560,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9671,10 +9581,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9895,10 +9803,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9918,10 +9824,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10137,18 +10041,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10157,6 +10056,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10204,10 +10104,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10227,10 +10125,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -2571,9 +2571,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2582,6 +2579,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -3075,10 +3073,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3187,13 +3183,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3738,10 +3732,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3761,10 +3753,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3980,18 +3970,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4000,6 +3985,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4047,10 +4033,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4070,10 +4054,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4294,10 +4276,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4317,10 +4297,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4536,18 +4514,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4556,6 +4529,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4603,10 +4577,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4626,10 +4598,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -5099,10 +5069,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6459,10 +6427,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6482,10 +6448,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6701,18 +6665,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6721,6 +6680,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6768,10 +6728,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6791,10 +6749,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7015,10 +6971,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7038,10 +6992,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7257,18 +7209,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7277,6 +7224,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7324,10 +7272,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7347,10 +7293,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7799,10 +7743,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7822,10 +7764,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8041,18 +7981,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8061,6 +7996,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8108,10 +8044,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8131,10 +8065,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8355,10 +8287,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8378,10 +8308,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8597,18 +8525,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8617,6 +8540,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8664,10 +8588,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8687,10 +8609,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9656,10 +9576,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9679,10 +9597,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9898,18 +9814,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9918,6 +9829,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9965,10 +9877,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9988,10 +9898,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10212,10 +10120,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10235,10 +10141,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10454,18 +10358,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10474,6 +10373,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10521,10 +10421,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10544,10 +10442,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -2457,9 +2457,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2468,6 +2465,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2961,10 +2959,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3073,13 +3069,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3608,10 +3602,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3631,10 +3623,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3850,18 +3840,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3870,6 +3855,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3917,10 +3903,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3940,10 +3924,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4164,10 +4146,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4187,10 +4167,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4406,18 +4384,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4426,6 +4399,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4473,10 +4447,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4496,10 +4468,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4942,10 +4912,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6169,10 +6137,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6192,10 +6158,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6411,18 +6375,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6431,6 +6390,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6478,10 +6438,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6501,10 +6459,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6725,10 +6681,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6748,10 +6702,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6967,18 +6919,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6987,6 +6934,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7034,10 +6982,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7057,10 +7003,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7491,10 +7435,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7514,10 +7456,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7733,18 +7673,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7753,6 +7688,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7800,10 +7736,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7823,10 +7757,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8047,10 +7979,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8070,10 +8000,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8289,18 +8217,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8309,6 +8232,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8356,10 +8280,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8379,10 +8301,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9323,10 +9243,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9346,10 +9264,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9565,18 +9481,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9585,6 +9496,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9632,10 +9544,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9655,10 +9565,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9879,10 +9787,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9902,10 +9808,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10121,18 +10025,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10141,6 +10040,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10188,10 +10088,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10211,10 +10109,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -2457,9 +2457,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2468,6 +2465,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2961,10 +2959,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3073,13 +3069,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3608,10 +3602,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3631,10 +3623,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3850,18 +3840,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3870,6 +3855,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3917,10 +3903,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3940,10 +3924,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4164,10 +4146,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4187,10 +4167,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4406,18 +4384,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4426,6 +4399,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4473,10 +4447,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4496,10 +4468,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4942,10 +4912,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6169,10 +6137,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6192,10 +6158,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6411,18 +6375,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6431,6 +6390,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6478,10 +6438,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6501,10 +6459,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6725,10 +6681,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6748,10 +6702,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6967,18 +6919,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6987,6 +6934,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7034,10 +6982,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7057,10 +7003,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7491,10 +7435,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7514,10 +7456,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7733,18 +7673,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7753,6 +7688,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7800,10 +7736,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7823,10 +7757,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8047,10 +7979,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8070,10 +8000,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8289,18 +8217,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8309,6 +8232,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8356,10 +8280,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8379,10 +8301,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9323,10 +9243,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9346,10 +9264,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9565,18 +9481,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9585,6 +9496,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9632,10 +9544,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9655,10 +9565,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9879,10 +9787,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9902,10 +9808,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10121,18 +10025,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10141,6 +10040,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10188,10 +10088,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10211,10 +10109,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -2474,9 +2474,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2485,6 +2482,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2978,10 +2976,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3090,13 +3086,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3625,10 +3619,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3648,10 +3640,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3867,18 +3857,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3887,6 +3872,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3934,10 +3920,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3957,10 +3941,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4181,10 +4163,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4204,10 +4184,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4423,18 +4401,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4443,6 +4416,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4490,10 +4464,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4513,10 +4485,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4959,10 +4929,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6186,10 +6154,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6209,10 +6175,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6428,18 +6392,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6448,6 +6407,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6495,10 +6455,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6518,10 +6476,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6742,10 +6698,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6765,10 +6719,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6984,18 +6936,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7004,6 +6951,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7051,10 +6999,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7074,10 +7020,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7508,10 +7452,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7531,10 +7473,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7750,18 +7690,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7770,6 +7705,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7817,10 +7753,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7840,10 +7774,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8064,10 +7996,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8087,10 +8017,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8306,18 +8234,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8326,6 +8249,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8373,10 +8297,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8396,10 +8318,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9340,10 +9260,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9363,10 +9281,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9582,18 +9498,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9602,6 +9513,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9649,10 +9561,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9672,10 +9582,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9896,10 +9804,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9919,10 +9825,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10138,18 +10042,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10158,6 +10057,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10205,10 +10105,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10228,10 +10126,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2371,9 +2371,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2382,6 +2379,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2875,10 +2873,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -2987,13 +2983,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3522,10 +3516,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3545,10 +3537,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3764,18 +3754,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3784,6 +3769,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3831,10 +3817,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3854,10 +3838,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4078,10 +4060,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4101,10 +4081,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4320,18 +4298,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4340,6 +4313,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4387,10 +4361,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4410,10 +4382,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4856,10 +4826,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6083,10 +6051,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6106,10 +6072,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6325,18 +6289,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6345,6 +6304,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6392,10 +6352,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6415,10 +6373,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6639,10 +6595,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6662,10 +6616,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6881,18 +6833,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6901,6 +6848,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6948,10 +6896,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6971,10 +6917,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7405,10 +7349,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7428,10 +7370,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7647,18 +7587,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7667,6 +7602,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7714,10 +7650,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7737,10 +7671,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7961,10 +7893,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7984,10 +7914,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8203,18 +8131,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8223,6 +8146,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8270,10 +8194,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8293,10 +8215,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9237,10 +9157,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9260,10 +9178,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9479,18 +9395,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9499,6 +9410,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9546,10 +9458,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9569,10 +9479,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9793,10 +9701,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9816,10 +9722,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10035,18 +9939,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10055,6 +9954,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10102,10 +10002,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10125,10 +10023,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -2457,9 +2457,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -2468,6 +2465,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -2961,10 +2959,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -3073,13 +3069,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -3608,10 +3602,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3631,10 +3623,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3850,18 +3840,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -3870,6 +3855,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -3917,10 +3903,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -3940,10 +3924,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4164,10 +4146,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4187,10 +4167,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4406,18 +4384,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -4426,6 +4399,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -4473,10 +4447,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4496,10 +4468,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -4942,10 +4912,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -6169,10 +6137,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6192,10 +6158,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6411,18 +6375,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6431,6 +6390,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -6478,10 +6438,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6501,10 +6459,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6725,10 +6681,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6748,10 +6702,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -6967,18 +6919,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -6987,6 +6934,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7034,10 +6982,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7057,10 +7003,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7491,10 +7435,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7514,10 +7456,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7733,18 +7673,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -7753,6 +7688,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -7800,10 +7736,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -7823,10 +7757,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8047,10 +7979,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8070,10 +8000,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8289,18 +8217,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -8309,6 +8232,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -8356,10 +8280,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -8379,10 +8301,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9323,10 +9243,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9346,10 +9264,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9565,18 +9481,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -9585,6 +9496,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -9632,10 +9544,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9655,10 +9565,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9879,10 +9787,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -9902,10 +9808,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10121,18 +10025,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -10141,6 +10040,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -10188,10 +10088,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -10211,10 +10109,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -37010,9 +37010,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -37021,6 +37018,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -37514,10 +37512,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -37626,13 +37622,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -38161,10 +38155,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38184,10 +38176,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38403,18 +38393,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -38423,6 +38408,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -38470,10 +38456,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38493,10 +38477,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38717,10 +38699,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38740,10 +38720,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38959,18 +38937,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -38979,6 +38952,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -39026,10 +39000,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39049,10 +39021,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39495,10 +39465,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -40722,10 +40690,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -40745,10 +40711,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -40964,18 +40928,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -40984,6 +40943,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -41031,10 +40991,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41054,10 +41012,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41278,10 +41234,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41301,10 +41255,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41520,18 +41472,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -41540,6 +41487,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -41587,10 +41535,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41610,10 +41556,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42044,10 +41988,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42067,10 +42009,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42286,18 +42226,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -42306,6 +42241,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -42353,10 +42289,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42376,10 +42310,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42600,10 +42532,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42623,10 +42553,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42842,18 +42770,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -42862,6 +42785,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -42909,10 +42833,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42932,10 +42854,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -43876,10 +43796,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -43899,10 +43817,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44118,18 +44034,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -44138,6 +44049,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -44185,10 +44097,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44208,10 +44118,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44432,10 +44340,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44455,10 +44361,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44674,18 +44578,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -44694,6 +44593,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -44741,10 +44641,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44764,10 +44662,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -37010,9 +37010,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -37021,6 +37018,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -37514,10 +37512,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -37626,13 +37622,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -38161,10 +38155,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38184,10 +38176,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38403,18 +38393,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -38423,6 +38408,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -38470,10 +38456,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38493,10 +38477,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38717,10 +38699,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38740,10 +38720,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38959,18 +38937,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -38979,6 +38952,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -39026,10 +39000,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39049,10 +39021,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39495,10 +39465,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -40722,10 +40690,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -40745,10 +40711,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -40964,18 +40928,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -40984,6 +40943,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -41031,10 +40991,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41054,10 +41012,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41278,10 +41234,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41301,10 +41255,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41520,18 +41472,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -41540,6 +41487,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -41587,10 +41535,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41610,10 +41556,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42044,10 +41988,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42067,10 +42009,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42286,18 +42226,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -42306,6 +42241,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -42353,10 +42289,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42376,10 +42310,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42600,10 +42532,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42623,10 +42553,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42842,18 +42770,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -42862,6 +42785,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -42909,10 +42833,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42932,10 +42854,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -43876,10 +43796,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -43899,10 +43817,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44118,18 +44034,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -44138,6 +44049,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -44185,10 +44097,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44208,10 +44118,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44432,10 +44340,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44455,10 +44361,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44674,18 +44578,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -44694,6 +44593,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -44741,10 +44641,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44764,10 +44662,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -37117,9 +37117,6 @@ spec:
                     tunnel IPs).
                   type: integer
                 bpfPSNATPorts:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
                     collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
@@ -37128,6 +37125,7 @@ spec:
                     a problem if this range overlaps with the operating systems. Both ends of the range are
                     inclusive. [Default: 20000:29999]
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 bpfPolicyDebugEnabled:
                   description: |-
@@ -37621,10 +37619,8 @@ spec:
                     KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
                     Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
                   items:
-                    anyOf:
-                      - type: integer
-                      - type: string
                     pattern: ^.*
+                    type: string
                     x-kubernetes-int-or-string: true
                   maxItems: 7
                   type: array
@@ -37733,13 +37729,11 @@ spec:
                     - IPPoolsAndHostIPs
                   type: string
                 natPortRange:
-                  anyOf:
-                    - type: integer
-                    - type: string
                   description: |-
                     NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
                     network stack is used.
                   pattern: ^.*
+                  type: string
                   x-kubernetes-int-or-string: true
                 netlinkTimeout:
                   description: |-
@@ -38284,10 +38278,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38307,10 +38299,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38526,18 +38516,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -38546,6 +38531,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -38593,10 +38579,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38616,10 +38600,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38840,10 +38822,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -38863,10 +38843,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39082,18 +39060,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -39102,6 +39075,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -39149,10 +39123,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39172,10 +39144,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -39645,10 +39615,8 @@ spec:
                         minimum: 1
                         type: integer
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                     required:
                       - name
@@ -41005,10 +40973,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41028,10 +40994,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41247,18 +41211,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -41267,6 +41226,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -41314,10 +41274,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41337,10 +41295,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41561,10 +41517,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41584,10 +41538,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41803,18 +41755,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -41823,6 +41770,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -41870,10 +41818,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -41893,10 +41839,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42345,10 +42289,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42368,10 +42310,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42587,18 +42527,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -42607,6 +42542,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -42654,10 +42590,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42677,10 +42611,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42901,10 +42833,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -42924,10 +42854,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -43143,18 +43071,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -43163,6 +43086,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -43210,10 +43134,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -43233,10 +43155,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44202,10 +44122,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44225,10 +44143,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44444,18 +44360,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -44464,6 +44375,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -44511,10 +44423,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44534,10 +44444,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44758,10 +44666,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -44781,10 +44687,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -45000,18 +44904,13 @@ spec:
                             reason: FieldValueInvalid
                             rule: "!has(self.code) || has(self.type)"
                       notProtocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description:
                           NotProtocol is the negated version of the Protocol
                           field.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       protocol:
-                        anyOf:
-                          - type: integer
-                          - type: string
                         description: |-
                           Protocol is an optional field that restricts the rule to only apply to traffic of
                           a specific IP protocol. Required if any of the EntityRules contain Ports
@@ -45020,6 +44919,7 @@ spec:
                           Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
                           or an integer in the range 1-255.
                         pattern: ^.*
+                        type: integer
                         x-kubernetes-int-or-string: true
                       source:
                         description:
@@ -45067,10 +44967,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array
@@ -45090,10 +44988,8 @@ spec:
                               Since only some protocols have ports, if any ports are specified it requires the
                               Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
                             items:
-                              anyOf:
-                                - type: integer
-                                - type: string
                               pattern: ^.*
+                              type: string
                               x-kubernetes-int-or-string: true
                             maxItems: 50
                             type: array


### PR DESCRIPTION
Alternative to https://github.com/projectcalico/calico/pull/12643. Adds three kubebuilder markers to each of `numorstring.Port`, `numorstring.Protocol`, and `numorstring.Uint8OrString` so vanilla controller-gen produces the correct CRD output without needing the patched controller-gen baked into `calico/go-build`.

Mirrors the existing pattern on `numorstring.DSCP`, which has been using these markers on master already.

Switches the `api` and `libcalico-go` Makefiles to invoke controller-gen via `go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0` so the upstream binary runs instead of the patched one in PATH.

The output collapses to `type: integer` (or `string`) plus `x-kubernetes-int-or-string: true`, instead of `anyOf: [integer, string]` plus `x-kubernetes-int-or-string: true`. The two forms are functionally identical at the API server, which special-cases `x-kubernetes-int-or-string` and accepts both regardless of declared type. DSCP fields on master already use this exact form.

The `IPAMBlock.allocations` nullable patch still applies cleanly with vanilla controller-gen and is left as-is.

## Follow-ups

- Drop the controller-gen patches from the `projectcalico/toolchain` `calico-go-build` image once this lands.

```release-note
None
```