### PR TITLE
Stabilize goldmane staged-policy flow log FV

### DIFF
--- a/felix/fv/flow_logs_goldmane_staged_test.go
+++ b/felix/fv/flow_logs_goldmane_staged_test.go
@@ -686,7 +686,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 			}
 
 			return nil
-		}, "30s", "3s").ShouldNot(HaveOccurred())
+		}, "90s", "3s").ShouldNot(HaveOccurred())
 	})
 })
 
@@ -1359,7 +1359,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 			}
 
 			return nil
-		}, "30s", "3s").ShouldNot(HaveOccurred())
+		}, "90s", "3s").ShouldNot(HaveOccurred())
 	})
 })
 

--- a/felix/fv/flowlogs/flow_tester.go
+++ b/felix/fv/flowlogs/flow_tester.go
@@ -200,7 +200,7 @@ func (t *FlowTester) CheckFlow(fl flowlog.FlowLog) {
 	}
 	existing, ok := t.flows[fm]
 	if !ok {
-		t.errors = append(t.errors, fmt.Sprintf("Flow was not present in logs: %#v", fm))
+		t.errors = append(t.errors, fmt.Sprintf("Flow was not present in logs: %#v\nReceived flows:%s", fm, t.dumpReceivedFlows()))
 		return
 	}
 	delete(t.flows, fm)
@@ -239,13 +239,33 @@ func (t *FlowTester) CheckFlow(fl flowlog.FlowLog) {
 // deltas.
 func (t *FlowTester) Finish() error {
 	for _, fl := range t.flows {
-		t.errors = append(t.errors, fmt.Sprintf("Unchecked flow: %#v", fl))
+		t.errors = append(t.errors, fmt.Sprintf("Unchecked flow: %s", formatFlow(fl)))
 	}
 
 	if len(t.errors) == 0 {
 		return nil
 	}
 	return errors.New(strings.Join(t.errors, "\n==============\n"))
+}
+
+// dumpReceivedFlows renders every flow currently held by the tester. Used in
+// failure messages so that flake reports show the policy sets the dataplane
+// actually reported, not just the meta-key the expected flow didn't match.
+func (t *FlowTester) dumpReceivedFlows() string {
+	if len(t.flows) == 0 {
+		return " (none)"
+	}
+	var b strings.Builder
+	for _, fl := range t.flows {
+		b.WriteString("\n  - ")
+		b.WriteString(formatFlow(fl))
+	}
+	return b.String()
+}
+
+func formatFlow(fl flowlog.FlowLog) string {
+	return fmt.Sprintf("meta=%#v enforced=%v pending=%v",
+		fl.FlowMeta, fl.FlowEnforcedPolicySet, fl.FlowPendingPolicySet)
 }
 
 // Return a test-specific flowMeta from the flowLog.  We may include policies and labels in the metadata so that


### PR DESCRIPTION
The staged-policy flow log FV is flaky on master. The Eventually window is 30s with a 5s flush interval, which leaves six flush windows to cover (a) the early flushes that arrive before the service-correlation cache is warm and report the wrong DstService, (b) policy-set aggregation transitions, and (c) flows from both felixes. 30s isn't a comfortable budget for that and the test fails roughly once every two weeks.

Two changes:

- Bump the Eventually to 90s on the two flow-checking blocks in `felix/fv/flow_logs_goldmane_staged_test.go`. Successful runs still exit as soon as flows match so this only costs wall time on the failure path.
- Improve `FlowTester` diagnostics. Today "Flow was not present in logs" only prints the meta-key the expected flow didn't match, and "Unchecked flow" prints a full `%#v` of the `FlowLog` which buries the policy sets in noise. After this, both messages print the meta plus the enforced and pending policy sets so the next recurrence is diagnosable from the test output without a re-run.

```release-note
None
```