### PR TITLE
e2e: promote conncheck Client/Server to interfaces

### DIFF
--- a/e2e/pkg/tests/bgp/bgp_password.go
+++ b/e2e/pkg/tests/bgp/bgp_password.go
@@ -47,8 +47,8 @@ var _ = describe.CalicoDescribe(
 	func() {
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var server1 *conncheck.Server
-		var client1 *conncheck.Client
+		var server1 conncheck.Server
+		var client1 conncheck.Client
 		var restoreBGPConfig func()
 
 		f := utils.NewDefaultFramework("bgp-password")

--- a/e2e/pkg/tests/bgp/export.go
+++ b/e2e/pkg/tests/bgp/export.go
@@ -45,8 +45,8 @@ var _ = describe.CalicoDescribe(
 		var err error
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var server1 *conncheck.Server
-		var client1 *conncheck.Client
+		var server1 conncheck.Server
+		var client1 conncheck.Client
 		var restoreBGPConfig func()
 		var bgpStatus *BGPStatusMonitor
 

--- a/e2e/pkg/tests/bgp/peers.go
+++ b/e2e/pkg/tests/bgp/peers.go
@@ -47,8 +47,8 @@ var _ = describe.CalicoDescribe(
 		var err error
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var server1 *conncheck.Server
-		var client1 *conncheck.Client
+		var server1 conncheck.Server
+		var client1 conncheck.Client
 		var restoreBGPConfig func()
 		var bgpStatus *BGPStatusMonitor
 

--- a/e2e/pkg/tests/bgp/route_reflector.go
+++ b/e2e/pkg/tests/bgp/route_reflector.go
@@ -49,9 +49,9 @@ var _ = describe.CalicoDescribe(
 		var err error
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var server1 *conncheck.Server
-		var client1 *conncheck.Client
-		var client2 *conncheck.Client
+		var server1 conncheck.Server
+		var client1 conncheck.Client
+		var client2 conncheck.Client
 		var restoreBGPConfig func()
 
 		// Create a new framework for the tests.

--- a/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/auto_hostendpoints.go
@@ -149,8 +149,8 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 
 		ginkgo.Context("with policies in place", func() {
 			var checker conncheck.ConnectionTester
-			var server *conncheck.Server
-			var cliHostNet *conncheck.Client
+			var server conncheck.Server
+			var cliHostNet conncheck.Client
 
 			ginkgo.BeforeEach(func() {
 				checker = conncheck.NewConnectionTester(f)
@@ -241,7 +241,7 @@ var _ = describe.CalicoDescribe(describe.WithTeam(describe.Core),
 			})
 
 			ginkgo.Context("with egress policy", func() {
-				var clientPod *conncheck.Client
+				var clientPod conncheck.Client
 
 				ginkgo.BeforeEach(func() {
 					clientNode := getNodeHostname(nodes.Items[1])

--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -107,8 +107,8 @@ var _ = describe.CalicoDescribe(
 		}
 
 		var checker conncheck.ConnectionTester
-		var hepServer1 *conncheck.Server
-		var client1 *conncheck.Client
+		var hepServer1 conncheck.Server
+		var client1 conncheck.Client
 		var hep *v3.HostEndpoint
 
 		BeforeEach(func() {

--- a/e2e/pkg/tests/hostendpoints/hostendpoints.go
+++ b/e2e/pkg/tests/hostendpoints/hostendpoints.go
@@ -369,12 +369,17 @@ var _ = describe.CalicoDescribe(
 					}
 				}
 
+				// Wrap the external node as a conncheck Client so the probes
+				// go through the standard ConnectionTester machinery.
+				ext := conncheck.NewExternalNodeClient("ext", extClient)
+				checker.AddClient(ext)
+
 				// Target the server's host IP + ports directly. The server pod is host-networked,
 				// so traffic from the external node hits the HEP-protected node on these ports.
 				serverHostIP := hepServer1.Pod().Status.HostIP
 				Expect(serverHostIP).NotTo(BeEmpty(), "server pod must have a host IP")
-				target1 := fmt.Sprintf("http://%s:%d/", serverHostIP, hepPort1)
-				target2 := fmt.Sprintf("http://%s:%d/", serverHostIP, hepPort2)
+				target1 := conncheck.NewTarget(serverHostIP, conncheck.TypePodIP, conncheck.TCP).Port(hepPort1)
+				target2 := conncheck.NewTarget(serverHostIP, conncheck.TypePodIP, conncheck.TCP).Port(hepPort2)
 
 				// create a networkpolicy that allows all incoming connections.
 				// assert external node can reach the hep.
@@ -402,8 +407,9 @@ var _ = describe.CalicoDescribe(
 				}()
 
 				By("asserting connections work now from the external node", func() {
-					extClient.TestCanConnect(target1)
-					extClient.TestCanConnect(target2)
+					checker.ExpectSuccess(ext, target1, target2)
+					checker.Execute()
+					checker.ResetExpectations()
 				})
 
 				// We need to enable generic XDP to test XDP in Iptables mode, otherwise the raw table
@@ -480,8 +486,9 @@ var _ = describe.CalicoDescribe(
 				}()
 
 				By(fmt.Sprintf("asserting that none of the ports (tcp %d, %d) are accessible from the external node", hepPort1, hepPort2), func() {
-					extClient.TestCannotConnect(target1)
-					extClient.TestCannotConnect(target2)
+					checker.ExpectFailure(ext, target1, target2)
+					checker.Execute()
+					checker.ResetExpectations()
 				})
 			})
 		})

--- a/e2e/pkg/tests/networking/hostports.go
+++ b/e2e/pkg/tests/networking/hostports.go
@@ -36,8 +36,8 @@ var _ = describe.CalicoDescribe(
 	func() {
 		f := utils.NewDefaultFramework("hostports")
 		var checker conncheck.ConnectionTester
-		var server *conncheck.Server
-		var client1 *conncheck.Client
+		var server conncheck.Server
+		var client1 conncheck.Client
 
 		ginkgo.BeforeEach(func() {
 			// Define a function to set the HostPort on the server pod.

--- a/e2e/pkg/tests/networking/ipip.go
+++ b/e2e/pkg/tests/networking/ipip.go
@@ -49,8 +49,8 @@ var _ = describe.CalicoDescribe(
 		var err error
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var server1 *conncheck.Server
-		var client1 *conncheck.Client
+		var server1 conncheck.Server
+		var client1 conncheck.Client
 		var poolName string
 
 		// Create a new framework for the tests.

--- a/e2e/pkg/tests/networking/mtu.go
+++ b/e2e/pkg/tests/networking/mtu.go
@@ -36,7 +36,7 @@ var _ = describe.CalicoDescribe(
 		f := utils.NewDefaultFramework("calico-mtu")
 
 		var checker conncheck.ConnectionTester
-		var clientPod *conncheck.Client
+		var clientPod conncheck.Client
 
 		ginkgo.BeforeEach(func() {
 			// Run the test pod as root and with NET_RAW capabiltiies to allow access to network interfaces.

--- a/e2e/pkg/tests/networking/packet_size.go
+++ b/e2e/pkg/tests/networking/packet_size.go
@@ -215,7 +215,7 @@ var _ = describe.CalicoDescribe(
 // packetBaseTarget returns a base target for the given target type. Callers add
 // protocol-specific options (WithHTTP for GET/POST, WithUDP for UDP) on top.
 type packetTarget struct {
-	server    *conncheck.Server
+	server    conncheck.Server
 	nodeIPs   []string
 	typ       int
 	podIP     string
@@ -224,7 +224,7 @@ type packetTarget struct {
 	clusterIP string
 }
 
-func packetBaseTarget(server *conncheck.Server, nodeIPs []string, targetType int) packetTarget {
+func packetBaseTarget(server conncheck.Server, nodeIPs []string, targetType int) packetTarget {
 	return packetTarget{
 		server:    server,
 		nodeIPs:   nodeIPs,
@@ -271,7 +271,7 @@ func (t packetTarget) makeTargetMultiOpt(opts ...conncheck.TargetOption) connche
 }
 
 // packetTestViaConncheck runs GET, POST, and UDP packet size tests using conncheck.
-func packetTestViaConncheck(ct conncheck.ConnectionTester, client *conncheck.Client, base packetTarget, getLengths, postLengths, udpLengths []int) {
+func packetTestViaConncheck(ct conncheck.ConnectionTester, client conncheck.Client, base packetTarget, getLengths, postLengths, udpLengths []int) {
 	for _, length := range getLengths {
 		By(fmt.Sprintf("Testing GET with payload length %d", length), func() {
 			target := base.getTarget(length)

--- a/e2e/pkg/tests/networking/snat.go
+++ b/e2e/pkg/tests/networking/snat.go
@@ -42,7 +42,7 @@ const (
 // behavior. The target must be an HTTP target pointing to an agnhost netexec
 // /clientip endpoint (created via WithHTTP("GET", "/clientip", nil)).
 // Uses ct.Connect() for all connectivity — never bypasses conncheck.
-func checkConnection(ct conncheck.ConnectionTester, client *conncheck.Client, target conncheck.Target, expected connectionResult) {
+func checkConnection(ct conncheck.ConnectionTester, client conncheck.Client, target conncheck.Target, expected connectionResult) {
 	logrus.WithFields(logrus.Fields{
 		"client":   client.Name(),
 		"target":   target.String(),

--- a/e2e/pkg/tests/networking/workload_egress.go
+++ b/e2e/pkg/tests/networking/workload_egress.go
@@ -110,7 +110,7 @@ var _ = describe.CalicoDescribe(
 		// runEgressTest executes the standard egress test flow for a single scenario.
 		runEgressTest := func(
 			ct conncheck.ConnectionTester,
-			clientPod *conncheck.Client,
+			clientPod conncheck.Client,
 			target conncheck.Target,
 			expectSNAT bool,
 			scenario egressScenario,
@@ -246,7 +246,7 @@ var _ = describe.CalicoDescribe(
 
 			// For loopback tests (dstPod==0), the source is the server pod itself.
 			// For other tests, create a separate client on node0.
-			var clientPod *conncheck.Client
+			var clientPod conncheck.Client
 			var applyLabels map[string]string
 
 			clientPod = conncheck.NewClient("client-0", f.Namespace,

--- a/e2e/pkg/tests/networking/workload_ingress.go
+++ b/e2e/pkg/tests/networking/workload_ingress.go
@@ -367,7 +367,7 @@ var _ = describe.CalicoDescribe(
 		// buildTarget returns the connection target for the given scenario, using the
 		// already-deployed server. All targets use HTTP GET /clientip so that
 		// checkConnection can verify SNAT behavior from the response body.
-		buildTarget := func(s ingressScenario, server *conncheck.Server) conncheck.Target {
+		buildTarget := func(s ingressScenario, server conncheck.Server) conncheck.Target {
 			clientIPOpt := conncheck.WithHTTP("GET", "/clientip", nil)
 			switch s.dest {
 			case "clusterIP":

--- a/e2e/pkg/tests/policy/policy.go
+++ b/e2e/pkg/tests/policy/policy.go
@@ -49,8 +49,8 @@ var _ = describe.CalicoDescribe(
 		var err error
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var server1 *conncheck.Server
-		var client1 *conncheck.Client
+		var server1 conncheck.Server
+		var client1 conncheck.Client
 
 		// Create a new framework for the tests.
 		f := utils.NewDefaultFramework("networkpolicy")

--- a/e2e/pkg/tests/policy/service_policy.go
+++ b/e2e/pkg/tests/policy/service_policy.go
@@ -43,8 +43,8 @@ var _ = describe.CalicoDescribe(
 	"service network policy",
 	func() {
 		var checker conncheck.ConnectionTester
-		var server *conncheck.Server
-		var client1 *conncheck.Client
+		var server conncheck.Server
+		var client1 conncheck.Client
 
 		f := utils.NewDefaultFramework("service-policy")
 

--- a/e2e/pkg/tests/policy/staged_policy.go
+++ b/e2e/pkg/tests/policy/staged_policy.go
@@ -69,8 +69,8 @@ var _ = describe.CalicoDescribe(
 		Context("Test presence in flow logs", func() {
 			var (
 				tierObj *v3.Tier
-				client1 *conncheck.Client
-				server  *conncheck.Server
+				client1 conncheck.Client
+				server  conncheck.Server
 
 				stopCh chan time.Time
 				url    string
@@ -220,8 +220,8 @@ var _ = describe.CalicoDescribe(
 		Context("enforcing staged-policies", func() {
 			var (
 				tierObj *v3.Tier
-				server  *conncheck.Server
-				client1 *conncheck.Client
+				server  conncheck.Server
+				client1 conncheck.Client
 			)
 
 			BeforeEach(func() {

--- a/e2e/pkg/tests/policy/tiers.go
+++ b/e2e/pkg/tests/policy/tiers.go
@@ -34,8 +34,8 @@ var _ = describe.CalicoDescribe(
 	func() {
 		var cli ctrlclient.Client
 		var checker conncheck.ConnectionTester
-		var client1 *conncheck.Client
-		var server *conncheck.Server
+		var client1 conncheck.Client
+		var server conncheck.Server
 		var ctx context.Context
 		var cancel context.CancelFunc
 

--- a/e2e/pkg/utils/conncheck/client.go
+++ b/e2e/pkg/utils/conncheck/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,15 +15,62 @@
 package conncheck
 
 import (
+	"context"
 	"fmt"
+	"io"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	"github.com/projectcalico/calico/e2e/pkg/utils/images"
 )
 
-func NewClient(id string, ns *v1.Namespace, opts ...ClientOption) *Client {
+// Client is a traffic source for connection checks. The default implementation
+// is PodClient, a long-lived sleep pod running in the cluster; ExternalNodeClient
+// runs commands over SSH on a host outside the cluster.
+type Client interface {
+	// ID returns a unique identifier for the client. For pod-backed clients
+	// this is "<namespace>/<name>".
+	ID() string
+
+	// Name returns the human-readable name of the client.
+	Name() string
+
+	// Namespace returns the namespace the client lives in, or nil for
+	// non-cluster clients.
+	Namespace() *v1.Namespace
+
+	// Pod returns the underlying pod, or nil for non-pod clients.
+	Pod() *v1.Pod
+
+	// Deploy creates the underlying resources (e.g. a sleep pod). Called by
+	// ConnectionTester.Deploy. Safe to call multiple times; second call is a
+	// no-op if already deployed.
+	Deploy(ctx context.Context, f *framework.Framework) error
+
+	// Cleanup tears down the resources created by Deploy.
+	Cleanup(ctx context.Context, f *framework.Framework) error
+
+	// WaitReady waits for the client to be ready to send traffic.
+	WaitReady(ctx context.Context, f *framework.Framework) error
+
+	// Exec runs a one-shot shell command on the client and returns the
+	// combined output and an error if the command exited non-zero.
+	Exec(ctx context.Context, cmd string) (string, error)
+
+	// ExecStream runs a long-lived command, writing combined output to w.
+	// Used for continuous probes (ExpectContinuously). Returns a stop
+	// function that terminates the remote command and waits for the
+	// streaming goroutine to drain.
+	ExecStream(ctx context.Context, cmd []string, w io.Writer) (stop func() error, err error)
+}
+
+// NewClient builds a PodClient. Most tests should use this; for an external
+// host see NewExternalNodeClient.
+func NewClient(id string, ns *v1.Namespace, opts ...ClientOption) Client {
 	if ns == nil {
 		msg := fmt.Sprintf("Namespace is required for client %s", id)
 		framework.Fail(msg, 1)
@@ -33,7 +80,7 @@ func NewClient(id string, ns *v1.Namespace, opts ...ClientOption) *Client {
 		framework.Fail(msg, 1)
 	}
 
-	c := &Client{
+	c := &PodClient{
 		name:      id,
 		namespace: ns,
 	}
@@ -43,7 +90,8 @@ func NewClient(id string, ns *v1.Namespace, opts ...ClientOption) *Client {
 	return c
 }
 
-type Client struct {
+// PodClient is a pod-backed Client.
+type PodClient struct {
 	name        string
 	namespace   *v1.Namespace
 	labels      map[string]string
@@ -53,7 +101,7 @@ type Client struct {
 
 // composedCustomizer returns a single customizer function that applies all
 // registered customizers in order, or nil if none are registered.
-func (c *Client) composedCustomizer() func(*v1.Pod) {
+func (c *PodClient) composedCustomizer() func(*v1.Pod) {
 	if len(c.customizers) == 0 {
 		return nil
 	}
@@ -64,15 +112,19 @@ func (c *Client) composedCustomizer() func(*v1.Pod) {
 	}
 }
 
-func (c *Client) ID() string {
+func (c *PodClient) ID() string {
 	return fmt.Sprintf("%s/%s", c.namespace.Name, c.name)
 }
 
-func (c *Client) Name() string {
+func (c *PodClient) Name() string {
 	return c.name
 }
 
-func (c *Client) Pod() *v1.Pod {
+func (c *PodClient) Namespace() *v1.Namespace {
+	return c.namespace
+}
+
+func (c *PodClient) Pod() *v1.Pod {
 	if c.pod == nil {
 		msg := fmt.Sprintf("No pod is running for client %s/%s", c.namespace.Name, c.name)
 		framework.Fail(msg, 1)
@@ -80,17 +132,67 @@ func (c *Client) Pod() *v1.Pod {
 	return c.pod
 }
 
-type ClientOption func(*Client) error
+func (c *PodClient) Deploy(ctx context.Context, f *framework.Framework) error {
+	if c.pod != nil {
+		return nil
+	}
+	pod, err := CreateClientPod(f, c.namespace, c.name, c.labels, c.composedCustomizer())
+	if err != nil {
+		return err
+	}
+	c.pod = pod
+	return nil
+}
+
+func (c *PodClient) WaitReady(ctx context.Context, f *framework.Framework) error {
+	if c.pod == nil {
+		return fmt.Errorf("PodClient %s/%s: WaitReady called before Deploy", c.namespace.Name, c.name)
+	}
+	if err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, c.pod.Name, c.pod.Namespace, podReadyTimeout(ctx)); err != nil {
+		return err
+	}
+	// Refresh the pod so callers see NodeName / PodIP.
+	p, err := f.ClientSet.CoreV1().Pods(c.namespace.Name).Get(ctx, c.pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	c.pod = p
+	return nil
+}
+
+func (c *PodClient) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if c.pod == nil {
+		return nil
+	}
+	err := f.ClientSet.CoreV1().Pods(c.namespace.Name).Delete(ctx, c.pod.Name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if err := e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, c.pod.Name, c.pod.Namespace, deletionTimeout); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *PodClient) Exec(ctx context.Context, cmd string) (string, error) {
+	return execShellInPod(c.Pod(), cmd)
+}
+
+func (c *PodClient) ExecStream(ctx context.Context, cmd []string, w io.Writer) (stop func() error, err error) {
+	return execStreamInPod(ctx, c.Pod(), cmd, w)
+}
+
+type ClientOption func(*PodClient) error
 
 func WithClientLabels(labels map[string]string) ClientOption {
-	return func(c *Client) error {
+	return func(c *PodClient) error {
 		c.labels = labels
 		return nil
 	}
 }
 
 func WithClientCustomizer(customizer func(pod *v1.Pod)) ClientOption {
-	return func(c *Client) error {
+	return func(c *PodClient) error {
 		c.customizers = append(c.customizers, customizer)
 		return nil
 	}

--- a/e2e/pkg/utils/conncheck/client.go
+++ b/e2e/pkg/utils/conncheck/client.go
@@ -171,6 +171,7 @@ func (c *PodClient) Cleanup(ctx context.Context, f *framework.Framework) error {
 	if err := e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, c.pod.Name, c.pod.Namespace, deletionTimeout); err != nil {
 		return err
 	}
+	c.pod = nil
 	return nil
 }
 

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -607,12 +607,16 @@ func logDiagsForConnection(f *framework.Framework, res connectionResult) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, fmt.Sprintf("%s-container", pod.Name))
+	container := ""
+	if len(pod.Spec.Containers) > 0 {
+		container = pod.Spec.Containers[0].Name
+	}
+	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, container)
 	if err != nil {
 		logrus.WithError(err).Error("Error getting container logs")
 	}
 	logrus.Infof("[DIAGS] Pod %s/%s logs:\n%s", pod.Namespace, pod.Name, logs)
-	prevLogs, err := e2epod.GetPreviousPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, fmt.Sprintf("%s-container", pod.Name))
+	prevLogs, err := e2epod.GetPreviousPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, container)
 	if err != nil {
 		logrus.WithError(err).Error("Error getting prev container logs")
 	}
@@ -857,9 +861,17 @@ func (c *checkpointer) ExpectNoDisruption(reason string, opts ...DisruptionOptio
 		break
 	}
 
+	if len(keys) == 0 {
+		framework.Fail(fmt.Sprintf("ExpectNoDisruption %s: no probe results captured. Did probes start?", reason), 2)
+	}
+
 	var problems []string
 	for _, k := range keys {
 		series := byTarget[k]
+		if len(series) == 0 {
+			problems = append(problems, fmt.Sprintf("target %s: no probe results captured", k))
+			continue
+		}
 		if cfg.lossSet {
 			consec := 0
 			worst := 0

--- a/e2e/pkg/utils/conncheck/conncheck.go
+++ b/e2e/pkg/utils/conncheck/conncheck.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -51,46 +50,47 @@ const (
 
 type connectionTester struct {
 	f              *framework.Framework
-	servers        map[string]*Server
-	clients        map[string]*Client
+	servers        map[string]Server
+	clients        map[string]Client
 	expectations   map[string]*Expectation
 	deployed       bool
 	executeTimeout time.Duration
 }
 
 type ConnectionTester interface {
-	// Methods for setup and teardown.
-	AddClient(client *Client)
-	AddServer(server *Server)
+	AddClient(client Client)
+	AddServer(server Server)
 	Deploy()
 	Stop()
-	StopClient(client *Client)
+	StopClient(client Client)
 
-	// Methods for one-shot execution.
-	ExpectSuccess(client *Client, targets ...Target)
-	ExpectFailure(client *Client, targets ...Target)
+	ExpectSuccess(client Client, targets ...Target)
+	ExpectFailure(client Client, targets ...Target)
 	Execute()
 	ResetExpectations()
 	WithTimeout(d time.Duration)
 
-	// Methods for continuous execution.
-	ExpectContinuously(client *Client, targets ...Target) Checkpointer
+	ExpectContinuously(client Client, targets ...Target) Checkpointer
 
-	// Connect executes a connection attempt from the client to the target and returns the output.
-	// This is useful for traffic generation where you don't need success/failure semantics.
-	Connect(client *Client, target Target) (string, error)
+	// Connect runs a one-shot probe and returns its output, without
+	// recording success/failure expectations.
+	Connect(client Client, target Target) (string, error)
 
-	// Methods for encryption verification. The client must have NET_RAW and NET_ADMIN
-	// capabilities for tcpdump (use WithCapture() client option).
-	ExpectEncrypted(client *Client, target Target)
-	ExpectPlaintext(client *Client, target Target)
+	// Encryption verification. The client must have NET_RAW and NET_ADMIN
+	// (use WithCapture()).
+	ExpectEncrypted(client Client, target Target)
+	ExpectPlaintext(client Client, target Target)
 }
 
-// Checkpointer provides a way to checkpoint continuous connection tests at specific points in time
-// during a test to verify that all connections are as expected up to that point.
+// Checkpointer asserts on results captured by a continuous probe.
 type Checkpointer interface {
 	ExpectSuccess(msg string)
 	ExpectFailure(msg string)
+	// ExpectNoDisruption asserts that the captured probe results have no
+	// disruption gap beyond what the supplied options allow. At least one
+	// of WithMaxGap / WithMaxConsecutiveLoss must be provided; there is
+	// no default tolerance.
+	ExpectNoDisruption(msg string, opts ...DisruptionOption)
 	Stop()
 }
 
@@ -99,8 +99,8 @@ var _ ConnectionTester = &connectionTester{}
 func NewConnectionTester(f *framework.Framework) ConnectionTester {
 	return &connectionTester{
 		f:            f,
-		clients:      make(map[string]*Client),
-		servers:      make(map[string]*Server),
+		clients:      make(map[string]Client),
+		servers:      make(map[string]Server),
 		expectations: make(map[string]*Expectation),
 	}
 }
@@ -113,10 +113,9 @@ func (c *connectionTester) ResetExpectations() {
 	c.executeTimeout = 0
 }
 
-// WithTimeout sets the timeout for the next Execute() call. The timeout
-// resets to the default after each ResetExpectations(). This is useful when
-// a particular connectivity check needs more time, e.g. waiting for Windows
-// HNS policy programming.
+// WithTimeout sets the timeout for the next Execute() call. Useful when a
+// connectivity check needs more time, e.g. waiting for Windows HNS policy
+// programming.
 func (c *connectionTester) WithTimeout(d time.Duration) {
 	c.executeTimeout = d
 }
@@ -126,62 +125,33 @@ func (c *connectionTester) Deploy() {
 }
 
 func (c *connectionTester) deploy() error {
-	// For each client and server, deploy a long lived pod.
-	for _, client := range c.clients {
-		if client.pod != nil {
-			// Pod was already deployed. Skip it, and only deploy new pods.
-			continue
-		}
-		By(fmt.Sprintf("Deploying client pod %s/%s", client.namespace.Name, client.name))
-		pod, err := CreateClientPod(c.f, client.namespace, client.name, client.labels, client.composedCustomizer())
-		if err != nil {
-			return err
-		}
-		client.pod = pod
-	}
-	for _, server := range c.servers {
-		if server.pod != nil {
-			// Pod was already deployed. Skip it, and only deploy new pods.
-			continue
-		}
-		By(fmt.Sprintf("Deploying server pod %s/%s", server.namespace.Name, server.name))
-		server.pod, server.service = server.deploy(c.f)
-	}
-
-	// Wait for all pods to be running.
-	By("Waiting for all pods in the connection checker to be running")
-	timeout := 1 * time.Minute
-	if windows.ClusterIsWindows() {
-		// Windows images are very large (sometimes 2GB+), so this needs a considerably
-		// longer timeout in order to allow them to be pulled
-		timeout = 15 * time.Minute
-	}
+	timeout := podReadyTimeout(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	for _, client := range c.clients {
-		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, timeout)
-		if err != nil {
-			return err
-		}
-		// Update the client pod object with the actual pod spec. i.e Spec.NodeName etc.
-		p, err := c.f.ClientSet.CoreV1().Pods(client.namespace.Name).Get(ctx, client.pod.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		client.pod = p
-	}
-	for _, server := range c.servers {
-		err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c.f.ClientSet, server.pod.Name, server.pod.Namespace, timeout)
-		if err != nil {
-			return err
-		}
 
-		// Update the server pod object with the actual pod IP.
-		p, err := c.f.ClientSet.CoreV1().Pods(server.namespace.Name).Get(ctx, server.pod.Name, metav1.GetOptions{})
-		if err != nil {
+	for _, cl := range c.clients {
+		By(fmt.Sprintf("Deploying client %s", cl.ID()))
+		if err := cl.Deploy(ctx, c.f); err != nil {
 			return err
 		}
-		server.pod = p
+	}
+	for _, srv := range c.servers {
+		By(fmt.Sprintf("Deploying server %s", srv.ID()))
+		if err := srv.Deploy(ctx, c.f); err != nil {
+			return err
+		}
+	}
+
+	By("Waiting for all clients and servers to be ready")
+	for _, cl := range c.clients {
+		if err := cl.WaitReady(ctx, c.f); err != nil {
+			return err
+		}
+	}
+	for _, srv := range c.servers {
+		if err := srv.WaitReady(ctx, c.f); err != nil {
+			return err
+		}
 	}
 	c.deployed = true
 	return nil
@@ -194,46 +164,20 @@ func (c *connectionTester) Stop() {
 func (c *connectionTester) stop() error {
 	By("Tearing down the connection tester")
 
-	// Delete all of the pods.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	for _, client := range c.clients {
-		By(fmt.Sprintf("Deleting client pod %s", client.pod.Name))
-		err := c.f.ClientSet.CoreV1().Pods(client.namespace.Name).Delete(ctx, client.pod.Name, metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
+	for _, cl := range c.clients {
+		By(fmt.Sprintf("Cleaning up client %s", cl.ID()))
+		if err := cl.Cleanup(ctx, c.f); err != nil {
 			return err
 		}
 	}
-
-	for _, server := range c.servers {
-		By(fmt.Sprintf("Deleting server pod %s", server.pod.Name))
-		err := c.f.ClientSet.CoreV1().Pods(server.namespace.Name).Delete(ctx, server.pod.Name, metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if server.service != nil {
-			By(fmt.Sprintf("Deleting server service %s", server.service.Name))
-			err = c.f.ClientSet.CoreV1().Services(server.namespace.Name).Delete(ctx, server.service.Name, metav1.DeleteOptions{})
-			if err != nil && !apierrors.IsNotFound(err) {
-				return err
-			}
-		}
-	}
-
-	// Wait for pods to be deleted.
-	for _, client := range c.clients {
-		By(fmt.Sprintf("Waiting for client pod %s to be deleted", client.pod.Name))
-		if err := e2epod.WaitForPodNotFoundInNamespace(ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, 1*time.Minute); err != nil {
+	for _, srv := range c.servers {
+		By(fmt.Sprintf("Cleaning up server %s", srv.ID()))
+		if err := srv.Cleanup(ctx, c.f); err != nil {
 			return err
 		}
 	}
-	for _, server := range c.servers {
-		By(fmt.Sprintf("Waiting for server pod %s to be deleted", server.pod.Name))
-		if err := e2epod.WaitForPodNotFoundInNamespace(ctx, c.f.ClientSet, server.pod.Name, server.pod.Namespace, 1*time.Minute); err != nil {
-			return err
-		}
-	}
-
 	return c.expectationsTested()
 }
 
@@ -246,140 +190,105 @@ func (c *connectionTester) expectationsTested() error {
 	return nil
 }
 
-func (c *connectionTester) AddClient(client *Client) {
-	if client.namespace == nil {
-		framework.Failf("Client %s has no namespace", client.name)
+func (c *connectionTester) AddClient(cl Client) {
+	if _, ok := c.clients[cl.ID()]; ok {
+		framework.Failf("Client with ID %s already exists", cl.ID())
 	}
-	if _, ok := c.clients[client.ID()]; ok {
-		framework.Failf("Client with ID %s already exists", client.ID())
-	}
-	c.clients[client.ID()] = client
+	c.clients[cl.ID()] = cl
 }
 
-func (c *connectionTester) StopClient(client *Client) {
-	framework.ExpectNoErrorWithOffset(1, c.stopClient(client))
+func (c *connectionTester) StopClient(cl Client) {
+	framework.ExpectNoErrorWithOffset(1, c.stopClient(cl))
 }
 
-func (c *connectionTester) stopClient(client *Client) error {
-	id := client.ID()
+func (c *connectionTester) stopClient(cl Client) error {
+	id := cl.ID()
 	if _, ok := c.clients[id]; !ok {
 		return fmt.Errorf("client %s not found", id)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	if client.pod != nil {
-		By(fmt.Sprintf("Stopping client pod %s", client.pod.Name))
-		err := c.f.ClientSet.CoreV1().Pods(client.namespace.Name).Delete(ctx, client.pod.Name, metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if err := e2epod.WaitForPodNotFoundInNamespace(
-			ctx, c.f.ClientSet, client.pod.Name, client.pod.Namespace, 1*time.Minute,
-		); err != nil {
-			return err
-		}
+	if err := c.clients[id].Cleanup(ctx, c.f); err != nil {
+		return err
 	}
 	delete(c.clients, id)
 	return nil
 }
 
-func (c *connectionTester) AddServer(server *Server) {
-	if server.namespace == nil {
-		framework.Failf("Server %s has no namespace", server.name)
+func (c *connectionTester) AddServer(srv Server) {
+	if _, ok := c.servers[srv.ID()]; ok {
+		framework.Failf("Server with ID %s already exists", srv.ID())
 	}
-	if _, ok := c.servers[server.ID()]; ok {
-		framework.Failf("Server with ID %s already exists", server.ID())
-	}
-	c.servers[server.ID()] = server
+	c.servers[srv.ID()] = srv
 }
 
 type Expectation struct {
-	Client         *v1.Pod
+	Client         Client
 	Target         Target
 	Description    string
 	ExpectedResult ResultStatus
 
-	// Track whether or not we have executed this expectation.
-	// This is helpful for spotting test bugs where we forget to execute.
 	executed bool
 }
 
 func (e *Expectation) String() string {
-	// An Expectation is defined by:
-	// - Client name and namespace.
-	// - The target name (and if applicable, namespace).
-	// - The type of connection, e.g., ClusterIP/ICMP.
-	return fmt.Sprintf("Client=%s/%s; Server=%s; Type=%s",
-		e.Client.Namespace,
-		e.Client.Name,
+	return fmt.Sprintf("Client=%s; Server=%s; Type=%s",
+		e.Client.ID(),
 		e.Target.String(),
 		e.Target.AccessType(),
 	)
 }
 
-func (c *connectionTester) ExpectSuccess(client *Client, targets ...Target) {
+func (c *connectionTester) ExpectSuccess(cl Client, targets ...Target) {
 	for _, target := range targets {
-		c.expectSuccess(client, target)
+		c.expectSuccess(cl, target)
 	}
 }
 
-func (c *connectionTester) expectSuccess(client *Client, target Target) {
-	if c.clients[client.ID()] == nil {
-		framework.Fail(fmt.Sprintf("Test bug: client %s not registered with connection tester. AddClient()?", client.ID()), 2)
+func (c *connectionTester) expectSuccess(cl Client, target Target) {
+	if c.clients[cl.ID()] == nil {
+		framework.Fail(fmt.Sprintf("Test bug: client %s not registered with connection tester. AddClient()?", cl.ID()), 2)
 	}
-	if c.clients[client.ID()].pod == nil {
-		framework.Fail(fmt.Sprintf("Client %s has no running pod. Did you Deploy()?", client.ID()), 2)
-	}
-
-	// Prevent duplication expectations. This is a common mistake when writing tests.
 	e := &Expectation{
-		Client:         c.clients[client.ID()].pod,
+		Client:         cl,
 		Target:         target,
-		Description:    fmt.Sprintf("%s -> %s", client.name, target.String()),
+		Description:    fmt.Sprintf("%s -> %s", cl.Name(), target.String()),
 		ExpectedResult: Success,
 	}
 	if c.expectations[e.String()] != nil {
-		// Protect against tests accidentally calling ExpectX with the same values
-		// multiple times, which is indicative of a test bug.
 		framework.Fail(fmt.Sprintf("Test bug: duplicate expectation: %s", e.String()), 2)
 	}
 	c.expectations[e.String()] = e
 }
 
-// ExpectContinuously starts continuous connection tests from the given client to the given targets.
-// It returns a Checkpointer that can be used to checkpoint and verify the results at specific points in time.
-// Callers must call Stop() on the returned Checkpointer when done.
-func (c *connectionTester) ExpectContinuously(client *Client, targets ...Target) Checkpointer {
-	checkpointer := &checkpointer{
+// ExpectContinuously starts continuous probes from cl to targets. Callers must
+// call Stop() on the returned Checkpointer when done.
+func (c *connectionTester) ExpectContinuously(cl Client, targets ...Target) Checkpointer {
+	cp := &checkpointer{
 		results: make(chan connectionResult, 1000),
 		done:    make(chan struct{}),
-		client:  client,
+		client:  cl,
 		targets: targets,
 		tester:  c,
 	}
-	checkpointer.start()
-	return checkpointer
+	cp.start()
+	return cp
 }
 
-func (c *connectionTester) ExpectFailure(client *Client, targets ...Target) {
+func (c *connectionTester) ExpectFailure(cl Client, targets ...Target) {
 	for _, target := range targets {
-		c.expectFailure(client, target)
+		c.expectFailure(cl, target)
 	}
 }
 
-func (c *connectionTester) expectFailure(client *Client, target Target) {
-	if c.clients[client.ID()] == nil {
-		framework.Fail(fmt.Sprintf("Test bug: client %s not registered with connection tester. AddClient()?", client.ID()), 2)
+func (c *connectionTester) expectFailure(cl Client, target Target) {
+	if c.clients[cl.ID()] == nil {
+		framework.Fail(fmt.Sprintf("Test bug: client %s not registered with connection tester. AddClient()?", cl.ID()), 2)
 	}
-	if c.clients[client.ID()].pod == nil {
-		framework.Fail(fmt.Sprintf("Client %s has no running pod. Did you Deploy()?", client.ID()), 2)
-	}
-
-	// Prevent duplication expectations. This is a common mistake when writing tests.
 	e := &Expectation{
-		Client:         c.clients[client.ID()].pod,
+		Client:         cl,
 		Target:         target,
-		Description:    fmt.Sprintf("%s -> %s", client.name, target.String()),
+		Description:    fmt.Sprintf("%s -> %s", cl.Name(), target.String()),
 		ExpectedResult: Failure,
 	}
 	if c.expectations[e.String()] != nil {
@@ -388,19 +297,14 @@ func (c *connectionTester) expectFailure(client *Client, target Target) {
 	c.expectations[e.String()] = e
 }
 
-// TestConnections tests one or more connections in parallel. It will fail the test if any of the connections fail.
 func (c *connectionTester) Execute() {
 	if !c.deployed {
 		framework.Fail("Execute() called before Deploy()", 1)
 	}
 	By(fmt.Sprintf("Testing %d connections in parallel", len(c.expectations)))
 
-	// Channel to collect results.
 	resultChan := make(chan connectionResult, len(c.expectations))
 
-	// Context to control overall timeout for all connections. After it times out, we'll forcefully
-	// terminate any remaining connections. This avoids deadlocking the test waiting for results if
-	// something goes wrong.
 	timeout := c.executeTimeout
 	if timeout == 0 {
 		timeout = defaultExecuteTimeout
@@ -408,12 +312,10 @@ func (c *connectionTester) Execute() {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Launch all of the connections in parallel. We'll wait for them all to finish at the end and report on success / failure.
 	for _, expectation := range c.expectations {
 		go c.runConnection(ctx, expectation, resultChan)
 	}
 
-	// Wait for all of the connections to finish.
 	var results []connectionResult
 	var failed bool
 	for range c.expectations {
@@ -424,48 +326,37 @@ func (c *connectionTester) Execute() {
 			logDiagsForConnection(c.f, result)
 		}
 	}
-
-	// Only close the result channel after all connections have finished to avoid
-	// connection goroutines attempting to write to a closed channel.
 	close(resultChan)
 
-	// If we had any errors, log out the per-test diags and then fail the test.
 	if failed {
 		logDiagsForNamespace(c.f, c.f.Namespace)
-		msg := buildFailureMessage(results)
-		framework.Fail(msg, 1)
+		framework.Fail(buildFailureMessage(results), 1)
 	}
 }
 
 func (c *connectionTester) runConnection(ctx context.Context, exp *Expectation, results chan<- connectionResult) {
-	// Exec into the client pod and try to connect to the server.
 	cmd := c.command(exp.Target)
 
 	logCtx := logrus.WithFields(logrus.Fields{
 		"cmd":      cmd,
-		"client":   fmt.Sprintf("%s/%s", exp.Client.Namespace, exp.Client.Name),
+		"client":   exp.Client.ID(),
 		"target":   exp.Target.String(),
 		"expected": exp.ExpectedResult,
 	})
 
-	// First attempt.
-	out, result, err := c.execCommandInPod(exp.Client, cmd)
+	out, result, err := c.execCommand(exp.Client, cmd)
 	if err != nil {
 		logCtx.WithError(err).Warn("Connection attempt returned an error")
 	}
 
-	// Retry until the context expires if we didn't get the expected result. This helps to avoid flakes due to transient issues.
-	// We don't want to retry too many times, as that could mask real issues and slow down tests. However, we know that
-	// especially on CPU constrained environments such as CI, there can be a delay between making changes (e.g., applying a NetworkPolicy) and
-	// those changes taking effect. So a short retry loop is helpful.
-
+	// Retry on mismatch until the context expires. Avoids flakes during
+	// short windows after policy/route changes propagate.
 loop:
 	for result != exp.ExpectedResult {
 		select {
 		case <-ctx.Done():
 			break loop
 		default:
-			// Not timed out yet.
 		}
 
 		logCtx.WithFields(logrus.Fields{
@@ -476,7 +367,7 @@ loop:
 
 		time.Sleep(1 * time.Second)
 
-		out, result, err = c.execCommandInPod(exp.Client, cmd)
+		out, result, err = c.execCommand(exp.Client, cmd)
 		if err != nil {
 			logCtx.WithError(err).Warn("Connection attempt returned an error")
 		}
@@ -490,46 +381,40 @@ loop:
 
 	exp.executed = true
 	results <- connectionResult{
-		clientPod: exp.Client,
-		target:    exp.Target,
-		expected:  exp.ExpectedResult,
-		actual:    result,
-		err:       err,
+		client:     exp.Client,
+		target:     exp.Target,
+		expected:   exp.ExpectedResult,
+		actual:     result,
+		err:        err,
+		recordedAt: time.Now(),
 	}
 }
 
-// Connect runs a one-shot connection attempt from the client pod to the given target, and returns the output of the command.
-func (c *connectionTester) Connect(client *Client, target Target) (string, error) {
-	if c.clients[client.ID()] == nil {
-		return "", fmt.Errorf("test bug: client %s not registered with connection tester. AddClient()?", client.ID())
+// Connect runs a one-shot probe from the client to target and returns the output.
+func (c *connectionTester) Connect(cl Client, target Target) (string, error) {
+	if c.clients[cl.ID()] == nil {
+		return "", fmt.Errorf("test bug: client %s not registered with connection tester. AddClient()?", cl.ID())
 	}
-	if c.clients[client.ID()].pod == nil {
-		return "", fmt.Errorf("Client %s has no running pod. Did you Deploy()?", client.ID())
-	}
-
 	cmd := c.command(target)
-	out, _, err := c.execCommandInPod(c.clients[client.ID()].pod, cmd)
+	out, _, err := c.execCommand(cl, cmd)
 	return out, err
 }
 
-func (c *connectionTester) execCommandInPod(pod *v1.Pod, cmd string) (string, ResultStatus, error) {
+func (c *connectionTester) execCommand(cl Client, cmd string) (string, ResultStatus, error) {
 	var out string
 	var err error
 
-	// Ensure the kubectl command executes in the remote cluster if required. Remote framework objects do not control
-	// how kubeconfigs are resolved by the kubectl command, so we must use this wrapper. See NewDefaultFrameworkForRemoteCluster.
+	// Wrap kubectl calls so they pick up the remote cluster kubeconfig when
+	// the framework is configured for one. See NewDefaultFrameworkForRemoteCluster.
 	remotecluster.RemoteFrameworkAwareExec(c.f, func() {
-		if windows.ClusterIsWindows() {
-			out, err = ExecInPod(pod, "powershell.exe", "-Command", cmd)
-		} else {
-			out, err = ExecInPod(pod, "sh", "-c", cmd)
-		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		out, err = cl.Exec(ctx, cmd)
 	})
 	result := Success
 	if err != nil {
 		result = Failure
 	}
-
 	return out, result, err
 }
 
@@ -537,7 +422,6 @@ func (c *connectionTester) command(t Target) string {
 	var cmd string
 
 	if windows.ClusterIsWindows() {
-		// Windows.
 		switch t.GetProtocol() {
 		case TCP:
 			cmd = fmt.Sprintf("Invoke-WebRequest %s -UseBasicParsing -TimeoutSec 5 -DisableKeepAlive -ErrorAction Stop | Out-Null", t.Destination())
@@ -547,7 +431,6 @@ func (c *connectionTester) command(t Target) string {
 			framework.Failf("Unsupported protocol %s", t.GetProtocol())
 		}
 	} else {
-		// Linux.
 		switch t.GetProtocol() {
 		case TCP:
 			cmd = fmt.Sprintf("wget -qO- -T 5 http://%s", t.Destination())
@@ -590,34 +473,32 @@ const (
 	Failure ResultStatus = "FAILURE"
 )
 
-func NewConnectionResult(exp, act ResultStatus, c v1.Pod, t Target, err error) connectionResult {
-	return connectionResult{
-		expected:  exp,
-		actual:    act,
-		clientPod: &c,
-		target:    t,
-		err:       err,
-	}
-}
-
 type connectionResult struct {
-	clientPod *v1.Pod
-	target    Target
-	expected  ResultStatus
-	actual    ResultStatus
-	err       error
+	client     Client
+	target     Target
+	expected   ResultStatus
+	actual     ResultStatus
+	err        error
+	recordedAt time.Time
 }
 
 func (r *connectionResult) Failed() bool {
 	return r.expected != r.actual
 }
 
+// clientLabel returns a printable identifier for the client, falling back to
+// the interface ID when there's no pod.
+func (r *connectionResult) clientLabel() string {
+	if r.client == nil {
+		return "<nil>"
+	}
+	return r.client.ID()
+}
+
 func buildFailureMessage(results []connectionResult) string {
-	// Builed an error message.
 	var msg strings.Builder
 	msg.WriteString("One or more connection tests failed:\n")
 
-	// Add expected results.
 	for _, res := range results {
 		exp := res.expected
 		actual := res.actual
@@ -626,9 +507,9 @@ func buildFailureMessage(results []connectionResult) string {
 			status = "ERROR"
 		}
 		msg.WriteString(fmt.Sprintf(
-			"\n%s: %s/%s -> %s (%s, %s, %s); Expected=%s, Actual=%s",
+			"\n%s: %s -> %s (%s, %s, %s); Expected=%s, Actual=%s",
 			status,
-			res.clientPod.Namespace, res.clientPod.Name,
+			res.clientLabel(),
 			res.target.String(),
 			res.target.Destination(),
 			res.target.GetProtocol(),
@@ -641,14 +522,13 @@ func buildFailureMessage(results []connectionResult) string {
 	return msg.String()
 }
 
-// CreateClientPod creates a long lived pod that sleeps, and can be used to execute connection tests as a client.
+// CreateClientPod creates a long-lived sleep pod usable as a connection-test client.
 func CreateClientPod(f *framework.Framework, namespace *v1.Namespace, baseName string, labels map[string]string, customizer func(pod *v1.Pod)) (*v1.Pod, error) {
 	var image string
 	var args []string
 	var command []string
 	nodeselector := map[string]string{}
 
-	// Randomize pod names to avoid clashes with previous tests.
 	podName := utils.GenerateRandomName(baseName)
 
 	if windows.ClusterIsWindows() {
@@ -663,13 +543,11 @@ func CreateClientPod(f *framework.Framework, namespace *v1.Namespace, baseName s
 		nodeselector["kubernetes.io/os"] = "linux"
 	}
 
-	// Merge the base labels with the pod name label.
 	mergedLabels := make(map[string]string)
 	maps.Copy(mergedLabels, labels)
 	mergedLabels["pod-name"] = baseName
 	mergedLabels[roleLabel] = roleClient
 
-	// Create the pod.
 	zero := int64(0)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -690,7 +568,7 @@ func CreateClientPod(f *framework.Framework, namespace *v1.Namespace, baseName s
 				},
 			},
 			Tolerations: []v1.Toleration{
-				v1.Toleration{
+				{
 					Key:      "kubernetes.io/arch",
 					Operator: v1.TolerationOpEqual,
 					Value:    "arm64",
@@ -709,38 +587,45 @@ func CreateClientPod(f *framework.Framework, namespace *v1.Namespace, baseName s
 }
 
 func logDiagsForConnection(f *framework.Framework, res connectionResult) {
-	By(fmt.Sprintf("Collecting diagnostics for connection %s -> %s", res.clientPod.Name, res.target.Destination()))
+	pod := res.client.Pod()
+	if pod == nil {
+		logrus.WithError(res.err).WithFields(logrus.Fields{
+			"from":   res.clientLabel(),
+			"to":     res.target.Destination(),
+			"expect": res.expected,
+		}).Error("Error running connection test (no pod for client)")
+		return
+	}
+	By(fmt.Sprintf("Collecting diagnostics for connection %s -> %s", pod.Name, res.target.Destination()))
 
 	logrus.WithError(res.err).WithFields(logrus.Fields{
-		"from":   fmt.Sprintf("%s/%s", res.clientPod.Namespace, res.clientPod.Name),
+		"from":   fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 		"to":     res.target.Destination(),
-		"ns":     res.clientPod.Namespace,
+		"ns":     pod.Namespace,
 		"expect": res.expected,
 	}).Error("Error running connection test")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, res.clientPod.Namespace, res.clientPod.Name, fmt.Sprintf("%s-container", res.clientPod.Name))
+	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, fmt.Sprintf("%s-container", pod.Name))
 	if err != nil {
 		logrus.WithError(err).Error("Error getting container logs")
 	}
-	logrus.Infof("[DIAGS] Pod %s/%s logs:\n%s", res.clientPod.Namespace, res.clientPod.Name, logs)
-	prevLogs, err := e2epod.GetPreviousPodLogs(ctx, f.ClientSet, res.clientPod.Namespace, res.clientPod.Name, fmt.Sprintf("%s-container", res.clientPod.Name))
+	logrus.Infof("[DIAGS] Pod %s/%s logs:\n%s", pod.Namespace, pod.Name, logs)
+	prevLogs, err := e2epod.GetPreviousPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, fmt.Sprintf("%s-container", pod.Name))
 	if err != nil {
 		logrus.WithError(err).Error("Error getting prev container logs")
 	}
-	logrus.Infof("[DIAGS] Pod %s/%s logs (previous):\n%s", res.clientPod.Namespace, res.clientPod.Name, prevLogs)
+	logrus.Infof("[DIAGS] Pod %s/%s logs (previous):\n%s", pod.Namespace, pod.Name, prevLogs)
 
-	// Get Pod Describe output.
-	podDesc, err := kubectl.RunKubectl(res.clientPod.Namespace, "describe", "pod", res.clientPod.Name)
+	podDesc, err := kubectl.RunKubectl(pod.Namespace, "describe", "pod", pod.Name)
 	if err != nil {
 		logrus.WithError(err).Error("Error getting pod description")
 	}
-	logrus.Infof("[DIAGS] Pod %s/%s describe:\n%s", res.clientPod.Namespace, res.clientPod.Name, podDesc)
+	logrus.Infof("[DIAGS] Pod %s/%s describe:\n%s", pod.Namespace, pod.Name, podDesc)
 }
 
 func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
-	// Collect current NetworkPolicies applied in the test namespace.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	policies, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).List(ctx, metav1.ListOptions{})
@@ -750,7 +635,6 @@ func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
 	logrus.Infof("[DIAGS] NetworkPolicies:\n\t%v", policies.Items)
 
 	if f.Namespace.Name != ns.Name {
-		// If the pod namespace is different from the test namespace, collect the NetworkPolicies for the pod namespace as well.
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		policies, err := f.ClientSet.NetworkingV1().NetworkPolicies(ns.Name).List(ctx, metav1.ListOptions{})
@@ -760,7 +644,6 @@ func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
 		logrus.Infof("[DIAGS] NetworkPolicies (pod NS):\n\t%v", policies.Items)
 	}
 
-	// Collect Calico network policies and heps.
 	nps := &v3.NetworkPolicyList{}
 	gnps := &v3.GlobalNetworkPolicyList{}
 	heps := &v3.HostEndpointList{}
@@ -787,7 +670,6 @@ func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
 	logrus.Infof("[DIAGS] Calico GlobalNetworkPolicies:\n\t%v", gnps.Items)
 	logrus.Infof("[DIAGS] Calico HostEndpoints:\n\t%v", heps.Items)
 
-	// Collect the list of pods running in the test namespace.
 	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	podsInNS, err := e2epod.GetPodsInNamespace(ctx, f.ClientSet, ns.Name, map[string]string{})
@@ -799,11 +681,10 @@ func logDiagsForNamespace(f *framework.Framework, ns *v1.Namespace) {
 		logrus.Infof("Namespace: %s, Pod: %s, Status: %s", ns.Name, p.Name, p.Status.String())
 	}
 
-	// Dump debug information for the test namespace.
 	e2eoutput.DumpDebugInfo(context.Background(), f.ClientSet, f.Namespace.Name)
 }
 
-// ExecInPod executes a kubectl command in a pod. Returns the response as a string, or an error upon failure.
+// ExecInPod runs a kubectl exec against pod and returns the output.
 func ExecInPod(pod *v1.Pod, sh, opt, cmd string) (string, error) {
 	args := []string{"exec", pod.Name, "--", sh, opt, cmd}
 	return kubectl.NewKubectlCommand(pod.Namespace, args...).
@@ -811,13 +692,12 @@ func ExecInPod(pod *v1.Pod, sh, opt, cmd string) (string, error) {
 		Exec()
 }
 
-// checkpointer implements the Checkpointer interface.
-// It runs continuous connection checks in the background, and allows
-// the test to checkpoint and verify the results at specific points in time.
+// checkpointer runs continuous connection probes in the background and lets
+// the test assert results at specific points in time.
 type checkpointer struct {
 	results               chan connectionResult
 	done                  chan struct{}
-	client                *Client
+	client                Client
 	targets               []Target
 	routinesDone          sync.WaitGroup
 	expectationInProgress sync.WaitGroup
@@ -840,7 +720,6 @@ func (c *checkpointer) ExpectFailure(reason string) {
 }
 
 func (c *checkpointer) start() {
-	// Start goroutines running continuous checks for each target.
 	for _, target := range c.targets {
 		c.routinesDone.Add(1)
 
@@ -848,27 +727,27 @@ func (c *checkpointer) start() {
 			for {
 				select {
 				case <-c.done:
-					// Stop the goroutine, and mark it as done.
 					c.routinesDone.Done()
 					return
 				default:
 				}
 
-				// Block if we are currently performing an expectation check.
 				c.expectationInProgress.Wait()
 
 				c.requestsInProgress.Add(1)
-				_, result, err := c.tester.execCommandInPod(c.tester.clients[c.client.ID()].pod, c.tester.command(t))
+				started := time.Now()
+				_, result, err := c.tester.execCommand(c.client, c.tester.command(t))
 				if err != nil {
 					logrus.WithError(err).Warn("Continuous connection attempt returned an error")
 				}
 
 				c.results <- connectionResult{
-					clientPod: c.tester.clients[c.client.ID()].pod,
-					target:    t,
-					expected:  Success,
-					actual:    result,
-					err:       err,
+					client:     c.client,
+					target:     t,
+					expected:   Success,
+					actual:     result,
+					err:        err,
+					recordedAt: started,
 				}
 				c.requestsInProgress.Done()
 				time.Sleep(10 * time.Millisecond)
@@ -889,7 +768,6 @@ func (c *checkpointer) expect(reason string, expectFailure bool) {
 		return ""
 	}
 
-	// Wait for at least one result to be available.
 	select {
 	case res := <-c.results:
 		if msg := checkResult(res); msg != "" {
@@ -899,17 +777,11 @@ func (c *checkpointer) expect(reason string, expectFailure bool) {
 		framework.Fail("Timeout waiting for continuous connection results", 2)
 	}
 
-	// Block new connection attempts, and wait for any in-progress attempts to complete before
-	// draining the results channel. This ensures we have a consistent view of all connection attempts
-	// up to this point in time, and prevents possible races where new attempts are started while we are
-	// checking results.
+	// Block new probe attempts and drain the channel for a consistent view.
 	c.expectationInProgress.Add(1)
 	defer c.expectationInProgress.Done()
-
-	// Wait for any in-progress requests to complete.
 	c.requestsInProgress.Wait()
 
-	// Drain the results channel and log any failures.
 	for {
 		select {
 		case res := <-c.results:
@@ -917,8 +789,109 @@ func (c *checkpointer) expect(reason string, expectFailure bool) {
 				framework.Fail(msg, 2)
 			}
 		default:
-			// No more results to process.
 			return
 		}
+	}
+}
+
+// disruptionConfig captures user-supplied tolerance for ExpectNoDisruption.
+// Either or both bounds may be set. A zero bound means that bound is not enforced.
+type disruptionConfig struct {
+	maxGap             time.Duration
+	maxConsecutiveLoss int
+	gapSet             bool
+	lossSet            bool
+}
+
+// DisruptionOption tunes ExpectNoDisruption's tolerance.
+type DisruptionOption func(*disruptionConfig)
+
+// WithMaxGap fails the assertion if any two consecutive probes (per target)
+// are recorded more than d apart.
+func WithMaxGap(d time.Duration) DisruptionOption {
+	return func(c *disruptionConfig) {
+		c.maxGap = d
+		c.gapSet = true
+	}
+}
+
+// WithMaxConsecutiveLoss fails the assertion if any target sees more than n
+// consecutive failed probes.
+func WithMaxConsecutiveLoss(n int) DisruptionOption {
+	return func(c *disruptionConfig) {
+		c.maxConsecutiveLoss = n
+		c.lossSet = true
+	}
+}
+
+func (c *checkpointer) ExpectNoDisruption(reason string, opts ...DisruptionOption) {
+	cfg := &disruptionConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if !cfg.gapSet && !cfg.lossSet {
+		framework.Fail("ExpectNoDisruption: must set WithMaxGap and/or WithMaxConsecutiveLoss", 2)
+	}
+
+	By(fmt.Sprintf("Checking continuous connection disruption %s", reason))
+
+	// Block new probe attempts and drain everything captured so far.
+	c.expectationInProgress.Add(1)
+	defer c.expectationInProgress.Done()
+	c.requestsInProgress.Wait()
+
+	// Group results by target so per-target gap/loss is meaningful.
+	byTarget := map[string][]connectionResult{}
+	keys := []string{}
+	for {
+		select {
+		case res := <-c.results:
+			k := res.target.String()
+			if _, ok := byTarget[k]; !ok {
+				keys = append(keys, k)
+			}
+			byTarget[k] = append(byTarget[k], res)
+			continue
+		default:
+		}
+		break
+	}
+
+	var problems []string
+	for _, k := range keys {
+		series := byTarget[k]
+		if cfg.lossSet {
+			consec := 0
+			worst := 0
+			for _, r := range series {
+				if r.actual != Success {
+					consec++
+					if consec > worst {
+						worst = consec
+					}
+				} else {
+					consec = 0
+				}
+			}
+			if worst > cfg.maxConsecutiveLoss {
+				problems = append(problems, fmt.Sprintf("target %s: %d consecutive failed probes (max allowed %d)", k, worst, cfg.maxConsecutiveLoss))
+			}
+		}
+		if cfg.gapSet && len(series) > 1 {
+			var worst time.Duration
+			for i := 1; i < len(series); i++ {
+				gap := series[i].recordedAt.Sub(series[i-1].recordedAt)
+				if gap > worst {
+					worst = gap
+				}
+			}
+			if worst > cfg.maxGap {
+				problems = append(problems, fmt.Sprintf("target %s: max inter-probe gap %s exceeds bound %s", k, worst, cfg.maxGap))
+			}
+		}
+	}
+
+	if len(problems) > 0 {
+		framework.Fail(fmt.Sprintf("ExpectNoDisruption %s:\n  %s", reason, strings.Join(problems, "\n  ")), 2)
 	}
 }

--- a/e2e/pkg/utils/conncheck/encryption.go
+++ b/e2e/pkg/utils/conncheck/encryption.go
@@ -25,21 +25,21 @@ import (
 // ExpectEncrypted verifies that TCP traffic from the client to the target is encrypted.
 // It uses tcpdump to capture packets and asserts that no plaintext HTTP patterns are visible.
 // The client pod must have NET_RAW and NET_ADMIN capabilities (use WithCapture() client option).
-func (c *connectionTester) ExpectEncrypted(client *Client, target Target) {
+func (c *connectionTester) ExpectEncrypted(client Client, target Target) {
 	c.verifyEncryption(client, target, true)
 }
 
 // ExpectPlaintext verifies that TCP traffic from the client to the target is NOT encrypted.
 // It uses tcpdump to capture packets and asserts that plaintext HTTP patterns are visible.
 // The client pod must have NET_RAW and NET_ADMIN capabilities (use WithCapture() client option).
-func (c *connectionTester) ExpectPlaintext(client *Client, target Target) {
+func (c *connectionTester) ExpectPlaintext(client Client, target Target) {
 	c.verifyEncryption(client, target, false)
 }
 
 // TODO: Hook encryption verification into the Execute() parallel loop so that multiple
 // encryption checks can run concurrently alongside connectivity checks. Currently these
 // run serially per client/target pair.
-func (c *connectionTester) verifyEncryption(client *Client, target Target, expectEncrypted bool) {
+func (c *connectionTester) verifyEncryption(client Client, target Target, expectEncrypted bool) {
 	pod := client.Pod()
 	dest := target.Destination()
 

--- a/e2e/pkg/utils/conncheck/external_node_client.go
+++ b/e2e/pkg/utils/conncheck/external_node_client.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/externalnode"
+)
+
+// ExternalNodeClient runs probes over SSH on a host outside the cluster.
+type ExternalNodeClient struct {
+	name string
+	node *externalnode.Client
+}
+
+// NewExternalNodeClient wraps an externalnode.Client as a conncheck.Client.
+func NewExternalNodeClient(name string, node *externalnode.Client) Client {
+	if name == "" {
+		framework.Fail("NewExternalNodeClient: name is required", 1)
+	}
+	if node == nil {
+		framework.Fail("NewExternalNodeClient: node is required", 1)
+	}
+	return &ExternalNodeClient{name: name, node: node}
+}
+
+func (c *ExternalNodeClient) ID() string                                       { return "external/" + c.name }
+func (c *ExternalNodeClient) Name() string                                     { return c.name }
+func (c *ExternalNodeClient) Namespace() *v1.Namespace                         { return nil }
+func (c *ExternalNodeClient) Pod() *v1.Pod                                     { return nil }
+func (c *ExternalNodeClient) Deploy(_ context.Context, _ *framework.Framework) error  { return nil }
+func (c *ExternalNodeClient) Cleanup(_ context.Context, _ *framework.Framework) error { return nil }
+func (c *ExternalNodeClient) WaitReady(_ context.Context, _ *framework.Framework) error {
+	return nil
+}
+
+func (c *ExternalNodeClient) Exec(_ context.Context, cmd string) (string, error) {
+	return c.node.Exec("sh", "-c", cmd)
+}
+
+// ExecStream runs cmd via a long-lived ssh and streams its merged output to w.
+// The returned stop function kills the ssh process and waits for it.
+func (c *ExternalNodeClient) ExecStream(ctx context.Context, cmd []string, w io.Writer) (func() error, error) {
+	dest := fmt.Sprintf("%s@%s", c.node.SSHUser(), c.node.SSHIP())
+	args := []string{
+		"-o", "ConnectTimeout=5",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "StrictHostKeyChecking=no",
+		"-i", c.node.SSHKeyPath(),
+		dest,
+		"--",
+		strings.Join(cmd, " "),
+	}
+	sshCmd := exec.CommandContext(ctx, "ssh", args...)
+	sshCmd.Stdout = w
+	sshCmd.Stderr = w
+	if err := sshCmd.Start(); err != nil {
+		return nil, fmt.Errorf("ExternalNodeClient: ssh start: %w", err)
+	}
+
+	var (
+		mu      sync.Mutex
+		stopped bool
+	)
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- sshCmd.Wait() }()
+
+	stop := func() error {
+		mu.Lock()
+		if stopped {
+			mu.Unlock()
+			return nil
+		}
+		stopped = true
+		mu.Unlock()
+		if sshCmd.Process != nil {
+			_ = sshCmd.Process.Kill()
+		}
+		<-waitCh
+		return nil
+	}
+	return stop, nil
+}

--- a/e2e/pkg/utils/conncheck/external_node_client.go
+++ b/e2e/pkg/utils/conncheck/external_node_client.go
@@ -45,12 +45,30 @@ func NewExternalNodeClient(name string, node *externalnode.Client) Client {
 	return &ExternalNodeClient{name: name, node: node}
 }
 
-func (c *ExternalNodeClient) ID() string                                       { return "external/" + c.name }
-func (c *ExternalNodeClient) Name() string                                     { return c.name }
-func (c *ExternalNodeClient) Namespace() *v1.Namespace                         { return nil }
-func (c *ExternalNodeClient) Pod() *v1.Pod                                     { return nil }
-func (c *ExternalNodeClient) Deploy(_ context.Context, _ *framework.Framework) error  { return nil }
-func (c *ExternalNodeClient) Cleanup(_ context.Context, _ *framework.Framework) error { return nil }
+func (c *ExternalNodeClient) ID() string {
+	return "external/" + c.name
+}
+
+func (c *ExternalNodeClient) Name() string {
+	return c.name
+}
+
+func (c *ExternalNodeClient) Namespace() *v1.Namespace {
+	return nil
+}
+
+func (c *ExternalNodeClient) Pod() *v1.Pod {
+	return nil
+}
+
+func (c *ExternalNodeClient) Deploy(_ context.Context, _ *framework.Framework) error {
+	return nil
+}
+
+func (c *ExternalNodeClient) Cleanup(_ context.Context, _ *framework.Framework) error {
+	return nil
+}
+
 func (c *ExternalNodeClient) WaitReady(_ context.Context, _ *framework.Framework) error {
 	return nil
 }

--- a/e2e/pkg/utils/conncheck/k8s.go
+++ b/e2e/pkg/utils/conncheck/k8s.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,10 +32,9 @@ import (
 	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
 )
 
-// deploy creates the server pod and (optionally) its service in the cluster.
-// It reads all configuration from the Server struct fields.
-func (s *Server) deploy(f *framework.Framework) (*v1.Pod, *v1.Service) {
-	// Determine the image, args, and readiness probe based on the server type.
+// create builds the server pod and (optionally) its service. The caller stores
+// the returned objects on the PodServer.
+func (s *PodServer) create(ctx context.Context, f *framework.Framework) (*v1.Pod, *v1.Service, error) {
 	var image string
 	containers := []v1.Container{}
 	servicePorts := []v1.ServicePort{}
@@ -60,14 +58,12 @@ func (s *Server) deploy(f *framework.Framework) (*v1.Pod, *v1.Service) {
 			env = []v1.EnvVar{
 				{
 					// porter (the windows server pod) uses the port value from the
-					// env var name, it doesn't care about the env var value here
+					// env var name; the env var value is ignored.
 					Name:  fmt.Sprintf("SERVE_PORT_%d", port),
 					Value: "value-not-used",
 				},
 			}
 		} else if s.echoServer {
-			// agnhost netexec serves HTTP on the specified port and returns
-			// client IP at /clientip.
 			args = []string{"netexec", fmt.Sprintf("--http-port=%d", port)}
 		} else {
 			args = []string{fmt.Sprintf("--port=%d", port)}
@@ -93,18 +89,14 @@ func (s *Server) deploy(f *framework.Framework) (*v1.Pod, *v1.Service) {
 			ReadinessProbe: &v1.Probe{
 				ProbeHandler: v1.ProbeHandler{
 					HTTPGet: &v1.HTTPGetAction{
-						Path: probePath,
-						Port: intstr.IntOrString{
-							IntVal: int32(port),
-						},
+						Path:   probePath,
+						Port:   intstr.IntOrString{IntVal: int32(port)},
 						Scheme: v1.URISchemeHTTP,
 					},
 				},
 			},
 		}
-
 		containers = append(containers, container)
-
 		servicePorts = append(servicePorts, v1.ServicePort{
 			Name:       fmt.Sprintf("%s-%d", s.name, port),
 			Port:       int32(port),
@@ -143,14 +135,16 @@ func (s *Server) deploy(f *framework.Framework) (*v1.Pod, *v1.Service) {
 	if podCustomizer != nil {
 		podCustomizer(pod)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	pod, err := f.ClientSet.CoreV1().Pods(s.namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	pod, err := f.ClientSet.CoreV1().Pods(s.namespace.Name).Create(cctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
 	logrus.Infof("Created pod %v", pod.Name)
 
 	if !s.autoCreateSvc {
-		return pod, nil
+		return pod, nil, nil
 	}
 
 	svcName := fmt.Sprintf("svc-%s", s.name)
@@ -162,18 +156,19 @@ func (s *Server) deploy(f *framework.Framework) (*v1.Pod, *v1.Service) {
 			Selector: map[string]string{"pod-name": s.name},
 		},
 	}
-
 	if svcCustomizer != nil {
 		svcCustomizer(v4Svc)
 	}
-	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	v4Svc, err = f.ClientSet.CoreV1().Services(s.namespace.Name).Create(ctx, v4Svc, metav1.CreateOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	cctx2, cancel2 := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel2()
+	v4Svc, err = f.ClientSet.CoreV1().Services(s.namespace.Name).Create(cctx2, v4Svc, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if !pod.Spec.HostNetwork {
-		// Create an ipv6 service for the pod instead, if the cluster supports v6.
-		// If creation of this service succeeds, it will be used instead of the v4 only service.
+		// Try a v6 service. If the cluster doesn't support v6 we'll get an
+		// Invalid error; fall through and use the v4 service.
 		ipFamilies := []v1.IPFamily{v1.IPv6Protocol}
 		v6SvcName := v6ServiceName(svcName)
 		policy := v1.IPFamilyPolicyRequireDualStack
@@ -190,26 +185,22 @@ func (s *Server) deploy(f *framework.Framework) (*v1.Pod, *v1.Service) {
 		if svcCustomizer != nil {
 			svcCustomizer(svc)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+		cctx3, cancel3 := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel3()
 
 		ginkgo.By(fmt.Sprintf("Creating a service %s for pod %s in namespace %s", v6SvcName, s.name, s.namespace.Name))
-		v6Svc, err := f.ClientSet.CoreV1().Services(s.namespace.Name).Create(ctx, svc, metav1.CreateOptions{})
+		v6Svc, err := f.ClientSet.CoreV1().Services(s.namespace.Name).Create(cctx3, svc, metav1.CreateOptions{})
 		if err == nil {
-			return pod, v6Svc
+			return pod, v6Svc, nil
 		} else if !kerrors.IsInvalid(err) {
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Error creating IPv6 service")
-		} else {
-			// If v6 is not enabled on the cluster, we will receive an "Invalid" error type. In this case,
-			// fall through and return the v4 service.
-			logrus.WithField("svc", v4Svc.Name).Info("IPv6 not enabled, using v4 service")
+			return nil, nil, fmt.Errorf("error creating IPv6 service: %w", err)
 		}
+		logrus.WithField("svc", v4Svc.Name).Info("IPv6 not enabled, using v4 service")
 	}
 
-	return pod, v4Svc
+	return pod, v4Svc, nil
 }
 
-// v6ServiceName returns an ipv6 service name based on a ipv4 service name.
 func v6ServiceName(name string) string {
 	return name + "-ipv6"
 }

--- a/e2e/pkg/utils/conncheck/pod_exec.go
+++ b/e2e/pkg/utils/conncheck/pod_exec.go
@@ -53,6 +53,9 @@ func execShellInPod(pod *v1.Pod, cmd string) (string, error) {
 // triggers the streamWrapper reaper to SIGTERM the child) and waits for the
 // stream to drain.
 func execStreamInPod(ctx context.Context, pod *v1.Pod, command []string, w io.Writer) (func() error, error) {
+	if windows.ClusterIsWindows() {
+		return nil, fmt.Errorf("execStreamInPod: streaming probes are not supported on Windows pods")
+	}
 	if len(pod.Spec.Containers) == 0 {
 		return nil, fmt.Errorf("execStreamInPod: pod %s/%s has no containers", pod.Namespace, pod.Name)
 	}

--- a/e2e/pkg/utils/conncheck/pod_exec.go
+++ b/e2e/pkg/utils/conncheck/pod_exec.go
@@ -97,8 +97,8 @@ func execStreamInPod(ctx context.Context, pod *v1.Pod, command []string, w io.Wr
 	stdinR, stdinW := io.Pipe()
 	doneCh := make(chan struct{})
 	var (
-		mu       sync.Mutex
-		stopping bool
+		mu        sync.Mutex
+		stopping  bool
 		streamErr error
 	)
 

--- a/e2e/pkg/utils/conncheck/pod_exec.go
+++ b/e2e/pkg/utils/conncheck/pod_exec.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/projectcalico/calico/e2e/pkg/utils/windows"
+)
+
+const deletionTimeout = 1 * time.Minute
+
+// podReadyTimeout is longer on Windows because the server image is multi-GB.
+func podReadyTimeout(_ context.Context) time.Duration {
+	if windows.ClusterIsWindows() {
+		return 15 * time.Minute
+	}
+	return 1 * time.Minute
+}
+
+// execShellInPod runs cmd in pod via sh -c (or powershell -Command on Windows).
+func execShellInPod(pod *v1.Pod, cmd string) (string, error) {
+	if windows.ClusterIsWindows() {
+		return ExecInPod(pod, "powershell.exe", "-Command", cmd)
+	}
+	return ExecInPod(pod, "sh", "-c", cmd)
+}
+
+// execStreamInPod launches a long-lived command in pod via SPDY exec, writing
+// merged stdout/stderr to w. The returned stop function closes stdin (which
+// triggers the streamWrapper reaper to SIGTERM the child) and waits for the
+// stream to drain.
+func execStreamInPod(ctx context.Context, pod *v1.Pod, command []string, w io.Writer) (func() error, error) {
+	if len(pod.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("execStreamInPod: pod %s/%s has no containers", pod.Namespace, pod.Name)
+	}
+	container := pod.Spec.Containers[0].Name
+
+	// "/bin/sh -c <wrapper> -- <user-argv>...": the "--" is consumed as $0,
+	// user argv expands as "$@" in the wrapper.
+	cmd := append([]string{"/bin/sh", "-c", streamWrapper, "--"}, command...)
+
+	cfg, err := framework.LoadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("execStreamInPod: load config: %w", err)
+	}
+	cs, err := framework.LoadClientset()
+	if err != nil {
+		return nil, fmt.Errorf("execStreamInPod: load clientset: %w", err)
+	}
+
+	req := cs.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Container: container,
+			Command:   cmd,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return nil, fmt.Errorf("execStreamInPod: build executor: %w", err)
+	}
+
+	stdinR, stdinW := io.Pipe()
+	doneCh := make(chan struct{})
+	var (
+		mu       sync.Mutex
+		stopping bool
+		streamErr error
+	)
+
+	go func() {
+		defer close(doneCh)
+		err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdin:  stdinR,
+			Stdout: w,
+			Stderr: w,
+		})
+		mu.Lock()
+		s := stopping
+		mu.Unlock()
+		if err != nil && !errors.Is(err, io.EOF) && !s {
+			mu.Lock()
+			streamErr = err
+			mu.Unlock()
+		}
+	}()
+
+	stop := func() error {
+		mu.Lock()
+		stopping = true
+		mu.Unlock()
+		_ = stdinW.Close()
+		<-doneCh
+		mu.Lock()
+		defer mu.Unlock()
+		return streamErr
+	}
+	return stop, nil
+}
+
+// streamWrapper is the /bin/sh -c body used by execStreamInPod. Closing the
+// SPDY stdin from outside causes the reaper subshell to read EOF and SIGTERM
+// the child. This is the only reliable way to terminate a remote process via
+// SPDY exec since signals are not forwarded.
+//
+// `exec 3<&0` saves the wrapper's stdin to fd 3 BEFORE backgrounding because
+// non-interactive shells redirect backgrounded subshell stdin to /dev/null.
+const streamWrapper = `exec 3<&0
+"$@" </dev/null &
+child=$!
+( cat <&3 >/dev/null ; kill -TERM "$child" 2>/dev/null || true ) &
+reaper=$!
+wait "$child"
+rc=$?
+kill -TERM "$reaper" 2>/dev/null || true
+exit "$rc"
+`

--- a/e2e/pkg/utils/conncheck/server.go
+++ b/e2e/pkg/utils/conncheck/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,23 +15,51 @@
 package conncheck
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
-func NewServer(name string, ns *v1.Namespace, opts ...ServerOption) *Server {
+// Server is a traffic destination for connection checks. The default
+// implementation is PodServer; VMServer wraps a KubeVirt VirtualMachineInstance.
+type Server interface {
+	ID() string
+	Name() string
+	Namespace() *v1.Namespace
+	Pod() *v1.Pod
+	Service() *v1.Service
+
+	// Target builders.
+	ClusterIPs(opts ...TargetOption) []Target
+	ClusterIP(opts ...TargetOption) Target
+	ClusterIPv4(opts ...TargetOption) Target
+	ClusterIPv6(opts ...TargetOption) Target
+	HostPorts(port int) []Target
+	NodePortPort() int
+	NodePort(nodeIP string, opts ...TargetOption) Target
+	ICMP() Target
+	ServiceDomain(opts ...TargetOption) Target
+
+	// Lifecycle.
+	Deploy(ctx context.Context, f *framework.Framework) error
+	Cleanup(ctx context.Context, f *framework.Framework) error
+	WaitReady(ctx context.Context, f *framework.Framework) error
+}
+
+func NewServer(name string, ns *v1.Namespace, opts ...ServerOption) Server {
 	if ns == nil {
-		msg := fmt.Sprintf("Namespace is required for server %s", name)
-		framework.Fail(msg, 1)
+		framework.Fail(fmt.Sprintf("Namespace is required for server %s", name), 1)
 	}
 	if name == "" {
-		msg := fmt.Sprintf("Name is required for server in namespace %s", ns.Name)
-		framework.Fail(msg, 1)
+		framework.Fail(fmt.Sprintf("Name is required for server in namespace %s", ns.Name), 1)
 	}
-	s := &Server{
+	s := &PodServer{
 		name:          name,
 		namespace:     ns,
 		ports:         []int{80},
@@ -43,7 +71,8 @@ func NewServer(name string, ns *v1.Namespace, opts ...ServerOption) *Server {
 	return s
 }
 
-type Server struct {
+// PodServer is a pod-backed Server.
+type PodServer struct {
 	name           string
 	namespace      *v1.Namespace
 	ports          []int
@@ -56,9 +85,7 @@ type Server struct {
 	echoServer     bool
 }
 
-// composedPodCustomizer returns a single customizer function that applies all
-// registered pod customizers in order, or nil if none are registered.
-func (s *Server) composedPodCustomizer() func(*v1.Pod) {
+func (s *PodServer) composedPodCustomizer() func(*v1.Pod) {
 	if len(s.podCustomizers) == 0 {
 		return nil
 	}
@@ -69,9 +96,7 @@ func (s *Server) composedPodCustomizer() func(*v1.Pod) {
 	}
 }
 
-// composedSvcCustomizer returns a single customizer function that applies all
-// registered service customizers in order, or nil if none are registered.
-func (s *Server) composedSvcCustomizer() func(*v1.Service) {
+func (s *PodServer) composedSvcCustomizer() func(*v1.Service) {
 	if len(s.svcCustomizers) == 0 {
 		return nil
 	}
@@ -82,33 +107,73 @@ func (s *Server) composedSvcCustomizer() func(*v1.Service) {
 	}
 }
 
-func (s *Server) ID() string {
-	return fmt.Sprintf("%s/%s", s.namespace.Name, s.name)
-}
+func (s *PodServer) ID() string               { return fmt.Sprintf("%s/%s", s.namespace.Name, s.name) }
+func (s *PodServer) Name() string             { return s.name }
+func (s *PodServer) Namespace() *v1.Namespace { return s.namespace }
 
-func (s *Server) Name() string {
-	return s.name
-}
-
-func (s *Server) Pod() *v1.Pod {
+func (s *PodServer) Pod() *v1.Pod {
 	if s.pod == nil {
-		msg := fmt.Sprintf("No pod is running for server %s/%s", s.namespace.Name, s.name)
-		framework.Fail(msg, 1)
+		framework.Fail(fmt.Sprintf("No pod is running for server %s/%s", s.namespace.Name, s.name), 1)
 	}
 	return s.pod
 }
 
-func (s *Server) Service() *v1.Service {
+func (s *PodServer) Service() *v1.Service {
 	if s.service == nil {
-		msg := fmt.Sprintf("No service is running for server %s/%s", s.namespace.Name, s.name)
-		framework.Fail(msg, 1)
+		framework.Fail(fmt.Sprintf("No service is running for server %s/%s", s.namespace.Name, s.name), 1)
 	}
 	return s.service
 }
 
-// ClusterIPs returns a list of targets that can be used to connect to the service's ClusterIPs, if
-// there are multiple (e.g., for dual-stack services).
-func (s *Server) ClusterIPs(opts ...TargetOption) []Target {
+func (s *PodServer) Deploy(ctx context.Context, f *framework.Framework) error {
+	if s.pod != nil {
+		return nil
+	}
+	pod, svc, err := s.create(ctx, f)
+	if err != nil {
+		return err
+	}
+	s.pod = pod
+	s.service = svc
+	return nil
+}
+
+func (s *PodServer) WaitReady(ctx context.Context, f *framework.Framework) error {
+	if s.pod == nil {
+		return fmt.Errorf("PodServer %s/%s: WaitReady called before Deploy", s.namespace.Name, s.name)
+	}
+	if err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, s.pod.Name, s.pod.Namespace, podReadyTimeout(ctx)); err != nil {
+		return err
+	}
+	p, err := f.ClientSet.CoreV1().Pods(s.namespace.Name).Get(ctx, s.pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	s.pod = p
+	return nil
+}
+
+func (s *PodServer) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if s.pod != nil {
+		err := f.ClientSet.CoreV1().Pods(s.namespace.Name).Delete(ctx, s.pod.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, s.pod.Name, s.pod.Namespace, deletionTimeout); err != nil {
+			return err
+		}
+	}
+	if s.service != nil {
+		err := f.ClientSet.CoreV1().Services(s.namespace.Name).Delete(ctx, s.service.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// ClusterIPs returns one target per ClusterIP on the underlying service (dual-stack capable).
+func (s *PodServer) ClusterIPs(opts ...TargetOption) []Target {
 	var targets []Target
 	for _, ip := range s.Service().Spec.ClusterIPs {
 		t := &target{
@@ -124,13 +189,12 @@ func (s *Server) ClusterIPs(opts ...TargetOption) []Target {
 		}
 		targets = append(targets, t)
 	}
-
 	return targets
 }
 
-// ClusterIP returns a target that can be used to connect to the service's Spec.ClusterIP.
-// Most callers should use ClusterIPs() instead in order to test both IPv4 and IPv6 (when enabled).
-func (s *Server) ClusterIP(opts ...TargetOption) Target {
+// ClusterIP returns a target for the service's primary ClusterIP. Most callers
+// should use ClusterIPs() to cover IPv4 and IPv6.
+func (s *PodServer) ClusterIP(opts ...TargetOption) Target {
 	t := &target{
 		server:      s,
 		targetType:  TypeClusterIP,
@@ -145,7 +209,7 @@ func (s *Server) ClusterIP(opts ...TargetOption) Target {
 	return t
 }
 
-func (s *Server) ClusterIPv4(opts ...TargetOption) Target {
+func (s *PodServer) ClusterIPv4(opts ...TargetOption) Target {
 	for _, ip := range s.Service().Spec.ClusterIPs {
 		if strings.Contains(ip, ":") {
 			continue
@@ -163,12 +227,11 @@ func (s *Server) ClusterIPv4(opts ...TargetOption) Target {
 		}
 		return t
 	}
-	msg := fmt.Sprintf("No IPv4 ClusterIP found for server %s/%s", s.namespace.Name, s.name)
-	framework.Fail(msg, 1)
+	framework.Fail(fmt.Sprintf("No IPv4 ClusterIP found for server %s/%s", s.namespace.Name, s.name), 1)
 	return nil
 }
 
-func (s *Server) ClusterIPv6(opts ...TargetOption) Target {
+func (s *PodServer) ClusterIPv6(opts ...TargetOption) Target {
 	for _, ip := range s.Service().Spec.ClusterIPs {
 		if !strings.Contains(ip, ":") {
 			continue
@@ -186,14 +249,12 @@ func (s *Server) ClusterIPv6(opts ...TargetOption) Target {
 		}
 		return t
 	}
-	msg := fmt.Sprintf("No IPv6 ClusterIP found for server %s/%s", s.namespace.Name, s.name)
-	framework.Fail(msg, 1)
+	framework.Fail(fmt.Sprintf("No IPv6 ClusterIP found for server %s/%s", s.namespace.Name, s.name), 1)
 	return nil
 }
 
-// HostPorts returns a list of targets that can be used to connect to the pod's host IPs on the given port.
-// It returns a target for each of the pod's host IPs, at the specified port.
-func (s *Server) HostPorts(port int) []Target {
+// HostPorts returns one target per host IP at the given port.
+func (s *PodServer) HostPorts(port int) []Target {
 	var targets []Target
 	for _, hostIP := range s.Pod().Status.HostIPs {
 		targets = append(targets, &target{
@@ -207,20 +268,15 @@ func (s *Server) HostPorts(port int) []Target {
 	return targets
 }
 
-// NodePortPort returns port number of a NodePort service associated with the server.
-func (s *Server) NodePortPort() int {
+func (s *PodServer) NodePortPort() int {
 	svc := s.Service()
 	if svc.Spec.Type != v1.ServiceTypeNodePort {
-		msg := fmt.Sprintf("Service running for server %s/%s is not NodePort type", s.namespace.Name, s.name)
-		framework.Fail(msg, 1)
+		framework.Fail(fmt.Sprintf("Service running for server %s/%s is not NodePort type", s.namespace.Name, s.name), 1)
 	}
-
 	return int(svc.Spec.Ports[0].NodePort)
 }
 
-// NodePort returns a target that can be used to connect to the service's NodePort.
-// Callers should pass in the IP of a cluster node.
-func (s *Server) NodePort(nodeIP string, opts ...TargetOption) Target {
+func (s *PodServer) NodePort(nodeIP string, opts ...TargetOption) Target {
 	t := &target{
 		server:      s,
 		targetType:  TypeNodePort,
@@ -236,8 +292,7 @@ func (s *Server) NodePort(nodeIP string, opts ...TargetOption) Target {
 	return t
 }
 
-// ICMP returns a target that can be used to connect to the pod's IP directly using ICMP.
-func (s *Server) ICMP() Target {
+func (s *PodServer) ICMP() Target {
 	return &target{
 		server:      s,
 		targetType:  TypePodIP,
@@ -246,8 +301,7 @@ func (s *Server) ICMP() Target {
 	}
 }
 
-// ServiceDomain returns a target that can be used to connect to the service via DNS lookup.
-func (s *Server) ServiceDomain(opts ...TargetOption) Target {
+func (s *PodServer) ServiceDomain(opts ...TargetOption) Target {
 	t := &target{
 		server:      s,
 		targetType:  TypeService,
@@ -262,17 +316,17 @@ func (s *Server) ServiceDomain(opts ...TargetOption) Target {
 	return t
 }
 
-type ServerOption func(*Server) error
+type ServerOption func(*PodServer) error
 
 func WithServerLabels(labels map[string]string) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.labels = labels
 		return nil
 	}
 }
 
 func WithHostNetworking() ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.podCustomizers = append(c.podCustomizers, func(pod *v1.Pod) {
 			pod.Spec.HostNetwork = true
 		})
@@ -281,46 +335,44 @@ func WithHostNetworking() ServerOption {
 }
 
 func WithServerPodCustomizer(customizer func(*v1.Pod)) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.podCustomizers = append(c.podCustomizers, customizer)
 		return nil
 	}
 }
 
 func WithServerSvcCustomizer(customizer func(*v1.Service)) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.svcCustomizers = append(c.svcCustomizers, customizer)
 		return nil
 	}
 }
 
 func WithPorts(ports ...int) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.ports = ports
 		return nil
 	}
 }
 
 func WithAutoCreateService(autoCreate bool) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.autoCreateSvc = autoCreate
 		return nil
 	}
 }
 
-// WithEchoServer configures the server to use the EchoServer (agnhost netexec)
-// image instead of TestWebserver. The EchoServer's /clientip endpoint returns
-// the client address in "IP:port" format, useful for SNAT detection.
+// WithEchoServer switches the server image to agnhost netexec. Its /clientip
+// endpoint returns the client address, useful for SNAT detection.
 func WithEchoServer() ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.echoServer = true
 		return nil
 	}
 }
 
-// WithNodePortService configures the server's service as type NodePort.
 func WithNodePortService() ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.svcCustomizers = append(c.svcCustomizers, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 		})
@@ -328,9 +380,8 @@ func WithNodePortService() ServerOption {
 	}
 }
 
-// WithExternalIP adds an external IP to the server's service.
 func WithExternalIP(ip string) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.svcCustomizers = append(c.svcCustomizers, func(svc *v1.Service) {
 			svc.Spec.ExternalIPs = append(svc.Spec.ExternalIPs, ip)
 		})
@@ -338,9 +389,8 @@ func WithExternalIP(ip string) ServerOption {
 	}
 }
 
-// WithExternalTrafficPolicy sets the external traffic policy on the server's service.
 func WithExternalTrafficPolicy(policy v1.ServiceExternalTrafficPolicy) ServerOption {
-	return func(c *Server) error {
+	return func(c *PodServer) error {
 		c.svcCustomizers = append(c.svcCustomizers, func(svc *v1.Service) {
 			svc.Spec.ExternalTrafficPolicy = policy
 		})

--- a/e2e/pkg/utils/conncheck/server.go
+++ b/e2e/pkg/utils/conncheck/server.go
@@ -162,12 +162,14 @@ func (s *PodServer) Cleanup(ctx context.Context, f *framework.Framework) error {
 		if err := e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, s.pod.Name, s.pod.Namespace, deletionTimeout); err != nil {
 			return err
 		}
+		s.pod = nil
 	}
 	if s.service != nil {
 		err := f.ClientSet.CoreV1().Services(s.namespace.Name).Delete(ctx, s.service.Name, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
+		s.service = nil
 	}
 	return nil
 }

--- a/e2e/pkg/utils/conncheck/target.go
+++ b/e2e/pkg/utils/conncheck/target.go
@@ -80,7 +80,7 @@ type Target interface {
 var _ Target = &target{}
 
 type target struct {
-	server      *Server
+	server      Server
 	destination string
 	port        int
 	protocol    Protocol
@@ -102,9 +102,13 @@ func (t *target) GetProtocol() Protocol {
 // String returns a human-readable name for the target.
 func (t *target) String() string {
 	if t.server != nil {
-		chunks := []string{
-			fmt.Sprintf("%s/%s", t.server.Pod().Namespace, t.server.Pod().Name),
+		var idTag string
+		if p := t.server.Pod(); p != nil {
+			idTag = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
+		} else {
+			idTag = t.server.ID()
 		}
+		chunks := []string{idTag}
 		if t.destination != "" {
 			chunks = append(chunks, t.destination)
 		}

--- a/e2e/pkg/utils/conncheck/target.go
+++ b/e2e/pkg/utils/conncheck/target.go
@@ -102,13 +102,7 @@ func (t *target) GetProtocol() Protocol {
 // String returns a human-readable name for the target.
 func (t *target) String() string {
 	if t.server != nil {
-		var idTag string
-		if p := t.server.Pod(); p != nil {
-			idTag = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
-		} else {
-			idTag = t.server.ID()
-		}
-		chunks := []string{idTag}
+		chunks := []string{t.server.ID()}
 		if t.destination != "" {
 			chunks = append(chunks, t.destination)
 		}

--- a/e2e/pkg/utils/conncheck/vm_server.go
+++ b/e2e/pkg/utils/conncheck/vm_server.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conncheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// VMServer wraps a KubeVirt VirtualMachineInstance as a Server. The test is
+// expected to create the VMI itself; this just locates the virt-launcher pod
+// (which shares the VM's netns, so its PodIP is the VM's IP) and exposes the
+// pod-IP-based Target builders.
+//
+// NewVMServer does not create or own the VMI; Cleanup is a no-op.
+type VMServer struct {
+	name      string
+	namespace *v1.Namespace
+	vmi       *kubevirtv1.VirtualMachineInstance
+	pod       *v1.Pod
+}
+
+func NewVMServer(vmi *kubevirtv1.VirtualMachineInstance) Server {
+	if vmi == nil {
+		framework.Fail("NewVMServer: vmi is required", 1)
+	}
+	return &VMServer{
+		name:      vmi.Name,
+		namespace: &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: vmi.Namespace}},
+		vmi:       vmi,
+	}
+}
+
+func (s *VMServer) ID() string               { return fmt.Sprintf("%s/%s", s.namespace.Name, s.name) }
+func (s *VMServer) Name() string             { return s.name }
+func (s *VMServer) Namespace() *v1.Namespace { return s.namespace }
+func (s *VMServer) Service() *v1.Service     { return nil }
+
+func (s *VMServer) Pod() *v1.Pod {
+	if s.pod == nil {
+		framework.Fail(fmt.Sprintf("VMServer %s: no launcher pod resolved; call Deploy first", s.ID()), 1)
+	}
+	return s.pod
+}
+
+// Deploy resolves the virt-launcher pod for the underlying VMI.
+func (s *VMServer) Deploy(ctx context.Context, f *framework.Framework) error {
+	return s.resolveLauncher(ctx, f)
+}
+
+// Cleanup is a no-op; the test owns the VMI lifecycle.
+func (s *VMServer) Cleanup(_ context.Context, _ *framework.Framework) error {
+	return nil
+}
+
+func (s *VMServer) WaitReady(ctx context.Context, f *framework.Framework) error {
+	if s.pod == nil {
+		if err := s.resolveLauncher(ctx, f); err != nil {
+			return err
+		}
+	}
+	if err := e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, s.pod.Name, s.pod.Namespace, podReadyTimeout(ctx)); err != nil {
+		return err
+	}
+	p, err := f.ClientSet.CoreV1().Pods(s.pod.Namespace).Get(ctx, s.pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	s.pod = p
+	return nil
+}
+
+// resolveLauncher polls for the virt-launcher pod matching this VMI.
+func (s *VMServer) resolveLauncher(ctx context.Context, f *framework.Framework) error {
+	deadline := time.Now().Add(podReadyTimeout(ctx))
+	selector := fmt.Sprintf("%s=%s", kubevirtv1.CreatedByLabel, string(s.vmi.UID))
+	for {
+		pods, err := f.ClientSet.CoreV1().Pods(s.namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err == nil {
+			for i := range pods.Items {
+				p := &pods.Items[i]
+				if p.DeletionTimestamp != nil {
+					continue
+				}
+				s.pod = p
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("VMServer %s: launcher pod not found via %q", s.ID(), selector)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// noService fails with a useful message; service-based targets aren't supported.
+func (s *VMServer) noService(method string) Target {
+	framework.Failf("VMServer %s: %s requires a Service. Use ICMP() or HostPorts() against the VM's PodIP.", s.ID(), method)
+	return nil
+}
+
+func (s *VMServer) ClusterIPs(_ ...TargetOption) []Target       { _ = s.noService("ClusterIPs"); return nil }
+func (s *VMServer) ClusterIP(_ ...TargetOption) Target          { return s.noService("ClusterIP") }
+func (s *VMServer) ClusterIPv4(_ ...TargetOption) Target        { return s.noService("ClusterIPv4") }
+func (s *VMServer) ClusterIPv6(_ ...TargetOption) Target        { return s.noService("ClusterIPv6") }
+func (s *VMServer) NodePortPort() int {
+	framework.Failf("VMServer %s: NodePortPort requires a Service", s.ID())
+	return 0
+}
+func (s *VMServer) NodePort(_ string, _ ...TargetOption) Target { return s.noService("NodePort") }
+func (s *VMServer) ServiceDomain(_ ...TargetOption) Target      { return s.noService("ServiceDomain") }
+
+// HostPorts returns one target per host IP of the launcher pod at the given port.
+func (s *VMServer) HostPorts(port int) []Target {
+	var targets []Target
+	for _, hostIP := range s.Pod().Status.HostIPs {
+		targets = append(targets, &target{
+			server:      s,
+			targetType:  TypePodIP,
+			destination: hostIP.IP,
+			port:        port,
+			protocol:    TCP,
+		})
+	}
+	return targets
+}
+
+// ICMP returns a target pinging the VM's PodIP (the launcher pod's PodIP).
+func (s *VMServer) ICMP() Target {
+	return &target{
+		server:      s,
+		targetType:  TypePodIP,
+		destination: s.Pod().Status.PodIP,
+		protocol:    ICMP,
+	}
+}
+
+// TCPPodIP returns a TCP target at the VM's PodIP and given port.
+func (s *VMServer) TCPPodIP(port int) Target {
+	return &target{
+		server:      s,
+		targetType:  TypePodIP,
+		destination: s.Pod().Status.PodIP,
+		port:        port,
+		protocol:    TCP,
+	}
+}

--- a/e2e/pkg/utils/conncheck/vm_server.go
+++ b/e2e/pkg/utils/conncheck/vm_server.go
@@ -122,16 +122,35 @@ func (s *VMServer) noService(method string) Target {
 	return nil
 }
 
-func (s *VMServer) ClusterIPs(_ ...TargetOption) []Target       { _ = s.noService("ClusterIPs"); return nil }
-func (s *VMServer) ClusterIP(_ ...TargetOption) Target          { return s.noService("ClusterIP") }
-func (s *VMServer) ClusterIPv4(_ ...TargetOption) Target        { return s.noService("ClusterIPv4") }
-func (s *VMServer) ClusterIPv6(_ ...TargetOption) Target        { return s.noService("ClusterIPv6") }
+func (s *VMServer) ClusterIPs(_ ...TargetOption) []Target {
+	_ = s.noService("ClusterIPs")
+	return nil
+}
+
+func (s *VMServer) ClusterIP(_ ...TargetOption) Target {
+	return s.noService("ClusterIP")
+}
+
+func (s *VMServer) ClusterIPv4(_ ...TargetOption) Target {
+	return s.noService("ClusterIPv4")
+}
+
+func (s *VMServer) ClusterIPv6(_ ...TargetOption) Target {
+	return s.noService("ClusterIPv6")
+}
+
 func (s *VMServer) NodePortPort() int {
 	framework.Failf("VMServer %s: NodePortPort requires a Service", s.ID())
 	return 0
 }
-func (s *VMServer) NodePort(_ string, _ ...TargetOption) Target { return s.noService("NodePort") }
-func (s *VMServer) ServiceDomain(_ ...TargetOption) Target      { return s.noService("ServiceDomain") }
+
+func (s *VMServer) NodePort(_ string, _ ...TargetOption) Target {
+	return s.noService("NodePort")
+}
+
+func (s *VMServer) ServiceDomain(_ ...TargetOption) Target {
+	return s.noService("ServiceDomain")
+}
 
 // HostPorts returns one target per host IP of the launcher pod at the given port.
 func (s *VMServer) HostPorts(port int) []Target {

--- a/e2e/pkg/utils/conncheck/vm_server.go
+++ b/e2e/pkg/utils/conncheck/vm_server.go
@@ -93,9 +93,12 @@ func (s *VMServer) WaitReady(ctx context.Context, f *framework.Framework) error 
 func (s *VMServer) resolveLauncher(ctx context.Context, f *framework.Framework) error {
 	deadline := time.Now().Add(podReadyTimeout(ctx))
 	selector := fmt.Sprintf("%s=%s", kubevirtv1.CreatedByLabel, string(s.vmi.UID))
+	var lastErr error
 	for {
 		pods, err := f.ClientSet.CoreV1().Pods(s.namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: selector})
-		if err == nil {
+		if err != nil {
+			lastErr = err
+		} else {
 			for i := range pods.Items {
 				p := &pods.Items[i]
 				if p.DeletionTimestamp != nil {
@@ -106,6 +109,9 @@ func (s *VMServer) resolveLauncher(ctx context.Context, f *framework.Framework) 
 			}
 		}
 		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("VMServer %s: launcher pod not found via %q (last list error: %w)", s.ID(), selector, lastErr)
+			}
 			return fmt.Errorf("VMServer %s: launcher pod not found via %q", s.ID(), selector)
 		}
 		select {

--- a/e2e/pkg/utils/conncheck/vm_server.go
+++ b/e2e/pkg/utils/conncheck/vm_server.go
@@ -50,10 +50,21 @@ func NewVMServer(vmi *kubevirtv1.VirtualMachineInstance) Server {
 	}
 }
 
-func (s *VMServer) ID() string               { return fmt.Sprintf("%s/%s", s.namespace.Name, s.name) }
-func (s *VMServer) Name() string             { return s.name }
-func (s *VMServer) Namespace() *v1.Namespace { return s.namespace }
-func (s *VMServer) Service() *v1.Service     { return nil }
+func (s *VMServer) ID() string {
+	return fmt.Sprintf("%s/%s", s.namespace.Name, s.name)
+}
+
+func (s *VMServer) Name() string {
+	return s.name
+}
+
+func (s *VMServer) Namespace() *v1.Namespace {
+	return s.namespace
+}
+
+func (s *VMServer) Service() *v1.Service {
+	return nil
+}
 
 func (s *VMServer) Pod() *v1.Pod {
 	if s.pod == nil {

--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -50,6 +50,15 @@ func (e *Client) IP() string {
 	return e.IPs()[0]
 }
 
+// SSHIP returns the address used to ssh to the external node.
+func (e *Client) SSHIP() string { return e.extIP }
+
+// SSHUser returns the ssh user.
+func (e *Client) SSHUser() string { return e.extUser }
+
+// SSHKeyPath returns the path to the private key used for ssh.
+func (e *Client) SSHKeyPath() string { return e.extKey }
+
 func (e *Client) IPs() []string {
 	e.lock.Lock()
 	defer e.lock.Unlock()

--- a/e2e/pkg/utils/externalnode/client.go
+++ b/e2e/pkg/utils/externalnode/client.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	//nolint:staticcheck // Ignore ST1001: should not use dot imports
 	. "github.com/onsi/gomega"
@@ -162,42 +161,6 @@ func (e *Client) UDP(target string, postdata string) string {
 	target = strings.Replace(target, "[", "", 1)
 	target = strings.Replace(target, "]", "", 1)
 	return fmt.Sprintf(`echo %v | nc -6 -u -w1 %v`, postdata, target)
-}
-
-func (e *Client) TestCanConnect(target string) {
-	command := fmt.Sprintf(`curl -s -m2 %v`, target)
-	tryConnect := func() error {
-		_, err := e.Exec("sh", "-c", command)
-		return err
-	}
-
-	// Test connectivity. Use Eventually to handle potential race conditions in setting up the service.
-	Eventually(tryConnect, 15*time.Second, 3*time.Second).ShouldNot(HaveOccurred())
-
-	// Once we get a single success, it should consistently succeed afterwards.
-	Consistently(tryConnect, 9*time.Second, 3*time.Second).ShouldNot(HaveOccurred())
-
-	// It's reliably up. Check output.
-	_, err := e.Exec("sh", "-c", command)
-	Expect(err).NotTo(HaveOccurred())
-}
-
-func (e *Client) TestCannotConnect(target string) {
-	command := fmt.Sprintf(`curl -s -m2 %v`, target)
-	tryConnect := func() error {
-		_, err := e.Exec("sh", "-c", command)
-		return err
-	}
-
-	// Test connectivity. Use Eventually to handle potential race conditions in setting up the service.
-	Eventually(tryConnect, 15*time.Second, 3*time.Second).Should(HaveOccurred())
-
-	// Once we get a single failure, it should consistently fail afterwards.
-	Consistently(tryConnect, 9*time.Second, 3*time.Second).Should(HaveOccurred())
-
-	// It's reliably not working. Check output.
-	_, err := e.Exec("sh", "-c", command)
-	Expect(err).To(HaveOccurred())
 }
 
 func (e *Client) SetupIperf() {


### PR DESCRIPTION
Foundation for [#12343](https://github.com/projectcalico/calico/pull/12343) (KubeVirt live migration tests). That PR currently builds a parallel `StreamSource` / `StreamProbe` hierarchy alongside `Client` / `Server` / `Target` / `Checkpointer` because two real gaps block alignment with the existing conncheck model:

1. `Client` is hardcoded to a v1.Pod, so the TOR external host can't be a Client today.
2. `Checkpointer` only knows "any-failure = fail", so a live-migration test that tolerates a brief blackhole has nowhere to express that.

This PR closes both gaps so the migration tests can rebase onto the existing vocabulary.

## What changed

- `Client` and `Server` are now interfaces. The current pod-backed structs are renamed `PodClient` and `PodServer`. `NewClient` / `NewServer` keep their signatures and return the interface type.
- New `VMServer` wraps a KubeVirt `VirtualMachineInstance` and resolves its virt-launcher pod for target construction. Service-based target builders return a clear error since a bare VM has no Service.
- New `ExternalNodeClient` runs commands over SSH on a host outside the cluster. Deploy/Cleanup are no-ops since the host is pre-provisioned.
- `Checkpointer` gains `ExpectNoDisruption(msg, ...DisruptionOption)` with `WithMaxGap` and `WithMaxConsecutiveLoss`. The caller must specify at least one bound; there is no default tolerance.
- 17 consumer files in `e2e/pkg/tests/...` drop the pointer on `*conncheck.{Client,Server}` declarations. Mechanical.

The wider conncheck API (target builders, expectation matching, encryption checks) is unchanged. Existing tests should be unaffected.

## Known follow-ups (out of scope here)

- `Connect` no longer wraps `remotecluster.RemoteFrameworkAwareExec` at the call site - the wrap moved into the exec helper. Identical for PodClient; double-check any remote-cluster tests that called `Connect` directly.
- `ExternalNodeClient.ExecStream` joins argv with spaces and runs under `sh -c` over SSH. Callers that want pipes or redirects need to single-quote tokens themselves. Same contract as the parallel `ContainerSource` from #12343.
- `(*PodServer).Cleanup` deletes only the stored Service. The previous code had the same behavior, so this preserves a latent leak when both v4 and v6 Services were created. Worth a separate fix.

```release-note
None
```