### PR TITLE
Replace aws-sdk-go-v2/service/ec2 with a minimal hand-rolled client

### DIFF
--- a/cmd/deps.txt
+++ b/cmd/deps.txt
@@ -16,7 +16,6 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10
@@ -317,6 +316,7 @@ local:confd/pkg/resource/template
 local:confd/pkg/run
 local:crypto/pkg/tls
 local:felix/aws
+local:felix/aws/ec2query
 local:felix/bpf
 local:felix/bpf/allowsources
 local:felix/bpf/arp

--- a/felix/aws/ec2.go
+++ b/felix/aws/ec2.go
@@ -209,7 +209,7 @@ func newEC2Client(ctx context.Context) (*ec2Client, error) {
 
 func (c *ec2Client) getEC2NetworkInterfaceId(ctx context.Context) (networkInstanceId string, err error) {
 	input := &ec2query.DescribeInstancesInput{
-		InstanceIDs: []string{c.ec2InstanceId},
+		InstanceIds: []string{c.ec2InstanceId},
 	}
 
 	var out *ec2query.DescribeInstancesOutput
@@ -244,8 +244,11 @@ func (c *ec2Client) getEC2NetworkInterfaceId(ctx context.Context) (networkInstan
 		// response to make sure the right device is updated.
 		for _, networkInterface := range instance.NetworkInterfaces {
 			if networkInterface.Attachment != nil &&
-				networkInterface.Attachment.DeviceIndex == deviceIndexZero {
-				interfaceId = networkInterface.NetworkInterfaceID
+				networkInterface.Attachment.DeviceIndex != nil &&
+				*networkInterface.Attachment.DeviceIndex == deviceIndexZero {
+				if networkInterface.NetworkInterfaceId != nil {
+					interfaceId = *networkInterface.NetworkInterfaceId
+				}
 				if interfaceId != "" {
 					log.Debugf("instance-id: %s, network-interface-id: %s", c.ec2InstanceId, interfaceId)
 					return interfaceId, nil
@@ -262,8 +265,8 @@ func (c *ec2Client) getEC2NetworkInterfaceId(ctx context.Context) (networkInstan
 
 func (c *ec2Client) setEC2SourceDestinationCheck(ctx context.Context, ec2NetId string, checkVal bool) error {
 	input := &ec2query.ModifyNetworkInterfaceAttributeInput{
-		NetworkInterfaceID: ec2NetId,
-		SourceDestCheck:    &checkVal,
+		NetworkInterfaceId: &ec2NetId,
+		SourceDestCheck:    &ec2query.AttributeBooleanValue{Value: &checkVal},
 	}
 
 	var err error

--- a/felix/aws/ec2.go
+++ b/felix/aws/ec2.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,39 +20,45 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/smithy-go"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 
+	"github.com/projectcalico/calico/felix/aws/ec2query"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 )
 
 const (
 	timeout         = 20 * time.Second
 	retries         = 3
-	deviceIndexZero = 0
+	deviceIndexZero = int32(0)
 )
 
+// apiError is satisfied by *ec2query.APIError. It is also (intentionally)
+// satisfied by smithy.APIError, so callers wrapping SDK-style errors continue
+// to be unwrapped correctly.
+type apiError interface {
+	error
+	ErrorCode() string
+	ErrorMessage() string
+}
+
 func convertError(err error) string {
-	var awsErr smithy.APIError
-	if errors.As(err, &awsErr) {
-		return fmt.Sprintf("%s: %s", awsErr.ErrorCode(), awsErr.ErrorMessage())
+	var aerr apiError
+	if errors.As(err, &aerr) {
+		return fmt.Sprintf("%s: %s", aerr.ErrorCode(), aerr.ErrorMessage())
 	}
 
 	return fmt.Sprintf("%v", err.Error())
 }
 
 func retriable(err error) bool {
-	var awsErr smithy.APIError
-	if errors.As(err, &awsErr) {
-		switch awsErr.ErrorCode() {
+	var aerr apiError
+	if errors.As(err, &aerr) {
+		switch aerr.ErrorCode() {
 		case "InternalError":
 			return true
 		case "InternalFailure":
@@ -148,8 +154,8 @@ type ec2MetadataAPI interface {
 }
 
 type ec2API interface {
-	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
-	ModifyNetworkInterfaceAttribute(ctx context.Context, params *ec2.ModifyNetworkInterfaceAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
+	DescribeInstances(ctx context.Context, in *ec2query.DescribeInstancesInput) (*ec2query.DescribeInstancesOutput, error)
+	ModifyNetworkInterfaceAttribute(ctx context.Context, in *ec2query.ModifyNetworkInterfaceAttributeInput) (*ec2query.ModifyNetworkInterfaceAttributeOutput, error)
 }
 
 func getEC2InstanceID(ctx context.Context, svc ec2MetadataAPI) (string, error) {
@@ -192,12 +198,8 @@ func newEC2Client(ctx context.Context) (*ec2Client, error) {
 		return nil, fmt.Errorf("error getting ec2 instance-id: %s", convertError(err))
 	}
 
-	ec2Svc := ec2.NewFromConfig(cfg, func(o *ec2.Options) {
-		o.Region = region
-	})
-	if ec2Svc == nil {
-		return nil, fmt.Errorf("error connecting to EC2 service")
-	}
+	cfg.Region = region
+	ec2Svc := ec2query.NewFromConfig(cfg)
 
 	return &ec2Client{
 		EC2Svc:        ec2Svc,
@@ -206,13 +208,11 @@ func newEC2Client(ctx context.Context) (*ec2Client, error) {
 }
 
 func (c *ec2Client) getEC2NetworkInterfaceId(ctx context.Context) (networkInstanceId string, err error) {
-	input := &ec2.DescribeInstancesInput{
-		InstanceIds: []string{
-			c.ec2InstanceId,
-		},
+	input := &ec2query.DescribeInstancesInput{
+		InstanceIDs: []string{c.ec2InstanceId},
 	}
 
-	var out *ec2.DescribeInstancesOutput
+	var out *ec2query.DescribeInstancesOutput
 	for range retries {
 		out, err = c.EC2Svc.DescribeInstances(ctx, input)
 		if err != nil {
@@ -244,9 +244,8 @@ func (c *ec2Client) getEC2NetworkInterfaceId(ctx context.Context) (networkInstan
 		// response to make sure the right device is updated.
 		for _, networkInterface := range instance.NetworkInterfaces {
 			if networkInterface.Attachment != nil &&
-				networkInterface.Attachment.DeviceIndex != nil &&
-				*(networkInterface.Attachment.DeviceIndex) == deviceIndexZero {
-				interfaceId = *(networkInterface.NetworkInterfaceId)
+				networkInterface.Attachment.DeviceIndex == deviceIndexZero {
+				interfaceId = networkInterface.NetworkInterfaceID
 				if interfaceId != "" {
 					log.Debugf("instance-id: %s, network-interface-id: %s", c.ec2InstanceId, interfaceId)
 					return interfaceId, nil
@@ -262,11 +261,9 @@ func (c *ec2Client) getEC2NetworkInterfaceId(ctx context.Context) (networkInstan
 }
 
 func (c *ec2Client) setEC2SourceDestinationCheck(ctx context.Context, ec2NetId string, checkVal bool) error {
-	input := &ec2.ModifyNetworkInterfaceAttributeInput{
-		NetworkInterfaceId: aws.String(ec2NetId),
-		SourceDestCheck: &types.AttributeBooleanValue{
-			Value: aws.Bool(checkVal),
-		},
+	input := &ec2query.ModifyNetworkInterfaceAttributeInput{
+		NetworkInterfaceID: ec2NetId,
+		SourceDestCheck:    &checkVal,
 	}
 
 	var err error

--- a/felix/aws/ec2_test.go
+++ b/felix/aws/ec2_test.go
@@ -73,6 +73,8 @@ func (c *mockClient) ModifyNetworkInterfaceAttribute(ctx context.Context, params
 func (c *mockClient) DescribeInstances(ctx context.Context, params *ec2query.DescribeInstancesInput) (*ec2query.DescribeInstancesOutput, error) {
 	c.UsageCounter++
 
+	deviceIndex := int32(0)
+	eniId := testEniId
 	return &ec2query.DescribeInstancesOutput{
 		Reservations: []ec2query.Reservation{
 			{
@@ -80,9 +82,9 @@ func (c *mockClient) DescribeInstances(ctx context.Context, params *ec2query.Des
 					{
 						NetworkInterfaces: []ec2query.InstanceNetworkInterface{
 							{
-								NetworkInterfaceID: testEniId,
+								NetworkInterfaceId: &eniId,
 								Attachment: &ec2query.InstanceNetworkInterfaceAttachment{
-									DeviceIndex: 0,
+									DeviceIndex: &deviceIndex,
 								},
 							},
 						},

--- a/felix/aws/ec2_test.go
+++ b/felix/aws/ec2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,14 +22,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/smithy-go"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	clock "k8s.io/utils/clock/testing"
 
+	"github.com/projectcalico/calico/felix/aws/ec2query"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 )
 
@@ -66,28 +64,25 @@ func (c *mockClient) GetRegion(
 	}, nil
 }
 
-func (c *mockClient) ModifyNetworkInterfaceAttribute(ctx context.Context, params *ec2.ModifyNetworkInterfaceAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
+func (c *mockClient) ModifyNetworkInterfaceAttribute(ctx context.Context, params *ec2query.ModifyNetworkInterfaceAttributeInput) (*ec2query.ModifyNetworkInterfaceAttributeOutput, error) {
 	c.UsageCounter++
 
-	return nil, nil
+	return &ec2query.ModifyNetworkInterfaceAttributeOutput{}, nil
 }
 
-func (c *mockClient) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+func (c *mockClient) DescribeInstances(ctx context.Context, params *ec2query.DescribeInstancesInput) (*ec2query.DescribeInstancesOutput, error) {
 	c.UsageCounter++
 
-	deviceIndexZero := int32(0)
-	eniId := testEniId
-
-	return &ec2.DescribeInstancesOutput{
-		Reservations: []types.Reservation{
+	return &ec2query.DescribeInstancesOutput{
+		Reservations: []ec2query.Reservation{
 			{
-				Instances: []types.Instance{
+				Instances: []ec2query.Instance{
 					{
-						NetworkInterfaces: []types.InstanceNetworkInterface{
+						NetworkInterfaces: []ec2query.InstanceNetworkInterface{
 							{
-								NetworkInterfaceId: &eniId,
-								Attachment: &types.InstanceNetworkInterfaceAttachment{
-									DeviceIndex: &deviceIndexZero,
+								NetworkInterfaceID: testEniId,
+								Attachment: &ec2query.InstanceNetworkInterfaceAttachment{
+									DeviceIndex: 0,
 								},
 							},
 						},
@@ -141,10 +136,9 @@ func (updater *mockSrcDstCheckUpdater) Update(option apiv3.AWSSrcDstCheckOption)
 }
 
 func newAPIError(code, msg string) error {
-	err := &smithy.GenericAPIError{
+	err := &ec2query.APIError{
 		Code:    code,
 		Message: msg,
-		Fault:   0,
 	}
 	return fmt.Errorf("wrapped err: %w", err)
 }

--- a/felix/aws/ec2query/client.go
+++ b/felix/aws/ec2query/client.go
@@ -41,7 +41,7 @@ const service = "ec2"
 
 // Client is a minimal EC2 Query API client. One Client is bound to one region.
 type Client struct {
-	HTTPClient *http.Client
+	HTTPClient aws.HTTPClient
 	Signer     *v4.Signer
 	Creds      aws.CredentialsProvider
 	Region     string
@@ -51,12 +51,20 @@ type Client struct {
 
 // NewFromConfig builds a Client from a loaded aws.Config.
 func NewFromConfig(cfg aws.Config) *Client {
-	return &Client{
-		HTTPClient: http.DefaultClient,
+	c := &Client{
+		HTTPClient: cfg.HTTPClient,
 		Signer:     v4.NewSigner(),
 		Creds:      cfg.Credentials,
 		Region:     cfg.Region,
 	}
+	if c.HTTPClient == nil {
+		c.HTTPClient = http.DefaultClient
+	}
+	// Honor a custom endpoint (AWS_ENDPOINT_URL / config override) when set.
+	if cfg.BaseEndpoint != nil {
+		c.Endpoint = *cfg.BaseEndpoint
+	}
+	return c
 }
 
 // Do issues a signed POST to the EC2 Query API. params is form-encoded into
@@ -73,7 +81,7 @@ func (c *Client) Do(ctx context.Context, action string, params url.Values, out a
 
 	endpoint := c.Endpoint
 	if endpoint == "" {
-		endpoint = fmt.Sprintf("https://ec2.%s.amazonaws.com/", c.Region)
+		endpoint = defaultEndpoint(c.Region)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(body))
 	if err != nil {
@@ -112,6 +120,17 @@ func (c *Client) Do(ctx context.Context, action string, params url.Values, out a
 		return fmt.Errorf("ec2query: decode %s response: %w", action, err)
 	}
 	return nil
+}
+
+// defaultEndpoint returns the regional EC2 Query API endpoint. The China
+// partition has a distinct DNS suffix; other partitions (including GovCloud)
+// use the standard amazonaws.com suffix.
+func defaultEndpoint(region string) string {
+	suffix := "amazonaws.com"
+	if strings.HasPrefix(region, "cn-") {
+		suffix = "amazonaws.com.cn"
+	}
+	return fmt.Sprintf("https://ec2.%s.%s/", region, suffix)
 }
 
 // APIError is returned for non-2xx responses from the EC2 Query API. It

--- a/felix/aws/ec2query/client.go
+++ b/felix/aws/ec2query/client.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ec2query is a minimal client for the EC2 Query API. It exists so
+// felix/aws can talk to a handful of EC2 operations without importing
+// github.com/aws/aws-sdk-go-v2/service/ec2, whose generated types alone add
+// ~30 MB to the compiled binary.
+package ec2query
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+// APIVersion is the EC2 Query API version we target. Stable since 2016.
+const APIVersion = "2016-11-15"
+
+const service = "ec2"
+
+// Client is a minimal EC2 Query API client. One Client is bound to one region.
+type Client struct {
+	HTTPClient *http.Client
+	Signer     *v4.Signer
+	Creds      aws.CredentialsProvider
+	Region     string
+	// Endpoint, if set, overrides the default https://ec2.<region>.amazonaws.com/.
+	Endpoint string
+}
+
+// NewFromConfig builds a Client from a loaded aws.Config.
+func NewFromConfig(cfg aws.Config) *Client {
+	return &Client{
+		HTTPClient: http.DefaultClient,
+		Signer:     v4.NewSigner(),
+		Creds:      cfg.Credentials,
+		Region:     cfg.Region,
+	}
+}
+
+// Do issues a signed POST to the EC2 Query API. params is form-encoded into
+// the request body along with Action and Version. The XML response is
+// unmarshalled into out; out should match the shape of the operation's
+// <ActionResponse> element (the XML root is unwrapped automatically).
+func (c *Client) Do(ctx context.Context, action string, params url.Values, out any) error {
+	if params == nil {
+		params = url.Values{}
+	}
+	params.Set("Action", action)
+	params.Set("Version", APIVersion)
+	body := params.Encode()
+
+	endpoint := c.Endpoint
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("https://ec2.%s.amazonaws.com/", c.Region)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("ec2query: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	creds, err := c.Creds.Retrieve(ctx)
+	if err != nil {
+		return fmt.Errorf("ec2query: retrieve credentials: %w", err)
+	}
+	sum := sha256.Sum256([]byte(body))
+	payloadHash := hex.EncodeToString(sum[:])
+	if err := c.Signer.SignHTTP(ctx, creds, req, payloadHash, service, c.Region, time.Now()); err != nil {
+		return fmt.Errorf("ec2query: sign request: %w", err)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("ec2query: %s: %w", action, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("ec2query: read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return parseError(action, resp.StatusCode, respBody)
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := xml.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("ec2query: decode %s response: %w", action, err)
+	}
+	return nil
+}
+
+// APIError is returned for non-2xx responses from the EC2 Query API. It
+// mirrors the smithy.APIError shape (Code/Message) so callers can switch on
+// the error code without depending on the smithy module.
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// ErrorCode returns the AWS error code (e.g. "InternalError"). Named to
+// match smithy.APIError so existing call sites that switched on ErrorCode()
+// don't need to change.
+func (e *APIError) ErrorCode() string { return e.Code }
+
+// ErrorMessage returns the AWS error message.
+func (e *APIError) ErrorMessage() string { return e.Message }
+
+// EC2 query errors come back as <Response><Errors><Error><Code>... or
+// <ErrorResponse><Error><Code>... depending on the operation. We accept both.
+type errorEnvelope struct {
+	XMLName xml.Name
+	Errors  struct {
+		Error []struct {
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+	} `xml:"Errors"`
+	Error struct {
+		Code    string `xml:"Code"`
+		Message string `xml:"Message"`
+	} `xml:"Error"`
+}
+
+func parseError(action string, status int, body []byte) error {
+	var env errorEnvelope
+	if err := xml.Unmarshal(body, &env); err == nil {
+		if len(env.Errors.Error) > 0 {
+			return &APIError{Status: status, Code: env.Errors.Error[0].Code, Message: env.Errors.Error[0].Message}
+		}
+		if env.Error.Code != "" {
+			return &APIError{Status: status, Code: env.Error.Code, Message: env.Error.Message}
+		}
+	}
+	return &APIError{Status: status, Code: fmt.Sprintf("HTTP%d", status), Message: fmt.Sprintf("%s failed: %s", action, strings.TrimSpace(string(body)))}
+}

--- a/felix/aws/ec2query/client_test.go
+++ b/felix/aws/ec2query/client_test.go
@@ -168,6 +168,42 @@ func TestErrorResponseParsed(t *testing.T) {
 	}
 }
 
+func TestDefaultEndpoint(t *testing.T) {
+	cases := map[string]string{
+		"us-west-2":     "https://ec2.us-west-2.amazonaws.com/",
+		"us-gov-west-1": "https://ec2.us-gov-west-1.amazonaws.com/",
+		"cn-north-1":    "https://ec2.cn-north-1.amazonaws.com.cn/",
+	}
+	for region, want := range cases {
+		if got := defaultEndpoint(region); got != want {
+			t.Errorf("defaultEndpoint(%q) = %q, want %q", region, got, want)
+		}
+	}
+}
+
+func TestNewFromConfigHonorsConfig(t *testing.T) {
+	custom := &http.Client{}
+	base := "https://ec2.example.local/"
+	c := NewFromConfig(aws.Config{
+		Region:       "us-west-2",
+		Credentials:  staticCreds{},
+		HTTPClient:   custom,
+		BaseEndpoint: &base,
+	})
+	if c.HTTPClient != custom {
+		t.Errorf("expected config HTTPClient to be used, got %v", c.HTTPClient)
+	}
+	if c.Endpoint != base {
+		t.Errorf("expected endpoint %q, got %q", base, c.Endpoint)
+	}
+
+	// With no HTTPClient on the config, fall back to the default.
+	c = NewFromConfig(aws.Config{Region: "us-west-2", Credentials: staticCreds{}})
+	if c.HTTPClient != http.DefaultClient {
+		t.Errorf("expected http.DefaultClient fallback, got %v", c.HTTPClient)
+	}
+}
+
 func TestErrorResponseAlternateEnvelope(t *testing.T) {
 	const errBody = `<?xml version="1.0"?>
 <ErrorResponse>

--- a/felix/aws/ec2query/client_test.go
+++ b/felix/aws/ec2query/client_test.go
@@ -80,7 +80,7 @@ func TestDescribeInstancesParsesResponse(t *testing.T) {
 		_, _ = w.Write([]byte(respBody))
 	}))
 
-	out, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIDs: []string{"i-abc"}})
+	out, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIds: []string{"i-abc"}})
 	if err != nil {
 		t.Fatalf("DescribeInstances: %v", err)
 	}
@@ -102,11 +102,12 @@ func TestDescribeInstancesParsesResponse(t *testing.T) {
 	if len(ifaces) != 2 {
 		t.Fatalf("expected 2 interfaces, got %d", len(ifaces))
 	}
-	if ifaces[0].NetworkInterfaceID != "eni-primary" || ifaces[0].Attachment == nil || ifaces[0].Attachment.DeviceIndex != 0 {
+	if ifaces[0].NetworkInterfaceId == nil || *ifaces[0].NetworkInterfaceId != "eni-primary" ||
+		ifaces[0].Attachment == nil || ifaces[0].Attachment.DeviceIndex == nil || *ifaces[0].Attachment.DeviceIndex != 0 {
 		t.Errorf("interface 0 wrong: %+v / %+v", ifaces[0], ifaces[0].Attachment)
 	}
-	if ifaces[1].Attachment.DeviceIndex != 1 {
-		t.Errorf("interface 1 device index wrong: %d", ifaces[1].Attachment.DeviceIndex)
+	if ifaces[1].Attachment.DeviceIndex == nil || *ifaces[1].Attachment.DeviceIndex != 1 {
+		t.Errorf("interface 1 device index wrong: %v", ifaces[1].Attachment.DeviceIndex)
 	}
 }
 
@@ -119,9 +120,10 @@ func TestModifyNetworkInterfaceAttributeEncodesParams(t *testing.T) {
 	}))
 
 	enabled := false
+	niid := "eni-1"
 	_, err := c.ModifyNetworkInterfaceAttribute(context.Background(), &ModifyNetworkInterfaceAttributeInput{
-		NetworkInterfaceID: "eni-1",
-		SourceDestCheck:    &enabled,
+		NetworkInterfaceId: &niid,
+		SourceDestCheck:    &AttributeBooleanValue{Value: &enabled},
 	})
 	if err != nil {
 		t.Fatalf("ModifyNetworkInterfaceAttribute: %v", err)
@@ -152,7 +154,7 @@ func TestErrorResponseParsed(t *testing.T) {
 		_, _ = w.Write([]byte(errBody))
 	}))
 
-	_, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIDs: []string{"i-abc"}})
+	_, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIds: []string{"i-abc"}})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -217,7 +219,7 @@ func TestErrorResponseAlternateEnvelope(t *testing.T) {
 		_, _ = w.Write([]byte(errBody))
 	}))
 
-	_, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIDs: []string{"i-abc"}})
+	_, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIds: []string{"i-abc"}})
 	var ae *APIError
 	if !errors.As(err, &ae) {
 		t.Fatalf("expected *APIError, got %T: %v", err, err)

--- a/felix/aws/ec2query/client_test.go
+++ b/felix/aws/ec2query/client_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2query
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+// staticCreds is a fixed credential provider for tests.
+type staticCreds struct{}
+
+func (staticCreds) Retrieve(context.Context) (aws.Credentials, error) {
+	return aws.Credentials{AccessKeyID: "AKID", SecretAccessKey: "SECRET"}, nil
+}
+
+func newTestClient(t *testing.T, h http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return &Client{
+		HTTPClient: srv.Client(),
+		Signer:     v4.NewSigner(),
+		Creds:      staticCreds{},
+		Region:     "us-west-2",
+		Endpoint:   srv.URL + "/",
+	}, srv
+}
+
+func TestDescribeInstancesParsesResponse(t *testing.T) {
+	const respBody = `<?xml version="1.0" encoding="UTF-8"?>
+<DescribeInstancesResponse>
+  <reservationSet>
+    <item>
+      <instancesSet>
+        <item>
+          <networkInterfaceSet>
+            <item>
+              <networkInterfaceId>eni-primary</networkInterfaceId>
+              <attachment><deviceIndex>0</deviceIndex></attachment>
+            </item>
+            <item>
+              <networkInterfaceId>eni-secondary</networkInterfaceId>
+              <attachment><deviceIndex>1</deviceIndex></attachment>
+            </item>
+          </networkInterfaceSet>
+        </item>
+      </instancesSet>
+    </item>
+  </reservationSet>
+</DescribeInstancesResponse>`
+
+	var gotBody string
+	var gotAuth string
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(respBody))
+	}))
+
+	out, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIDs: []string{"i-abc"}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if !strings.Contains(gotBody, "Action=DescribeInstances") || !strings.Contains(gotBody, "Version="+APIVersion) {
+		t.Errorf("request body missing required params: %q", gotBody)
+	}
+	if !strings.Contains(gotBody, "InstanceId.1=i-abc") {
+		t.Errorf("request body missing InstanceId.1: %q", gotBody)
+	}
+	if !strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256 ") {
+		t.Errorf("Authorization header not SigV4: %q", gotAuth)
+	}
+
+	if len(out.Reservations) != 1 || len(out.Reservations[0].Instances) != 1 {
+		t.Fatalf("unexpected reservations/instances: %+v", out)
+	}
+	ifaces := out.Reservations[0].Instances[0].NetworkInterfaces
+	if len(ifaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(ifaces))
+	}
+	if ifaces[0].NetworkInterfaceID != "eni-primary" || ifaces[0].Attachment == nil || ifaces[0].Attachment.DeviceIndex != 0 {
+		t.Errorf("interface 0 wrong: %+v / %+v", ifaces[0], ifaces[0].Attachment)
+	}
+	if ifaces[1].Attachment.DeviceIndex != 1 {
+		t.Errorf("interface 1 device index wrong: %d", ifaces[1].Attachment.DeviceIndex)
+	}
+}
+
+func TestModifyNetworkInterfaceAttributeEncodesParams(t *testing.T) {
+	var gotBody string
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	enabled := false
+	_, err := c.ModifyNetworkInterfaceAttribute(context.Background(), &ModifyNetworkInterfaceAttributeInput{
+		NetworkInterfaceID: "eni-1",
+		SourceDestCheck:    &enabled,
+	})
+	if err != nil {
+		t.Fatalf("ModifyNetworkInterfaceAttribute: %v", err)
+	}
+	if !strings.Contains(gotBody, "Action=ModifyNetworkInterfaceAttribute") {
+		t.Errorf("missing Action: %q", gotBody)
+	}
+	if !strings.Contains(gotBody, "NetworkInterfaceId=eni-1") {
+		t.Errorf("missing NetworkInterfaceId: %q", gotBody)
+	}
+	if !strings.Contains(gotBody, "SourceDestCheck.Value=false") {
+		t.Errorf("missing SourceDestCheck.Value: %q", gotBody)
+	}
+}
+
+func TestErrorResponseParsed(t *testing.T) {
+	const errBody = `<?xml version="1.0"?>
+<Response>
+  <Errors>
+    <Error>
+      <Code>InternalError</Code>
+      <Message>retry me</Message>
+    </Error>
+  </Errors>
+</Response>`
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(errBody))
+	}))
+
+	_, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIDs: []string{"i-abc"}})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ae *APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if ae.ErrorCode() != "InternalError" {
+		t.Errorf("code: %q", ae.ErrorCode())
+	}
+	if ae.ErrorMessage() != "retry me" {
+		t.Errorf("message: %q", ae.ErrorMessage())
+	}
+}
+
+func TestErrorResponseAlternateEnvelope(t *testing.T) {
+	const errBody = `<?xml version="1.0"?>
+<ErrorResponse>
+  <Error>
+    <Code>AuthFailure</Code>
+    <Message>nope</Message>
+  </Error>
+</ErrorResponse>`
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(errBody))
+	}))
+
+	_, err := c.DescribeInstances(context.Background(), &DescribeInstancesInput{InstanceIDs: []string{"i-abc"}})
+	var ae *APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if ae.Code != "AuthFailure" {
+		t.Errorf("code: %q", ae.Code)
+	}
+}

--- a/felix/aws/ec2query/operations.go
+++ b/felix/aws/ec2query/operations.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2query
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
+// DescribeInstancesInput is the subset of parameters we need.
+type DescribeInstancesInput struct {
+	InstanceIDs []string
+}
+
+// DescribeInstancesOutput is the subset of fields we read from the response.
+// The XML root element <DescribeInstancesResponse> is unmarshalled into this
+// struct directly.
+type DescribeInstancesOutput struct {
+	Reservations []Reservation `xml:"reservationSet>item"`
+}
+
+type Reservation struct {
+	Instances []Instance `xml:"instancesSet>item"`
+}
+
+type Instance struct {
+	NetworkInterfaces []InstanceNetworkInterface `xml:"networkInterfaceSet>item"`
+}
+
+type InstanceNetworkInterface struct {
+	NetworkInterfaceID string                              `xml:"networkInterfaceId"`
+	Attachment         *InstanceNetworkInterfaceAttachment `xml:"attachment"`
+}
+
+type InstanceNetworkInterfaceAttachment struct {
+	DeviceIndex int32 `xml:"deviceIndex"`
+}
+
+// DescribeInstances calls the EC2 DescribeInstances operation.
+func (c *Client) DescribeInstances(ctx context.Context, in *DescribeInstancesInput) (*DescribeInstancesOutput, error) {
+	params := url.Values{}
+	for i, id := range in.InstanceIDs {
+		params.Set("InstanceId."+strconv.Itoa(i+1), id)
+	}
+	var out DescribeInstancesOutput
+	if err := c.Do(ctx, "DescribeInstances", params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ModifyNetworkInterfaceAttributeInput covers the SourceDestCheck use case.
+// Only one attribute may be modified per call.
+type ModifyNetworkInterfaceAttributeInput struct {
+	NetworkInterfaceID string
+	SourceDestCheck    *bool
+}
+
+type ModifyNetworkInterfaceAttributeOutput struct{}
+
+// ModifyNetworkInterfaceAttribute calls the EC2 ModifyNetworkInterfaceAttribute
+// operation. Today only SourceDestCheck is supported.
+func (c *Client) ModifyNetworkInterfaceAttribute(ctx context.Context, in *ModifyNetworkInterfaceAttributeInput) (*ModifyNetworkInterfaceAttributeOutput, error) {
+	params := url.Values{}
+	params.Set("NetworkInterfaceId", in.NetworkInterfaceID)
+	if in.SourceDestCheck != nil {
+		params.Set("SourceDestCheck.Value", strconv.FormatBool(*in.SourceDestCheck))
+	}
+	if err := c.Do(ctx, "ModifyNetworkInterfaceAttribute", params, nil); err != nil {
+		return nil, err
+	}
+	return &ModifyNetworkInterfaceAttributeOutput{}, nil
+}

--- a/felix/aws/ec2query/operations.go
+++ b/felix/aws/ec2query/operations.go
@@ -22,12 +22,15 @@ import (
 
 // The Input/Output structs below mirror their counterparts in
 // aws-sdk-go-v2/service/ec2 and service/ec2/types at EC2 API version 2016-11-15
-// (see APIVersion). They carry only the fields felix/aws sends or reads; adding
-// a field means copying it from the matching upstream type.
+// (see APIVersion). Field names and pointer-ness match the upstream types so
+// that callers read them the same way; each struct carries only the fields
+// felix/aws sends or reads, and adding a field means copying it from the
+// matching upstream type. The xml tags name the elements of the EC2 Query API
+// response.
 
 // DescribeInstancesInput mirrors ec2.DescribeInstancesInput.
 type DescribeInstancesInput struct {
-	InstanceIDs []string
+	InstanceIds []string
 }
 
 // DescribeInstancesOutput mirrors ec2.DescribeInstancesOutput. The XML root
@@ -48,19 +51,19 @@ type Instance struct {
 
 // InstanceNetworkInterface mirrors ec2types.InstanceNetworkInterface.
 type InstanceNetworkInterface struct {
-	NetworkInterfaceID string                              `xml:"networkInterfaceId"`
+	NetworkInterfaceId *string                             `xml:"networkInterfaceId"`
 	Attachment         *InstanceNetworkInterfaceAttachment `xml:"attachment"`
 }
 
 // InstanceNetworkInterfaceAttachment mirrors ec2types.InstanceNetworkInterfaceAttachment.
 type InstanceNetworkInterfaceAttachment struct {
-	DeviceIndex int32 `xml:"deviceIndex"`
+	DeviceIndex *int32 `xml:"deviceIndex"`
 }
 
 // DescribeInstances calls the EC2 DescribeInstances operation.
 func (c *Client) DescribeInstances(ctx context.Context, in *DescribeInstancesInput) (*DescribeInstancesOutput, error) {
 	params := url.Values{}
-	for i, id := range in.InstanceIDs {
+	for i, id := range in.InstanceIds {
 		params.Set("InstanceId."+strconv.Itoa(i+1), id)
 	}
 	var out DescribeInstancesOutput
@@ -70,12 +73,17 @@ func (c *Client) DescribeInstances(ctx context.Context, in *DescribeInstancesInp
 	return &out, nil
 }
 
+// AttributeBooleanValue mirrors ec2types.AttributeBooleanValue.
+type AttributeBooleanValue struct {
+	Value *bool
+}
+
 // ModifyNetworkInterfaceAttributeInput mirrors the SourceDestCheck subset of
 // ec2.ModifyNetworkInterfaceAttributeInput. Only one attribute may be modified
 // per call.
 type ModifyNetworkInterfaceAttributeInput struct {
-	NetworkInterfaceID string
-	SourceDestCheck    *bool
+	NetworkInterfaceId *string
+	SourceDestCheck    *AttributeBooleanValue
 }
 
 // ModifyNetworkInterfaceAttributeOutput mirrors ec2.ModifyNetworkInterfaceAttributeOutput.
@@ -85,9 +93,11 @@ type ModifyNetworkInterfaceAttributeOutput struct{}
 // operation. Today only SourceDestCheck is supported.
 func (c *Client) ModifyNetworkInterfaceAttribute(ctx context.Context, in *ModifyNetworkInterfaceAttributeInput) (*ModifyNetworkInterfaceAttributeOutput, error) {
 	params := url.Values{}
-	params.Set("NetworkInterfaceId", in.NetworkInterfaceID)
-	if in.SourceDestCheck != nil {
-		params.Set("SourceDestCheck.Value", strconv.FormatBool(*in.SourceDestCheck))
+	if in.NetworkInterfaceId != nil {
+		params.Set("NetworkInterfaceId", *in.NetworkInterfaceId)
+	}
+	if in.SourceDestCheck != nil && in.SourceDestCheck.Value != nil {
+		params.Set("SourceDestCheck.Value", strconv.FormatBool(*in.SourceDestCheck.Value))
 	}
 	if err := c.Do(ctx, "ModifyNetworkInterfaceAttribute", params, nil); err != nil {
 		return nil, err

--- a/felix/aws/ec2query/operations.go
+++ b/felix/aws/ec2query/operations.go
@@ -20,31 +20,39 @@ import (
 	"strconv"
 )
 
-// DescribeInstancesInput is the subset of parameters we need.
+// The Input/Output structs below mirror their counterparts in
+// aws-sdk-go-v2/service/ec2 and service/ec2/types at EC2 API version 2016-11-15
+// (see APIVersion). They carry only the fields felix/aws sends or reads; adding
+// a field means copying it from the matching upstream type.
+
+// DescribeInstancesInput mirrors ec2.DescribeInstancesInput.
 type DescribeInstancesInput struct {
 	InstanceIDs []string
 }
 
-// DescribeInstancesOutput is the subset of fields we read from the response.
-// The XML root element <DescribeInstancesResponse> is unmarshalled into this
-// struct directly.
+// DescribeInstancesOutput mirrors ec2.DescribeInstancesOutput. The XML root
+// element <DescribeInstancesResponse> is unmarshalled into this struct directly.
 type DescribeInstancesOutput struct {
 	Reservations []Reservation `xml:"reservationSet>item"`
 }
 
+// Reservation mirrors ec2types.Reservation.
 type Reservation struct {
 	Instances []Instance `xml:"instancesSet>item"`
 }
 
+// Instance mirrors ec2types.Instance.
 type Instance struct {
 	NetworkInterfaces []InstanceNetworkInterface `xml:"networkInterfaceSet>item"`
 }
 
+// InstanceNetworkInterface mirrors ec2types.InstanceNetworkInterface.
 type InstanceNetworkInterface struct {
 	NetworkInterfaceID string                              `xml:"networkInterfaceId"`
 	Attachment         *InstanceNetworkInterfaceAttachment `xml:"attachment"`
 }
 
+// InstanceNetworkInterfaceAttachment mirrors ec2types.InstanceNetworkInterfaceAttachment.
 type InstanceNetworkInterfaceAttachment struct {
 	DeviceIndex int32 `xml:"deviceIndex"`
 }
@@ -62,13 +70,15 @@ func (c *Client) DescribeInstances(ctx context.Context, in *DescribeInstancesInp
 	return &out, nil
 }
 
-// ModifyNetworkInterfaceAttributeInput covers the SourceDestCheck use case.
-// Only one attribute may be modified per call.
+// ModifyNetworkInterfaceAttributeInput mirrors the SourceDestCheck subset of
+// ec2.ModifyNetworkInterfaceAttributeInput. Only one attribute may be modified
+// per call.
 type ModifyNetworkInterfaceAttributeInput struct {
 	NetworkInterfaceID string
 	SourceDestCheck    *bool
 }
 
+// ModifyNetworkInterfaceAttributeOutput mirrors ec2.ModifyNetworkInterfaceAttributeOutput.
 type ModifyNetworkInterfaceAttributeOutput struct{}
 
 // ModifyNetworkInterfaceAttribute calls the EC2 ModifyNetworkInterfaceAttribute

--- a/felix/deps.txt
+++ b/felix/deps.txt
@@ -13,7 +13,6 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10
@@ -181,6 +180,7 @@ local:cni-plugin/pkg/dataplane/linux
 local:cni-plugin/pkg/types
 local:crypto/pkg/tls
 local:felix/aws
+local:felix/aws/ec2query
 local:felix/bpf
 local:felix/bpf/allowsources
 local:felix/bpf/arp

--- a/go.mod
+++ b/go.mod
@@ -125,24 +125,6 @@ require (
 )
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 // indirect
-	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/moby/term v0.5.2 // indirect
-	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/xlab/treeprint v1.2.0 // indirect
-	k8s.io/cli-runtime v0.35.5 // indirect
-	sigs.k8s.io/kustomize/api v0.20.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
-)
-
-require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect
@@ -153,10 +135,12 @@ require (
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
+	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hnslib v0.1.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
@@ -174,6 +158,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.69.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.78.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.8 // indirect
@@ -200,6 +185,7 @@ require (
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
@@ -225,6 +211,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
@@ -265,6 +252,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
@@ -284,6 +272,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/libopenstorage/openstorage v1.0.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
@@ -299,13 +288,16 @@ require (
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/cgroups v0.0.3 // indirect
@@ -317,6 +309,7 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
@@ -341,6 +334,7 @@ require (
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -372,6 +366,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/cli-runtime v0.35.5 // indirect
 	k8s.io/cloud-provider v0.35.5 // indirect
 	k8s.io/component-helpers v0.35.5 // indirect
 	k8s.io/controller-manager v0.35.5 // indirect
@@ -388,6 +383,8 @@ require (
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
+	sigs.k8s.io/kustomize/api v0.20.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 	github.com/aws/smithy-go v1.25.0
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/buger/jsonparser v1.1.2
@@ -126,6 +125,24 @@ require (
 )
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/MakeNowJust/heredoc v1.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 // indirect
+	github.com/chai2010/gettext-go v1.0.2 // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
+	k8s.io/cli-runtime v0.35.5 // indirect
+	sigs.k8s.io/kustomize/api v0.20.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
+)
+
+require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect
@@ -136,12 +153,10 @@ require (
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
-	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hnslib v0.1.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
@@ -185,7 +200,6 @@ require (
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
@@ -211,7 +225,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
-	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
@@ -252,7 +265,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
@@ -272,7 +284,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/libopenstorage/openstorage v1.0.0 // indirect
-	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
@@ -288,16 +299,13 @@ require (
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
-	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/cgroups v0.0.3 // indirect
@@ -309,7 +317,6 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
@@ -334,7 +341,6 @@ require (
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -366,7 +372,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/cli-runtime v0.35.5 // indirect
 	k8s.io/cloud-provider v0.35.5 // indirect
 	k8s.io/component-helpers v0.35.5 // indirect
 	k8s.io/controller-manager v0.35.5 // indirect
@@ -383,8 +388,6 @@ require (
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/api v0.20.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/node/deps.txt
+++ b/node/deps.txt
@@ -14,7 +14,6 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10


### PR DESCRIPTION
felix/aws only uses two EC2 operations (DescribeInstances, ModifyNetworkInterfaceAttribute) to toggle the source/dest check on the primary ENI. The generated service/ec2 package adds ~30 MB to the binary just to ship those two calls.

This PR introduces a small felix/aws/ec2query package that posts to the EC2 Query API directly, signs requests with the existing aws-sdk-go-v2 SigV4 signer, and parses just the response fields we read. The high-level retry/error semantics in felix/aws/ec2.go are unchanged (the error code switch still works because both \`*ec2query.APIError\` and \`smithy.APIError\` satisfy the same shape).

Measured against \`cmd/calico\` on master (\`go build -trimpath -ldflags '-s -w'\`):

| | master | this PR | delta |
|---|---|---|---|
| binary | 154 MB | 123 MB | -31 MB (-20%) |
| aws-sdk-go-v2 in binary | 33 MB | 2.2 MB | -31 MB |

\`aws-sdk-go-v2/service/ec2\` moves from a direct dependency to indirect (still referenced by terratest in \`charts/test\`, so it shows up in \`go.mod\` but isn't linked into the production binary).

Related: CORE-12749

```release-note
None
```