### PR TITLE
Move BPF pol-prog FV helpers out of felix/fv/infrastructure

### DIFF
--- a/felix/fv/bpf_pol_scale_test.go
+++ b/felix/fv/bpf_pol_scale_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/infrastructure/bpfpolprog"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -94,9 +95,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ BPF policy scale tests", []
 		// This test does take some time to converge, make sure that we wait for
 		// convergence before doing policy tests.
 		const expectedNumberOfPolicySubprogs = 5
-		Eventually(tc.Felixes[0].BPFNumContiguousPolProgramsFn(w[0].InterfaceName, "ingress", 4), "240s", "1s").Should(
+		Eventually(bpfpolprog.NumContiguousPolProgramsFn(tc.Felixes[0], w[0].InterfaceName, "ingress", 4), "240s", "1s").Should(
 			BeNumerically(">", expectedNumberOfPolicySubprogs))
-		Eventually(tc.Felixes[0].BPFNumContiguousPolProgramsFn(w[1].InterfaceName, "ingress", 4), "20s", "1s").Should(
+		Eventually(bpfpolprog.NumContiguousPolProgramsFn(tc.Felixes[0], w[1].InterfaceName, "ingress", 4), "20s", "1s").Should(
 			BeNumerically(">", expectedNumberOfPolicySubprogs))
 
 		// The network sets use IPs from outside the IP pool so we get no
@@ -136,9 +137,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ BPF policy scale tests", []
 			w[1].ConfigureInInfra(infra)
 
 			const expectedNumberOfPolicySubprogs = 2
-			Eventually(tc.Felixes[0].BPFNumContiguousPolProgramsFn(w[0].InterfaceName, "ingress", 4), "60s", "1s").Should(
+			Eventually(bpfpolprog.NumContiguousPolProgramsFn(tc.Felixes[0], w[0].InterfaceName, "ingress", 4), "60s", "1s").Should(
 				BeNumerically(">=", expectedNumberOfPolicySubprogs))
-			Eventually(tc.Felixes[0].BPFNumContiguousPolProgramsFn(w[1].InterfaceName, "ingress", 4), "20s", "1s").Should(
+			Eventually(bpfpolprog.NumContiguousPolProgramsFn(tc.Felixes[0], w[1].InterfaceName, "ingress", 4), "20s", "1s").Should(
 				BeNumerically(">=", expectedNumberOfPolicySubprogs))
 			addW0NetSet(numSets)
 
@@ -156,17 +157,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ BPF policy scale tests", []
 			// Remove one EP.
 			w[0].RemoveFromInfra(infra)
 			// After removing workload, we get a dummy "drop all" policy program.
-			Eventually(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxIngress, "ingress"), "60s", "1s").Should(Equal(1),
+			Eventually(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxIngress, "ingress"), "60s", "1s").Should(Equal(1),
 				"w[0] ingress policy programs not cleaned up after removing ep?")
-			Eventually(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxEgress, "egress"), "60s", "1s").Should(Equal(1),
+			Eventually(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxEgress, "egress"), "60s", "1s").Should(Equal(1),
 				"w[0] egress policy programs not cleaned up after removing ep?")
 
 			// Stop it, should get full cleanup now.
 			w[0].Stop()
 			w[0] = nil // Prevent second call to Stop in AfterEach.
-			Eventually(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxIngress, "ingress"), "60s", "1s").Should(Equal(0),
+			Eventually(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxIngress, "ingress"), "60s", "1s").Should(Equal(0),
 				"w[0] ingress policy programs not cleaned up?")
-			Eventually(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxEgress, "egress"), "60s", "1s").Should(Equal(0),
+			Eventually(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxEgress, "egress"), "60s", "1s").Should(Equal(0),
 				"w[0] egress policy programs not cleaned up?")
 		})
 
@@ -178,16 +179,16 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ BPF policy scale tests", []
 				w[0] = nil
 			}()
 			// After stopping workload, interface is gone and programs get cleaned up.
-			Eventually(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxIngress, "ingress"), "60s", "1s").Should(Equal(0),
+			Eventually(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxIngress, "ingress"), "60s", "1s").Should(Equal(0),
 				"w[0] ingress policy programs not cleaned up?")
