### PR TITLE
[BPF] Fix inverted jump-map selection in pol-prog FV helper

### DIFF
--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -96,6 +96,23 @@ var NetkitEgressMapParameters = maps.MapParameters{
 	Version:    2,
 }
 
+// PolicyJumpMapName returns the pinned name of the policy program jump map for
+// the given attach mode (netkit vs TC/TCX) and direction ("ingress"/"egress").
+// Each direction lives in its own prog_array, so picking the wrong one returns
+// indices from the wrong namespace.
+func PolicyJumpMapName(netkit bool, ingressOrEgress string) string {
+	switch {
+	case netkit && ingressOrEgress == "egress":
+		return NetkitEgressMapParameters.VersionedName()
+	case netkit:
+		return NetkitIngressMapParameters.VersionedName()
+	case ingressOrEgress == "egress":
+		return EgressMapParameters.VersionedName()
+	default:
+		return IngressMapParameters.VersionedName()
+	}
+}
+
 func NetkitMaps() []maps.Map {
 	return []maps.Map{
 		maps.NewPinnedMap(NetkitIngressMapParameters),

--- a/felix/bpf/jump/map_test.go
+++ b/felix/bpf/jump/map_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jump
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPolicyJumpMapName pins the direction/mode -> map-name mapping so a future
+// inversion (the bug this test was added with) cannot regress silently.
+func TestPolicyJumpMapName(t *testing.T) {
+	cases := []struct {
+		name            string
+		netkit          bool
+		ingressOrEgress string
+		wantDir         string // substring that must appear (direction marker)
+		wantNetkit      bool   // whether the netkit marker must appear
+	}{
+		{"tc ingress", false, "ingress", "_ing", false},
+		{"tc egress", false, "egress", "_egr", false},
+		{"netkit ingress", true, "ingress", "_ing", true},
+		{"netkit egress", true, "egress", "_egr", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PolicyJumpMapName(tc.netkit, tc.ingressOrEgress)
+			if !strings.Contains(got, tc.wantDir) {
+				t.Errorf("PolicyJumpMapName(%v, %q) = %q, want substring %q",
+					tc.netkit, tc.ingressOrEgress, got, tc.wantDir)
+			}
+			hasNetkit := strings.Contains(got, "_nk_")
+			if hasNetkit != tc.wantNetkit {
+				t.Errorf("PolicyJumpMapName(%v, %q) = %q, want netkit=%v",
+					tc.netkit, tc.ingressOrEgress, got, tc.wantNetkit)
+			}
+			// Direction substrings must be mutually exclusive in the name.
+			otherDir := "_egr"
+			if tc.wantDir == "_egr" {
+				otherDir = "_ing"
+			}
+			if strings.Contains(got, otherDir) {
+				t.Errorf("PolicyJumpMapName(%v, %q) = %q, contains opposite-direction marker %q",
+					tc.netkit, tc.ingressOrEgress, got, otherDir)
+			}
+		})
+	}
+}

--- a/felix/fv/infrastructure/bpfpolprog/bpfpolprog.go
+++ b/felix/fv/infrastructure/bpfpolprog/bpfpolprog.go
@@ -48,19 +48,7 @@ func NumPolProgramsTotalByEntryPointFn(f *infrastructure.Felix, entryPointIdx in
 
 func NumPolProgramsByEntryPoint(f *infrastructure.Felix, entryPointIdx int, ingressOrEgress string) (contiguous, total int) {
 	gapSeen := false
-	var jmpMapName string
-	if infrastructure.NetkitMode() {
-		jmpMapName = jump.NetkitEgressMapParameters.VersionedName()
-		if ingressOrEgress == "egress" {
-			jmpMapName = jump.NetkitIngressMapParameters.VersionedName()
-		}
-	} else {
-		jmpMapName = jump.EgressMapParameters.VersionedName()
-		if ingressOrEgress == "egress" {
-			jmpMapName = jump.IngressMapParameters.VersionedName()
-		}
-	}
-	pinnedMap := "/sys/fs/bpf/tc/globals/" + jmpMapName
+	pinnedMap := "/sys/fs/bpf/tc/globals/" + jump.PolicyJumpMapName(infrastructure.NetkitMode(), ingressOrEgress)
 	for i := range jump.MaxSubPrograms {
 		k := polprog.SubProgramJumpIdx(entryPointIdx, i, jump.TCMaxEntryPoints)
 		out, err := f.ExecOutput(


### PR DESCRIPTION
## Summary

`NumPolProgramsByEntryPoint()` in `felix/fv/infrastructure/bpfpolprog/bpfpolprog.go` selects the wrong jump map: it queries the **Egress** map when the caller asks for `"ingress"` and the **Ingress** map when the caller asks for `"egress"`. Both the netkit and TC branches are inverted the same way.

The entry-point index passed in is already direction-specific (the caller looks up `IngressPolicyV4` or `EgressPolicyV4` from `BPFIfState`) and the programs are pinned in the matching map, so querying the opposite map silently returns counts from the wrong index space.

Introduced by #12167 and moved verbatim into the new sub-package by #12717. Reported by Copilot review on the EE auto-pick.

## Why CI didn't catch it

The only caller is `bpf_pol_scale_test.go`, which asserts the same value (1, then 0) for both directions. After the EP is removed/stopped both maps converge to 0 either way, and the "1 dummy drop-all" state also happens to match for both directions, so the inversion was masked.

## What this PR does

1. Moves the `(netkit, direction) -> map name` selection into a new `jump.PolicyJumpMapName()` helper, next to the map parameter definitions it returns. The helper has the corrected mapping.
2. Adds a table-driven unit test in `felix/bpf/jump` that pins the contract for all four `{tc,netkit} × {ingress,egress}` combinations. The test asserts on direction (`_ing` vs `_egr`) and netkit (`_nk_`) substrings of the map name independent of the implementation, so an inversion would fail it.
3. Puts the test under `felix/bpf/jump/` (rather than `felix/fv/infrastructure/bpfpolprog/`) so `make ut` picks it up — `felix/fv/` is excluded from the unit-test run.

## Test plan

- [x] `make -C felix ut` covers `TestPolicyJumpMapName` (passes).
- [ ] `make -C felix fv-bpf GINKGO_FOCUS="sub-program cleanup tests"` still green (no regression on the existing FV path).

## Notes for reviewers

Test-helper-only change; no shipping behaviour changes.