### PR TITLE
Add Makefile knobs for capping build resource usage

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -127,6 +127,14 @@ endif
 endif
 endif
 
+# Optional cap on go build/test package parallelism. Appended to GOFLAGS so
+# it flows through every docker invocation that already passes GOFLAGS in.
+# Useful for limiting memory pressure when running multiple parallel builds
+# on a workstation (each in-flight package can fork its own compiler).
+ifneq ($(GO_BUILD_PARALLELISM),)
+GOFLAGS := $(GOFLAGS) -p=$(GO_BUILD_PARALLELISM)
+endif
+
 # For building, we use the go-build image for the *host* architecture, even if the target is different
 # the one for the host should contain all the necessary cross-compilation tools
 # we do not need to use the arch since go-build:v0.15 now is multi-arch manifest
@@ -308,6 +316,23 @@ else
 endif
 
 EXTRA_DOCKER_ARGS += -v $(GOMOD_CACHE):/go/pkg/mod:rw
+
+# Optional per-build resource caps. When unset, no flags are added and the
+# container has full host access (current behaviour). Useful when running
+# multiple parallel builds on a workstation to avoid memory thrash.
+#   DOCKER_CPUS=N           Hard cap on total CPU bandwidth (any core).
+#   DOCKER_CPUSET_CPUS=0-3  Pin container to specific cores (true affinity).
+#   GOMAXPROCS=N            Cap goroutine parallelism inside each go invocation
+#                           (linker, vet, etc.); complements -p=N from GOFLAGS.
+ifneq ($(DOCKER_CPUS),)
+EXTRA_DOCKER_ARGS += --cpus=$(DOCKER_CPUS)
+endif
+ifneq ($(DOCKER_CPUSET_CPUS),)
+EXTRA_DOCKER_ARGS += --cpuset-cpus=$(DOCKER_CPUSET_CPUS)
+endif
+ifneq ($(GOMAXPROCS),)
+EXTRA_DOCKER_ARGS += -e GOMAXPROCS=$(GOMAXPROCS)
+endif
 
 # Define go architecture flags
 GOARCH_FLAGS :=-e GOARCH=$(ARCH)


### PR DESCRIPTION
Adds four opt-in Makefile/env variables that let you cap the resources used by docker-based Go builds. The motivation is workstation ergonomics: running multiple parallel builds (e.g. several Claude Code sessions in different worktrees) currently has each `calico/go-build` container assume it owns the host, which causes memory thrash.

All four knobs are no-ops when unset, so CI behaviour is unchanged.

| Variable | Effect |
| --- | --- |
| `DOCKER_CPUS` | `--cpus=N` on the build container (hard CPU bandwidth cap, container can run on any core). |
| `DOCKER_CPUSET_CPUS` | `--cpuset-cpus=0-3` etc. (pin container to specific cores; lets two sessions use disjoint cores). |
| `GOMAXPROCS` | Threaded into the container env; caps goroutine parallelism inside each `go` invocation (linker, vet, etc.). |
| `GO_BUILD_PARALLELISM` | Appended to `GOFLAGS` as `-p=N`; caps how many packages `go build`/`go test` compile concurrently — the biggest memory lever, since each in-flight package can fork its own compiler. |

Example two-session setup:

```
# session A
DOCKER_CPUSET_CPUS=0-3 GO_BUILD_PARALLELISM=4 GOMAXPROCS=4 make -C felix build
# session B
DOCKER_CPUSET_CPUS=4-7 GO_BUILD_PARALLELISM=4 GOMAXPROCS=4 make -C typha build
```

### Implementation

All variables live in `lib.Makefile`. They feed into `EXTRA_DOCKER_ARGS` / `GOFLAGS`, which are already spliced into every `DOCKER_RUN` / `DOCKER_GO_BUILD` invocation, so no callers had to change.

### Testing

Verified with `make -C felix --just-print build`:
- Unset → docker line has no `--cpus`, `--cpuset-cpus`, or `GOMAXPROCS`, and `GOFLAGS` has no `-p=`.
- All set → docker line contains `--cpus=2 --cpuset-cpus=0-1 -e GOMAXPROCS=2` and `GOFLAGS` contains `-p=2`.

Also greped `.semaphore/` to confirm no name collisions with existing CI variables.