### PR TITLE
fix(felix): exclude LB-only IPPools from all-ipam-pools ipset

### DIFF
--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -666,13 +666,18 @@ func (buf *EventSequencer) OnIPPoolUpdate(key model.IPPoolKey, pool *model.IPPoo
 
 func (buf *EventSequencer) flushIPPoolUpdates() {
 	for key, pool := range buf.pendingIPPoolUpdates {
+		allowedUses := make([]string, len(pool.AllowedUses))
+		for i, u := range pool.AllowedUses {
+			allowedUses[i] = string(u)
+		}
 		buf.Callback(&proto.IPAMPoolUpdate{
 			Id: cidrToIPPoolID(key),
 			Pool: &proto.IPAMPool{
-				Cidr:       pool.CIDR.String(),
-				Masquerade: pool.Masquerade,
-				IpipMode:   string(pool.IPIPMode),
-				VxlanMode:  string(pool.VXLANMode),
+				Cidr:        pool.CIDR.String(),
+				Masquerade:  pool.Masquerade,
+				IpipMode:    string(pool.IPIPMode),
+				VxlanMode:   string(pool.VXLANMode),
+				AllowedUses: allowedUses,
 			},
 		})
 		buf.sentIPPools.Add(key)

--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -18,9 +18,8 @@ import (
 	"slices"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
 
 	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ipsets"

--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -15,6 +15,7 @@
 package intdataplane
 
 import (
+	"slices"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -105,7 +106,9 @@ func (d *masqManager) OnUpdate(msg any) {
 		// defers and coalesces the update so removing then adding the
 		// same IP is a no-op anyway.
 		logCxt.Debug("Removing old pool.")
-		d.ipsetsDataplane.RemoveMembers(rules.IPSetIDAllPools, []string{oldPool.Cidr})
+		if !isLoadBalancerOnly(oldPool) {
+			d.ipsetsDataplane.RemoveMembers(rules.IPSetIDAllPools, []string{oldPool.Cidr})
+		}
 		if oldPool.Masquerade {
 			logCxt.Debug("Masquerade was enabled on pool.")
 			d.ipsetsDataplane.RemoveMembers(rules.IPSetIDNATOutgoingMasqPools, []string{oldPool.Cidr})
@@ -123,8 +126,15 @@ func (d *masqManager) OnUpdate(msg any) {
 		}
 
 		// Update the IP sets.
-		logCxt.Debug("Adding IPAM pool to IP sets.")
-		d.ipsetsDataplane.AddMembers(rules.IPSetIDAllPools, []string{newPool.Cidr})
+		// Exclude pools that are exclusively for LoadBalancer use from the
+		// all-ipam-pools ipset. These pools don't contain workload or tunnel
+		// addresses, so traffic destined to them should still be masqueraded.
+		if !isLoadBalancerOnly(newPool) {
+			logCxt.Debug("Adding IPAM pool to all-pools IP set.")
+			d.ipsetsDataplane.AddMembers(rules.IPSetIDAllPools, []string{newPool.Cidr})
+		} else {
+			logCxt.Debug("Skipping LoadBalancer-only pool from all-pools IP set.")
+		}
 		if newPool.Masquerade {
 			logCxt.Debug("IPAM has masquerade enabled.")
 			d.ipsetsDataplane.AddMembers(rules.IPSetIDNATOutgoingMasqPools, []string{newPool.Cidr})
@@ -148,4 +158,17 @@ func (m *masqManager) CompleteDeferredWork() error {
 	m.dirty = false
 
 	return nil
+}
+
+// isLoadBalancerOnly returns true if the pool's AllowedUses contains only
+// "LoadBalancer" and no workload/tunnel uses. Such pools should not be
+// included in the all-ipam-pools ipset because their CIDRs do not represent
+// local workload addresses and traffic to them should still be masqueraded.
+func isLoadBalancerOnly(pool *proto.IPAMPool) bool {
+	uses := pool.GetAllowedUses()
+	if len(uses) == 0 {
+		// Empty means default (Workload + Tunnel), so include in all-pools.
+		return false
+	}
+	return !slices.Contains(uses, "Workload") && !slices.Contains(uses, "Tunnel")
 }

--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -131,11 +131,11 @@ func (d *masqManager) OnUpdate(msg any) {
 		// Exclude pools that are exclusively for LoadBalancer use from the
 		// all-ipam-pools ipset. These pools don't contain workload or tunnel
 		// addresses, so traffic destined to them should still be masqueraded.
-		if !isLoadBalancerOnly(newPool) {
+		if isLoadBalancerOnly(newPool) {
+			logCxt.Debug("Skipping LoadBalancer-only pool from all-pools IP set.")
+		} else {
 			logCxt.Debug("Adding IPAM pool to all-pools IP set.")
 			d.ipsetsDataplane.AddMembers(rules.IPSetIDAllPools, []string{newPool.Cidr})
-		} else {
-			logCxt.Debug("Skipping LoadBalancer-only pool from all-pools IP set.")
 		}
 		if newPool.Masquerade {
 			logCxt.Debug("IPAM has masquerade enabled.")

--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -20,6 +20,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/felix/proto"
@@ -170,5 +172,5 @@ func isLoadBalancerOnly(pool *proto.IPAMPool) bool {
 		// Empty means default (Workload + Tunnel), so include in all-pools.
 		return false
 	}
-	return !slices.Contains(uses, "Workload") && !slices.Contains(uses, "Tunnel")
+	return slices.Contains(uses, string(apiv3.IPPoolAllowedUseLoadBalancer)) && len(uses) == 1
 }

--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -129,12 +129,12 @@ func (d *masqManager) OnUpdate(msg any) {
 
 		// Update the IP sets.
 		// Exclude pools that are exclusively for LoadBalancer use from the
-		// all-ipam-pools ipset. These pools don't contain workload or tunnel
+		// network-ip-pools ipset. These pools don't contain workload or tunnel
 		// addresses, so traffic destined to them should still be masqueraded.
 		if isLoadBalancerOnly(newPool) {
-			logCxt.Debug("Skipping LoadBalancer-only pool from all-pools IP set.")
+			logCxt.Debug("Skipping LoadBalancer-only pool from network-ip-pools IP set.")
 		} else {
-			logCxt.Debug("Adding IPAM pool to all-pools IP set.")
+			logCxt.Debug("Adding IPAM pool to network-ip-pools IP set.")
 			d.ipsetsDataplane.AddMembers(rules.IPSetIDAllPools, []string{newPool.Cidr})
 		}
 		if newPool.Masquerade {
@@ -164,12 +164,12 @@ func (m *masqManager) CompleteDeferredWork() error {
 
 // isLoadBalancerOnly returns true if the pool's AllowedUses contains only
 // "LoadBalancer" and no workload/tunnel uses. Such pools should not be
-// included in the all-ipam-pools ipset because their CIDRs do not represent
+// included in the network-ip-pools ipset because their CIDRs do not represent
 // local workload addresses and traffic to them should still be masqueraded.
 func isLoadBalancerOnly(pool *proto.IPAMPool) bool {
 	uses := pool.GetAllowedUses()
 	if len(uses) == 0 {
-		// Empty means default (Workload + Tunnel), so include in all-pools.
+		// Empty means default (Workload + Tunnel), so include in network-ip-pools.
 		return false
 	}
 	return slices.Contains(uses, string(apiv3.IPPoolAllowedUseLoadBalancer)) && len(uses) == 1

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -17,7 +17,6 @@ package intdataplane
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
@@ -59,8 +58,8 @@ var _ = Describe("Masquerade manager", func() {
 
 	It("should create its IP sets on startup", func() {
 		Expect(ipSets.Members).To(Equal(map[string]set.Set[string]{
-			"network-ip-pools":  set.New[string](),
-			"masq-ipam-pools": set.New[string](),
+			"network-ip-pools": set.New[string](),
+			"masq-ipam-pools":  set.New[string](),
 		}))
 	})
 

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -227,4 +227,64 @@ var _ = Describe("Masquerade manager", func() {
 			}}})
 		})
 	})
+
+	Describe("after adding a LoadBalancer-only pool", func() {
+		BeforeEach(func() {
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "lb-pool",
+				Pool: &proto.IPAMPool{
+					Cidr:        "10.20.40.64/27",
+					Masquerade:  true,
+					AllowedUses: []string{"LoadBalancer"},
+				},
+			})
+			err := masqMgr.CompleteDeferredWork()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should add the pool to the masq IP set", func() {
+			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.20.40.64/27")))
+		})
+		It("should NOT add the pool to the all IP set", func() {
+			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.New[string]()))
+		})
+
+		Describe("after removing the LoadBalancer-only pool", func() {
+			BeforeEach(func() {
+				masqMgr.OnUpdate(&proto.IPAMPoolRemove{
+					Id: "lb-pool",
+				})
+				err := masqMgr.CompleteDeferredWork()
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("masq set should be empty", func() {
+				Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New[string]()))
+			})
+			It("all set should be empty", func() {
+				Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.New[string]()))
+			})
+		})
+	})
+
+	Describe("after adding a pool with Workload and LoadBalancer uses", func() {
+		BeforeEach(func() {
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "mixed-pool",
+				Pool: &proto.IPAMPool{
+					Cidr:        "10.1.0.0/16",
+					Masquerade:  true,
+					AllowedUses: []string{"Workload", "LoadBalancer"},
+				},
+			})
+			err := masqMgr.CompleteDeferredWork()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should add the pool to the masq IP set", func() {
+			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.1.0.0/16")))
+		})
+		It("should add the pool to the all IP set since it includes Workload", func() {
+			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.1.0.0/16")))
+		})
+	})
 })

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -18,6 +18,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/generictables"
 	"github.com/projectcalico/calico/felix/ipsets"
