### PR TITLE
Add Semaphore job for KubeVirt live migration on KIND

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1359,6 +1359,43 @@ blocks:
         always:
           commands:
             - 'test-results publish --name "${SEMAPHORE_JOB_NAME}" ./report/*.xml || true'
+  - name: "KubeVirt live migration (KinD)"
+    run:
+      when: "true"
+    dependencies:
+      - Prerequisites
+      - "Build: calico image"
+      - "Build: node image"
+    task:
+      env_vars:
+        - name: BUILD_CACHE_GROUP
+          value: "calico"
+      agent:
+        machine:
+          type: f1-standard-4
+          os_image: ubuntu2204
+      prologue:
+        commands:
+          - docker system prune -af
+          - .semaphore/load-cached-images
+      jobs:
+        - name: "KubeVirt live migration: deploy simulation mode"
+          commands:
+            # Create KIND cluster with Calico
+            - make kind-up
+            # Download KubeVirt release assets
+            - export KUBEVIRT_RELEASE_URL="https://github.com/tigera/kubevirt/releases/download/mockvirt-v1.8.1"
+            - mkdir -p /tmp/kubevirt-manifests
+            - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/ci-deploy-kind.sh" -o /tmp/kubevirt-manifests/ci-deploy-kind.sh
+            - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/kubevirt-operator.yaml" -o /tmp/kubevirt-manifests/kubevirt-operator.yaml
+            - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/kubevirt-cr.yaml" -o /tmp/kubevirt-manifests/kubevirt-cr.yaml
+            - chmod +x /tmp/kubevirt-manifests/ci-deploy-kind.sh
+            # Deploy KubeVirt simulation mode
+            - MOCKVIRT_KUBECONFIG="$(pwd)/hack/test/kind/kind-kubeconfig.yaml" MOCKVIRT_MANIFESTS_DIR=/tmp/kubevirt-manifests /tmp/kubevirt-manifests/ci-deploy-kind.sh
+      epilogue:
+        on_fail:
+          commands:
+            - .semaphore/collect-kind-diags
   - name: Libraries (lib)
     run:
       when: >-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3650,6 +3650,204 @@ blocks:
         always:
           commands:
             - 'test-results publish --name "${SEMAPHORE_JOB_NAME}" ./report/*.xml || true'
