### PR TITLE
[BPF] Don't BYPASS HEP egress for NAT-outgoing flows (CI-1988)

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -210,7 +210,7 @@ enum calico_skb_mark {
 	/* The NAT_OUT bit is used by programs that are towards the host namespace to tell iptables to
 	 * do SNAT for this flow.  Subsequent packets will also be allowed to fall through to the host
 	 * netns. */
-	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_BYPASS  | 0x00800000,
+	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_SEEN  | 0x00800000,
 	/* CALI_SKB_MARK_MASQ enforces MASQ on the connection. */
 	CALI_SKB_MARK_MASQ                   = CALI_SKB_MARK_BYPASS  | 0x00600000,
 	/* CALI_SKB_MARK_SKIP_FIB is used for packets that should pass through host IP stack. */

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -31,8 +31,8 @@ const (
 	MarkSeenBypassForward     = MarkSeenBypass | 0x00300000
 	MarkSeenBypassXDP         = MarkSeenBypass | 0x00500000
 	MarkSeenBypassForwardMask = MarkSeenBypassMask | 0x00f00000
-	MarkSeenNATOutgoing       = MarkSeenBypass | 0x00800000
-	MarkSeenNATOutgoingMask   = MarkSeenBypassMask | 0x00f00000
+	MarkSeenNATOutgoing       = MarkSeen | 0x00800000
+	MarkSeenNATOutgoingMask   = MarkSeenMask | 0x00f00000
 	MarkSeenMASQ              = MarkSeenBypass | 0x00600000
 	MarkSeenMASQMask          = MarkSeenBypassMask | 0x00f00000
 	MarkSeenSkipFIB           = MarkSeen | 0x00100000

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1719,6 +1719,67 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "egress", "host-0-1")
 					})
 
