### PR TITLE
Install kubectl in scheduled e2e runner

### DIFF
--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -70,7 +70,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # exec-into-pod step (RunHostCmd, etc.), so kubectl must be on PATH inside
   # the runner. Fetch a K8S_VERSION-pinned binary via the repo's `make
   # kubectl` target; it lands in hack/test/kind/ which is bind-mounted into
-  # the container, and we prepend that to PATH below.
+  # the container, and we prepend that to PATH inside the bash -c below.
   make kubectl
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
@@ -82,7 +82,6 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
-    -e PATH=/go/src/github.com/projectcalico/calico/hack/test/kind:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
@@ -90,6 +89,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -w /go/src/github.com/projectcalico/calico \
     "${RUN_IMAGE}" \
     bash -c "${PRE_RUN} && \
+      export PATH=/go/src/github.com/projectcalico/calico/hack/test/kind:\$PATH && \
       git config --global --add safe.directory '*' && \
       make e2e-run \
         KUBECONFIG=/kubeconfig \

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -66,6 +66,13 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     PRE_RUN="apt-get update -qq && apt-get install -y --no-install-recommends libelf1 zlib1g uuid-runtime"
   fi
 
+  # The upstream k8s e2e framework shells out to `kubectl` for any
+  # exec-into-pod step (RunHostCmd, etc.), so kubectl must be on PATH inside
+  # the runner. Fetch a K8S_VERSION-pinned binary via the repo's `make
+  # kubectl` target; it lands in hack/test/kind/ which is bind-mounted into
+  # the container, and we prepend that to PATH below.
+  make kubectl
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
@@ -75,6 +82,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e GOPATH=/go \
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
+    -e PATH=/go/src/github.com/projectcalico/calico/hack/test/kind:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \


### PR DESCRIPTION
The scheduled k8s-e2e job runs the e2e binary inside `golang:${GO_VERSION}-bookworm`, which doesn't ship kubectl. The upstream k8s e2e framework shells out to `kubectl` for any exec-into-pod step (`RunHostCmd` etc.), so every test that calls into a pod failed with `exec: "kubectl": executable file not found in $PATH`. That accounted for the run of 33 nftables failures in https://tigera-delivery.semaphoreci.com/jobs/ae1d5130-3edc-4fe1-b2b8-2d5b33218c38 - the failures had nothing to do with the dataplane.

Run `make kubectl` on the host (the target already exists in `lib.Makefile`, version-pinned to `K8S_VERSION`) and prepend the in-container path of `hack/test/kind/` to `PATH` so the runner can find it.

```release-note
None
```