### PR TITLE
OpenStack: force 'qos' into service_plugins when using our driver

### DIFF
--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -95,10 +95,6 @@ EOF
                     # support to the core DevStack repository.
                     iniset $NEUTRON_CONF DEFAULT core_plugin calico
 
-                    # Calico itself implements the 'router' extension, but we need a service plugin
-                    # for QoS.
-                    iniset $NEUTRON_CONF DEFAULT service_plugins qos
-
                     # Propagate ENABLE_DEBUG_LOG_LEVEL to neutron.conf, so that
                     # it applies to the Calico DHCP agent on each compute node.
                     iniset $NEUTRON_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL

--- a/networking-calico/networking_calico/plugins/calico/plugin.py
+++ b/networking-calico/networking_calico/plugins/calico/plugin.py
@@ -66,6 +66,17 @@ class CalicoPlugin(Ml2Plugin, l3_db.L3_NAT_db_mixin):
                 group="ml2",
             )
 
+        # Calico's QoS support requires Neutron's 'qos' service plugin to be loaded.
+        # Add to whatever the operator has configured rather than forcing the whole
+        # list, since deployments often need other service plugins (segments, trunk,
+        # log, etc.).  Neutron loads core_plugin first and then iterates
+        # cfg.CONF.service_plugins to load the rest, so an override here is honoured for
+        # the subsequent load.
+        LOG.info("Add 'qos' to service_plugins, if not already present")
+        existing_service_plugins = cfg.CONF.service_plugins or []
+        if "qos" not in existing_service_plugins:
+            cfg.CONF.set_override("service_plugins", existing_service_plugins + ["qos"])
+
         # This is a bit of a hack to get the models_v2.Port attributes setup in such
         # a way as to avoid tracebacks in the neutron-server log.
         #


### PR DESCRIPTION
CalicoPlugin (our driver) already forces the ML2 mechanism_drivers / type_drivers / tenant_network_types settings and adds 'qos' to ml2.extension_drivers, so the operator doesn't have to repeat this in neutron.conf.  Do the same for the 'qos' service plugin -- Calico's QoS support requires it, and there's no good reason to make the operator remember an extra neutron.conf line for it.

(This is especially motivated by a recent customer issue which _might_ have been caused by missing the `service_plugins = qos` setting on one of their control nodes.)

Additive (rather than replacing the whole list) because deployments often need other service plugins (segments, trunk, log, port_forwarding, ...).  Neutron loads core_plugin first and then iterates cfg.CONF.service_plugins to load the rest, so an override during CalicoPlugin.__init__ is honoured for the subsequent load.

Drop the now-redundant `iniset $NEUTRON_CONF DEFAULT service_plugins qos` from the DevStack plugin -- CalicoPlugin handles it.

**Release note:**
```release-note
The Calico driver for OpenStack now overrides the Neutron `[DEFAULT] service_plugins` setting to ensure that it includes `qos`, as required for our QoS support.  This means that it's no longer necessary for to configure `service_plugins` in `neutron.conf`, when using Calico.
```
