### PR TITLE
Split repo architecture from .claude/CLAUDE.md into DESIGN.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,7 @@
+# CLAUDE.md
+
+This file is **operational guidance** for agents working in this repo: build commands, test invocation, debugging, conventions, and the process rules every PR follows. For **architecture, invariants, and review criteria**, see [`DESIGN.md`](../DESIGN.md) at the repo root, and the per-component `DESIGN.md` files it links to. Do not look here for architecture; look there.
+
 ## Repository Overview
 
 Project Calico is a large monorepo providing container networking and security 
@@ -167,103 +171,6 @@ eBPF files in `felix/bpf-gpl/` require dual Apache/GPL headers with SPDX identif
   - Utility functions; can be interspersed with methods if tightly coupled with particular methods.
   - Larger secondary structs at the bottom.
 
-## Repository Architecture
-
-### Component Dependency Order
-
-Core components (dependency order):
-```
-api/              - Calico API definitions (CRDs, protobuf), separate go.mod
-libcalico-go/     - Core Go client library and data model
-typha/            - Datastore fan-out proxy for scaling (reduces etcd load)
-felix/            - Core per-host networking agent (eBPF/iptables/nftables dataplane)
-node/             - Node initialization container (includes Felix, confd, BIRD, startup scripts)
-calicoctl/        - CLI tool for Calico management
-kube-controllers/ - Kubernetes-specific controllers (namespace, pod, node, serviceaccount)
-cni-plugin/       - Kubernetes CNI integration
-confd/            - Configuration management daemon
-app-policy/       - Application layer policy (L7)
-apiserver/        - Kubernetes API aggregation layer
-```
-
-Additional components:
-```
-goldmane/             - Log aggregation and flow log storage
-guardian/             - Secure tunnel proxy for management cluster connections
-pod2daemon/           - Flex volume driver for injecting credentials into pods
-key-cert-provisioner/ - TLS certificate provisioner for Calico components
-whisker/              - Flow log UI (TypeScript/React frontend)
-whisker-backend/      - Backend for whisker flow log UI
-e2e/                  - End-to-end test suites
-release/              - Release tooling and automation
-lib/std/              - Internal shared Go library (separate go.mod)
-lib/httpmachinery/    - Internal HTTP utility library (separate go.mod)
-```
-
-### Key Architectural Concepts
-
-**Felix** is the core per-host agent responsible for:
-- Programming dataplane (eBPF, iptables, nftables)
-- Maintaining routing tables
-- Processing policy and programming ACLs
-- Source: `felix/daemon/daemon.go`
-- **Calculation graph** (`felix/calc/`): DAG that processes datastore updates and calculates dataplane state. Changes here require calc graph FV tests.
-
-**Typha** is a fan-out proxy that:
-- Sits between Felix instances and the datastore (etcd/K8s API)
-- Reduces load on datastore by caching and fanning out to multiple Felix instances
-- Optional but recommended for clusters >50 nodes
-
-**Node container** orchestrates node initialization:
-- Runs Felix, confd, and BIRD in a single container
-- Handles CNI plugin installation
-- Source: `node/pkg/lifecycle/startup/startup.go`
-
-### Combined `calico` binary
-
-Most component daemons are registered as subcommands of a single `calico` binary rather than shipping as independent binaries — felix, confd, kube-controllers, goldmane, guardian, whisker-backend, key-cert-provisioner, typha, dikastes, csi, flexvol, and webhooks all dispatch through `calico component <name>`. Inside the node container, runit services exec the subcommand directly (see `node/filesystem/etc/service/available/<name>/run`).
-
-**Adding a new component:**
-
-1. Expose a `NewCommand() *cobra.Command` from the component's package.
-2. Register it in `cmd/calico/component.go` under `newComponentCommand`.
-3. If the component runs in the node container, add a runit service at `node/filesystem/etc/service/available/<name>/run` whose body is `exec calico component <name>`.
-4. The component's `Run` handler should call `logutils.ConfigureFormatter("<name>")` so log lines carry a consistent component prefix.
-
-**Restart-on-config-change (exit 129):** A component that intentionally exits with `cmdwrapper.RestartReturnCode` (129) to request a live restart on config change (currently felix and kube-controllers) must wrap its cobra `Run` with `cmdwrapper.WrapSelf(innerEnvVar, fn)` from `pkg/cmdwrapper`. Without this, `exec calico component <name>` from runit just exits — there is no outer process to restart the child.
-
-- Pick a unique `innerEnvVar` per component (e.g. `CALICO_FELIX_INNER`, `CALICO_KUBE_CONTROLLERS_INNER`). `WrapSelf` strips any pre-existing value before re-execing.
-- The caller configures logrus before calling `WrapSelf`; `fn` is the inner daemon body.
-- Don't change the log line format in `cmdwrapper` — integration tests grep stdout for `"Received exit status N, restarting"`.
-
-### Health reporting
-
-Components expose liveness/readiness through the shared aggregator in `libcalico-go/lib/health`.
-
-1. Construct once per component: `ha := health.NewHealthAggregator()`.
-2. For each independent health source, register a named reporter declaring what it will report: `ha.RegisterReporter("Startup", &health.HealthReport{Live: true, Ready: true}, timeout)`. A non-zero timeout means reports must refresh before expiry or the aggregator treats that reporter as unhealthy — use this for long-running loops where silent stalls matter.
-3. Call `ha.Report(name, &health.HealthReport{...})` at startup and as state changes inside running goroutines.
-4. Serve the endpoints with `ha.ServeHTTP(enabled, host, port)` — this exposes `/readiness` and `/liveness` on the given port.
-
-For Kubernetes probes, use the generic `calico health --port=<port> --type=readiness|liveness` exec command (`cmd/calico/health.go`) rather than adding a per-component healthcheck binary or a bare `httpGet` probe. It does the HTTP GET and exits 0 on 2xx/3xx — that's the standard for pods running the combined image.
-
-Examples worth copying from: `kube-controllers/pkg/kubecontrollers/run.go` (Startup / CalicoDatastore / KubeAPIServer reporters, no timeout) and `felix/daemon/daemon.go` (lifecycle reporter plus per-subsystem reporters with timeouts).
-
-### Go Module Structure
-
-- Root `go.mod` (`github.com/projectcalico/calico`) is the primary module for most components
-- `api/go.mod` (`github.com/projectcalico/api`) is separate (API exported as independent repo)
-- `lib/std/go.mod` and `lib/httpmachinery/go.mod` are internal libraries
-- When adding Go dependencies: `cd <component> && go mod tidy && cd .. && make check-go-mod`
-
-### Docker Build System
-
-- All builds run inside Docker containers using `calico/go-build` (version pinned in `metadata.mk`)
-- Base images configured in `metadata.mk`
-- Build cache in `.go-pkg-cache/` (speeds up rebuilds)
-- Supported architectures: amd64, arm64, ppc64le, s390x (plus Windows builds)
-- Cross-compilation via `ARCH=<target>` and binfmt registration (`calico/binfmt`)
-
 ## Documentation map
 
 This repo carries an extensive corpus of architecture and review