+  - name: "KubeVirt live migration (KinD)"
+    run:
+      when: >-
+        change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml',
+        '/.semaphore/semaphore.yml.d/02-global_job_config.yml',
+        '/.semaphore/semaphore.yml.d/03-promotions.yml',
+        '/.semaphore/semaphore.yml.d/09-blocks.yml',
+        '/.semaphore/semaphore.yml.d/99-after_pipeline.yml',
+        '/.semaphore/semaphore.yml.d/blocks/20-kubevirt-live-migration.yml',
+        '/Makefile',
+        '/api/pkg/apis/projectcalico/v3/*.go',
+        '/api/pkg/defaults/*.go',
+        '/api/pkg/lib/numorstring/*.go',
+        '/app-policy/checker/*.go',
+        '/app-policy/policystore/*.go',
+        '/app-policy/types/*.go',
+        '/cni-plugin/cmd/calico/*.go',
+        '/cni-plugin/cmd/install/*.go',
+        '/cni-plugin/internal/pkg/azure/*.go',
+        '/cni-plugin/internal/pkg/utils/*.go',
+        '/cni-plugin/internal/pkg/utils/cri/*.go',
+        '/cni-plugin/pkg/dataplane/*.go',
+        '/cni-plugin/pkg/dataplane/grpc/*.go',
+        '/cni-plugin/pkg/dataplane/grpc/proto/*.go',
+        '/cni-plugin/pkg/dataplane/linux/*.go',
+        '/cni-plugin/pkg/install/*.go',
+        '/cni-plugin/pkg/ipamplugin/*.go',
+        '/cni-plugin/pkg/k8s/*.go',
+        '/cni-plugin/pkg/plugin/*.go',
+        '/cni-plugin/pkg/types/*.go',
+        '/cni-plugin/pkg/upgrade/*.go',
+        '/cni-plugin/pkg/wait/*.go',
+        '/cni-plugin/tests/*.go',
+        '/confd/*.go',
+        '/confd/etc',
+        '/confd/pkg/backends/*.go',
+        '/confd/pkg/backends/calico/*.go',
+        '/confd/pkg/backends/types/*.go',
+        '/confd/pkg/config/*.go',
+        '/confd/pkg/log/*.go',
+        '/confd/pkg/resource/template/*.go',
+        '/confd/pkg/run/*.go',
+        '/crypto/pkg/tls/*.go',
+        '/e2e/cmd/k8s/*.go',
+        '/e2e/images/rapidclient/*.go',
+        '/felix/**',
+        '/felix/bpf-apache',
+        '/felix/bpf-gpl',
+        '/goldmane/pkg/client/*.go',
+        '/goldmane/pkg/goldmane/*.go',
+        '/goldmane/pkg/internal/flowcache/*.go',
+        '/goldmane/pkg/server/*.go',
+        '/goldmane/pkg/storage/*.go',
+        '/goldmane/pkg/stream/*.go',
+        '/goldmane/pkg/types/*.go',
+        '/goldmane/proto/*.go',
+        '/hack/test/certs/',
+        '/hack/test/kind',
+        '/lib.Makefile',
+        '/lib/std/chanutil/*.go',
+        '/lib/std/time/*.go',
+        '/lib/std/uniquelabels/*.go',
+        '/lib/std/uniquestr/*.go',
+        '/libcalico-go/config/*.go',
+        '/libcalico-go/lib/apiconfig/*.go',
+        '/libcalico-go/lib/apis/crd.projectcalico.org/v1/scheme/*.go',
+        '/libcalico-go/lib/apis/internalapi/*.go',
+        '/libcalico-go/lib/apis/v1/*.go',
+        '/libcalico-go/lib/apis/v1/unversioned/*.go',
+        '/libcalico-go/lib/backend/*.go',
+        '/libcalico-go/lib/backend/api/*.go',
+        '/libcalico-go/lib/backend/encap/*.go',
+        '/libcalico-go/lib/backend/etcdv3/*.go',
+        '/libcalico-go/lib/backend/k8s/*.go',
+        '/libcalico-go/lib/backend/k8s/conversion/*.go',
+        '/libcalico-go/lib/backend/k8s/resources/*.go',
+        '/libcalico-go/lib/backend/model/*.go',
+        '/libcalico-go/lib/backend/syncersv1/bgpsyncer/*.go',
+        '/libcalico-go/lib/backend/syncersv1/dedupebuffer/*.go',
+        '/libcalico-go/lib/backend/syncersv1/felixsyncer/*.go',
+        '/libcalico-go/lib/backend/syncersv1/updateprocessors/*.go',
+        '/libcalico-go/lib/backend/watchersyncer/*.go',
+        '/libcalico-go/lib/clientv3/*.go',
+        '/libcalico-go/lib/consistenthash/*.go',
+        '/libcalico-go/lib/debugserver/*.go',
+        '/libcalico-go/lib/dispatcher/*.go',
+        '/libcalico-go/lib/epstatusfile/*.go',
+        '/libcalico-go/lib/errors/*.go',
+        '/libcalico-go/lib/hash/*.go',
+        '/libcalico-go/lib/health/*.go',
+        '/libcalico-go/lib/ipam/*.go',
+        '/libcalico-go/lib/ipam/vmipam/*.go',
+        '/libcalico-go/lib/kubevirt/*.go',
+        '/libcalico-go/lib/logutils/*.go',
+        '/libcalico-go/lib/metricsserver/*.go',
+        '/libcalico-go/lib/names/*.go',
+        '/libcalico-go/lib/namespace/*.go',
+        '/libcalico-go/lib/net/*.go',
+        '/libcalico-go/lib/netlinkutils/*.go',
+        '/libcalico-go/lib/options/*.go',
+        '/libcalico-go/lib/packedmap/*.go',
+        '/libcalico-go/lib/prometheus/*.go',
+        '/libcalico-go/lib/readlogger/*.go',
+        '/libcalico-go/lib/resources/*.go',
+        '/libcalico-go/lib/scope/*.go',
+        '/libcalico-go/lib/selector/*.go',
+        '/libcalico-go/lib/selector/parser/*.go',
+        '/libcalico-go/lib/selector/tokenizer/*.go',
+        '/libcalico-go/lib/set/*.go',
+        '/libcalico-go/lib/testutils/stacktrace/*.go',
+        '/libcalico-go/lib/validator/v1/*.go',
+        '/libcalico-go/lib/validator/v3/*.go',
+        '/libcalico-go/lib/watch/*.go',
+        '/libcalico-go/lib/winutils/*.go',
+        '/metadata.mk',
+        '/node/cmd/calico-ipam/*.go',
+        '/node/cmd/calico/*.go',
+        '/node/cmd/mountns/*.go',
+        '/node/pkg/cni/*.go',
+        '/node/pkg/lifecycle/utils/*.go',
+        '/node/windows-packaging/tests/*.go',
+        '/pkg/buildinfo/*.go',
+        '/pod2daemon/binder/*.go',
+        '/typha/pkg/discovery/*.go',
+        '/typha/pkg/syncclient/*.go',
+        '/typha/pkg/syncclientutils/*.go',
+        '/typha/pkg/syncproto/*.go',
+        '/typha/pkg/tlsutils/*.go',
+        'cni-plugin/**/*Dockerfile*',
+        'cni-plugin/Makefile',
+        'cni-plugin/deps.txt',
+        'confd/**/*Dockerfile*',
+        'confd/Makefile',
+        'confd/deps.txt',
+        'e2e/**/*Dockerfile*',
+        'e2e/Makefile',
+        'e2e/deps.txt',
+        'libcalico-go/**/*Dockerfile*',
+        'libcalico-go/Makefile',
+        'libcalico-go/deps.txt',
+        'node/**/*Dockerfile*',
+        'node/Makefile',
+        'node/deps.txt'],
+        {pipeline_file: 'ignore', exclude: ['/**/*.md',
+        '/**/.gitignore',
+        '/**/AUTHORS*',
+        '/**/CONTRIBUTING*',
+        '/**/DEVELOPER_GUIDE*',
+        '/**/LICENSE*',
+        '/**/README*',
+        '/**/SECURITY.md',
+        '/api/**/*_test.go',
+        '/app-policy/**/*_test.go',
+        '/cni-plugin/**/*_test.go',
+        '/confd/**/*_test.go',
+        '/crypto/**/*_test.go',
+        '/e2e/**/*_test.go',
+        '/goldmane/**/*_test.go',
+        '/lib/**/*_test.go',
+        '/libcalico-go/**/*_test.go',
+        '/node/**/*_test.go',
+        '/pkg/**/*_test.go',
+        '/pod2daemon/**/*_test.go',
+        '/typha/**/*_test.go']})
+    dependencies:
+      - Prerequisites
+      - "Build: calico image"
+      - "Build: node image"
+    task:
+      env_vars:
+        - name: BUILD_CACHE_GROUP
+          value: "calico"
+      agent:
+        machine:
+          type: f1-standard-4
+          os_image: ubuntu2204
+      prologue:
+        commands:
+          - docker system prune -af
+          - .semaphore/load-cached-images
+      jobs:
+        - name: "KubeVirt live migration: deploy simulation mode"
+          commands:
+            # Create KIND cluster with Calico
+            - make kind-up
+            # Download KubeVirt release assets
+            - export KUBEVIRT_RELEASE_URL="https://github.com/tigera/kubevirt/releases/download/mockvirt-v1.8.1"
+            - mkdir -p /tmp/kubevirt-manifests
+            - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/ci-deploy-kind.sh" -o /tmp/kubevirt-manifests/ci-deploy-kind.sh
+            - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/kubevirt-operator.yaml" -o /tmp/kubevirt-manifests/kubevirt-operator.yaml
+            - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/kubevirt-cr.yaml" -o /tmp/kubevirt-manifests/kubevirt-cr.yaml
+            - chmod +x /tmp/kubevirt-manifests/ci-deploy-kind.sh
+            # Deploy KubeVirt simulation mode
+            - MOCKVIRT_KUBECONFIG="$(pwd)/hack/test/kind/kind-kubeconfig.yaml" MOCKVIRT_MANIFESTS_DIR=/tmp/kubevirt-manifests /tmp/kubevirt-manifests/ci-deploy-kind.sh
+      epilogue:
+        on_fail:
+          commands:
+            - .semaphore/collect-kind-diags
   - name: Libraries (lib)
     run:
       when: >-

