### PR TITLE
felix: don't drop wireguard pubkey publish after a transient datastore failure

### DIFF
--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -1357,6 +1357,7 @@ func (fc *DataplaneConnector) reconcileWireguardStatUpdate(dpPubKey string, ipVe
 
 func (fc *DataplaneConnector) handleWireguardStatUpdateFromDataplane(
 	reconcile func(pubKey string, ipVersion proto.IPVersion) error,
+	done <-chan struct{},
 ) {
 	// pending tracks the latest desired public key per IP version that we have
 	// not yet successfully written to the datastore. We must track per IP
@@ -1375,6 +1376,11 @@ func (fc *DataplaneConnector) handleWireguardStatUpdateFromDataplane(
 			pending[msg.IpVersion] = msg.PublicKey
 		case <-retryC:
 			log.Debug("retrying failed Wireguard status update")
+		case <-done:
+			if ticker != nil {
+				ticker.Stop()
+			}
+			return
 		}
 		if ticker != nil {
 			ticker.Stop()
@@ -1462,7 +1468,7 @@ func (fc *DataplaneConnector) Start() {
 	go fc.readMessagesFromDataplane()
 
 	// Start a background thread to handle Wireguard update to Node.
-	go fc.handleWireguardStatUpdateFromDataplane(fc.reconcileWireguardStatUpdate)
+	go fc.handleWireguardStatUpdateFromDataplane(fc.reconcileWireguardStatUpdate, nil)
 
 	log.WithFields(log.Fields{
 		"statusUpdatesFromDataplaneConsumers": len(fc.statusUpdatesFromDataplaneConsumers),

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -1355,30 +1355,44 @@ func (fc *DataplaneConnector) reconcileWireguardStatUpdate(dpPubKey string, ipVe
 	return nil
 }
 
-func (fc *DataplaneConnector) handleWireguardStatUpdateFromDataplane() {
-	var current *proto.WireguardStatusUpdate
+func (fc *DataplaneConnector) handleWireguardStatUpdateFromDataplane(
+	reconcile func(pubKey string, ipVersion proto.IPVersion) error,
+) {
+	// pending tracks the latest desired public key per IP version that we have
+	// not yet successfully written to the datastore. We must track per IP
+	// version: v4 and v6 status updates are independent, and an in-flight
+	// retry for one version must not be displaced by an arriving update for
+	// the other.
+	pending := make(map[proto.IPVersion]string)
 	var ticker *jitter.Ticker
 	var retryC <-chan time.Time
 
 	for {
 		// Block until we either get an update or it's time to retry a failed update.
 		select {
-		case current = <-fc.wireguardStatUpdateFromDataplane:
-			log.Debugf("Wireguard status update from dataplane driver: %s, IP version: %d", current.PublicKey, current.IpVersion)
+		case msg := <-fc.wireguardStatUpdateFromDataplane:
+			log.Debugf("Wireguard status update from dataplane driver: %s, IP version: %d", msg.PublicKey, msg.IpVersion)
+			pending[msg.IpVersion] = msg.PublicKey
 		case <-retryC:
 			log.Debug("retrying failed Wireguard status update")
 		}
 		if ticker != nil {
 			ticker.Stop()
+			ticker = nil
+			retryC = nil
 		}
 
-		// Try and reconcile the current wireguard status data.
-		err := fc.reconcileWireguardStatUpdate(current.PublicKey, current.IpVersion)
-		if err == nil {
-			current = nil
-			retryC = nil
-			ticker = nil
-		} else {
+		// Reconcile every IP version that has a pending update. Drop entries
+		// that succeed; on any failure, schedule a retry tick.
+		anyFailed := false
+		for ipVersion, pubKey := range pending {
+			if err := reconcile(pubKey, ipVersion); err != nil {
+				anyFailed = true
+				continue
+			}
+			delete(pending, ipVersion)
+		}
+		if anyFailed {
 			// retry reconciling between 2-4 seconds.
 			ticker = jitter.NewTicker(2*time.Second, 2*time.Second)
 			retryC = ticker.C
@@ -1448,7 +1462,7 @@ func (fc *DataplaneConnector) Start() {
 	go fc.readMessagesFromDataplane()
 
 	// Start a background thread to handle Wireguard update to Node.
-	go fc.handleWireguardStatUpdateFromDataplane()
+	go fc.handleWireguardStatUpdateFromDataplane(fc.reconcileWireguardStatUpdate)
 
 	log.WithFields(log.Fields{
 		"statusUpdatesFromDataplaneConsumers": len(fc.statusUpdatesFromDataplaneConsumers),

--- a/felix/daemon/wireguard_status_test.go
+++ b/felix/daemon/wireguard_status_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"errors"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+var _ = Describe("handleWireguardStatUpdateFromDataplane", func() {
+	var (
+		fc       *DataplaneConnector
+		fake     *fakeReconciler
+		stopAll  func()
+	)
+
+	BeforeEach(func() {
+		fake = newFakeReconciler()
+		fc = &DataplaneConnector{
+			wireguardStatUpdateFromDataplane: make(chan *proto.WireguardStatusUpdate, 1),
+		}
+		// Run the handler in a goroutine. The handler loops forever; the
+		// test simply leaks it once the channel has no more senders, since
+		// the handler will block in select{}. AfterEach is purely advisory.
+		stopAll = func() {}
+		go fc.handleWireguardStatUpdateFromDataplane(fake.reconcile)
+	})
+
+	AfterEach(func() {
+		stopAll()
+	})
+
+	It("retries a failed v6 update even when a v4 update arrives during the failure", func() {
+		// Make the first v6 reconcile call fail (simulating an etcd
+		// context-deadline-exceeded). Subsequent v6 calls succeed.
+		fake.failOnce(proto.IPVersion_IPV6)
+
+		// Send v6 first so it is the in-flight reconcile when v4 arrives.
+		fc.wireguardStatUpdateFromDataplane <- &proto.WireguardStatusUpdate{
+			PublicKey: "v6-key",
+			IpVersion: proto.IPVersion_IPV6,
+		}
+		// Send v4 while v6 is failing. Without the fix, this displaces the
+		// pending v6 retry and the v6 publication is silently lost.
+		fc.wireguardStatUpdateFromDataplane <- &proto.WireguardStatusUpdate{
+			PublicKey: "v4-key",
+			IpVersion: proto.IPVersion_IPV4,
+		}
+
+		// v4 should reconcile successfully promptly.
+		Eventually(func() string {
+			return fake.lastSucceeded(proto.IPVersion_IPV4)
+		}, "5s", "50ms").Should(Equal("v4-key"))
+
+		// v6 must also eventually be reconciled — this is the assertion
+		// that fails on the unpatched code. The retry loop runs every 2-4s.
+		Eventually(func() string {
+			return fake.lastSucceeded(proto.IPVersion_IPV6)
+		}, "10s", "50ms").Should(Equal("v6-key"))
+	})
+})
+
+// fakeReconciler is a stub for reconcileWireguardStatUpdate that records calls
+// and lets a test inject one-shot failures per IP version.
+type fakeReconciler struct {
+	mu          sync.Mutex
+	failNext    map[proto.IPVersion]bool
+	succeededAt map[proto.IPVersion]string
+}
+
+func newFakeReconciler() *fakeReconciler {
+	return &fakeReconciler{
+		failNext:    map[proto.IPVersion]bool{},
+		succeededAt: map[proto.IPVersion]string{},
+	}
+}
+
+func (f *fakeReconciler) failOnce(ipVersion proto.IPVersion) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failNext[ipVersion] = true
+}
+
+func (f *fakeReconciler) reconcile(pubKey string, ipVersion proto.IPVersion) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNext[ipVersion] {
+		delete(f.failNext, ipVersion)
+		return errors.New("injected failure")
+	}
+	f.succeededAt[ipVersion] = pubKey
+	return nil
+}
+
+func (f *fakeReconciler) lastSucceeded(ipVersion proto.IPVersion) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.succeededAt[ipVersion]
+}

--- a/felix/daemon/wireguard_status_test.go
+++ b/felix/daemon/wireguard_status_test.go
@@ -26,9 +26,10 @@ import (
 
 var _ = Describe("handleWireguardStatUpdateFromDataplane", func() {
 	var (
-		fc       *DataplaneConnector
-		fake     *fakeReconciler
-		stopAll  func()
+		fc      *DataplaneConnector
+		fake    *fakeReconciler
+		done    chan struct{}
+		stopped chan struct{}
 	)
 
 	BeforeEach(func() {
@@ -36,15 +37,17 @@ var _ = Describe("handleWireguardStatUpdateFromDataplane", func() {
 		fc = &DataplaneConnector{
 			wireguardStatUpdateFromDataplane: make(chan *proto.WireguardStatusUpdate, 1),
 		}
-		// Run the handler in a goroutine. The handler loops forever; the
-		// test simply leaks it once the channel has no more senders, since
-		// the handler will block in select{}. AfterEach is purely advisory.
-		stopAll = func() {}
-		go fc.handleWireguardStatUpdateFromDataplane(fake.reconcile)
+		done = make(chan struct{})
+		stopped = make(chan struct{})
+		go func() {
+			defer close(stopped)
+			fc.handleWireguardStatUpdateFromDataplane(fake.reconcile, done)
+		}()
 	})
 
 	AfterEach(func() {
-		stopAll()
+		close(done)
+		Eventually(stopped, "5s").Should(BeClosed())
 	})
 
 	It("retries a failed v6 update even when a v4 update arrives during the failure", func() {


### PR DESCRIPTION
`handleWireguardStatUpdateFromDataplane` tracked the in-flight update in a single `current` variable shared across IP versions. If a v6 reconcile failed (e.g. context deadline exceeded talking to etcd) and a v4 update arrived from the dataplane while the retry was pending, the v4 update overwrote `current` and the v6 retry was silently dropped. The peer node then never saw the v6 pubkey and v6 wireguard tunnels stayed broken until the next time felix restarted or the v6 key changed.

Track pending pubkeys per IP version instead, so a new update for one version doesn't displace a pending retry for the other.

Also adds a unit test that fault-injects a one-shot v6 reconcile failure followed by a v4 update. Fails on master, passes with the fix.

**Release note:**
```release-note
Fix a bug where felix could silently drop a wireguard public key publication after a transient datastore failure if an update for the other IP version arrived during the retry window, leaving wireguard tunnels broken until the next restart.
```