@@ -273,8 +180,13 @@ criteria that are hard to recover from the source alone.
 
 Where it lives:
 
-- **`<component>/DESIGN.md`** — architecture, invariants, and
-  per-section review notes for that component. Authoritative source
+- **[`DESIGN.md`](../DESIGN.md) at the repo root** — Calico's
+  cross-cutting architecture: the component dependency tables,
+  the combined `calico` binary pattern, health reporting, Go
+  module structure, build system, and entry points. The
+  authoritative starting point for *what the repo is*.
+- **`<component>/DESIGN.md`** — per-component architecture,
+  invariants, and per-section review notes. Authoritative source
   for "what does this code promise?". A coding agent writing a PR
   and a reviewer checking one read the same file and apply the
   same embedded review notes.
@@ -419,12 +331,7 @@ Image loading is incremental — `kind-reload` and `kind-deploy` compare local D
 - `lib.Makefile` - Shared Makefile logic for all components
 - `Makefile` - Root orchestration
 
-**Component Entry Points:**
-- `felix/daemon/daemon.go` - Felix main entry point
-- `felix/calc/` - Felix calculation graph (policy processing brain)
-- `felix/dataplane/` - Dataplane implementations (eBPF, iptables, nftables)
-- `node/pkg/lifecycle/startup/startup.go` - Node initialization
-- `calicoctl/calicoctl/calicoctl.go` - CLI entry point
+For component entry points and architectural code paths, see [`DESIGN.md`](../DESIGN.md) §6.
 
 **Kind Cluster Infrastructure:**
 - `hack/test/kind/` - Kind cluster scripts (creation, image loading, deployment, teardown)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,6 +44,14 @@ make image
 make -C felix build ARCH=arm64
 ```
 
+### Docker Build System
+
+- All builds run inside Docker containers using `calico/go-build` (version pinned in `metadata.mk`)
+- Base images configured in `metadata.mk`
+- Build cache in `.go-pkg-cache/` (speeds up rebuilds)
+- Supported architectures: amd64, arm64, ppc64le, s390x (plus Windows builds)
+- Cross-compilation via `ARCH=<target>` and binfmt registration (`calico/binfmt`)
+
 ### Running Tests
 
 ```bash
