### PR TITLE
api: make FelixConfiguration.iptablesBackend case-insensitive

### DIFF
--- a/api/config/crd/projectcalico.org_felixconfigurations.yaml
+++ b/api/config/crd/projectcalico.org_felixconfigurations.yaml
@@ -824,11 +824,7 @@ spec:
 
                     Warning: changing this on a running system can leave "orphaned" rules in the "other" backend. These
                     should be cleaned up to avoid confusing interactions.
-                  enum:
-                    - Legacy
-                    - NFT
-                    - Auto
-                  pattern: ^(?i)(Auto|Legacy|NFT)?$
+                  pattern: ^(?i)(Auto|Legacy|NFT)$
                   type: string
                 iptablesFilterAllowAction:
                   description: |-

--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -50,7 +50,6 @@ const (
 	KindFelixConfigurationList = "FelixConfigurationList"
 )
 
-// +kubebuilder:validation:Enum=Legacy;NFT;Auto
 type IptablesBackend string
 
 const (
@@ -266,7 +265,7 @@ type FelixConfigurationSpec struct {
 	// Warning: changing this on a running system can leave "orphaned" rules in the "other" backend. These
 	// should be cleaned up to avoid confusing interactions.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern=`^(?i)(Auto|Legacy|NFT)?$`
+	// +kubebuilder:validation:Pattern=`^(?i)(Auto|Legacy|NFT)$`
 	IptablesBackend *IptablesBackend `json:"iptablesBackend,omitempty"`
 
 	// XDPRefreshInterval is the period at which Felix re-checks all XDP state to ensure that no

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -825,11 +825,7 @@ spec:
 
                     Warning: changing this on a running system can leave "orphaned" rules in the "other" backend. These
                     should be cleaned up to avoid confusing interactions.
-                  enum:
-                    - Legacy
-                    - NFT
-                    - Auto
-                  pattern: ^(?i)(Auto|Legacy|NFT)?$
+                  pattern: ^(?i)(Auto|Legacy|NFT)$
                   type: string
                 iptablesFilterAllowAction:
                   description: |-

--- a/libcalico-go/lib/validator/v3/validator_test.go
+++ b/libcalico-go/lib/validator/v3/validator_test.go
@@ -118,6 +118,9 @@ func init() {
 	iptablesBackendLegacy := api.IptablesBackend(api.IptablesBackendLegacy)
 	iptablesBackendNFTables := api.IptablesBackend(api.IptablesBackendNFTables)
 	iptablesBackendAuto := api.IptablesBackend(api.IptablesBackendAuto)
+	iptablesBackendLowerNFT := api.IptablesBackend("nft")
+	iptablesBackendUpperLegacy := api.IptablesBackend("LEGACY")
+	iptablesBackendEmpty := api.IptablesBackend("")
 	iptablesBackendbadVal := api.IptablesBackend("badVal")
 
 	// longLabelsValue is 63 and 64 chars long
@@ -786,6 +789,19 @@ func init() {
 			ObjectMeta: v1.ObjectMeta{Name: "default"},
 			Spec:       api.FelixConfigurationSpec{IptablesBackend: &iptablesBackendbadVal},
 		}, false),
+		Entry("should reject an empty IptablesBackend value", &api.FelixConfiguration{
+			ObjectMeta: v1.ObjectMeta{Name: "default"},
+			Spec:       api.FelixConfigurationSpec{IptablesBackend: &iptablesBackendEmpty},
+		}, false),
+		// CRD pattern is case-insensitive, matching API server behavior.
+		Entry("should accept a lowercase IptablesBackend value 'nft'", &api.FelixConfiguration{
+			ObjectMeta: v1.ObjectMeta{Name: "default"},
+			Spec:       api.FelixConfigurationSpec{IptablesBackend: &iptablesBackendLowerNFT},
+		}, true),
+		Entry("should accept an uppercase IptablesBackend value 'LEGACY'", &api.FelixConfiguration{
+			ObjectMeta: v1.ObjectMeta{Name: "default"},
+			Spec:       api.FelixConfigurationSpec{IptablesBackend: &iptablesBackendUpperLegacy},
+		}, true),
 		Entry("should accept a valid DefaultEndpointToHostAction value", &api.FelixConfiguration{
 			ObjectMeta: v1.ObjectMeta{Name: "default"},
 			Spec:       api.FelixConfigurationSpec{DefaultEndpointToHostAction: "Drop"},


### PR DESCRIPTION
The `IptablesBackend` type carried a case-sensitive kubebuilder `Enum` annotation that conflicted with the field-level case-insensitive `Pattern`. Both ended up in the generated CRD, and the stricter `enum` won at the kube-apiserver — so values like `nft` were rejected via a `FelixConfiguration` CR even though felix's internal config parser (and the docs) treat the field as case-insensitive.

Drop the type-level `Enum` annotation, leaving the case-insensitive pattern as the single source of truth. Also tighten the pattern from `^(?i)(Auto|Legacy|NFT)?$` to `^(?i)(Auto|Legacy|NFT)$` so the empty string is no longer accepted (felix's internal `oneof` parser rejects it anyway).

**Before:**
```yaml
iptablesBackend:
  enum: [Legacy, NFT, Auto]
  pattern: ^(?i)(Auto|Legacy|NFT)?$
  type: string
```

**After:**
```yaml
iptablesBackend:
  pattern: ^(?i)(Auto|Legacy|NFT)$
  type: string
```

Unit tests in `libcalico-go/lib/validator/v3` cover the new behavior: lowercase `nft`, uppercase `LEGACY`, and empty string.

**Release note:**
```release-note
FelixConfiguration.iptablesBackend now accepts any case (e.g. `nft`, `Legacy`, `AUTO`), matching the documented behavior and felix's internal config parser.
```