@@ -235,7 +237,7 @@ var _ = Describe("Masquerade manager", func() {
 				Pool: &proto.IPAMPool{
 					Cidr:        "10.20.40.64/27",
 					Masquerade:  true,
-					AllowedUses: []string{"LoadBalancer"},
+					AllowedUses: []string{string(apiv3.IPPoolAllowedUseLoadBalancer)},
 				},
 			})
 			err := masqMgr.CompleteDeferredWork()
@@ -273,7 +275,7 @@ var _ = Describe("Masquerade manager", func() {
 				Pool: &proto.IPAMPool{
 					Cidr:        "10.1.0.0/16",
 					Masquerade:  true,
-					AllowedUses: []string{"Workload", "LoadBalancer"},
+					AllowedUses: []string{string(apiv3.IPPoolAllowedUseWorkload), string(apiv3.IPPoolAllowedUseLoadBalancer)},
 				},
 			})
 			err := masqMgr.CompleteDeferredWork()
@@ -285,6 +287,36 @@ var _ = Describe("Masquerade manager", func() {
 		})
 		It("should add the pool to the all IP set since it includes Workload", func() {
 			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.1.0.0/16")))
+		})
+	})
+
+	Describe("after adding a Workload pool and a LoadBalancer-only pool", func() {
+		BeforeEach(func() {
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "workload-pool",
+				Pool: &proto.IPAMPool{
+					Cidr:        "10.0.0.0/16",
+					Masquerade:  false,
+					AllowedUses: []string{string(apiv3.IPPoolAllowedUseWorkload)},
+				},
+			})
+			masqMgr.OnUpdate(&proto.IPAMPoolUpdate{
+				Id: "lb-pool",
+				Pool: &proto.IPAMPool{
+					Cidr:        "10.20.0.0/16",
+					Masquerade:  true,
+					AllowedUses: []string{string(apiv3.IPPoolAllowedUseLoadBalancer)},
+				},
+			})
+			err := masqMgr.CompleteDeferredWork()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should only add the Workload pool to the all IP set", func() {
+			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+		})
+		It("should only add the LoadBalancer pool to the masq IP set", func() {
+			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.20.0.0/16")))
 		})
 	})
 })

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Masquerade manager", func() {
 
 	It("should create its IP sets on startup", func() {
 		Expect(ipSets.Members).To(Equal(map[string]set.Set[string]{
-			"all-ipam-pools":  set.New[string](),
+			"network-ip-pools":  set.New[string](),
 			"masq-ipam-pools": set.New[string](),
 		}))
 	})
