### PR TITLE
Default kind/image build parallelism to 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,16 +181,18 @@ $(CHART_DESTINATION)/projectcalico.org.v3-$(GIT_VERSION).tgz: bin/helm $(shell f
 #   make image                                              # build + tag as calico/<name>:<version>
 #   make push DEV_IMAGE_PATH=myuser DEV_IMAGE_TAG=latest    # build + tag + push to myuser/<name>:latest
 #
-# Component images are independent targets, so `make -jN` builds them in
-# parallel (e.g., `make -j4 push DEV_IMAGE_PATH=myuser`).
+# Component images are independent targets and build in parallel up to
+# NUM_BUILD_JOBS (default 4 to keep memory usage sane on a workstation;
+# raise via NUM_BUILD_JOBS=8 etc. for a bigger machine).
 #
 # To force a full rebuild, remove the stamp directory:
 #   rm -rf .dev-stamps && make push ...
 ###############################################################################
 
 .PHONY: image
-## Build all component images and tag for dev registry. Supports make -jN for parallel builds.
-image: $(KIND_IMAGE_MARKERS)
+## Build all component images and tag for dev registry.
+image:
+	$(MAKE) -j$(NUM_BUILD_JOBS) $(KIND_IMAGE_MARKERS)
 	@CALICO_IMAGES="$(KIND_CALICO_IMAGES)" \
 	  DEV_IMAGE_PREFIX="$(DEV_IMAGE_PREFIX)" \
 	  DEV_IMAGE_TAG="$(DEV_IMAGE_TAG)" \
@@ -238,7 +240,7 @@ CLUSTER_ROUTING ?= BIRD
 ## Build all test images, create a kind cluster, and deploy Calico on it.
 .PHONY: kind-up
 kind-up:
-	$(MAKE) -j$$(nproc) kind-build-images
+	$(MAKE) -j$(NUM_BUILD_JOBS) kind-build-images
 	$(MAKE) kind-cluster-create CALICO_API_GROUP=$(KIND_CALICO_API_GROUP)
 	$(MAKE) kind-deploy
 

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -135,6 +135,13 @@ ifneq ($(GO_BUILD_PARALLELISM),)
 GOFLAGS := $(GOFLAGS) -p=$(GO_BUILD_PARALLELISM)
 endif
 
+# Outer parallelism for image / kind-build-images / kind-reload. Each parallel
+# job spawns a docker go-build container, so `-j$(nproc)` on a workstation with
+# limited RAM (e.g. 32G running alongside an IDE/LSP/AI session) will thrash
+# into swap. Default to a conservative 4. Raise via NUM_BUILD_JOBS=N for a
+# bigger machine.
+NUM_BUILD_JOBS ?= 4
+
 # For building, we use the go-build image for the *host* architecture, even if the target is different
 # the one for the host should contain all the necessary cross-compilation tools
 # we do not need to use the arch since go-build:v0.15 now is multi-arch manifest
@@ -1794,7 +1801,7 @@ kind-deploy:
 # re-pulls the new digests under the test-build tag (PullAlways).
 .PHONY: kind-reload
 kind-reload:
-	$(MAKE) -j$$(nproc) kind-build-images
+	$(MAKE) -j$(NUM_BUILD_JOBS) kind-build-images
 	$(MAKE) -C $(REPO_ROOT) chart CALICO_API_GROUP=$(KIND_CALICO_API_GROUP)
 	KUBECONFIG=$(KIND_KUBECONFIG) $(REPO_ROOT)/bin/helm upgrade calico \
 		$(REPO_ROOT)/bin/tigera-operator-$(GIT_VERSION).tgz \


### PR DESCRIPTION
The `kind-up` / `image` / `kind-reload` targets defaulted to `-j\$(nproc)`, which spawns N docker go-build containers concurrently. On a 32G workstation with an editor and AI session co-resident, that's enough to thrash into swap.

Cap the outer parallelism at `NUM_BUILD_JOBS` (default 4). Raise via `NUM_BUILD_JOBS=N make ...` on a bigger machine. CI agents in this repo are typically 4-core so this matches existing behavior on those; bigger CI agents can crank `NUM_BUILD_JOBS` if needed.

```release-note
None
```