### PR TITLE
Run hashrelease build and publish loops in parallel

### DIFF
--- a/.semaphore/release/hashrelease.yml
+++ b/.semaphore/release/hashrelease.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish hashrelease
 agent:
   machine:
-    type: f1-standard-4
+    type: e1-standard-8
     os_image: ubuntu2204
 execution_time_limit:
   hours: 6

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v3"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projectcalico/calico/release/internal/command"
 	"github.com/projectcalico/calico/release/internal/hashreleaseserver"
@@ -1254,20 +1255,37 @@ func (r *CalicoManager) buildContainerImages() error {
 		env = append(env, fmt.Sprintf("ARCHES=%s", strings.Join(r.architectures, " ")))
 	}
 
+	// Build linux images concurrently. Each component writes its make output
+	// to its own per-component log file under logsDir, so per-component output
+	// stays disambiguated even when builds overlap.
+	var g errgroup.Group
 	for _, dir := range releaseDirs {
-		fullDir := filepath.Join(r.repoRoot, dir)
-		if _, err := r.makeInDirectoryToFile(fullDir, "release-build", "build", env...); err != nil {
-			return fmt.Errorf("failed to build %s: %s", dir, err)
-		}
+		g.Go(func() error {
+			fullDir := filepath.Join(r.repoRoot, dir)
+			if _, err := r.makeInDirectoryToFile(fullDir, "release-build", "build", env...); err != nil {
+				return fmt.Errorf("failed to build %s: %s", dir, err)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
+	// Windows images run after linux finishes: node's linux release-build
+	// also produces the windows release archive into node/dist, so we keep
+	// the two phases sequential to avoid concurrent writes to that directory.
+	var gw errgroup.Group
 	for _, dir := range windowsReleaseDirs {
-		fullDir := filepath.Join(r.repoRoot, dir)
-		if _, err := r.makeInDirectoryToFile(fullDir, "image-windows", "build-windows", env...); err != nil {
-			return fmt.Errorf("failed to build %s windows images: %s", dir, err)
-		}
+		gw.Go(func() error {
+			fullDir := filepath.Join(r.repoRoot, dir)
+			if _, err := r.makeInDirectoryToFile(fullDir, "image-windows", "build-windows", env...); err != nil {
+				return fmt.Errorf("failed to build %s windows images: %s", dir, err)
+			}
+			return nil
+		})
 	}
-	return nil
+	return gw.Wait()
 }
 
 func (r *CalicoManager) publishGitTag() error {
@@ -1371,17 +1389,29 @@ func (r *CalicoManager) publishContainerImages() error {
 			return nil
 		}
 	}
+
+	// Publish linux images concurrently. Each component writes its make output
+	// to its own per-component log file, so per-component output stays
+	// disambiguated even when publishes overlap.
+	var g errgroup.Group
 	for _, dir := range imageReleaseDirs {
-		if err := publish(dir, "release-publish", "publish"); err != nil {
-			return err
-		}
+		g.Go(func() error {
+			return publish(dir, "release-publish", "publish")
+		})
 	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Windows publish runs after linux finishes to mirror the build-side
+	// ordering (see buildContainerImages).
+	var gw errgroup.Group
 	for _, dir := range windowsReleaseDirs {
-		if err := publish(dir, "release-windows", "publish-windows"); err != nil {
-			return err
-		}
+		gw.Go(func() error {
+			return publish(dir, "release-windows", "publish-windows")
+		})
 	}
-	return nil
+	return gw.Wait()
 }
 
 func (r *CalicoManager) publishHelmCharts() error {


### PR DESCRIPTION
Hashrelease today builds and publishes each component serially. `node` is a ~41m build, mostly QEMU-emulated multi-arch, so it sits at the front of the queue and the wall clock ends up being the sum of every component's build time (~112m for build, ~42m for publish on a recent run).

This PR runs both loops concurrently via `errgroup` in `release/pkg/manager/calico/manager.go`. `imageReleaseDirs` and `windowsReleaseDirs` stay as separate sequential phases (node writes its windows release archive during the linux phase, so the two need to be ordered), but components within each phase run in parallel. The build floor becomes `max(component)` instead of `sum(component)`, same for publish.

Bumps the Semaphore agent from `f1-standard-4` to `e1-standard-8` so the parallel work has cores to use. `e1-standard-8` is the largest x86_64 type Semaphore Cloud offers.

Per-component output stays disambiguated for free: `makeInDirectoryToFile` already writes each component's stdout to its own log file under `LOGS_DIR/<phase>/<component>.log`, so parallelizing doesn't tangle the logs.

## Expected impact

Based on the breakdown from a recent 2h50m hashrelease run (job `9f1b698a-771d-4c00-a90f-7b844c36bb5b`):

- Build phase: 112m → bounded by `node` (~41m on the old agent, less on e1-standard-8).
- Publish phase: 42m → bounded by `istio` (~10m).

Total wall clock should land in the ~60-80m range, depending on how much the bigger agent helps each individual component build.

## Test plan

- [ ] Schedule a hashrelease run from this branch and confirm it completes successfully.
- [ ] Confirm per-component log files under the `hashrelease-logs` artifact look the same as today.
- [ ] Compare wall clock against the master baseline.