### PR TITLE
Use Installation.Spec.ImagePullPolicy instead of sed-hacking the operator

### DIFF
--- a/hack/test/kind/infra/build-operator.sh
+++ b/hack/test/kind/infra/build-operator.sh
@@ -66,9 +66,6 @@ sed -e "s/test-build/${DEV_IMAGE_TAG}/g" \
 build/_output/bin/gen-versions -os-versions="$VERSIONS_FILE" > pkg/components/calico.go
 rm -f "$VERSIONS_FILE"
 
-# Pull every image fresh so clusters pick up new digests under stable tags.
-find . -name '*.go' | xargs sed -i 's/PullIfNotPresent/PullAlways/g'
-
 make image
 # Strip docker.io/ since Docker Hub doesn't use it.
 if [ "${DEV_IMAGE_REGISTRY}" = "docker.io" ]; then

--- a/hack/test/kind/infra/values.yaml
+++ b/hack/test/kind/infra/values.yaml
@@ -2,6 +2,10 @@
 installation:
   enabled: true
 
+  # Always re-pull so clusters pick up new digests under stable tags
+  # (e.g. test-build) on `make kind-reload`.
+  imagePullPolicy: Always
+
   # Disable HA control plane.
   controlPlaneReplicas: 1
 


### PR DESCRIPTION
Replaces the `sed 's/PullIfNotPresent/PullAlways/g'` hack in `hack/test/kind/infra/build-operator.sh` with `installation.imagePullPolicy: Always` in the kind values.yaml. The helm chart already splats every `installation.*` value into the Installation spec via `toYaml`, so this propagates to all operator-managed pods.

Depends on https://github.com/tigera/operator/pull/4797 — keep as draft until that lands and is picked up by the operator master image built here.

```release-note
NONE
```