@@ -331,7 +339,7 @@ Image loading is incremental — `kind-reload` and `kind-deploy` compare local D
 - `lib.Makefile` - Shared Makefile logic for all components
 - `Makefile` - Root orchestration
 
-For component entry points and architectural code paths, see [`DESIGN.md`](../DESIGN.md) §6.
+For component entry points and architectural code paths, see [`DESIGN.md`](../DESIGN.md) §5.
 
 **Kind Cluster Infrastructure:**
 - `hack/test/kind/` - Kind cluster scripts (creation, image loading, deployment, teardown)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,17 +98,38 @@ services exec the subcommand directly (see
    `logutils.ConfigureFormatter("<name>")` so log lines carry a
    consistent component prefix.
 
-**Restart-on-config-change (exit 129):** A component that
-intentionally exits with `cmdwrapper.RestartReturnCode` (129) to
-request a live restart on config change (currently felix and
-kube-controllers) must wrap its cobra `Run` with
-`cmdwrapper.WrapSelf(innerEnvVar, fn)` from `pkg/cmdwrapper`.
-Without this, `exec calico component <name>` from runit just
-exits — there is no outer process to restart the child.
+**Restart-on-config-change (exit 129):** A component can request
+an in-place restart on a live config change by exiting with
+`cmdwrapper.RestartReturnCode` (129) — currently felix and
+kube-controllers do. The exit code only has an effect if *some*
+outer supervisor re-launches the process on it, and the codebase
+has three such supervisors depending on how the component is run:
+
+- **runit**, in the node container, restarts a service when its
+  `run` script's process exits. Felix runs this way:
+  `node/filesystem/etc/service/available/felix/run` ends in
+  `exec calico component felix`, and runit re-runs it on exit.
+- **`felix/docker-image/calico-felix-wrapper`**, a bash loop that
+  re-runs `calico component felix` whenever it exits 129. Used for
+  the standalone felix image and FV, where runit isn't present.
+- **`cmdwrapper.WrapSelf(innerEnvVar, fn)`** (`pkg/cmdwrapper`),
+  an in-process self-re-exec for components that run with no
+  external supervisor — currently only kube-controllers, whose
+  container entrypoint is `calico component kube-controllers`
+  directly. The outer invocation re-execs itself (setting
+  `innerEnvVar=1`) on exit 129; the inner runs the daemon body.
+
+When adding a component that wants exit-129 reload semantics, make
+sure one of these supervisors covers it — a bare
+`exec calico component <name>` with no supervising parent gives no
+restart.
+
+Notes specific to `cmdwrapper.WrapSelf` (the kube-controllers
+path; see `kube-controllers/pkg/kubecontrollers/command.go`):
 
 - Pick a unique `innerEnvVar` per component (e.g.
-  `CALICO_FELIX_INNER`, `CALICO_KUBE_CONTROLLERS_INNER`).
-  `WrapSelf` strips any pre-existing value before re-execing.
+  `CALICO_KUBE_CONTROLLERS_INNER`). `WrapSelf` strips any
+  pre-existing value before re-execing.
 - The caller configures logrus before calling `WrapSelf`; `fn`
   is the inner daemon body.
 - Don't change the log line format in `cmdwrapper` — integration

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,187 @@
+# Calico — Architecture
+
+This file is the repo-wide architecture index. Per-component
+architecture, invariants, and review criteria live in each
+component's `DESIGN.md` (linked below). Operational guidance —
+build commands, test invocation, debugging, in-repo conventions
+— lives in [`.claude/CLAUDE.md`](.claude/CLAUDE.md) at the root
+and in each component's `CLAUDE.md` (or `AGENTS.md`).
+
+If you're looking for *how* to do something in this repo, look in
+`CLAUDE.md`. If you're looking for *what the code promises*, look
+here or in the matching component's `DESIGN.md`.
+
+## 1. Calico in one paragraph
+
+Project Calico is a container networking and security platform
+for Kubernetes. A typical deployment programs the per-node
+dataplane (eBPF, iptables, nftables, or Windows) to enforce
+network policy, route traffic, and report on flows; a small set
+of cluster-wide controllers and a fan-out proxy coordinate the
+nodes against the Kubernetes API or an etcd datastore. Optional
+add-ons cover flow-log aggregation, UI, management-cluster
+tunnelling, application-layer policy, and other Enterprise
+features.
+
+## 2. Components
+
+### Core components (dependency order)
+
+```
+api/              - Calico API definitions (CRDs, protobuf), separate go.mod
+libcalico-go/     - Core Go client library and data model
+typha/            - Datastore fan-out proxy for scaling (reduces etcd load)
+felix/            - Core per-host networking agent (eBPF/iptables/nftables dataplane)
+node/             - Node initialization container (includes Felix, confd, BIRD, startup scripts)
+calicoctl/        - CLI tool for Calico management
+kube-controllers/ - Kubernetes-specific controllers (namespace, pod, node, serviceaccount)
+cni-plugin/       - Kubernetes CNI integration
+confd/            - Configuration management daemon
+app-policy/       - Application layer policy (L7)
+apiserver/        - Kubernetes API aggregation layer
+```
+
+### Additional components
+
+```
+goldmane/             - Log aggregation and flow log storage
+guardian/             - Secure tunnel proxy for management cluster connections
+pod2daemon/           - Flex volume driver for injecting credentials into pods
+key-cert-provisioner/ - TLS certificate provisioner for Calico components
+whisker/              - Flow log UI (TypeScript/React frontend)
+whisker-backend/      - Backend for whisker flow log UI
+e2e/                  - End-to-end test suites
+release/              - Release tooling and automation
+lib/std/              - Internal shared Go library (separate go.mod)
+lib/httpmachinery/    - Internal HTTP utility library (separate go.mod)
+```
+
+### Per-component design
+
+Components with their own design doc:
+
+| Component | Design doc |
+|---|---|
+| Felix | [`felix/DESIGN.md`](felix/DESIGN.md) — index with topic sub-designs under [`felix/design/`](felix/design/) |
+| Goldmane | [`goldmane/DESIGN.md`](goldmane/DESIGN.md) |
+| Typha | [`typha/DESIGN.md`](typha/DESIGN.md) |
+| Node container | [`node/DESIGN.md`](node/DESIGN.md) |
+
+Components without a `DESIGN.md` inherit constraints from the
+code and from this top-level overview. Adding a `DESIGN.md` when
+a component's invariants warrant one is encouraged — see
+[`felix/DESIGN.md`](felix/DESIGN.md) §5 for the shape to follow.
+
+## 3. Cross-cutting patterns
+
+### Combined `calico` binary
+
+Most component daemons are registered as subcommands of a single
+`calico` binary rather than shipping as independent binaries —
+felix, confd, kube-controllers, goldmane, guardian,
+whisker-backend, key-cert-provisioner, typha, dikastes, csi,
+flexvol, and webhooks all dispatch through
+`calico component <name>`. Inside the node container, runit
+services exec the subcommand directly (see
+`node/filesystem/etc/service/available/<name>/run`).
+
+**Adding a new component:**
+
+1. Expose a `NewCommand() *cobra.Command` from the component's
+   package.
+2. Register it in `cmd/calico/component.go` under
+   `newComponentCommand`.
+3. If the component runs in the node container, add a runit
+   service at `node/filesystem/etc/service/available/<name>/run`
+   whose body is `exec calico component <name>`.
+4. The component's `Run` handler should call
+   `logutils.ConfigureFormatter("<name>")` so log lines carry a
+   consistent component prefix.
+
+**Restart-on-config-change (exit 129):** A component that
+intentionally exits with `cmdwrapper.RestartReturnCode` (129) to
+request a live restart on config change (currently felix and
+kube-controllers) must wrap its cobra `Run` with
+`cmdwrapper.WrapSelf(innerEnvVar, fn)` from `pkg/cmdwrapper`.
+Without this, `exec calico component <name>` from runit just
+exits — there is no outer process to restart the child.
+
+- Pick a unique `innerEnvVar` per component (e.g.
+  `CALICO_FELIX_INNER`, `CALICO_KUBE_CONTROLLERS_INNER`).
+  `WrapSelf` strips any pre-existing value before re-execing.
+- The caller configures logrus before calling `WrapSelf`; `fn`
+  is the inner daemon body.
+- Don't change the log line format in `cmdwrapper` — integration
+  tests grep stdout for `"Received exit status N, restarting"`.
+
+### Health reporting
+
+Components expose liveness/readiness through the shared
+aggregator in `libcalico-go/lib/health`.
+
+1. Construct once per component:
+   `ha := health.NewHealthAggregator()`.
+2. For each independent health source, register a named reporter
+   declaring what it will report:
+   `ha.RegisterReporter("Startup", &health.HealthReport{Live: true, Ready: true}, timeout)`.
+   A non-zero timeout means reports must refresh before expiry
+   or the aggregator treats that reporter as unhealthy — use
+   this for long-running loops where silent stalls matter.
+3. Call `ha.Report(name, &health.HealthReport{...})` at startup
+   and as state changes inside running goroutines.
+4. Serve the endpoints with `ha.ServeHTTP(enabled, host, port)`
+   — this exposes `/readiness` and `/liveness` on the given
+   port.
+
+For Kubernetes probes, use the generic
+`calico health --port=<port> --type=readiness|liveness` exec
+command (`cmd/calico/health.go`) rather than adding a
+per-component healthcheck binary or a bare `httpGet` probe. It
+does the HTTP GET and exits 0 on 2xx/3xx — the standard for pods
+running the combined image.
+
+Examples worth copying from:
+`kube-controllers/pkg/kubecontrollers/run.go` (Startup /
+CalicoDatastore / KubeAPIServer reporters, no timeout) and
+`felix/daemon/daemon.go` (lifecycle reporter plus per-subsystem
+reporters with timeouts).
+
+## 4. Go module structure
+
+- Root `go.mod` (`github.com/projectcalico/calico`) is the
+  primary module for most components.
+- `api/go.mod` (`github.com/projectcalico/api`) is separate (API
+  exported as an independent repo).
+- `lib/std/go.mod` and `lib/httpmachinery/go.mod` are internal
+  libraries with their own modules.
+- When adding Go dependencies:
+  `cd <component> && go mod tidy && cd .. && make check-go-mod`.
+
+## 5. Docker build system
+
+- All builds run inside Docker containers using
+  `calico/go-build` (version pinned in `metadata.mk`).
+- Base images configured in `metadata.mk`.
+- Build cache in `.go-pkg-cache/` (speeds up rebuilds).
+- Supported architectures: amd64, arm64, ppc64le, s390x (plus
+  Windows builds).
+- Cross-compilation via `ARCH=<target>` and binfmt registration
+  (`calico/binfmt`).
+
+## 6. Entry points
+
+| Path | Role |
+|---|---|
+| `cmd/calico/component.go` | Dispatcher for `calico component <name>` |
+| `felix/daemon/daemon.go` | Felix main entry point |
+| `felix/calc/` | Felix calculation graph (policy processing brain) |
+| `felix/dataplane/` | Dataplane implementations (eBPF, iptables, nftables) |
+| `node/pkg/lifecycle/startup/startup.go` | Node initialization |
+| `calicoctl/calicoctl/calicoctl.go` | CLI entry point |
+| `libcalico-go/lib/health/` | Shared health aggregator |
+| `pkg/cmdwrapper/` | Exit-129 restart-on-config-change wrapper |
+
+For deeper architecture (data flow, calculation-graph internals,
+dataplane backends, BPF specifics), see the per-component design
+docs above — Felix in particular has a fleshed-out family of
+sub-designs under [`felix/design/`](felix/design/).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -157,18 +157,7 @@ reporters with timeouts).
 - When adding Go dependencies:
   `cd <component> && go mod tidy && cd .. && make check-go-mod`.
 
