### PR TITLE
Fix race in wireguard metrics collection.

### DIFF
--- a/felix/wireguard/metrics_linux.go
+++ b/felix/wireguard/metrics_linux.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -62,53 +63,54 @@ type Metrics struct {
 	wireguardClient    netlinkshim.Wireguard
 	logCtx             *logrus.Entry
 
-	peerRx, peerTx map[wgtypes.Key]int64
+	rateLimitInterval time.Duration
 
+	lock               sync.Mutex
 	lastCollectionTime time.Time
-	rateLimitInterval  time.Duration
+	cachedMetrics      []prometheus.Metric
 }
 
 func (collector *Metrics) Describe(d chan<- *prometheus.Desc) {
-	for _, dev := range collector.getDevices() {
-		collector.descsByDevice(d, dev)
-	}
-}
-
-func (collector *Metrics) descsByDevice(d chan<- *prometheus.Desc, device *wgtypes.Device) {
-	if device == nil {
-		collector.logCtx.Error("BUG: called descsByDevice with nil device")
-		return
-	}
-
-	labels := collector.defaultLabelValues("pub", deviceMetaLabelValues(device))
-	for fqName, help := range map[string]string{
-		wireguardMetaFQName: wireguardMetaHelpText,
-	} {
-		d <- prometheus.NewDesc(fqName, help, nil, labels)
-	}
-	for _, peer := range device.Peers {
-		collector.descByPeer(d, &peer)
-	}
-}
-
-func (collector *Metrics) descByPeer(d chan<- *prometheus.Desc, peer *wgtypes.Peer) {
-	if peer == nil {
-		collector.logCtx.Error("BUG: called descByPeer with nil peer")
-		return
-	}
-
-	labels := collector.defaultLabelValues("pub", peerServiceLabelValues(peer))
-	for fqName, help := range map[string]string{
-		wireguardBytesRcvdFQName:               wireguardBytesRcvdHelpText,
-		wireguardBytesSentFQName:               wireguardBytesSentHelpText,
-		wireguardLatestHandshakeIntervalFQName: wireguardLatestHandshakeIntervalHelpText,
-	} {
-		d <- prometheus.NewDesc(fqName, help, nil, labels)
-	}
+	// Send nothing, this marks our collector as "unchecked", which we need
+	// because our Collect() method is dynamic.
 }
 
 func (collector *Metrics) Collect(m chan<- prometheus.Metric) {
-	collector.refreshStats(m)
+	metrics := collector.maybeRefresh()
+	for _, met := range metrics {
+		m <- met
+	}
+}
+
+func (collector *Metrics) maybeRefresh() []prometheus.Metric {
+	// Compute staleness relative to the time we were asked for the metrics
+	// so that multiple concurrent calls will collect metrics only once even
+	// if the collection was slow for some reason.
+	collectCallTime := time.Now()
+
+	collector.lock.Lock()
+	defer collector.lock.Unlock()
+	var metrics []prometheus.Metric
+	if ct := collectCallTime.Sub(collector.lastCollectionTime); ct < collector.rateLimitInterval {
+		collector.logCtx.WithFields(logrus.Fields{
+			"since":              ct.String(),
+			"ratelimit_interval": collector.rateLimitInterval.String(),
+		}).Debug("refreshStats disallowed due to rate limit")
+		metrics = collector.cachedMetrics
+	} else {
+		metrics = make([]prometheus.Metric, 0, len(collector.cachedMetrics))
+		devices := collector.getDevices()
+		collector.logCtx.WithFields(logrus.Fields{
+			"count": len(devices),
+			"dev":   devices,
+		}).Debug("collect device metrics enumerated devices")
+		metrics = collector.appendDeviceMetrics(devices, metrics)
+		metrics = collector.appendDevicePeerMetrics(devices, metrics)
+		collector.lastCollectionTime = time.Now()
+		collector.cachedMetrics = metrics
+	}
+
+	return metrics
 }
 
 func MustNewWireguardMetrics() *Metrics {
@@ -136,9 +138,6 @@ func NewWireguardMetricsWithShims(hostname string, newWireguardClient func() (ne
 			"prometheus_collector": "wireguard",
 		}),
 
-		peerRx: map[wgtypes.Key]int64{},
-		peerTx: map[wgtypes.Key]int64{},
-
 		rateLimitInterval: rateLimitInterval,
 	}
 }
