### PR TITLE
Wire up built-in tier deletion protection

### DIFF
--- a/api/admission/protect-builtin-tiers.yaml
+++ b/api/admission/protect-builtin-tiers.yaml
@@ -15,8 +15,8 @@ spec:
         resources: ["tiers"]
         operations: ["DELETE"]
   validations:
-    - expression: "!(object.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
-      messageExpression: "'The built-in tier ' + object.metadata.name + ' cannot be deleted'"
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -32,3 +32,6 @@ exclude:
 
     - label: RequiresXtables
       reason: "requires iptables or nftables dataplane, but this cluster uses BPF"
+
+    - label: RequiresCalicoAPIServer
+      reason: "this job runs with USE_API_SERVER=false (v3 CRD mode, no aggregated Calico API server)"

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -13366,6 +13366,37 @@ spec:
           - stagednetworkpolicies
           - stagedglobalnetworkpolicies
 ---
+# Source: calico/templates/admission-policies.yaml
+---
+# ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
+# (default, kube-admin, kube-baseline). These tiers are required for correct
+# operation and should never be deleted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        resources: ["tiers"]
+        operations: ["DELETE"]
+  validations:
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
+---
+# Source: calico/templates/admission-policies.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  policyName: protect-builtin-tiers.projectcalico.org
+  validationActions:
+    - Deny
+---
 # Source: calico/templates/calico-webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
The ValidatingAdmissionPolicy added in #12026 to block deletion of the built-in tiers (`default`, `kube-admin`, `kube-baseline`) was placed in `api/config/admission/` and never bundled into any chart or operator manifest. Nothing was applying it, so default tier deletion was succeeding in v3 CRD mode (caught by an e2e failure in the gcp-bpf job - see https://tigera.semaphoreci.com/workflows/ed1045c6-79db-430b-a653-2a0e6a76252c).

Move the policy into `api/admission/`, which the calico Helm chart already picks up via the `charts/calico/admission` symlink, and regenerate `manifests/calico-v3-crds.yaml`. The operator inherits this naturally since it consumes the v3 CRD bundle from here.

Also fix the CEL expressions to read `oldObject.metadata.name` instead of `object.metadata.name` - `object` is null on DELETE requests, so the original expressions wouldn't have matched anything even if the policy had been deployed.

Separately, skip `RequiresCalicoAPIServer` tests in the gcp-bpf e2e config since that job runs with `USE_API_SERVER=false`. Six other failures in the same run were tier RBAC tests that have no enforcement path in v3 CRD mode without the aggregated API server.

```release-note
Prevent deletion of built-in tiers in CRD mode. 
```