### PR TITLE
node, istio: order nft-rpms-image after register

### DIFF
--- a/istio/Makefile
+++ b/istio/Makefile
@@ -122,7 +122,8 @@ image: $(BUILD_IMAGES)
 include ../hack/rpms/nftables/image.mk
 
 .PHONY: nft-rpms-image
-nft-rpms-image:
+# `| register` so binfmt is set up before cross-arch buildx.
+nft-rpms-image: | register
 	$(MAKE) -C ../hack/rpms/nftables image ARCH=$(ARCH)
 
 # istio-install-cni image

--- a/node/Makefile
+++ b/node/Makefile
@@ -279,7 +279,8 @@ image $(NODE_IMAGE): $(NODE_CONTAINER_MARKER)
 # so buildkit sources it from the local daemon (avoiding `--pull=always`
 # trying to fetch it from a registry where it may not have been pushed yet).
 .PHONY: nft-rpms-image
-nft-rpms-image:
+# `| register` so binfmt is set up before cross-arch buildx.
+nft-rpms-image: | register
 	$(MAKE) -C ../hack/rpms/nftables image ARCH=$(ARCH)
 
 # Drop --pull from DOCKER_BUILD: with --pull=always, buildkit treats the


### PR DESCRIPTION
Both `register` and `nft-rpms-image` are order-only prereqs of the consumer image target, and `make` doesn't order multiple order-only prereqs against each other. Without this, a local cross-arch build (e.g. `make image ARCH=arm64` on an amd64 host) can run the buildx `--platform linux/$(ARCH)` step before binfmt is registered, and the `--load` fails.

Caught by a Copilot review on the calico-private cherry-pick of #12660 - fixing it here so the fix flows through the OSS pick rather than diverging.

```release-note
NONE
```