### PR TITLE
Remove redundant processing of node address

### DIFF
--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -415,7 +415,7 @@ func NewCalculationGraph(
 	//         |
 	//      <dataplane>
 	//
-	hostIPPassthru := NewDataplanePassthru(callbacks, conf.Ipv6Support)
+	hostIPPassthru := NewDataplanePassthru(callbacks)
 	hostIPPassthru.RegisterWith(allUpdDispatcher)
 	cg.hostIPPassthru = hostIPPassthru
 

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -33,9 +33,8 @@ import (
 // with the rest of the dataplane API.
 //
 // HostMetadataUpdate is sourced from the v3 Node resource: BGP IPv4/IPv6 plus labels and ASN.
-// IPv4 falls back to the Node's address list (Internal preferred, External as backup) whenever
-// BGP doesn't supply one — mirroring the old felixnodeprocessor logic that previously fed the
-// retired HostIPKey channel. IPv6 falls back to the address list only when BGP is absent.
+// IPv4/IPv6 falls back to the Node's address list (Internal preferred, External as backup) whenever
+// BGP doesn't supply one.
 type DataplanePassthru struct {
 	callbacks passthruCallbacks
 

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -37,19 +37,17 @@ import (
 // BGP doesn't supply one — mirroring the old felixnodeprocessor logic that previously fed the
 // retired HostIPKey channel. IPv6 falls back to the address list only when BGP is absent.
 type DataplanePassthru struct {
-	ipv6Support bool
-	callbacks   passthruCallbacks
+	callbacks passthruCallbacks
 
 	// nodeInfo is the per-host info derived from a Node resource. A non-nil entry
 	// means the Node resource currently exists for that host.
 	nodeInfo map[string]*HostInfo
 }
 
-func NewDataplanePassthru(callbacks passthruCallbacks, ipv6Support bool) *DataplanePassthru {
+func NewDataplanePassthru(callbacks passthruCallbacks) *DataplanePassthru {
 	return &DataplanePassthru{
-		ipv6Support: ipv6Support,
-		callbacks:   callbacks,
-		nodeInfo:    map[string]*HostInfo{},
+		callbacks: callbacks,
+		nodeInfo:  map[string]*HostInfo{},
 	}
 }
 
@@ -134,8 +132,8 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 
 	info := &HostInfo{
 		labels:  node.Labels,
-		ip4Addr: extractNodeAddress(node, 4, true),
-		ip6Addr: extractNodeAddress(node, 6, h.ipv6Support),
+		ip4Addr: extractNodeAddress(node, 4),
+		ip6Addr: extractNodeAddress(node, 6),
 	}
 
 	if node.Spec.BGP != nil && node.Spec.BGP.ASNumber != nil {
@@ -150,9 +148,8 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 }
 
 // extractNodeAddress returns the IPv4/6 host address for a Node resource, preferring
-// the BGP IPv4/6Address and falling back to the Node's InternalIP/ExternalIP — the
-// same source as the retired HostIPKey channel (see dataplane_passthru.go).
-func extractNodeAddress(node *internalapi.Node, ipVersion int, ipv6Support bool) string {
+// the BGP IPv4/6Address and falling back to the Node's InternalIP/ExternalIP.
+func extractNodeAddress(node *internalapi.Node, ipVersion int) string {
 	if node == nil {
 		return ""
 	}
@@ -172,23 +169,16 @@ func extractNodeAddress(node *internalapi.Node, ipVersion int, ipv6Support bool)
 			if s, ok := parseCIDR(addr); ok {
 				return s
 			}
-			logrus.WithField("addr", addr).Warn("Ignoring Node BGP address: not a CIDR")
+			logrus.WithFields(logrus.Fields{
+				"ipVersion": ipVersion,
+				"address":   addr,
+			}).Warn("Ignoring Node BGP address: not a CIDR")
 		}
 	}
 
 	// Fallback path.
-	if ipVersion == 6 && (!ipv6Support || bgpSpec != nil) {
-		// IPv6 fallback only fires when BGP is absent, preserving the historical
-		// asymmetry: IPv4 had a backup channel (HostIPKey) but IPv6 did not, so
-		// the Address list was only consulted for IPv6 when BGP itself was nil.
-		return ""
-	}
-
 	// If BGP didn't supply an address, fall back to the Node's address
-	// list. This applies whether BGP is nil or BGP is set without an
-	// IPv4/6Address — matching the legacy felixnodeprocessor behaviour that fed
-	// the retired HostIPKey channel.
-
+	// list. This applies whether BGP is nil or BGP is set without an IPv4/6Address.
 	ip, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, ipVersion)
 	if ipnet == nil {
 		ip, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, ipVersion)

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -177,7 +177,7 @@ func extractNodeAddress(node *internalapi.Node, ipVersion int, ipv6Support bool)
 	}
 
 	// Fallback path.
-	if ipVersion == 6 && !ipv6Support {
+	if ipVersion == 6 && (!ipv6Support || bgpSpec != nil) {
 		// IPv6 fallback only fires when BGP is absent, preserving the historical
 		// asymmetry: IPv4 had a backup channel (HostIPKey) but IPv6 did not, so
 		// the Address list was only consulted for IPv6 when BGP itself was nil.

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -119,6 +119,19 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	node, _ := update.Value.(*internalapi.Node)
 	logrus.WithField("update", update).Debug("Passing-through Node update")
 
+	// An explicitly-empty BGP spec (`BGP: &NodeBGPSpec{}`) is treated as if the
+	// Node had been deleted — there is no useful metadata to pass through. A nil
+	// BGP, by contrast, leaves the Node entry alive (with empty IPs) since other
+	// Node info such as labels may still be relevant.
+	bgpSpec := node.Spec.BGP
+	if bgpSpec != nil && bgpSpec.IPv4Address == "" && bgpSpec.IPv6Address == "" && bgpSpec.ASNumber == nil {
+		delete(h.nodeInfo, hostname)
+		if before != nil {
+			h.callbacks.OnHostMetadataRemove(hostname)
+		}
+		return
+	}
+
 	info := &HostInfo{
 		labels:  node.Labels,
 		ip4Addr: extractNodeAddress(node, 4, true),
@@ -128,16 +141,6 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	if node.Spec.BGP != nil && node.Spec.BGP.ASNumber != nil {
 		info.asnumber = node.Spec.BGP.ASNumber.String()
 	}
-
-	// There is no useful metadata to pass through.
-	if info.ip4Addr == "" && info.ip6Addr == "" && info.asnumber == "" {
-		delete(h.nodeInfo, hostname)
-		if before != nil {
-			h.callbacks.OnHostMetadataRemove(hostname)
-		}
-		return
-	}
-
 	h.nodeInfo[hostname] = info
 
 	if before != nil && before.equals(info) {

--- a/felix/calc/dataplane_passthru.go
+++ b/felix/calc/dataplane_passthru.go
@@ -119,12 +119,18 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 	node, _ := update.Value.(*internalapi.Node)
 	logrus.WithField("update", update).Debug("Passing-through Node update")
 
-	// An explicitly-empty BGP spec (`BGP: &NodeBGPSpec{}`) is treated as if the
-	// Node had been deleted — there is no useful metadata to pass through. A nil
-	// BGP, by contrast, leaves the Node entry alive (with empty IPs) since other
-	// Node info such as labels may still be relevant.
-	bgpSpec := node.Spec.BGP
-	if bgpSpec != nil && bgpSpec.IPv4Address == "" && bgpSpec.IPv6Address == "" && bgpSpec.ASNumber == nil {
+	info := &HostInfo{
+		labels:  node.Labels,
+		ip4Addr: extractNodeAddress(node, 4, true),
+		ip6Addr: extractNodeAddress(node, 6, h.ipv6Support),
+	}
+
+	if node.Spec.BGP != nil && node.Spec.BGP.ASNumber != nil {
+		info.asnumber = node.Spec.BGP.ASNumber.String()
+	}
+
+	// There is no useful metadata to pass through.
+	if info.ip4Addr == "" && info.ip6Addr == "" && info.asnumber == "" {
 		delete(h.nodeInfo, hostname)
 		if before != nil {
 			h.callbacks.OnHostMetadataRemove(hostname)
@@ -132,62 +138,64 @@ func (h *DataplanePassthru) processKindNode(key model.ResourceKey, update api.Up
 		return
 	}
 
-	info := &HostInfo{labels: node.Labels}
-	if bgpSpec != nil {
-		// BGP IPv4Address/IPv6Address must already be in CIDR form per the v3
-		// CRD validation (`cidrv4`/`cidrv6` tags). Bare IPs are dropped silently
-		// here so the dataplane never sees an ambiguous address.
-		if addr := bgpSpec.IPv4Address; addr != "" {
-			if s, ok := parseCIDR(addr); ok {
-				info.ip4Addr = s
-			} else {
-				logrus.WithField("addr", addr).Warn("Ignoring Node BGP IPv4Address: not a CIDR")
-			}
-		}
-		if addr := bgpSpec.IPv6Address; addr != "" {
-			if s, ok := parseCIDR(addr); ok {
-				info.ip6Addr = s
-			} else {
-				logrus.WithField("addr", addr).Warn("Ignoring Node BGP IPv6Address: not a CIDR")
-			}
-		}
-		if node.Spec.BGP.ASNumber != nil {
-			info.asnumber = node.Spec.BGP.ASNumber.String()
-		}
-	}
-	// If BGP didn't supply an IPv4 address, fall back to the Node's address
-	// list. This applies whether BGP is nil or BGP is set without an
-	// IPv4Address — matching the legacy felixnodeprocessor behaviour that fed
-	// the retired HostIPKey channel.
-	if info.ip4Addr == "" {
-		ipv4, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, 4)
-		if ipnet == nil {
-			ipv4, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, 4)
-		}
-		if ipnet != nil {
-			ipnet.IP = ipv4.IP
-			info.ip4Addr = ipnet.String()
-		}
-	}
-	// IPv6 fallback only fires when BGP is absent, preserving the historical
-	// asymmetry: IPv4 had a backup channel (HostIPKey) but IPv6 did not, so
-	// the Address list was only consulted for IPv6 when BGP itself was nil.
-	if bgpSpec == nil && h.ipv6Support {
-		ipv6, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, 6)
-		if ipnet == nil {
-			ipv6, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, 6)
-		}
-		if ipnet != nil {
-			ipnet.IP = ipv6.IP
-			info.ip6Addr = ipnet.String()
-		}
-	}
-
 	h.nodeInfo[hostname] = info
+
 	if before != nil && before.equals(info) {
 		return
 	}
 	h.callbacks.OnHostMetadataUpdate(hostname, info)
+}
+
+// extractNodeAddress returns the IPv4/6 host address for a Node resource, preferring
+// the BGP IPv4/6Address and falling back to the Node's InternalIP/ExternalIP — the
+// same source as the retired HostIPKey channel (see dataplane_passthru.go).
+func extractNodeAddress(node *internalapi.Node, ipVersion int, ipv6Support bool) string {
+	if node == nil {
+		return ""
+	}
+
+	bgpSpec := node.Spec.BGP
+	if bgpSpec != nil {
+		// BGP IPv4/6Address must already be in CIDR form per the v3
+		// CRD validation (`cidrv4`/`cidrv6` tags). Bare IPs are dropped silently
+		// here so the dataplane never sees an ambiguous address.
+		var addr string
+		if ipVersion == 6 {
+			addr = bgpSpec.IPv6Address
+		} else {
+			addr = bgpSpec.IPv4Address
+		}
+		if addr != "" {
+			if s, ok := parseCIDR(addr); ok {
+				return s
+			}
+			logrus.WithField("addr", addr).Warn("Ignoring Node BGP address: not a CIDR")
+		}
+	}
+
+	// Fallback path.
+	if ipVersion == 6 && !ipv6Support {
+		// IPv6 fallback only fires when BGP is absent, preserving the historical
+		// asymmetry: IPv4 had a backup channel (HostIPKey) but IPv6 did not, so
+		// the Address list was only consulted for IPv6 when BGP itself was nil.
+		return ""
+	}
+
+	// If BGP didn't supply an address, fall back to the Node's address
+	// list. This applies whether BGP is nil or BGP is set without an
+	// IPv4/6Address — matching the legacy felixnodeprocessor behaviour that fed
+	// the retired HostIPKey channel.
+
+	ip, ipnet := cresources.FindNodeAddress(node, internalapi.InternalIP, ipVersion)
+	if ipnet == nil {
+		ip, ipnet = cresources.FindNodeAddress(node, internalapi.ExternalIP, ipVersion)
+	}
+	if ipnet != nil {
+		ipnet.IP = ip.IP
+		return ipnet.String()
+	}
+
+	return ""
 }
 
 // parseCIDR strictly parses a CIDR string and returns it normalized to "host

--- a/felix/calc/dataplane_passthru_test.go
+++ b/felix/calc/dataplane_passthru_test.go
@@ -121,7 +121,7 @@ var _ = Describe("DataplanePassthru host metadata sourcing", func() {
 
 	BeforeEach(func() {
 		recorder = &hostMetaRecorder{}
-		passthru = NewDataplanePassthru(recorder, true)
+		passthru = NewDataplanePassthru(recorder)
 	})
 
 	It("uses BGP IPv4 when supplied", func() {
@@ -221,22 +221,6 @@ var _ = Describe("DataplanePassthru host metadata sourcing", func() {
 		Expect(recorder.updates).To(HaveLen(1))
 		Expect(recorder.updates[0].ip4Addr).To(Equal("10.0.0.5/32"))
 		Expect(recorder.updates[0].ip6Addr).To(Equal("fd00::99/64"))
-	})
-
-	It("does not populate IPv6 from Addresses when ipv6Support is off", func() {
-		passthru = NewDataplanePassthru(recorder, false)
-		passthru.OnUpdate(nodeUpdate(host, &internalapi.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: host},
-			Spec: internalapi.NodeSpec{
-				Addresses: []internalapi.NodeAddress{
-					{Address: "10.0.0.5", Type: internalapi.InternalIP},
-					{Address: "fd00::99", Type: internalapi.InternalIP},
-				},
-			},
-		}))
-		Expect(recorder.updates).To(HaveLen(1))
-		Expect(recorder.updates[0].ip4Addr).To(Equal("10.0.0.5/32"))
-		Expect(recorder.updates[0].ip6Addr).To(BeEmpty())
 	})
 
 	It("ignores Addresses without a recognised Type", func() {


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Moving retrieving address from a Node resource and the fallback logic to a separate function. It's also used in [ipsec binding](https://github.com/tigera/calico-private/blob/545613c9a4712d7a4a6524089b395c7d624bdf25/felix/calc/ipsec_binding_calculator.go#L443) in calc graph. It was needed as part of this pick PR: https://github.com/tigera/calico-private/pull/11915

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
