### PR TITLE
hack: add format-go-file tool and Claude Code post-edit hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,6 @@ Project Calico is a large monorepo providing container networking and security f
 
 - **NEVER** run `make ci` or `make cd` locally — destructive CI-only targets
 - **NEVER** run `make test` at root — takes hours. Always test components individually.
-- **ALWAYS** run `make fix-changed` before committing — CI rejects formatting errors
 - **ALWAYS** remove `FIt`/`FDescribe` before committing — pre-commit hook rejects Ginkgo focused tests
 - **ALWAYS** commit generated files alongside source changes
 
@@ -136,7 +135,7 @@ import (
 )
 ```
 
-Run `make fix-changed` to auto-fix import ordering. Do not run `goimports` or `go fmt` directly — the project uses a custom 3-step pipeline (`hack/format-changed-files.sh`).
+A repo-scoped Claude Code PostToolUse hook (`.claude/settings.json`) re-formats `.go` files automatically after every Edit/Write/MultiEdit, and `make generate` invokes `make fix-changed` on the files it regenerates. You don't need to run anything by hand. Do not run `goimports` or `go fmt` directly — the project uses a custom 3-step pipeline (`hack/cmd/format-go-file`).
 
 ### Copyright Headers
 
@@ -355,10 +354,9 @@ the BPF dataplane).
 2. Make changes to relevant component(s)
 3. Run component-specific tests: `make -C <component> test` or `go test ./...`
 4. Run validation: `make yaml-lint` (if YAML changed)
-5. If APIs/config/CI changed: `make generate`
-6. **MANDATORY:** Run `make fix-changed` to fix formatting
-7. Commit changes (generated files must be included)
-8. Push and create PR
+5. If APIs/config/CI changed: `make generate` (formats regenerated files itself)
+6. Commit changes (generated files must be included)
+7. Push and create PR
 
 ### Updating Helm Charts and Manifests
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,8 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Repository Overview
 
-Project Calico is a large monorepo providing container networking and security for Kubernetes. The codebase contains ~2000 Go files across 30+ components, supporting multiple dataplanes (eBPF, iptables, nftables, Windows, VPP).
+Project Calico is a large monorepo providing container networking and security 
+for Kubernetes. The codebase contains ~2000 Go files across 30+ components, 
+supporting multiple dataplanes (eBPF, iptables, nftables, Windows, VPP).
 
 **Primary language:** Go (also C/eBPF, Python, Shell, TypeScript/React)
 **Build system:** Make + Docker-based reproducible builds
@@ -21,7 +19,7 @@ Project Calico is a large monorepo providing container networking and security f
 
 ## Essential Build Commands
 
-**Prerequisites:** Docker, Make, Git, Linux environment (Ubuntu 24.04+ recommended)
+**Prerequisites:** Docker, Make, Go, Git, Linux environment (Ubuntu 24.04+ recommended)
 
 ### Building Components
 
@@ -105,9 +103,12 @@ make generate
 make protobuf               # Regenerate protobuf files
 make gen-manifests          # Update manifests/ from helm charts
 make gen-semaphore-yaml     # Regenerate .semaphore/semaphore.yml from templates
+make gen-deps-files         # Regenerate deps.txt files after adding new imports to a component; used to trigger downstream CI.
 ```
 
-**After modifying API types** (e.g., `api/pkg/apis/projectcalico/v3/felixconfig.go`), run `make generate` — it regenerates OpenAPI specs, CRDs, deep copy, Felix config docs, manifests, and runs `fix-changed`. See also `hack/docs/adding-an-api.md`.
+**After modifying API types** (e.g., `api/pkg/apis/projectcalico/v3/felixconfig.go`), 
+run `make generate` — it regenerates OpenAPI specs, CRDs, deep copy, Felix 
+config docs, manifests, and runs `fix-changed`. See also `hack/docs/adding-an-api.md`.
 
 ## Generated Files (DO NOT edit directly)
 