-## 5. Docker build system
-
-- All builds run inside Docker containers using
-  `calico/go-build` (version pinned in `metadata.mk`).
-- Base images configured in `metadata.mk`.
-- Build cache in `.go-pkg-cache/` (speeds up rebuilds).
-- Supported architectures: amd64, arm64, ppc64le, s390x (plus
-  Windows builds).
-- Cross-compilation via `ARCH=<target>` and binfmt registration
-  (`calico/binfmt`).
-
-## 6. Entry points
+## 5. Entry points
 
 | Path | Role |
 |---|---|

--- a/node/DESIGN.md
+++ b/node/DESIGN.md
@@ -1,0 +1,49 @@
+# Node — Architecture
+
+The node container orchestrates Calico's per-node lifecycle: it
+bootstraps the node, installs the CNI plugin, and runs the
+per-node daemons (Felix, confd, BIRD) under runit inside a
+single container.
+
+- **Role.** A single multi-process container deployed as a
+  DaemonSet on every cluster node. It is the entry point for
+  Calico on the node — kubelet starts it, and it owns
+  everything from CNI plugin installation through dataplane
+  programming.
+- **Contents.** Runs Felix (dataplane agent), confd
+  (configuration templater), and BIRD (BGP daemon). Each lives
+  as a runit service under
+  `node/filesystem/etc/service/available/<name>/run` and is
+  dispatched via the combined `calico` binary (see root
+  [`DESIGN.md`](../DESIGN.md) → Combined `calico` binary).
+- **Startup.** `node/pkg/lifecycle/startup/startup.go` is the
+  startup entry point — it provisions the node's resources in
+  the datastore (Node resource, BGP peers, etc.) before the
+  per-node daemons take over.
+- **CNI plugin installation.** The node container drops the
+  CNI plugin binary and configuration into the host's CNI
+  directories so kubelet can invoke it for pod-network setup.
+
+## Cross-cutting
+
+- Combined `calico` binary, restart-on-config-change, health
+  reporting, build system: see the root
+  [`DESIGN.md`](../DESIGN.md).
+- Dataplane details (eBPF / iptables / nftables / Windows)
+  live in [`felix/DESIGN.md`](../felix/DESIGN.md) and the
+  per-topic sub-designs under [`felix/design/`](../felix/design/).
+
+## Keep this doc in sync with the code
+
+A PR that changes how the node container works — startup
+sequence, runit service set, CNI plugin installation path, or
+any documented invariant — must update this file in the same
+PR. Exemptions: bug fix restoring documented behaviour,
+mechanical refactor with no observable change, comment /
+log-message edits, dependency bumps. If in doubt, update.
+
+This doc is currently a stub. Sections to flesh out as the
+content grows: startup flow detail (datastore-side resource
+provisioning, lock semantics), runit service supervision and
+restart semantics, CNI plugin installation and upgrade flow,
+BGP integration via BIRD/confd.

