### PR TITLE
Ship upstream CNI plugins via a separate init image

### DIFF
--- a/.semaphore/push-images/cni-plugins.yml
+++ b/.semaphore/push-images/cni-plugins.yml
@@ -1,0 +1,35 @@
+version: v1.0
+name: Publish cni-plugins images
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+execution_time_limit:
+  minutes: 60
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+      - ssh-add ~/.ssh/id_rsa
+blocks:
+  - name: Publish cni-plugins images and multi-arch manifests
+    dependencies: []
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C third_party/cni-plugins cd push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/third-party-cni-plugins.yml
+++ b/.semaphore/push-images/third-party-cni-plugins.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Publish cni-plugins images
+name: Publish third-party-cni-plugins images
 agent:
   machine:
     type: f1-standard-2
@@ -24,7 +24,7 @@ global_job_config:
       - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
       - ssh-add ~/.ssh/id_rsa
 blocks:
-  - name: Publish cni-plugins images and multi-arch manifests
+  - name: Publish third-party-cni-plugins images and multi-arch manifests
     dependencies: []
     skip:
       when: "branch !~ '.+'"

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -725,7 +725,6 @@ blocks:
             - export AZURE_RESOURCE_GROUP=${RG_PREFIX}-${BACKEND}-rg
             - echo AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
             - ../.semaphore/run-and-monitor win-fv-containerd.log ~/calico/process/testing/winfv-cni-plugin/run-win-fv.sh
-  blocks:
   - name: CNI plugins image
     run:
       when: >-

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -174,8 +174,8 @@ promotions:
     pipeline_file: push-images/node.yml
   - name: Push cni-plugin images
     pipeline_file: push-images/cni-plugin.yml
-  - name: Push cni-plugins images
-    pipeline_file: push-images/cni-plugins.yml
+  - name: Push third-party-cni-plugins images
+    pipeline_file: push-images/third-party-cni-plugins.yml
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
   - name: Push Whisker images
@@ -725,32 +725,6 @@ blocks:
             - export AZURE_RESOURCE_GROUP=${RG_PREFIX}-${BACKEND}-rg
             - echo AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
             - ../.semaphore/run-and-monitor win-fv-containerd.log ~/calico/process/testing/winfv-cni-plugin/run-win-fv.sh
-  - name: CNI plugins image
-    run:
-      when: >-
-        true or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'],
-        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
-    execution_time_limit:
-      minutes: 30
-    dependencies:
-      - Prerequisites
-    task:
-      prologue:
-        commands:
-          - cd third_party/cni-plugins
-      jobs:
-        - name: "CNI plugins: CI"
-          commands:
-            - ../../.semaphore/run-and-monitor make-ci.log make ci
-        - name: "CNI plugins: build multi-arch binaries"
-          matrix:
-            - env_var: ARCH
-              values:
-                - arm64
-                - ppc64le
-                - s390x
-          commands:
-            - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH
   - name: confd
     run:
       when: "true"
@@ -1645,6 +1619,32 @@ blocks:
           commands:
             - ../.semaphore/run-and-monitor ci.log make ci
             - 'test-results publish ./report/*.xml --name "pod2daemon: UT" || true'
+  - name: Third-party CNI plugins image
+    run:
+      when: >-
+        true or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'],
+        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
+    execution_time_limit:
+      minutes: 30
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd third_party/cni-plugins
+      jobs:
+        - name: "Third-party CNI plugins: CI"
+          commands:
+            - ../../.semaphore/run-and-monitor make-ci.log make ci
+        - name: "Third-party CNI plugins: build multi-arch binaries"
+          matrix:
+            - env_var: ARCH
+              values:
+                - arm64
+                - ppc64le
+                - s390x
+          commands:
+            - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH
   - name: "Tools (hack directory)"
     run:
       when: >-

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -174,6 +174,8 @@ promotions:
     pipeline_file: push-images/node.yml
   - name: Push cni-plugin images
     pipeline_file: push-images/cni-plugin.yml
+  - name: Push cni-plugins images
+    pipeline_file: push-images/cni-plugins.yml
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
   - name: Push Whisker images
@@ -723,6 +725,33 @@ blocks:
             - export AZURE_RESOURCE_GROUP=${RG_PREFIX}-${BACKEND}-rg
             - echo AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
             - ../.semaphore/run-and-monitor win-fv-containerd.log ~/calico/process/testing/winfv-cni-plugin/run-win-fv.sh
+  blocks:
+  - name: CNI plugins image
+    run:
+      when: >-
+        true or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'],
+        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
+    execution_time_limit:
+      minutes: 30
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd third_party/cni-plugins
+      jobs:
+        - name: "CNI plugins: CI"
+          commands:
+            - ../../.semaphore/run-and-monitor make-ci.log make ci
+        - name: "CNI plugins: build multi-arch binaries"
+          matrix:
+            - env_var: ARCH
+              values:
+                - arm64
+                - ppc64le
+                - s390x
+          commands:
+            - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH
   - name: confd
     run:
       when: "true"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2406,7 +2406,6 @@ blocks:
             - export AZURE_RESOURCE_GROUP=${RG_PREFIX}-${BACKEND}-rg
             - echo AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
             - ../.semaphore/run-and-monitor win-fv-containerd.log ~/calico/process/testing/winfv-cni-plugin/run-win-fv.sh
-  blocks:
   - name: CNI plugins image
     run:
       when: >-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -174,8 +174,8 @@ promotions:
     pipeline_file: push-images/node.yml
   - name: Push cni-plugin images
     pipeline_file: push-images/cni-plugin.yml
-  - name: Push cni-plugins images
-    pipeline_file: push-images/cni-plugins.yml
+  - name: Push third-party-cni-plugins images
+    pipeline_file: push-images/third-party-cni-plugins.yml
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
   - name: Push Whisker images
@@ -2406,32 +2406,6 @@ blocks:
             - export AZURE_RESOURCE_GROUP=${RG_PREFIX}-${BACKEND}-rg
             - echo AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
             - ../.semaphore/run-and-monitor win-fv-containerd.log ~/calico/process/testing/winfv-cni-plugin/run-win-fv.sh
-  - name: CNI plugins image
-    run:
-      when: >-
-        false or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'],
-        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
-    execution_time_limit:
-      minutes: 30
-    dependencies:
-      - Prerequisites
-    task:
-      prologue:
-        commands:
-          - cd third_party/cni-plugins
-      jobs:
-        - name: "CNI plugins: CI"
-          commands:
-            - ../../.semaphore/run-and-monitor make-ci.log make ci
-        - name: "CNI plugins: build multi-arch binaries"
-          matrix:
-            - env_var: ARCH
-              values:
-                - arm64
-                - ppc64le
-                - s390x
-          commands:
-            - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH
   - name: confd
     run:
       when: >-