@@ -89,7 +89,7 @@ var _ = Describe("Masquerade manager", func() {
 			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
 		})
 		It("should add the pool to the all IP set", func() {
-			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+			Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.From("10.0.0.0/16")))
 		})
 		It("should program the chain", func() {
 			Expect(natTable.UpdateCalled).To(BeTrue())
@@ -100,7 +100,7 @@ var _ = Describe("Masquerade manager", func() {
 						Action: iptables.MasqAction{},
 						Match: iptables.Match().
 							SourceIPSet("cali40masq-ipam-pools").
-							NotDestIPSet("cali40all-ipam-pools"),
+							NotDestIPSet("cali40network-ip-pools"),
 					},
 				},
 			}}})
@@ -139,7 +139,7 @@ var _ = Describe("Masquerade manager", func() {
 				Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
 			})
 			It("should add the pool to the all IP set", func() {
-				Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From(
+				Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.From(
 					"10.0.0.0/16", "10.2.0.0/16")))
 			})
 			It("should program the chain", func() {
@@ -150,7 +150,7 @@ var _ = Describe("Masquerade manager", func() {
 							Action: iptables.MasqAction{},
 							Match: iptables.Match().
 								SourceIPSet("cali40masq-ipam-pools").
-								NotDestIPSet("cali40all-ipam-pools"),
+								NotDestIPSet("cali40network-ip-pools"),
 						},
 					},
 				}}})
