### PR TITLE
Mark operator CRDs and ocp-upgrade manifest as linguist-generated

### DIFF
--- a/charts/crd.projectcalico.org.v1/templates/.gitattributes
+++ b/charts/crd.projectcalico.org.v1/templates/.gitattributes
@@ -1,0 +1,1 @@
+operator.tigera.io_*.yaml linguist-generated=true

--- a/charts/projectcalico.org.v3/templates/.gitattributes
+++ b/charts/projectcalico.org.v3/templates/.gitattributes
@@ -1,0 +1,1 @@
+operator.tigera.io_*.yaml linguist-generated=true

--- a/manifests/.gitattributes
+++ b/manifests/.gitattributes
@@ -12,3 +12,4 @@ v1_crd_projectcalico_org.yaml linguist-generated=true
 calico-v3-crds.yaml           linguist-generated=true
 calicoctl.yaml                linguist-generated=true
 flannel-migration/calico.yaml linguist-generated=true
+tigera-operator-ocp-upgrade.yaml linguist-generated=true


### PR DESCRIPTION
Follow-up to #12728. Flags three more generated paths so GitHub collapses them in diff review:

- `charts/crd.projectcalico.org.v1/templates/operator.tigera.io_*.yaml` — synced from `tigera/operator` by `make get-operator-crds` (Makefile:111+).
- `charts/projectcalico.org.v3/templates/operator.tigera.io_*.yaml` — copied from the v1 chart by the same target.
- `manifests/tigera-operator-ocp-upgrade.yaml` — concatenated from `manifests/ocp/` by `manifests/generate.sh:170+`.

Verified with `git check-attr linguist-generated` on a sample from each path and confirmed the new `.gitattributes` files are safe from `rm -rf` / prettier passes in nearby Makefile targets.