### PR TITLE
Render MutatingAdmissionPolicy as v1 when the cluster serves it

### DIFF
--- a/charts/calico/templates/admission-policies.yaml
+++ b/charts/calico/templates/admission-policies.yaml
@@ -1,6 +1,17 @@
 {{- if .Values.useV3CRDs }}
+{{- /*
+  MutatingAdmissionPolicy was promoted to admissionregistration.k8s.io/v1 in
+  Kubernetes 1.36 and v1beta1 is targeted for removal in 1.37. Prefer v1 when
+  the cluster serves it; otherwise emit v1beta1 (the source-of-truth version
+  in this chart). If neither is served the apply will fail naturally, which
+  matches what the operator would do.
+*/ -}}
+{{- $apiVersion := "admissionregistration.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1" -}}
+{{- end }}
 {{ range $path, $_ := .Files.Glob "admission/*" }}
 ---
-{{ $.Files.Get $path }}
+{{ $.Files.Get $path | replace "admissionregistration.k8s.io/v1beta1" $apiVersion }}
 {{- end }}
 {{- end }}

--- a/charts/calico/templates/admission-policies.yaml
+++ b/charts/calico/templates/admission-policies.yaml
@@ -1,11 +1,4 @@
 {{- if .Values.useV3CRDs }}
-{{- /*
-  MutatingAdmissionPolicy was promoted to admissionregistration.k8s.io/v1 in
-  Kubernetes 1.36 and v1beta1 is targeted for removal in 1.37. Prefer v1 when
-  the cluster serves it; otherwise emit v1beta1 (the source-of-truth version
-  in this chart). If neither is served the apply will fail naturally, which
-  matches what the operator would do.
-*/ -}}
 {{- $apiVersion := "admissionregistration.k8s.io/v1beta1" -}}
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/MutatingAdmissionPolicy" -}}
 {{- $apiVersion = "admissionregistration.k8s.io/v1" -}}

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -13224,7 +13224,7 @@ spec:
 ---
 # Source: calico/templates/admission-policies.yaml
 # This MutatingAdmissionPolicy defaults the types/policyTypes field on Calico policy resources.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "policytypes.policy.projectcalico.org"
@@ -13286,7 +13286,7 @@ spec:
 # Source: calico/templates/admission-policies.yaml
 # This MutatingAdmissionPolicy defaults the spec.tier field to "default" if not specified,
 # and sets the projectcalico.org/tier label to match.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "tierlabel.policy.projectcalico.org"
@@ -13329,7 +13329,7 @@ spec:
 ---
 # Source: calico/templates/admission-policies.yaml
 # This MutatingAdmissionPolicyBinding binds the policy types defaulting mutation to the relevant resources.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: set-policytypes-binding
@@ -13349,7 +13349,7 @@ spec:
 ---
 # Source: calico/templates/admission-policies.yaml
 # This MutatingAdmissionPolicyBinding binds the tier label mutation to the relevant resources.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: set-tier-label-binding

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -136,6 +136,7 @@ for FILE in $VALUES_FILES; do
 	${HELM} -n kube-system template \
 		../charts/calico \
 		--set version=$CALICO_VERSION \
+		--api-versions admissionregistration.k8s.io/v1/MutatingAdmissionPolicy \
 		-f ../charts/values/$FILE > $FILE
 done
 


### PR DESCRIPTION
K8s 1.36 promoted `MutatingAdmissionPolicy` to `admissionregistration.k8s.io/v1` and v1beta1 is scheduled for removal in 1.37, so installs against clusters that only serve v1 fail. This uses Helm's `.Capabilities.APIVersions.Has` to detect the served version and rewrite the apiVersion at template-render time. If neither is served we fall back to v1beta1 and the apply fails naturally, same as today.

The companion operator-side fix is https://github.com/tigera/operator/pull/4837.

Verified that `helm template` without `--api-versions` still produces v1beta1 (so the generated `manifests/calico-v3-crds.yaml` is unchanged), and that passing `--api-versions admissionregistration.k8s.io/v1/MutatingAdmissionPolicy` flips all four resources to v1.

```release-note
HELM: Render MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding as admissionregistration.k8s.io/v1 when the cluster serves it (Kubernetes 1.36+), falling back to v1beta1 otherwise.
```