@@ -165,34 +164,17 @@ func (collector *Metrics) getDevices() []*wgtypes.Device {
 	devices, err := wgClient.Devices()
 	if err != nil {
 		collector.logCtx.WithError(err).Debug("something went wrong enumerating wireguard devices")
-		wgClient.Close()
+		err := wgClient.Close()
+		if err != nil {
+			collector.logCtx.WithError(err).Warn("Error from wgClient.Close.")
+		}
 		collector.wireguardClient = nil
 		return nil
 	}
 	return devices
 }
 
-func (collector *Metrics) refreshStats(m chan<- prometheus.Metric) {
-	if ct := time.Since(collector.lastCollectionTime); ct < collector.rateLimitInterval {
-		collector.logCtx.WithFields(logrus.Fields{
-			"since":              ct.String(),
-			"ratelimit_interval": collector.rateLimitInterval.String(),
-		}).Debug("refreshStats disallowed due to rate limit")
-		return
-	}
-	devices := collector.getDevices()
-	collector.logCtx.WithFields(logrus.Fields{
-		"count": len(devices),
-		"dev":   devices,
-	}).Debug("collect device metrics enumerated devices")
-
-	collector.collectDeviceMetrics(devices, m)
-	collector.collectDevicePeerMetrics(devices, m)
-
-	collector.lastCollectionTime = time.Now()
-}
-
-func (collector *Metrics) collectDeviceMetrics(devices []*wgtypes.Device, m chan<- prometheus.Metric) {
+func (collector *Metrics) appendDeviceMetrics(devices []*wgtypes.Device, m []prometheus.Metric) []prometheus.Metric {
 	collector.logCtx.Debug("collecting wg device metrics")
 
 	for _, device := range devices {
@@ -203,17 +185,18 @@ func (collector *Metrics) collectDeviceMetrics(devices []*wgtypes.Device, m chan
 			"labels": l,
 		}).Debug("iterate device")
 
-		m <- prometheus.MustNewConstMetric(
+		m = append(m, prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				wireguardMetaFQName, wireguardMetaHelpText, nil, l,
 			),
 			prometheus.GaugeValue,
 			1,
-		)
+		))
 	}
+	return m
 }
 
-func (collector *Metrics) collectDevicePeerMetrics(devices []*wgtypes.Device, m chan<- prometheus.Metric) {
+func (collector *Metrics) appendDevicePeerMetrics(devices []*wgtypes.Device, m []prometheus.Metric) []prometheus.Metric {
 	collector.logCtx.Debug("collecting wg peer(s) metrics")
 
 	collector.logCtx.WithFields(logrus.Fields{
@@ -241,32 +224,32 @@ func (collector *Metrics) collectDevicePeerMetrics(devices []*wgtypes.Device, m 
 				"handshake_ts":   hs,
 			}).Debug("collected peer metrics")
 
-			m <- prometheus.MustNewConstMetric(
+			m = append(m, prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					wireguardBytesRcvdFQName, wireguardBytesRcvdHelpText, nil, labels,
 				),
 				prometheus.CounterValue,
 				float64(peer.ReceiveBytes),
-			)
+			))
 
-			m <- prometheus.MustNewConstMetric(
+			m = append(m, prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					wireguardBytesSentFQName, wireguardBytesSentHelpText, nil, labels,
 				),
 				prometheus.CounterValue,
 				float64(peer.TransmitBytes),
-			)
+			))
 
-			m <- prometheus.MustNewConstMetric(
+			m = append(m, prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					wireguardLatestHandshakeIntervalFQName, wireguardLatestHandshakeIntervalHelpText, nil, labels,
 				),
 				prometheus.GaugeValue,
 				hs,
-			)
+			))
 		}
 	}
