### PR TITLE
semaphore: improve nftables build logging

### DIFF
--- a/.semaphore/scripts/build-nft-rpms.sh
+++ b/.semaphore/scripts/build-nft-rpms.sh
@@ -17,20 +17,20 @@ NFT_RPMS_IMAGE="calico/nftables-rpms:${NFT_RPMS_TAG}-${ARCH}"
 CACHE_PATH="${GCS_WORKFLOW_DIR}/nft-rpms-${ARCH}.tar.zst"
 BUILD_LOG="/tmp/nft-build-${ARCH}.log"
 
-echo "Building nftables RPMs for ${ARCH}..."
-echo "NFT_RPMS_TAG: ${NFT_RPMS_TAG}"
-echo "NFT_RPMS_IMAGE: ${NFT_RPMS_IMAGE}"
-
 # Use a subshell to capture all output to the log file while still printing to stdout.
 {
-  if docker manifest inspect "$NFT_RPMS_IMAGE" >/dev/null 2>&1; then
+  echo "Building nftables RPMs for ${ARCH}..."
+  echo "NFT_RPMS_TAG: ${NFT_RPMS_TAG}"
+  echo "NFT_RPMS_IMAGE: ${NFT_RPMS_IMAGE}"
+
+  if docker manifest inspect "$NFT_RPMS_IMAGE"; then
     echo "Cache hit for $NFT_RPMS_IMAGE, pulling"
     docker pull "$NFT_RPMS_IMAGE"
   else
     echo "Cache miss for $NFT_RPMS_IMAGE, building"
     docker run --privileged --rm tonistiigi/binfmt --install all
     make -C hack/rpms/nftables image ARCH="$ARCH"
-    
+
     # SEMAPHORE_GIT_BRANCH is the PR target branch on PR builds (so it
     # equals "master" for every PR landing on master), not the source
     # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect

--- a/.semaphore/scripts/build-nft-rpms.sh
+++ b/.semaphore/scripts/build-nft-rpms.sh
@@ -11,11 +11,14 @@ if [ -z "$ARCH" ]; then
   echo "Usage: $0 <arch>"
   exit 1
 fi
+if [ -z "$BUILD_LOG" ]; then
+  echo "Error: BUILD_LOG environment variable must be set to the path of the log file."
+  exit 1
+fi
 
 NFT_RPMS_TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
 NFT_RPMS_IMAGE="calico/nftables-rpms:${NFT_RPMS_TAG}-${ARCH}"
 CACHE_PATH="${GCS_WORKFLOW_DIR}/nft-rpms-${ARCH}.tar.zst"
-BUILD_LOG="/tmp/nft-build-${ARCH}.log"
 
 # Use a subshell to capture all output to the log file while still printing to stdout.
 {

--- a/.semaphore/scripts/build-nft-rpms.sh
+++ b/.semaphore/scripts/build-nft-rpms.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# build-nft-rpms.sh: Builds and caches nftables RPMs for a specific architecture.
+# This script is intended to be run from Semaphore CI.
+# It produces a log file at /tmp/nft-build-${ARCH}.log.
+
+ARCH=$1
+if [ -z "$ARCH" ]; then
+  echo "Usage: $0 <arch>"
+  exit 1
+fi
+
+NFT_RPMS_TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
+NFT_RPMS_IMAGE="calico/nftables-rpms:${NFT_RPMS_TAG}-${ARCH}"
+CACHE_PATH="${GCS_WORKFLOW_DIR}/nft-rpms-${ARCH}.tar.zst"
+BUILD_LOG="/tmp/nft-build-${ARCH}.log"
+
+echo "Building nftables RPMs for ${ARCH}..."
+echo "NFT_RPMS_TAG: ${NFT_RPMS_TAG}"
+echo "NFT_RPMS_IMAGE: ${NFT_RPMS_IMAGE}"
+
+# Use a subshell to capture all output to the log file while still printing to stdout.
+{
+  if docker manifest inspect "$NFT_RPMS_IMAGE" >/dev/null 2>&1; then
+    echo "Cache hit for $NFT_RPMS_IMAGE, pulling"
+    docker pull "$NFT_RPMS_IMAGE"
+  else
+    echo "Cache miss for $NFT_RPMS_IMAGE, building"
+    docker run --privileged --rm tonistiigi/binfmt --install all
+    make -C hack/rpms/nftables image ARCH="$ARCH"
+    
+    # SEMAPHORE_GIT_BRANCH is the PR target branch on PR builds (so it
+    # equals "master" for every PR landing on master), not the source
+    # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
+    # an actual branch build before pushing.
+    if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
+      echo "Pushing $NFT_RPMS_IMAGE"
+      docker push "$NFT_RPMS_IMAGE"
+    fi
+  fi
+
+  echo "Saving and uploading image tarball..."
+  docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar
+  zstd -3 --rm /tmp/nft-rpms.tar
+  gcloud storage cp /tmp/nft-rpms.tar.zst "$CACHE_PATH"
+} 2>&1 | tee "$BUILD_LOG"

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -359,6 +359,15 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      epilogue:
+        always:
+          commands:
+            - |-
+              build_log="/tmp/nft-build-${ARCH}.log"
+              if [ -f "$build_log" ]; then
+                gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
+                artifact push job "$build_log" --destination semaphore/logs/nft-build.log || true
+              fi
       jobs:
         - name: "Build/cache nftables RPMs"
           matrix:
@@ -369,28 +378,7 @@ blocks:
                 - ppc64le
                 - s390x
           commands:
-            - NFT_RPMS_TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
-            - NFT_RPMS_IMAGE="calico/nftables-rpms:${NFT_RPMS_TAG}-${ARCH}"
-            - cache_path="${GCS_WORKFLOW_DIR}/nft-rpms-${ARCH}.tar.zst"
-            - |-
-              if docker manifest inspect "$NFT_RPMS_IMAGE" >/dev/null 2>&1; then
-                echo "Cache hit for $NFT_RPMS_IMAGE, pulling"
-                docker pull "$NFT_RPMS_IMAGE"
-              else
-                echo "Cache miss for $NFT_RPMS_IMAGE, building"
-                docker run --privileged --rm tonistiigi/binfmt --install all
-                make -C hack/rpms/nftables image ARCH="$ARCH"
-                # SEMAPHORE_GIT_BRANCH is the PR target branch on PR builds (so it
-                # equals "master" for every PR landing on master), not the source
-                # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
-                # an actual branch build before pushing.
-                if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
-                  docker push "$NFT_RPMS_IMAGE"
-                fi
-              fi
-            - docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar
-            - zstd -3 --rm /tmp/nft-rpms.tar
-            - gcloud storage cp /tmp/nft-rpms.tar.zst "$cache_path"
+            - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
   - name: "Pull: go-build image"
     # Populate the GCS cache of calico/go-build so that every downstream job can
     # docker-load it from GCS (faster, and avoids Docker Hub rate limits) rather

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -359,13 +359,18 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      secrets:
+        # Needed for pushing to Docker Hub on cache miss.
+        - name: docker-hub
       prologue:
         commands:
-          - export BUILD_LOG="~/build-nft-rpms-${ARCH}.log"
+          - mkdir logs
+          - export BUILD_LOG="logs/build-nft-rpms-${ARCH}.log"
+          - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       epilogue:
         always:
           commands:
-            - artifact push job ${BUILD_LOG} --destination semaphore/logs || true
+            - artifact push job logs --destination semaphore/logs || true
       jobs:
         - name: "Build/cache nftables RPMs"
           matrix:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -366,7 +366,7 @@ blocks:
               build_log="/tmp/nft-build-${ARCH}.log"
               if [ -f "$build_log" ]; then
                 gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
-                artifact push job "$build_log" --destination semaphore/logs/nft-build.log || true
+                artifact push job "$build_log" --destination semaphore/logs/nft-build-${ARCH}.log || true
               fi
       jobs:
         - name: "Build/cache nftables RPMs"

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -359,15 +359,13 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      prologue:
+        commands:
+          - export BUILD_LOG="~/build-nft-rpms-${ARCH}.log"
       epilogue:
         always:
           commands:
-            - |-
-              build_log="/tmp/nft-build-${ARCH}.log"
-              if [ -f "$build_log" ]; then
-                gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
-                artifact push job "$build_log" --destination semaphore/logs/nft-build-${ARCH}.log || true
-              fi
+            - artifact push job ${BUILD_LOG} --destination semaphore/logs || true
       jobs:
         - name: "Build/cache nftables RPMs"
           matrix:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -359,6 +359,15 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      epilogue:
+        always:
+          commands:
+            - |-
+              build_log="/tmp/nft-build-${ARCH}.log"
+              if [ -f "$build_log" ]; then
+                gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
+                artifact push job "$build_log" --destination semaphore/logs/nft-build.log || true
+              fi
       jobs:
         - name: "Build/cache nftables RPMs"
           matrix:
@@ -369,28 +378,7 @@ blocks:
                 - ppc64le
                 - s390x
           commands:
-            - NFT_RPMS_TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
-            - NFT_RPMS_IMAGE="calico/nftables-rpms:${NFT_RPMS_TAG}-${ARCH}"
-            - cache_path="${GCS_WORKFLOW_DIR}/nft-rpms-${ARCH}.tar.zst"
-            - |-
-              if docker manifest inspect "$NFT_RPMS_IMAGE" >/dev/null 2>&1; then
-                echo "Cache hit for $NFT_RPMS_IMAGE, pulling"
-                docker pull "$NFT_RPMS_IMAGE"
-              else
-                echo "Cache miss for $NFT_RPMS_IMAGE, building"
-                docker run --privileged --rm tonistiigi/binfmt --install all
-                make -C hack/rpms/nftables image ARCH="$ARCH"
-                # SEMAPHORE_GIT_BRANCH is the PR target branch on PR builds (so it
-                # equals "master" for every PR landing on master), not the source
-                # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
-                # an actual branch build before pushing.
-                if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
-                  docker push "$NFT_RPMS_IMAGE"
-                fi
-              fi
-            - docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar
-            - zstd -3 --rm /tmp/nft-rpms.tar
-            - gcloud storage cp /tmp/nft-rpms.tar.zst "$cache_path"
+            - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
   - name: "Pull: go-build image"
     # Populate the GCS cache of calico/go-build so that every downstream job can
     # docker-load it from GCS (faster, and avoids Docker Hub rate limits) rather

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -359,13 +359,18 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      secrets:
+        # Needed for pushing to Docker Hub on cache miss.
+        - name: docker-hub
       prologue:
         commands:
-          - export BUILD_LOG="~/build-nft-rpms-${ARCH}.log"
+          - mkdir logs
+          - export BUILD_LOG="logs/build-nft-rpms-${ARCH}.log"
+          - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       epilogue:
         always:
           commands:
-            - artifact push job ${BUILD_LOG} --destination semaphore/logs || true
+            - artifact push job logs --destination semaphore/logs || true
       jobs:
         - name: "Build/cache nftables RPMs"
           matrix:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -366,7 +366,7 @@ blocks:
               build_log="/tmp/nft-build-${ARCH}.log"
               if [ -f "$build_log" ]; then
                 gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
-                artifact push job "$build_log" --destination semaphore/logs/nft-build.log || true
+                artifact push job "$build_log" --destination semaphore/logs/nft-build-${ARCH}.log || true
               fi
       jobs:
         - name: "Build/cache nftables RPMs"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -359,15 +359,13 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
+      prologue:
+        commands:
+          - export BUILD_LOG="~/build-nft-rpms-${ARCH}.log"
       epilogue:
         always:
           commands:
-            - |-
-              build_log="/tmp/nft-build-${ARCH}.log"
-              if [ -f "$build_log" ]; then
-                gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
-                artifact push job "$build_log" --destination semaphore/logs/nft-build-${ARCH}.log || true
-              fi
+            - artifact push job ${BUILD_LOG} --destination semaphore/logs || true
       jobs:
         - name: "Build/cache nftables RPMs"
           matrix:

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -126,6 +126,7 @@
           - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
           - gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
           - gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+
 - name: "Build: nftables RPMs"
   # Producer for the patched nftables + libnftnl RPMs that calico/node and the
   # istio CNI install image consume. The image tag is content-addressed (sha
@@ -142,6 +143,15 @@
       machine:
         type: f1-standard-4
         os_image: ubuntu2204
+    epilogue:
+      always:
+        commands:
+          - |-
+            build_log="/tmp/nft-build-${ARCH}.log"
+            if [ -f "$build_log" ]; then
+              gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
+              artifact push job "$build_log" --destination semaphore/logs/nft-build.log || true
+            fi
     jobs:
       - name: "Build/cache nftables RPMs"
         matrix:
@@ -152,28 +162,8 @@
               - ppc64le
               - s390x
         commands:
-          - NFT_RPMS_TAG=$(make --no-print-directory -C hack/rpms/nftables print-tag)
-          - NFT_RPMS_IMAGE="calico/nftables-rpms:${NFT_RPMS_TAG}-${ARCH}"
-          - cache_path="${GCS_WORKFLOW_DIR}/nft-rpms-${ARCH}.tar.zst"
-          - |-
-            if docker manifest inspect "$NFT_RPMS_IMAGE" >/dev/null 2>&1; then
-              echo "Cache hit for $NFT_RPMS_IMAGE, pulling"
-              docker pull "$NFT_RPMS_IMAGE"
-            else
-              echo "Cache miss for $NFT_RPMS_IMAGE, building"
-              docker run --privileged --rm tonistiigi/binfmt --install all
-              make -C hack/rpms/nftables image ARCH="$ARCH"
-              # SEMAPHORE_GIT_BRANCH is the PR target branch on PR builds (so it
-              # equals "master" for every PR landing on master), not the source
-              # branch — gate on SEMAPHORE_GIT_PR_NUMBER being empty to detect
-              # an actual branch build before pushing.
-              if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && ( "$SEMAPHORE_GIT_BRANCH" == "master" || "$SEMAPHORE_GIT_BRANCH" == release-* ) ]]; then
-                docker push "$NFT_RPMS_IMAGE"
-              fi
-            fi
-          - docker save "$NFT_RPMS_IMAGE" -o /tmp/nft-rpms.tar
-          - zstd -3 --rm /tmp/nft-rpms.tar
-          - gcloud storage cp /tmp/nft-rpms.tar.zst "$cache_path"
+          - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
+
 - name: "Pull: go-build image"
   # Populate the GCS cache of calico/go-build so that every downstream job can
   # docker-load it from GCS (faster, and avoids Docker Hub rate limits) rather

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -143,13 +143,19 @@
       machine:
         type: f1-standard-4
         os_image: ubuntu2204
