### PR TITLE
felix/bpf-gpl: parameterise ringbuf drop helpers for reuse

### DIFF
--- a/felix/bpf-gpl/ringbuf.h
+++ b/felix/bpf-gpl/ringbuf.h
@@ -55,13 +55,12 @@ static CALI_BPF_INLINE void ringbuf_bump_drops_at(struct rb_drops_val *val)
 	}
 }
 
-// ringbuf_flush_drops_to emits the accumulated drop count for `val` as a
-// TYPE_LOST_EVENTS event through the ring buffer pointed to by `rb`, at
-// most once every CALI_RB_FLUSH_INTERVAL_NS.  Shared between every ring
-// buffer in this tree (cali_rb_evnt today, cali_rb_l7 from the L7 obs
-// programs) so the rate-limiting and atomic-restore semantics live in
-// one place.  Per-map wrappers handle the typed lookup that a generic
-// helper can't share (the lookup function name is macro-expanded).
+// ringbuf_flush_drops_to emits the accumulated drop count for `val` as an
+// EVENT_LOST_EVENTS event through the ring buffer pointed to by `rb`, at
+// most once every CALI_RB_FLUSH_INTERVAL_NS. Shared between ring buffers
+// so the rate-limiting and atomic-restore semantics live in one place.
+// Per-map wrappers handle the typed lookup that a generic helper can't
+// share (the lookup function name is macro-expanded).
 static CALI_BPF_INLINE void ringbuf_flush_drops_to(void *rb, struct rb_drops_val *val)
 {
 	if (!val) {

--- a/felix/bpf-gpl/ringbuf.h
+++ b/felix/bpf-gpl/ringbuf.h
@@ -41,12 +41,29 @@ struct rb_drops_val {
 
 CALI_MAP_V1(cali_rb_drops, BPF_MAP_TYPE_ARRAY, __u32, struct rb_drops_val, 1, 0)
 
-// ringbuf_flush_drops emits accumulated drop count as a TYPE_LOST_EVENTS
-// event through the ring buffer, at most once every CALI_RB_FLUSH_INTERVAL_NS.
-static CALI_BPF_INLINE void ringbuf_flush_drops(void)
+// ringbuf_bump_drops_at increments the drop counter for the given drops-map
+// value pointer.  Centralised so any future change to the synchronisation
+// primitive (e.g. swapping __sync builtins for explicit-ordering atomics)
+// touches one site for every ring buffer that consumes this header.
+// NULL-tolerant: BPF map lookups can in principle return NULL even for
+// single-entry array maps, and the caller would otherwise have to repeat
+// the guard.
+static CALI_BPF_INLINE void ringbuf_bump_drops_at(struct rb_drops_val *val)
 {
-	__u32 key = 0;
-	struct rb_drops_val *val = cali_rb_drops_lookup_elem(&key);
+	if (val) {
+		__sync_fetch_and_add(&val->count, 1);
+	}
+}
+
+// ringbuf_flush_drops_to emits the accumulated drop count for `val` as a
+// TYPE_LOST_EVENTS event through the ring buffer pointed to by `rb`, at
+// most once every CALI_RB_FLUSH_INTERVAL_NS.  Shared between every ring
+// buffer in this tree (cali_rb_evnt today, cali_rb_l7 from the L7 obs
+// programs) so the rate-limiting and atomic-restore semantics live in
+// one place.  Per-map wrappers handle the typed lookup that a generic
+// helper can't share (the lookup function name is macro-expanded).
+static CALI_BPF_INLINE void ringbuf_flush_drops_to(void *rb, struct rb_drops_val *val)
+{
 	if (!val) {
 		return;
 	}
@@ -72,7 +89,7 @@ static CALI_BPF_INLINE void ringbuf_flush_drops(void)
 		},
 		.count = dropped,
 	};
-	if (bpf_ringbuf_output(&cali_rb_evnt, &evt, sizeof(evt), 0) != 0) {
+	if (bpf_ringbuf_output(rb, &evt, sizeof(evt), 0) != 0) {
 		/* Ring still full — restore the counter so drops are not lost.
 		 * Concurrent increments between unlock and here are preserved:
 		 * the restore adds back the original amount on top of any new
@@ -87,6 +104,13 @@ static CALI_BPF_INLINE void ringbuf_flush_drops(void)
 	val->last_flush_ts = now;
 }
 
+// Per-map wrapper for the shared event ring buffer.
+static CALI_BPF_INLINE void ringbuf_flush_drops(void)
+{
+	__u32 key = 0;
+	ringbuf_flush_drops_to(&cali_rb_evnt, cali_rb_drops_lookup_elem(&key));
+}
+
 // Submit helper — drop-in replacement for perf_commit_event().
 // Unlike perf_commit_event, does not require a program context pointer.
 // On failure (ring buffer full), increments the shared drop counter.
@@ -96,10 +120,7 @@ static CALI_BPF_INLINE int ringbuf_submit_event(void *data, __u64 size)
 	int err = bpf_ringbuf_output(&cali_rb_evnt, data, size, 0);
 	if (err != 0) {
 		__u32 key = 0;
-		struct rb_drops_val *val = cali_rb_drops_lookup_elem(&key);
-		if (val) {
-			__sync_fetch_and_add(&val->count, 1);
-		}
+		ringbuf_bump_drops_at(cali_rb_drops_lookup_elem(&key));
 	} else {
 		ringbuf_flush_drops();
 	}

--- a/felix/bpf/events/events.go
+++ b/felix/bpf/events/events.go
@@ -139,7 +139,7 @@ func (r *ringBufferEventsReader) Next() (Event, error) {
 		return Event{}, err
 	}
 
-	// The BPF side emits TYPE_LOST_EVENTS with a u64 count payload when
+	// The BPF side emits EVENT_LOST_EVENTS with a u64 count payload when
 	// accumulated drops are flushed. Convert to ErrLostEvents so callers
 	// (bpfEventPoller) handle it the same way as the old perf lost records.
 	if evt.typ == TypeLostEvents {

--- a/felix/bpf/ringbuf/ringbuf.go
+++ b/felix/bpf/ringbuf/ringbuf.go
@@ -44,7 +44,7 @@ const (
 	MapName = "cali_rb_evnt"
 
 	// DropsMapName is the name of the shared array that tracks dropped events.
-	// The BPF side emits drops as TYPE_LOST_EVENTS events through the ring buffer.
+	// The BPF side emits drops as EVENT_LOST_EVENTS events through the ring buffer.
 	DropsMapName = "cali_rb_drops"
 )
 

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -697,7 +697,7 @@ const rbSize = 1024 * 1024
 //
 // Prefer this helper over calling ringbuf.New directly — the ring buffer map
 // is pinned and shared across tests, so a naked reader can pick up stray
-// records (TYPE_LOST_EVENTS markers, kprobe stats, etc.) and mis-parse them.
+// records (EVENT_LOST_EVENTS markers, kprobe stats, etc.) and mis-parse them.
 func newTestRingBuf(t *testing.T) *ringbuf.RingBuffer {
 	rb, err := ringbuf.New(ringBufMap, rbSize)
 	Expect(err).NotTo(HaveOccurred())

--- a/felix/bpf/ut/ringbuf_events_test.go
+++ b/felix/bpf/ut/ringbuf_events_test.go
@@ -119,7 +119,7 @@ func TestRingBufReaderRecovery(t *testing.T) {
 // TestRingBufFillup verifies that the ring buffer correctly handles being filled
 // to capacity. When full, bpf_ringbuf_output returns an error and the BPF program
 // returns TC_ACT_SHOT. After draining, a subsequent successful event triggers
-// ringbuf_flush_drops, emitting a TYPE_LOST_EVENTS event with the accumulated
+// ringbuf_flush_drops, emitting an EVENT_LOST_EVENTS event with the accumulated
 // drop count.
 func TestRingBufFillup(t *testing.T) {
 	if testing.Short() {
@@ -178,7 +178,7 @@ func TestRingBufFillup(t *testing.T) {
 	Expect(drained).To(Equal(eventsWritten))
 
 	// Send one more event after draining. This succeeds and triggers
-	// ringbuf_flush_drops(), which emits a TYPE_LOST_EVENTS event with the
+	// ringbuf_flush_drops(), which emits an EVENT_LOST_EVENTS event with the
 	// drop count (exactly 1 from the failed submit above).
 	// The ring order is: data event first, then lost event.
 	runBpfUnitTest(t, "ringbuf_events.c",
@@ -195,7 +195,7 @@ func TestRingBufFillup(t *testing.T) {
 	dataHdr := eventHdrFromBytes(dataEvent.Data()[0:8])
 	Expect(dataHdr.typ).To(Equal(uint32(0xdead)))
 
-	// Second: the TYPE_LOST_EVENTS event with exactly 1 drop.
+	// Second: the EVENT_LOST_EVENTS event with exactly 1 drop.
 	lostEvent := ringBufNextWithTimeout(t, rb)
 	lostData := lostEvent.Data()
 	lostHdr := eventHdrFromBytes(lostData[0:8])

--- a/third_party/deps.txt
+++ b/third_party/deps.txt
@@ -1,4 +1,4 @@
 !!! GENERATED FILE, DO NOT EDIT !!!
 Run 'make gen-deps-files' to regenerate.
 
-go 1.26.2
+go 1.26.3


### PR DESCRIPTION
## Description

Refactor `felix/bpf-gpl/ringbuf.h` so the drops-counter bump and flush logic is parameterised on the ring buffer and drops-map value, instead of hard-coded to `cali_rb_evnt`. This lets additional ring buffers (e.g Calico Enterprise has its own ring buffers for L7 observability) reuse the same rate-limiting and atomic-restore semantics without duplicating the implementation.

### Changes

- New `ringbuf_bump_drops_at(val)` — NULL-tolerant atomic increment. Centralises the `__sync_fetch_and_add` site so a future change to the synchronisation primitive (e.g. swapping `__sync` builtins for explicit-ordering atomics) touches one place.
- New `ringbuf_flush_drops_to(rb, val)` — generic version of the flush body. Takes the ring buffer pointer and drops-map value pointer as parameters.
- Existing `ringbuf_flush_drops()` becomes a thin per-map wrapper around `ringbuf_flush_drops_to(&cali_rb_evnt, …)`.
- `ringbuf_submit_event()` routes its drop accounting through the new `ringbuf_bump_drops_at()` helper.

Behaviour is unchanged for `cali_rb_evnt`.

### Motivation

This is a pure refactor ported back from the enterprise tree to keep the OSS and EE versions of `ringbuf.h` aligned and avoid future merge conflicts.

### Testing

- `make -C felix build-bpf` — all BPF objects compile cleanly.

**Release note:**
\`\`\`release-note
None
\`\`\`