### PR TITLE
Make kind-cluster tests reuse the cached node image

### DIFF
--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -24,7 +24,7 @@ vm_name_prefix=$1
 artifacts_dir="$repo_dir/artifacts"
 zone=${ZONE:-europe-west3-c}
 : "${VM_MACHINE_TYPE:=n4-standard-4}"
-: "${IMAGE_FAMILY:=ubuntu-minimal-2204-lts}"
+: "${IMAGE_FAMILY:=ubuntu-minimal-2404-lts}"
 : "${MAX_RUN_DURATION:=4h}"
 disk_size=${VM_DISK_SIZE:-20GB}
 

--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -24,7 +24,7 @@ vm_name_prefix=$1
 artifacts_dir="$repo_dir/artifacts"
 zone=${ZONE:-europe-west3-c}
 : "${VM_MACHINE_TYPE:=n4-standard-4}"
-: "${IMAGE_FAMILY:=ubuntu-minimal-2404-lts}"
+: "${IMAGE_FAMILY:=ubuntu-minimal-2404-lts-amd64}"
 : "${MAX_RUN_DURATION:=4h}"
 disk_size=${VM_DISK_SIZE:-20GB}
 

--- a/node/.semaphore/load-test-artifacts
+++ b/node/.semaphore/load-test-artifacts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2025 Tigera, Inc. All rights reserved.
+# Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,15 +22,38 @@ set -ex
 ARCH=${ARCH:-amd64}
 REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 
-# Load any pre-built images that were cached by the Prerequisites build blocks.
-for item in calico-image:cmd/calico node-image:node whisker-image:whisker; do
+# image-ref strings must match exactly what the .image.created-* recipes in
+# lib.Makefile write, so hack/image-exists can re-find them in the daemon.
+# Item format: "<tarball-prefix>:<marker-dir>:<image-ref>".
+loaded_any=0
+for item in \
+    calico-image:cmd/calico:calico:latest-${ARCH} \
+    node-image:node:node:latest-${ARCH} \
+    whisker-image:whisker:whisker:latest-${ARCH}; do
   tarball="${item%%:*}.tar.zst"
-  marker_dir="${item#*:}"
+  rest="${item#*:}"
+  marker_dir="${rest%%:*}"
+  image_ref="${rest#*:}"
   if [ -f "/tmp/${tarball}" ]; then
     echo "Loading cached ${tarball}..."
     zstd -dc "/tmp/${tarball}" | docker load
     mkdir -p "${REPO_ROOT}/${marker_dir}"
-    touch "${REPO_ROOT}/${marker_dir}/.image.created-${ARCH}"
+    # Write the image ref so hack/image-exists treats the stamp as
+    # backed by a concrete image (not just a touched empty file), and
+    # so a pruned image forces a rebuild via MISSING-IMAGE.
+    echo "${image_ref}" > "${REPO_ROOT}/${marker_dir}/.image.created-${ARCH}"
     rm -f "/tmp/${tarball}"
+    loaded_any=1
   fi
 done
+
+# Stub LIBBPF_MARKER so kind-build-images doesn't drag the cached node/cmd/calico
+# image stamps back out-of-date by rebuilding libbpf.a (whose freshly-built mtime
+# would be newer than the stamps). Only relevant when at least one image was
+# loaded — otherwise let the normal build path produce the real artifact.
+if [ "${loaded_any}" = 1 ]; then
+  libbpf_stub="${REPO_ROOT}/felix/bpf-gpl/libbpf/src/${ARCH}/libbpf.a"
+  mkdir -p "$(dirname "${libbpf_stub}")"
+  : > "${libbpf_stub}"
+  touch -d '2000-01-01' "${libbpf_stub}"
+fi


### PR DESCRIPTION
The kind-cluster job is supposed to load the pre-built calico/node image from the Prerequisites cache so it doesn't rebuild on the test VM. It wasn't doing that - on every run it rebuilt nftables-rpms and then calico/node from scratch. On a 22.04 VM that rebuild also tripped the daemon's old BuildKit on the new `--build-context` flag and failed outright.

Two things were going on:

- `load-test-artifacts` `touch`ed the `.image.created` stamp, leaving it empty. The recipes in `lib.Makefile` write the image ref into the stamp so `hack/image-exists` can verify the daemon still has it. An empty stamp short-circuits image-exists into a no-op, so the cache check works only by accident.
- More importantly, `LIBBPF_MARKER` (`felix/bpf-gpl/libbpf/src/$(ARCH)/libbpf.a`) isn't in the cached working copy, so Make builds it on the VM. The fresh `.a` mtime ends up newer than the touched stamp, which drags the `.image.created` rule back out of date and the node image rebuilds.

Fix: write the image ref into the stamp like the lib.Makefile recipes do, and stub LIBBPF_MARKER with an old mtime when we've loaded a cached image. With the cache actually short-circuiting, the rebuild path doesn't run at all.

Also bumped the default VM image family from 22.04 to 24.04 so the rebuild path - if it ever does run - uses a Docker version with BuildKit new enough to handle `--build-context`. The bootstrap script already has a noble path pinned to Docker 27.5.1.

```release-note
None
```