### PR TITLE
OpenStack: add Neutron->Calico resync scale benchmark for CI

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1693,6 +1693,8 @@ blocks:
         machine:
           type: f1-standard-2
           os_image: ubuntu2204
+      secrets:
+        - name: banzai-secrets
       prologue:
         commands:
           - cd networking-calico
@@ -1702,6 +1704,10 @@ blocks:
             - ../.semaphore/run-and-monitor tox.log make tox-caracal
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
+            # Env vars needed for saving performance results.
+            - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
+            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
             # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
             # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
             # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5147,6 +5147,8 @@ blocks:
         machine:
           type: f1-standard-2
           os_image: ubuntu2204
+      secrets:
+        - name: banzai-secrets
       prologue:
         commands:
           - cd networking-calico
@@ -5156,6 +5158,10 @@ blocks:
             - ../.semaphore/run-and-monitor tox.log make tox-caracal
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
+            # Env vars needed for saving performance results.
+            - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
+            - export ELASTICSEARCH_USER=elastic
+            - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
             # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
             # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
             # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -8,6 +8,8 @@
       machine:
         type: f1-standard-2
         os_image: ubuntu2204
+    secrets:
+      - name: banzai-secrets
     prologue:
       commands:
         - cd networking-calico
@@ -17,6 +19,10 @@
           - ../.semaphore/run-and-monitor tox.log make tox-caracal
       - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
         commands:
+          # Env vars needed for saving performance results.
+          - export ELASTICSEARCH_URL=https://banzai-lens-es.dev-tools.tigera.net:9200
+          - export ELASTICSEARCH_USER=elastic
+          - export ELASTICSEARCH_TOKEN=${LENS_ELASTICSEARCH_TOKEN}
           # For some reason python3-wrapt is pre-installed on a Semaphore ubuntu2004 node, but with
           # a version (1.11.2) that is different from the version that OpenStack needs (1.13.3), and
           # this was causing the DevStack setup to fail, because pip doesn't know how to uninstall

--- a/hack/deps.txt
+++ b/hack/deps.txt
@@ -117,6 +117,7 @@ local:hack/cmd/deps
 local:hack/cmd/format-go-file
 local:hack/cmd/gomodder
 local:hack/cmd/ipam-hammer
+local:hack/perf/cmd/send-perf-results
 local:hack/test/spider
 local:lib/std/uniquelabels
 local:lib/std/uniquestr

