### PR TITLE
Use calicoctl cluster diags for kind e2e on_fail collection

### DIFF
--- a/.semaphore/collect-kind-diags
+++ b/.semaphore/collect-kind-diags
@@ -14,17 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Collect diagnostics from a kind-based e2e cluster into artifacts/kind-diags/
-# so that .semaphore/publish-artifacts uploads them for inspection.
+# Collect diagnostics from a kind-based e2e cluster into artifacts/ so that
+# .semaphore/publish-artifacts uploads them for inspection. Drives
+# `calico ctl cluster diags`, which packages logs, descriptions, TLS state,
+# and Calico resources into a single tarball.
 #
 # Intended to be called from the e2e job epilogue. Best-effort: missing
-# kubeconfig or a torn-down cluster is not an error.
+# kubeconfig, missing image, or a torn-down cluster is not an error.
 
 set -x
 
 my_dir="$(dirname "$0")"
-repo_dir="$my_dir/.."
-diags_dir="$repo_dir/artifacts/kind-diags"
+repo_dir="$(cd "$my_dir/.." && pwd)"
+artifacts_dir="$repo_dir/artifacts"
 
 kubeconfig="${KUBECONFIG:-$repo_dir/hack/test/kind/kind-kubeconfig.yaml}"
 if [ ! -f "$kubeconfig" ]; then
@@ -32,54 +34,55 @@ if [ ! -f "$kubeconfig" ]; then
   exit 0
 fi
 
-kubectl=(kubectl --kubeconfig="$kubeconfig")
-if ! "${kubectl[@]}" cluster-info >/dev/null 2>&1; then
+# Use the kubectl that the kind setup downloaded; the diags binary shells out
+# to `kubectl` for some collection steps.
+kubectl_bin="$repo_dir/hack/test/kind/kubectl"
+if [ ! -x "$kubectl_bin" ]; then
+  kubectl_bin="$(command -v kubectl || true)"
+fi
+if [ -z "$kubectl_bin" ]; then
+  echo "collect-kind-diags: kubectl not found, skipping"
+  exit 0
+fi
+
+if ! "$kubectl_bin" --kubeconfig="$kubeconfig" cluster-info >/dev/null 2>&1; then
   echo "collect-kind-diags: cluster unreachable, skipping"
   exit 0
 fi
 
-mkdir -p "$diags_dir"
-
-"${kubectl[@]}" get nodes -o wide > "$diags_dir/nodes.txt" 2>&1 || true
-"${kubectl[@]}" get pods --all-namespaces -o wide > "$diags_dir/pods.txt" 2>&1 || true
-"${kubectl[@]}" get events --all-namespaces --sort-by=.lastTimestamp > "$diags_dir/events.txt" 2>&1 || true
-"${kubectl[@]}" get apiservices > "$diags_dir/apiservices.txt" 2>&1 || true
-
-# Describe any pods that are not in Running/Completed state.
-"${kubectl[@]}" get pods --all-namespaces --no-headers 2>/dev/null \
-  | awk '$4 != "Running" && $4 != "Completed" {print $1, $2}' \
-  | while read -r ns pod; do
-      "${kubectl[@]}" -n "$ns" describe pod "$pod" \
-        > "$diags_dir/describe-${ns}-${pod}.txt" 2>&1 || true
-    done
-
-# Collect logs from the control-plane components most likely to be relevant
-# when e2e tests fail. Grabs both current and previous logs so we can see
-# what a restart killed. Missing namespaces are tolerated.
-namespaces=(
-  "calico-system"
-  "tigera-operator"
-)
-for ns in "${namespaces[@]}"; do
-  "${kubectl[@]}" -n "$ns" get pods --no-headers 2>/dev/null \
-    | awk '{print $1}' \
-    | while read -r pod; do
-        "${kubectl[@]}" -n "$ns" logs "$pod" --all-containers --prefix \
-          > "$diags_dir/logs-${ns}-${pod}.log" 2>&1 || true
-        # kubectl logs --previous exits non-zero for pods that never restarted;
-        # only keep the file when the fetch actually succeeded.
-        if ! "${kubectl[@]}" -n "$ns" logs "$pod" --all-containers --prefix --previous \
-            > "$diags_dir/logs-${ns}-${pod}.previous.log" 2>&1; then
-          rm -f "$diags_dir/logs-${ns}-${pod}.previous.log"
-        fi
-      done
-done
-
-# Compress so the upload stays small. If archiving fails (e.g. zstd missing,
-# disk full) keep the raw directory so we still get the diagnostics through
-# publish-artifacts.
-if tar --use-compress-program="zstd -3" -cf "$repo_dir/artifacts/kind-diags.tar.zstd" -C "$repo_dir/artifacts" kind-diags; then
-  rm -rf "$diags_dir"
+# Extract the calico binary from the image that's already loaded for the
+# e2e run. The combined `calico` binary dispatches `ctl` to the calicoctl
+# subcommand.
+calico_image="${CALICO_IMAGE:-localhost:5000/calico/calico:test-build}"
+calico_bin="$(mktemp -d)/calico"
+cid="$(docker create "$calico_image" 2>/dev/null)"
+if [ -z "$cid" ]; then
+  echo "collect-kind-diags: could not create container from $calico_image, skipping"
+  exit 0
 fi