+					// CI-1988: With a HostEndpoint Deny-ingress policy on the source node,
+					// the SNAT'd return traffic for pod-to-off-cluster connections must
+					// still be matched by BPF conntrack and forwarded back to the pod —
+					// i.e. it must not be evaluated against the host-endpoint policy
+					// (which would deny it as host-bound).
+					//
+					// applyOnForward defaults to false on the deny GNP, so pod egress
+					// (forwarded through eth0) is unaffected. Only a packet that the
+					// dataplane classifies as host-bound hits this policy. In iptables
+					// mode the reply matches nf_conntrack uniformly across protocols and
+					// is classified as forwarded ESTABLISHED. The bug report (Visa) is
+					// that in BPF mode UDP replies miss conntrack and get denied, while
+					// TCP/ICMP replies are correctly matched.
+					It("should not block SNAT'd return traffic via HEP policy", func() {
+						denyPol := api.NewGlobalNetworkPolicy()
+						denyPol.Name = "ci-1988-hep-deny-ingress"
+						denyOrder := float64(10)
+						denyPol.Spec.Order = &denyOrder
+						denyPol.Spec.Selector = "ep-type == 'host' && node == '" + tc.Felixes[0].Name + "'"
+						denyPol.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
+						denyPol.Spec.Ingress = []api.Rule{{Action: "Deny"}}
+						_ = createPolicy(denyPol)
+
+						bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "ingress", "ci-1988-hep-deny-ingress")
+
+						// hostW[1] sits at felixIP(1), outside the cluster IP pool, so
+						// pod traffic to it is SNAT'd to felixIP(0) by natOutgoing.
+						// felix[1]'s HEP is unaffected by the deny policy (it selects
+						// felix[0] only), so the reply leaves hostW[1] normally; the
+						// question is whether felix[0]'s ingress hook lets the reply
+						// back in.
+						cc.ExpectSNAT(w[0][0], felixIP(0), hostW[1])
+						cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+
+						// The NAT-outgoing flow has two BPF conntrack entries on the source
+						// node: a workload-side entry keyed by the pre-SNAT 5-tuple
+						// (pod IP) and a host-side entry keyed by the post-SNAT 5-tuple
+						// (node IP). The host-side entry must exist for the reply at
+						// FROM_HEP to skip policy.
+						ctDumpArgs := []string{"calico-bpf", "conntrack", "dump", "--raw"}
+						if testOpts.ipv6 {
+							ctDumpArgs = []string{"calico-bpf", "conntrack", "-6", "dump", "--raw"}
+						}
+						ctDump, err := tc.Felixes[0].ExecOutput(ctDumpArgs...)
+						Expect(err).NotTo(HaveOccurred())
+						// BPF conntrack keys are canonicalized (smaller IP first), so each
+						// entry can appear in either A<->B or B<->A order.
+						ctEntry := func(ipA, ipB string) *regexp.Regexp {
+							qA, qB := regexp.QuoteMeta(ipA), regexp.QuoteMeta(ipB)
+							return regexp.MustCompile(fmt.Sprintf(
+								`proto=%d (?:%s:\d+ <-> %s:8055|%s:8055 <-> %s:\d+)`,
+								numericProto, qA, qB, qB, qA))
+						}
+						podToHost := ctEntry(w[0][0].IP, hostW[1].IP)
+						nodeToHost := ctEntry(felixIP(0), hostW[1].IP)
+						Expect(podToHost.MatchString(ctDump)).To(BeTrue(),
+							"BPF conntrack missing workload-side (pre-SNAT) entry; dump:\n"+ctDump)
+						Expect(nodeToHost.MatchString(ctDump)).To(BeTrue(),
+							"BPF conntrack missing host-side (post-SNAT) entry; dump:\n"+ctDump)
+					})
+
 					It("should handle NAT outgoing", func() {
 						By("SNATting outgoing traffic with the flag set")
 						cc.ExpectSNAT(w[0][0], felixIP(0), hostW[1])

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1732,53 +1732,82 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					// is classified as forwarded ESTABLISHED. The bug report (Visa) is
 					// that in BPF mode UDP replies miss conntrack and get denied, while
 					// TCP/ICMP replies are correctly matched.
-					It("should not block SNAT'd return traffic via HEP policy", func() {
-						denyPol := api.NewGlobalNetworkPolicy()
-						denyPol.Name = "ci-1988-hep-deny-ingress"
-						denyOrder := float64(10)
-						denyPol.Spec.Order = &denyOrder
-						denyPol.Spec.Selector = "ep-type == 'host' && node == '" + tc.Felixes[0].Name + "'"
-						denyPol.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
-						denyPol.Spec.Ingress = []api.Rule{{Action: "Deny"}}
-						_ = createPolicy(denyPol)
+					//
+					// The bug is in the workload-side -> host-side BPF conntrack handoff,
+					// which is independent of tunnel/DSR mode, so we only exercise the
+					// non-tunnel non-DSR matrix point to keep the test cheap.
+					if testOpts.tunnel == "none" && !testOpts.dsr {
+						It("should not block SNAT'd return traffic via HEP policy", func() {
+							// Clear the parent Context's HEP egress policies — they constrain
+							// HEP forward egress to felixIP(1) only, which prevents our pod
+							// from reaching externalClient. This test only wants its own
+							// ingress-deny GNP on the source node's HEP.
+							_, err := calicoClient.GlobalNetworkPolicies().Delete(context.Background(), "host-0-1", options2.DeleteOptions{})
+							Expect(err).NotTo(HaveOccurred())
+							_, err = calicoClient.GlobalNetworkPolicies().Delete(context.Background(), "host-0-1-forward", options2.DeleteOptions{})
+							Expect(err).NotTo(HaveOccurred())
 
-						bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "ingress", "ci-1988-hep-deny-ingress")
+							denyPol := api.NewGlobalNetworkPolicy()
+							denyPol.Name = "ci-1988-hep-deny-ingress"
+							denyOrder := float64(10)
+							denyPol.Spec.Order = &denyOrder
+							denyPol.Spec.Selector = "ep-type == 'host' && node == '" + tc.Felixes[0].Name + "'"
+							denyPol.Spec.Types = []api.PolicyType{api.PolicyTypeIngress}
+							denyPol.Spec.Ingress = []api.Rule{{Action: "Deny"}}
+							_ = createPolicy(denyPol)
 
-						// hostW[1] sits at felixIP(1), outside the cluster IP pool, so
-						// pod traffic to it is SNAT'd to felixIP(0) by natOutgoing.
-						// felix[1]'s HEP is unaffected by the deny policy (it selects
-						// felix[0] only), so the reply leaves hostW[1] normally; the
-						// question is whether felix[0]'s ingress hook lets the reply
-						// back in.
-						cc.ExpectSNAT(w[0][0], felixIP(0), hostW[1])
-						cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+							bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "ingress", "ci-1988-hep-deny-ingress")
 
-						// The NAT-outgoing flow has two BPF conntrack entries on the source
-						// node: a workload-side entry keyed by the pre-SNAT 5-tuple
-						// (pod IP) and a host-side entry keyed by the post-SNAT 5-tuple
-						// (node IP). The host-side entry must exist for the reply at
-						// FROM_HEP to skip policy.
-						ctDumpArgs := []string{"calico-bpf", "conntrack", "dump", "--raw"}
-						if testOpts.ipv6 {
-							ctDumpArgs = []string{"calico-bpf", "conntrack", "-6", "dump", "--raw"}
-						}
-						ctDump, err := tc.Felixes[0].ExecOutput(ctDumpArgs...)
-						Expect(err).NotTo(HaveOccurred())
-						// BPF conntrack keys are canonicalized (smaller IP first), so each
-						// entry can appear in either A<->B or B<->A order.
-						ctEntry := func(ipA, ipB string) *regexp.Regexp {
-							qA, qB := regexp.QuoteMeta(ipA), regexp.QuoteMeta(ipB)
-							return regexp.MustCompile(fmt.Sprintf(
-								`proto=%d (?:%s:\d+ <-> %s:8055|%s:8055 <-> %s:\d+)`,
-								numericProto, qA, qB, qB, qA))
-						}
-						podToHost := ctEntry(w[0][0].IP, hostW[1].IP)
-						nodeToHost := ctEntry(felixIP(0), hostW[1].IP)
-						Expect(podToHost.MatchString(ctDump)).To(BeTrue(),
-							"BPF conntrack missing workload-side (pre-SNAT) entry; dump:\n"+ctDump)
-						Expect(nodeToHost.MatchString(ctDump)).To(BeTrue(),
-							"BPF conntrack missing host-side (post-SNAT) entry; dump:\n"+ctDump)
-					})
+							// externalClient sits outside the cluster — not a felix node and not
+							// in any IP pool — so NAT-outgoing applies regardless of
+							// NATOutgoingExclusions setting. Start a listener on it.
+							//
+							// Use containerIP() so the workload's IP matches the cluster's
+							// IP family — the connectivity checker defaults to ipVersion=4
+							// and reads the workload's IP field, like hostW above.
+							extSrv := &workload.Workload{
+								C:        externalClient,
+								Name:     "ext-srv",
+								IP:       containerIP(externalClient),
+								Ports:    "8055",
+								Protocol: testOpts.protocol,
+							}
+							Expect(extSrv.Start(infra)).NotTo(HaveOccurred())
+							defer extSrv.Stop()
+
+							// Pod traffic to externalClient is SNAT'd to felixIP(0) by
+							// natOutgoing. The reply targets felixIP(0); the question is whether
+							// felix[0]'s ingress hook lets it back in despite the HEP deny.
+							cc.ExpectSNAT(w[0][0], felixIP(0), extSrv)
+							cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+
+							// The NAT-outgoing flow has two BPF conntrack entries on the source
+							// node: a workload-side entry keyed by the pre-SNAT 5-tuple
+							// (pod IP) and a host-side entry keyed by the post-SNAT 5-tuple
+							// (node IP). The host-side entry must exist for the reply at
+							// FROM_HEP to skip policy.
+							ctDumpArgs := []string{"calico-bpf", "conntrack", "dump", "--raw"}
+							if testOpts.ipv6 {
+								ctDumpArgs = []string{"calico-bpf", "conntrack", "-6", "dump", "--raw"}
+							}
+							ctDump, err := tc.Felixes[0].ExecOutput(ctDumpArgs...)
+							Expect(err).NotTo(HaveOccurred())
+							// BPF conntrack keys are canonicalized (smaller IP first), so each
+							// entry can appear in either A<->B or B<->A order.
+							ctEntry := func(ipA, ipB string) *regexp.Regexp {
+								qA, qB := regexp.QuoteMeta(ipA), regexp.QuoteMeta(ipB)
+								return regexp.MustCompile(fmt.Sprintf(
+									`proto=%d (?:%s:\d+ <-> %s:8055|%s:8055 <-> %s:\d+)`,
+									numericProto, qA, qB, qB, qA))
+							}
+							podToExt := ctEntry(w[0][0].IP, extSrv.IP)
+							nodeToExt := ctEntry(felixIP(0), extSrv.IP)
+							Expect(podToExt.MatchString(ctDump)).To(BeTrue(),
+								"BPF conntrack missing workload-side (pre-SNAT) entry; dump:\n"+ctDump)
+							Expect(nodeToExt.MatchString(ctDump)).To(BeTrue(),
+								"BPF conntrack missing host-side (post-SNAT) entry; dump:\n"+ctDump)
+						})
+					}
 
 					It("should handle NAT outgoing", func() {
 						By("SNATting outgoing traffic with the flag set")

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -1947,7 +1947,7 @@ var _ = Describe("Static", func() {
 				Comment: []string{"MarkSeenMASQ Mark"},
 			},
 			{
-				Match:   iptables.Match().MarkMatchesWithMask(0x3800000, 0x3f00000),
+				Match:   iptables.Match().MarkMatchesWithMask(0x1800000, 0x1f00000),
 				Action:  iptables.ReturnAction{},
 				Comment: []string{"MarkSeenNATOutgoing Mark"},
 			},


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Bug fix.

For NAT-outgoing flows the BPF dataplane uses two conntrack entries: a workload-side entry keyed by the pre-SNAT 5-tuple (with the `NAT_OUT` flag) and a host-side entry keyed by the post-SNAT 5-tuple. The host-side entry is what lets reply traffic at `FROM_HEP` skip policy on the source node.

`CALI_SKB_MARK_NAT_OUT` has been a member of the BYPASS family since dc3bb62b94 (Jul 2020). That commit's rationale was "NAT outgoing means the traffic is leaving the cluster so there can only be one workload program in play" — but the HEP egress program is the only place on the outbound path where the post-SNAT 5-tuple is observable to BPF. The bypass mark short-circuits HEP egress at the top of `calico_tc_main`, so the host-side entry is never written. The first reply packet at `FROM_HEP` therefore misses BPF conntrack and is evaluated against host-endpoint policy.

For TCP the mid-flow-fall-through-to-iptables path saves the reply; UDP has no equivalent, so a HEP deny-ingress policy drops the reply. This is the customer-reported behaviour in [CI-1988](https://tigera.atlassian.net/browse/CI-1988): on eBPF clusters with a HostEndpoint GNP, UDP responses to pod-originated egress are blocked while TCP/ICMP work.

Change: `CALI_SKB_MARK_NAT_OUT` is now a SEEN mark (not BYPASS). The iptables SNAT rule still triggers off the NAT_OUT bit; HEP egress now runs and writes the host-side conntrack entry. Effectively a revert of dc3bb62b94.

Added FV reproducer in `felix/fv/bpf_test.go` that applies a HEP ingress-Deny GNP on the source node, runs pod → externalClient with NAT-outgoing, and asserts the two expected BPF conntrack entries (pre-SNAT workload-side and post-SNAT host-side) are present.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
ebpf: Fix HostEndpoint policy blocking UDP return traffic for SNAT'd pod egress.
```

[CI-1988]: https://tigera.atlassian.net/browse/CI-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