### PR TITLE
[v3.32] [BPF] Re-wire SetTriggerFn on syncer swap in proxy.SetSyncer

### DIFF
--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -365,6 +365,12 @@ func (p *proxy) SetSyncer(s DPSyncer) {
 	p.syncerLck.Lock()
 	p.dpSyncer.Stop()
 	p.dpSyncer = s
+	// Re-wire the trigger so that the new syncer's expand-NodePort fixup
+	// goroutine can schedule a dataplane Apply when previously-missed
+	// route lookups resolve. proxy.New() does this for the initial syncer;
+	// without it here, swapping in a fresh syncer (e.g. on a host-IP
+	// change) would silently lose that wakeup path.
+	s.SetTriggerFn(p.runner.Run)
 	p.syncerLck.Unlock()
 
 	p.forceSyncDP()

--- a/felix/bpf/proxy/proxy_test.go
+++ b/felix/bpf/proxy/proxy_test.go
@@ -69,6 +69,50 @@ var _ = Describe("BPF Proxy", func() {
 		})
 	})
 
+	It("should re-arm the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap", func() {
+		// expand-NodePort fixup (used for ExternalTrafficPolicy=Local
+		// NodePort services with remote endpoints) parks unresolved
+		// route lookups on a goroutine that calls back into the proxy
+		// via syncer.triggerFn() once the missing route arrives. proxy.New()
+		// wires that callback on the initial syncer; SetSyncer must do the
+		// same when swapping a fresh syncer in (e.g. on a host-IP change),
+		// otherwise local-policy NodePort traffic to backends that landed
+		// after the swap is silently never applied to the dataplane.
+		k8s := fake.NewClientset()
+		syncStop = make(chan struct{})
+
+		first := newMockSyncer(syncStop)
+		p, err := proxy.New(k8s, first, "testnode", proxy.WithImmediateSync())
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			close(syncStop)
+			p.Stop()
+		}()
+
+		// Drain the initial sync.
+		first.checkState(func(proxy.DPSyncerState) {})
+
+		// SetSyncer calls forceSyncDP synchronously, which calls Apply on
+		// the new syncer; that blocks until checkState drains it. Run
+		// SetSyncer in a goroutine so the test can drain in parallel.
+		second := newMockSyncer(syncStop)
+		go p.SetSyncer(second)
+
+		// Drain the forceSyncDP triggered by SetSyncer.
+		second.checkState(func(proxy.DPSyncerState) {})
+
+		// SetSyncer must have wired the fixup callback on the new syncer
+		// before any of its background goroutines could fire.
+		Expect(second.triggerFn).NotTo(BeNil(), "SetSyncer must wire the fixup callback on the new syncer")
+
+		// Simulate the fixup goroutine resolving a missed route by
+		// invoking the callback the syncer was handed. The proxy must
+		// schedule another Apply.
+		second.triggerFn()
+		second.checkState(func(proxy.DPSyncerState) {})
+	})
+
 	testSvc := &v1.Service{
 		TypeMeta:   typeMetaV1("Service"),
 		ObjectMeta: objectMetaV1("testService"),
@@ -645,12 +689,14 @@ var _ = Describe("BPF Proxy", func() {
 
 type mockSyncer struct {
 	syncerConntrackAPIDummy
-	out  chan proxy.DPSyncerState
-	in   chan error
-	stop chan struct{}
+	out       chan proxy.DPSyncerState
+	in        chan error
+	stop      chan struct{}
+	triggerFn func()
 }
 
 func (s *mockSyncer) SetTriggerFn(f func()) {
+	s.triggerFn = f
 }
 
 func newMockSyncer(stop chan struct{}) *mockSyncer {


### PR DESCRIPTION
## Description

Cherry-pick of #12701 to `release-v3.32`. `proxy.New()` wires the syncer's expand-NodePort fixup callback via `dp.SetTriggerFn(p.runner.Run)`. `proxy.SetSyncer()` swaps in a fresh syncer (e.g. on a host-IP change inside `KubeProxy.run()`) but did **not** re-wire that callback. After any host-IP change the new syncer's expand-NodePort fixup goroutine resolves previously-missed routes for `ExternalTrafficPolicy=Local` NodePort backends, but cannot schedule the dataplane Apply that would program them — the fix-up is silently lost until something else piggybacks an Apply.

Pre-existing bug (`kp.run()` always created a fresh syncer and called `SetSyncer` on it); #12667 made it plain to read because the first call now goes through `proxy.New()` which sets the trigger, leaving the asymmetry with `SetSyncer` obvious. Caught on the v3.31 backport review (#12693).

### Fix

Have `SetSyncer` call `s.SetTriggerFn(p.runner.Run)` on the new syncer, under the same lock as the dpSyncer swap, mirroring `proxy.New()`.

### Test

Regression test in `proxy_test.go` swaps a syncer via `SetSyncer`, verifies the new syncer received a non-nil trigger callback, and confirms invoking it schedules an Apply. The test fails on master / 3.32 / 3.31 before this change.

## Related issues/PRs

Cherry-pick of #12701. Follow-up to #12667; pairs with #12694 (already merged on this branch).

## Release Note

```release-note
ebpf - Fix kube-proxy losing the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap, which could cause stale NAT entries on remote backends.
```

## Reminder for the reviewer

- [x] `release-note-required`
- [x] `docs-not-required` (no user-facing config change; bug fix)