--- a/typha/DESIGN.md
+++ b/typha/DESIGN.md
@@ -1,0 +1,39 @@
+# Typha — Architecture
+
+Typha is a fan-out proxy between Felix instances and the
+datastore. It exists so that large clusters (typically >50
+nodes) can scale without each Felix opening its own datastore
+connection.
+
+- **Role.** Sits between Felix instances and the datastore
+  (etcd or the Kubernetes API). Connects once upstream, caches,
+  and fans the stream out to many downstream Felix instances.
+- **Effect.** Reduces datastore load and the number of upstream
+  watchers. Datastore latency to Felix becomes
+  Typha-amortised rather than per-Felix.
+- **Deployment.** Optional but recommended for clusters above
+  ~50 nodes. The typical operator-managed deployment runs
+  Typha as a DaemonSet or Deployment in front of the datastore.
+
+## Cross-cutting
+
+- Combined `calico` binary, restart-on-config-change, health
+  reporting, build system: see the root
+  [`DESIGN.md`](../DESIGN.md).
+- Felix's view of Typha (the consumer side) is documented in
+  [`felix/DESIGN.md`](../felix/DESIGN.md) §1 under the data
+  flow / lifecycle sections.
+
+## Keep this doc in sync with the code
+
+A PR that changes how Typha works — its fan-out behaviour, the
+datastore-side connection shape, the Felix-facing protocol, or
+any documented invariant — must update this file in the same PR.
+Exemptions: bug fix restoring documented behaviour, mechanical
+refactor with no observable change, comment / log-message edits,
+dependency bumps. If in doubt, update.
+
+This doc is currently a stub. Sections to flesh out as the
+content grows: fan-out architecture and connection management,
+the snapshot+delta protocol Felix consumes, scaling
+characteristics, configuration surface.


