### PR TITLE
felix/fv: make NumTCBPFProgs netkit-aware for workload interfaces

### DIFF
--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -956,10 +956,16 @@ func (c *Container) NumIPSets() int {
 }
 
 // NumTCBPFProgs Returns the number of TC BPF programs attached to the given interface.  Only direct-action
-// programs are listed (i.e. the type that we use).
+// programs are listed (i.e. the type that we use). In netkit mode, workload
+// interfaces (cali*) are netkit-attached rather than TC-attached, so fall
+// through to the bpftool path which surfaces both attach types.
 func (c *Container) NumTCBPFProgs(ifaceName string) int {
 	var total int
-	if strings.ToLower(os.Getenv("FELIX_FV_BPFATTACHTYPE")) == "tc" {
+	useTC := strings.ToLower(os.Getenv("FELIX_FV_BPFATTACHTYPE")) == "tc"
+	if strings.ToLower(os.Getenv("FELIX_FV_NETKIT")) == "enabled" && strings.HasPrefix(ifaceName, "cali") {
+		useTC = false
+	}
+	if useTC {
 		for _, dir := range []string{"ingress", "egress"} {
 			out, err := c.ExecOutput("tc", "filter", "show", "dev", ifaceName, dir)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

When `FELIX_FV_BPFATTACHTYPE=tc` and `FELIX_FV_NETKIT=Enabled`, host interfaces are still TC-attached but workload interfaces (`cali*`) are netkit-attached. `tc filter show` returns nothing for netkit-attached ifaces, so `NumTCBPFProgs` returns 0 for workload interfaces in that mode.

No current OSS netkit FV test happens to hit this — the netkit suite only calls `NumTCBPFProgsEth0()` (host iface, still TC). But any caller that asks about a workload interface in netkit mode fails silently.

Fall through to the `bpftool net show` branch for `cali*` interfaces when netkit mode is enabled. `bpftool` surfaces both TC and netkit attach links so the count is still correct. Host interfaces preserve the existing `tc filter show` path.

## Release note

```release-note
None
```

## Test plan

- [x] Existing netkit FV suite (calls `NumTCBPFProgsEth0` — host iface, unaffected) still passes.
- [x] Verified that the new `bpftool` branch correctly counts netkit attachments on workload ifaces in a manual netkit run.