### PR TITLE
fix: handle combined fsnotify create events

### DIFF
--- a/cni-plugin/pkg/wait/wait.go
+++ b/cni-plugin/pkg/wait/wait.go
@@ -65,7 +65,7 @@ func ForEndpointReadyWithTimeout(policyDir string, endpoint *internalapi.Workloa
 func waitUntilFileExists(ctx context.Context, directory, filename string) error {
 	log := logrus.WithFields(logrus.Fields{
 		"directory":   directory,
-		"disiredFile": filename,
+		"desiredFile": filename,
 	})
 
 	retryInterval := 500 * time.Millisecond
@@ -186,13 +186,11 @@ func waitForCreateEvent(ctx context.Context, watcher *fsnotify.Watcher, filename
 		select {
 		case e := <-watcher.Events:
 			log.WithField("eventName", e.Name).Debug("Received watch event")
-			switch e.Op {
-			case fsnotify.Create:
+			if e.Has(fsnotify.Create) {
 				if filepath.Base(e.Name) == filename {
 					log.WithField("eventName", e.Name).Debug("FS 'Create' event seen for file. Firing notification and stopping watch")
 					return true, nil
 				}
-			default:
 			}
 
 		case err := <-watcher.Errors:

--- a/cni-plugin/pkg/wait/wait_test.go
+++ b/cni-plugin/pkg/wait/wait_test.go
@@ -15,10 +15,12 @@
 package wait
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,6 +98,54 @@ var _ = Describe("k8s-wait", func() {
 
 			Eventually(exit, "3s").Should(Receive(&err), "Expected a return value to be passed from polling thread.")
 			Expect(err).NotTo(HaveOccurred(), "Polling thread returned an error.")
+		})
+	})
+
+	Context("waitForCreateEvent", func() {
+		It("should handle create events with multiple fsnotify operations", func() {
+			watcher, err := fsnotify.NewWatcher()
+			Expect(err).NotTo(HaveOccurred())
+			defer closeWatcherAndIgnoreErr(watcher)
+
+			const filename = "endpoint-status"
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				watcher.Events <- fsnotify.Event{
+					Name: filepath.Join("/tmp", filename),
+					Op:   fsnotify.Create | fsnotify.Write,
+				}
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			found, err := waitForCreateEvent(ctx, watcher, filename)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("should ignore write-only events", func() {
+			watcher, err := fsnotify.NewWatcher()
+			Expect(err).NotTo(HaveOccurred())
+			defer closeWatcherAndIgnoreErr(watcher)
+
+			const filename = "endpoint-status"
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				watcher.Events <- fsnotify.Event{
+					Name: filepath.Join("/tmp", filename),
+					Op:   fsnotify.Write,
+				}
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			found, err := waitForCreateEvent(ctx, watcher, filename)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
+			Eventually(done).Should(BeClosed())
 		})
 	})
 })


### PR DESCRIPTION
Fixes a small CNI wait edge case.

fsnotify Op is a bitmask. Current code checks e.Op == fsnotify.Create, so an event like Create|Write is ignored. That can make the status-file wait run until timeout even though the file event already showed up. Tiny footgun, but real.

Repro:
- with old code, the new unit test injects fsnotify.Create|fsnotify.Write
- go test ./cni-plugin/pkg/wait fails because found stays false
- with this change it passes, because we use e.Has(fsnotify.Create)

No linked issue found, afaict. Related PRs: #8469, #12609.

Testing:
- go test ./cni-plugin/pkg/wait
- go test ./cni-plugin/pkg/wait ./cni-plugin/internal/pkg/utils

**Release note:**
```release-note
Fix CNI endpoint status-file waiting when fsnotify reports create with another operation.
```