### PR TITLE
Remove duplicate make rules in cmd/calico/Makefile

### DIFF
--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -85,9 +85,6 @@ $(BINDIR)/calico-race-$(ARCH): $(LIBBPF_A) $(SRC_FILES)
 		$(CALICO_BUILD) \
 		sh -c '$(GIT_CONFIG_SSH) go build -race -o $@ -v -buildvcs=false -ldflags "$(LDFLAGS)" ./'
 
-$(LIBBPF_A):
-	$(MAKE) -C $(REPO_ROOT)/felix libbpf ARCH=$(ARCH)
-
 $(BINDIR)/LICENSE: $(REPO_ROOT)/LICENSE.md
 	mkdir -p $(BINDIR)
 	cp $(REPO_ROOT)/LICENSE.md $@
@@ -138,8 +135,3 @@ release-publish: release-prereqs .release-$(VERSION).published
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	$(MAKE) FIPS=true push-images-to-registries push-manifests IMAGETAG=$(VERSION)-fips RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	touch $@
-
-release-prereqs:
-ifndef VERSION
-	$(error VERSION is undefined - set VERSION=vX.Y.Z)
-endif

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1673,7 +1673,7 @@ KIND_IMAGE_MARKERS = \
 LIBBPF_MARKER = $(REPO_ROOT)/felix/bpf-gpl/libbpf/src/$(ARCH)/libbpf.a
 
 $(LIBBPF_MARKER):
-	$(MAKE) -C $(REPO_ROOT)/felix libbpf
+	$(MAKE) -C $(REPO_ROOT)/felix libbpf ARCH=$(ARCH)
 
 # MISSING-IMAGE forces a rebuild when the previously-built image has been
 # pruned from the local Docker daemon. Each stamp records the image ref


### PR DESCRIPTION
The \`\$(LIBBPF_A)\` and \`release-prereqs\` targets in \`cmd/calico/Makefile\` duplicate rules already provided by \`lib.Makefile\`, which triggered \`overriding recipe\` warnings on every recursive make in this directory. The cmd/calico libbpf rule had one meaningful difference - passing \`ARCH=\$(ARCH)\` to the sub-make - so I lifted that into the shared rule before deleting the duplicates.

```release-note
None
```