### PR TITLE
[release-v3.32] Fix server-side apply on BGPConfiguration object lists

### DIFF
--- a/api/config/crd/projectcalico.org_bgpconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_bgpconfigurations.yaml
@@ -48,7 +48,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -107,7 +107,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -122,7 +122,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -132,7 +132,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -148,7 +148,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/api/pkg/apis/projectcalico/v3/bgpconfig.go
+++ b/api/pkg/apis/projectcalico/v3/bgpconfig.go
@@ -84,17 +84,17 @@ type BGPConfigurationSpec struct {
 
 	// ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes Service LoadBalancer IPs.
 	// Kubernetes Service status.LoadBalancer.Ingress IPs will only be advertised if they are within one of these blocks.
-	// +listType=set
+	// +listType=atomic
 	ServiceLoadBalancerIPs []ServiceLoadBalancerIPBlock `json:"serviceLoadBalancerIPs,omitempty" validate:"omitempty,dive" confignamev1:"svc_loadbalancer_ips"`
 
 	// ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
 	// Kubernetes Service ExternalIPs will only be advertised if they are within one of these blocks.
-	// +listType=set
+	// +listType=atomic
 	ServiceExternalIPs []ServiceExternalIPBlock `json:"serviceExternalIPs,omitempty" validate:"omitempty,dive" confignamev1:"svc_external_ips"`
 
 	// ServiceClusterIPs are the CIDR blocks from which service cluster IPs are allocated.
 	// If specified, Calico will advertise these blocks, as well as any cluster IPs within them.
-	// +listType=set
+	// +listType=atomic
 	ServiceClusterIPs []ServiceClusterIPBlock `json:"serviceClusterIPs,omitempty" validate:"omitempty,dive" confignamev1:"svc_cluster_ips"`
 
 	// ServiceLoadBalancerAggregation controls how LoadBalancer service IPs are advertised.
@@ -105,11 +105,11 @@ type BGPConfigurationSpec struct {
 	ServiceLoadBalancerAggregation *ServiceLoadBalancerAggregation `json:"serviceLoadBalancerAggregation,omitempty" validate:"omitempty" confignamev1:"svc_loadbalancer_aggregation"`
 
 	// Communities is a list of BGP community values and their arbitrary names for tagging routes.
-	// +listType=set
+	// +listType=atomic
 	Communities []Community `json:"communities,omitempty" validate:"omitempty,dive" confignamev1:"communities"`
 
 	// PrefixAdvertisements contains per-prefix advertisement configuration.
-	// +listType=set
+	// +listType=atomic
 	PrefixAdvertisements []PrefixAdvertisement `json:"prefixAdvertisements,omitempty" validate:"omitempty,dive" confignamev1:"prefix_advertisements"`
 
 	// ListenPort is the port where BGP protocol should listen. Defaults to 179

--- a/api/pkg/client/applyconfiguration_generated/internal/internal.go
+++ b/api/pkg/client/applyconfiguration_generated/internal/internal.go
@@ -87,7 +87,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.Community
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: ignoredInterfaces
       type:
         list:
@@ -126,7 +126,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.PrefixAdvertisement
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: programClusterRoutes
       type:
         scalar: string
@@ -135,13 +135,13 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.ServiceClusterIPBlock
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: serviceExternalIPs
       type:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.ServiceExternalIPBlock
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: serviceLoadBalancerAggregation
       type:
         scalar: string
@@ -150,7 +150,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: com.github.projectcalico.api.pkg.apis.projectcalico.v3.ServiceLoadBalancerIPBlock
-          elementRelationship: associative
+          elementRelationship: atomic
 - name: com.github.projectcalico.api.pkg.apis.projectcalico.v3.BGPDaemonStatus
   map:
     fields:

--- a/api/pkg/openapi/generated.openapi.go
+++ b/api/pkg/openapi/generated.openapi.go
@@ -686,7 +686,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"serviceLoadBalancerIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -705,7 +705,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"serviceExternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -724,7 +724,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"serviceClusterIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -750,7 +750,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"communities": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -769,7 +769,7 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 					"prefixAdvertisements": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
@@ -45,7 +45,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -104,7 +104,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -119,7 +119,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -129,7 +129,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -145,7 +145,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -139,7 +139,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -198,7 +198,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -213,7 +213,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -223,7 +223,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -239,7 +239,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -149,7 +149,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -208,7 +208,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -223,7 +223,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -233,7 +233,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -249,7 +249,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -150,7 +150,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -209,7 +209,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -224,7 +224,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -234,7 +234,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -250,7 +250,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -144,7 +144,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -203,7 +203,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -218,7 +218,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -228,7 +228,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -244,7 +244,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -134,7 +134,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -193,7 +193,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -208,7 +208,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -218,7 +218,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -234,7 +234,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -134,7 +134,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -193,7 +193,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -208,7 +208,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -218,7 +218,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -234,7 +234,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -151,7 +151,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -210,7 +210,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -225,7 +225,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -235,7 +235,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -251,7 +251,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -48,7 +48,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -107,7 +107,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -122,7 +122,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -132,7 +132,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -148,7 +148,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -134,7 +134,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -193,7 +193,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -208,7 +208,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -218,7 +218,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -234,7 +234,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -33342,7 +33342,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -33401,7 +33401,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -33416,7 +33416,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -33426,7 +33426,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -33442,7 +33442,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -33342,7 +33342,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -33401,7 +33401,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -33416,7 +33416,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -33426,7 +33426,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -33442,7 +33442,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -33345,7 +33345,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 ignoredInterfaces:
                   items:
                     type: string
@@ -33404,7 +33404,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   enum:
                     - Enabled
@@ -33419,7 +33419,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceExternalIPs:
                   items:
                     properties:
@@ -33429,7 +33429,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
                 serviceLoadBalancerAggregation:
                   default: Enabled
                   enum:
@@ -33445,7 +33445,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
               type: object
               x-kubernetes-validations:
                 - message:

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,20 +9,22 @@ include ../lib.Makefile
 .PHONY: ut-validation
 ## Run CRD validation tests against the default K8s version.
 ut-validation: setup-envtest
+	mkdir -p report
 	$(DOCKER_RUN) \
 		-v $$(ls -d $(ENVTEST_DIR)/k8s/*-$(BUILDOS)-$(BUILDARCH) | tail -1):/envtest:ro \
 		-e KUBEBUILDER_ASSETS=/envtest \
 		$(CALICO_BUILD) \
-		go test -count=1 -v ./test/validation/...
+		gotestsum --junitfile test/report/ut-validation.xml -- -count=1 -v ./test/validation/...
 
 .PHONY: ut-validation-min-k8s
 ## Run CRD validation tests against the minimum supported K8s version (1.29).
 ut-validation-min-k8s: setup-envtest-min
+	mkdir -p report
 	$(DOCKER_RUN) \
 		-v $$(ls -d $(ENVTEST_DIR)/k8s/$(ENVTEST_MIN_K8S_MINOR)*-$(BUILDOS)-$(BUILDARCH) | tail -1):/envtest:ro \
 		-e KUBEBUILDER_ASSETS=/envtest \
 		$(CALICO_BUILD) \
-		go test -count=1 -v ./test/validation/...
+		gotestsum --junitfile test/report/ut-validation-min-k8s.xml -- -count=1 -v ./test/validation/...
 
 .PHONY: ci
 ## Run all test/ CI jobs.

--- a/test/validation/serverside_apply_test.go
+++ b/test/validation/serverside_apply_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	"context"
+	"testing"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// expectApplySucceeds asserts that a server-side apply of obj succeeds. This is
+// the same code path used by FluxCD, ArgoCD, and `kubectl apply --server-side`,
+// and exercises the structural-merge-diff schema built from the CRD's listType,
+// listMapKey, and mapType annotations. CRDs that misuse those annotations
+// (e.g. listType=set on a list of objects) fail to build a typed schema and
+// produce errors like "associative list without keys has an element that's a
+// map type", regardless of the spec content.
+func expectApplySucceeds(t *testing.T, obj client.Object) {
+	t.Helper()
+	ctx := context.Background()
+	err := testClient.Patch(ctx, obj, client.Apply,
+		client.FieldOwner("validation-test"),
+		client.ForceOwnership)
+	if err != nil {
+		t.Fatalf("expected server-side apply to succeed but got: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = testClient.Delete(context.Background(), obj)
+	})
+}
+
+// TestBGPConfiguration_ServerSideApply locks in the fix for
+// https://github.com/projectcalico/calico/issues/12700. Each of the object-list
+// fields below was tagged +listType=set in v3.32.0, which is invalid for lists
+// of objects and breaks any server-side-apply client. Apply must succeed for
+// all of them.
+func TestBGPConfiguration_ServerSideApply(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v3.BGPConfigurationSpec
+	}{
+		{
+			name: "serviceLoadBalancerIPs populated",
+			spec: v3.BGPConfigurationSpec{
+				ServiceLoadBalancerIPs: []v3.ServiceLoadBalancerIPBlock{
+					{CIDR: "10.0.0.0/24"},
+					{CIDR: "10.1.0.0/24"},
+				},
+			},
+		},
+		{
+			name: "serviceExternalIPs populated",
+			spec: v3.BGPConfigurationSpec{
+				ServiceExternalIPs: []v3.ServiceExternalIPBlock{
+					{CIDR: "192.168.0.0/24"},
+				},
+			},
+		},
+		{
+			name: "serviceClusterIPs populated",
+			spec: v3.BGPConfigurationSpec{
+				ServiceClusterIPs: []v3.ServiceClusterIPBlock{
+					{CIDR: "172.16.0.0/16"},
+				},
+			},
+		},
+		{
+			name: "communities populated",
+			spec: v3.BGPConfigurationSpec{
+				Communities: []v3.Community{
+					{Name: "my-community", Value: "65001:100"},
+				},
+				PrefixAdvertisements: []v3.PrefixAdvertisement{
+					{CIDR: "10.0.0.0/24", Communities: []string{"my-community"}},
+				},
+			},
+		},
+		{
+			name: "prefixAdvertisements populated",
+			spec: v3.BGPConfigurationSpec{
+				PrefixAdvertisements: []v3.PrefixAdvertisement{
+					{CIDR: "10.0.0.0/24", Communities: []string{"65001:100"}},
+				},
+			},
+		},
+		{
+			name: "all object lists populated together",
+			spec: v3.BGPConfigurationSpec{
+				ServiceLoadBalancerIPs: []v3.ServiceLoadBalancerIPBlock{{CIDR: "10.0.0.0/24"}},
+				ServiceExternalIPs:     []v3.ServiceExternalIPBlock{{CIDR: "192.168.0.0/24"}},
+				ServiceClusterIPs:      []v3.ServiceClusterIPBlock{{CIDR: "172.16.0.0/16"}},
+				Communities:            []v3.Community{{Name: "my-community", Value: "65001:100"}},
+				PrefixAdvertisements: []v3.PrefixAdvertisement{
+					{CIDR: "10.0.0.0/24", Communities: []string{"my-community"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &v3.BGPConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v3.GroupVersionCurrent,
+					Kind:       v3.KindBGPConfiguration,
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: uniqueName("bgpconfig-ssa")},
+				Spec:       tt.spec,
+			}
+			expectApplySucceeds(t, obj)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/projectcalico/calico/pull/12702 to release-v3.32.

Conflict in api/pkg/apis/projectcalico/v3/bgpconfig.go: master had picked up MaxItems=500 markers on Communities/PrefixAdvertisements that don't exist on release-v3.32. Resolved by keeping the release-v3.32 structure and only flipping listType=set to listType=atomic, which is the actual fix.

Generated files (CRDs, openapi, applyconfiguration, manifests) come along cleanly - the only delta is set -> atomic for the 5 affected fields.

```release-note
Fix server-side apply (FluxCD, ArgoCD, `kubectl apply --server-side`) failures on BGPConfiguration resources that set serviceLoadBalancerIPs, serviceExternalIPs, serviceClusterIPs, communities, or prefixAdvertisements.
```