+if ! docker cp "$cid:/usr/bin/calico" "$calico_bin"; then
+  docker rm -f "$cid" >/dev/null 2>&1 || true
+  echo "collect-kind-diags: could not extract calico binary, skipping"
+  exit 0
+fi
+docker rm -f "$cid" >/dev/null 2>&1 || true
+chmod +x "$calico_bin"
+
+mkdir -p "$artifacts_dir"
+
+# `calico ctl cluster diags` writes a calico-diagnostics-<timestamp>.tar.gz
+# into the working directory. Run it in artifacts/ so publish-artifacts picks
+# it up. The default --config points at /etc/calico/calicoctl.cfg, which
+# doesn't exist on the CI host — calicoctl tolerates that and falls back to
+# DATASTORE_TYPE / KUBECONFIG. Up max-logs from the default 5 so we don't
+# miss restarted pods on busier kind runs.
+cd "$artifacts_dir"
+PATH="$(dirname "$kubectl_bin"):$PATH" \
+DATASTORE_TYPE=kubernetes \
+KUBECONFIG="$kubeconfig" \
+  "$calico_bin" ctl cluster diags \
+    --max-logs=100 \
+    --allow-version-mismatch \
+  || echo "collect-kind-diags: cluster diags exited non-zero (continuing)"
 
 exit 0

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -35,6 +35,8 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
@@ -165,14 +167,17 @@ func collectDiags(opts *diagOpts) error {
 	dir := fmt.Sprintf("%s/%s", tempDir, directoryName)
 
 	// Create Kubernetes client from config or env vars.
-	kubeClient, _, _, err := clientmgr.GetClients(opts.Config)
+	kubeClient, calicoClient, _, err := clientmgr.GetClients(opts.Config)
 	if err != nil {
 		fmt.Printf("ERROR creating clients: %v\n", err)
 		return err
 	}
+	// Skip the per-node BPF dumps if the BPF dataplane isn't enabled —
+	// they are slow and on iptables/nftables clusters produce no useful data.
+	bpfEnabled := isBPFEnabled(calicoClient)
 	if kubeClient != nil {
 		collectTLSSecrets(kubeClient, dir+"/tls")
-		collectSelectedNodeLogs(kubeClient, dir+"/nodes", dir+"/links", opts)
+		collectSelectedNodeLogs(kubeClient, dir+"/nodes", dir+"/links", opts, bpfEnabled)
 	}
 	collectGlobalClusterInformation(dir + "/cluster")
 	collectUnsupportedAnnotations(tempDir, directoryName)
@@ -181,7 +186,28 @@ func collectDiags(opts *diagOpts) error {
 	return nil
 }
 
-func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts) {
+// isBPFEnabled reports whether the BPF dataplane is turned on in the cluster's
+// default FelixConfiguration. If we can't tell (no client, lookup error, field
+// unset), we fall back to assuming it is on — better to collect noisy-but-empty
+// BPF diags than to silently drop them on a real BPF cluster.
+func isBPFEnabled(calicoClient clientv3.Interface) bool {
+	if calicoClient == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	fc, err := calicoClient.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
+	if err != nil {
+		log.WithError(err).Debug("Could not read default FelixConfiguration; assuming BPF is enabled")
+		return true
+	}
+	if fc.Spec.BPFEnabled == nil {
+		return false
+	}
+	return *fc.Spec.BPFEnabled
+}
+
+func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts, bpfEnabled bool) {
 	// If --focus-nodes is specified, put those node names at the start of the node list.
 	nodeList := strings.Split(opts.FocusNodes, ",")
 
@@ -225,7 +251,7 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			// Continue because deployments or other namespaces might work.
 		} else {
 			for _, ds := range dsl.Items {
-				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, ns.Name, ds.Spec.Selector)
+				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, bpfEnabled, ns.Name, ds.Spec.Selector)
 			}
 		}
 