-			Eventually(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxEgress, "egress"), "60s", "1s").Should(Equal(0),
+			Eventually(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxEgress, "egress"), "60s", "1s").Should(Equal(0),
 				"w[0] egress policy programs not cleaned up?")
 
 			// Remove should have no further effect.
 			w[0].RemoveFromInfra(infra)
-			Consistently(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxIngress, "ingress"), "10s", "1s").Should(Equal(0),
+			Consistently(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxIngress, "ingress"), "10s", "1s").Should(Equal(0),
 				"w[0] ingress policy programs came back?")
-			Consistently(tc.Felixes[0].BPFNumPolProgramsTotalByEntryPointFn(w0PolIdxEgress, "egress"), "10s", "1s").Should(Equal(0),
+			Consistently(bpfpolprog.NumPolProgramsTotalByEntryPointFn(tc.Felixes[0], w0PolIdxEgress, "egress"), "10s", "1s").Should(Equal(0),
 				"w[0] egress policy programs came back?")
 		})
 	})

--- a/felix/fv/infrastructure/bpfpolprog/bpfpolprog.go
+++ b/felix/fv/infrastructure/bpfpolprog/bpfpolprog.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bpfpolprog contains FV helpers for inspecting Felix's BPF policy
+// program jump maps. It is split out from felix/fv/infrastructure so importers
+// of that package (e.g. kube-controllers FV tests) don't pull in the cgo
+// libbpf chain via felix/bpf/jump and felix/bpf/polprog.
+package bpfpolprog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/projectcalico/calico/felix/bpf/jump"
+	"github.com/projectcalico/calico/felix/bpf/polprog"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+)
+
+func NumContiguousPolProgramsFn(f *infrastructure.Felix, iface, ingressOrEgress string, family int) func() int {
+	return func() int {
+		cont, _ := NumPolProgramsByName(f, iface, ingressOrEgress, family)
+		return cont
+	}
+}
+
+func NumPolProgramsByName(f *infrastructure.Felix, iface, ingressOrEgress string, family int) (contiguous, total int) {
+	entryPointIdx := f.BPFPolEntryPointIdx(iface, ingressOrEgress, family)
+	return NumPolProgramsByEntryPoint(f, entryPointIdx, ingressOrEgress)
+}
+
+func NumPolProgramsTotalByEntryPointFn(f *infrastructure.Felix, entryPointIdx int, ingressOrEgress string) func() int {
+	return func() int {
+		_, total := NumPolProgramsByEntryPoint(f, entryPointIdx, ingressOrEgress)
+		return total
+	}
+}
+
+func NumPolProgramsByEntryPoint(f *infrastructure.Felix, entryPointIdx int, ingressOrEgress string) (contiguous, total int) {
+	gapSeen := false
+	var jmpMapName string
+	if infrastructure.NetkitMode() {
+		jmpMapName = jump.NetkitEgressMapParameters.VersionedName()
+		if ingressOrEgress == "egress" {
+			jmpMapName = jump.NetkitIngressMapParameters.VersionedName()
+		}
+	} else {
+		jmpMapName = jump.EgressMapParameters.VersionedName()
+		if ingressOrEgress == "egress" {
+			jmpMapName = jump.IngressMapParameters.VersionedName()
+		}
+	}
+	pinnedMap := "/sys/fs/bpf/tc/globals/" + jmpMapName
+	for i := range jump.MaxSubPrograms {
+		k := polprog.SubProgramJumpIdx(entryPointIdx, i, jump.TCMaxEntryPoints)
+		out, err := f.ExecOutput(
+			"bpftool", "map", "lookup",
+			"pinned", pinnedMap,
+			"key",
+			fmt.Sprintf("%d", k&0xff),
+			fmt.Sprintf("%d", (k>>8)&0xff),
+			fmt.Sprintf("%d", (k>>16)&0xff),
+			fmt.Sprintf("%d", (k>>24)&0xff),
+		)
+		if err != nil {
+			gapSeen = true
+		}
+		if strings.Contains(out, `value:`) || strings.Contains(out, `"value":`) {
+			total++
+			if !gapSeen {
+				contiguous++
+			}
+		} else {
+			gapSeen = true
+		}
+	}
+	return
+}

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -38,8 +38,6 @@ import (
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/felix/bpf/jump"
-	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/collector/flowlog"
 	"github.com/projectcalico/calico/felix/collector/goldmane"
 	"github.com/projectcalico/calico/felix/collector/local"
@@ -654,18 +652,6 @@ func (f *Felix) BPFIfState(family int) map[string]BPFIfState {
 	return states
 }
 
-func (f *Felix) BPFNumContiguousPolProgramsFn(iface string, ingressOrEgress string, family int) func() int {
-	return func() int {
-		cont, _ := f.BPFNumPolProgramsByName(iface, ingressOrEgress, family)
-		return cont
-	}
-}
-
-func (f *Felix) BPFNumPolProgramsByName(iface string, ingressOrEgress string, family int) (contiguous, total int) {
-	entryPointIdx := f.BPFPolEntryPointIdx(iface, ingressOrEgress, family)
-	return f.BPFNumPolProgramsByEntryPoint(entryPointIdx, ingressOrEgress)
-}
-
 func (f *Felix) BPFPolEntryPointIdx(iface string, ingressOrEgress string, family int) int {
 	ifState := f.BPFIfState(family)[iface]
 	var entryPointIdx int
@@ -681,54 +667,6 @@ func (f *Felix) BPFPolEntryPointIdx(iface string, ingressOrEgress string, family
 		}
 	}
 	return entryPointIdx
-}
-
-func (f *Felix) BPFNumPolProgramsTotalByEntryPointFn(entryPointIdx int, ingressOrEgress string) func() (total int) {
-	return func() (total int) {
-		_, total = f.BPFNumPolProgramsByEntryPoint(entryPointIdx, ingressOrEgress)
-		return
-	}
-}
-
-func (f *Felix) BPFNumPolProgramsByEntryPoint(entryPointIdx int, ingressOrEgress string) (contiguous, total int) {
-	gapSeen := false
-	var jmpMapName string
-	if NetkitMode() {
-		jmpMapName = jump.NetkitEgressMapParameters.VersionedName()
-		if ingressOrEgress == "egress" {
-			jmpMapName = jump.NetkitIngressMapParameters.VersionedName()
-		}
-	} else {
-		jmpMapName = jump.EgressMapParameters.VersionedName()
-		if ingressOrEgress == "egress" {
-			jmpMapName = jump.IngressMapParameters.VersionedName()
-		}
-	}
-	pinnedMap := "/sys/fs/bpf/tc/globals/" + jmpMapName
-	for i := range jump.MaxSubPrograms {
-		k := polprog.SubProgramJumpIdx(entryPointIdx, i, jump.TCMaxEntryPoints)
-		out, err := f.ExecOutput(
-			"bpftool", "map", "lookup",
-			"pinned", pinnedMap,
-			"key",
-			fmt.Sprintf("%d", k&0xff),
-			fmt.Sprintf("%d", (k>>8)&0xff),
-			fmt.Sprintf("%d", (k>>16)&0xff),
-			fmt.Sprintf("%d", (k>>24)&0xff),
-		)
-		if err != nil {
-			gapSeen = true
-		}
-		if strings.Contains(out, `value:`) || strings.Contains(out, `"value":`) {
-			total++
-			if !gapSeen {
-				contiguous++
-			}
-		} else {
-			gapSeen = true
-		}
-	}
-	return
 }
 
 func (f *Felix) IPTablesChains(table string) map[string][]string {


### PR DESCRIPTION
`felix/fv/infrastructure` imported `felix/bpf/jump` and `felix/bpf/polprog`, which transitively pulled in `felix/bpf/libbpf` (cgo). Any importer of the infrastructure package then needed `libbpf.h` on disk to typecheck - which bites lint runs that have CGO enabled by default. The cgo edge was used in exactly one method (`BPFNumPolProgramsByEntryPoint`) and a few helpers that chain into it.

This PR moves the four `BPFNum*` helpers into a new `felix/fv/infrastructure/bpfpolprog` sub-package as free functions taking `*infrastructure.Felix`. The remaining `infrastructure` package no longer references `felix/bpf/*`. The only caller, `felix/fv/bpf_pol_scale_test.go`, is updated to use the new package.

```release-note
None
```