### PR TITLE
[release-v3.32] fix(release): register operator git flags on hashrelease publish (#12684)

### DIFF
--- a/release/cmd/flags.go
+++ b/release/cmd/flags.go
@@ -227,9 +227,9 @@ var (
 		operatorFlag(envBuildOperator, envReleaseOperator),
 	)
 
-	operatorPublishCommandFlags = []cli.Flag{
+	operatorPublishCommandFlags = append(slices.Clone(operatorGitFlags),
 		operatorFlag(envPublishOperator, envReleaseOperator),
-	}
+	)
 
 	// Operator git flags
 	operatorOrgFlagName = "operator-org"

--- a/release/cmd/flags_test.go
+++ b/release/cmd/flags_test.go
@@ -298,6 +298,25 @@ func TestEnvVarPrecedence(t *testing.T) {
 	}
 }
 
+// TestHashreleasePublishFlagsRegisterOperatorGit guards against the regression
+// where the publish subcommand referenced operatorRepoFlag in its action but
+// did not register operatorGitFlags, so c.String("operator-repo") returned ""
+// and the operator dir collapsed to cfg.TmpDir.
+func TestHashreleasePublishFlagsRegisterOperatorGit(t *testing.T) {
+	flags := hashreleasePublishFlags()
+	have := map[string]bool{}
+	for _, f := range flags {
+		for _, n := range f.Names() {
+			have[n] = true
+		}
+	}
+	for _, n := range []string{operatorOrgFlagName, operatorRepoFlagName, operatorBranchFlagName} {
+		if !have[n] {
+			t.Errorf("hashreleasePublishFlags is missing --%s", n)
+		}
+	}
+}
+
 func TestInverseFlagName(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
Backport of #12684 to release-v3.32. Without this, the `make hashrelease` job on release-v3.32 fails at the publish step (failing run [here](https://tigera.semaphoreci.com/workflows/96ac30b9-8839-40cd-b546-4cdba5b04979?pipeline_id=96c3ca7f-823d-4159-a5a1-bf36f2545af5)).

The hashrelease publish action computes the operator dir as `filepath.Join(cfg.TmpDir, c.String(operatorRepoFlag.Name))`, but `operatorPublishCommandFlags` only registered the boolean `--operator` flag. With `--operator-repo` unregistered, `c.String("operator-repo")` returned `""` and the publish step ran `make -C release/tmp release-publish` instead of `make -C release/tmp/operator release-publish`, failing with `No rule to make target 'release-publish'`.

Append `operatorGitFlags` to `operatorPublishCommandFlags` so `--operator-org`, `--operator-repo`, and `--operator-branch` are registered (and resolve their metadata.mk-backed defaults) on the publish subcommand, matching the build subcommand.

**Release note:**
```release-note
TBD
```
