### PR TITLE
Stop Felix from churning BIRD routes on workload BGP peer interfaces.

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -649,16 +649,19 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 	var routeTableV4 routetable.Interface
 	var routeTableV6 routetable.Interface
+	var mainTablePolV4 *ownershippol.MainTableOwnershipPolicy
+	var mainTablePolV6 *ownershippol.MainTableOwnershipPolicy
 
 	if !config.RouteSyncDisabled {
 		log.Debug("Route management is enabled.")
+		mainTablePolV4 = ownershippol.NewMainTable(
+			dataplanedefs.VXLANIfaceNameV4,
+			config.DeviceRouteProtocol,
+			config.RulesConfig.WorkloadIfacePrefixes,
+			config.RemoveExternalRoutes,
+		)
 		routeTableV4 = routetable.New(
-			ownershippol.NewMainTable(
-				dataplanedefs.VXLANIfaceNameV4,
-				config.DeviceRouteProtocol,
-				config.RulesConfig.WorkloadIfacePrefixes,
-				config.RemoveExternalRoutes,
-			),
+			mainTablePolV4,
 			4,
 			config.NetlinkTimeout,
 			config.DeviceRouteSourceAddress,
@@ -672,13 +675,14 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			routetable.WithRouteCleanupGracePeriod(routeCleanupGracePeriod),
 		)
 		if config.IPv6Enabled {
+			mainTablePolV6 = ownershippol.NewMainTable(
+				dataplanedefs.VXLANIfaceNameV6,
+				config.DeviceRouteProtocol,
+				config.RulesConfig.WorkloadIfacePrefixes,
+				config.RemoveExternalRoutes,
+			)
 			routeTableV6 = routetable.New(
-				ownershippol.NewMainTable(
-					dataplanedefs.VXLANIfaceNameV6,
-					config.DeviceRouteProtocol,
-					config.RulesConfig.WorkloadIfacePrefixes,
-					config.RemoveExternalRoutes,
-				),
+				mainTablePolV6,
 				6,
 				config.NetlinkTimeout,
 				config.DeviceRouteSourceAddressIPv6,
@@ -1184,6 +1188,9 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	dp.RegisterManager(epManager)
 	dp.endpointsSourceV4 = epManager
 	dp.liveMigrationMonitor.listener = epManager
+	if mainTablePolV4 != nil {
+		mainTablePolV4.IsWorkloadBGPPeerIface = epManager.ifaceIsForLocalBGPPeer
+	}
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4, config.FloatingIPsEnabled))
 	dp.RegisterManager(newMasqManager(ipSetsV4, natTableV4, ruleRenderer, config.MaxIPSetSize, 4))
 
@@ -1374,7 +1381,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 		dp.linkAddrsManagers = append(dp.linkAddrsManagers, linkAddrsManagerV6)
 
-		dp.RegisterManager(newEndpointManager(
+		epManagerV6 := newEndpointManager(
 			&endpointManagerConfig{
 				kubeIPVSSupportEnabled: config.RulesConfig.KubeIPVSSupportEnabled,
 				wlInterfacePrefixes:    config.RulesConfig.WorkloadIfacePrefixes,
@@ -1400,7 +1407,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			linkAddrsManagerV6,
 			nil, // arpTable - ARP is IPv4 only
 			nil, // arpMaps
-		))
+		)
+		dp.RegisterManager(epManagerV6)
+		if mainTablePolV6 != nil {
+			mainTablePolV6.IsWorkloadBGPPeerIface = epManagerV6.ifaceIsForLocalBGPPeer
+		}
 		dp.RegisterManager(newFloatingIPManager(natTableV6, ruleRenderer, 6, config.FloatingIPsEnabled))
 		dp.RegisterManager(newMasqManager(ipSetsV6, natTableV6, ruleRenderer, config.MaxIPSetSize, 6))
 		dp.RegisterManager(newServiceLoopManager(filterTableV6, ruleRenderer, 6))

--- a/felix/routetable/ownershippol/main_route_table_policy.go
+++ b/felix/routetable/ownershippol/main_route_table_policy.go
@@ -100,6 +100,11 @@ type MainTableOwnershipPolicy struct {
 	// interface belongs to a workload that is acting as a local BGP peer.
 	// BIRD installs routes on such interfaces with RTPROT_BIRD; those
 	// routes must not be cleaned up by Felix.
+	//
+	// Concurrency: this is a read-only callback so it is thread-safe.
+	// CompleteDeferredWork on all managers finishes before route table
+	// Apply goroutines are spawned, so the endpoint manager's workload
+	// endpoint maps won't be written during route reconciliation.
 	IsWorkloadBGPPeerIface func(ifaceName string) bool
 }
 

--- a/felix/routetable/ownershippol/main_route_table_policy.go
+++ b/felix/routetable/ownershippol/main_route_table_policy.go
@@ -95,6 +95,12 @@ type MainTableOwnershipPolicy struct {
 	// ExclusiveRouteProtocols is a list of protocols that should only be
 	// used by Calico.
 	ExclusiveRouteProtocols []netlink.RouteProtocol
+
+	// IsWorkloadBGPPeerIface, if non-nil, reports whether the named
+	// interface belongs to a workload that is acting as a local BGP peer.
+	// BIRD installs routes on such interfaces with RTPROT_BIRD; those
+	// routes must not be cleaned up by Felix.
+	IsWorkloadBGPPeerIface func(ifaceName string) bool
 }
 
 func (d *MainTableOwnershipPolicy) IfaceShouldHaveARPEntries(ifaceName string) bool {
@@ -141,6 +147,14 @@ func (d *MainTableOwnershipPolicy) RouteIsOurs(ifaceName string, route *netlink.
 
 	if d.isWorkloadInterface(ifaceName) {
 		if d.RemoveNonCalicoWorkloadRoutes {
+			// BIRD installs routes with RTPROT_BIRD on workload interfaces
+			// that are acting as local BGP peers.  Those routes belong to
+			// BIRD, not Felix, so we must leave them alone.
+			if route.Protocol == unix.RTPROT_BIRD &&
+				d.IsWorkloadBGPPeerIface != nil &&
+				d.IsWorkloadBGPPeerIface(ifaceName) {
+				return false
+			}
 			// We're configured to assume that any route to one of our
 			// interfaces is ours, no need to check the protocol.
 			return true

--- a/felix/routetable/ownershippol/main_route_table_policy_test.go
+++ b/felix/routetable/ownershippol/main_route_table_policy_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ownershippol
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func TestRouteIsOurs_BIRDRoutesOnBGPPeerIfaces(t *testing.T) {
+	const (
+		wlIface    = "cali12345"
+		nonWlIface = "eth0"
+	)
+	exclusiveProto := netlink.RouteProtocol(80) // dataplanedefs.DefaultRouteProto
+
+	peerTrue := func(string) bool { return true }
+	peerFalse := func(string) bool { return false }
+
+	tests := []struct {
+		name                string
+		removeExternal      bool
+		ifaceName           string
+		protocol            netlink.RouteProtocol
+		peerCallback        func(string) bool
+		expectedRouteIsOurs bool
+	}{
+		{
+			name:                "workload iface, RTPROT_BIRD, peer=true, removeExternal=true => not ours",
+			removeExternal:      true,
+			ifaceName:           wlIface,
+			protocol:            unix.RTPROT_BIRD,
+			peerCallback:        peerTrue,
+			expectedRouteIsOurs: false,
+		},
+		{
+			name:                "workload iface, RTPROT_BIRD, peer=false, removeExternal=true => ours",
+			removeExternal:      true,
+			ifaceName:           wlIface,
+			protocol:            unix.RTPROT_BIRD,
+			peerCallback:        peerFalse,
+			expectedRouteIsOurs: true,
+		},
+		{
+			name:                "workload iface, non-BIRD proto, peer=true, removeExternal=true => ours",
+			removeExternal:      true,
+			ifaceName:           wlIface,
+			protocol:            unix.RTPROT_BOOT,
+			peerCallback:        peerTrue,
+			expectedRouteIsOurs: true,
+		},
+		{
+			name:                "workload iface, RTPROT_BIRD, nil callback, removeExternal=true => ours",
+			removeExternal:      true,
+			ifaceName:           wlIface,
+			protocol:            unix.RTPROT_BIRD,
+			peerCallback:        nil,
+			expectedRouteIsOurs: true,
+		},
+		{
+			name:                "non-workload iface, RTPROT_BIRD => not ours",
+			removeExternal:      true,
+			ifaceName:           nonWlIface,
+			protocol:            unix.RTPROT_BIRD,
+			peerCallback:        peerTrue,
+			expectedRouteIsOurs: false,
+		},
+		{
+			name:                "removeExternal=false, workload iface, RTPROT_BIRD => not ours (proto mismatch)",
+			removeExternal:      false,
+			ifaceName:           wlIface,
+			protocol:            unix.RTPROT_BIRD,
+			peerCallback:        peerTrue,
+			expectedRouteIsOurs: false,
+		},
+		{
+			name:                "exclusive proto route on workload iface => ours",
+			removeExternal:      true,
+			ifaceName:           wlIface,
+			protocol:            exclusiveProto,
+			peerCallback:        peerTrue,
+			expectedRouteIsOurs: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pol := &MainTableOwnershipPolicy{
+				WorkloadInterfacePrefixes:     []string{"cali"},
+				RemoveNonCalicoWorkloadRoutes: tt.removeExternal,
+				CalicoSpecialInterfaces:       []string{"vxlan.calico"},
+				AllRouteProtocols:             []netlink.RouteProtocol{unix.RTPROT_BOOT, exclusiveProto},
+				ExclusiveRouteProtocols:       []netlink.RouteProtocol{exclusiveProto},
+				IsWorkloadBGPPeerIface:        tt.peerCallback,
+			}
+
+			route := &netlink.Route{Protocol: tt.protocol}
+			got := pol.RouteIsOurs(tt.ifaceName, route)
+			if got != tt.expectedRouteIsOurs {
+				t.Errorf("RouteIsOurs(%q, proto=%d) = %v, want %v",
+					tt.ifaceName, tt.protocol, got, tt.expectedRouteIsOurs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/projectcalico/calico/issues/12784

When a workload advertises routes via BGP (workload BGP peer), BIRD installs
those routes on the workload interface with `RTPROT_BIRD` (protocol 12).
Felix's periodic route reconciliation was deleting these routes because
`RouteIsOurs()` claimed ALL routes on workload interfaces when
`removeExternalRoutes=true` (the default). BIRD would re-add the route, but
the delete+re-add cycle caused packet drops and conntrack flushes.

### Fix

- Add an `IsWorkloadBGPPeerIface` callback field to `MainTableOwnershipPolicy`.
- In `RouteIsOurs()`, when `RemoveNonCalicoWorkloadRoutes` is true, check if
  the route has `RTPROT_BIRD` and the interface is a BGP peer before claiming
  ownership. If so, return `false` (not ours).
- Wire the callback from the endpoint manager's `ifaceIsForLocalBGPPeer()`
  method into the ownership policy after the endpoint managers are created.

**Release note:**
```release-note
Fix Felix periodically deleting and re-adding BIRD-installed routes on workload BGP peer interfaces, which caused packet drops and conntrack flushes.
```