### PR TITLE
Handle DeletedFinalStateUnknown across kube-controllers and confd delete handlers

### DIFF
--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -545,10 +545,12 @@ func (rg *routeGenerator) advertiseThisService(svc *v1.Service, eps []*discovery
 }
 
 // unsetRouteForSvc removes the route from the svcClusterRouteMap
-// but checks to see if it wasn't already deleted by its sibling resource
+// but checks to see if it wasn't already deleted by its sibling resource.
+// Only called from delete handlers, so it must use the deletion-handling
+// key func to unwrap any cache.DeletedFinalStateUnknown tombstone.
 func (rg *routeGenerator) unsetRouteForSvc(obj any) {
 	// generate key
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		log.WithError(err).Warn("unsetRouteForSvc: error on retrieving key for object, passing")
 		return

--- a/kube-controllers/pkg/controllers/ippool/pool_controller.go
+++ b/kube-controllers/pkg/controllers/ippool/pool_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,8 +69,12 @@ func NewController(
 	// Configure events for new IP pools.
 	poolHandlers := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
-			logrus.WithField("name", obj.(*v3.IPPool).Name).Info("Handling pool deletion")
-			if err := c.Reconcile(obj.(*v3.IPPool)); err != nil {
+			pool, ok := poolFromDeleteObj(obj)
+			if !ok {
+				return
+			}
+			logrus.WithField("name", pool.Name).Info("Handling pool deletion")
+			if err := c.Reconcile(pool); err != nil {
 				logrus.WithError(err).Error("Error handling pool deletion")
 			}
 		},
@@ -95,7 +99,10 @@ func NewController(
 	// deleting IP pools when blocks are deleted, to ensure we can finalize the pool.
 	blockHandlers := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
-			block := obj.(*v3.IPAMBlock)
+			block, ok := blockFromDeleteObj(obj)
+			if !ok {
+				return
+			}
 
 			// Find any pools that might be associated with this block and trigger a reconcile.
 			for _, i := range poolInformer.GetIndexer().List() {
@@ -474,4 +481,43 @@ func setConditionOnPool(p *v3.IPPool, condition metav1.Condition) bool {
 	condition.LastTransitionTime = metav1.Now()
 	p.Status.Conditions = append(p.Status.Conditions, condition)
 	return true
+}
+
+// poolFromDeleteObj extracts an *v3.IPPool from an informer delete event
+// object, unwrapping cache.DeletedFinalStateUnknown if present. Returns
+// ok=false (and logs) when the object isn't an IPPool so callers can skip
+// the delete instead of panicking.
+func poolFromDeleteObj(obj any) (*v3.IPPool, bool) {
+	if pool, ok := obj.(*v3.IPPool); ok {
+		return pool, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		logrus.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in IPPool delete event")
+		return nil, false
+	}
+	pool, ok := tombstone.Obj.(*v3.IPPool)
+	if !ok {
+		logrus.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-IPPool object")
+		return nil, false
+	}
+	return pool, true
+}
+
+// blockFromDeleteObj is the IPAMBlock counterpart to poolFromDeleteObj.
+func blockFromDeleteObj(obj any) (*v3.IPAMBlock, bool) {
+	if block, ok := obj.(*v3.IPAMBlock); ok {
+		return block, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		logrus.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in IPAMBlock delete event")
+		return nil, false
+	}
+	block, ok := tombstone.Obj.(*v3.IPAMBlock)
+	if !ok {
+		logrus.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-IPAMBlock object")
+		return nil, false
+	}
+	return block, true
 }

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,14 +213,25 @@ func (c *loadBalancerController) onServiceUpdate(objNew any, objOld any) {
 	}
 }
 
-func (c *loadBalancerController) onServiceDelete(objNew any) {
-	if svc, ok := objNew.(*v1.Service); ok {
-		svcKey, err := serviceKeyFromService(svc)
-		if err != nil {
+func (c *loadBalancerController) onServiceDelete(obj any) {
+	svc, ok := obj.(*v1.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in Service delete event")
 			return
 		}
-		c.serviceUpdates <- *svcKey
+		svc, ok = tombstone.Obj.(*v1.Service)
+		if !ok {
+			log.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-Service object")
+			return
+		}
 	}
+	svcKey, err := serviceKeyFromService(svc)
+	if err != nil {
+		return
+	}
+	c.serviceUpdates <- *svcKey
 }
 
 func (c *loadBalancerController) RegisterWith(f *utils.DataFeed) {

--- a/kube-controllers/pkg/controllers/migration/controller.go
+++ b/kube-controllers/pkg/controllers/migration/controller.go
@@ -244,7 +244,7 @@ func (m *migrationController) RunWithContext(ctx context.Context) {
 }
 
 func (m *migrationController) enqueue(obj any) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get key for object")
 		return

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -104,17 +105,25 @@ func NewNodeController(ctx context.Context,
 	// respective informers.
 	nodeHandlers := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
+			node, ok := nodeFromDeleteObj(obj)
+			if !ok {
+				return
+			}
 			// Call all of the registered node deletion funcs.
 			for _, f := range nodeDeletionFuncs {
-				f(obj.(*v1.Node))
+				f(node)
 			}
 		},
 	}
 	podHandlers := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
+			pod, ok := podFromDeleteObj(obj)
+			if !ok {
+				return
+			}
 			// Call all of the registered pod deletion funcs.
 			for _, f := range podDeletionFuncs {
-				f(obj.(*v1.Pod))
+				f(pod)
 			}
 		},
 	}
@@ -145,6 +154,45 @@ func NewNodeController(ctx context.Context,
 	}
 
 	return nc
+}
+
+// nodeFromDeleteObj extracts a *v1.Node from an informer delete event object,
+// unwrapping the cache.DeletedFinalStateUnknown tombstone the informer may
+// deliver when its watch state is lost. Returns ok=false (and logs) if the
+// object is not a Node, so callers can skip the delete instead of panicking.
+func nodeFromDeleteObj(obj any) (*v1.Node, bool) {
+	if node, ok := obj.(*v1.Node); ok {
+		return node, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in node delete event")
+		return nil, false
+	}
+	node, ok := tombstone.Obj.(*v1.Node)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-Node object")
+		return nil, false
+	}
+	return node, true
+}
+
+// podFromDeleteObj is the pod counterpart to nodeFromDeleteObj.
+func podFromDeleteObj(obj any) (*v1.Pod, bool) {
+	if pod, ok := obj.(*v1.Pod); ok {
+		return pod, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", obj)).Warn("Unexpected object type in pod delete event")
+		return nil, false
+	}
+	pod, ok := tombstone.Obj.(*v1.Pod)
+	if !ok {
+		log.WithField("type", fmt.Sprintf("%T", tombstone.Obj)).Warn("Tombstone contained non-Pod object")
+		return nil, false
+	}
+	return pod, true
 }
 
 // getK8sNodeName is a helper method that searches a calicoNode for its kubernetes nodeRef.

--- a/kube-controllers/pkg/controllers/node/controller_test.go
+++ b/kube-controllers/pkg/controllers/node/controller_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestNodeFromDeleteObj(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+
+	tests := []struct {
+		name    string
+		obj     any
+		want    *v1.Node
+		wantOk  bool
+	}{
+		{"direct node", node, node, true},
+		{"tombstone with node", cache.DeletedFinalStateUnknown{Key: "n1", Obj: node}, node, true},
+		{"tombstone with pod", cache.DeletedFinalStateUnknown{Key: "n1", Obj: &v1.Pod{}}, nil, false},
+		{"unrelated type", &v1.Pod{}, nil, false},
+		{"nil", nil, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := nodeFromDeleteObj(tc.obj)
+			if ok != tc.wantOk || got != tc.want {
+				t.Fatalf("got (%v, %v), want (%v, %v)", got, ok, tc.want, tc.wantOk)
+			}
+		})
+	}
+}
+
+func TestPodFromDeleteObj(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+
+	tests := []struct {
+		name    string
+		obj     any
+		want    *v1.Pod
+		wantOk  bool
+	}{
+		{"direct pod", pod, pod, true},
+		{"tombstone with pod", cache.DeletedFinalStateUnknown{Key: "p1", Obj: pod}, pod, true},
+		{"tombstone with node", cache.DeletedFinalStateUnknown{Key: "p1", Obj: &v1.Node{}}, nil, false},
+		{"unrelated type", &v1.Node{}, nil, false},
+		{"nil", nil, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := podFromDeleteObj(tc.obj)
+			if ok != tc.wantOk || got != tc.want {
+				t.Fatalf("got (%v, %v), want (%v, %v)", got, ok, tc.want, tc.wantOk)
+			}
+		})
+	}
+}

