### PR TITLE
[v3.31] Include producer Dockerfile in nftables-rpms image hash

### DIFF
--- a/hack/rpms/nftables/image.mk
+++ b/hack/rpms/nftables/image.mk
@@ -11,11 +11,12 @@
 
 NFT_RPMS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-# Content-addressed tag. Hashes the spec files, patches, and the four
-# nftables/libnftnl version pins from metadata.mk. First 12 hex chars so the
-# tag stays human-scannable.
+# Content-addressed tag. Hashes the producer Dockerfile (whose base image
+# determines the dist tag and glibc requirements of the resulting RPMs), the
+# spec files, patches, and the four nftables/libnftnl version pins from
+# metadata.mk. First 12 hex chars so the tag stays human-scannable.
 NFT_RPMS_TAG := $(shell ( \
-		cat $(NFT_RPMS_DIR)libnftnl.spec $(NFT_RPMS_DIR)nftables.spec $(NFT_RPMS_DIR)patches/*.patch && \
+		cat $(NFT_RPMS_DIR)Dockerfile $(NFT_RPMS_DIR)libnftnl.spec $(NFT_RPMS_DIR)nftables.spec $(NFT_RPMS_DIR)patches/*.patch && \
 		echo $(NFTABLES_VER) $(NFTABLES_SHA256) $(LIBNFTNL_VER) $(LIBNFTNL_SHA256) \
 	) | sha256sum | cut -c1-12)
 


### PR DESCRIPTION
The content-addressed tag for `calico/nftables-rpms` hashes the spec files, patches, and version pins but not the producer `Dockerfile`. On release-v3.31 the cherry-pick of #12714 flipped the producer base from `almalinux:9` to `almalinux:8` to match the UBI 8 node base, but the tag stayed identical to master's (`af87a3eebfaf`), so consumers pulled the master-built el9 RPMs and `rpm -Uvh` failed on UBI 8 (glibc 2.28) with:

\`\`\`
libc.so.6(GLIBC_2.33)(64bit) is needed by nftables-1.1.1-1.tigera.el9.x86_64
libc.so.6(GLIBC_2.34)(64bit) is needed by nftables-1.1.1-1.tigera.el9.x86_64
\`\`\`

Reported in #11750.

Including the producer Dockerfile in the hash inputs busts the cache on any base-image change. After this lands, the new tag will be a cache miss on CI, which rebuilds from `almalinux:8` and pushes el8 RPMs.

\`\`\`release-note
None
\`\`\`