@@ -5757,6 +5731,32 @@ blocks:
           commands:
             - ../.semaphore/run-and-monitor ci.log make ci
             - 'test-results publish ./report/*.xml --name "pod2daemon: UT" || true'
+  - name: Third-party CNI plugins image
+    run:
+      when: >-
+        false or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'],
+        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
+    execution_time_limit:
+      minutes: 30
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd third_party/cni-plugins
+      jobs:
+        - name: "Third-party CNI plugins: CI"
+          commands:
+            - ../../.semaphore/run-and-monitor make-ci.log make ci
+        - name: "Third-party CNI plugins: build multi-arch binaries"
+          matrix:
+            - env_var: ARCH
+              values:
+                - arm64
+                - ppc64le
+                - s390x
+          commands:
+            - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH
   - name: "Tools (hack directory)"
     run:
       when: >-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -174,6 +174,8 @@ promotions:
     pipeline_file: push-images/node.yml
   - name: Push cni-plugin images
     pipeline_file: push-images/cni-plugin.yml
+  - name: Push cni-plugins images
+    pipeline_file: push-images/cni-plugins.yml
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
   - name: Push Whisker images
@@ -2404,6 +2406,33 @@ blocks:
             - export AZURE_RESOURCE_GROUP=${RG_PREFIX}-${BACKEND}-rg
             - echo AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
             - ../.semaphore/run-and-monitor win-fv-containerd.log ~/calico/process/testing/winfv-cni-plugin/run-win-fv.sh
+  blocks:
+  - name: CNI plugins image
+    run:
+      when: >-
+        false or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'],
+        {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})
+    execution_time_limit:
+      minutes: 30
+    dependencies:
+      - Prerequisites
+    task:
+      prologue:
+        commands:
+          - cd third_party/cni-plugins
+      jobs:
+        - name: "CNI plugins: CI"
+          commands:
+            - ../../.semaphore/run-and-monitor make-ci.log make ci
+        - name: "CNI plugins: build multi-arch binaries"
+          matrix:
+            - env_var: ARCH
+              values:
+                - arm64
+                - ppc64le
+                - s390x
+          commands:
+            - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH
   - name: confd
     run:
       when: >-

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -46,6 +46,8 @@ promotions:
     pipeline_file: push-images/node.yml
   - name: Push cni-plugin images
     pipeline_file: push-images/cni-plugin.yml
+  - name: Push cni-plugins images
+    pipeline_file: push-images/cni-plugins.yml
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
   - name: Push Whisker images

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -46,8 +46,8 @@ promotions:
     pipeline_file: push-images/node.yml
   - name: Push cni-plugin images
     pipeline_file: push-images/cni-plugin.yml
-  - name: Push cni-plugins images
-    pipeline_file: push-images/cni-plugins.yml
+  - name: Push third-party-cni-plugins images
+    pipeline_file: push-images/third-party-cni-plugins.yml
   - name: Push mock calico-node images
     pipeline_file: push-images/mock-node.yml
   - name: Push Whisker images

--- a/.semaphore/semaphore.yml.d/blocks/20-cni-plugins.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-cni-plugins.yml
@@ -1,4 +1,3 @@
-blocks:
 - name: CNI plugins image
   run:
     when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml.d/blocks/20-cni-plugins.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-cni-plugins.yml
@@ -1,0 +1,25 @@
+blocks:
+- name: CNI plugins image
+  run:
+    when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  execution_time_limit:
+    minutes: 30
+  dependencies:
+    - Prerequisites
+  task:
+    prologue:
+      commands:
+        - cd third_party/cni-plugins
+    jobs:
+      - name: "CNI plugins: CI"
+        commands:
+          - ../../.semaphore/run-and-monitor make-ci.log make ci
+      - name: "CNI plugins: build multi-arch binaries"
+        matrix:
+          - env_var: ARCH
+            values:
+              - arm64
+              - ppc64le
+              - s390x
+        commands:
+          - ../../.semaphore/run-and-monitor image-$ARCH.log make build ARCH=$ARCH

--- a/.semaphore/semaphore.yml.d/blocks/20-third-party-cni-plugins.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-third-party-cni-plugins.yml
@@ -1,4 +1,4 @@
-- name: CNI plugins image
+- name: Third-party CNI plugins image
   run:
     when: "${FORCE_RUN} or change_in(['/metadata.mk', '/lib.Makefile', '/third_party/cni-plugins'], {pipeline_file: 'ignore', exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   execution_time_limit:
@@ -10,10 +10,10 @@
       commands:
         - cd third_party/cni-plugins
     jobs:
-      - name: "CNI plugins: CI"
+      - name: "Third-party CNI plugins: CI"
         commands:
           - ../../.semaphore/run-and-monitor make-ci.log make ci
-      - name: "CNI plugins: build multi-arch binaries"
+      - name: "Third-party CNI plugins: build multi-arch binaries"
         matrix:
           - env_var: ARCH
             values:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ clean:
 	$(MAKE) -C key-cert-provisioner clean
 	$(MAKE) -C typha clean
 	$(MAKE) -C release clean
+	$(MAKE) -C third_party/cni-plugins clean
 	rm -rf ./bin .stamp.*
 
 check-go-mod:

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -35,7 +35,6 @@ clean: clean-windows
 	rm -f *.created
 	rm -rf bin pkg/install/install.test
 	rm -rf config/ dist/
-	rm -rf containernetworking-plugins .containernetworking-plugins-*
 	rm -rf flannel-cni-plugin .flannel-cni-plugin-*
 
 clean-windows: clean-windows-builder
@@ -81,46 +80,30 @@ bin/LICENSE: ../LICENSE.md
 ###############################################################################
 # Supplementary CNI binaries required by unit tests and the Windows image.
 ###############################################################################
-# These are the files that we need to copy from the containernetworking-plugins project to our image.
-CN_FILES := host-local portmap loopback tuning
+# Linux plugin binaries (host-local, portmap, loopback, tuning, flannel) are
+# built by the third_party/cni-plugins component and consumed here for unit
+# tests. The Windows flannel.exe is built locally below — the Windows image
+# bundles the plugins directly, not via an init container.
+CNI_PLUGINS_DIR = $(REPO_ROOT)/third_party/cni-plugins
+CNI_PLUGINS_BIN = $(CNI_PLUGINS_DIR)/bin/$(ARCH)
 
-CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins-$(CNI_VERSION).cloned
+$(CNI_PLUGINS_BIN)/host-local $(CNI_PLUGINS_BIN)/loopback $(CNI_PLUGINS_BIN)/portmap $(CNI_PLUGINS_BIN)/tuning $(CNI_PLUGINS_BIN)/flannel &:
+	$(MAKE) -C $(CNI_PLUGINS_DIR) build ARCH=$(ARCH)
 
-$(CONTAINERNETWORKING_PLUGINS_CLONED):
-	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
-	@$(foreach file,$(CN_FILES),find bin -name $(file) -type f -delete;)
-	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
-	touch $@
-
-CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
-
-$(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning  &: $(CONTAINERNETWORKING_PLUGINS_CLONED)
-	docker run \
-		$(EXTRA_DOCKER_ARGS) \
-		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
-		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/containernetworking/plugins --rm $(CALICO_BUILD) \
-		/bin/sh -xe -c ' \
-			GOFLAGS='-buildvcs=false' CGO_ENABLED=0 GOARCH=$(ARCH) ./build_linux.sh $(CN_FLAGS)'
-	-mkdir -p $(BIN)
-	@$(foreach file,$(CN_FILES),cp containernetworking-plugins/bin/$(file) $(BIN);)
+$(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning &: $(CNI_PLUGINS_BIN)/host-local $(CNI_PLUGINS_BIN)/loopback $(CNI_PLUGINS_BIN)/portmap $(CNI_PLUGINS_BIN)/tuning
+	mkdir -p $(BIN)
+	cp $(CNI_PLUGINS_BIN)/host-local $(BIN)/host-local
+	cp $(CNI_PLUGINS_BIN)/loopback   $(BIN)/loopback
+	cp $(CNI_PLUGINS_BIN)/portmap    $(BIN)/portmap
+	cp $(CNI_PLUGINS_BIN)/tuning     $(BIN)/tuning
 
 FLANNEL_CNI_PLUGIN_CLONED=.flannel-cni-plugin-$(FLANNEL_VERSION).cloned
 
 $(FLANNEL_CNI_PLUGIN_CLONED):
 	rm -rf flannel-cni-plugin .flannel-cni-plugin-*.cloned
-	-rm -rf $(BIN)/flannel $(WINDOWS_BIN)/flannel.exe
+	-rm -rf $(WINDOWS_BIN)/flannel.exe
 	git clone --single-branch --branch $(FLANNEL_VERSION) https://github.com/projectcalico/flannel-cni-plugin.git
 	touch $@
-
-$(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
-	docker run \
-		$(EXTRA_DOCKER_ARGS) \
-		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
-		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
-		/bin/sh -xe -c ' \
-			ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_linux'
-	-mkdir -p $(BIN)
-	cp flannel-cni-plugin/dist/flannel-$(ARCH) $(BIN)/flannel
 
 $(WINDOWS_BIN)/flannel.exe: $(FLANNEL_CNI_PLUGIN_CLONED)
 	docker run \
@@ -131,8 +114,7 @@ $(WINDOWS_BIN)/flannel.exe: $(FLANNEL_CNI_PLUGIN_CLONED)
 	-mkdir -p $(WINDOWS_BIN)
 	cp flannel-cni-plugin/dist/flannel-$(ARCH).exe $(WINDOWS_BIN)/flannel.exe
 
-.PHONY: build-cni-bins build-win-cni-bins
-build-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning
+.PHONY: build-win-cni-bins
 build-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
 
 ###############################################################################
@@ -218,7 +200,7 @@ ut-datastore:
 	$(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 			cd  /go/src/$(PACKAGE_NAME) && \
 			mkdir -p report && \
-			ginkgo -cover -r --junit-report=$(JUNIT_REPORT_NAME) --output-dir=report/ -skip-package pkg/install,containernetworking-plugins,flannel-cni-plugin $(GINKGO_ARGS)'
+			ginkgo -cover -r --junit-report=$(JUNIT_REPORT_NAME) --output-dir=report/ -skip-package pkg/install,flannel-cni-plugin $(GINKGO_ARGS)'
 
 ###############################################################################
 # Install test

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -285,7 +285,6 @@ func Install(version string) error {
 			if fileExists(fmt.Sprintf("%s/%s", d, calicoBinName)) {
 				logrus.Infof("No writeable CNI bin directory found but %s already exists at %s and UPDATE_CNI_BINARIES=false; continuing", calicoBinName, d)
 				binsWritten = true
-				calicoBinaryOK = true
 				break
 			}
 		}

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -273,17 +273,27 @@ func Install(version string) error {
 	}
 
 	// If no candidate directory was writeable but the user opted out of binary
-	// updates (UPDATE_CNI_BINARIES=false) and the calico binary is already on
+	// updates (UPDATE_CNI_BINARIES=false) and the calico binaries are already on
 	// the host, treat that as success. This covers read-only systems that bake
 	// the CNI binaries into the OS image. See projectcalico/calico#7486.
 	if !binsWritten && !c.UpdateCNIBinaries {
-		calicoBinName := "calico"
+		// Require both binaries this installer owns: calico provides the CNI
+		// plugin, calico-ipam the IPAM plugin. Auxiliary plugins (portmap etc.)
+		// come from the host image and are its responsibility to bake in.
+		requiredBins := []string{"calico", "calico-ipam"}
 		if runtime.GOOS == "windows" {
-			calicoBinName = "calico.exe"
+			requiredBins = []string{"calico.exe", "calico-ipam.exe"}
 		}
 		for _, d := range dirs {
-			if fileExists(fmt.Sprintf("%s/%s", d, calicoBinName)) {
-				logrus.Infof("No writeable CNI bin directory found but %s already exists at %s and UPDATE_CNI_BINARIES=false; continuing", calicoBinName, d)
+			allPresent := true
+			for _, name := range requiredBins {
+				if !fileExists(fmt.Sprintf("%s/%s", d, name)) {
+					allPresent = false
+					break
+				}
+			}
+			if allPresent {
+				logrus.Infof("No writeable CNI bin directory found but %v already exist at %s and UPDATE_CNI_BINARIES=false; continuing", requiredBins, d)
 				binsWritten = true
 				break
 			}

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -272,6 +272,25 @@ func Install(version string) error {
 		}
 	}
 
+	// If no candidate directory was writeable but the user opted out of binary
+	// updates (UPDATE_CNI_BINARIES=false) and the calico binary is already on
+	// the host, treat that as success. This covers read-only systems that bake
+	// the CNI binaries into the OS image. See projectcalico/calico#7486.
+	if !binsWritten && !c.UpdateCNIBinaries {
+		calicoBinName := "calico"
+		if runtime.GOOS == "windows" {
+			calicoBinName = "calico.exe"
+		}
+		for _, d := range dirs {
+			if fileExists(fmt.Sprintf("%s/%s", d, calicoBinName)) {
+				logrus.Infof("No writeable CNI bin directory found but %s already exists at %s and UPDATE_CNI_BINARIES=false; continuing", calicoBinName, d)
+				binsWritten = true
+				calicoBinaryOK = true
+				break
+			}
+		}
+	}
+
 	// If binaries were not placed, exit
 	if !binsWritten {
 		logrus.WithError(err).Fatalf("found no writeable directory, exiting")

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -306,16 +306,29 @@ PuB/TL+u2y+iQUyXxLy3
 	})
 
 	It("should succeed on read-only bin dir when calico is pre-installed and UPDATE_CNI_BINARIES=false", func() {
-		// Pre-populate the host bin dir with a stub calico binary so the
-		// install can detect that it has nothing left to do, even though the
+		// Pre-populate the host bin dir with stub calico and calico-ipam binaries
+		// so the install can detect that it has nothing left to do, even though the
 		// directory is mounted read-only. Covers projectcalico/calico#7486.
 		Expect(os.WriteFile(tempDir+"/bin/calico", []byte("stub"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(tempDir+"/bin/calico-ipam", []byte("stub"), 0o755)).To(Succeed())
 		err := runCniContainer(
 			tempDir, false,
 			"-v", tempDir+"/secondary-bin-dir:/host/secondary-bin-dir:ro",
 			"-e", "UPDATE_CNI_BINARIES=false",
 		)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail on read-only bin dir when calico-ipam is missing and UPDATE_CNI_BINARIES=false", func() {
+		// Only calico is present, so the read-only fallback must not report
+		// success: kubelet would later fail when it invokes calico-ipam.
+		Expect(os.WriteFile(tempDir+"/bin/calico", []byte("stub"), 0o755)).To(Succeed())
+		err := runCniContainer(
+			tempDir, false,
+			"-v", tempDir+"/secondary-bin-dir:/host/secondary-bin-dir:ro",
+			"-e", "UPDATE_CNI_BINARIES=false",
+		)
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should support CNI_CONF_NAME", func() {

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -305,6 +305,19 @@ PuB/TL+u2y+iQUyXxLy3
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should succeed on read-only bin dir when calico is pre-installed and UPDATE_CNI_BINARIES=false", func() {
+		// Pre-populate the host bin dir with a stub calico binary so the
+		// install can detect that it has nothing left to do, even though the
+		// directory is mounted read-only. Covers projectcalico/calico#7486.
+		Expect(os.WriteFile(tempDir+"/bin/calico", []byte("stub"), 0o755)).To(Succeed())
+		err := runCniContainer(
+			tempDir, false,
+			"-v", tempDir+"/secondary-bin-dir:/host/secondary-bin-dir:ro",
+			"-e", "UPDATE_CNI_BINARIES=false",
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should support CNI_CONF_NAME", func() {
 		err := runCniContainer(tempDir, true, "-e", "CNI_CONF_NAME=20-calico.conflist")
 		Expect(err).NotTo(HaveOccurred())

--- a/metadata.mk
+++ b/metadata.mk
@@ -57,10 +57,12 @@ WINDOWS_HPC_VERSION ?= v1.0.0
 # The Windows versions used as base for Calico Windows images
 WINDOWS_VERSIONS ?= ltsc2019 ltsc2022
 
-# The CNI plugin and flannel code that will be cloned and rebuilt with this repo's go-build image
-# whenever the cni-plugin image is created.
-CNI_VERSION=master
-FLANNEL_VERSION=main
+# The CNI plugin and flannel code that will be cloned and rebuilt with this repo's go-build image.
+# Pinned so the content-addressed third-party-cni-plugins image hash changes when these move.
+# CNI_VERSION is a commit SHA because the fork has no release tag at the toolchain we build with;
+# bump it to pick up upstream changes.
+CNI_VERSION=9ffe547cb3b66f80dd32a00fc69a6d0082b55321
+FLANNEL_VERSION=v1.2.0-flannel2-go1.22.7
 
 # The libbpf version to use
 LIBBPF_VERSION=v1.6.2

--- a/release/internal/pinnedversion/pinnedversion_test.TestGeneratePinnedVersionFile.approved.txt
+++ b/release/internal/pinnedversion/pinnedversion_test.TestGeneratePinnedVersionFile.approved.txt
@@ -12,6 +12,8 @@
       version: v3.31.0
     calico:
       version: v3.31.0
+    cni-plugins:
+      version: v3.31.0
     cni-windows:
       version: v3.31.0
     envoy-gateway:

--- a/release/internal/pinnedversion/pinnedversion_test.TestGeneratePinnedVersionFile.approved.txt
+++ b/release/internal/pinnedversion/pinnedversion_test.TestGeneratePinnedVersionFile.approved.txt
@@ -12,8 +12,6 @@
       version: v3.31.0
     calico:
       version: v3.31.0
-    cni-plugins:
-      version: v3.31.0
     cni-windows:
       version: v3.31.0
     envoy-gateway:
@@ -39,6 +37,8 @@
     node:
       version: v3.31.0
     node-windows:
+      version: v3.31.0
+    third-party-cni-plugins:
       version: v3.31.0
     whisker:
       version: v3.31.0

--- a/release/internal/pinnedversion/pinnedversion_test.go
+++ b/release/internal/pinnedversion/pinnedversion_test.go
@@ -67,6 +67,7 @@ func TestImageComponents(t *testing.T) {
 		"node":              {Version: "v3.31.0", Image: "node"},
 		"node-windows":      {Version: "v3.31.0", Image: "node-windows"},
 		"cni-windows":       {Version: "v3.31.0", Image: "cni-windows"},
+		"cni-plugins":       {Version: "v3.31.0", Image: "cni-plugins"},
 		"flannel":           {Version: "v0.12.0", Image: "coreos/flannel", Registry: "quay.io"},
 		"envoy-gateway":     {Version: "v3.31.0", Image: "envoy-gateway"},
 		"envoy-proxy":       {Version: "v3.31.0", Image: "envoy-proxy"},

--- a/release/internal/pinnedversion/pinnedversion_test.go
+++ b/release/internal/pinnedversion/pinnedversion_test.go
@@ -64,19 +64,19 @@ func TestImageComponents(t *testing.T) {
 	// ImageComponents (see noImageComponents), so the expected maps below
 	// do not include it.
 	commonComponents := map[string]registry.Component{
-		"node":              {Version: "v3.31.0", Image: "node"},
-		"node-windows":      {Version: "v3.31.0", Image: "node-windows"},
-		"cni-windows":       {Version: "v3.31.0", Image: "cni-windows"},
-		"cni-plugins":       {Version: "v3.31.0", Image: "cni-plugins"},
-		"flannel":           {Version: "v0.12.0", Image: "coreos/flannel", Registry: "quay.io"},
-		"envoy-gateway":     {Version: "v3.31.0", Image: "envoy-gateway"},
-		"envoy-proxy":       {Version: "v3.31.0", Image: "envoy-proxy"},
-		"envoy-ratelimit":   {Version: "v3.31.0", Image: "envoy-ratelimit"},
-		"whisker":           {Version: "v3.31.0", Image: "whisker"},
-		"istio-install-cni": {Version: "v3.31.0", Image: "istio-install-cni"},
-		"istio-pilot":       {Version: "v3.31.0", Image: "istio-pilot"},
-		"istio-proxyv2":     {Version: "v3.31.0", Image: "istio-proxyv2"},
-		"istio-ztunnel":     {Version: "v3.31.0", Image: "istio-ztunnel"},
+		"node":                    {Version: "v3.31.0", Image: "node"},
+		"node-windows":            {Version: "v3.31.0", Image: "node-windows"},
+		"cni-windows":             {Version: "v3.31.0", Image: "cni-windows"},
+		"third-party-cni-plugins": {Version: "v3.31.0", Image: "third-party-cni-plugins"},
+		"flannel":                 {Version: "v0.12.0", Image: "coreos/flannel", Registry: "quay.io"},
+		"envoy-gateway":           {Version: "v3.31.0", Image: "envoy-gateway"},
+		"envoy-proxy":             {Version: "v3.31.0", Image: "envoy-proxy"},
+		"envoy-ratelimit":         {Version: "v3.31.0", Image: "envoy-ratelimit"},
+		"whisker":                 {Version: "v3.31.0", Image: "whisker"},
+		"istio-install-cni":       {Version: "v3.31.0", Image: "istio-install-cni"},
+		"istio-pilot":             {Version: "v3.31.0", Image: "istio-pilot"},
+		"istio-proxyv2":           {Version: "v3.31.0", Image: "istio-proxyv2"},
+		"istio-ztunnel":           {Version: "v3.31.0", Image: "istio-ztunnel"},
 	}
 	t.Run("without operator", func(t *testing.T) {
 		expectedComponents := map[string]registry.Component{}

--- a/release/internal/utils/utils.go
+++ b/release/internal/utils/utils.go
@@ -115,6 +115,7 @@ var (
 		"cmd/calico",
 		"istio",
 		"node",
+		"third_party/cni-plugins",
 		"third_party/envoy-gateway",
 		"third_party/envoy-proxy",
 		"third_party/envoy-ratelimit",

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -877,7 +877,7 @@ func (r *CalicoManager) assertImageVersions() error {
 			}
 		case "cni-windows", "node-windows":
 			// Skip windows images
-		case "cni-plugins", "envoy-gateway", "envoy-proxy", "envoy-ratelimit", "istio-install-cni", "istio-pilot", "istio-proxyv2", "istio-ztunnel", "whisker":
+		case "third-party-cni-plugins", "envoy-gateway", "envoy-proxy", "envoy-ratelimit", "istio-install-cni", "istio-pilot", "istio-proxyv2", "istio-ztunnel", "whisker":
 			for _, reg := range r.imageRegistries {
 				out, err := r.runner.Run("docker", []string{"inspect", `--format='{{ index .Config.Labels "org.opencontainers.image.version" }}'`, fmt.Sprintf("%s/%s:%s", reg, img, r.calicoVersion)}, nil)
 				if err != nil {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -877,7 +877,7 @@ func (r *CalicoManager) assertImageVersions() error {
 			}
 		case "cni-windows", "node-windows":
 			// Skip windows images
-		case "envoy-gateway", "envoy-proxy", "envoy-ratelimit", "istio-install-cni", "istio-pilot", "istio-proxyv2", "istio-ztunnel", "whisker":
+		case "cni-plugins", "envoy-gateway", "envoy-proxy", "envoy-ratelimit", "istio-install-cni", "istio-pilot", "istio-proxyv2", "istio-ztunnel", "whisker":
 			for _, reg := range r.imageRegistries {
 				out, err := r.runner.Run("docker", []string{"inspect", `--format='{{ index .Config.Labels "org.opencontainers.image.version" }}'`, fmt.Sprintf("%s/%s:%s", reg, img, r.calicoVersion)}, nil)
 				if err != nil {

--- a/third_party/cni-plugins/.gitignore
+++ b/third_party/cni-plugins/.gitignore
@@ -1,0 +1,8 @@
+bin/
+containernetworking-plugins/
+flannel-cni-plugin/
+.containernetworking-plugins-*.cloned
+.flannel-cni-plugin-*.cloned
+.cni-plugins.created-*
+.release-*.created
+.release-*.published

--- a/third_party/cni-plugins/Dockerfile
+++ b/third_party/cni-plugins/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+ARG CALICO_BASE
+
+FROM ${CALICO_BASE}
+
+ARG TARGETARCH
+ARG GIT_VERSION=unknown
+
+# Upstream CNI plugins built from projectcalico/containernetworking-plugins
+# and projectcalico/flannel-cni-plugin. See ../../metadata.mk for the pinned
+# versions.
+COPY bin/${TARGETARCH}/host-local /plugins/host-local
+COPY bin/${TARGETARCH}/portmap    /plugins/portmap
+COPY bin/${TARGETARCH}/loopback   /plugins/loopback
+COPY bin/${TARGETARCH}/tuning     /plugins/tuning
+COPY bin/${TARGETARCH}/flannel    /plugins/flannel
+
+# Entrypoint: copies /plugins/ into the shared stage dir read by install-cni.
+COPY bin/${TARGETARCH}/install-cni-plugins /usr/local/bin/install-cni-plugins
+
+# These labels are required for OCP Certification.
+LABEL description="Upstream CNI plugins (host-local, portmap, loopback, tuning, flannel) shipped by Calico for staging onto cluster nodes."
+LABEL maintainer="maintainers@tigera.io"
+LABEL name="Calico CNI plugins"
+LABEL release="1"
+LABEL summary="Upstream CNI plugins installed by Calico onto each node."
+LABEL vendor="Project Calico"
+LABEL version="${GIT_VERSION}"
+
+LABEL org.opencontainers.image.description="Upstream CNI plugins (host-local, portmap, loopback, tuning, flannel) shipped by Calico for staging onto cluster nodes."
+LABEL org.opencontainers.image.authors="maintainers@tigera.io"
+LABEL org.opencontainers.image.source="https://github.com/projectcalico/calico"
+LABEL org.opencontainers.image.title="Calico CNI plugins"
+LABEL org.opencontainers.image.vendor="Project Calico"
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENTRYPOINT ["/usr/local/bin/install-cni-plugins"]

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -39,7 +39,11 @@ BIN = bin/$(ARCH)
 
 CN_FLAGS = -ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
 
+# Pre-create the host-side module cache before docker mounts it. Without this,
+# Docker creates the path as root if it doesn't exist, leaving user 1001 inside
+# the container unable to write to /go/pkg/mod (e.g. fresh CI workers).
 $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning &: $(CONTAINERNETWORKING_PLUGINS_CLONED)
+	mkdir -p $(GOMOD_CACHE)
 	docker run \
 		$(EXTRA_DOCKER_ARGS) \
 		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
@@ -49,6 +53,7 @@ $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning &: $(CONTAINERNET
 	@$(foreach file,$(CN_FILES),cp containernetworking-plugins/bin/$(file) $(BIN)/$(file);)
 
 $(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
+	mkdir -p $(GOMOD_CACHE)
 	docker run \
 		$(EXTRA_DOCKER_ARGS) \
 		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -1,0 +1,168 @@
+include ../../metadata.mk
+
+PACKAGE_NAME ?= github.com/projectcalico/calico/third_party/cni-plugins
+
+CNI_PLUGINS_IMAGE ?= cni-plugins
+BUILD_IMAGES      ?= $(CNI_PLUGINS_IMAGE)
+
+##############################################################################
+# Include lib.Makefile before anything else
+#   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
+#   that variable is evaluated when we declare DOCKER_RUN and siblings.
+##############################################################################
+include ../../lib.Makefile
+
+##############################################################################
+# Upstream sources
+##############################################################################
+# The four plugins we copy from projectcalico/containernetworking-plugins.
+# bandwidth is intentionally excluded — Calico has its own QoS support.
+CN_FILES := host-local portmap loopback tuning
+
+CONTAINERNETWORKING_PLUGINS_CLONED = .containernetworking-plugins-$(CNI_VERSION).cloned
+FLANNEL_CNI_PLUGIN_CLONED          = .flannel-cni-plugin-$(FLANNEL_VERSION).cloned
+
+$(CONTAINERNETWORKING_PLUGINS_CLONED):
+	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
+	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
+	touch $@
+
+$(FLANNEL_CNI_PLUGIN_CLONED):
+	rm -rf flannel-cni-plugin .flannel-cni-plugin-*.cloned
+	git clone --single-branch --branch $(FLANNEL_VERSION) https://github.com/projectcalico/flannel-cni-plugin.git
+	touch $@
+
+##############################################################################
+# Plugin binaries (Linux only — Windows flannel is built in ../../cni-plugin)
+##############################################################################
+BIN = bin/$(ARCH)
+
+CN_FLAGS = -ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
+
+$(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning &: $(CONTAINERNETWORKING_PLUGINS_CLONED)
+	docker run \
+		$(EXTRA_DOCKER_ARGS) \
+		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/containernetworking/plugins --rm $(CALICO_BUILD) \
+		/bin/sh -xe -c 'GOFLAGS="-buildvcs=false" CGO_ENABLED=0 GOARCH=$(ARCH) ./build_linux.sh $(CN_FLAGS)'
+	mkdir -p $(BIN)
+	@$(foreach file,$(CN_FILES),cp containernetworking-plugins/bin/$(file) $(BIN)/$(file);)
+
+$(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
+	docker run \
+		$(EXTRA_DOCKER_ARGS) \
+		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
+		/bin/sh -xe -c 'ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_linux'
+	mkdir -p $(BIN)
+	cp flannel-cni-plugin/dist/flannel-$(ARCH) $(BIN)/flannel
+
+##############################################################################
+# Installer entrypoint (Calico-owned)
+##############################################################################
+# Small static Go binary used as the image entrypoint. Copies /plugins/ into
+# the shared stage dir read by the install-cni init container. calico/base is
+# distroless so a static binary is the right entrypoint here.
+INSTALLER_SRCS = $(shell find cmd -name '*.go')
+
+$(BIN)/install-cni-plugins: $(INSTALLER_SRCS)
+	mkdir -p $(BIN)
+	$(DOCKER_GO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
+		CGO_ENABLED=0 GOARCH=$(ARCH) go build -buildvcs=false -ldflags="-s -w" -o $@ ./cmd/install'
+
+.PHONY: build
+build: $(BIN)/host-local $(BIN)/portmap $(BIN)/loopback $(BIN)/tuning $(BIN)/flannel $(BIN)/install-cni-plugins
+
+.PHONY: clean
+clean:
+	rm -f .containernetworking-plugins-*.cloned .flannel-cni-plugin-*.cloned .*.created* .*.published* .release.*
+	rm -rf bin/ containernetworking-plugins/ flannel-cni-plugin/
+	-docker image rm -f $$(docker images $(CNI_PLUGINS_IMAGE) -a -q) 2>/dev/null || true
+
+##############################################################################
+# Content-addressed image tag
+#
+# The plugin image rebuilds rarely — only when upstream pins move, the build
+# toolchain changes, or this directory's files change. To avoid repetitive
+# CI rebuilds we tag the image with a hash of its inputs and let CI probe the
+# registry for a matching tag before building. See `image-content-addressed`.
+##############################################################################
+CNI_PLUGINS_HASH_INPUTS := \
+	$(CNI_VERSION) \
+	$(FLANNEL_VERSION) \
+	$(GO_BUILD_VER) \
+	$(CALICO_BASE_VER) \
+	$(shell find Dockerfile Makefile cmd -type f | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+CNI_PLUGINS_HASH := $(shell echo "$(CNI_PLUGINS_HASH_INPUTS)" | sha256sum | cut -c1-12)
+
+# The cache registry to probe for an existing content-addressed image. Defaults
+# to the first dev registry. Override via CNI_PLUGINS_CACHE_REGISTRY if needed.
+CNI_PLUGINS_CACHE_REGISTRY ?= $(firstword $(DEV_REGISTRIES))
+CNI_PLUGINS_HASH_REF := $(CNI_PLUGINS_CACHE_REGISTRY)/$(CNI_PLUGINS_IMAGE):cache-$(CNI_PLUGINS_HASH)-$(ARCH)
+
+##############################################################################
+# Image build
+##############################################################################
+CNI_PLUGINS_IMAGE_CREATED = .cni-plugins.created-$(ARCH)
+
+.PHONY: image-all
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
+sub-image-%:
+	$(MAKE) image ARCH=$*
+
+.PHONY: image
+image: $(BUILD_IMAGES)
+
+$(CNI_PLUGINS_IMAGE): $(CNI_PLUGINS_IMAGE_CREATED)
+$(CNI_PLUGINS_IMAGE_CREATED): Dockerfile build | register
+	$(DOCKER_BUILD) -t $(CNI_PLUGINS_IMAGE):latest-$(ARCH) -f Dockerfile .
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
+	touch $@
+
+# image-content-addressed probes the cache registry for the content-hash tag
+# and either pulls + retags it (fast path) or falls through to a real build
+# followed by a push of the hash tag (slow path, after a content change).
+#
+# Used by CI; not typically run by developers.
+.PHONY: image-content-addressed
+image-content-addressed: $(REPO_ROOT)/bin/crane
+	@echo "Probing for cached image $(CNI_PLUGINS_HASH_REF)"
+	@if $(CRANE_CMD) manifest $(CNI_PLUGINS_HASH_REF) >/dev/null 2>&1; then \
+		echo "Cache hit — pulling $(CNI_PLUGINS_HASH_REF)"; \
+		docker pull $(CNI_PLUGINS_HASH_REF); \
+		docker tag $(CNI_PLUGINS_HASH_REF) $(CNI_PLUGINS_IMAGE):latest-$(ARCH); \
+		$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest; \
+		touch $(CNI_PLUGINS_IMAGE_CREATED); \
+	else \
+		echo "Cache miss — building image and pushing cache tag"; \
+		$(MAKE) image ARCH=$(ARCH); \
+		docker tag $(CNI_PLUGINS_IMAGE):latest-$(ARCH) $(CNI_PLUGINS_HASH_REF); \
+		docker push $(CNI_PLUGINS_HASH_REF); \
+	fi
+
+.PHONY: print-cni-plugins-hash
+print-cni-plugins-hash:
+	@echo $(CNI_PLUGINS_HASH)
+
+##############################################################################
+# CI/CD
+##############################################################################
+.PHONY: ci
+ci: image
+
+.PHONY: cd
+cd: image-all cd-common
+
+.PHONY: release-build
+release-build: .release-$(VERSION).created
+.release-$(VERSION).created:
+	$(MAKE) clean image-all RELEASE=true
+	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
+	# Generate the `latest` images.
+	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
+	touch $@
+
+release-publish: release-prereqs .release-$(VERSION).published
+.release-$(VERSION).published:
+	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+	touch $@

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -152,8 +152,10 @@ print-cni-plugins-hash:
 ##############################################################################
 # CI/CD
 ##############################################################################
+# Probe the cache registry for a content-addressed image first; fall through to
+# a real build (and push the cache tag) on cache miss. See image-content-addressed.
 .PHONY: ci
-ci: image
+ci: image-content-addressed
 
 .PHONY: cd
 cd: image-all cd-common

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -128,21 +128,25 @@ $(CNI_PLUGINS_IMAGE_CREATED): Dockerfile build | register
 # and either pulls + retags it (fast path) or falls through to a real build
 # followed by a push of the hash tag (slow path, after a content change).
 #
+# The push tolerates failure so PR builds from contributors who can't write
+# to the cache registry still pass; scheduled/master builds with credentials
+# warm the cache for subsequent PRs.
+#
 # Used by CI; not typically run by developers.
 .PHONY: image-content-addressed
 image-content-addressed: $(REPO_ROOT)/bin/crane
 	@echo "Probing for cached image $(CNI_PLUGINS_HASH_REF)"
 	@if $(CRANE_CMD) manifest $(CNI_PLUGINS_HASH_REF) >/dev/null 2>&1; then \
-		echo "Cache hit — pulling $(CNI_PLUGINS_HASH_REF)"; \
+		echo "Cache hit - pulling $(CNI_PLUGINS_HASH_REF)"; \
 		docker pull $(CNI_PLUGINS_HASH_REF); \
 		docker tag $(CNI_PLUGINS_HASH_REF) $(CNI_PLUGINS_IMAGE):latest-$(ARCH); \
 		$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest; \
 		touch $(CNI_PLUGINS_IMAGE_CREATED); \
 	else \
-		echo "Cache miss — building image and pushing cache tag"; \
+		echo "Cache miss - building image"; \
 		$(MAKE) image ARCH=$(ARCH); \
 		docker tag $(CNI_PLUGINS_IMAGE):latest-$(ARCH) $(CNI_PLUGINS_HASH_REF); \
-		docker push $(CNI_PLUGINS_HASH_REF); \
+		docker push $(CNI_PLUGINS_HASH_REF) || echo "Cache push skipped (no registry credentials)"; \
 	fi
 
 .PHONY: print-cni-plugins-hash

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -156,10 +156,14 @@ print-cni-plugins-hash:
 ##############################################################################
 # CI/CD
 ##############################################################################
+.PHONY: ut
+ut:
+	$(DOCKER_GO_BUILD) go test ./cmd/...
+
 # Probe the cache registry for a content-addressed image first; fall through to
 # a real build (and push the cache tag) on cache miss. See image-content-addressed.
 .PHONY: ci
-ci: image-content-addressed
+ci: ut image-content-addressed
 
 .PHONY: cd
 cd: image-all cd-common

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -2,7 +2,7 @@ include ../../metadata.mk
 
 PACKAGE_NAME ?= github.com/projectcalico/calico/third_party/cni-plugins
 
-CNI_PLUGINS_IMAGE ?= cni-plugins
+CNI_PLUGINS_IMAGE ?= third-party-cni-plugins
 BUILD_IMAGES      ?= $(CNI_PLUGINS_IMAGE)
 
 ##############################################################################

--- a/third_party/cni-plugins/Makefile
+++ b/third_party/cni-plugins/Makefile
@@ -22,9 +22,12 @@ CN_FILES := host-local portmap loopback tuning
 CONTAINERNETWORKING_PLUGINS_CLONED = .containernetworking-plugins-$(CNI_VERSION).cloned
 FLANNEL_CNI_PLUGIN_CLONED          = .flannel-cni-plugin-$(FLANNEL_VERSION).cloned
 
+# CNI_VERSION is a commit SHA (the fork has no release tag at the toolchain we
+# build with), so clone then check it out rather than passing it to --branch.
 $(CONTAINERNETWORKING_PLUGINS_CLONED):
 	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
-	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
+	git clone https://github.com/projectcalico/containernetworking-plugins.git
+	git -C containernetworking-plugins checkout $(CNI_VERSION)
 	touch $@
 
 $(FLANNEL_CNI_PLUGIN_CLONED):

--- a/third_party/cni-plugins/README.md
+++ b/third_party/cni-plugins/README.md
@@ -1,4 +1,4 @@
-# calico/cni-plugins
+# calico/third-party-cni-plugins
 
 Image containing the upstream CNI plugins that Calico installs onto each node:
 

--- a/third_party/cni-plugins/README.md
+++ b/third_party/cni-plugins/README.md
@@ -1,0 +1,22 @@
+# calico/cni-plugins
+
+Image containing the upstream CNI plugins that Calico installs onto each node:
+
+- `host-local`, `portmap`, `loopback`, `tuning` from
+  [projectcalico/containernetworking-plugins](https://github.com/projectcalico/containernetworking-plugins)
+- `flannel` from
+  [projectcalico/flannel-cni-plugin](https://github.com/projectcalico/flannel-cni-plugin)
+
+The image is intended to be used as an init container in the `calico-node`
+DaemonSet. Its entrypoint copies the plugin binaries from `/plugins/` into a
+shared volume (default `/stage/`), which the `install-cni` init container then
+mounts at `/opt/cni/bin` and copies onto the host. The plugins ship as a
+separate image rather than being baked into `calico/calico` so that the main
+image stays small.
+
+Versions of the upstream sources are pinned via `CNI_VERSION` and
+`FLANNEL_VERSION` in `metadata.mk`.
+
+This component lives under `third_party/` to mark the plugin source as not
+ours. The Calico-specific wrapper (Dockerfile, entrypoint, Makefile) is in
+this directory.

--- a/third_party/cni-plugins/cmd/install/main.go
+++ b/third_party/cni-plugins/cmd/install/main.go
@@ -47,6 +47,20 @@ func envOrDefault(key, def string) string {
 }
 
 func stage(src, dst string) error {
+	// Refuse to stage in place — copyFile opens dst with O_TRUNC before
+	// reading src, so src==dst silently zeroes every plugin binary.
+	srcAbs, err := filepath.Abs(src)
+	if err != nil {
+		return fmt.Errorf("resolve src %s: %w", src, err)
+	}
+	dstAbs, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("resolve dst %s: %w", dst, err)
+	}
+	if filepath.Clean(srcAbs) == filepath.Clean(dstAbs) {
+		return fmt.Errorf("src and dst resolve to the same path (%s)", srcAbs)
+	}
+
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return fmt.Errorf("create %s: %w", dst, err)
 	}

--- a/third_party/cni-plugins/cmd/install/main.go
+++ b/third_party/cni-plugins/cmd/install/main.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Entrypoint for the calico/cni-plugins init image. Copies upstream CNI
+// plugin binaries from a source directory into a staging directory shared
+// with the install-cni init container, which mounts the staging dir at
+// /opt/cni/bin and copies the binaries onto the host.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const fileMode = 0o755
+
+func main() {
+	src := flag.String("src", "/plugins", "directory containing the plugin binaries")
+	dst := flag.String("dst", envOrDefault("STAGE_DIR", "/stage"), "directory to stage the plugin binaries into")
+	flag.Parse()
+
+	if err := stage(*src, *dst); err != nil {
+		log.Fatalf("staging plugins: %v", err)
+	}
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func stage(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if err := copyFile(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
+			return err
+		}
+		log.Printf("staged %s -> %s", e.Name(), dst)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s -> %s: %w", src, dst, err)
+	}
+	if err := out.Chmod(fileMode); err != nil {
+		return fmt.Errorf("chmod %s: %w", dst, err)
+	}
+	return nil
+}

--- a/third_party/cni-plugins/cmd/install/main_test.go
+++ b/third_party/cni-plugins/cmd/install/main_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStageRefusesSrcEqualsDst(t *testing.T) {
+	d := t.TempDir()
+	binPath := filepath.Join(d, "calico")
+	const payload = "binary contents"
+	if err := os.WriteFile(binPath, []byte(payload), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := stage(d, d)
+	if err == nil {
+		t.Fatal("stage(src=dst) returned nil; expected error to avoid self-truncation")
+	}
+	if !strings.Contains(err.Error(), "same path") {
+		t.Errorf("unexpected error %q", err)
+	}
+
+	got, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payload {
+		t.Errorf("source file was modified: got %q, want %q", got, payload)
+	}
+}
+
+func TestStageCopiesPlugins(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "stage")
+	for _, name := range []string{"portmap", "host-local"} {
+		if err := os.WriteFile(filepath.Join(src, name), []byte(name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := stage(src, dst); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+
+	for _, name := range []string{"portmap", "host-local"} {
+		got, err := os.ReadFile(filepath.Join(dst, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != name {
+			t.Errorf("%s: got %q, want %q", name, got, name)
+		}
+	}
+}

--- a/third_party/deps.txt
+++ b/third_party/deps.txt
@@ -2,3 +2,6 @@
 Run 'make gen-deps-files' to regenerate.
 
 go 1.26.3
+github.com/projectcalico/calico
+
+local:third_party/cni-plugins/cmd/install


### PR DESCRIPTION
Fixes the regression from the mono-image consolidation where `calico/calico` no longer ships the upstream CNI plugin binaries baked into `/opt/cni/bin`.

On platforms that don't pre-populate the host CNI bin dir, `install.go` finds nothing to copy and pods that depend on `host-local`, `portmap`, `loopback`, `tuning`, or `flannel` break.

This adds a separate, small init image (`calico/third-party-cni-plugins`) under `third_party/` that contains the plugins.

The new image is a content-addressed image build: `make image-content-addressed` hashes `CNI_VERSION`, `FLANNEL_VERSION`, `GO_BUILD_VER`, `CALICO_BASE_VER`, plus the contents of `Dockerfile` / `Makefile` / `cmd`. Probes the dev registry for a matching tag and either pulls or builds + pushes. Keeps CI rebuilds cheap when nothing has changed.

Companion operator PR: TBD (will add the init container + emptyDir to the calico-node DaemonSet once this lands and produces a dev tag).

Fixes https://github.com/projectcalico/calico/issues/7486

```release-note
NONE
```