--- a/kube-controllers/pkg/controllers/node/controller_test.go
+++ b/kube-controllers/pkg/controllers/node/controller_test.go
@@ -26,10 +26,10 @@ func TestNodeFromDeleteObj(t *testing.T) {
 	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
 
 	tests := []struct {
-		name    string
-		obj     any
-		want    *v1.Node
-		wantOk  bool
+		name   string
+		obj    any
+		want   *v1.Node
+		wantOk bool
 	}{
 		{"direct node", node, node, true},
 		{"tombstone with node", cache.DeletedFinalStateUnknown{Key: "n1", Obj: node}, node, true},
@@ -51,10 +51,10 @@ func TestPodFromDeleteObj(t *testing.T) {
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
 
 	tests := []struct {
-		name    string
-		obj     any
-		want    *v1.Pod
-		wantOk  bool
+		name   string
+		obj    any
+		want   *v1.Pod
+		wantOk bool
 	}{
 		{"direct pod", pod, pod, true},
 		{"tombstone with pod", cache.DeletedFinalStateUnknown{Key: "p1", Obj: pod}, pod, true},


### PR DESCRIPTION
The informer can deliver a `cache.DeletedFinalStateUnknown` tombstone to `DeleteFunc` when its watch state is lost. Several delete paths in kube-controllers and confd cast the object directly or used `cache.MetaNamespaceKeyFunc`, which either panic (crash-looping the pod) or silently drop the cleanup on the tombstone case.

Fixes #12741

Files touched:

- `kube-controllers/.../node/controller.go` - node and pod delete handlers (the original report)
- `kube-controllers/.../ippool/pool_controller.go` - IPPool and IPAMBlock delete handlers
- `kube-controllers/.../loadbalancer/loadbalancer_controller.go` - Service delete handler
- `kube-controllers/.../migration/controller.go` - swap to `DeletionHandlingMetaNamespaceKeyFunc`
- `confd/.../routes.go` - `unsetRouteForSvc` is called from delete handlers, same swap

```release-note
Fixes a panic in kube-controllers when the informer delivers a tombstone object to a delete handler.
```