### PR DESCRIPTION
**Stacked on top of #12511.** Until that PR merges, the diff against `master` includes both sets of commits; the new content in this PR is the last commit only (`Split architecture from .claude/CLAUDE.md into DESIGN.md`).

## Summary

Apply the `CLAUDE.md = ops, DESIGN.md = architecture` pattern at the repo root, mirroring how `felix/` and `goldmane/` already separate their docs. `.claude/CLAUDE.md` was carrying both jobs.

- New root `DESIGN.md` — component dependency tables, per-component `DESIGN.md` index, the Combined `calico` binary pattern, health reporting, Go module structure, Docker build system, and the entry-point map.
- New `typha/DESIGN.md` and `node/DESIGN.md` as stubs (~40 and ~50 lines) holding the blurbs that lived in the root CLAUDE.md, with framing for future expansion. Felix had no equivalent blurb to lift — `felix/DESIGN.md` §1 already covers it.
- `.claude/CLAUDE.md` is now purely operational + cross-cutting process rules (Gotchas, Build commands, Generated Files, Code Conventions, Documentation map, Tests required, Workflows, PR Requirements). Documentation map updated to point at the new root `DESIGN.md` as the architecture entry point.
- "Critical Files and Locations" in CLAUDE.md slimmed: the Component Entry Points list moves to `DESIGN.md` §6; build configuration, kind-cluster infra, and testing locations stay in CLAUDE.md as operational pointers.

Net change: `.claude/CLAUDE.md` shrinks by ~90 lines; the architecture content lands in 3 new files (1 root, 2 component stubs).

## Test plan

- [ ] Visual check that the root `DESIGN.md` reads coherently as an architecture index
- [ ] Stubs (`typha/DESIGN.md`, `node/DESIGN.md`) cover what was in the root CLAUDE.md without inventing facts
- [ ] All cross-references resolve (root → component DESIGN.md, CLAUDE.md → root DESIGN.md)

```release-note
NONE
```