### PR TITLE
cni-plugin: drop standalone Linux binaries from Make targets

### DIFF
--- a/cmd/calico/main.go
+++ b/cmd/calico/main.go
@@ -73,10 +73,10 @@ const (
 //   - argv[0] basename of "uds" → Cobra, with "component flexvol" inserted
 //     so kubelet's "<plugin-dir>/uds <init|mount|unmount>" calls route
 //     into the flexvol subcommand.
-//   - Otherwise, CNI_COMMAND in the env dispatches to the CNI plugin, but
-//     only when no subcommand args were passed. This guards against a stray
-//     CNI_COMMAND in a shell environment silently hijacking "calicoctl get
-//     nodes" or "calico component foo".
+//   - Otherwise, CNI_COMMAND in the env dispatches to the CNI plugin. If
+//     args[1] is a known top-level cobra subcommand, prefer cobra — that
+//     guards against a stray CNI_COMMAND silently hijacking "calico
+//     component foo".
 //   - Otherwise, Cobra.
 func dispatch(args []string, cniCommand string) (dispatchMode, []string) {
 	_, filename := filepath.Split(args[0])
@@ -90,11 +90,24 @@ func dispatch(args []string, cniCommand string) (dispatchMode, []string) {
 		rewritten := append([]string{args[0], "component", "flexvol"}, args[1:]...)
 		return modeCobra, rewritten
 	default:
-		if len(args) == 1 && cniCommand != "" {
+		if cniCommand != "" {
+			if len(args) > 1 && isCobraSubcommand(args[1]) {
+				return modeCobra, args
+			}
 			return modeCNI, args
 		}
 		return modeCobra, args
 	}
+}
+
+// isCobraSubcommand reports whether s is a known top-level subcommand of the
+// calico cobra tree. Used by dispatch to disambiguate when CNI_COMMAND is set.
+func isCobraSubcommand(s string) bool {
+	switch s {
+	case "component", "ctl", "health", "version", "help":
+		return true
+	}
+	return false
 }
 
 func main() {

--- a/cmd/calico/main_test.go
+++ b/cmd/calico/main_test.go
@@ -91,11 +91,25 @@ func TestDispatch(t *testing.T) {
 			wantArgs:   []string{"/usr/bin/calico"},
 		},
 		{
-			name:       "plain calico with subcommand ignores CNI_COMMAND (footgun guard)",
+			name:       "plain calico with cobra subcommand ignores CNI_COMMAND (footgun guard)",
 			args:       []string{"/usr/bin/calico", "component", "felix"},
 			cniCommand: "ADD",
 			wantMode:   modeCobra,
 			wantArgs:   []string{"/usr/bin/calico", "component", "felix"},
+		},
+		{
+			name:       "plain calico with CNI_COMMAND and netconf positional arg dispatches to CNI plugin",
+			args:       []string{"/opt/cni/bin/calico", `{"name":"net","type":"calico"}`},
+			cniCommand: "ADD",
+			wantMode:   modeCNI,
+			wantArgs:   []string{"/opt/cni/bin/calico", `{"name":"net","type":"calico"}`},
+		},
+		{
+			name:       "plain calico with CNI_COMMAND and -t flag dispatches to CNI plugin",
+			args:       []string{"/opt/cni/bin/calico", "-t"},
+			cniCommand: "VERSION",
+			wantMode:   modeCNI,
+			wantArgs:   []string{"/opt/cni/bin/calico", "-t"},
 		},
 		{
 			name:       "plain calico with subcommand and no CNI_COMMAND runs Cobra",

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -44,10 +44,7 @@ clean-windows: clean-windows-builder
 ###############################################################################
 # Building the binary
 ###############################################################################
-# The Linux cni-plugin ships in the combined calico/calico image; this
-# Makefile no longer builds standalone Linux binaries. Unit tests source the
-# calico/calico-ipam binaries from cmd/calico (see the ut targets below).
-# Only the Windows image is built standalone here.
+# Only the Windows image is built standalone here; Linux ships in calico/calico.
 .PHONY: build
 build:
 ifeq ($(ARCH),amd64)
@@ -166,12 +163,8 @@ remove-kubevirt-crds:
 		echo "KubeVirt CRDs already removed or not present"
 
 
-# The combined calico binary (built by cmd/calico) supplies the CNI plugin and
-# IPAM entry points used by unit tests. Tests invoke it via BIN/PLUGIN env
-# vars under the names "calico" and "calico-ipam"; the binary's argv[0]
-# dispatch (cmd/calico/main.go) routes those calls to the right entry point.
-# The combined binary's deps come from cmd/deps.txt, which transitively
-# covers cni-plugin sources, so changes here trigger a rebuild here.
+# Source the CNI plugin and IPAM binaries from the combined calico binary;
+# argv[0] dispatch in cmd/calico/main.go picks the right entry point.
 COMBINED_BINARY = $(REPO_ROOT)/cmd/calico/bin/calico-$(ARCH)
 
 $(COMBINED_BINARY): $(call local-deps-go-files,cmd)

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -15,7 +15,6 @@ BUILD_IMAGES  ?= $(WINDOWS_IMAGE)
 include ../lib.Makefile
 
 ## SRC_FILES is auto-populated from deps.txt by lib.Makefile.
-TEST_SRC_FILES=$(shell find tests -name '*.go')
 WINFV_SRCFILES=$(shell find win_tests -name '*.go')
 
 # fail if unable to download
@@ -45,27 +44,18 @@ clean-windows: clean-windows-builder
 ###############################################################################
 # Building the binary
 ###############################################################################
-# Linux binaries are only built locally for running unit tests. The production
-# Linux cni-plugin ships in the calico/calico image.
+# The Linux cni-plugin ships in the combined calico/calico image; this
+# Makefile no longer builds standalone Linux binaries. Unit tests source the
+# calico/calico-ipam binaries from cmd/calico (see the ut targets below).
+# Only the Windows image is built standalone here.
 .PHONY: build
-build: $(BIN)/install $(BIN)/calico $(BIN)/calico-ipam
+build:
 ifeq ($(ARCH),amd64)
 # Go only supports amd64 for Windows builds.
 WINDOWS_BIN=bin/windows
 # calico-ipam.exe is not built: install.exe copies calico.exe to both names on the host.
 build: $(WINDOWS_BIN)/install.exe $(WINDOWS_BIN)/calico.exe
 endif
-
-## Build the Calico installation binary for the network and ipam plugins
-$(BIN)/install binary: $(SRC_FILES)
-	$(call build_binary, $(PACKAGE_NAME)/cmd/install, $@)
-
-## Build the Calico network and ipam plugins
-$(BIN)/calico: $(SRC_FILES)
-	$(call build_binary, $(PACKAGE_NAME)/cmd/calico, $@)
-
-$(BIN)/calico-ipam: $(BIN)/calico
-	ln -sf "./calico" "$@"
 
 ## Build the Calico network and ipam plugins for Windows
 $(WINDOWS_BIN)/install.exe: $(SRC_FILES)
@@ -176,7 +166,25 @@ remove-kubevirt-crds:
 		echo "KubeVirt CRDs already removed or not present"
 
 
-UT_PREREQS = run-k8s-controller-manager $(BIN)/install $(BIN)/host-local $(BIN)/calico-ipam $(BIN)/calico
+# The combined calico binary (built by cmd/calico) supplies the CNI plugin and
+# IPAM entry points used by unit tests. Tests invoke it via BIN/PLUGIN env
+# vars under the names "calico" and "calico-ipam"; the binary's argv[0]
+# dispatch (cmd/calico/main.go) routes those calls to the right entry point.
+# The combined binary's deps come from cmd/deps.txt, which transitively
+# covers cni-plugin sources, so changes here trigger a rebuild here.
+COMBINED_BINARY = $(REPO_ROOT)/cmd/calico/bin/calico-$(ARCH)
+
+$(COMBINED_BINARY): $(call local-deps-go-files,cmd)
+	$(MAKE) -C $(REPO_ROOT)/cmd/calico build
+
+$(BIN)/calico: $(COMBINED_BINARY)
+	mkdir -p $(BIN)
+	cp $< $@
+
+$(BIN)/calico-ipam: $(BIN)/calico
+	ln -sf ./calico $@
+
+UT_PREREQS = run-k8s-controller-manager $(BIN)/host-local $(BIN)/calico $(BIN)/calico-ipam
 
 ## Run all unit tests.
 ut: $(UT_PREREQS)
@@ -263,6 +271,6 @@ $(WINDOWS_BIN)/win-fv.exe: $(WINFV_SRCFILES)
 ###############################################################################
 .PHONY: test-watch
 ## Run the unit tests, watching for changes.
-test-watch: $(BIN)/install run-etcd run-k8s-apiserver
+test-watch: run-etcd run-k8s-apiserver
 	# The tests need to run as root
 	CGO_ENABLED=0 ETCD_IP=127.0.0.1 PLUGIN=calico GOPATH=$(GOPATH) ginkgo watch -skip-package pkg/install

--- a/cni-plugin/cmd/install/install.go
+++ b/cni-plugin/cmd/install/install.go
@@ -21,9 +21,6 @@ import (
 	"github.com/projectcalico/calico/pkg/buildinfo"
 )
 
-// VERSION is filled out during the build process (using git describe output)
-var VERSION string
-
 func main() {
 	err := install.Install(buildinfo.Version)
 	if err != nil {

--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -3305,6 +3305,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName, k8s.BackendAPIGroup(&config.Spec))
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
+			c.Env = append(os.Environ(), "CNI_COMMAND=VERSION")
 			stdin, err := c.StdinPipe()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -3342,6 +3343,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName, k8s.BackendAPIGroup(&config.Spec))
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
+			c.Env = append(os.Environ(), "CNI_COMMAND=VERSION")
 			stdin, err := c.StdinPipe()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/cni-plugin/tests/calico_cni_test.go
+++ b/cni-plugin/tests/calico_cni_test.go
@@ -906,6 +906,7 @@ var _ = Describe("CalicoCni", func() {
 }`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
+			c.Env = append(os.Environ(), "CNI_COMMAND=VERSION")
 			stdin, err := c.StdinPipe()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -936,6 +937,7 @@ var _ = Describe("CalicoCni", func() {
 }`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
+			c.Env = append(os.Environ(), "CNI_COMMAND=VERSION")
 			stdin, err := c.StdinPipe()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/node/Makefile
+++ b/node/Makefile
@@ -368,12 +368,6 @@ dist/calicoctl:
 	make -C ../calicoctl build
 	cp ../calicoctl/bin/calicoctl-linux-$(ARCH) $@
 
-dist/calico dist/calico-ipam:
-	mkdir -p dist
-	make -C ../cni-plugin build
-	cp ../cni-plugin/bin/$(ARCH)/calico dist/calico
-	cp ../cni-plugin/bin/$(ARCH)/calico-ipam dist/calico-ipam
-
 # Create images for containers used in the tests
 busybox.tar:
 	docker pull $(ARCH)/busybox:latest


### PR DESCRIPTION
Follow-on cleanup from the combined calico/calico image work. The Linux cni-plugin already ships in the combined image, but the cni-plugin Makefile was still building standalone Linux install/calico/calico-ipam binaries solely for unit tests. This switches the unit tests to source the binary from cmd/calico (via argv[0] dispatch as calico and calico-ipam) and drops the standalone Linux build path.

The cni-windows image is unaffected - its install.exe and calico.exe are still built from cni-plugin/cmd/{install,calico} since the combined cmd/calico binary pulls in Linux-only deps and can't build for Windows.

Also removes a dead `dist/calico` rule in node/Makefile that copied from the now-gone cni-plugin/bin path and had no consumers.

Fixes CORE-12712.

```release-note
None
```