### PR TITLE
Include producer Dockerfile in nftables-rpms image hash

### DIFF
--- a/hack/rpms/nftables/image.mk
+++ b/hack/rpms/nftables/image.mk
@@ -11,11 +11,12 @@
 
 NFT_RPMS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-# Content-addressed tag. Hashes the spec files, patches, and the four
-# nftables/libnftnl version pins from metadata.mk. First 12 hex chars so the
-# tag stays human-scannable.
+# Content-addressed tag. Hashes the producer Dockerfile (whose base image
+# determines the dist tag and glibc requirements of the resulting RPMs), the
+# spec files, patches, and the four nftables/libnftnl version pins from
+# metadata.mk. First 12 hex chars so the tag stays human-scannable.
 NFT_RPMS_TAG := $(shell ( \
-		cat $(NFT_RPMS_DIR)libnftnl.spec $(NFT_RPMS_DIR)nftables.spec $(NFT_RPMS_DIR)patches/*.patch && \
+		cat $(NFT_RPMS_DIR)Dockerfile $(NFT_RPMS_DIR)libnftnl.spec $(NFT_RPMS_DIR)nftables.spec $(NFT_RPMS_DIR)patches/*.patch && \
 		echo $(NFTABLES_VER) $(NFTABLES_SHA256) $(LIBNFTNL_VER) $(LIBNFTNL_SHA256) \
 	) | sha256sum | cut -c1-12)
 


### PR DESCRIPTION
The content-addressed tag for `calico/nftables-rpms` hashes the spec files, patches, and version pins but not the producer `Dockerfile`. That means flipping the base image (e.g. when cherry-picking back to a release branch with an older node base) does not bust the cache, and consumers can end up pulling RPMs built against the wrong glibc.

This already burned us on release-v3.31: the cherry-pick of #12660 flipped the producer to `almalinux:8` but kept the same tag as master's `almalinux:9` build, so UBI 8 consumers got `.el9` RPMs requiring GLIBC_2.33/2.34 and failed at install time. Reported in #11750, fixed for v3.31 in #12733.

Defensive fix for master to prevent the same trap in future.

\`\`\`release-note
None
\`\`\`