### PR TITLE
Fix IPAM GC stuck in update-conflict loop on stale sequence number

### DIFF
--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -575,6 +575,7 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 			// it has been reallocated. Update the allocation in place and mark it as valid.
 			if existing.sequenceNumber != alloc.sequenceNumber {
 				existing.sequenceNumber = alloc.sequenceNumber
+				existing.attrs = alloc.attrs
 				existing.markValid()
 			}
 			continue

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -570,7 +570,22 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 		currentAllocations[alloc.id()] = true
 
 		// Check if we already know about this allocation.
-		if _, ok := c.allocationsByBlock[blockCIDR][alloc.id()]; ok {
+		if existing, ok := c.allocationsByBlock[blockCIDR][alloc.id()]; ok {
+			// We already track this (handle, IP). Refresh the sequence number
+			// from the latest block, preserving leak-tracking state.
+			//
+			// The per-ordinal sequence number is bumped by IPAM every time the
+			// address is (re)allocated. A coalesced block update can carry a new
+			// sequence number for an allocation whose (handle, IP) identity is
+			// unchanged. If we keep the stale value, every attempt to release
+			// this IP fails with a sequence-number conflict (ErrorBadSequenceNumber,
+			// surfaced as "update conflict"), which is not a retryable datastore
+			// conflict and never resolves on its own. The GC then spins forever
+			// re-attempting a release it can never complete, and only a restart
+			// (which rebuilds this cache from scratch) clears it. Refreshing in
+			// place keeps our cached view accurate so the release uses the
+			// current sequence number and succeeds.
+			existing.sequenceNumber = alloc.sequenceNumber
 			continue
 		}
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -571,21 +571,12 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 
 		// Check if we already know about this allocation.
 		if existing, ok := c.allocationsByBlock[blockCIDR][alloc.id()]; ok {
-			// We already track this (handle, IP). Refresh the sequence number
-			// from the latest block, preserving leak-tracking state.
-			//
-			// The per-ordinal sequence number is bumped by IPAM every time the
-			// address is (re)allocated. A coalesced block update can carry a new
-			// sequence number for an allocation whose (handle, IP) identity is
-			// unchanged. If we keep the stale value, every attempt to release
-			// this IP fails with a sequence-number conflict (ErrorBadSequenceNumber,
-			// surfaced as "update conflict"), which is not a retryable datastore
-			// conflict and never resolves on its own. The GC then spins forever
-			// re-attempting a release it can never complete, and only a restart
-			// (which rebuilds this cache from scratch) clears it. Refreshing in
-			// place keeps our cached view accurate so the release uses the
-			// current sequence number and succeeds.
-			existing.sequenceNumber = alloc.sequenceNumber
+			// If the sequence number has changed for an existing allocation, it means
+			// it has been reallocated. Update the allocation in place and mark it as valid.
+			if existing.sequenceNumber != alloc.sequenceNumber {
+				existing.sequenceNumber = alloc.sequenceNumber
+				existing.markValid()
+			}
 			continue
 		}
 

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -723,18 +723,13 @@ var _ = Describe("IPAM controller UTs", func() {
 	})
 
 	It("should refresh the sequence number of an already-tracked allocation on block update", func() {
-		// Regression test: a coalesced block update that carries a new sequence
-		// number for an allocation whose (handle, IP) identity is unchanged must
-		// refresh the cached sequence number. If it doesn't, the cached value
-		// goes stale and every attempt to release the IP fails with a
-		// sequence-number conflict (ErrorBadSequenceNumber, surfaced as "update
-		// conflict"), which is not a retryable datastore conflict - so the GC
-		// spins forever and only a restart clears it.
+		// Regression test: if a reallocation bumps an allocation's sequence number
+		// but we keep the stale one, every GC release of that IP fails with "update
+		// conflict" forever (until restart). See onBlockUpdated.
 		c.Start(stopChan)
 
-		// A /30 block affine to "cnode" with one address allocated to a handle.
-		// The block has been written 10 times, and the address was allocated at
-		// that sequence number.
+		// A /30 block affine to "cnode" with one address allocated to a handle,
+		// at the block's current sequence number (10).
 		cidr := net.MustParseCIDR("10.0.0.0/30")
 		aff := "host:cnode"
 		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
@@ -774,15 +769,22 @@ var _ = Describe("IPAM controller UTs", func() {
 			return 0
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(uint64(10)))
 
-		// Simulate the address being released and re-allocated to the same
-		// handle in between syncs, such that the syncer only delivers the net
-		// result: the same (handle, IP) is still present, but the block has been
-		// written again and the address now carries a newer sequence number.
+		// Mark it a leak candidate - state tied to the current incarnation that
+		// must not survive a reallocation.
+		func() {
+			done := c.pause()
+			defer done()
+			c.allocationsByBlock[blockCIDR][id].markLeak(gracePeriod)
+			Expect(c.allocationsByBlock[blockCIDR][id].isCandidateLeak()).To(BeTrue())
+		}()
+
+		// Reallocate: same (handle, IP), but the block is rewritten with a newer
+		// sequence number.
 		b.SequenceNumber = 11
 		b.SetSequenceNumberForOrdinal(0)
 		c.onUpdate(update)
 
-		// The cached allocation's sequence number must track the latest block.
+		// The cache must now track the latest sequence number.
 		Eventually(func() uint64 {
 			done := c.pause()
 			defer done()
@@ -792,13 +794,23 @@ var _ = Describe("IPAM controller UTs", func() {
 			return 0
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(uint64(11)))
 
-		// And the release options derived from it must carry that sequence
-		// number, so a release uses the current value and won't conflict.
-		done := c.pause()
-		defer done()
-		opts := c.allocationsByBlock[blockCIDR][id].ReleaseOptions()
-		Expect(opts.SequenceNumber).NotTo(BeNil())
-		Expect(*opts.SequenceNumber).To(Equal(uint64(11)))
+		func() {
+			done := c.pause()
+			defer done()
+
+			// Reallocation clears the stale leak state...
+			a := c.allocationsByBlock[blockCIDR][id]
+			Expect(a.isCandidateLeak()).To(BeFalse())
+			Expect(a.isConfirmedLeak()).To(BeFalse())
+
+			// ...and release uses the current sequence number, so it won't conflict.
+			opts := a.ReleaseOptions()
+			Expect(opts.SequenceNumber).NotTo(BeNil())
+			Expect(*opts.SequenceNumber).To(Equal(uint64(11)))
+		}()
+
+		// assertConsistentState pauses internally; don't call it while paused.
+		assertConsistentState(c)
 	})
 
 	It("should maintain pool and block mappings", func() {

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -722,6 +722,85 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 	})
 
+	It("should refresh the sequence number of an already-tracked allocation on block update", func() {
+		// Regression test: a coalesced block update that carries a new sequence
+		// number for an allocation whose (handle, IP) identity is unchanged must
+		// refresh the cached sequence number. If it doesn't, the cached value
+		// goes stale and every attempt to release the IP fails with a
+		// sequence-number conflict (ErrorBadSequenceNumber, surfaced as "update
+		// conflict"), which is not a retryable datastore conflict - so the GC
+		// spins forever and only a restart clears it.
+		c.Start(stopChan)
+
+		// A /30 block affine to "cnode" with one address allocated to a handle.
+		// The block has been written 10 times, and the address was allocated at
+		// that sequence number.
+		cidr := net.MustParseCIDR("10.0.0.0/30")
+		aff := "host:cnode"
+		key := model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}
+		idx := 0
+		handle := "test-handle"
+		b := model.AllocationBlock{
+			CIDR:           cidr,
+			Affinity:       &aff,
+			Allocations:    []*int{&idx, nil, nil, nil},
+			Unallocated:    []int{1, 2, 3},
+			SequenceNumber: 10,
+			Attributes: []model.AllocationAttribute{
+				{
+					HandleID: &handle,
+					ActiveOwnerAttrs: map[string]string{
+						ipam.AttributeNode:      "cnode",
+						ipam.AttributePod:       "test-pod",
+						ipam.AttributeNamespace: "test-namespace",
+					},
+				},
+			},
+		}
+		b.SetSequenceNumberForOrdinal(0)
+		kvp := model.KVPair{Key: key, Value: &b}
+		blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+		id := fmt.Sprintf("%s/%s", handle, "10.0.0.0")
+		update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(update)
+
+		// The allocation is tracked with the original sequence number.
+		Eventually(func() uint64 {
+			done := c.pause()
+			defer done()
+			if a := c.allocationsByBlock[blockCIDR][id]; a != nil {
+				return a.sequenceNumber
+			}
+			return 0
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(uint64(10)))
+
+		// Simulate the address being released and re-allocated to the same
+		// handle in between syncs, such that the syncer only delivers the net
+		// result: the same (handle, IP) is still present, but the block has been
+		// written again and the address now carries a newer sequence number.
+		b.SequenceNumber = 11
+		b.SetSequenceNumberForOrdinal(0)
+		c.onUpdate(update)
+
+		// The cached allocation's sequence number must track the latest block.
+		Eventually(func() uint64 {
+			done := c.pause()
+			defer done()
+			if a := c.allocationsByBlock[blockCIDR][id]; a != nil {
+				return a.sequenceNumber
+			}
+			return 0
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(uint64(11)))
+
+		// And the release options derived from it must carry that sequence
+		// number, so a release uses the current value and won't conflict.
+		done := c.pause()
+		defer done()
+		opts := c.allocationsByBlock[blockCIDR][id].ReleaseOptions()
+		Expect(opts.SequenceNumber).NotTo(BeNil())
+		Expect(*opts.SequenceNumber).To(Equal(uint64(11)))
+	})
+
 	It("should maintain pool and block mappings", func() {
 		// Start the controller.
 		c.Start(stopChan)


### PR DESCRIPTION
Fixes #12838.

  The IPAM garbage collector in calico-kube-controllers can get permanently stuck trying to release a leaked IP, failing every time with `update conflict` and never making progress until the deployment is restarted (after which it's fine again
  for weeks/months).

  The `update conflict` isn't a datastore/resourceVersion CAS conflict — it's the sequence-number check in `allocationBlock.release()`, which returns `ErrorResourceUpdateConflict{Err: ErrorBadSequenceNumber{...}}` when the sequence number it's
  handed doesn't match the block. That error skips the retry loop in `releaseIPsFromBlock`, so re-reading the block doesn't help — the controller keeps submitting the same stale sequence number from its cache.

  The stale value comes from `onBlockUpdated()`. Allocations are tracked by `handle/IP` (the sequence number isn't part of the key), and when a block update arrives for an allocation we already know about, we `continue` without refreshing the
  cached sequence number. The per-ordinal sequence number is bumped every time the address is re-allocated, so a coalesced block update where the same `(handle, IP)` is still present but the sequence number has moved (IP released and
  re-allocated between syncs, common under StatefulSet / IP-reuse churn) leaves the cached value stale for good. From then on every GC release of that IP fails the sequence-number check, which is exactly the "wedged until restart" behaviour.

  This refreshes the cached sequence number in place on each block update, preserving the leak-tracking state, so releases use the current value and succeed.

  **Testing:** added a regression unit test in `ipam_test.go` that drives a coalesced sequence-number change through `onBlockUpdated` and asserts the cached allocation is refreshed. It passes with the fix and fails without it (times out waiting
  for the cached sequence number to update). Full `kube-controllers` node controller UT suite passes.

  **Release note:**

  ```release-note
  Fix a bug where the IPAM garbage collector in calico-kube-controllers could get stuck in a loop failing to release a leaked IP with an "update conflict" error until the controller was restarted.
```