### PR TITLE
Fix tiered RBAC e2e tests and fix e2e CI failures (#12271)

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -655,7 +655,13 @@ blocks:
         - name: PRIVATE_REGISTRY
           value: "quay.io/"
         - name: K8S_E2E_FLAGS
-          value: --ginkgo.focus=(\[sig-calico\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])
+          # Skipped test labels:
+          # - Slow: long-running tests not suitable for CI
+          # - Disruptive: tests that break cluster state for other tests
+          # - RequiresBGPMesh: requires BGP routing, but this cluster uses VXLAN
+          # - NoEncap: requires non-encapsulated routing, but this cluster uses VXLAN
+          # - Feature:Istio: Calico policy not enforced with Istio ambient on BPF dataplane
+          value: --ginkgo.focus=(\[sig-calico\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[RequiresBGPMesh\]|\[NoEncap\]|\[Feature:Istio\])
         - name: USE_API_SERVER
           value: "false"
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -655,7 +655,13 @@ blocks:
         - name: PRIVATE_REGISTRY
           value: "quay.io/"
         - name: K8S_E2E_FLAGS
-          value: --ginkgo.focus=(\[sig-calico\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])
+          # Skipped test labels:
+          # - Slow: long-running tests not suitable for CI
+          # - Disruptive: tests that break cluster state for other tests
+          # - RequiresBGPMesh: requires BGP routing, but this cluster uses VXLAN
+          # - NoEncap: requires non-encapsulated routing, but this cluster uses VXLAN
+          # - Feature:Istio: Calico policy not enforced with Istio ambient on BPF dataplane
+          value: --ginkgo.focus=(\[sig-calico\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[RequiresBGPMesh\]|\[NoEncap\]|\[Feature:Istio\])
         - name: USE_API_SERVER
           value: "false"
       jobs:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e-gcp.yml
@@ -29,7 +29,13 @@
       - name: PRIVATE_REGISTRY
         value: "quay.io/"
       - name: K8S_E2E_FLAGS
-        value: --ginkgo.focus=(\[sig-calico\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\])
+        # Skipped test labels:
+        # - Slow: long-running tests not suitable for CI
+        # - Disruptive: tests that break cluster state for other tests
+        # - RequiresBGPMesh: requires BGP routing, but this cluster uses VXLAN
+        # - NoEncap: requires non-encapsulated routing, but this cluster uses VXLAN
+        # - Feature:Istio: Calico policy not enforced with Istio ambient on BPF dataplane
+        value: --ginkgo.focus=(\[sig-calico\]) --ginkgo.skip=(\[Slow\]|\[Disruptive\]|\[RequiresBGPMesh\]|\[NoEncap\]|\[Feature:Istio\])
       - name: USE_API_SERVER
         value: "false"
     jobs:

--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -85,12 +85,27 @@ func RequiresNoEncap() any {
 	return framework.WithLabel("NoEncap")
 }
 
+// RequiresBGPMesh marks tests that depend on the BGP node-to-node mesh being the sole
+// routing mechanism. These tests disable the mesh and expect connectivity to break, which
+// only works when there's no other routing path (e.g., VXLAN). Skip these on VXLAN clusters
+// via --ginkgo.skip=RequiresBGPMesh.
+func RequiresBGPMesh() any {
+	return framework.WithLabel("RequiresBGPMesh")
+}
+
 // WithFeature marks tests as verifying a specific feature.
 func WithFeature(feature string) any {
 	if !features[feature] {
 		framework.Failf("%s is not a supported feature", feature)
 	}
 	return framework.WithLabel(fmt.Sprintf("Feature:%s", feature))
+}
+
+// WithNoTierPrefix marks tests that use bare policy names (without tier prefix).
+// This naming style is only supported in v3.32+. Older branches should skip
+// these tests via -skip=NoTierPrefix.
+func WithNoTierPrefix() any {
+	return framework.WithLabel("NoTierPrefix")
 }
 
 // WithWindows marks tests that can run on clusters with Windows nodes.

--- a/e2e/pkg/tests/bgp/export.go
+++ b/e2e/pkg/tests/bgp/export.go
@@ -37,6 +37,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGPMesh(),
 	describe.WithSerial(),
 	"BGP export tests",
 	func() {
@@ -47,6 +48,7 @@ var _ = describe.CalicoDescribe(
 		var server1 *conncheck.Server
 		var client1 *conncheck.Client
 		var restoreBGPConfig func()
+		var bgpStatus *BGPStatusMonitor
 
 		// Create a new framework for the tests.
 		f := utils.NewDefaultFramework("bgp-export")
@@ -69,9 +71,13 @@ var _ = describe.CalicoDescribe(
 			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
 			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
 			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			requireNonVXLANCluster(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)
+
+			// Set up CalicoNodeStatus resources for BGP diagnostics and convergence waits.
+			bgpStatus = NewBGPStatusMonitor(cli)
 
 			// Create an IP pool for the test.
 			pool := v3.NewIPPool()
@@ -112,6 +118,9 @@ var _ = describe.CalicoDescribe(
 			checker.AddClient(client1)
 			checker.Deploy()
 
+			// Wait for BGP to be fully established before baseline connectivity check.
+			bgpStatus.WaitForEstablished()
+
 			// Verify initial connectivity.
 			checker.ResetExpectations()
 			checker.ExpectSuccess(client1, server1.ClusterIPs()...)
@@ -148,6 +157,8 @@ var _ = describe.CalicoDescribe(
 			pool.Spec.DisableBGPExport = true
 			err = cli.Update(context.Background(), pool)
 			Expect(err).NotTo(HaveOccurred(), "Error updating IP pool")
+
+			bgpStatus.Log()
 
 			// Routing should stop working on the IPv4 pool. If there is an IPv6 pool in the cluster, it will
 			// continue to work, so only test the IPv4 address.

--- a/e2e/pkg/tests/bgp/peers.go
+++ b/e2e/pkg/tests/bgp/peers.go
@@ -39,6 +39,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("BGPPeer"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresBGPMesh(),
 	describe.WithSerial(),
 	"BGPPeer",
 	func() {
@@ -49,6 +50,7 @@ var _ = describe.CalicoDescribe(
 		var server1 *conncheck.Server
 		var client1 *conncheck.Client
 		var restoreBGPConfig func()
+		var bgpStatus *BGPStatusMonitor
 
 		// Create a new framework for the tests.
 		f := utils.NewDefaultFramework("bgppeer")
@@ -71,9 +73,13 @@ var _ = describe.CalicoDescribe(
 			Expect(installation.Spec.CalicoNetwork).NotTo(BeNil(), "CalicoNetwork is not configured in the Installation")
 			Expect(installation.Spec.CalicoNetwork.BGP).NotTo(BeNil(), "BGP is not enabled in the cluster")
 			Expect(*installation.Spec.CalicoNetwork.BGP).To(Equal(v1.BGPEnabled), "BGP is not enabled in the cluster")
+			requireNonVXLANCluster(cli)
 
 			// Ensure full mesh BGP is functioning before each test.
 			restoreBGPConfig = ensureInitialBGPConfig(cli)
+
+			// Set up CalicoNodeStatus resources for BGP diagnostics and convergence waits.
+			bgpStatus = NewBGPStatusMonitor(cli)
 
 			// Before each test, perform the following steps:
 			// - Create a server pod and corresponding service in the main namespace for the test.
@@ -109,6 +115,8 @@ var _ = describe.CalicoDescribe(
 			// Disable full mesh BGP.
 			disableFullMesh(cli)
 
+			bgpStatus.WaitForNoMeshPeers()
+
 			// Verify connectivity is lost.
 			checker.ResetExpectations()
 			checker.ExpectFailure(client1, server1.ClusterIPs()...)
@@ -141,6 +149,8 @@ var _ = describe.CalicoDescribe(
 			ginkgo.By("Deleting the BGPPeer to disable connectivity again")
 			err = cli.Delete(context.Background(), peer)
 			Expect(err).NotTo(HaveOccurred(), "Error deleting BGPPeer resource")
+
+			bgpStatus.WaitForNoPeers()
 
 			// Verify connectivity is lost again.
 			checker.ResetExpectations()

--- a/e2e/pkg/tests/bgp/utils.go
+++ b/e2e/pkg/tests/bgp/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/sirupsen/logrus"
 
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
@@ -12,11 +13,31 @@ import (
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
 )
+
+// requireNonVXLANCluster checks that no IP pool uses VXLAN encapsulation. Tests that
+// disable the BGP mesh and expect connectivity to break cannot work on VXLAN clusters
+// because Felix programs VXLAN tunnel routes independently of BGP.
+func requireNonVXLANCluster(cli ctrlclient.Client) {
+	pools := &v3.IPPoolList{}
+	err := cli.List(context.Background(), pools)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Error listing IP pools")
+
+	for _, pool := range pools.Items {
+		switch pool.Spec.VXLANMode {
+		case v3.VXLANModeAlways, v3.VXLANModeCrossSubnet:
+			framework.Failf(
+				"This test requires BGP full mesh as the sole routing mechanism, and cannot run with VXLAN enabled (pool %s uses VXLANMode %s)",
+				pool.Name, pool.Spec.VXLANMode,
+			)
+		}
+	}
+}
 
 // ensureInitialBGPConfig updates the default BGPConfiguration to ensures that full mesh BGP is enabled.
 // It returns a cleanup function to restore the original state after the test.
@@ -168,4 +189,149 @@ func waitForBGPEstablishedForNode(cli ctrlclient.Client, node string) {
 		}
 		return nil
 	}, "1m", "1s").ShouldNot(HaveOccurred(), "BGPPeer count did not reach expected value")
+}
+
+// BGPStatusMonitor manages CalicoNodeStatus resources for observing BGP session
+// state during tests. Create one per test suite via NewBGPStatusMonitor, which
+// creates the status resources and registers cleanup. Then use Log, WaitForEstablished,
+// and WaitForNoEstablished to orchestrate test assertions around BGP convergence.
+type BGPStatusMonitor struct {
+	cli       ctrlclient.Client
+	nodeNames []string
+}
+
+// NewBGPStatusMonitor creates CalicoNodeStatus resources for all nodes in the cluster
+// with BGP and Routes classes enabled and a fast (1s) update period. Registers a
+// DeferCleanup to remove them when the test completes.
+func NewBGPStatusMonitor(cli ctrlclient.Client) *BGPStatusMonitor {
+	nodes := &corev1.NodeList{}
+	err := cli.List(context.Background(), nodes)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Error listing nodes")
+
+	m := &BGPStatusMonitor{cli: cli}
+	for _, node := range nodes.Items {
+		status := &v3.CalicoNodeStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: node.Name},
+			Spec: v3.CalicoNodeStatusSpec{
+				Node: node.Name,
+				Classes: []v3.NodeStatusClassType{
+					v3.NodeStatusClassTypeBGP,
+					v3.NodeStatusClassTypeRoutes,
+				},
+				UpdatePeriodSeconds: ptr.To[uint32](1),
+			},
+		}
+		err := cli.Create(context.Background(), status)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Error creating CalicoNodeStatus for node %s", node.Name)
+		m.nodeNames = append(m.nodeNames, node.Name)
+	}
+
+	ginkgo.DeferCleanup(func() {
+		for _, name := range m.nodeNames {
+			status := &v3.CalicoNodeStatus{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			if err := cli.Delete(context.Background(), status); err != nil {
+				logrus.WithError(err).Warnf("Failed to delete CalicoNodeStatus %s", name)
+			}
+		}
+	})
+
+	return m
+}
+
+// Log dumps the current BGP session and route state for all nodes. Useful for
+// diagnostics inside Eventually loops or at key test checkpoints.
+func (m *BGPStatusMonitor) Log() {
+	for _, name := range m.nodeNames {
+		status := &v3.CalicoNodeStatus{}
+		err := m.cli.Get(context.Background(), ctrlclient.ObjectKey{Name: name}, status)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to get CalicoNodeStatus for %s", name)
+			continue
+		}
+
+		bgp := status.Status.BGP
+		logrus.Infof("[BGP] Node %s: established_v4=%d not_established_v4=%d established_v6=%d not_established_v6=%d last_updated=%s",
+			name,
+			bgp.NumberEstablishedV4, bgp.NumberNotEstablishedV4,
+			bgp.NumberEstablishedV6, bgp.NumberNotEstablishedV6,
+			status.Status.LastUpdated.Time,
+		)
+		for _, peer := range bgp.PeersV4 {
+			logrus.Infof("[BGP]   Node %s peer %s type=%s state=%s since=%s", name, peer.PeerIP, peer.Type, peer.State, peer.Since)
+		}
+		for _, route := range status.Status.Routes.RoutesV4 {
+			logrus.Infof("[BGP]   Node %s route: %s via %s type=%s", name, route.Destination, route.Gateway, route.Type)
+		}
+	}
+}
+
+// WaitForEstablished waits until all nodes have at least one established BGP peer
+// and no non-established peers. Logs BGP state on each poll for diagnostics.
+func (m *BGPStatusMonitor) WaitForEstablished() {
+	ginkgo.By("Waiting for all BGP sessions to be established")
+	EventuallyWithOffset(1, func() error {
+		for _, name := range m.nodeNames {
+			status := &v3.CalicoNodeStatus{}
+			if err := m.cli.Get(context.Background(), ctrlclient.ObjectKey{Name: name}, status); err != nil {
+				return fmt.Errorf("failed to get CalicoNodeStatus for %s: %w", name, err)
+			}
+			bgp := status.Status.BGP
+			if bgp.NumberEstablishedV4+bgp.NumberEstablishedV6 == 0 {
+				return fmt.Errorf("node %s: no BGP peers established yet", name)
+			}
+			if bgp.NumberNotEstablishedV4+bgp.NumberNotEstablishedV6 > 0 {
+				return fmt.Errorf("node %s: %d v4 + %d v6 peers not established",
+					name, bgp.NumberNotEstablishedV4, bgp.NumberNotEstablishedV6)
+			}
+		}
+		return nil
+	}, "2m", "1s").Should(Succeed(), "BGP sessions did not all reach Established state")
+}
+
+// WaitForNoPeers waits until no node reports any established BGP peers of any type.
+// Logs BGP state on each poll for diagnostics.
+func (m *BGPStatusMonitor) WaitForNoPeers() {
+	ginkgo.By("Waiting for all BGP peers to be removed")
+	EventuallyWithOffset(1, func() error {
+		for _, name := range m.nodeNames {
+			status := &v3.CalicoNodeStatus{}
+			if err := m.cli.Get(context.Background(), ctrlclient.ObjectKey{Name: name}, status); err != nil {
+				return fmt.Errorf("failed to get CalicoNodeStatus for %s: %w", name, err)
+			}
+			bgp := status.Status.BGP
+			total := bgp.NumberEstablishedV4 + bgp.NumberNotEstablishedV4 + bgp.NumberEstablishedV6 + bgp.NumberNotEstablishedV6
+			if total > 0 {
+				m.Log()
+				return fmt.Errorf("node %s still has %d BGP peers", name, total)
+			}
+		}
+		return nil
+	}, "2m", "1s").Should(Succeed(), "BGP peers still present")
+}
+
+// WaitForNoMeshPeers waits until no node reports any NodeMesh BGP peers. This is
+// used after disabling the node-to-node mesh to confirm sessions have torn down.
+// Logs BGP state on each poll for diagnostics.
+func (m *BGPStatusMonitor) WaitForNoMeshPeers() {
+	ginkgo.By("Waiting for all NodeMesh BGP sessions to be torn down")
+	EventuallyWithOffset(1, func() error {
+		for _, name := range m.nodeNames {
+			status := &v3.CalicoNodeStatus{}
+			if err := m.cli.Get(context.Background(), ctrlclient.ObjectKey{Name: name}, status); err != nil {
+				return fmt.Errorf("failed to get CalicoNodeStatus for %s: %w", name, err)
+			}
+			for _, peer := range status.Status.BGP.PeersV4 {
+				if peer.Type == v3.BGPPeerTypeNodeMesh {
+					m.Log()
+					return fmt.Errorf("node %s still has NodeMesh peer %s (state=%s)", name, peer.PeerIP, peer.State)
+				}
+			}
+			for _, peer := range status.Status.BGP.PeersV6 {
+				if peer.Type == v3.BGPPeerTypeNodeMesh {
+					return fmt.Errorf("node %s still has NodeMesh v6 peer %s (state=%s)", name, peer.PeerIP, peer.State)
+				}
+			}
+		}
+		return nil
+	}, "2m", "1s").Should(Succeed(), "NodeMesh BGP sessions still present after disabling mesh")
 }

--- a/e2e/pkg/tests/networking/ipip.go
+++ b/e2e/pkg/tests/networking/ipip.go
@@ -142,12 +142,7 @@ var _ = describe.CalicoDescribe(
 			err = cli.Update(context.Background(), pool)
 			Expect(err).NotTo(HaveOccurred(), "Error updating IP pool to disable IPIP")
 
-			// Verify connectivity still works.
-			checker.ResetExpectations()
-			checker.ExpectSuccess(client1, server1.ClusterIPs()...)
-			checker.Execute()
-
-			// Eventually, the routes for the test's IP pool should no longer use tunl0.
+			// Wait for routes to converge before checking connectivity.
 			ginkgo.By("Verifying that node routes no longer use tunl0")
 			Eventually(func() error {
 				routes := getNodeRoutes(cli, "203.0.113")
@@ -160,7 +155,12 @@ var _ = describe.CalicoDescribe(
 					}
 				}
 				return nil
-			}, 10*time.Second, 1*time.Second).Should(Succeed(), "Routes for the test IP pool are still using tunl0")
+			}, 30*time.Second, 1*time.Second).Should(Succeed(), "Routes for the test IP pool are still using tunl0")
+
+			// Verify connectivity still works.
+			checker.ResetExpectations()
+			checker.ExpectSuccess(client1, server1.ClusterIPs()...)
+			checker.Execute()
 
 			// CrossSubnet.
 			ginkgo.By("Setting IPIP mode to CrossSubnet on the IP pool")

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -232,6 +232,11 @@ var _ = describe.CalicoDescribe(
 				tierObj.Name = customTier
 				tierObj.Spec.Order = ptr.To[float64](200)
 				Expect(cli.Create(context.TODO(), tierObj)).ToNot(HaveOccurred())
+				DeferCleanup(func() {
+					Eventually(func() error {
+						return cli.Delete(context.TODO(), tierObj)
+					}, 30*time.Second, 1*time.Second).Should(Succeed(), "Failed to delete tier %s", tierObj.Name)
+				})
 
 				// Create server
 				server = conncheck.NewServer(utils.GenerateRandomName(serverPodNamePrefix), f.Namespace)
@@ -242,7 +247,6 @@ var _ = describe.CalicoDescribe(
 			})
 
 			AfterEach(func() {
-				Expect(cli.Delete(context.TODO(), tierObj)).ShouldNot(HaveOccurred())
 				checker.Stop()
 			})
 

--- a/e2e/pkg/tests/policy/tiered_rbac.go
+++ b/e2e/pkg/tests/policy/tiered_rbac.go
@@ -51,7 +51,9 @@ const (
 )
 
 // DESCRIPTION: Verify tiered RBAC correctly enforces tier-based access control
-// for policy create, update, and delete operations.
+// for policy create, update, and delete operations using bare policy names
+// (without tier prefix). This naming style is only supported in v3.32+.
+// Older branches should skip these tests via -skip=NoTierPrefix.
 //
 // The tiered RBAC implementation requires that users have:
 //  1. GET access to the tier (resource: "tiers")
@@ -64,6 +66,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithCategory(describe.Policy),
 	describe.WithFeature("Tiered-RBAC"),
+	describe.WithNoTierPrefix(),
 	describe.WithSerial(),
 	"Tiered RBAC",
 	func() {
@@ -579,3 +582,119 @@ func buildTieredRBACResources() tieredRBACSetup {
 
 	return setup
 }
+
+// DESCRIPTION: Verify tiered RBAC using tier-prefixed policy names (e.g., "tier.policyname"),
+// which is supported on all Calico versions. This provides basic tiered RBAC coverage on
+// older branches where the bare-name tests above are skipped.
+//
+// PRECONDITIONS: The tiered RBAC webhook or Calico API server must be installed.
+var _ = describe.CalicoDescribe(
+	describe.WithTeam(describe.Core),
+	describe.WithCategory(describe.Policy),
+	describe.WithFeature("Tiered-RBAC"),
+	describe.WithSerial(),
+	"Tiered RBAC with tier-prefixed names",
+	func() {
+		f := utils.NewDefaultFramework("tiered-rbac-prefixed")
+
+		var (
+			adminCli ctrlclient.Client
+			ctx      context.Context
+			cancel   context.CancelFunc
+		)
+
+		BeforeEach(func() {
+			var err error
+			ctx, cancel = context.WithCancel(context.Background())
+
+			adminCli, err = client.New(f.ClientConfig())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating test tier")
+			tier := v3.NewTier()
+			tier.Name = rbacTestTier
+			tier.Spec.Order = ptr.To(500.0)
+			tier.Labels = map[string]string{utils.TestResourceLabel: "true"}
+			Expect(adminCli.Create(ctx, tier)).To(Succeed())
+
+			By("Creating RBAC resources for test users")
+			setup := buildTieredRBACResources()
+			for i := range setup.roles {
+				_, err := f.ClientSet.RbacV1().ClusterRoles().Create(ctx, &setup.roles[i], metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+			for i := range setup.bindings {
+				_, err := f.ClientSet.RbacV1().ClusterRoleBindings().Create(ctx, &setup.bindings[i], metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			defer cancel()
+			var errOccurred bool
+
+			By("Cleaning up RBAC resources")
+			setup := buildTieredRBACResources()
+			for _, binding := range setup.bindings {
+				if err := f.ClientSet.RbacV1().ClusterRoleBindings().Delete(ctx, binding.Name, metav1.DeleteOptions{}); err != nil {
+					logrus.WithError(err).WithField("name", binding.Name).Error("Failed to delete ClusterRoleBinding")
+					errOccurred = true
+				}
+			}
+			for _, role := range setup.roles {
+				if err := f.ClientSet.RbacV1().ClusterRoles().Delete(ctx, role.Name, metav1.DeleteOptions{}); err != nil {
+					logrus.WithError(err).WithField("name", role.Name).Error("Failed to delete ClusterRole")
+					errOccurred = true
+				}
+			}
+
+			By("Cleaning up test tier")
+			tier := v3.NewTier()
+			tier.Name = rbacTestTier
+			if err := adminCli.Delete(ctx, tier); err != nil {
+				logrus.WithError(err).WithField("name", rbacTestTier).Error("Failed to delete Tier")
+				errOccurred = true
+			}
+
+			Expect(errOccurred).To(BeFalse(), "errors occurred during teardown")
+		})
+
+		It("should allow create and deny based on tier RBAC with prefixed names", func() {
+			By("Creating a policy as the tier admin using tier-prefixed name")
+			cfg := rest.CopyConfig(f.ClientConfig())
+			cfg.Impersonate = rest.ImpersonationConfig{UserName: rbacTierAdminUser}
+			cli, err := client.NewAPIClient(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			np := v3.NewNetworkPolicy()
+			np.Name = rbacTestTier + "." + "rbac-test-prefixed-allow"
+			np.Namespace = f.Namespace.Name
+			np.Spec.Tier = rbacTestTier
+			np.Spec.Order = ptr.To(100.0)
+			np.Spec.Selector = "all()"
+			np.Spec.Ingress = []v3.Rule{{Action: v3.Allow}}
+
+			Expect(cli.Create(ctx, np)).To(Succeed(), "tier admin should be able to create policy with prefixed name")
+			Expect(adminCli.Delete(ctx, np)).To(Succeed())
+
+			By("Verifying a user without tier GET is denied with prefixed name")
+			cfg2 := rest.CopyConfig(f.ClientConfig())
+			cfg2.Impersonate = rest.ImpersonationConfig{UserName: rbacNoTierGetUser}
+			noCli, err := client.NewAPIClient(cfg2)
+			Expect(err).NotTo(HaveOccurred())
+
+			np2 := v3.NewNetworkPolicy()
+			np2.Name = rbacTestTier + "." + "rbac-test-prefixed-deny"
+			np2.Namespace = f.Namespace.Name
+			np2.Spec.Tier = rbacTestTier
+			np2.Spec.Order = ptr.To(100.0)
+			np2.Spec.Selector = "all()"
+			np2.Spec.Ingress = []v3.Rule{{Action: v3.Allow}}
+
+			err = noCli.Create(ctx, np2)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsForbidden(err)).To(BeTrue(), "expected forbidden error, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("tier"))
+		})
+	},
+)

--- a/e2e/pkg/utils/conncheck/client.go
+++ b/e2e/pkg/utils/conncheck/client.go
@@ -19,6 +19,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/images"
 )
 
 func NewClient(id string, ns *v1.Namespace, opts ...ClientOption) *Client {
@@ -96,7 +98,7 @@ func WithClientCustomizer(customizer func(pod *v1.Pod)) ClientOption {
 
 // WithCapture configures the client pod with NET_RAW and NET_ADMIN capabilities required
 // for packet capture with tcpdump. Use this when calling ExpectEncrypted/ExpectPlaintext.
-// The client image must include tcpdump (e.g., netshoot or a custom image).
+// Switches the image to netshoot which includes tcpdump and other network tools.
 func WithCapture() ClientOption {
 	return WithClientCustomizer(func(pod *v1.Pod) {
 		if pod.Spec.SecurityContext == nil {
@@ -105,6 +107,7 @@ func WithCapture() ClientOption {
 		pod.Spec.SecurityContext.RunAsUser = ptrInt64(0)
 		if len(pod.Spec.Containers) > 0 {
 			c := &pod.Spec.Containers[0]
+			c.Image = images.Netshoot
 			if c.SecurityContext == nil {
 				c.SecurityContext = &v1.SecurityContext{}
 			}

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -454,7 +454,7 @@ func (c *connectionTester) runConnection(ctx context.Context, exp *Expectation, 
 	// those changes taking effect. So a short retry loop is helpful.
 
 loop:
-	for err != nil || result != exp.ExpectedResult {
+	for result != exp.ExpectedResult {
 		select {
 		case <-ctx.Done():
 			break loop

--- a/e2e/pkg/utils/images/images.go
+++ b/e2e/pkg/utils/images/images.go
@@ -26,7 +26,7 @@ const (
 	TestWebserver = "gcr.io/kubernetes-e2e-test-images/test-webserver:1.0"
 	Agnhost       = "registry.k8s.io/e2e-test-images/agnhost:2.47"
 	RapidClient   = "quay.io/tigeradev/rapidclient"
-	Iperf3        = "docker.io/networkstatic/iperf3:3.16"
+	Iperf3        = "docker.io/networkstatic/iperf3:latest"
 	Netutils      = "calico/k8s-e2e-netutils:stable"
 	Socat         = "docker.io/alpine/socat:1.8.0.1"
 	Netshoot      = "docker.io/nicolaka/netshoot:v0.13"


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->
Cherry-pick of https://github.com/projectcalico/calico/pull/12271

Two things in this PR:

**Tiered RBAC cross-version compat fix**

The existing tiered RBAC e2e tests use bare policy names (setting `Spec.Tier` without including the tier prefix in the policy name), which is only supported in v3.32+. On v3.31 and earlier the API requires the `tier.policyname` format, so these tests fail.

Tags the existing tests with `NoTierPrefix` so older branches can skip them via `-skip=NoTierPrefix`, and adds a new `CalicoDescribe` with a tier-prefixed test that provides basic RBAC coverage on all versions.

**E2E CI fixes**

Fixes several e2e test failures from the real GCP kubeadm CI run:

- **QoS tests**: Update `iperf3` image tag from `3.16` (deleted from Docker Hub) to `latest`
- **Staged policy tests**: Fix tier cleanup ordering — the `AfterEach` was trying to delete the tier before `DeferCleanup` had removed the policies inside it. Moved tier deletion to `DeferCleanup` (registered before policies, so it runs after them in LIFO order) and wrapped in `Eventually` to handle propagation delay
- **Conncheck retry loop**: Fix bug where expected-failure checks retried for the full 30s timeout. The loop condition `err != nil || result != exp.ExpectedResult` kept retrying on `err` even when `result` already matched, since `err` is inherently non-nil for any FAILURE result
- **Istio ambient test**: `tcpdump` not found in the client pod (`alpine:3` doesn't have it). `WithCapture()` now also sets the image to `netshoot` which has tcpdump and other network tools
- **IPIP toggle test**: Connectivity check was running before route convergence. Moved the `Eventually` wait for tunl0 routes before the connectivity check
- **BGP peer/export tests**: Added `CalicoNodeStatus`-based diagnostics (BGP session state, peer info, learned routes) so we have better data next time these fail
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
