### PR TITLE
[v3.31] Fix IPAM GC hanging on rapid node cleanup (#11906)

### DIFF
--- a/kube-controllers/pkg/controllers/node/fake_client.go
+++ b/kube-controllers/pkg/controllers/node/fake_client.go
@@ -79,6 +79,24 @@ func (f *FakeCalicoClient) IPAMUpgradeNodeNames() []string {
 	return nil
 }
 
+// SetReleaseHostAffinityError configures the fake IPAM client to return the given
+// error from ReleaseHostAffinities for the specified host, simulating cleanup failures.
+// Pass nil to clear the error for a host.
+func (f *FakeCalicoClient) SetReleaseHostAffinityError(host string, err error) {
+	if fic, ok := f.ipamClient.(*fakeIPAMClient); ok {
+		fic.Lock()
+		defer fic.Unlock()
+		if fic.releaseHostAffinityErrors == nil {
+			fic.releaseHostAffinityErrors = make(map[string]error)
+		}
+		if err == nil {
+			delete(fic.releaseHostAffinityErrors, host)
+		} else {
+			fic.releaseHostAffinityErrors[host] = err
+		}
+	}
+}
+
 // StagedGlobalNetworkPolicies returns an interface for managing staged global network policy resources.
 func (f *FakeCalicoClient) StagedGlobalNetworkPolicies() clientv3.StagedGlobalNetworkPolicyInterface {
 	panic("not implemented") // TODO: Implement
@@ -266,6 +284,10 @@ type fakeIPAMClient struct {
 	upgradeCalls     int
 	upgradeNodeNames []string
 	upgradeErrors    []error // returned in order on successive calls
+
+	// releaseHostAffinityErrors maps host names to errors that ReleaseHostAffinities
+	// should return, simulating per-node "block not empty" failures during cleanup.
+	releaseHostAffinityErrors map[string]error
 }
 
 func (f *fakeIPAMClient) affinityReleased(aff string) bool {
@@ -372,7 +394,9 @@ func (f *fakeIPAMClient) ReleaseBlockAffinity(ctx context.Context, block *model.
 func (f *fakeIPAMClient) ReleaseHostAffinities(ctx context.Context, affinityCfg ipam.AffinityConfig, mustBeEmpty bool) error {
 	f.Lock()
 	defer f.Unlock()
-
+	if err, ok := f.releaseHostAffinityErrors[affinityCfg.Host]; ok {
+		return err
+	}
 	f.affinitiesReleased[affinityCfg.Host] = true
 	return nil
 }

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -850,6 +850,7 @@ func (c *IPAMController) checkAllocations() ([]string, error) {
 			} else {
 				log.WithError(err).Warnf("Failed to lookup corresponding node, skipping %s", cnode)
 			}
+			c.allocationState.markClean(cnode, "node lookup skipped")
 			continue
 		}
 		logc := log.WithFields(log.Fields{"calicoNode": cnode, "k8sNode": knode})
@@ -939,19 +940,24 @@ func (c *IPAMController) checkAllocations() ([]string, error) {
 			if !canDelete {
 				// There are still valid allocations on the node.
 				logc.Infof("Can't cleanup node yet - IPs still in use on this node")
+				c.allocationState.markClean(cnode, "allocations still in use")
 				continue
 			}
 
-			// Mark the node's tunnel addresses for GC.
+			// Mark the node's tunnel addresses as confirmed leaks for GC.
 			for _, a := range tunnelAddresses {
 				a.markConfirmedLeak()
 				c.confirmedLeaks[a.id()] = a
 			}
 
-			// The node is ready have its IPAM affinities released. It exists in Calico IPAM, but
+			// The node is ready to have its IPAM affinities released. It exists in Calico IPAM, but
 			// not in the Kubernetes API. Additionally, we've checked that there are no
-			// outstanding valid allocations on the node.
+			// outstanding valid allocations on the node. Leave the node dirty — it will be
+			// marked clean by releaseNodes once cleanup succeeds.
 			nodesToRelease = append(nodesToRelease, cnode)
+		} else {
+			// Node still exists in Kubernetes, we've finished checking it.
+			c.allocationState.markClean(cnode, "node still exists in Kubernetes")
 		}
 	}
 	return nodesToRelease, nil
@@ -1079,7 +1085,9 @@ func (c *IPAMController) syncIPAM() error {
 	log.Debug("Synchronizing IPAM data")
 
 	// Scan known allocations, determining if there are any IP address leaks
-	// or nodes that should have their block affinities released.
+	// or nodes that should have their block affinities released. Each node is
+	// individually marked clean in the dirty set as it is processed, so an early
+	// return here only leaves unprocessed nodes dirty for retry.
 	nodesToRelease, err := c.checkAllocations()
 	if err != nil {
 		return err
@@ -1101,18 +1109,15 @@ func (c *IPAMController) syncIPAM() error {
 
 	// Delete any nodes that we determined can be removed in checkAllocations. These
 	// nodes are no longer in the Kubernetes API, and have no valid allocations, so can be cleaned up entirely
-	// from Calico IPAM.
-	if err = c.releaseNodes(nodesToRelease); err != nil {
-		return err
-	}
-
-	c.allocationState.syncComplete()
+	// from Calico IPAM. Successfully released nodes are marked clean inside releaseNodes;
+	// failed nodes remain dirty and will be retried on the next sync.
+	failedNodes := c.releaseNodes(nodesToRelease)
 	log.Debug("IPAM sync completed")
 
-	// If there is still dirty state, then we need to do another pass.
-	if len(c.confirmedLeaks) > 0 {
-		log.WithField("num", len(c.confirmedLeaks)).Info("Confirmed leaks still exist, scheduling another pass")
-		kick(c.syncChan)
+	// If there is remaining work, return an error so the retry controller schedules
+	// the next sync with exponential backoff, avoiding tight-loop retries.
+	if len(failedNodes) > 0 || len(c.confirmedLeaks) > 0 {
+		return fmt.Errorf("work remaining: %d nodes, %d confirmed leaks", len(failedNodes), len(c.confirmedLeaks))
 	}
 	return nil
 }
@@ -1199,25 +1204,26 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 	return nil
 }
 
-func (c *IPAMController) releaseNodes(nodes []string) error {
+// releaseNodes attempts to release IPAM affinities for the given nodes. Returns the
+// list of nodes that failed cleanup so they can be retried on the next sync.
+func (c *IPAMController) releaseNodes(nodes []string) []string {
 	if len(nodes) == 0 {
 		return nil
 	}
 
 	log.WithField("num", len(nodes)).Info("Found a batch of nodes to release")
-	var storedErr error
+	var failedNodes []string
 	for _, cnode := range nodes {
 		logc := log.WithField("node", cnode)
-
-		// Potentially rate limit node cleanup.
 		logc.Info("Cleaning up IPAM affinities for deleted node")
 		if err := c.cleanupNode(cnode); err != nil {
-			// Store the error, but continue. Storing the error ensures we'll retry.
-			logc.WithError(err).Warnf("Error cleaning up node")
-			storedErr = err
+			logc.WithError(err).Warnf("Error cleaning up node, will retry on next sync")
+			failedNodes = append(failedNodes, cnode)
+		} else {
+			c.allocationState.markClean(cnode, "node released successfully")
 		}
 	}
-	return storedErr
+	return failedNodes
 }
 
 func (c *IPAMController) cleanupNode(cnode string) error {
@@ -1230,7 +1236,6 @@ func (c *IPAMController) cleanupNode(cnode string) error {
 		Host:         cnode,
 	}
 
-	// Release the affinities for this node, requiring that the blocks are empty.
 	if err := c.client.IPAM().ReleaseHostAffinities(context.TODO(), affinityCfg, true); err != nil {
 		logc.WithError(err).Errorf("Failed to release block affinities for node")
 		return err

--- a/kube-controllers/pkg/controllers/node/ipam_allocation.go
+++ b/kube-controllers/pkg/controllers/node/ipam_allocation.go
@@ -296,9 +296,11 @@ func (t *allocationState) markDirty(node string, reason string) {
 	}
 }
 
-func (t *allocationState) syncComplete() {
-	for node := range t.dirtyNodes {
-		log.WithField("node", node).Debug("Node is no longer dirty")
+// markClean removes a single node from the dirty set after it has been
+// successfully processed.
+func (t *allocationState) markClean(node string, reason string) {
+	if _, ok := t.dirtyNodes[node]; ok {
+		log.WithFields(log.Fields{"node": node, "reason": reason}).Debug("Node is no longer dirty")
 		delete(t.dirtyNodes, node)
 	}
 }

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -1894,6 +1894,262 @@ var _ = Describe("IPAM controller UTs", func() {
 			}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "IP was not marked as leaked")
 		})
 	})
+
+	It("should clean up node with tunnel IPs in a single sync pass", func() {
+		// Start the controller.
+		c.Start(stopChan)
+
+		// Create a block with a tunnel address allocation for a node that doesn't exist.
+		tunnelHandle := "vxlan-tunnel-addr-dead-node"
+		cidr := net.MustParseCIDR("10.0.0.0/30")
+		aff := "host:dead-node"
+		idx := 0
+		key := model.BlockKey{CIDR: cidr}
+		b := model.AllocationBlock{
+			CIDR:        cidr,
+			Affinity:    &aff,
+			Allocations: []*int{&idx, nil, nil, nil},
+			Unallocated: []int{1, 2, 3},
+			Attributes: []model.AllocationAttribute{
+				{
+					AttrPrimary: &tunnelHandle,
+					AttrSecondary: map[string]string{
+						ipam.AttributeNode: "dead-node",
+						ipam.AttributeType: ipam.AttributeTypeVXLAN,
+					},
+				},
+			},
+		}
+		kvp := model.KVPair{Key: key, Value: &b}
+		update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(update)
+
+		// Wait for internal caches to update.
+		blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			_, ok := c.allBlocks[blockCIDR]
+			return ok
+		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		// Mark the syncer as InSync and trigger a full scan.
+		c.fullScanNextSync("forced by test")
+		c.onStatusUpdate(bapi.InSync)
+
+		// Both the tunnel IP GC and the node affinity release should eventually complete.
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		Eventually(func() bool {
+			return fakeClient.handlesReleased[tunnelHandle]
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "Tunnel IP handle should be released via GC")
+
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("dead-node")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "Node affinity should be released")
+	})
+
+	// Regression test for https://github.com/projectcalico/calico/issues/8643
+	//
+	// Scenario: When nodes are rapidly scaled down, the IPAM GC controller can get
+	// stuck in an infinite retry loop. The root cause is that if
+	// ReleaseHostAffinities(mustBeEmpty=true) fails (e.g., because blocks still have
+	// allocations due to a race between IP release and block update propagation),
+	// dirty nodes accumulated and each subsequent sync processed more and more
+	// nodes, increasing contention and making recovery impossible.
+	//
+	// The fix uses incremental dirty-node tracking: each node is individually marked
+	// clean as it is successfully processed or released. Failed nodes simply remain
+	// dirty and are retried on the next pass.
+	//
+	// This test creates three deleted nodes, injects cleanup errors for two of them,
+	// and verifies that:
+	//   - The healthy node is cleaned up immediately
+	//   - The failing nodes are retained and retried
+	//   - As errors are cleared, each node is eventually cleaned up
+	It("should not get stuck when node cleanup fails (issue #8643)", func() {
+		// Start the controller.
+		c.Start(stopChan)
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		fc := cli.(*FakeCalicoClient)
+
+		// Inject errors for node-b and node-c to simulate "block not empty" failures.
+		// node-a will succeed immediately.
+		fc.SetReleaseHostAffinityError("node-b", fmt.Errorf("block is not empty"))
+		fc.SetReleaseHostAffinityError("node-c", fmt.Errorf("block is not empty"))
+
+		// Create blocks with tunnel address allocations for three nodes that don't
+		// exist in Kubernetes (simulating node deletion during scale-down).
+		type testNode struct {
+			name   string
+			cidr   string
+			handle string
+		}
+		nodes := []testNode{
+			{"node-a", "10.0.0.0/30", "vxlan-tunnel-addr-node-a"},
+			{"node-b", "10.0.1.0/30", "vxlan-tunnel-addr-node-b"},
+			{"node-c", "10.0.2.0/30", "vxlan-tunnel-addr-node-c"},
+		}
+		for _, n := range nodes {
+			cidr := net.MustParseCIDR(n.cidr)
+			aff := fmt.Sprintf("host:%s", n.name)
+			handle := n.handle
+			idx := 0
+			b := model.AllocationBlock{
+				CIDR:        cidr,
+				Affinity:    &aff,
+				Allocations: []*int{&idx, nil, nil, nil},
+				Unallocated: []int{1, 2, 3},
+				Attributes: []model.AllocationAttribute{
+					{
+						AttrPrimary: &handle,
+						AttrSecondary: map[string]string{
+							ipam.AttributeNode: n.name,
+							ipam.AttributeType: ipam.AttributeTypeVXLAN,
+						},
+					},
+				},
+			}
+			kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &b}
+			c.onUpdate(bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew})
+		}
+
+		// Wait for all blocks to be cached.
+		for _, n := range nodes {
+			cidr := n.cidr
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				_, ok := c.allBlocks[cidr]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue(), "Block %s should be cached", cidr)
+		}
+
+		// Trigger a full sync.
+		c.fullScanNextSync("forced by test")
+		c.onStatusUpdate(bapi.InSync)
+
+		// node-a should be cleaned up (no error injected).
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-a")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-a affinity should be released")
+
+		// node-b and node-c should NOT be released — their cleanup is failing.
+		Consistently(func() bool {
+			return fakeClient.affinityReleased("node-b") || fakeClient.affinityReleased("node-c")
+		}, 2*time.Second, 100*time.Millisecond).Should(BeFalse(), "node-b and node-c should not be released while errors persist")
+
+		// Verify that the dirty node count is bounded — it should only contain the two failing
+		// nodes, not grow unbounded across syncs.
+		done := c.pause()
+		Expect(len(c.allocationState.dirtyNodes)).To(BeNumerically("<=", 2),
+			"dirty node count should not grow unbounded")
+		done()
+
+		// Clear the error for node-b. The retry controller will eventually schedule
+		// another sync and node-b should be cleaned up.
+		fc.SetReleaseHostAffinityError("node-b", nil)
+
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-b")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-b affinity should be released after error is cleared")
+
+		// node-c should still be failing.
+		Expect(fakeClient.affinityReleased("node-c")).To(BeFalse(), "node-c should still be stuck")
+
+		// Clear the error for node-c.
+		fc.SetReleaseHostAffinityError("node-c", nil)
+
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-c")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-c affinity should be released after error is cleared")
+	})
+
+	// Regression test: verifies the controller makes progress even when ALL nodes fail
+	// cleanup simultaneously (zero progress in a pass). The dirty node set should stay
+	// bounded across syncs, and nodes should recover once errors clear.
+	It("should handle all nodes failing cleanup without growing dirty set", func() {
+		c.Start(stopChan)
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		fc := cli.(*FakeCalicoClient)
+
+		// Inject errors for ALL nodes.
+		fc.SetReleaseHostAffinityError("node-x", fmt.Errorf("block is not empty"))
+		fc.SetReleaseHostAffinityError("node-y", fmt.Errorf("block is not empty"))
+
+		type testNode struct {
+			name   string
+			cidr   string
+			handle string
+		}
+		nodes := []testNode{
+			{"node-x", "10.0.10.0/30", "vxlan-tunnel-addr-node-x"},
+			{"node-y", "10.0.11.0/30", "vxlan-tunnel-addr-node-y"},
+		}
+		for _, n := range nodes {
+			cidr := net.MustParseCIDR(n.cidr)
+			aff := fmt.Sprintf("host:%s", n.name)
+			handle := n.handle
+			idx := 0
+			b := model.AllocationBlock{
+				CIDR:        cidr,
+				Affinity:    &aff,
+				Allocations: []*int{&idx, nil, nil, nil},
+				Unallocated: []int{1, 2, 3},
+				Attributes: []model.AllocationAttribute{
+					{
+						AttrPrimary: &handle,
+						AttrSecondary: map[string]string{
+							ipam.AttributeNode: n.name,
+							ipam.AttributeType: ipam.AttributeTypeVXLAN,
+						},
+					},
+				},
+			}
+			kvp := model.KVPair{Key: model.BlockKey{CIDR: cidr}, Value: &b}
+			c.onUpdate(bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew})
+		}
+
+		// Wait for blocks to be cached.
+		for _, n := range nodes {
+			cidr := n.cidr
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				_, ok := c.allBlocks[cidr]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue(), "Block %s should be cached", cidr)
+		}
+
+		// Trigger a full sync.
+		c.fullScanNextSync("forced by test")
+		c.onStatusUpdate(bapi.InSync)
+
+		// Neither node should be released since all are failing.
+		Consistently(func() bool {
+			return fakeClient.affinityReleased("node-x") || fakeClient.affinityReleased("node-y")
+		}, 2*time.Second, 100*time.Millisecond).Should(BeFalse(), "no nodes should be released while all errors persist")
+
+		// Dirty node count should stay bounded at the number of failing nodes (2),
+		// not grow across repeated sync attempts.
+		done := c.pause()
+		Expect(len(c.allocationState.dirtyNodes)).To(BeNumerically("<=", 2),
+			"dirty node count should not grow unbounded when all nodes fail")
+		done()
+
+		// Clear errors — both nodes should recover.
+		fc.SetReleaseHostAffinityError("node-x", nil)
+		fc.SetReleaseHostAffinityError("node-y", nil)
+
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-x")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-x should be released after error is cleared")
+
+		Eventually(func() bool {
+			return fakeClient.affinityReleased("node-y")
+		}, assertionTimeout, 100*time.Millisecond).Should(BeTrue(), "node-y should be released after error is cleared")
+	})
 })
 
 // createBlock creates a block based on the given pods and CIDR, and sends it as an update to the controller.


### PR DESCRIPTION
## Description

Backport of #11906 to release-v3.31.

### Backport notes

The cherry-pick from master (commit `8a861463db`) applied cleanly via 3-way merge. One small adaptation was needed in `ipam_test.go`:

- The new test cases in #11906 reference `AllocationAttribute.HandleID` and `AllocationAttribute.ActiveOwnerAttrs`. Those field names were introduced in v3.32 as part of a libcalico-go IPAM refactor. In v3.31 the equivalent fields are still called `AttrPrimary` and `AttrSecondary` (same types, same JSON tags `handle_id` / `secondary`).
- Renamed in 6 locations across 3 test cases. No behavioral change.

Production code (`ipam.go`, `ipam_allocation.go`, `fake_client.go`) is byte-identical to the master patch — the `RetryController`, `ProcessBatch`, `iterDirty` etc. APIs that #11906 builds on are all from #10333, which is already in v3.31.

### Related issues/PRs

- Original master PR: #11906

**Release note:**
```release-note
Fix calico-kube-controllers IPAM GC controller getting stuck when cleaning up nodes during rapid scale-down.
```


