### PR TITLE
libcalico-go/epstatusfile: handle combined fsnotify ops via bitmask

### DIFF
--- a/libcalico-go/lib/epstatusfile/status_file_watcher.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher.go
@@ -141,7 +141,11 @@ func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
 			}).Debug("received file events")
 
 			filePath := event.Name
-			if event.Op == fsnotify.Remove {
+			// fsnotify Op is a bitmask: a single event can combine ops
+			// (e.g. Create|Write when a file is created and written in
+			// the same syscall, common on Linux for os.Create). Use Has
+			// so combined events are not silently dropped.
+			if event.Op.Has(fsnotify.Remove) {
 				w.callbacks.OnFileDeletion(filePath)
 				delete(w.lastState, filePath)
 			} else {
@@ -149,11 +153,13 @@ func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
 				if err != nil {
 					log.WithError(err).Error("Failed to get file info on a fsnotify event.")
 				} else if !fileInfo.IsDir() {
-					if event.Op == fsnotify.Create {
+					// Prefer Create over Write so a Create|Write event
+					// fires exactly one callback for the same logical
+					// "file appeared" change.
+					if event.Op.Has(fsnotify.Create) {
 						w.lastState[filePath] = fileInfo
 						w.callbacks.OnFileCreation(filePath)
-					}
-					if event.Op == fsnotify.Write {
+					} else if event.Op.Has(fsnotify.Write) {
 						w.lastState[filePath] = fileInfo
 						w.callbacks.OnFileUpdate(filePath)
 					}

--- a/libcalico-go/lib/epstatusfile/status_file_watcher.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher.go
@@ -141,10 +141,6 @@ func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
 			}).Debug("received file events")
 
 			filePath := event.Name
-			// fsnotify Op is a bitmask: a single event can combine ops
-			// (e.g. Create|Write when a file is created and written in
-			// the same syscall, common on Linux for os.Create). Use Has
-			// so combined events are not silently dropped.
 			if event.Op.Has(fsnotify.Remove) {
 				w.callbacks.OnFileDeletion(filePath)
 				delete(w.lastState, filePath)
@@ -153,9 +149,6 @@ func (w *FileWatcher) runFsnotifyWatcher(watcher *fsnotify.Watcher) error {
 				if err != nil {
 					log.WithError(err).Error("Failed to get file info on a fsnotify event.")
 				} else if !fileInfo.IsDir() {
-					// Prefer Create over Write so a Create|Write event
-					// fires exactly one callback for the same logical
-					// "file appeared" change.
 					if event.Op.Has(fsnotify.Create) {
 						w.lastState[filePath] = fileInfo
 						w.callbacks.OnFileCreation(filePath)

--- a/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
@@ -242,6 +242,59 @@ var _ = Describe("Workload endpoint status file watcher test", func() {
 
 	})
 
+	// runFsnotifyWatcher consumes events directly from fsnotify.Watcher.Events,
+	// so a synthetic-injection test can drive the bitmask handling
+	// deterministically without depending on which op combinations the kernel
+	// happens to emit for a given file operation.
+	driveSyntheticEvent := func(filePath string, op fsnotify.Op) {
+		watcher, err := fsnotify.NewWatcher()
+		Expect(err).NotTo(HaveOccurred())
+
+		loopDone := make(chan struct{})
+		go func() {
+			defer close(loopDone)
+			_ = w.runFsnotifyWatcher(watcher)
+		}()
+
+		watcher.Events <- fsnotify.Event{Name: filePath, Op: op}
+
+		// Stop the loop by closing the watcher; w.stopChan is also closed
+		// in the outer defer w.Stop(), but closing the watcher unblocks
+		// the select directly via the Errors channel close.
+		_ = watcher.Close()
+		Eventually(loopDone, "2s").Should(BeClosed())
+	}
+
+	It("should fire OnFileCreation on a combined Create|Write event", func() {
+		filePath := filepath.Join(statusDir, "pod-create-write")
+		Expect(os.WriteFile(filePath, []byte("name: pod1"), 0644)).To(Succeed())
+
+		driveSyntheticEvent(filePath, fsnotify.Create|fsnotify.Write)
+		Expect(r.Events()[filePath]).To(Equal([]string{"create"}))
+	})
+
+	It("should fire OnFileUpdate on a combined Write|Chmod event", func() {
+		filePath := filepath.Join(statusDir, "pod-write-chmod")
+		Expect(os.WriteFile(filePath, []byte("name: pod1"), 0644)).To(Succeed())
+
+		driveSyntheticEvent(filePath, fsnotify.Write|fsnotify.Chmod)
+		Expect(r.Events()[filePath]).To(Equal([]string{"update"}))
+	})
+
+	It("should fire OnFileDeletion on a combined Remove|Rename event", func() {
+		filePath := filepath.Join(statusDir, "pod-remove-rename")
+		driveSyntheticEvent(filePath, fsnotify.Remove|fsnotify.Rename)
+		Expect(r.Events()[filePath]).To(Equal([]string{"delete"}))
+	})
+
+	It("should not fire any callback on a Chmod-only event", func() {
+		filePath := filepath.Join(statusDir, "pod-chmod-only")
+		Expect(os.WriteFile(filePath, []byte("name: pod1"), 0644)).To(Succeed())
+
+		driveSyntheticEvent(filePath, fsnotify.Chmod)
+		Expect(r.Events()[filePath]).To(BeNil())
+	})
+
 	It("should receive events when fsnotify fails", func() {
 		w.Start()
 		defer w.Stop()

--- a/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
+++ b/libcalico-go/lib/epstatusfile/status_file_watcher_test.go
@@ -242,10 +242,6 @@ var _ = Describe("Workload endpoint status file watcher test", func() {
 
 	})
 
-	// runFsnotifyWatcher consumes events directly from fsnotify.Watcher.Events,
-	// so a synthetic-injection test can drive the bitmask handling
-	// deterministically without depending on which op combinations the kernel
-	// happens to emit for a given file operation.
 	driveSyntheticEvent := func(filePath string, op fsnotify.Op) {
 		watcher, err := fsnotify.NewWatcher()
 		Expect(err).NotTo(HaveOccurred())
@@ -258,9 +254,6 @@ var _ = Describe("Workload endpoint status file watcher test", func() {
 
 		watcher.Events <- fsnotify.Event{Name: filePath, Op: op}
 
-		// Stop the loop by closing the watcher; w.stopChan is also closed
-		// in the outer defer w.Stop(), but closing the watcher unblocks
-		// the select directly via the Errors channel close.
 		_ = watcher.Close()
 		Eventually(loopDone, "2s").Should(BeClosed())
 	}


### PR DESCRIPTION
## Summary

`fsnotify.Event.Op` is a bitmask: a single event can carry multiple ops at once. The most common case is `Create|Write`, which Linux delivers when a writer uses `O_CREAT|O_WRONLY|O_TRUNC` (exactly what `os.Create()` does). The current code in `libcalico-go/lib/epstatusfile/status_file_watcher.go` compares with `==`, so combined events silently drop on the floor:

```go
if event.Op == fsnotify.Remove { ... OnFileDeletion ... }
...
if event.Op == fsnotify.Create { ... OnFileCreation ... }
if event.Op == fsnotify.Write  { ... OnFileUpdate ... }
```

Concrete impact:

* `OnFileCreation` does not fire when a producer writes a status file with `os.Create()` (the common case), so `lastState` misses the file entirely.
* A later plain `Write` then fires `OnFileUpdate` without any preceding `OnFileCreation`, leaving consumers in an inconsistent state.
* `OnFileDeletion` can also miss when `Remove` combines with `Rename`.

Switch all three checks to `event.Op.Has(...)`. Prefer `Create` over `Write` (via `else if`) so a combined `Create|Write` fires exactly one callback for the same logical change, matching consumer expectations.

## Tests

Adds synthetic-event unit tests that drive `runFsnotifyWatcher` directly. Driving the loop with a controlled `fsnotify.Watcher` lets the tests assert bitmask handling deterministically without depending on which op combinations the kernel happens to emit for a given file operation. Cases:

* `Create|Write` fires `OnFileCreation` exactly once
* `Write|Chmod` fires `OnFileUpdate` exactly once
* `Remove|Rename` fires `OnFileDeletion` exactly once
* `Chmod` alone fires no callback


**Release note:**
```release-note
Fix epstatusfile FileWatcher so combined fsnotify operations (e.g. Create|Write) reliably trigger the right callback. Previously such events were silently dropped, which could cause OnFileCreation to miss new status files written with os.Create.
```