@@ -168,7 +168,7 @@ var _ = Describe("Masquerade manager", func() {
 					Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New[string]()))
 				})
 				It("should remove from the all IP set", func() {
-					Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From(
+					Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.From(
 						"10.2.0.0/16")))
 				})
 				It("should program empty chain", func() {
@@ -190,7 +190,7 @@ var _ = Describe("Masquerade manager", func() {
 						Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New[string]()))
 					})
 					It("all set should be empty", func() {
-						Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.New[string]()))
+						Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.New[string]()))
 					})
 					It("should program empty chain", func() {
 						natTable.checkChains([][]*generictables.Chain{{{
@@ -220,7 +220,7 @@ var _ = Describe("Masquerade manager", func() {
 			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New[string]()))
 		})
 		It("should add the pool to the all IP set", func() {
-			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+			Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.From("10.0.0.0/16")))
 		})
 		It("should program empty chain", func() {
 			natTable.checkChains([][]*generictables.Chain{{{
@@ -248,7 +248,7 @@ var _ = Describe("Masquerade manager", func() {
 			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.20.40.64/27")))
 		})
 		It("should NOT add the pool to the all IP set", func() {
-			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.New[string]()))
+			Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.New[string]()))
 		})
 
 		Describe("after removing the LoadBalancer-only pool", func() {
@@ -263,7 +263,7 @@ var _ = Describe("Masquerade manager", func() {
 				Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.New[string]()))
 			})
 			It("all set should be empty", func() {
-				Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.New[string]()))
+				Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.New[string]()))
 			})
 		})
 	})
@@ -286,7 +286,7 @@ var _ = Describe("Masquerade manager", func() {
 			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.1.0.0/16")))
 		})
 		It("should add the pool to the all IP set since it includes Workload", func() {
-			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.1.0.0/16")))
+			Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.From("10.1.0.0/16")))
 		})
 	})
 