--- a/hack/perf/README.md
+++ b/hack/perf/README.md
@@ -1,0 +1,407 @@
+# Cross-monorepo performance-result publishing
+
+This directory is the canonical home for plumbing that gets perf-test
+measurements into the Lens Elasticsearch cluster, where they can be tracked
+over time.
+
+## Why this exists
+
+The monorepo has a growing collection of perf tests -- tiger-bench,
+`felix/k8sfv`, OpenStack Neutron→etcd resync timings, and others -- but
+historically their results have been ephemeral: printed to a CI log, then lost
+when the log rotates.  That makes it impossible to answer questions like "did
+this PR slow down endpoint programming?" or "has Felix memory occupancy been
+creeping up over the last quarter?"
+
+The Lens ES/Kibana stack at `banzai-lens.dev-tools.tigera.net` gives us a
+place to land structured perf data and visualise it over time.  This README
+covers how to wire a new test into it.  Tiger-bench's
+`pkg/elasticsearch/elasticsearch.go` is prior art and worth reading if you're
+curious about the lower-level ES client side; this directory abstracts that
+away behind a producer-side "write JSON files" contract.
+
+This is **not** about per-PR perf gating (synchronous, blocks merges).  It's
+about long-term trend visibility: spotting gradual regressions, validating
+performance work, and comparing dataplanes/branches over time.
+
+## The Lens store
+
+- **ES + Kibana**: <https://banzai-lens.dev-tools.tigera.net>
+- **Existing dashboards**: tiger-bench results live at
+  `/app/dashboards#/view/856d49ee-c097-4c58-a6e7-1433475698fc`.
+- **Credentials and endpoint**: ask in `#banzai` (or whoever owns the Lens
+  cluster) for the ES endpoint URL (set as `ELASTICSEARCH_URL` -- typically
+  on port 9200, distinct from the Kibana URL above) plus *one* of:
+  - `ELASTICSEARCH_USER` + `ELASTICSEARCH_TOKEN` (basic auth), or
+  - `ELASTICSEARCH_KEY` (API key -- preferred).
+- **In CI**: wire these as Semaphore secrets attached to the pipeline that
+  runs your test.
+- **Locally**: same env vars work, but see [Operational hygiene](#operational-hygiene)
+  -- don't pollute trend data with dev runs.
+
+## What lives here
+
+```
+hack/perf/
+├── cmd/send-perf-results/main.go     The tool that pushes JSON docs to ES.
+├── index-templates/<family>.json     One ES index template per family.
+└── README.md                         (this file)
+```
+
+## How a test publishes a measurement
+
+A test producing perf data does **two** things:
+
+1. Write one JSON file per measurement to
+   `artifacts/perf/<index_family>/<descriptive_name>.json`.  Each file is a
+   single ES document containing **only the scenario-specific scalars** --
+   scale dimensions, metrics, test_name, and so on.  CI metadata
+   (`git_commit`, `ci_run_id`, etc.) is NOT the producer's job.  See
+   [Schema](#schema-what-makes-a-good-datapoint) below for what counts as
+   scenario-specific.
+
+2. Arrange for `send-perf-results` to run once at the end of the producing
+   Semaphore job.  The simplest pattern is to add a line near the end of the
+   job's commands:
+
+   ```sh
+   go run ./hack/perf/cmd/send-perf-results --dir artifacts/perf
+   ```
+
+   (or invoke a pre-built binary).  Calling it exactly once per job is the
+   only operational discipline required -- see [Idempotency](#idempotency).
+
+`artifacts/perf/` lives under the existing `artifacts/` upload, so the
+per-measurement JSON files are also automatically captured as Semaphore
+artifacts -- useful for post-mortem when a number looks off.
+
+## What `send-perf-results` does
+
+On each invocation, in order:
+
+1. **Apply index templates.**  For every `hack/perf/index-templates/<family>.json`,
+   PUT it to `/_index_template/<family>` in ES.  Idempotent upsert; committing
+   a template change propagates automatically on the next CI run.
+2. **Walk `artifacts/perf/<family>/*.json`** for every `<family>` subdirectory.
+3. **Augment each doc** with CI metadata (`@timestamp`, `git_commit`,
+   `git_branch`, `code_version`, `ci_run_id`, `pr_number`, `env`) unless the
+   producer already supplied that field -- producer values win.  Picked up
+   from `SEMAPHORE_GIT_SHA`, `SEMAPHORE_GIT_BRANCH`, `SEMAPHORE_JOB_ID`,
+   `SEMAPHORE_GIT_PR_NUMBER`.
+4. **POST to `<family>_<UTC year>/_doc`.**  The year suffix is computed at
+   send time; producer side stays date-free.  ES auto-creates the dated
+   index on first write using the template applied in step 1.
+5. Exit 0.
+
+"Lens is observability, not a critical path": the tool only returns non-zero
+in genuinely unrecoverable cases.  Missing credentials, unreachable ES,
+malformed JSON, mapping conflicts -- all log a warning and continue.  A
+`--require-creds` flag flips the missing-creds case to a hard failure, for
+places that want a strict gate on the publish step.
+
+## Schema: what makes a good datapoint
+
+**One measurement = one document.**  Don't push your test's whole raw output
+as a single deeply-nested doc; decompose it into individual scalar
+measurements first.
+
+**Flat scalars only.**  Every field should be a scalar (string, number,
+boolean) or a flat array of scalars.  Avoid:
+
+- **Nested objects** (e.g. `cold.phases.endpoints.compare_ms`).  They
+  technically work, but they're harder to discover in Kibana and they make
+  visualisations clunkier than they need to be.
+- **Arrays of objects** (e.g. `steady: [{phases: ...}, {phases: ...}]`).
+  ES's default mapping flattens these into parallel arrays-of-scalars,
+  losing per-element correlation.  Lens can't chart them; the proper fix
+  (mapping the field as `nested` type) makes them queryable but Lens *still*
+  won't chart them -- you'd have to drop down to TSVB or Vega.
+
+If your test produces multiple sub-measurements (e.g. a "cold" run plus
+three "steady" iterations), explode them into separate documents
+distinguished by `phase` / `iter` / `test_step` fields.  See
+[Patterns for tricky cases](#patterns-for-tricky-cases).
+
+### Producer-supplied fields
+
+Scenario-specific scalars are the producer's responsibility:
+
+- **`test_name`** -- a stable string identifying the scenario family,
+  distinct from the index name (e.g. `neutron_resync`).
+- **Scale parameters** -- e.g. `scale_endpoints: 10000`, `scale_policies:
+  100`, `scale_hosts: 10`.  Field names should be specific to your scenario,
+  but consistent within a test.
+- **The measured metrics**, flattened (e.g. `endpoints_total_ms`, not
+  `endpoints.total_ms`).
+- **`phase` / `iter` / `test_step` keywords** if the doc is one of several
+  related sub-measurements.
+- **`ok: bool`** and optional **`error: string`** if the test can partially
+  succeed.
+- **Scenario context** when applicable: `dataplane` (`iptables`,
+  `nftables`, `ebpf`), `encap` (`vxlan`, `ipip`, `none`), `k8s_version`,
+  `cloud` (`gcp`, `aws`, `azure`, `kind`), `node_type`, `node_count`.
+
+### Tool-injected fields (don't set these)
+
+`send-perf-results` adds these from the CI environment unless the producer
+already supplied a value (producer wins):
+
+- **`@timestamp`** -- ISO-8601 UTC; Kibana's time field.
+- **`git_commit`** -- from `SEMAPHORE_GIT_SHA`.
+- **`git_branch`** -- from `SEMAPHORE_GIT_BRANCH`.
+- **`code_version`** -- short SHA derived from `git_commit`.
+- **`ci_run_id`** -- from `SEMAPHORE_JOB_ID`.
+- **`pr_number`** -- from `SEMAPHORE_GIT_PR_NUMBER`, if set.
+- **`env`** -- `ci` if `SEMAPHORE_JOB_ID` is set, else `dev`.  Filter
+  dashboards to `env: ci` to keep dev runs out of trend data.
+
+### `phase` vs `iter` vs `test_step`
+
+- **`iter`** *(integer)*: index of a repeated whole-test iteration
+  (e.g. `0` for cold, `1..N` for steady runs).
+- **`phase`** *(keyword)*: tag for distinct phases of a test (`cold`,
+  `steady`, `setup`, `teardown`).  Use alongside `iter` when each phase is
+  run multiple times.
+- **`test_step`** *(keyword)*: label for snapshots *within* a single test
+  run (e.g. `snap_0`, `snap_1`, ... in `felix/k8sfv`'s memory-leak
+  scenario).  Use this for in-test time series; use `iter` for repeated
+  whole-test runs.  All three can coexist: a test running three steady
+  iterations of twenty heap snapshots would have `iter ∈ {1,2,3}`,
+  `phase = "steady"`, `test_step ∈ {"snap_0", ..., "snap_19"}`.
+
+## Index naming convention
+
+Indices are named `<family>_<period-suffix>`, where:
+
+- **`<family>`** is `benchmark_data_<test>` (e.g. `benchmark_data_neutron_resync`).
+- **`<period-suffix>`** is either `YYYY` (yearly) or `YYYY-MM` (monthly).
+  **Don't use daily.**
+
+`send-perf-results` writes to a yearly suffix.  For most monorepo perf
+tests, **yearly is the right default** -- it minimises shard count, keeps
+cluster-state overhead lowest, and the data volumes leave plenty of
+headroom.  Pick monthly only if:
+
+- **High document volume.**  A year's worth could plausibly exceed 10 GB in
+  a single index.  ES wants primary shards in the 10–50 GB range; at ~500
+  bytes per doc a yearly index can fit ~20M docs comfortably.  None of our
+  current tests come close.
+- **Sub-yearly retention.**  Yearly forces you to wait until the year rolls
+  over before shedding any data.
+- **Frequent schema evolution.**  Monthly gives you a natural reset point.
+
+In Kibana, create a single index pattern per family with a wildcard
+(`benchmark_data_<test>_*`).  That picks up both yearly and monthly so you
+can switch granularity later without losing continuity.
+
+**Why not daily?**  Daily indices over-fragment intrinsically low-volume
+perf data: hundreds of nearly-empty shards waste heap, cluster state
+balloons, query fan-out gets expensive, and dynamic mapping inference (see
+[ES schema gotchas](#es-schema-gotchas)) gets 365 chances per year to drift
+instead of 1.  Tiger-bench's existing indices predate this convention and
+can stay where they are; new test families should follow it.
+
+## Adding a new index family
+
+1. Pick a family name following `benchmark_data_<test>`.
+2. Add `hack/perf/index-templates/<family>.json` covering at least the
+   metadata fields plus your scenario-specific numeric metrics.  See the
+   [starter template](#starter-index-template) below.
+3. Have your test write to `artifacts/perf/<family>/*.json`.
+4. Add a `send-perf-results` invocation to the end of the producing
+   Semaphore job (if not already there from a previous family).
+5. After the first CI run, [verify the data landed](#verifying-data-landed).
+
+### Starter index template
+
+A minimal template covering the metadata fields and a `total_ms` metric.
+Drop it at `hack/perf/index-templates/benchmark_data_<test>.json` and add
+your scenario-specific numeric fields alongside `total_ms`:
+
+```json
+{
+  "index_patterns": ["benchmark_data_<test>_*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp":   {"type": "date"},
+        "git_commit":   {"type": "keyword"},
+        "git_branch":   {"type": "keyword"},
+        "ci_run_id":    {"type": "keyword"},
+        "code_version": {"type": "keyword"},
+        "pr_number":    {"type": "keyword"},
+        "test_name":    {"type": "keyword"},
+        "dataplane":    {"type": "keyword"},
+        "encap":        {"type": "keyword"},
+        "k8s_version":  {"type": "keyword"},
+        "cloud":        {"type": "keyword"},
+        "node_type":    {"type": "keyword"},
+        "env":          {"type": "keyword"},
+        "phase":        {"type": "keyword"},
+        "test_step":    {"type": "keyword"},
+        "iter":         {"type": "integer"},
+        "ok":           {"type": "boolean"},
+        "error":        {"type": "keyword"},
+        "total_ms":     {"type": "double"}
+      }
+    }
+  }
+}
+```
+
+Replace `<test>` in `index_patterns` with your family suffix.  Pin every
+numeric metric you care about as `double` if there's any chance it'll go
+fractional (see "Numeric type widening" below).
+
+## ES schema gotchas
+
+- **Dynamic mapping inference.**  ES infers field types from the *first*
+  document indexed into each new index.  If the first doc in one period
+  has `error: null` and the first doc in the next has `error: "timeout"`,
+  you get mapping inconsistency across the index pattern and Kibana shows
+  "conflict" warnings.  **Fix:** rely on the index template
+  (`send-perf-results` applies them on every invocation, so a template
+  change auto-propagates).  Even pinning a handful of known fields
+  prevents most surprises.
+- **`text` vs `keyword`.**  ES's default dynamic mapping maps strings as
+  `text` (full-text searchable, **not aggregatable**) with a `.keyword`
+  subfield.  To filter or group by `git_branch` in Kibana, you'd then have
+  to use `git_branch.keyword`.  Less awkward to pin string fields as
+  `keyword` in the template.
+- **Field count limit.**  ES caps an index at 1000 fields by default.  You
+  won't hit this with a flat doc; you can hit it surprisingly fast with a
+  deeply-nested one.
+- **Numeric type widening.**  If your first doc has `total_ms: 100` (mapped
+  as `long`) and a later doc has `total_ms: 100.5`, the later push fails
+  the mapping.  Pin numeric metrics as `double` in the template if there's
+  any chance they'll go fractional.
+
+## Kibana visualisation gotchas
+
+- **Lens, the default visualiser, doesn't chart `nested`-typed fields.**
+  TSVB and Vega can, but you'd rather not be writing Vega.  Avoid nested
+  fields.
+- **Time field required.**  Kibana index patterns need a date field to
+  enable time-series views.  Use `@timestamp`.
+- **Index pattern wildcards.**  One per test family:
+  `benchmark_data_neutron_resync_*` covers yearly and monthly suffixes.
+
+## Patterns for tricky cases
+
+### Multiple iterations per run (cold + N steady)
+
+Push one document per iteration.  Distinguish via `phase` and `iter`:
+
+```
+{ phase: "cold",   iter: 0, total_ms: 6798, ... }
+{ phase: "steady", iter: 1, total_ms: 4769, ... }
+{ phase: "steady", iter: 2, total_ms: 4730, ... }
+{ phase: "steady", iter: 3, total_ms: 4672, ... }
+```
+
+In Kibana, chart median of `total_ms` filtered by `phase: "steady"`, or
+compare cold vs steady side-by-side.
+
+### Time-series within a single run
+
+For tests like `felix/k8sfv`'s memory-leak scenario -- heap snapshots
+throughout a long-running test -- push one doc per snapshot with a
+`test_step` label:
+
+```
+{ test_step: "snap_0",  heap_alloc_bytes: 12345678, ... }
+{ test_step: "snap_1",  heap_alloc_bytes: 13456789, ... }
+...
+{ test_step: "snap_19", heap_alloc_bytes: 25678901, ... }
+```
+
+Each doc still gets the full metadata (commit, branch, ci_run_id) -- those
+are repeated across docs in the run.  ES handles this fine and Kibana lets
+you chart `heap_alloc_bytes` over `test_step`, with `git_commit` as a
+series breakdown for cross-run comparison.
+
+### Pass/fail alongside continuous metrics
+
+Just include `ok: true|false` (and optional `error: "<message>"`) on the
+same doc as the timing.  Kibana can chart failure rate per scenario as a
+separate visualisation in the same dashboard.
+
+### Test failure or partial results
+
+If your test crashes partway through:
+
+- **Partial metrics available**: write the file you have with `ok: false`
+  and `error: "<reason>"`.  A "test failed at scale=1000" data point is
+  itself useful trend information.
+- **Nothing usable** (e.g. infra failed before the test started): don't
+  write a file.  A doc with `null` everywhere just creates noise -- use
+  the CI log for the failure record instead.
+
+## Operational hygiene
+
+- **Don't push from local dev runs.**  Most developers won't have Lens
+  creds anyway -- `send-perf-results` already skips silently when
+  `ELASTICSEARCH_URL` is unset.  If you *do* push locally (e.g. for
+  testing the tool itself), the injected `env: dev` lets dashboards
+  filter dev runs out.
+- **Index retention.**  Check with the Lens cluster owners whether ILM
+  (Index Lifecycle Management) is configured for `benchmark_data_*`.  If
+  not, indices accumulate forever.  Worth setting up an ILM policy that
+  rolls older indices to a cheaper tier.
+- **Schema evolution.**  If you need to change the *meaning* of a field,
+  don't try to patch the existing family in place -- start a new one
+  (`benchmark_data_neutron_resync_v2_*`) and update dashboards.  Fighting
+  type drift across periods is more pain than starting fresh.
+
+## Verifying data landed
+
+After your first CI run, confirm the doc made it into ES before going
+further.  From Kibana → **Dev Tools**:
+
+```
+GET benchmark_data_<test>_*/_search
+{
+  "size": 5,
+  "sort": [{"@timestamp": "desc"}]
+}
+```
+
+You should see your most recent docs with the expected fields and types.
+If a field shows up as `text` when you wanted `keyword`, your index
+template didn't take effect -- check that the template's `index_patterns`
+matches your actual index name.
+
+From the shell:
+
+```bash
+curl -s "$ELASTICSEARCH_URL/benchmark_data_<test>_*/_search?size=5&sort=@timestamp:desc" \
+  -H "Authorization: ApiKey $ELASTICSEARCH_KEY" | jq '.hits.hits'
+```
+
+To see the inferred mapping for a specific index:
+
+```
+GET benchmark_data_<test>_2026/_mapping
+```
+
+## Next steps once you've pushed data
+
+1. **Create a Kibana index pattern.**  Stack Management → Index Patterns →
+   Create.  Pattern: `benchmark_data_<your_test>_*`.  Time field: `@timestamp`.
+2. **Build a starter Lens visualisation.**  Drag your primary metric onto
+   Y, `@timestamp` onto X.  Break out by `dataplane` or `git_branch` as a
+   series.
+3. **Save it to a dashboard.**  Add filters for `env: ci` and any baseline
+   scenario settings.
+4. **Share the dashboard URL.**  Add it next to your test's documentation
+   so others can see how the test has trended.
+
+## Local development
+
+To test the tool itself against a local files-only flow:
+
+```sh
+go run ./hack/perf/cmd/send-perf-results --dry-run --dir /tmp/some/perf
+```
+
+`--dry-run` prints what would be POSTed without contacting ES.

--- a/hack/perf/README.md
+++ b/hack/perf/README.md
@@ -80,8 +80,9 @@ artifacts -- useful for post-mortem when a number looks off.
 On each invocation, in order:
 
 1. **Apply index templates.**  For every `hack/perf/index-templates/<family>.json`,
-   PUT it to `/_index_template/<family>` in ES.  Idempotent upsert; committing
-   a template change propagates automatically on the next CI run.
+   PUT it to `/_index_template/<family>` in ES.  Idempotent upsert -- see
+   [When does the PUT have effect?](#when-does-the-put-have-effect) for what
+   this is and isn't buying.
 2. **Walk `artifacts/perf/<family>/*.json`** for every `<family>` subdirectory.
 3. **Augment each doc** with CI metadata (`@timestamp`, `git_commit`,
    `git_branch`, `code_version`, `ci_run_id`, `pr_number`, `env`) unless the
@@ -98,6 +99,37 @@ in genuinely unrecoverable cases.  Missing credentials, unreachable ES,
 malformed JSON, mapping conflicts -- all log a warning and continue.  A
 `--require-creds` flag flips the missing-creds case to a hard failure, for
 places that want a strict gate on the publish step.
+
+### When does the PUT have effect?
+
+Index templates in Elasticsearch apply at *index-creation* time, not to live
+indices.  Once `benchmark_data_<family>_2026` exists, its mapping is fixed;
+PUTing the template again does not modify that index.  So the PUT-every-time
+behaviour is meaningful in four narrow cases:
+
+1. **First-ever run for a family** -- creates the template before the first
+   doc lands, so the first auto-created index gets pinned types instead of
+   ES's dynamic inference.
+2. **Year rollover** -- the next `benchmark_data_<family>_<YYYY>` is
+   auto-created on the first write of the new year, using whatever template
+   is in cluster state at that moment.
+3. **Cluster rebuild or migration** -- equivalent to case (1).
+4. **Defensive replay** -- if anything ever deletes the template (master
+   failover edge cases have been known to lose entries), the next run puts
+   it back.
+
+In normal steady-state operation -- template already in place, mid-year --
+the PUT is a no-op.  We do it on every run anyway because (a) it's a single
+HTTP per family per CI job, effectively free, and (b) the self-heal property
+in case (4) is worth more than the cost.
+
+Mid-year template *edits* (adding/removing/renaming a field, changing a type)
+do not affect the live index.  An added field gets dynamic-mapping inference
+on first sight; a removed field still appears in old docs' `_source` and the
+live index's mapping; a type change risks a write rejection (mapping
+conflict) until the next year's index rolls over with the new template.  For
+type changes that need to take effect mid-year, reindex into a renamed index
+(`_2026_v2`) rather than fighting the existing mapping.
 
 ## Schema: what makes a good datapoint
 

--- a/hack/perf/cmd/send-perf-results/main.go
+++ b/hack/perf/cmd/send-perf-results/main.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// send-perf-results scans a directory of per-test JSON measurement files,
+// augments each with CI metadata, and POSTs them to the Lens Elasticsearch
+// cluster.  See hack/perf/README.md for the convention.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// Field names injected into every doc unless the producer already
+	// supplied them.  Keep in sync with hack/perf/README.md.
+	fieldTimestamp   = "@timestamp"
+	fieldGitCommit   = "git_commit"
+	fieldGitBranch   = "git_branch"
+	fieldCodeVersion = "code_version"
+	fieldCIRunID     = "ci_run_id"
+	fieldPRNumber    = "pr_number"
+	fieldEnv         = "env"
+)
+
+func main() {
+	dir := flag.String("dir", "artifacts/perf", "Directory to scan for per-family subdirectories of JSON docs.")
+	tmplDir := flag.String("templates", "hack/perf/index-templates", "Directory containing one <family>.json template per index family.")
+	dryRun := flag.Bool("dry-run", false, "Parse and augment but do not POST.  Prints each doc to stdout.")
+	requireCreds := flag.Bool("require-creds", false, "Exit non-zero if Elasticsearch credentials are not configured.")
+	flag.Parse()
+
+	esURL := os.Getenv("ELASTICSEARCH_URL")
+	auth, authOK := buildAuthHeader()
+	if esURL == "" || !authOK {
+		// "Lens is observability, not a critical path" -- see
+		// hack/perf/README.md.  Missing creds in a local dev run is normal;
+		// in CI it usually means the pipeline secret wasn't attached, which
+		// a --require-creds caller can turn into a hard failure.
+		msg := "ELASTICSEARCH_URL or credentials unset; skipping send"
+		if *requireCreds {
+			log.Fatalf("%s (--require-creds set)", msg)
+		}
+		log.Printf("%s", msg)
+		if *dryRun {
+			// Continue so the dry-run prints can still be useful.
+		} else {
+			return
+		}
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	metadata := ciMetadata()
+
+	// Apply index templates first.  ES treats PUT _index_template/<name>
+	// as an upsert, so committing template changes auto-propagates the next
+	// time the tool runs.  Failures here are warnings -- a missing template
+	// means new fields will get default mappings, which is a Kibana
+	// inconvenience, not a data-loss event.
+	if !*dryRun {
+		if err := applyTemplates(client, esURL, auth, *tmplDir); err != nil {
+			log.Printf("warning: applying templates failed: %v", err)
+		}
+	}
+
+	if err := walkAndSend(client, esURL, auth, *dir, metadata, *dryRun); err != nil {
+		// Observability failures should not propagate into CI (see README).
+		log.Printf("warning: walkAndSend returned an error: %v", err)
+	}
+}
+
+// buildAuthHeader returns the value for the Authorization header constructed
+// from environment variables, plus a bool reporting whether credentials are
+// configured at all.  Prefers an API key over basic auth.
+func buildAuthHeader() (string, bool) {
+	if key := os.Getenv("ELASTICSEARCH_KEY"); key != "" {
+		return "ApiKey " + key, true
+	}
+	user := os.Getenv("ELASTICSEARCH_USER")
+	token := os.Getenv("ELASTICSEARCH_TOKEN")
+	if user != "" && token != "" {
+		return basicAuthHeader(user, token), true
+	}
+	return "", false
+}
+
+// basicAuthHeader assembles a Basic auth header value the same way
+// net/http does in (*Request).SetBasicAuth, without importing encoding/base64
+// directly.
+func basicAuthHeader(user, password string) string {
+	r, _ := http.NewRequest("GET", "http://x/", nil)
+	r.SetBasicAuth(user, password)
+	return r.Header.Get("Authorization")
+}
+
+// ciMetadata gathers the fields the tool injects into every doc whose
+// producer hasn't already set them.
+func ciMetadata() map[string]any {
+	sha := os.Getenv("SEMAPHORE_GIT_SHA")
+	codeVer := sha
+	if len(codeVer) > 12 {
+		codeVer = codeVer[:12]
+	}
+	env := "dev"
+	if os.Getenv("SEMAPHORE_JOB_ID") != "" {
+		env = "ci"
+	}
+	m := map[string]any{
+		fieldTimestamp:   time.Now().UTC().Format(time.RFC3339),
+		fieldGitCommit:   sha,
+		fieldGitBranch:   os.Getenv("SEMAPHORE_GIT_BRANCH"),
+		fieldCodeVersion: codeVer,
+		fieldCIRunID:     os.Getenv("SEMAPHORE_JOB_ID"),
+		fieldEnv:         env,
+	}
+	if pr := os.Getenv("SEMAPHORE_GIT_PR_NUMBER"); pr != "" {
+		m[fieldPRNumber] = pr
+	}
+	return m
+}
+
+// applyTemplates PUTs each <family>.json in tmplDir to ES at
+// /_index_template/<family>.
+func applyTemplates(client *http.Client, esURL, auth, tmplDir string) error {
+	entries, err := os.ReadDir(tmplDir)
+	if err != nil {
+		// A missing templates directory is not fatal: a deployment might
+		// rely entirely on dynamic mapping inference.  Just warn.
+		if os.IsNotExist(err) {
+			log.Printf("templates directory %s does not exist; no templates applied", tmplDir)
+			return nil
+		}
+		return fmt.Errorf("read templates dir %s: %w", tmplDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		family := strings.TrimSuffix(e.Name(), ".json")
+		path := filepath.Join(tmplDir, e.Name())
+		body, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("warning: read %s: %v", path, err)
+			continue
+		}
+		endpoint := fmt.Sprintf("%s/_index_template/%s", strings.TrimRight(esURL, "/"), url.PathEscape(family))
+		if err := esRequest(client, "PUT", endpoint, auth, body); err != nil {
+			log.Printf("warning: PUT template %s: %v", family, err)
+			continue
+		}
+		log.Printf("applied template %s", family)
+	}
+	return nil
+}
+
+// walkAndSend processes every <dir>/<family>/*.json file, augmenting and
+// POSTing to <family>_<UTC year>.
+func walkAndSend(client *http.Client, esURL, auth, dir string, metadata map[string]any, dryRun bool) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("perf-results directory %s does not exist; nothing to send", dir)
+			return nil
+		}
+		return fmt.Errorf("read dir %s: %w", dir, err)
+	}
+	year := time.Now().UTC().Format("2006")
+	for _, e := range entries {
+		if !e.IsDir() {
+			// Stray files at the top level are not part of the convention.
+			// Warn and skip rather than silently dropping; that way a
+			// producer that writes to the wrong place gets a visible cue.
+			log.Printf("warning: skipping %s (not a family subdirectory)", e.Name())
+			continue
+		}
+		family := e.Name()
+		familyDir := filepath.Join(dir, family)
+		sent, failed, err := sendFamily(client, esURL, auth, familyDir, family, year, metadata, dryRun)
+		if err != nil {
+			log.Printf("warning: family %s: %v", family, err)
+		}
+		log.Printf("family %s: sent %d, failed %d", family, sent, failed)
+	}
+	return nil
+}
+
+// sendFamily handles one <family> subdirectory: walks all *.json under it,
+// augments with metadata, and POSTs to <family>_<year>.
+func sendFamily(client *http.Client, esURL, auth, familyDir, family, year string, metadata map[string]any, dryRun bool) (sent, failed int, err error) {
+	files, err := filepath.Glob(filepath.Join(familyDir, "*.json"))
+	if err != nil {
+		return 0, 0, fmt.Errorf("glob %s: %w", familyDir, err)
+	}
+	endpoint := fmt.Sprintf("%s/%s_%s/_doc",
+		strings.TrimRight(esURL, "/"),
+		url.PathEscape(family),
+		year,
+	)
+	for _, f := range files {
+		raw, rerr := os.ReadFile(f)
+		if rerr != nil {
+			log.Printf("warning: read %s: %v", f, rerr)
+			failed++
+			continue
+		}
+		var doc map[string]any
+		if jerr := json.Unmarshal(raw, &doc); jerr != nil {
+			log.Printf("warning: parse %s: %v", f, jerr)
+			failed++
+			continue
+		}
+		// Producer-supplied values win.  Inject only what isn't already set.
+		for k, v := range metadata {
+			if _, present := doc[k]; !present {
+				doc[k] = v
+			}
+		}
+		body, _ := json.Marshal(doc)
+		if dryRun {
+			log.Printf("dry-run: would POST %s\n  %s", endpoint, string(body))
+			sent++
+			continue
+		}
+		if perr := esRequest(client, "POST", endpoint, auth, body); perr != nil {
+			log.Printf("warning: POST %s (%s): %v", f, family, perr)
+			failed++
+			continue
+		}
+		sent++
+	}
+	return sent, failed, nil
+}
+
+// esRequest performs a single HTTP request to ES with the given method,
+// endpoint, auth header, and JSON body.  Returns an error on transport
+// failure or any non-2xx response.
+func esRequest(client *http.Client, method, endpoint, auth string, body []byte) error {
+	req, err := http.NewRequest(method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("%s %s: HTTP %d: %s", method, endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/hack/perf/index-templates/benchmark_data_neutron_resync.json
+++ b/hack/perf/index-templates/benchmark_data_neutron_resync.json
@@ -1,0 +1,67 @@
+{
+  "index_patterns": ["benchmark_data_neutron_resync_*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp":       {"type": "date"},
+        "git_commit":       {"type": "keyword"},
+        "git_branch":       {"type": "keyword"},
+        "code_version":     {"type": "keyword"},
+        "ci_run_id":        {"type": "keyword"},
+        "test_name":        {"type": "keyword"},
+        "env":              {"type": "keyword"},
+        "phase":            {"type": "keyword"},
+        "iter":             {"type": "integer"},
+        "ok":               {"type": "boolean"},
+        "error":            {"type": "keyword"},
+
+        "scale_ports":      {"type": "integer"},
+        "scale_networks":   {"type": "integer"},
+        "scale_sgs":        {"type": "integer"},
+        "scale_hosts":      {"type": "integer"},
+
+        "total_ms":         {"type": "double"},
+
+        "expand_total_ms":         {"type": "double"},
+
+        "subnets_total_ms":        {"type": "double"},
+        "subnets_compare_ms":      {"type": "double"},
+        "subnets_etcd_read_ms":    {"type": "double"},
+        "subnets_neutron_read_ms": {"type": "double"},
+        "subnets_create_ms":       {"type": "double"},
+        "subnets_etcd_items":      {"type": "integer"},
+        "subnets_neutron_items":   {"type": "integer"},
+        "subnets_correct":         {"type": "integer"},
+        "subnets_updated":         {"type": "integer"},
+        "subnets_deleted":         {"type": "integer"},
+        "subnets_created":         {"type": "integer"},
+
+        "policy_total_ms":         {"type": "double"},
+        "policy_compare_ms":       {"type": "double"},
+        "policy_etcd_read_ms":     {"type": "double"},
+        "policy_neutron_read_ms":  {"type": "double"},
+        "policy_create_ms":        {"type": "double"},
+        "policy_etcd_items":       {"type": "integer"},
+        "policy_neutron_items":    {"type": "integer"},
+        "policy_correct":          {"type": "integer"},
+        "policy_updated":          {"type": "integer"},
+        "policy_deleted":          {"type": "integer"},
+        "policy_created":          {"type": "integer"},
+
+        "endpoints_total_ms":         {"type": "double"},
+        "endpoints_compare_ms":       {"type": "double"},
+        "endpoints_etcd_read_ms":     {"type": "double"},
+        "endpoints_neutron_read_ms":  {"type": "double"},
+        "endpoints_create_ms":        {"type": "double"},
+        "endpoints_etcd_items":       {"type": "integer"},
+        "endpoints_neutron_items":    {"type": "integer"},
+        "endpoints_correct":          {"type": "integer"},
+        "endpoints_updated":          {"type": "integer"},
+        "endpoints_deleted":          {"type": "integer"},
+        "endpoints_created":          {"type": "integer"},
+
+        "felix_config_total_ms":      {"type": "double"}
+      }
+    }
+  }
+}

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -221,12 +221,43 @@ echo "Running QoS responsiveness tests..."
 cd /opt/stack/devstack
 . openrc admin admin
 
-# Install required Python packages for QoS tests
-sudo pip install openstacksdk etcd3
+# Install required Python packages for QoS tests.
+sudo pip install openstacksdk etcd3 pymysql
 
 export ETCD_HOST=${SERVICE_HOST}
 python3 ../calico/networking-calico/devstack/qos_responsiveness_tests.py -v
 EOF
+
+# Run resync scale benchmark.  Prints one RESYNC_SCALE_RESULT line per
+# scale; grep for that to extract the numbers.
+sudo -u stack -H -E bash -x <<'EOF'
+cd /opt/stack/devstack
+. openrc admin admin
+
+export ETCD_HOST=${SERVICE_HOST}
+
+# calico-resync is installed alongside calico-dhcp-agent under
+# ${DEVSTACK_VENV:-/usr/local}/bin, which is not necessarily on the
+# stack user's PATH under sudo.  Pass the absolute path explicitly.
+export RESYNC_CALICO_RESYNC=${DEVSTACK_VENV:-/usr/local}/bin/calico-resync
+
+# Override via RESYNC_SCALES if a Semaphore run is too slow for the
+# default 100,1000,3000 ladder.  The test drops per-iteration JSON
+# files under artifacts/perf/benchmark_data_neutron_resync/; the
+# send-perf-results call below picks them up.
+mkdir -p /home/semaphore/calico/artifacts/perf
+export RESYNC_PERF_ARTIFACTS_DIR=/home/semaphore/calico/artifacts/perf
+python3 ../calico/networking-calico/devstack/resync_scale_test.py || true
+EOF
+
+# Publish perf measurements to Lens.  No-op unless ELASTICSEARCH_URL +
+# credentials are wired in via Semaphore secrets; see hack/perf/README.md.
+(
+  cd /home/semaphore/calico && \
+  go run ./hack/perf/cmd/send-perf-results \
+     --dir artifacts/perf \
+     --templates hack/perf/index-templates
+) || true
 
 # Run Tempest tests
 sudo -u stack -H -E bash -x <<'EOF'

--- a/networking-calico/devstack/resync_scale_test.py
+++ b/networking-calico/devstack/resync_scale_test.py
@@ -373,7 +373,18 @@ def create_ports(conn, num_ports, networks, subnets, sgs, hosts):
         created.extend(p for p in results if p is not None)
         if (batch_start // PORT_BULK_BATCH) % 10 == 0:
             LOG.info("  ...created %d/%d ports", len(created), num_ports)
+
     LOG.info("Port creation done: %d ports", len(created))
+    if len(created) != num_ports:
+        # A shortfall here is a real problem (quota, race, transient DB
+        # pressure, ...) -- not something to paper over.  Raise so the
+        # caller aborts this scale before any resync runs, and we don't
+        # ship a perf doc to Lens labelled at full scale that actually
+        # measured scale - N.
+        raise RuntimeError(
+            "Port creation shortfall: only %d/%d ports created"
+            % (len(created), num_ports)
+        )
     return created
 
 
@@ -696,6 +707,26 @@ def run_one_scale(scale, conn, etcd_client, db_args, neutron_conf, extra_conf):
         LOG.info("Cold-etcd run")
         cold = run_calico_resync(neutron_conf, extra_conf)
 
+        # Belt-and-braces: cross-check that the cold run actually saw the
+        # full expected set of endpoints.  ``created`` is what landed in
+        # etcd from a cold start (we just wiped it), so it should equal
+        # ``scale``; ``correct`` should be 0 because nothing pre-existed.
+        # Mismatches indicate either a populate-phase bug we missed
+        # above, or a bind/postcommit failure between port-create and
+        # the resync (port made it into Neutron but never into etcd).
+        endpoints = (cold.get("phases") or {}).get("endpoints") or {}
+        if endpoints.get("created") != scale or endpoints.get("correct") != 0:
+            raise RuntimeError(
+                "Cold resync mismatch at scale=%d: endpoints.created=%r "
+                "(want %d), endpoints.correct=%r (want 0)"
+                % (
+                    scale,
+                    endpoints.get("created"),
+                    scale,
+                    endpoints.get("correct"),
+                )
+            )
+
         summarise(scale, num_networks, num_sgs, num_hosts, cold, steady_runs)
         return True
     finally:
@@ -772,8 +803,15 @@ def main():
                 extra_conf,
             )
         except Exception:
-            LOG.exception("Scale %d failed", scale)
+            # Abort the whole run on the first scale failure -- if
+            # scale=100 can't even populate cleanly, the numbers from
+            # subsequent (larger) scales aren't trustworthy and burning
+            # 30+ minutes of CI to find that out is wasteful.  Cleanup
+            # of THIS scale's resources already happened in
+            # run_one_scale's finally block.
+            LOG.exception("Scale %d failed; aborting remaining scales", scale)
             failed = True
+            break
 
     LOG.info(
         "Resync scale benchmark finished at %s", datetime.datetime.utcnow().isoformat()

--- a/networking-calico/devstack/resync_scale_test.py
+++ b/networking-calico/devstack/resync_scale_test.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Neutron->Calico resync scale benchmark.
+
+Populates a real Neutron DB (via the REST API as admin) with N ports spread across F
+fake hosts, then runs ``calico-resync`` against it and times how long the resync takes.
+Each scale produces one CSV-style ``RESYNC_SCALE_RESULT`` line so the numbers can be
+grepped out of the Semaphore log.
+
+Realism: nothing about Neutron, neutron-lib or SQLAlchemy is mocked.  Ports go through
+the real REST API and the real ML2 bind_port flow.  The one exception is the ``agents``
+table: we INSERT fake "Calico per-host agent (felix)" rows directly so the Calico mech
+driver accepts ports bound to hosts other than this devstack node.
+
+This is *not* a correctness test; it does not assert any resync output.  It measures
+only.
+
+Run as the ``stack`` user with the admin openrc sourced, plus:
+
+    ETCD_HOST=<ip>         (default localhost)
+    ETCD_PORT=<port>       (default 2379)
+    NEUTRON_CONF=<path>    (default /etc/neutron/neutron.conf)
+    RESYNC_SCALES=100,1000 (default; comma-separated port counts)
+    RESYNC_HOSTS_PER_SCALE=auto  (default: sqrt(ports), min 1)
+    RESYNC_CALICO_RESYNC=calico-resync  (default; path to the CLI)
+    RESYNC_CALICO_RESYNC_CONF=<path>  (default /tmp/calico-resync-scale.ini;
+                                       extra config file layered on top of
+                                       neutron.conf)
+    RESYNC_CALICO_RESYNC_LOG=<path>   (default /tmp/calico-resync-scale.log;
+                                       where calico-resync writes its logs)
+
+One JSON document per resync iteration is also dropped into
+``artifacts/perf/benchmark_data_neutron_resync/`` so that the
+``hack/perf/cmd/send-perf-results`` tool can pick them up and publish to the Lens
+Elasticsearch cluster for long-term trend tracking.  This test itself does not talk to
+Elastic -- it just writes the files.  See ``hack/perf/README.md`` for conventions.
+
+    RESYNC_PERF_ARTIFACTS_DIR=<path>  (default artifacts/perf; set to "" to
+                                       disable JSON-file writes)
+"""
+
+import argparse
+import concurrent.futures
+import configparser
+import datetime
+import json
+import logging
+import math
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import uuid
+from urllib.parse import urlparse
+
+import etcd3
+import openstack
+import pymysql
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+LOG = logging.getLogger("resync-scale")
+
+# Default scales to measure if RESYNC_SCALES is not set.  Stops at 3000 because larger
+# scales take longer than Semaphore CI is willing to wait — 10000 ports took >12 minutes
+# just to populate.  Override via the env var to push higher when running off-CI.
+DEFAULT_SCALES = "100,1000,3000"
+
+# Calico's mech driver looks for this exact agent_type in the agents table when binding
+# a port to a host.  Must match AGENT_TYPE_FELIX in mech_calico.py.
+AGENT_TYPE_FELIX = "Calico per-host agent (felix)"
+
+# How many ports to ask the Neutron API to create in one HTTP request.  Bulk create is
+# supported by the v2 API and is much faster than one-at-a-time.
+PORT_BULK_BATCH = 50
+
+# How many concurrent worker threads to use when populating resources.  Modest
+# concurrency keeps the single neutron-server fork from self-bottlenecking.
+POPULATE_WORKERS = 8
+
+# Default tag we attach to every resource we create, so the cleanup pass can find them
+# even if a previous run crashed mid-flight.
+TEST_TAG = "calico-resync-scale-test"
+
+
+def env_int(name, default):
+    val = os.environ.get(name)
+    return int(val) if val else default
+
+
+def parse_scales():
+    raw = os.environ.get("RESYNC_SCALES", DEFAULT_SCALES)
+    return [int(s) for s in raw.split(",") if s.strip()]
+
+
+def hosts_for_scale(num_ports):
+    """How many fake hosts to spread `num_ports` across.
+
+    Override with RESYNC_HOSTS_PER_SCALE=<n>.  Default is sqrt(N), which keeps the
+    agents table bounded as we scale up the port count.
+    """
+    override = os.environ.get("RESYNC_HOSTS_PER_SCALE", "auto")
+    if override != "auto":
+        return max(1, int(override))
+    return max(1, int(math.sqrt(num_ports)))
+
+
+# ---------------------------------------------------------------------------
+# MySQL helpers (for agent-row insertion).
+# ---------------------------------------------------------------------------
+
+
+def parse_db_connection(neutron_conf_path):
+    """Read [database] connection from neutron.conf and return a dict
+    that pymysql.connect understands.
+
+    Example value:
+      mysql+pymysql://neutron:secret@127.0.0.1/neutron?charset=utf8
+    """
+    parser = configparser.ConfigParser()
+    parser.read(neutron_conf_path)
+    conn_str = parser.get("database", "connection")
+    parsed = urlparse(conn_str)
+    if not parsed.username or not parsed.password:
+        raise RuntimeError(
+            "Could not parse user/password from neutron.conf [database] connection=%s"
+            % conn_str
+        )
+    return {
+        "host": parsed.hostname or "127.0.0.1",
+        "port": parsed.port or 3306,
+        "user": parsed.username,
+        "password": parsed.password,
+        "database": (parsed.path or "/neutron").lstrip("/") or "neutron",
+        "charset": "utf8",
+    }
+
+
+def insert_fake_agents(db_args, hosts):
+    """INSERT one Calico-felix agent row per host into the Neutron DB.
+
+    Idempotent: existing rows for (agent_type, host) are left alone.
+
+    heartbeat_timestamp is set to one day in the future, so Neutron's aliveness check
+    (`now - heartbeat <= agent_down_time`) reads them as alive throughout the test
+    without needing a refresh thread.  Real felix processes would heartbeat naturally;
+    for a benchmark that's just churning bind_port we don't care.
+    """
+    conn = pymysql.connect(**db_args)
+    try:
+        with conn.cursor() as cur:
+            for host in hosts:
+                cur.execute(
+                    "SELECT id FROM agents WHERE agent_type=%s AND host=%s",
+                    (AGENT_TYPE_FELIX, host),
+                )
+                if cur.fetchone():
+                    continue
+                # `binary` and `load` are MySQL reserved words and must
+                # be quoted.  Backtick the rest for consistency.
+                cur.execute(
+                    """
+                    INSERT INTO agents (
+                        `id`, `agent_type`, `binary`, `topic`, `host`,
+                        `admin_state_up`, `created_at`, `started_at`,
+                        `heartbeat_timestamp`, `configurations`, `load`
+                    ) VALUES (
+                        %s, %s, %s, %s, %s,
+                        1, UTC_TIMESTAMP(), UTC_TIMESTAMP(),
+                        DATE_ADD(UTC_TIMESTAMP(), INTERVAL 1 DAY),
+                        '{}', 0
+                    )
+                    """,
+                    (
+                        str(uuid.uuid4()),
+                        AGENT_TYPE_FELIX,
+                        "calico-felix",
+                        "calico-felix",
+                        host,
+                    ),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def delete_fake_agents(db_args):
+    """Drop every calico-felix agent row.  Used by cleanup."""
+    conn = pymysql.connect(**db_args)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM agents WHERE agent_type=%s", (AGENT_TYPE_FELIX,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Neutron resource creation (via openstacksdk as admin).
+# ---------------------------------------------------------------------------
+
+
+def connect_openstack():
+    return openstack.connection.Connection(
+        auth_url=os.environ.get("OS_AUTH_URL", "http://localhost/identity"),
+        project_name=os.environ.get("OS_PROJECT_NAME", "admin"),
+        username=os.environ.get("OS_USERNAME", "admin"),
+        password=os.environ["OS_PASSWORD"],
+        region_name=os.environ.get("OS_REGION_NAME", "RegionOne"),
+        project_domain_id=os.environ.get("OS_PROJECT_DOMAIN_ID", "default"),
+        user_domain_id=os.environ.get("OS_USER_DOMAIN_ID", "default"),
+        identity_api_version=3,
+    )
+
+
+def bump_quotas(conn):
+    """Set the current project's Neutron quotas to unlimited (-1).
+
+    Defaults are 10 networks / 50 ports / 10 SGs / 100 SG rules, way
+    below what the 10000-port scale needs.  -1 means unlimited.
+    """
+    project = conn.identity.find_project(os.environ.get("OS_PROJECT_NAME", "admin"))
+    LOG.info(
+        "Bumping Neutron quotas for project %s (%s) to unlimited",
+        project.name,
+        project.id,
+    )
+    conn.network.update_quota(
+        project.id,
+        networks=-1,
+        subnets=-1,
+        ports=-1,
+        security_groups=-1,
+        security_group_rules=-1,
+    )
+
+
+def create_networks_and_subnets(conn, num_networks):
+    """Create N flat networks, each with a /24 subnet.
+
+    Uses provider:network_type=local so check_segment_for_agent accepts the network for
+    the Calico agent (which only supports local/flat).
+    """
+    nets = []
+    subs = []
+    for i in range(num_networks):
+        net = conn.network.create_network(
+            name=f"{TEST_TAG}-net-{i:05d}",
+            provider_network_type="local",
+            shared=True,
+        )
+        nets.append(net)
+        # /24 is enough because run_one_scale picks num_networks = scale // 100,
+        # so ports-per-network stays ~100 -- well under the /24's ~250 usable IPs.
+        # Bump to a wider subnet if that ratio ever changes.
+        cidr = f"10.{(i // 256) & 0xff}.{i & 0xff}.0/24"
+        sub = conn.network.create_subnet(
+            name=f"{TEST_TAG}-sub-{i:05d}",
+            network_id=net.id,
+            ip_version=4,
+            cidr=cidr,
+            gateway_ip=f"10.{(i // 256) & 0xff}.{i & 0xff}.1",
+            enable_dhcp=True,
+        )
+        subs.append(sub)
+    return nets, subs
+
+
+def create_security_groups(conn, num_sgs):
+    """Create N security groups (each gets the default 4 rules).
+
+    Then add 4 extra custom rules per SG (tcp/22, tcp/80, tcp/443, udp/53) so the resync
+    has non-trivial NetworkPolicy content to compare.
+    """
+    sgs = []
+    for i in range(num_sgs):
+        sg = conn.network.create_security_group(
+            name=f"{TEST_TAG}-sg-{i:05d}",
+            description="resync scale test",
+        )
+        sgs.append(sg)
+
+    # Add rules in parallel: ~4N rule creates.
+    rule_args = []
+    for sg in sgs:
+        for proto, port in [("tcp", 22), ("tcp", 80), ("tcp", 443), ("udp", 53)]:
+            rule_args.append(
+                {
+                    "security_group_id": sg.id,
+                    "direction": "ingress",
+                    "ether_type": "IPv4",
+                    "protocol": proto,
+                    "port_range_min": port,
+                    "port_range_max": port,
+                    "remote_ip_prefix": "0.0.0.0/0",
+                }
+            )
+
+    def _add_rule(args):
+        try:
+            conn.network.create_security_group_rule(**args)
+        except Exception as exc:
+            # Duplicate rules from earlier runs / races are non-fatal.
+            LOG.debug("create_security_group_rule failed: %s", exc)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=POPULATE_WORKERS) as ex:
+        list(ex.map(_add_rule, rule_args))
+
+    return sgs
+
+
+def create_ports(conn, num_ports, networks, subnets, sgs, hosts):
+    """Create N ports spread across networks, subnets, SGs and hosts.
+
+    Uses single-port REST calls in a thread pool.  Ports go in with binding:host_id set
+    so the Calico ML2 bind_port flow runs and the port reaches ACTIVE.
+    """
+    LOG.info(
+        "Populating %d ports across %d networks, %d sgs, %d hosts...",
+        num_ports,
+        len(networks),
+        len(sgs),
+        len(hosts),
+    )
+
+    def _build_port_spec(i):
+        net = networks[i % len(networks)]
+        sub = subnets[i % len(subnets)]
+        sg = sgs[i % len(sgs)]
+        host = hosts[i % len(hosts)]
+        return {
+            "name": f"{TEST_TAG}-port-{i:08d}",
+            "network_id": net.id,
+            "fixed_ips": [{"subnet_id": sub.id}],
+            "security_groups": [sg.id],
+            "device_id": f"{TEST_TAG}-inst-{i:08d}",
+            "device_owner": "compute:fake",
+            "binding_host_id": host,
+        }
+
+    def _create_one(spec):
+        try:
+            return conn.network.create_port(**spec)
+        except Exception as exc:
+            LOG.error("create_port failed for %s: %s", spec["name"], exc)
+            return None
+
+    created = []
+    for batch_start in range(0, num_ports, PORT_BULK_BATCH):
+        batch = [
+            _build_port_spec(i)
+            for i in range(batch_start, min(batch_start + PORT_BULK_BATCH, num_ports))
+        ]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=POPULATE_WORKERS) as ex:
+            results = list(ex.map(_create_one, batch))
+        created.extend(p for p in results if p is not None)
+        if (batch_start // PORT_BULK_BATCH) % 10 == 0:
+            LOG.info("  ...created %d/%d ports", len(created), num_ports)
+    LOG.info("Port creation done: %d ports", len(created))
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Cleanup (best-effort).
+# ---------------------------------------------------------------------------
+
+
+def cleanup_neutron(conn):
+    """Best-effort cleanup of every resource tagged with TEST_TAG.
+
+    Order matters: ports first, then SGs and networks.  Subnets are not deleted
+    explicitly -- they cascade away when their network is deleted, which is why ports
+    (the only resource that can hold a subnet "in use") have to go first.
+    """
+    LOG.info("Cleaning up %s ports...", TEST_TAG)
+    deleted = 0
+    for port in conn.network.ports():
+        if port.name and port.name.startswith(TEST_TAG):
+            try:
+                conn.network.delete_port(port.id)
+                deleted += 1
+            except Exception as exc:
+                LOG.warning("delete_port %s: %s", port.id, exc)
+    LOG.info("  deleted %d ports", deleted)
+
+    deleted = 0
+    for sg in conn.network.security_groups():
+        if sg.name and sg.name.startswith(TEST_TAG):
+            try:
+                conn.network.delete_security_group(sg.id)
+                deleted += 1
+            except Exception as exc:
+                LOG.warning("delete_security_group %s: %s", sg.id, exc)
+    LOG.info("  deleted %d SGs", deleted)
+
+    deleted = 0
+    for net in conn.network.networks():
+        if net.name and net.name.startswith(TEST_TAG):
+            try:
+                conn.network.delete_network(net.id)
+                deleted += 1
+            except Exception as exc:
+                LOG.warning("delete_network %s: %s", net.id, exc)
+    LOG.info("  deleted %d networks", deleted)
+
+
+def cleanup_etcd(etcd_client):
+    """Wipe everything under /calico so the next resync starts cold."""
+    LOG.info("Wiping /calico from etcd...")
+    etcd_client.delete_prefix("/calico")
+
+
+# ---------------------------------------------------------------------------
+# calico-resync invocation.
+# ---------------------------------------------------------------------------
+
+
+def run_calico_resync(neutron_conf_path, extra_conf_path):
+    """Run calico-resync once and return the parsed ResyncResult dict.
+
+    Layers a benchmark-specific config file on top of neutron.conf so calico-resync's
+    logs land in a file rather than competing with the JSON result on stdout (oslo.log's
+    neutron-server defaults can put log lines on stdout in this environment).  Uses
+    --output to direct the JSON to a dedicated file for the same reason.
+
+    Timing comes from the ResyncResult's own ``total_ms`` -- we don't bother with
+    subprocess wall-clock, which would just add ~200 ms of Python startup that isn't
+    interesting trend signal.
+    """
+    with tempfile.NamedTemporaryFile(
+        mode="w+", suffix=".json", prefix="calico-resync-"
+    ) as out_file:
+        cmd = [
+            os.environ.get("RESYNC_CALICO_RESYNC", "calico-resync"),
+            "--config-file",
+            neutron_conf_path,
+            "--config-file",
+            extra_conf_path,
+            "--output",
+            out_file.name,
+        ]
+        LOG.info("Running %s", " ".join(cmd))
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            LOG.error(
+                "calico-resync exited %d.  stderr:\n%s",
+                proc.returncode,
+                proc.stderr,
+            )
+        out_file.seek(0)
+        raw = out_file.read()
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError:
+            LOG.error(
+                "calico-resync did not produce valid JSON in --output.  "
+                "Contents:\n%s\nstderr:\n%s",
+                raw,
+                proc.stderr,
+            )
+            result = {"ok": False, "error": "non-json output", "phases": {}}
+    if not result.get("ok"):
+        LOG.warning("calico-resync result ok=False: %s", result.get("error"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Summary line.
+# ---------------------------------------------------------------------------
+
+
+def phase_ms(result, phase):
+    """Get total_ms for a named phase from a ResyncResult dict.
+
+    Returns 0 if the phase wasn't run (e.g. felix_config on a narrow scope, or endpoints
+    when the run errored out before reaching it) or the result is malformed.
+    """
+    phases = result.get("phases", {}) or {}
+    phase_dict = phases.get(phase) or {}
+    return int(phase_dict.get("total_ms", 0))
+
+
+# Family name for the Lens ES index that this test writes into.  The matching index
+# template lives at hack/perf/index-templates/benchmark_data_neutron_resync.json, and
+# hack/perf/cmd/send-perf-results picks up the JSON files we write below and POSTs them
+# to Elastic.
+_PERF_FAMILY = "benchmark_data_neutron_resync"
+
+# Phase names emitted by calico-resync's ResyncResult.phases dict.  Used to flatten
+# phase metrics into ``<phase>_<metric>`` ES fields.
+_SYNCER_PHASES = ("expand", "subnets", "policy", "endpoints", "felix_config")
+
+
+def _make_perf_docs(scale, num_networks, num_sgs, num_hosts, cold, steady_runs):
+    """Build one perf doc per resync iteration (1 cold + N steady).
+
+    Schema follows conventions as in `hack/perf/README.md`: flat scalars only, no nested
+    structures.  Per-syncer-phase metrics are flattened into ``<syncer_phase>_<metric>``
+    fields so Kibana Lens can chart them directly.
+
+    Only scenario-specific scalars belong here.  CI metadata
+    (git_commit/branch/ci_run_id/env/...) is added later by
+    hack/perf/cmd/send-perf-results, so producers don't have to know about Semaphore env
+    vars.
+    """
+    common = {
+        "test_name": "neutron_resync",
+        "scale_ports": scale,
+        "scale_networks": num_networks,
+        "scale_sgs": num_sgs,
+        "scale_hosts": num_hosts,
+    }
+
+    # iter=0 is the cold run; iter=1..N are the steady runs.
+    iterations = [(0, "cold", cold)]
+    for i, result in enumerate(steady_runs):
+        iterations.append((i + 1, "steady", result))
+
+    docs = []
+    for iter_idx, phase, result in iterations:
+        doc = dict(common)
+        doc["phase"] = phase
+        doc["iter"] = iter_idx
+        doc["total_ms"] = int(result.get("total_ms", 0))
+        doc["ok"] = bool(result.get("ok"))
+        error = result.get("error")
+        if error:
+            doc["error"] = error
+
+        # Flatten per-syncer-phase metrics into <phase>_<metric>.  Skip any non-scalar
+        # values defensively in case the syncer ever grows one.
+        phases = result.get("phases") or {}
+        for syncer_phase in _SYNCER_PHASES:
+            metrics = phases.get(syncer_phase) or {}
+            for metric, value in metrics.items():
+                if isinstance(value, (int, float, bool)):
+                    doc[f"{syncer_phase}_{metric}"] = value
+        docs.append(doc)
+
+    return docs
+
+
+def _write_perf_docs(scale, docs):
+    """Write each perf doc to its own JSON file under
+    ``$RESYNC_PERF_ARTIFACTS_DIR/<family>/``.
+
+    Default base dir is ``artifacts/perf``; set ``RESYNC_PERF_ARTIFACTS_DIR`` to "" to
+    disable.  ``hack/perf/cmd/send-perf-results`` later picks these up and posts them to
+    Lens ES.
+    """
+    base = os.environ.get("RESYNC_PERF_ARTIFACTS_DIR", "artifacts/perf")
+    if not base:
+        return
+    family_dir = os.path.join(base, _PERF_FAMILY)
+    os.makedirs(family_dir, exist_ok=True)
+    for doc in docs:
+        # Filename embeds scale/phase/iter so it's grep-able and so two
+        # successive test runs don't collide.
+        name = "scale%d_%s_iter%d.json" % (scale, doc["phase"], doc["iter"])
+        path = os.path.join(family_dir, name)
+        with open(path, "w") as f:
+            json.dump(doc, f, indent=2, sort_keys=True)
+            f.write("\n")
+    LOG.info("Wrote %d perf docs to %s", len(docs), family_dir)
+
+
+def summarise(scale, num_networks, num_sgs, num_hosts, cold, steady_runs):
+    """Print one RESYNC_SCALE_RESULT line for grep, then a JSON dump.
+
+    cold is one ResyncResult dict from the cold-etcd run.  steady_runs is a list of such
+    dicts from the steady-state runs.
+    """
+    # Accumulate total_ms values only when runs succeeded.
+    steady_totals = [int(r["total_ms"]) for r in steady_runs if r.get("ok")]
+    cold_totals = [int(cold["total_ms"])] if cold.get("ok") else []
+
+    def stat(values, fn):
+        return int(fn(values)) if values else -1
+
+    line_fields = [
+        f"scale={scale}",
+        f"ports={scale}",
+        f"networks={num_networks}",
+        f"sgs={num_sgs}",
+        f"hosts={num_hosts}",
+        f"cold_ms={stat(cold_totals, max)}",
+        f"steady_min_ms={stat(steady_totals, min)}",
+        f"steady_med_ms={stat(steady_totals, statistics.median)}",
+        f"steady_max_ms={stat(steady_totals, max)}",
+        f"cold_subnets_ms={phase_ms(cold, 'subnets')}",
+        f"cold_policy_ms={phase_ms(cold, 'policy')}",
+        f"cold_endpoints_ms={phase_ms(cold, 'endpoints')}",
+        f"cold_felix_config_ms={phase_ms(cold, 'felix_config')}",
+    ]
+
+    # Pick the median *successful* run for the per-phase breakdown.  Failed runs are
+    # excluded because their phase dicts are partial (e.g. no endpoints phase if the
+    # failure happened earlier), which would otherwise show up as misleading zeros in
+    # the summary line.
+    successful = [r for r in steady_runs if r.get("ok")]
+    if successful:
+        successful_sorted = sorted(successful, key=lambda r: r.get("total_ms", 0))
+        median_result = successful_sorted[len(successful_sorted) // 2]
+        line_fields.extend(
+            [
+                f"steady_med_subnets_ms={phase_ms(median_result, 'subnets')}",
+                f"steady_med_policy_ms={phase_ms(median_result, 'policy')}",
+                f"steady_med_endpoints_ms={phase_ms(median_result, 'endpoints')}",
+                f"steady_med_felix_config_ms={phase_ms(median_result, 'felix_config')}",
+            ]
+        )
+
+    print("RESYNC_SCALE_RESULT " + " ".join(line_fields))
+    sys.stdout.flush()
+
+    # Also dump the raw JSON for each run for ad-hoc analysis.
+    dump = {
+        "scale": scale,
+        "networks": num_networks,
+        "sgs": num_sgs,
+        "hosts": num_hosts,
+        "cold": cold,
+        "steady": steady_runs,
+    }
+    print("RESYNC_SCALE_JSON " + json.dumps(dump))
+    sys.stdout.flush()
+
+    # Drop per-iteration JSON files for the central send-perf-results tool to pick up.
+    # Silently no-op if RESYNC_PERF_ARTIFACTS_DIR is "".
+    _write_perf_docs(
+        scale,
+        _make_perf_docs(scale, num_networks, num_sgs, num_hosts, cold, steady_runs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# One scale iteration.
+# ---------------------------------------------------------------------------
+
+
+def run_one_scale(scale, conn, etcd_client, db_args, neutron_conf, extra_conf):
+    """Populate, measure, clean up.  Returns True on success."""
+    LOG.info("=" * 60)
+    LOG.info("Scale = %d ports", scale)
+    LOG.info("=" * 60)
+
+    num_hosts = hosts_for_scale(scale)
+    num_networks = max(1, scale // 100)
+    num_sgs = max(1, num_networks * 2)
+    hosts = [f"resync-fake-{i:05d}" for i in range(num_hosts)]
+
+    try:
+        # Provision fake agent rows first.  The mech driver checks
+        # agent presence and aliveness during bind_port; both queries
+        # hit MySQL directly.
+        LOG.info("Inserting %d fake agent rows...", num_hosts)
+        insert_fake_agents(db_args, hosts)
+
+        nets, subs = create_networks_and_subnets(conn, num_networks)
+        sgs = create_security_groups(conn, num_sgs)
+        create_ports(conn, scale, nets, subs, sgs, hosts)
+
+        # Steady-state: etcd is whatever the postcommit hooks left,
+        # which should be the full set of WEPs/Subnets/Policies for
+        # everything we just created.  3 runs to get min/median/max.
+        steady_runs = []
+        for run_i in range(3):
+            LOG.info("Steady-state run %d/3", run_i + 1)
+            steady_runs.append(run_calico_resync(neutron_conf, extra_conf))
+
+        # Cold: wipe etcd, then resync.  This forces every WEP /
+        # NetworkPolicy / Subnet to be re-created.
+        cleanup_etcd(etcd_client)
+        LOG.info("Cold-etcd run")
+        cold = run_calico_resync(neutron_conf, extra_conf)
+
+        summarise(scale, num_networks, num_sgs, num_hosts, cold, steady_runs)
+        return True
+    finally:
+        cleanup_neutron(conn)
+        delete_fake_agents(db_args)
+
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--neutron-conf",
+        default=os.environ.get("NEUTRON_CONF", "/etc/neutron/neutron.conf"),
+        help="Path to neutron.conf (default %(default)s).",
+    )
+    args = parser.parse_args()
+
+    LOG.info(
+        "Resync scale benchmark started at %s", datetime.datetime.utcnow().isoformat()
+    )
+    LOG.info("Reading DB config from %s", args.neutron_conf)
+    db_args = parse_db_connection(args.neutron_conf)
+    LOG.info("DB host=%s database=%s", db_args["host"], db_args["database"])
+
+    conn = connect_openstack()
+    etcd_host = os.environ.get("ETCD_HOST", "localhost")
+    etcd_port = env_int("ETCD_PORT", 2379)
+    etcd_client = etcd3.client(host=etcd_host, port=etcd_port)
+    LOG.info("etcd %s:%d", etcd_host, etcd_port)
+
+    bump_quotas(conn)
+
+    # Write a small INI that calico-resync will read on top of neutron.conf, the same
+    # way neutron-dhcp-agent layers neutron.conf + dhcp_agent.ini.  This sends
+    # calico-resync logs to a file so they don't compete with the JSON result on stdout.
+    extra_conf = os.environ.get(
+        "RESYNC_CALICO_RESYNC_CONF", "/tmp/calico-resync-scale.ini"
+    )
+    log_file = os.environ.get(
+        "RESYNC_CALICO_RESYNC_LOG", "/tmp/calico-resync-scale.log"
+    )
+    with open(extra_conf, "w") as f:
+        f.write("[DEFAULT]\n")
+        f.write("log_file = %s\n" % log_file)
+        f.write("use_stderr = False\n")
+        # oslo_db's default max_pool_size=5 / max_overflow=50 isn't enough
+        # for calico-resync at scale=1000+ — we see intermittent QueuePool
+        # timeouts in the steady-state runs.  Bump generously as a quick
+        # mitigation; the proper fix is to migrate _txn_from_context off
+        # the deprecated session.begin(subtransactions=True) idiom, which
+        # is suspected of leaking connections back to the pool.  Tracked
+        # alongside the parked QoS-resync investigation.
+        f.write("[database]\n")
+        f.write("max_pool_size = 50\n")
+        f.write("max_overflow = 200\n")
+    LOG.info("calico-resync extra config: %s (logs -> %s)", extra_conf, log_file)
+
+    scales = parse_scales()
+    LOG.info("Scales: %s", scales)
+
+    failed = False
+    for scale in scales:
+        try:
+            run_one_scale(
+                scale,
+                conn,
+                etcd_client,
+                db_args,
+                args.neutron_conf,
+                extra_conf,
+            )
+        except Exception:
+            LOG.exception("Scale %d failed", scale)
+            failed = True
+
+    LOG.info(
+        "Resync scale benchmark finished at %s", datetime.datetime.utcnow().isoformat()
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a large-scale benchmark exercising the new ``calico-resync`` one-shot resync tool against a populated Neutron DB, run as part of the existing networking-calico Semaphore pipeline.  At each scale (default 100, 1000, 3000 ports) the test populates real Neutron resources via the REST API as admin, INSERTs fake "Calico per-host agent (felix)" rows into the agents table so ports can bind to arbitrary hosts, runs three steady-state resyncs and one cold-etcd resync, and prints both a grep-able ``RESYNC_SCALE_RESULT`` summary line and per-run JSON.  Nothing about Neutron, neutron-lib or SQLAlchemy is mocked.

Adds a generic perf-publishing pipeline under ``hack/perf/`` so the resync numbers (and future perf measurements from any test in the monorepo) can be landed in the Lens ElasticSearch cluster for long-term trend tracking:

* Producers write one JSON file per measurement (scenario scalars only) to ``artifacts/perf/<index_family>/``.
* ``hack/perf/cmd/send-perf-results`` (stdlib-only Go binary) walks that tree once at the end of a CI job, applies any ``hack/perf/index-templates/<family>.json`` templates (idempotent upserts so template changes auto-propagate), augments each doc with CI metadata (``@timestamp``, ``git_commit``, ``git_branch``, ``code_version``, ``ci_run_id``, ``pr_number``, ``env``), and POSTs to ``<family>_<UTC year>/_doc``.
* All failure paths log + exit 0 unless ``--require-creds`` is set; Lens outages must not fail the producing test.
* Local runs skip silently when ``ELASTICSEARCH_URL`` is unset, and the injected ``env=dev`` field lets dashboards filter out accidental dev pushes.
* ``hack/perf/README.md`` documents the full convention -- producer contract, schema rules (flat scalars only, one measurement per doc), ES/Kibana gotchas, index-naming convention, starter index template, verification queries, and operational hygiene.

The resync benchmark writes per-iteration docs to ``artifacts/perf/benchmark_data_neutron_resync/`` and bootstrap.sh invokes ``send-perf-results`` once after the test.

Setup steps that aren't code (called out in the README); these will be automated later, or must be done manually:
* Get the Lens ES endpoint + API key from ``#banzai`` and attach as Semaphore secrets to the OpenStack pipeline.
* Create a Kibana index pattern (``benchmark_data_neutron_resync_*``) with ``@timestamp`` as the time field, plus a starter Lens visualisation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>