@@ -236,7 +262,7 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			// Continue because other namespaces might work.
 		} else {
 			for _, d := range dl.Items {
-				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, ns.Name, d.Spec.Selector)
+				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, bpfEnabled, ns.Name, d.Spec.Selector)
 			}
 		}
 
@@ -247,13 +273,13 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			// Continue because other namespaces might work.
 		} else {
 			for _, s := range sl.Items {
-				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, ns.Name, s.Spec.Selector)
+				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, bpfEnabled, ns.Name, s.Spec.Selector)
 			}
 		}
 	}
 }
 
-func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient kubernetes.Interface, nodeList []string, ns string, selector *v1.LabelSelector) {
+func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient kubernetes.Interface, nodeList []string, bpfEnabled bool, ns string, selector *v1.LabelSelector) {
 	labelMap, err := v1.LabelSelectorAsMap(selector)
 	if err != nil {
 		fmt.Printf("ERROR forming pod selector: %v\n", err)
@@ -268,10 +294,10 @@ func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient
 		return
 	}
 
-	// Map the pod names against their node names.
-	podNamesByNode := map[string][]string{}
+	// Map the pods against their node names.
+	podsByNode := map[string][]apiv1.Pod{}
 	for _, p := range pl.Items {
-		podNamesByNode[p.Spec.NodeName] = append(podNamesByNode[p.Spec.NodeName], p.Name)
+		podsByNode[p.Spec.NodeName] = append(podsByNode[p.Spec.NodeName], p)
 	}
 
 	nextNodeIndex := 0
@@ -285,13 +311,13 @@ func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient
 		nodeName := nodeList[nextNodeIndex]
 		nextNodeIndex++
 
-		for _, podName := range podNamesByNode[nodeName] {
-			fmt.Printf("Collecting detailed diags for pod %v in namespace %v on node %v...\n", podName, ns, nodeName)
-			if strings.HasPrefix(podName, "calico-node-") {
+		for _, pod := range podsByNode[nodeName] {
+			fmt.Printf("Collecting detailed diags for pod %v in namespace %v on node %v...\n", pod.Name, ns, nodeName)
+			if strings.HasPrefix(pod.Name, "calico-node-") {
 				nodeDir := dir + "/" + nodeName
-				collectCalicoNodeDiags(nodeDir, nodeName, ns, podName)
+				collectCalicoNodeDiags(nodeDir, nodeName, ns, pod.Name, bpfEnabled)
 			}
-			cmds = append(cmds, diagsCmdsForPod(dir, linkDir, opts, nodeName, ns, podName)...)
+			cmds = append(cmds, diagsCmdsForPod(dir, linkDir, opts, nodeName, ns, &pod)...)
 			logsWanted--
 			if logsWanted <= 0 {
 				break
@@ -674,30 +700,52 @@ func collectGlobalClusterInformation(dir string) {
 	collectThirdPartyResource(dir + "/third-party")
 }
 
-// func diagsCmdsForPod(pod, namespace, dir /*node_name*/, sinceFlag string) {
-func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace, podName string) []common.Cmd {
+func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace string, pod *apiv1.Pod) []common.Cmd {
 	nodeDir := dir + "/" + nodeName
 	namespaceDir := nodeDir + "/" + namespace
 	cmds := []common.Cmd{
 		{
-			Info:     fmt.Sprintf("Collect logs for pod %s", podName),
-			CmdStr:   fmt.Sprintf("kubectl logs --since=%s -n %s %s --all-containers", opts.Since, namespace, podName),
-			FilePath: fmt.Sprintf("%s/%s.log", namespaceDir, podName),
-			SymLink:  fmt.Sprintf("%s/%s/%s.log", linkDir, namespace, podName),
+			Info:     fmt.Sprintf("Collect logs for pod %s", pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl logs --since=%s -n %s %s --all-containers", opts.Since, namespace, pod.Name),
+			FilePath: fmt.Sprintf("%s/%s.log", namespaceDir, pod.Name),
+			SymLink:  fmt.Sprintf("%s/%s/%s.log", linkDir, namespace, pod.Name),
 		},
 		{
-			Info:     fmt.Sprintf("Collect describe for pod %s", podName),
-			CmdStr:   fmt.Sprintf("kubectl -n %s describe pods %s", namespace, podName),
-			FilePath: fmt.Sprintf("%s/%s.txt", namespaceDir, podName),
-			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, podName),
+			Info:     fmt.Sprintf("Collect describe for pod %s", pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl -n %s describe pods %s", namespace, pod.Name),
+			FilePath: fmt.Sprintf("%s/%s.txt", namespaceDir, pod.Name),
+			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, pod.Name),
 		},
+	}
+	// If any container has restarted, also grab the previous incarnation's
+	// logs — those are usually the ones that explain the restart.
+	if hasPreviousLogs(pod) {
+		cmds = append(cmds, common.Cmd{
+			Info:     fmt.Sprintf("Collect previous logs for pod %s", pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s --all-containers", opts.Since, namespace, pod.Name),
+			FilePath: fmt.Sprintf("%s/%s.previous.log", namespaceDir, pod.Name),
+			SymLink:  fmt.Sprintf("%s/%s/%s.previous.log", linkDir, namespace, pod.Name),
+		})
 	}
 	return cmds
 }
 
-func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName string) {
+// hasPreviousLogs reports whether any container in the pod has a prior
+// incarnation worth fetching logs from.
+func hasPreviousLogs(pod *apiv1.Pod) bool {
+	statuses := append([]apiv1.ContainerStatus{}, pod.Status.ContainerStatuses...)
+	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	for _, cs := range statuses {
+		if cs.RestartCount > 0 || cs.LastTerminationState.Terminated != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName string, bpfEnabled bool) {
 	fmt.Printf("Collecting dataplane diags for calico-node: %s\n", podName)
-	common.ExecAllCmdsWriteToFile([]common.Cmd{
+	cmds := []common.Cmd{
 		// ip diagnostics
 		{
 			Info:     fmt.Sprintf("Collect iptables (legacy) for node %s", nodeName),
@@ -754,43 +802,53 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- conntrack -LSC", namespace, podName),
 			FilePath: fmt.Sprintf("%s/conntrack-list.txt", curNodeDir),
 		},
-		// eBPF diagnostics
-		{
-			Info:     fmt.Sprintf("Collect eBPF conntrack for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf conntrack dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-conntrack.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF ipsets for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf ipsets dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-ipsets.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF nat for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf nat dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-nat.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF routes for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf routes dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-routes.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-prog.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF map for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map list", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-maps.txt", curNodeDir),
-		},
 		{
 			Info:     fmt.Sprintf("Collect tc qdisc for node %s", nodeName),
 			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- tc qdisc show", namespace, podName),
 			FilePath: fmt.Sprintf("%s/tc-qdisc.txt", curNodeDir),
 		},
-	})
+	}
+	if bpfEnabled {
+		// eBPF diagnostics. The calico-bpf tool is reached via the combined
+		// calico binary's `component node bpf` subcommand.
+		cmds = append(cmds,
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF conntrack for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf conntrack dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-conntrack.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF ipsets for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf ipsets dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-ipsets.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF nat for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf nat dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-nat.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF routes for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf routes dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-routes.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-prog.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF map for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map list", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-maps.txt", curNodeDir),
+			},
+		)
+	}
+	common.ExecAllCmdsWriteToFile(cmds)
+
+	if !bpfEnabled {
+		return
+	}
 
 	output, err := common.ExecCmd(fmt.Sprintf(
 		"kubectl exec -n %s -t %s -c calico-node -- bpftool map list",

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -187,9 +187,10 @@ func collectDiags(opts *diagOpts) error {
 }
 
 // isBPFEnabled reports whether the BPF dataplane is turned on in the cluster's
-// default FelixConfiguration. If we can't tell (no client, lookup error, field
-// unset), we fall back to assuming it is on — better to collect noisy-but-empty
-// BPF diags than to silently drop them on a real BPF cluster.
+// default FelixConfiguration. If the field is unset, BPF defaults to off and
+// we skip the BPF section. If we can't tell at all (no client, lookup error),
+// fall back to assuming it is on — better to collect noisy-but-empty BPF
+// diags than to silently drop them on a real BPF cluster we couldn't query.
 func isBPFEnabled(calicoClient clientv3.Interface) bool {
 	if calicoClient == nil {
 		return true
@@ -846,45 +847,43 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 	}
 	common.ExecAllCmdsWriteToFile(cmds)
 
-	if !bpfEnabled {
-		return
-	}
+	if bpfEnabled {
+		output, err := common.ExecCmd(fmt.Sprintf(
+			"kubectl exec -n %s -t %s -c calico-node -- bpftool map list",
+			namespace,
+			podName,
+		))
+		if err != nil {
+			fmt.Printf("Could not retrieve eBPF maps: %s\n", err)
+		} else {
+			bpfMaps := strings.Split(strings.TrimSpace(output.String()), "\n")
+			log.Debugf("eBPF maps: %s\n", bpfMaps)
 
-	output, err := common.ExecCmd(fmt.Sprintf(
-		"kubectl exec -n %s -t %s -c calico-node -- bpftool map list",
-		namespace,
-		podName,
-	))
-	if err != nil {
-		fmt.Printf("Could not retrieve eBPF maps: %s\n", err)
-	} else {
-		bpfMaps := strings.Split(strings.TrimSpace(output.String()), "\n")
-		log.Debugf("eBPF maps: %s\n", bpfMaps)
+			// Output looks like this:
+			//
+			// 35: lru_hash  name cali_v4_srmsg  flags 0x0
+			//	key 16B  value 8B  max_entries 510000  memlock 12242944B
+			//	pids calico-node(28576)
 
-		// Output looks like this:
-		//
-		// 35: lru_hash  name cali_v4_srmsg  flags 0x0
-		//	key 16B  value 8B  max_entries 510000  memlock 12242944B
-		//	pids calico-node(28576)
-
-		bpfInfoLineRe := regexp.MustCompile(`^(\d+):.*name (cali\w+)`)
-		var bpfDumpCmds []common.Cmd
-		for _, line := range bpfMaps {
-			if m := bpfInfoLineRe.FindStringSubmatch(line); m != nil {
-				id := m[1]
-				name := m[2]
-				bpfDumpCmds = append(bpfDumpCmds, common.Cmd{
-					Info:     fmt.Sprintf("Collect eBPF map %s:%s for node %s", id, name, nodeName),
-					CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map dump id %s", namespace, podName, id),
-					FilePath: fmt.Sprintf("%s/bpf-maps/%s-id_%s.txt", curNodeDir, name, id),
-				})
+			bpfInfoLineRe := regexp.MustCompile(`^(\d+):.*name (cali\w+)`)
+			var bpfDumpCmds []common.Cmd
+			for _, line := range bpfMaps {
+				if m := bpfInfoLineRe.FindStringSubmatch(line); m != nil {
+					id := m[1]
+					name := m[2]
+					bpfDumpCmds = append(bpfDumpCmds, common.Cmd{
+						Info:     fmt.Sprintf("Collect eBPF map %s:%s for node %s", id, name, nodeName),
+						CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map dump id %s", namespace, podName, id),
+						FilePath: fmt.Sprintf("%s/bpf-maps/%s-id_%s.txt", curNodeDir, name, id),
+					})
+				}
 			}
+			common.ExecAllCmdsWriteToFile(bpfDumpCmds)
 		}
-		common.ExecAllCmdsWriteToFile(bpfDumpCmds)
 	}
 
 	// Collect all of the CNI logs
-	output, err = common.ExecCmd(fmt.Sprintf(
+	output, err := common.ExecCmd(fmt.Sprintf(
 		"kubectl exec -n %s -t %s -c calico-node -- ls /var/log/calico/cni",
 		namespace,
 		podName,

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
 
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
@@ -152,4 +154,42 @@ func TestDiags(t *testing.T) {
 			FocusNodes:           "infra1,control2",
 			AllowVersionMismatch: false,
 		})
+}
+
+func TestDiagsCmdsForPod_Previous(t *testing.T) {
+	RegisterTestingT(t)
+
+	opts := &diagOpts{Since: "0s"}
+
+	// A pod with no restarts gets only the current-log and describe commands.
+	steady := &apiv1.Pod{}
+	steady.Name = "calico-typha-0"
+	steady.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 0}}
+	cmds := diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", steady)
+	Expect(cmdStrs(cmds)).NotTo(ContainElement(ContainSubstring("--previous")))
+
+	// A pod whose container has restarted picks up an extra previous-log
+	// command alongside the usual current-log + describe.
+	restarted := &apiv1.Pod{}
+	restarted.Name = "calico-apiserver-0"
+	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 2}}
+	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-apiserver", restarted)
+	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+
+	// An init container that previously terminated also flips the flag.
+	initTerminated := &apiv1.Pod{}
+	initTerminated.Name = "calico-node-xyz"
+	initTerminated.Status.InitContainerStatuses = []apiv1.ContainerStatus{{
+		LastTerminationState: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+	}}
+	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", initTerminated)
+	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+}
+
+func cmdStrs(cmds []common.Cmd) []string {
+	out := make([]string, len(cmds))
+	for i, c := range cmds {
+		out[i] = c.CmdStr
+	}
+	return out
 }


### PR DESCRIPTION
The e2e on_fail epilogue added in https://github.com/projectcalico/calico/pull/12799 dumped a custom set of kubectl outputs. Switch it to drive `calico ctl cluster diags`, which is the same bundle we ship to customers - so we get TLS state, per-node iptables/nft/ipset/conntrack/routes/CNI, Calico CRs, k8s policy and webhook state, and pod logs all in one tarball, instead of a much narrower hand-rolled dump.

While here, fix a few things in `cluster diags` itself that were noticed along the way:

- The BPF dumps were shelling out to `calico-node -bpf ...`. There is no `calico-node` binary in the combined-binary image, so those steps had been failing silently. Switch to `calico component node bpf ...`.
- Skip the per-node eBPF section when the default FelixConfiguration does not have BPFEnabled set. Saves time on iptables/nftables clusters and avoids a directory full of empty BPF state.
- Auto-collect previous-incarnation logs (`kubectl logs --previous`) for any pod with a container that has restarted. This was the main motivation for the original epilogue script - catching apiserver crashes before teardown - and is now baked into `cluster diags` itself rather than special-cased per-caller.

Verified locally against a kind cluster: bundle contains 532 files covering all relevant namespaces, and the BPF section is correctly skipped on an iptables cluster.

```release-note
None
```