@@ -313,7 +313,7 @@ var _ = Describe("Masquerade manager", func() {
 		})
 
 		It("should only add the Workload pool to the all IP set", func() {
-			Expect(ipSets.Members["all-ipam-pools"]).To(Equal(set.From("10.0.0.0/16")))
+			Expect(ipSets.Members["network-ip-pools"]).To(Equal(set.From("10.0.0.0/16")))
 		})
 		It("should only add the LoadBalancer pool to the masq IP set", func() {
 			Expect(ipSets.Members["masq-ipam-pools"]).To(Equal(set.From("10.20.0.0/16")))

--- a/felix/fv/cali-nftables-dump.txt
+++ b/felix/fv/cali-nftables-dump.txt
@@ -5,7 +5,7 @@ table ip calico {
 			     127.0.0.1, 192.168.122.1 }
 	}
 
-	set cali40all-ipam-pools {
+	set cali40network-ip-pools {
 		type ipv4_addr
 		flags interval
 		elements = { 192.168.0.0/16 }
@@ -123,7 +123,7 @@ table ip calico {
 	}
 
 	chain nat-cali-nat-outgoing {
-		ip saddr @cali40masq-ipam-pools ip daddr != @cali40all-ipam-pools counter packets 0 bytes 0 masquerade fully-random comment "cali:JjuWIaIfSLZi41Xk;"
+		ip saddr @cali40masq-ipam-pools ip daddr != @cali40network-ip-pools counter packets 0 bytes 0 masquerade fully-random comment "cali:JjuWIaIfSLZi41Xk;"
 	}
 
 	chain mangle-cali-PREROUTING {

--- a/felix/fv/dscp_test.go
+++ b/felix/fv/dscp_test.go
@@ -156,7 +156,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 			if ipVersion == 6 {
 				binary = "ip6tables-save"
 			}
-			allPoolsIPSet := fmt.Sprintf("cali%v0all-ipam-pools", ipVersion)
+			allPoolsIPSet := fmt.Sprintf("cali%v0network-ip-pools", ipVersion)
 			thisHostIPSet := fmt.Sprintf("cali%v0this-host", ipVersion)
 			dscpIPSet := fmt.Sprintf("cali%v0dscp-src-net", ipVersion)
 			tmpl := "-m set --match-set %v src -m set ! --match-set %v dst -m set ! --match-set %v dst -j cali-egress-dscp"
@@ -174,7 +174,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 			if ipVersion == 6 {
 				ipFamily = "ip6"
 			}
-			allPoolsIPSet := fmt.Sprintf("@cali%v0all-ipam-pools", ipVersion)
+			allPoolsIPSet := fmt.Sprintf("@cali%v0network-ip-pools", ipVersion)
 			thisHostIPSet := fmt.Sprintf("@cali%v0this-host", ipVersion)
 			dscpIPSet := fmt.Sprintf("@cali%v0dscp-src-net", ipVersion)
 			tmpl := "%v saddr %v %v daddr != %v %v daddr != %v .* jump mangle-cali-egress-dscp"

--- a/felix/proto/felixbackend.pb.go
+++ b/felix/proto/felixbackend.pb.go
@@ -4520,6 +4520,7 @@ type IPAMPool struct {
 	Masquerade    bool                   `protobuf:"varint,2,opt,name=masquerade,proto3" json:"masquerade,omitempty"`
 	IpipMode      string                 `protobuf:"bytes,3,opt,name=ipip_mode,json=ipipMode,proto3" json:"ipip_mode,omitempty"`
 	VxlanMode     string                 `protobuf:"bytes,4,opt,name=vxlan_mode,json=vxlanMode,proto3" json:"vxlan_mode,omitempty"`
+	AllowedUses   []string               `protobuf:"bytes,5,rep,name=allowed_uses,json=allowedUses,proto3" json:"allowed_uses,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4580,6 +4581,13 @@ func (x *IPAMPool) GetVxlanMode() string {
 		return x.VxlanMode
 	}
 	return ""
+}
+
+func (x *IPAMPool) GetAllowedUses() []string {
+	if x != nil {
+		return x.AllowedUses
+	}
+	return nil
 }
 
 type Encapsulation struct {
@@ -6545,7 +6553,7 @@ const file_felixbackend_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12#\n" +
 	"\x04pool\x18\x02 \x01(\v2\x0f.felix.IPAMPoolR\x04pool\" \n" +
 	"\x0eIPAMPoolRemove\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"z\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x9d\x01\n" +
 	"\bIPAMPool\x12\x12\n" +
 	"\x04cidr\x18\x01 \x01(\tR\x04cidr\x12\x1e\n" +
 	"\n" +
@@ -6553,7 +6561,8 @@ const file_felixbackend_proto_rawDesc = "" +
 	"masquerade\x12\x1b\n" +
 	"\tipip_mode\x18\x03 \x01(\tR\bipipMode\x12\x1d\n" +
 	"\n" +
-	"vxlan_mode\x18\x04 \x01(\tR\tvxlanMode\"\xab\x01\n" +
+	"vxlan_mode\x18\x04 \x01(\tR\tvxlanMode\x12!\n" +
+	"\fallowed_uses\x18\x05 \x03(\tR\vallowedUses\"\xab\x01\n" +
 	"\rEncapsulation\x12!\n" +
 	"\fipip_enabled\x18\x01 \x01(\bR\vipipEnabled\x12#\n" +
 	"\rvxlan_enabled\x18\x02 \x01(\bR\fvxlanEnabled\x12(\n" +

--- a/felix/proto/felixbackend.proto
+++ b/felix/proto/felixbackend.proto
@@ -560,6 +560,7 @@ message IPAMPool {
   bool masquerade = 2;
   string ipip_mode = 3;
   string vxlan_mode = 4;
+  repeated string allowed_uses = 5;
 }
 
 message Encapsulation {

--- a/felix/rules/nat_test.go
+++ b/felix/rules/nat_test.go
@@ -55,7 +55,7 @@ var _ = Describe("NAT", func() {
 					Action: MasqAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools"),
+						NotDestIPSet("cali40network-ip-pools"),
 				},
 			},
 		}))
@@ -72,7 +72,7 @@ var _ = Describe("NAT", func() {
 					Action: MasqAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").
+						NotDestIPSet("cali40network-ip-pools").
 						NotDestIPSet("cali40all-hosts-net"),
 				},
 			},
@@ -91,7 +91,7 @@ var _ = Describe("NAT", func() {
 					Action: SNATAction{ToAddr: snatAddress},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools"),
+						NotDestIPSet("cali40network-ip-pools"),
 				},
 			},
 		}))
@@ -109,31 +109,31 @@ var _ = Describe("NAT", func() {
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
 				},
 				{
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
 				},
 				{
 					Action: MasqAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools"),
+						NotDestIPSet("cali40network-ip-pools"),
 				},
 			},
 		}))
@@ -152,35 +152,35 @@ var _ = Describe("NAT", func() {
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp").
+						NotDestIPSet("cali40network-ip-pools").Protocol("tcp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp").
+						NotDestIPSet("cali40network-ip-pools").Protocol("tcp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("udp").
+						NotDestIPSet("cali40network-ip-pools").Protocol("udp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("udp").
+						NotDestIPSet("cali40network-ip-pools").Protocol("udp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: MasqAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").
+						NotDestIPSet("cali40network-ip-pools").
 						OutInterface("cali-123"),
 				},
 			},
@@ -203,31 +203,31 @@ var _ = Describe("NAT", func() {
 					Action: SNATAction{ToAddr: expectedAddress},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("tcp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
 				},
 				{
 					Action: SNATAction{ToAddr: expectedAddress},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools").Protocol("udp"),
+						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
 				},
 				{
 					Action: SNATAction{ToAddr: snatAddress},
 					Match: Match().
 						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40all-ipam-pools"),
+						NotDestIPSet("cali40network-ip-pools"),
 				},
 			},
 		}))

--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -64,7 +64,7 @@ const (
 	ChainEgressDSCP      = ChainNamePrefix + "egress-dscp"
 	IPSetIDDSCPEndpoints = "dscp-src-net"
 
-	IPSetIDAllPools             = "all-ipam-pools"
+	IPSetIDAllPools             = "network-ip-pools"
 	IPSetIDNATOutgoingMasqPools = "masq-ipam-pools"
 
 	IPSetIDAllHostNets        = "all-hosts-net"

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Static", func() {
 		It("should generate expected cali-POSTROUTING chain in the mangle table", func() {
 			expRules := []generictables.Rule{}
 			if !rr.BPFEnabled {
-				allPoolSetName := fmt.Sprintf("cali%v0all-ipam-pools", ipVersion)
+				allPoolSetName := fmt.Sprintf("cali%v0network-ip-pools", ipVersion)
 				thisHostSetName := fmt.Sprintf("cali%v0this-host", ipVersion)
 				dscpSetName := fmt.Sprintf("cali%v0dscp-src-net", ipVersion)
 				expRules = append(expRules, generictables.Rule{

--- a/libcalico-go/lib/backend/k8s/resources/ippool.go
+++ b/libcalico-go/lib/backend/k8s/resources/ippool.go
@@ -104,6 +104,7 @@ func IPPoolV3ToV1(kvp *model.KVPair) (*model.KVPair, error) {
 			Disabled:         v3res.Spec.Disabled,
 			DisableBGPExport: v3res.Spec.DisableBGPExport,
 			AssignmentMode:   *v3res.Spec.AssignmentMode,
+			AllowedUses:      v3res.Spec.AllowedUses,
 		},
 		Revision: kvp.Revision,
 	}, nil

--- a/libcalico-go/lib/backend/model/ippool.go
+++ b/libcalico-go/lib/backend/model/ippool.go
@@ -105,13 +105,14 @@ func (options IPPoolListOptions) KeyFromDefaultPath(path string) Key {
 }
 
 type IPPool struct {
-	CIDR             net.IPNet         `json:"cidr"`
-	IPIPInterface    string            `json:"ipip"`
-	IPIPMode         encap.Mode        `json:"ipip_mode"`
-	VXLANMode        encap.Mode        `json:"vxlan_mode"`
-	Masquerade       bool              `json:"masquerade"`
-	IPAM             bool              `json:"ipam"`
-	Disabled         bool              `json:"disabled"`
-	DisableBGPExport bool              `json:"disableBGPExport"`
-	AssignmentMode   v3.AssignmentMode `json:"assignment_mode"`
+	CIDR             net.IPNet             `json:"cidr"`
+	IPIPInterface    string                `json:"ipip"`
+	IPIPMode         encap.Mode            `json:"ipip_mode"`
+	VXLANMode        encap.Mode            `json:"vxlan_mode"`
+	Masquerade       bool                  `json:"masquerade"`
+	IPAM             bool                  `json:"ipam"`
+	Disabled         bool                  `json:"disabled"`
+	DisableBGPExport bool                  `json:"disableBGPExport"`
+	AssignmentMode   v3.AssignmentMode     `json:"assignment_mode"`
+	AllowedUses      []v3.IPPoolAllowedUse `json:"allowedUses,omitempty"`
 }

--- a/libcalico-go/lib/backend/model/ippool.go
+++ b/libcalico-go/lib/backend/model/ippool.go
@@ -114,5 +114,5 @@ type IPPool struct {
 	Disabled         bool                  `json:"disabled"`
 	DisableBGPExport bool                  `json:"disableBGPExport"`
 	AssignmentMode   v3.AssignmentMode     `json:"assignment_mode"`
-	AllowedUses      []v3.IPPoolAllowedUse `json:"allowedUses,omitempty"`
+	AllowedUses      []v3.IPPoolAllowedUse `json:"allowed_uses,omitempty"`
 }

--- a/libcalico-go/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/bgpsyncer/bgpsyncer_e2e_test.go
@@ -189,6 +189,7 @@ var _ = testutils.E2eDatastoreDescribe("BGP syncer tests", testutils.DatastoreAl
 					IPAM:           true,
 					Disabled:       false,
 					AssignmentMode: apiv3.Automatic,
+					AllowedUses:    []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseWorkload, apiv3.IPPoolAllowedUseTunnel},
 				},
 				Revision: pool.ResourceVersion,
 			})

--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -460,6 +460,7 @@ var _ = testutils.E2eDatastoreDescribe("Felix syncer tests", testutils.Datastore
 					IPAM:           true,
 					Disabled:       false,
 					AssignmentMode: apiv3.Automatic,
+					AllowedUses:    []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseWorkload, apiv3.IPPoolAllowedUseTunnel},
 				},
 				Revision: pool.ResourceVersion,
 			})

--- a/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/tunnelipsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/tunnelipsyncer/tunnelipsyncer_e2e_test.go
@@ -108,6 +108,7 @@ var _ = testutils.E2eDatastoreDescribe("Tunnel IP allocation syncer tests", test
 					IPAM:           true,
 					Disabled:       false,
 					AssignmentMode: apiv3.Automatic,
+					AllowedUses:    []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseWorkload, apiv3.IPPoolAllowedUseTunnel},
 				},
 				Revision: pool.ResourceVersion,
 			})


### PR DESCRIPTION
IPPools with `allowedUses: [LoadBalancer]` were unconditionally added to the `cali40all-ipam-pools` ipset, causing traffic destined to LoadBalancer VIPs to be exempted from SNAT. This broke cross-cluster connectivity when a shared LB pool was used across clusters.

Only add pools that include Workload or Tunnel uses to the `all-ipam-pools` ipset. LoadBalancer-only pools are excluded so that the NAT-outgoing rule continues to masquerade traffic destined to those CIDRs.

Fixes: https://github.com/projectcalico/calico/issues/12767

BPF may have a similar issue but is out of scope for this PR.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Fix SNAT being skipped for traffic destined to LoadBalancer-only IPPools by excluding them from the all-ipam-pools ipset.
```