+
+    secrets:
+      # Needed for pushing to Docker Hub on cache miss.
+      - name: docker-hub
     prologue:
       commands:
-        - export BUILD_LOG="~/build-nft-rpms-${ARCH}.log"
+        - mkdir logs
+        - export BUILD_LOG="logs/build-nft-rpms-${ARCH}.log"
+        - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
     epilogue:
       always:
         commands:
-          - artifact push job ${BUILD_LOG} --destination semaphore/logs || true
+          - artifact push job logs --destination semaphore/logs || true
     jobs:
       - name: "Build/cache nftables RPMs"
         matrix:

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -150,7 +150,7 @@
             build_log="/tmp/nft-build-${ARCH}.log"
             if [ -f "$build_log" ]; then
               gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
-              artifact push job "$build_log" --destination semaphore/logs/nft-build.log || true
+              artifact push job "$build_log" --destination semaphore/logs/nft-build-${ARCH}.log || true
             fi
     jobs:
       - name: "Build/cache nftables RPMs"

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -143,15 +143,13 @@
       machine:
         type: f1-standard-4
         os_image: ubuntu2204
+    prologue:
+      commands:
+        - export BUILD_LOG="~/build-nft-rpms-${ARCH}.log"
     epilogue:
       always:
         commands:
-          - |-
-            build_log="/tmp/nft-build-${ARCH}.log"
-            if [ -f "$build_log" ]; then
-              gcloud storage cp "$build_log" "${GCS_WORKFLOW_DIR}/nft-build-${ARCH}.log" || true
-              artifact push job "$build_log" --destination semaphore/logs/nft-build-${ARCH}.log || true
-            fi
+          - artifact push job ${BUILD_LOG} --destination semaphore/logs || true
     jobs:
       - name: "Build/cache nftables RPMs"
         matrix:


### PR DESCRIPTION
Moves the nftables RPM build logic to a dedicated script and adds logging to GCS and Semaphore job artifacts. This should help us diagnose the caching issues by providing visibility into the tag generation and `docker manifest inspect` output.