-
+	return m
 }
 
 func (collector *Metrics) defaultLabelValues(publicKey string, extend prometheus.Labels) prometheus.Labels {

--- a/felix/wireguard/metrics_test.go
+++ b/felix/wireguard/metrics_test.go
@@ -119,8 +119,8 @@ var _ = Describe("wireguard metrics", func() {
 	var wgClient *wireguardDevicesOnly
 	var mockPeers []*mockPeerInfo
 	const (
-		hostname                 = "l0c4lh057"
-		defaultRateLimitInterval = time.Second * 5
+		hostname              = "l0c4lh057"
+		testRateLimitInterval = 100 * time.Millisecond
 	)
 
 	newWireguardDevicesOnly := func() (netlinkshim.Wireguard, error) {
@@ -138,7 +138,7 @@ var _ = Describe("wireguard metrics", func() {
 		wgStats = wireguard.NewWireguardMetricsWithShims(
 			hostname,
 			newWireguardDevicesOnly,
-			defaultRateLimitInterval,
+			testRateLimitInterval,
 		)
 	})
 
@@ -157,19 +157,20 @@ var _ = Describe("wireguard metrics", func() {
 		Expect(mfs).To(HaveLen(4))
 
 		By("checking if rate-limiting works")
+		ts := wgClient.generatePeerTraffic(1024, 1024)
 		mfs2, err := registry.Gather()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(mfs2).To(BeEmpty())
+		Expect(mfs2).To(Equal(mfs))
 
-		<-time.After(5 * time.Second)
-		ts := wgClient.generatePeerTraffic(1024, 1024)
-		mfs, err = registry.Gather()
+		<-time.After(101 * time.Millisecond)
+		mfs3, err := registry.Gather()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(mfs).To(HaveLen(4))
+		Expect(mfs3).To(HaveLen(4))
+		Expect(mfs3).NotTo(Equal(mfs))
 
 		By("comparing text output")
 		buf := &bytes.Buffer{}
-		for _, mf := range mfs {
+		for _, mf := range mfs3 {
 			_, err := expfmt.MetricFamilyToText(buf, mf)
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -203,27 +204,6 @@ wireguard_meta{hostname="{{.hostname}}",iface="{{.iface}}",listen_port="{{.liste
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(buf.String()).To(Equal(buf2.String()))
-	})
-
-	It("should not yield metrics if unregistered", func() {
-		By("checking if it's constructable")
-		Expect(wgStats).ToNot(BeNil())
-
-		By("registering it in a prometheus.Registry")
-		registry := prometheus.NewRegistry()
-		registry.MustRegister(wgStats)
-
-		By("unregistering with no issue")
-		ok := registry.Unregister(wgStats)
-		Expect(ok).To(BeTrue())
-
-		By("checking if gathering metrics will not error")
-		wgClient.generatePeerTraffic(512, 512)
-		mfs, err := registry.Gather()
-		Expect(err).ToNot(HaveOccurred())
-
-		By("checking if there are no metrics at all since it is unregistered")
-		Expect(mfs).To(HaveLen(0))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Prometheus can call Gather() and Collect() concurrently. Fix is different for each:

- Gather() was incorrect: it returned the current list of metrics, but that was dynamic.  For a dynamic collector, the Collector interface specs that we should return no metrics instead.

- Collect() was concurrently updating the rate limit fields and, when the rate limit fired, it incorrectly returned no metrics at all. Cache the most recent metrics and re-use those if the rate limit fires instead.

Drive-by cleanups: remove unused fields, address missing err check.

Race detector hit:
```
WARNING: DATA RACE
Write at 0x00c0012b5240 by goroutine 894:
  github.com/projectcalico/calico/felix/wireguard.(*Metrics).refreshStats()
      /go/src/github.com/projectcalico/calico/felix/wireguard/metrics_linux.go:192 +0x664
  github.com/projectcalico/calico/felix/wireguard.(*Metrics).Collect()
      /go/src/github.com/projectcalico/calico/felix/wireguard/metrics_linux.go:111 +0x33
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
      /go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/registry.go:458 +0x10a

Previous read at 0x00c0012b5240 by goroutine 899:
  github.com/projectcalico/calico/felix/wireguard.(*Metrics).refreshStats()
      /go/src/github.com/projectcalico/calico/felix/wireguard/metrics_linux.go:176 +0x59
  github.com/projectcalico/calico/felix/wireguard.(*Metrics).Collect()
      /go/src/github.com/projectcalico/calico/felix/wireguard/metrics_linux.go:111 +0x33
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
      /go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/registry.go:458 +0x10a

```

**Release note:**
```release-note
Fix a race in wireguard metrics collection that could result in spuriously missing metrics when metrics were collected faster than the rate limit.
```