@@ -135,7 +136,7 @@ import (
 )
 ```
 
-A repo-scoped Claude Code PostToolUse hook (`.claude/settings.json`) re-formats `.go` files automatically after every Edit/Write/MultiEdit, and `make generate` invokes `make fix-changed` on the files it regenerates. You don't need to run anything by hand. Do not run `goimports` or `go fmt` directly — the project uses a custom 3-step pipeline (`hack/cmd/format-go-file`).
+A repo-scoped PostToolUse hook (`.claude/settings.json`) re-formats `.go` files automatically after every Edit/Write/MultiEdit.
 
 ### Copyright Headers
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && go run ./hack/cmd/format-go-file --claude-hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/projectcalico/calico
 
 go 1.26.3
 
+tool golang.org/x/tools/cmd/goimports
+
 require (
 	cloud.google.com/go/storage v1.62.1
 	github.com/BurntSushi/toml v1.6.0
@@ -136,6 +138,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	k8s.io/cli-runtime v0.35.5 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1187,6 +1187,8 @@ golang.org/x/telemetry v0.0.0-20250710130107-8d8967aff50b/go.mod h1:4ZwOYna0/zsO
 golang.org/x/telemetry v0.0.0-20250807160809-1a19826ec488/go.mod h1:fGb/2+tgXXjhjHsTNdVEEMZNWA0quBnfrO+AfoDSAKw=
 golang.org/x/telemetry v0.0.0-20250908211612-aef8a434d053/go.mod h1:+nZKN+XVh4LCiA9DV3ywrzN4gumyCnKjau3NGb9SGoE=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJEkyFTI5/Ocsu2jXyDr6iSdgJiYE/uwE=
+golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 h1:HjU6IWBiAgRIdAJ9/y1rwCn+UELEmwV+VsTLzj/W4sE=
+golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/hack/cmd/format-go-file/format-go-file.go
+++ b/hack/cmd/format-go-file/format-go-file.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 const localImportPrefix = "github.com/projectcalico/calico/"
@@ -101,8 +102,10 @@ func pathFromClaudeHook(r *os.File) (string, error) {
 }
 
 // findRepoRoot walks up from $CLAUDE_PROJECT_DIR (if set) or the current
-// directory until it finds a go.mod, and returns that directory. The
-// containing repo has a go.mod at the root so this is unambiguous.
+// directory looking for the top-level Calico module. We can't just stop at
+// the first go.mod because the repo also has nested modules (api/,
+// lib/std/, lib/httpmachinery/) — only the root carries the goimports
+// tool dep and the coalesce-imports source we shell out to.
 func findRepoRoot() (string, error) {
 	start := os.Getenv("CLAUDE_PROJECT_DIR")
 	if start == "" {
@@ -117,15 +120,35 @@ func findRepoRoot() (string, error) {
 		return "", err
 	}
 	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+		if isCalicoRoot(dir) {
 			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", fmt.Errorf("no go.mod found above %s", start)
+			return "", fmt.Errorf("no Calico root module found above %s", start)
 		}
 		dir = parent
 	}
+}
+
+// isCalicoRoot returns true if dir is the top-level Calico module: it has
+// a go.mod whose module path is github.com/projectcalico/calico. We don't
+// rely on the presence of hack/cmd/coalesce-imports alone because a
+// future restructure could move that, but the module path is stable.
+func isCalicoRoot(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return false
+	}
+	// modfile is overkill for one line; the module directive is always
+	// at the top in the form `module <path>`.
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest) == "github.com/projectcalico/calico"
+		}
+	}
+	return false
 }
 
 // filterAndRelativize resolves each input path to an absolute path, drops

--- a/hack/cmd/format-go-file/format-go-file.go
+++ b/hack/cmd/format-go-file/format-go-file.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// format-go-file applies the project's canonical 3-step formatting pipeline
+// (goimports / coalesce-imports / goimports) to one or more Go files. It is
+// intended to be cheap enough to run on every editor save or on every
+// Claude Code Edit/Write tool call.
+//
+// Usage:
+//
+//	go run ./hack/cmd/format-go-file <path>...
+//	go run ./hack/cmd/format-go-file --claude-hook < <hook-event-json>
+//
+// Paths may be absolute, repo-relative, or $PWD-relative. Paths that are
+// not Go files, that live under vendor/ or third_party/, that don't exist,
+// or that fall outside the repo are silently skipped, so callers (editor
+// hooks, Claude PostToolUse hooks) can pass any file path without
+// pre-filtering.
+//
+// With --claude-hook, the program reads the Claude Code PostToolUse JSON
+// event on stdin and pulls tool_input.file_path out of it. This avoids
+// depending on jq in the hook command itself.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const localImportPrefix = "github.com/projectcalico/calico/"
+
+var claudeHook = flag.Bool("claude-hook", false,
+	"Read a Claude Code PostToolUse JSON event on stdin and use its tool_input.file_path.")
+
+func main() {
+	flag.Parse()
+
+	paths := flag.Args()
+	if *claudeHook {
+		p, err := pathFromClaudeHook(os.Stdin)
+		if err != nil {
+			// Malformed input: not fatal — silently no-op so a stray
+			// invocation can never block an edit.
+			return
+		}
+		if p == "" {
+			return
+		}
+		paths = append(paths, p)
+	}
+
+	if len(paths) == 0 {
+		return
+	}
+
+	repoDir, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "format-go-file: %v\n", err)
+		os.Exit(1)
+	}
+
+	relPaths := filterAndRelativize(paths, repoDir)
+	if len(relPaths) == 0 {
+		return
+	}
+
+	if err := formatFiles(repoDir, relPaths); err != nil {
+		fmt.Fprintf(os.Stderr, "format-go-file: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type hookEvent struct {
+	ToolInput struct {
+		// Edit / Write / MultiEdit all carry file_path on tool_input.
+		FilePath string `json:"file_path"`
+	} `json:"tool_input"`
+}
+
+func pathFromClaudeHook(r *os.File) (string, error) {
+	var ev hookEvent
+	if err := json.NewDecoder(r).Decode(&ev); err != nil {
+		return "", err
+	}
+	return ev.ToolInput.FilePath, nil
+}
+
+// findRepoRoot walks up from $CLAUDE_PROJECT_DIR (if set) or the current
+// directory until it finds a go.mod, and returns that directory. The
+// containing repo has a go.mod at the root so this is unambiguous.
+func findRepoRoot() (string, error) {
+	start := os.Getenv("CLAUDE_PROJECT_DIR")
+	if start == "" {
+		var err error
+		start, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getwd: %w", err)
+		}
+	}
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found above %s", start)
+		}
+		dir = parent
+	}
+}
+
+// filterAndRelativize resolves each input path to an absolute path, drops
+// anything that is not a .go file inside the repo, and returns the
+// surviving paths as repo-root-relative paths.
+func filterAndRelativize(paths []string, repoDir string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		abs, err := resolveExistingFile(p, repoDir)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(repoDir, abs)
+		if err != nil || rel == "" {
+			continue
+		}
+		// filepath.Rel can return e.g. "../foo" for paths outside the
+		// repo. Reject those.
+		if rel == ".." || len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator) {
+			continue
+		}
+		if filepath.Ext(rel) != ".go" {
+			continue
+		}
+		// Skip vendored / third_party trees.
+		first := firstPathSegment(rel)
+		if first == "vendor" || first == "third_party" {
+			continue
+		}
+		out = append(out, rel)
+	}
+	return out
+}
+
+// resolveExistingFile picks the first interpretation of p that names an
+// existing regular file: as-given (relative to $PWD or already absolute),
+// then relative to the repo root.
+func resolveExistingFile(p, repoDir string) (string, error) {
+	candidates := []string{p}
+	if !filepath.IsAbs(p) {
+		candidates = append(candidates, filepath.Join(repoDir, p))
+	}
+	for _, c := range candidates {
+		abs, err := filepath.Abs(c)
+		if err != nil {
+			continue
+		}
+		fi, err := os.Stat(abs)
+		if err != nil || !fi.Mode().IsRegular() {
+			continue
+		}
+		return abs, nil
+	}
+	return "", fmt.Errorf("not found: %s", p)
+}
+
+func firstPathSegment(rel string) string {
+	for i := 0; i < len(rel); i++ {
+		if rel[i] == filepath.Separator {
+			return rel[:i]
+		}
+	}
+	return rel
+}
+
+// formatFiles runs the canonical 3-step pipeline against the given
+// repo-root-relative paths.
+func formatFiles(repoDir string, relPaths []string) error {
+	steps := []struct {
+		name string
+		args []string
+	}{
+		{"goimports (coalesce)", append([]string{"tool", "goimports", "-w", "-local", localImportPrefix}, relPaths...)},
+		{"coalesce-imports", append([]string{"run", "./hack/cmd/coalesce-imports", "-w"}, relPaths...)},
+		{"goimports (whitespace)", append([]string{"tool", "goimports", "-w", "-local", localImportPrefix}, relPaths...)},
+	}
+	for _, s := range steps {
+		cmd := exec.Command("go", s.args...)
+		cmd.Dir = repoDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%s: %w", s.name, err)
+		}
+	}
+	return nil
+}

--- a/hack/deps.txt
+++ b/hack/deps.txt
@@ -114,6 +114,7 @@ local:felix/stringutils
 local:hack/cmd/calico-selector
 local:hack/cmd/coalesce-imports
 local:hack/cmd/deps
+local:hack/cmd/format-go-file
 local:hack/cmd/gomodder
 local:hack/cmd/ipam-hammer
 local:hack/test/spider

--- a/hack/format-all-files.sh
+++ b/hack/format-all-files.sh
@@ -8,6 +8,12 @@ repo_dir="$(dirname $hack_dir)"
 file_list=$(mktemp)
 trap "rm -f $file_list" EXIT
 
+# Always operate from the repo root: the `find` should walk the whole tree
+# and `go tool goimports` needs to resolve against the top-level Calico
+# module (the repo also contains nested go.mod files under api/, lib/std/,
+# lib/httpmachinery/ that don't carry the tool dependency).
+pushd "$repo_dir" > /dev/null
+
 find . -iname "*.go" \
        ! -wholename "./vendor/*" \
        ! -wholename "./third_party/*" \
@@ -18,6 +24,7 @@ find . -iname "*.go" \
 # into blocks.
 xargs -0 go tool goimports -w -local github.com/projectcalico/calico/ < ${file_list}
 # Coalesce imports then removes whitespace within blocks.
-xargs -0 go run "${repo_dir}/hack/cmd/coalesce-imports" -w < ${file_list}
+xargs -0 go run ./hack/cmd/coalesce-imports -w < ${file_list}
 # Finally run goimports again to insert only the desired whitespace.
 xargs -0 go tool goimports -w -local github.com/projectcalico/calico/ < ${file_list}
+popd > /dev/null

--- a/hack/format-all-files.sh
+++ b/hack/format-all-files.sh
@@ -16,8 +16,8 @@ find . -iname "*.go" \
 
 # Run extra copy of goimports first to coalesce multiple single-line imports
 # into blocks.
-xargs -0 goimports -w -local github.com/projectcalico/calico/ < ${file_list}
+xargs -0 go tool goimports -w -local github.com/projectcalico/calico/ < ${file_list}
 # Coalesce imports then removes whitespace within blocks.
 xargs -0 go run "${repo_dir}/hack/cmd/coalesce-imports" -w < ${file_list}
 # Finally run goimports again to insert only the desired whitespace.
-xargs -0 goimports -w -local github.com/projectcalico/calico/ < ${file_list}
+xargs -0 go tool goimports -w -local github.com/projectcalico/calico/ < ${file_list}

--- a/hack/format-changed-files.sh
+++ b/hack/format-changed-files.sh
@@ -52,9 +52,9 @@ pushd "$repo_dir" > /dev/null
 
 # Run extra copy of goimports first to coalesce multiple single-line imports
 # into blocks.
-xargs -0 goimports -w -local github.com/projectcalico/calico/ < $file_list
+xargs -0 go tool goimports -w -local github.com/projectcalico/calico/ < $file_list
 # Coalesce imports then removes whitespace within blocks.
 xargs -0 go run ./hack/cmd/coalesce-imports -w < $file_list
 # Finally run goimports again to insert only the desired whitespace.
-xargs -0 goimports -w -local github.com/projectcalico/calico/ < $file_list
+xargs -0 go tool goimports -w -local github.com/projectcalico/calico/ < $file_list
 popd > /dev/null

--- a/hack/git-hooks/pre-commit-in-container
+++ b/hack/git-hooks/pre-commit-in-container
@@ -125,7 +125,13 @@ for filename in $changed_go_files; do
     continue
   fi
   if [[ -z "${skipped_files[${filename}]+isset}" ]]; then
-    if go tool goimports -d "${filename}" | grep '.'; then
+    # Capture the diff into a variable rather than piping straight into
+    # grep: a piped form would let a non-zero exit from goimports (e.g.
+    # missing tool, parse error) be swallowed by grep's exit status and
+    # silently pass the hook. With "set -e" at the top of the script the
+    # command substitution propagates the failure.
+    gofmt_diff=$(go tool goimports -d "${filename}")
+    if [ -n "${gofmt_diff}" ]; then
       echo "  goimports would make changes to file:" ${filename}
       gofmt_failed=true
     fi

--- a/hack/git-hooks/pre-commit-in-container
+++ b/hack/git-hooks/pre-commit-in-container
@@ -125,7 +125,7 @@ for filename in $changed_go_files; do
     continue
   fi
   if [[ -z "${skipped_files[${filename}]+isset}" ]]; then
-    if goimports -d "${filename}" | grep '.'; then
+    if go tool goimports -d "${filename}" | grep '.'; then
       echo "  goimports would make changes to file:" ${filename}
       gofmt_failed=true
     fi


### PR DESCRIPTION
Adds a small Go tool, `hack/cmd/format-go-file`, that applies the project's canonical 3-step formatting pipeline (goimports + coalesce-imports + goimports) against one or more Go files without going through Make or Docker. It also accepts `--claude-hook`, in which case it reads a Claude Code PostToolUse JSON event from stdin and pulls `tool_input.file_path` out of it — so the hook command has no dependency on `jq` or other host tools beyond the Go toolchain.

Wires that into a repo-scoped `.claude/settings.json` so every `Edit` / `Write` / `MultiEdit` Claude makes against a `.go` file gets silently re-formatted, removing the manual `make fix-changed` step before commit.

To make the pipeline runnable on the host (the `calico/go-build` image has `goimports` pre-installed, host machines typically don't), pins `goimports` as a Go tool dep in `go.mod` and switches the existing `format-changed-files.sh`, `format-all-files.sh`, and `pre-commit-in-container` scripts to `go tool goimports`. Docker / Make / CI behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)