--- a/.semaphore/semaphore.yml.d/blocks/20-kubevirt-live-migration.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-kubevirt-live-migration.yml
@@ -1,0 +1,37 @@
+- name: "KubeVirt live migration (KinD)"
+  run:
+    when: "${CHANGE_IN(felix,cni-plugin,confd,node,e2e,libcalico-go)}"
+  dependencies:
+    - Prerequisites
+    - "Build: calico image"
+    - "Build: node image"
+  task:
+    env_vars:
+      - name: BUILD_CACHE_GROUP
+        value: "calico"
+    agent:
+      machine:
+        type: f1-standard-4
+        os_image: ubuntu2204
+    prologue:
+      commands:
+        - docker system prune -af
+        - .semaphore/load-cached-images
+    jobs:
+      - name: "KubeVirt live migration: deploy simulation mode"
+        commands:
+          # Create KIND cluster with Calico
+          - make kind-up
+          # Download KubeVirt release assets
+          - export KUBEVIRT_RELEASE_URL="https://github.com/tigera/kubevirt/releases/download/mockvirt-v1.8.1"
+          - mkdir -p /tmp/kubevirt-manifests
+          - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/ci-deploy-kind.sh" -o /tmp/kubevirt-manifests/ci-deploy-kind.sh
+          - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/kubevirt-operator.yaml" -o /tmp/kubevirt-manifests/kubevirt-operator.yaml
+          - curl --retry 9 --retry-all-errors -fsSL "${KUBEVIRT_RELEASE_URL}/kubevirt-cr.yaml" -o /tmp/kubevirt-manifests/kubevirt-cr.yaml
+          - chmod +x /tmp/kubevirt-manifests/ci-deploy-kind.sh
+          # Deploy KubeVirt simulation mode
+          - MOCKVIRT_KUBECONFIG="$(pwd)/hack/test/kind/kind-kubeconfig.yaml" MOCKVIRT_MANIFESTS_DIR=/tmp/kubevirt-manifests /tmp/kubevirt-manifests/ci-deploy-kind.sh
+    epilogue:
+      on_fail:
+        commands:
+          - .semaphore/collect-kind-diags


### PR DESCRIPTION
## Summary
- Add a new Semaphore block that deploys KubeVirt simulation mode onto a KIND cluster for live-migration network testing
- Downloads pre-built manifests and deploy script from the `tigera/kubevirt` GitHub release (`mockvirt-v1.8.1`)
- Runs `ci-deploy-kind.sh` to stand up the KubeVirt operator with simulation mode enabled
- Triggered on branch `song-kubevirt-ci` for initial testing