### PR TITLE
lib/std/log: add new logging package

### DIFF
--- a/lib/std/go.mod
+++ b/lib/std/go.mod
@@ -1,3 +1,10 @@
 module github.com/projectcalico/calico/lib/std
 
 go 1.26.3
+
+require github.com/sirupsen/logrus v1.9.4
+
+require (
+	github.com/stretchr/testify v1.11.1 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+)

--- a/lib/std/go.sum
+++ b/lib/std/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
+github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lib/std/log/another_caller_for_test.go
+++ b/lib/std/log/another_caller_for_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import "github.com/sirupsen/logrus"
+
+// debugFromAnotherCaller emits a debug log from a different source file so the
+// background hook's debug-filename regex filter can be exercised.
+func debugFromAnotherCaller(lg *logrus.Logger, msg string) {
+	lg.Debug(msg)
+}

--- a/lib/std/log/benchmark_test.go
+++ b/lib/std/log/benchmark_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// slowWriter discards every Write but pauses for `delay` per call.
+// Simulates a slow downstream sink (terminal, container stdout consumer).
+type slowWriter struct {
+	delay time.Duration
+}
+
+func (w *slowWriter) Write(p []byte) (int, error) {
+	if w.delay > 0 {
+		time.Sleep(w.delay)
+	}
+	return len(p), nil
+}
+
+// installBenchHook attaches a background log hook with the given writer/
+// channel-size/disableLogDropping wired in, just like Configure does, but
+// without going through Configure's sync.Once guard. Returns a cleanup
+// function that restores logrus's prior state and lets the background
+// goroutine exit.
+func installBenchHook(tb testing.TB, w io.Writer, channelSize int, disableLogDropping bool) {
+	tb.Helper()
+	stdLogger := logrus.StandardLogger()
+	origHooks := stdLogger.Hooks
+	origFormatter := stdLogger.Formatter
+	origLevel := stdLogger.Level
+	origOut := stdLogger.Out
+
+	stdLogger.SetFormatter(newFormatter("benchmark"))
+	stdLogger.SetLevel(logrus.InfoLevel)
+
+	ch := make(chan queuedLog, channelSize)
+	dest := newStreamDestination(
+		logrus.InfoLevel,
+		w,
+		ch,
+		disableLogDropping,
+		nil,
+	)
+	hook := newBackgroundHook(
+		filterLevels(logrus.InfoLevel),
+		logrus.PanicLevel,
+		"benchmark",
+		[]*destination{dest},
+		nil,
+		nil,
+	)
+	hook.start()
+	stdLogger.ReplaceHooks(logrus.LevelHooks{})
+	stdLogger.AddHook(hook)
+	stdLogger.SetOutput(io.Discard)
+
+	tb.Cleanup(func() {
+		// Close the destination's channel so loopWritingLogs exits and
+		// doesn't leak into subsequent benchmarks/tests.
+		close(ch)
+		stdLogger.ReplaceHooks(origHooks)
+		stdLogger.SetFormatter(origFormatter)
+		stdLogger.SetLevel(origLevel)
+		stdLogger.SetOutput(origOut)
+	})
+}
+
+// BenchmarkLogChannelDispatch measures throughput of log emission through
+// the full backgroundHook.Fire path. Each iteration emits one log line
+// across multiple goroutines.
+//
+// The single-goroutine number is the per-emission cost (formatter +
+// findUserCaller + channel send + queue handoff). The parallel variant
+// shows how contention on logrus's internal mutex affects throughput.
+func BenchmarkLogChannelDispatch(b *testing.B) {
+	cases := []struct {
+		name          string
+		writeDelay    time.Duration
+		numGoroutines int
+		channelSize   int
+	}{
+		{"serial/fast-writer", 0, 1, logQueueSize},
+		{"parallel-4/fast-writer", 0, 4, logQueueSize},
+		{"parallel-16/fast-writer", 0, 16, logQueueSize},
+		{"parallel-16/slow-writer-200us", 200 * time.Microsecond, 16, 10_000},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			installBenchHook(b, &slowWriter{delay: c.writeDelay}, c.channelSize, true)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			if c.numGoroutines <= 1 {
+				for i := 0; i < b.N; i++ {
+					logrus.WithField("i", i).Info("benchmark")
+				}
+				return
+			}
+
+			perG := b.N / c.numGoroutines
+			extra := b.N % c.numGoroutines
+			var wg sync.WaitGroup
+			wg.Add(c.numGoroutines)
+			for g := 0; g < c.numGoroutines; g++ {
+				n := perG
+				if g < extra {
+					n++
+				}
+				go func(gid, n int) {
+					defer wg.Done()
+					for i := 0; i < n; i++ {
+						logrus.WithField("g", gid).Info("benchmark")
+					}
+				}(g, n)
+			}
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkLogChannelWorstCallerLatency reports the worst observed
+// per-emission caller latency under heavy contention. With a small
+// channel + disableLogDropping=true, the destination's send call blocks
+// when the channel fills; this measures how long callers actually wait
+// inside one log.Info under that pressure.
+//
+// Reported as a custom metric "max-caller-ns/op" via b.ReportMetric;
+// ns/op itself is the average emission time (less interesting here).
+func BenchmarkLogChannelWorstCallerLatency(b *testing.B) {
+	const (
+		writeDelay    = 200 * time.Microsecond
+		numGoroutines = 16
+		channelSize   = logQueueSize
+	)
+
+	installBenchHook(b, &slowWriter{delay: writeDelay}, channelSize, true)
+
+	var maxLatencyNS int64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	perG := b.N / numGoroutines
+	extra := b.N % numGoroutines
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for g := 0; g < numGoroutines; g++ {
+		n := perG
+		if g < extra {
+			n++
+		}
+		go func(gid, n int) {
+			defer wg.Done()
+			for i := 0; i < n; i++ {
+				start := time.Now()
+				logrus.WithField("g", gid).Info("benchmark")
+				lat := int64(time.Since(start))
+				for {
+					prev := atomic.LoadInt64(&maxLatencyNS)
+					if lat <= prev || atomic.CompareAndSwapInt64(&maxLatencyNS, prev, lat) {
+						break
+					}
+				}
+			}
+		}(g, n)
+	}
+	wg.Wait()
+
+	b.ReportMetric(float64(atomic.LoadInt64(&maxLatencyNS)), "max-caller-ns/op")
+}

--- a/lib/std/log/configure.go
+++ b/lib/std/log/configure.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Counter is the minimal interface used by the log package for incrementing
+// log-health metrics. It is deliberately one method so any metric system
+// (Prometheus, statsd, OpenTelemetry, a custom collector, a test fake) can
+// satisfy it without lib/std/log depending on that system.
+//
+// prometheus.Counter satisfies this interface directly — its Inc method
+// matches verbatim — so existing call sites pass *prometheus.Counter values
+// unchanged.
+type Counter interface {
+	Inc()
+}
+
+// Options is the full configuration passed to Configure().
+//
+// A nil pointer for Screen, File, or Syslog disables that destination.
+// Configure panics if called twice; pass everything you need in one call.
+type Options struct {
+	// Component is the prefix used in log lines (e.g. "felix", "typha").
+	// Equivalent to a prior SetComponent call.
+	Component string
+
+	// Screen, File, Syslog control destinations. nil disables.
+	Screen *ScreenConfig
+	File   *FileConfig
+	Syslog *SyslogConfig
+
+	// DebugFilenameRegex restricts debug-level logs to source files whose
+	// basename matches the regex. nil means "no restriction".
+	DebugFilenameRegex *regexp.Regexp
+
+	// DebugDisableLogDropping forces all logs to be queued even if the
+	// destination's channel is full. Off by default.
+	DebugDisableLogDropping bool
+
+	// SingleThreaded disables the standard logger's internal mutex. Safe
+	// only when all writes go through the background hook (typha pattern).
+	SingleThreaded bool
+
+	// Counters is optional metrics. Zero-value (nil counters) is fine.
+	Counters Counters
+}
+
+// ScreenConfig controls the stdout destination.
+type ScreenConfig struct {
+	Level Level
+}
+
+// FileConfig controls the file destination. The parent directory is created
+// if necessary. On Linux the file is opened with a rotation-aware writer; on
+// other platforms with a plain os.OpenFile.
+type FileConfig struct {
+	Level Level
+	Path  string
+}
+
+// SyslogConfig controls the syslog destination. Tag is the syslog program
+// name (e.g. "calico-felix"). Syslog is Linux-only; on other platforms
+// configuring it returns an error from Configure.
+type SyslogConfig struct {
+	Level Level
+	Tag   string
+}
+
+// Counters carry counters that record logging health. Both fields are
+// optional; nil values are silently absorbed.
+type Counters struct {
+	// DroppedLogs counts logs dropped because a destination's channel was full.
+	DroppedLogs Counter
+	// WriteErrors counts errors writing to any destination.
+	WriteErrors Counter
+}
+
+// ErrAlreadyConfigured is returned (or panicked with) if Configure is called twice.
+var ErrAlreadyConfigured = errors.New("log.Configure has already been called")
+
+// Configure installs the full logging configuration. Must be called exactly
+// once per process, at startup. Panics if called twice.
+//
+// Errors opening the file or connecting to syslog are returned as a joined
+// error so the caller can log and continue (or treat as fatal). The logger
+// remains in a working state regardless: any destinations that did open are
+// active.
+func Configure(opts Options) error {
+	var (
+		ran    bool
+		runErr error
+	)
+	configureOnce.Do(func() {
+		ran = true
+		runErr = doConfigure(opts)
+	})
+	if !ran {
+		panic(ErrAlreadyConfigured)
+	}
+	return runErr
+}
+
+// IsConfigured reports whether Configure has been called.
+func IsConfigured() bool {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return configured
+}
+
+func doConfigure(opts Options) error {
+	stateMu.Lock()
+	if opts.Component != "" {
+		currentComponent = opts.Component
+	}
+	currentFormatter = newFormatter(currentComponent)
+	logrus.SetFormatter(currentFormatter)
+	component := currentComponent
+	stateMu.Unlock()
+
+	// Resolve levels and pick the most verbose. logrus drops anything
+	// less verbose globally before the hook even runs. Only touch the
+	// global level if at least one destination is configured — otherwise
+	// we'd silently ratchet down to PanicLevel and suppress every log,
+	// even though the caller may have intended to keep the init-time
+	// default and only set SingleThreaded/Component/etc.
+	var screenLevel, fileLevel, syslogLevel logrus.Level
+	mostVerbose := logrus.PanicLevel
+	haveDest := false
+	if opts.Screen != nil {
+		screenLevel = logrus.Level(opts.Screen.Level)
+		if screenLevel > mostVerbose {
+			mostVerbose = screenLevel
+		}
+		haveDest = true
+	}
+	if opts.File != nil {
+		fileLevel = logrus.Level(opts.File.Level)
+		if fileLevel > mostVerbose {
+			mostVerbose = fileLevel
+		}
+		haveDest = true
+	}
+	if opts.Syslog != nil {
+		syslogLevel = logrus.Level(opts.Syslog.Level)
+		if syslogLevel > mostVerbose {
+			mostVerbose = syslogLevel
+		}
+		haveDest = true
+	}
+	if haveDest {
+		logrus.SetLevel(mostVerbose)
+	}
+
+	var dests []*destination
+	var errs []error
+
+	if opts.Screen != nil {
+		dests = append(dests, newStreamDestination(
+			screenLevel,
+			os.Stdout,
+			make(chan queuedLog, logQueueSize),
+			opts.DebugDisableLogDropping,
+			opts.Counters.WriteErrors,
+		))
+	}
+
+	if opts.File != nil && opts.File.Path != "" {
+		fd, err := newFileDestination(
+			fileLevel,
+			opts.File.Path,
+			opts.DebugDisableLogDropping,
+			opts.Counters.WriteErrors,
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("opening log file %q: %w", opts.File.Path, err))
+		} else {
+			dests = append(dests, fd)
+		}
+	}
+
+	if opts.Syslog != nil && opts.Syslog.Tag != "" {
+		sd, err := newSyslogDestinationForTag(
+			syslogLevel,
+			opts.Syslog.Tag,
+			opts.DebugDisableLogDropping,
+			opts.Counters.WriteErrors,
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("connecting to syslog: %w", err))
+		} else if sd != nil {
+			dests = append(dests, sd)
+		}
+	}
+
+	if len(dests) > 0 {
+		hook := newBackgroundHook(
+			filterLevels(mostVerbose),
+			syslogLevel,
+			component,
+			dests,
+			opts.DebugFilenameRegex,
+			opts.Counters.DroppedLogs,
+		)
+		hook.start()
+		logrus.AddHook(hook)
+		// Disable logrus's single-output path. Logs now fan out via the hook.
+		logrus.SetOutput(&nullWriter{})
+	}
+
+	if opts.SingleThreaded {
+		logrus.StandardLogger().SetNoLock()
+	}
+
+	stateMu.Lock()
+	configured = true
+	stateMu.Unlock()
+
+	return errors.Join(errs...)
+}

--- a/lib/std/log/default.go
+++ b/lib/std/log/default.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// State held outside the Logger interface for the package-level API:
+// the formatter (mutated by SetComponent / Configure), the default Logger
+// backing the top-level functions, and the configure-once guard.
+var (
+	stateMu          sync.Mutex
+	currentComponent string
+	currentFormatter *formatter
+	configureOnce    sync.Once
+	configured       bool
+)
+
+// defaultLogger is typed as the concrete *logrusLogger (not Logger) so the
+// package-level wrappers below dispatch to a concrete method — inlinable by
+// the compiler — rather than through an interface call on every log.
+var defaultLogger = newLogrusLogger(logrus.NewEntry(logrus.StandardLogger()))
+
+func init() {
+	// Install the Calico formatter and match logrus's default of writing
+	// to stderr. Binaries like the CNI plugin and the FV test-workload
+	// helper emit structured data on stdout, and log lines leaking there
+	// would corrupt that data. Components that need stdout (notably felix —
+	// FV tests grep felix's stdout via WatchStdoutFor) override via
+	// SetOutput or Configure.
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	currentFormatter = newFormatter("")
+	logrus.SetFormatter(currentFormatter)
+	logrus.SetOutput(os.Stderr)
+	// We do our own caller walking in the formatter so logrus's own
+	// detection is not needed.
+	logrus.SetReportCaller(false)
+}
+
+// SetComponent sets the component prefix used in log output (e.g. "felix").
+// Safe to call any time; the most recent value wins. Replaces the formatter
+// with one carrying the new component.
+func SetComponent(name string) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	if name == currentComponent {
+		return
+	}
+	currentComponent = name
+	currentFormatter = newFormatter(name)
+	logrus.SetFormatter(currentFormatter)
+}
+
+// SetLevel sets the global log level. Safe to call any time, including before
+// Configure (useful for early-startup adjustments from environment variables).
+func SetLevel(level Level) {
+	logrus.SetLevel(logrus.Level(level))
+}
+
+// SetOutput swaps the destination writer for the default logger. Useful in
+// tests and for tools that don't go through Configure. After Configure is
+// called, logs are emitted via the background hook to its destinations and
+// SetOutput has no effect.
+func SetOutput(w io.Writer) {
+	logrus.SetOutput(w)
+}
+
+// Default returns the default Logger backing the top-level package functions.
+// Prefer log.New("component") in code; Default is for cases that genuinely
+// need a Logger value without a component.
+func Default() Logger {
+	return defaultLogger
+}
+
+// Top-level convenience functions. Each delegates to defaultLogger so call
+// sites can use either `log.Info("msg")` or `log.New("comp").Info("msg")`.
+
+func Trace(args ...any)                   { defaultLogger.Trace(args...) }
+func Tracef(format string, args ...any)   { defaultLogger.Tracef(format, args...) }
+func Debug(args ...any)                   { defaultLogger.Debug(args...) }
+func Debugf(format string, args ...any)   { defaultLogger.Debugf(format, args...) }
+func Info(args ...any)                    { defaultLogger.Info(args...) }
+func Infof(format string, args ...any)    { defaultLogger.Infof(format, args...) }
+func Warn(args ...any)                    { defaultLogger.Warn(args...) }
+func Warnf(format string, args ...any)    { defaultLogger.Warnf(format, args...) }
+func Warning(args ...any)                 { defaultLogger.Warning(args...) }
+func Warningf(format string, args ...any) { defaultLogger.Warningf(format, args...) }
+func Error(args ...any)                   { defaultLogger.Error(args...) }
+func Errorf(format string, args ...any)   { defaultLogger.Errorf(format, args...) }
+
+// Fatal/Panic call os.Exit / panic explicitly so static analyzers (notably
+// staticcheck SA5011) see these wrappers as non-returning. defaultLogger's
+// Fatal/Panic also terminate, so the terminator below is unreachable in
+// practice — but writing it out is what tells the analyzer.
+
+func Fatal(args ...any) {
+	defaultLogger.Fatal(args...)
+	os.Exit(1)
+}
+
+func Fatalf(format string, args ...any) {
+	defaultLogger.Fatalf(format, args...)
+	os.Exit(1)
+}
+
+func Panic(args ...any) {
+	defaultLogger.Panic(args...)
+	panic(fmt.Sprint(args...))
+}
+
+func Panicf(format string, args ...any) {
+	defaultLogger.Panicf(format, args...)
+	panic(fmt.Sprintf(format, args...))
+}
+
+// Stdlib-shaped Print* aliases (emit at Info level).
+func Print(args ...any)                 { defaultLogger.Print(args...) }
+func Printf(format string, args ...any) { defaultLogger.Printf(format, args...) }
+func Println(args ...any)               { defaultLogger.Println(args...) }
+
+// logrus-shaped *ln aliases.
+func Debugln(args ...any)   { defaultLogger.Debugln(args...) }
+func Infoln(args ...any)    { defaultLogger.Infoln(args...) }
+func Warnln(args ...any)    { defaultLogger.Warnln(args...) }
+func Warningln(args ...any) { defaultLogger.Warningln(args...) }
+func Errorln(args ...any)   { defaultLogger.Errorln(args...) }
+
+func Fatalln(args ...any) {
+	defaultLogger.Fatalln(args...)
+	os.Exit(1)
+}
+
+func Panicln(args ...any) {
+	defaultLogger.Panicln(args...)
+	panic(fmt.Sprintln(args...))
+}
+
+// SetReportCaller is a no-op for compatibility with logrus call sites.
+// lib/std/log walks the stack itself in the formatter so logrus's own
+// caller detection is unnecessary; we always disable it. Callers that
+// previously did `logrus.SetReportCaller(true)` no longer need to.
+func SetReportCaller(bool) {}
+
+func WithField(key string, value any) Logger { return defaultLogger.WithField(key, value) }
+func WithFields(fields Fields) Logger        { return defaultLogger.WithFields(fields) }
+func WithError(err error) Logger             { return defaultLogger.WithError(err) }
+
+// IsLevelEnabled reports whether logs at the given level will be emitted.
+func IsLevelEnabled(level Level) bool { return defaultLogger.IsLevelEnabled(level) }
+
+// GetLevel returns the global log level.
+func GetLevel() Level { return defaultLogger.Level() }

--- a/lib/std/log/destination.go
+++ b/lib/std/log/destination.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// All types in this file are internal. The public surface for configuration
+// is Configure(Options); these types implement the background fanout
+// described there.
+
+const logQueueSize = 100
+
+// nullWriter discards everything. Used to disable logrus's default single
+// output once we install the background hook for multi-destination fanout.
+type nullWriter struct{}
+
+func (w *nullWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// queuedLog is the envelope passed from the foreground hook to background
+// destination goroutines.
+type queuedLog struct {
+	Level         logrus.Level
+	Message       []byte
+	SyslogMessage string
+	WaitGroup     *sync.WaitGroup
+	// NumSkippedLogs is set when the destination's channel was full and one
+	// or more logs ahead of this one were dropped.
+	NumSkippedLogs uint
+}
+
+func (ql queuedLog) onLogDone() {
+	if ql.WaitGroup != nil {
+		ql.WaitGroup.Done()
+	}
+}
+
+// destination is a single log output target: a channel + a level filter +
+// a writer function. Logs are dispatched into the channel by the foreground
+// hook and pulled by a background goroutine running loopWritingLogs.
+type destination struct {
+	level    logrus.Level
+	channel  chan queuedLog
+	writeLog func(ql queuedLog) error
+
+	// disableLogDropping forces all logs to be queued even if the channel
+	// is full. Trades latency for completeness.
+	disableLogDropping bool
+
+	// lock protects numDroppedLogs.
+	lock           sync.Mutex
+	numDroppedLogs uint
+
+	// writeErrors is incremented when writeLog returns an error.
+	writeErrors Counter
+}
+
+func newStreamDestination(
+	level logrus.Level,
+	writer io.Writer,
+	c chan queuedLog,
+	disableLogDropping bool,
+	writeErrors Counter,
+) *destination {
+	return &destination{
+		level:              level,
+		channel:            c,
+		disableLogDropping: disableLogDropping,
+		writeErrors:        writeErrors,
+		writeLog: func(ql queuedLog) error {
+			if ql.NumSkippedLogs > 0 {
+				_, _ = fmt.Fprintf(writer, "... dropped %d logs ...\n", ql.NumSkippedLogs)
+			}
+			_, err := writer.Write(ql.Message)
+			return err
+		},
+	}
+}
+
+func newSyslogDestination(
+	level logrus.Level,
+	writer syslogWriter,
+	c chan queuedLog,
+	disableLogDropping bool,
+	writeErrors Counter,
+) *destination {
+	return &destination{
+		level:              level,
+		channel:            c,
+		disableLogDropping: disableLogDropping,
+		writeErrors:        writeErrors,
+		writeLog: func(ql queuedLog) error {
+			if ql.NumSkippedLogs > 0 {
+				_ = writer.Warning(fmt.Sprintf("... dropped %d logs ...\n", ql.NumSkippedLogs))
+			}
+			return writeToSyslog(writer, ql)
+		},
+	}
+}
+
+// send enqueues a log. Returns true on success, false if the channel was full
+// and the log was dropped (unless disableLogDropping is set, in which case it
+// blocks until the channel accepts the message).
+func (d *destination) send(ql queuedLog) (ok bool) {
+	if d.disableLogDropping {
+		d.channel <- ql
+		return true
+	}
+
+	d.lock.Lock()
+	ql.NumSkippedLogs = d.numDroppedLogs
+	select {
+	case d.channel <- ql:
+		d.numDroppedLogs = 0
+		ok = true
+	default:
+		d.numDroppedLogs++
+	}
+	d.lock.Unlock()
+	return
+}
+
+// loopWritingLogs is the background goroutine for a destination.
+func (d *destination) loopWritingLogs() {
+	for ql := range d.channel {
+		if err := d.writeLog(ql); err != nil && d.writeErrors != nil {
+			d.writeErrors.Inc()
+		}
+		ql.onLogDone()
+	}
+}
+
+// syslogWriter is the subset of *syslog.Writer that we depend on. Allows
+// platforms without syslog (Windows) to compile with a stub.
+type syslogWriter interface {
+	Debug(m string) error
+	Info(m string) error
+	Warning(m string) error
+	Err(m string) error
+	Crit(m string) error
+}
+
+func writeToSyslog(writer syslogWriter, ql queuedLog) error {
+	switch ql.Level {
+	case logrus.PanicLevel, logrus.FatalLevel:
+		return writer.Crit(ql.SyslogMessage)
+	case logrus.ErrorLevel:
+		return writer.Err(ql.SyslogMessage)
+	case logrus.WarnLevel:
+		return writer.Warning(ql.SyslogMessage)
+	case logrus.InfoLevel:
+		return writer.Info(ql.SyslogMessage)
+	case logrus.DebugLevel:
+		return writer.Debug(ql.SyslogMessage)
+	}
+	return nil
+}
+
+// backgroundHook is the logrus hook that (synchronously) formats each entry
+// and pushes it to one or more destinations for writing on a background
+// thread. The synchronous formatting and per-destination level filtering are
+// preserved from libcalico-go/lib/logutils.
+type backgroundHook struct {
+	levels          []logrus.Level
+	syslogLevel     logrus.Level
+	debugFileNameRE *regexp.Regexp
+	destinations    []*destination
+	component       string
+
+	// dropped is incremented for each destination that dropped a log.
+	dropped Counter
+}
+
+func newBackgroundHook(
+	levels []logrus.Level,
+	syslogLevel logrus.Level,
+	component string,
+	destinations []*destination,
+	debugFileNameRE *regexp.Regexp,
+	dropped Counter,
+) *backgroundHook {
+	return &backgroundHook{
+		levels:          levels,
+		syslogLevel:     syslogLevel,
+		component:       component,
+		destinations:    destinations,
+		debugFileNameRE: debugFileNameRE,
+		dropped:         dropped,
+	}
+}
+
+func (h *backgroundHook) Levels() []logrus.Level { return h.levels }
+
+func (h *backgroundHook) Fire(entry *logrus.Entry) (err error) {
+	if entry.Buffer != nil {
+		defer entry.Buffer.Truncate(0)
+	}
+
+	// Walk the stack once and stash on entry.Caller so the formatter and
+	// formatForSyslog don't each repeat the walk. We disable logrus's own
+	// SetReportCaller, so entry.Caller is otherwise nil here.
+	if entry.Caller == nil {
+		entry.Caller = findUserCaller()
+	}
+
+	if entry.Level >= logrus.DebugLevel && h.debugFileNameRE != nil {
+		var file string
+		if entry.Caller != nil {
+			file = baseName(entry.Caller.File)
+		}
+		if file == "" || !h.debugFileNameRE.MatchString(file) {
+			return nil
+		}
+	}
+
+	var serialized []byte
+	if serialized, err = entry.Logger.Formatter.Format(entry); err != nil {
+		return
+	}
+
+	// entry's buffer is reused; copy before sending across the channel.
+	bufCopy := make([]byte, len(serialized))
+	copy(bufCopy, serialized)
+
+	ql := queuedLog{
+		Level:   entry.Level,
+		Message: bufCopy,
+	}
+
+	if entry.Level <= h.syslogLevel {
+		ql.SyslogMessage = formatForSyslog(entry, componentFromEntry(entry, h.component))
+	}
+
+	var waitGroup *sync.WaitGroup
+	if entry.Level <= logrus.FatalLevel || entry.Data[fieldForceFlush] == true {
+		waitGroup = &sync.WaitGroup{}
+		ql.WaitGroup = waitGroup
+	}
+
+	for _, dest := range h.destinations {
+		if ql.Level > dest.level {
+			continue
+		}
+		if waitGroup != nil {
+			// Add before send: the goroutine may schedule and call Done
+			// before we return from the send.
+			waitGroup.Add(1)
+		}
+		if ok := dest.send(ql); !ok {
+			if waitGroup != nil {
+				waitGroup.Done()
+			}
+			if h.dropped != nil {
+				h.dropped.Inc()
+			}
+		}
+	}
+	if waitGroup != nil {
+		waitGroup.Wait()
+	}
+	return
+}
+
+func (h *backgroundHook) start() {
+	for _, d := range h.destinations {
+		go d.loopWritingLogs()
+	}
+}
+
+func componentFromEntry(entry *logrus.Entry, fallback string) string {
+	if c, ok := entry.Data[fieldComponent].(string); ok && c != "" {
+		return c
+	}
+	return fallback
+}
+
+// baseName returns the file basename without using path.Base, to avoid the
+// path package in the hot path.
+func baseName(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			return p[i+1:]
+		}
+	}
+	return p
+}
+
+// filterLevels returns all logrus levels ≤ maxLevel.
+func filterLevels(maxLevel logrus.Level) []logrus.Level {
+	out := make([]logrus.Level, 0, len(logrus.AllLevels))
+	for _, l := range logrus.AllLevels {
+		if l <= maxLevel {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/lib/std/log/destination_linux.go
+++ b/lib/std/log/destination_linux.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"log/syslog"
+	"os"
+	"path"
+
+	"github.com/sirupsen/logrus"
+)
+
+// newFileDestination opens a rotation-aware writer at the given path and
+// returns a destination that writes to it. The parent directory is created
+// if needed.
+func newFileDestination(
+	level logrus.Level,
+	filePath string,
+	disableLogDropping bool,
+	writeErrors Counter,
+) (*destination, error) {
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return nil, err
+	}
+	w, err := newRotatingFile(filePath, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return newStreamDestination(
+		level,
+		w,
+		make(chan queuedLog, logQueueSize),
+		disableLogDropping,
+		writeErrors,
+	), nil
+}
+
+// newSyslogDestinationForTag connects to the system syslog daemon with the
+// given tag and returns a destination that writes to it.
+func newSyslogDestinationForTag(
+	level logrus.Level,
+	tag string,
+	disableLogDropping bool,
+	writeErrors Counter,
+) (*destination, error) {
+	// LOG_USER facility; severity is overridden per-log by writeToSyslog.
+	priority := syslog.LOG_USER | syslog.LOG_INFO
+	w, err := syslog.Dial("", "", priority, tag)
+	if err != nil {
+		return nil, err
+	}
+	return newSyslogDestination(
+		level,
+		w,
+		make(chan queuedLog, logQueueSize),
+		disableLogDropping,
+		writeErrors,
+	), nil
+}

--- a/lib/std/log/destination_other.go
+++ b/lib/std/log/destination_other.go
@@ -1,0 +1,61 @@
+//go:build !linux
+
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+)
+
+// newFileDestination on non-Linux opens the file with a plain os.OpenFile.
+// Log rotation under SIGHUP is not supported on these platforms.
+func newFileDestination(
+	level logrus.Level,
+	filePath string,
+	disableLogDropping bool,
+	writeErrors Counter,
+) (*destination, error) {
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return newStreamDestination(
+		level,
+		f,
+		make(chan queuedLog, logQueueSize),
+		disableLogDropping,
+		writeErrors,
+	), nil
+}
+
+// newSyslogDestinationForTag is a no-op stub. Syslog is not supported on
+// non-Linux platforms.
+func newSyslogDestinationForTag(
+	level logrus.Level,
+	tag string,
+	disableLogDropping bool,
+	writeErrors Counter,
+) (*destination, error) {
+	return nil, fmt.Errorf("syslog is not supported on %s", runtime.GOOS)
+}

--- a/lib/std/log/formatter.go
+++ b/lib/std/log/formatter.go
@@ -1,0 +1,362 @@
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// fileNameUnknown is the string used in logs when the filename/line number
+// cannot be determined.
+const fileNameUnknown = "<nil>"
+
+// FieldForceFlush is a log field that, when set to true, signals to the
+// background destination hook to wait for the log to flush before returning.
+// Useful immediately before a process exit. Use as:
+//
+//	log.WithField(log.FieldForceFlush, true).Info("about to exit")
+const FieldForceFlush = "__flush__"
+
+// fieldForceFlush is the internal alias for FieldForceFlush kept for use
+// inside the formatter without circular references.
+const fieldForceFlush = FieldForceFlush
+
+// fieldComponent carries the per-logger component name set by New(component).
+// The formatter promotes it to the log line's file-path prefix and strips it
+// from the key/value output. Internal-only.
+const fieldComponent = "__component__"
+
+// timeFormat is the timestamp format used in log lines.
+const timeFormat = "2006-01-02 15:04:05.000"
+
+const timeFormatLen = len(timeFormat)
+
+// formatter is the Calico log formatter. It produces lines like:
+//
+//	2017-01-05 09:17:48.238 [INFO][85386] felix/endpoint_mgr.go 434: msg key="value"
+//
+// Format is preserved byte-for-byte from libcalico-go/lib/logutils so operator
+// grep patterns continue to work.
+type formatter struct {
+	component string
+
+	initOnce                sync.Once
+	preComputedInfixByLevel []string
+}
+
+var maxLogrusLevel = logrus.Level(len(logrus.AllLevels))
+
+func newFormatter(component string) *formatter {
+	f := &formatter{component: component}
+	f.init()
+	return f
+}
+
+func (f *formatter) init() {
+	f.initOnce.Do(func() {
+		f.preComputedInfixByLevel = make([]string, len(logrus.AllLevels))
+		for _, level := range logrus.AllLevels {
+			var buf bytes.Buffer
+			f.computeInfix(&buf, level)
+			f.preComputedInfixByLevel[level] = buf.String()
+		}
+	})
+}
+
+func (f *formatter) Format(entry *logrus.Entry) ([]byte, error) {
+	f.init()
+
+	b := entry.Buffer
+	if b == nil {
+		b = &bytes.Buffer{}
+	}
+
+	fileName, lineNo := f.callerInfo(entry)
+	component := f.componentFor(entry)
+
+	b.Grow(timeFormatLen + 32 + len(component) + len(fileName) + len(entry.Message) + len(entry.Data)*32)
+	appendTime(b, entry.Time)
+	f.writeInfix(b, entry.Level)
+	if component != "" {
+		b.WriteString(component)
+		b.WriteByte('/')
+	}
+	b.WriteString(fileName)
+	b.WriteByte(' ')
+	if lineNo == 0 {
+		b.WriteString(fileNameUnknown)
+	} else {
+		buf := b.AvailableBuffer()
+		buf = strconv.AppendInt(buf, int64(lineNo), 10)
+		_, _ = b.Write(buf)
+	}
+	b.WriteString(": ")
+	b.WriteString(entry.Message)
+	appendKVsAndNewLine(b, entry.Data)
+
+	return b.Bytes(), nil
+}
+
+func (f *formatter) writeInfix(b *bytes.Buffer, level logrus.Level) {
+	if level >= maxLogrusLevel {
+		f.computeInfix(b, level)
+		return
+	}
+	_, _ = b.WriteString(f.preComputedInfixByLevel[level])
+}
+
+func (f *formatter) computeInfix(b *bytes.Buffer, level logrus.Level) {
+	_, _ = fmt.Fprintf(b, " [%s][%d] ", strings.ToUpper(level.String()), os.Getpid())
+}
+
+// componentFor returns the component label to use for this entry. A
+// per-logger component attached via New() wins; otherwise the formatter's
+// global component (set via SetComponent/Configure) is used.
+func (f *formatter) componentFor(entry *logrus.Entry) string {
+	if c, ok := entry.Data[fieldComponent].(string); ok && c != "" {
+		return c
+	}
+	return f.component
+}
+
+// callerInfo returns the file basename and line number of the user code
+// that invoked the log call. If entry.Caller was populated by the caller
+// (e.g. a unit test setting a specific frame), it wins; otherwise we walk
+// the stack ourselves so we can skip both logrus frames and lib/std/log
+// wrapper frames. Production code never sets entry.Caller — we force
+// logrus.SetReportCaller(false) on the first Format call — so the stack
+// walk is what runs in practice.
+func (f *formatter) callerInfo(entry *logrus.Entry) (string, int) {
+	if entry.Caller != nil {
+		return path.Base(entry.Caller.File), entry.Caller.Line
+	}
+	frame := findUserCaller()
+	if frame == nil {
+		return fileNameUnknown, 0
+	}
+	return path.Base(frame.File), frame.Line
+}
+
+// appendTime appends the time to the buffer in our format "2006-01-02 15:04:05.000".
+// It uses RFC3339Nano's optimised formatter and rewrites the result in place.
+func appendTime(b *bytes.Buffer, t time.Time) {
+	b.Grow(timeFormatLen)
+	buf := b.AvailableBuffer()
+	buf = t.AppendFormat(buf, time.RFC3339Nano)
+	buf = buf[:timeFormatLen]
+	const tPos = len("2006-01-02T") - 1
+	buf[tPos] = ' '
+	const dotPos = len("2006-01-02T15:04:05.") - 1
+
+	overwrite := false
+	if buf[dotPos] != '.' {
+		buf[dotPos] = '.'
+		overwrite = true
+	}
+	for i := dotPos + 1; i < len(buf); i++ {
+		if overwrite || buf[i] < '0' || buf[i] > '9' {
+			buf[i] = '0'
+			overwrite = true
+		}
+	}
+	_, _ = b.Write(buf)
+}
+
+var preComputedInfixByLevelSyslog = func() []string {
+	out := make([]string, len(logrus.AllLevels))
+	for _, level := range logrus.AllLevels {
+		out[level] = strings.ToUpper(level.String()) + " "
+	}
+	return out
+}()
+
+// formatForSyslog formats logs for syslog, omitting timestamp/PID (which syslog
+// adds itself) and keeping the level.
+func formatForSyslog(entry *logrus.Entry, component string) string {
+	b := entry.Buffer
+	if b == nil {
+		b = &bytes.Buffer{}
+	}
+
+	var fileName string
+	var lineNo int
+	if entry.Caller != nil {
+		fileName, lineNo = path.Base(entry.Caller.File), entry.Caller.Line
+	} else if frame := findUserCaller(); frame != nil {
+		fileName, lineNo = path.Base(frame.File), frame.Line
+	} else {
+		fileName = fileNameUnknown
+	}
+
+	b.Grow(32 + len(fileName) + len(entry.Message) + len(entry.Data)*32)
+	if entry.Level < maxLogrusLevel {
+		b.WriteString(preComputedInfixByLevelSyslog[entry.Level])
+	} else {
+		b.WriteString(strings.ToUpper(entry.Level.String()))
+		b.WriteByte(' ')
+	}
+	if component != "" {
+		b.WriteString(component)
+		b.WriteByte('/')
+	}
+	b.WriteString(fileName)
+	b.WriteByte(' ')
+	if lineNo == 0 {
+		b.WriteString(fileNameUnknown)
+	} else {
+		buf := b.AvailableBuffer()
+		buf = strconv.AppendInt(buf, int64(lineNo), 10)
+		_, _ = b.Write(buf)
+	}
+	b.WriteString(": ")
+	b.WriteString(entry.Message)
+	appendKVsAndNewLine(b, entry.Data)
+
+	return b.String()
+}
+
+// appendKVsAndNewLine writes the entry's key/value pairs to the end of the buffer,
+// in sorted order, followed by a newline.
+func appendKVsAndNewLine(b *bytes.Buffer, data logrus.Fields) {
+	if len(data) == 0 {
+		b.WriteByte('\n')
+		return
+	}
+
+	var keys []string
+	const arrSize = 16
+	if len(data) < arrSize {
+		var dataArr [arrSize]string
+		keys = dataArr[:0]
+	} else {
+		keys = make([]string, 0, len(data))
+	}
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if key == fieldForceFlush || key == fieldComponent {
+			continue
+		}
+		value := data[key]
+		b.WriteByte(' ')
+		b.WriteString(key)
+		b.WriteByte('=')
+
+		switch v := value.(type) {
+		case string:
+			buf := b.AvailableBuffer()
+			buf = strconv.AppendQuote(buf, v)
+			b.Write(buf)
+		case *string:
+			if v == nil {
+				b.WriteString("<nil>")
+			} else {
+				b.WriteByte('*')
+				buf := b.AvailableBuffer()
+				buf = strconv.AppendQuote(buf, *v)
+				b.Write(buf)
+			}
+		case error:
+			b.WriteString(v.Error())
+		case fmt.Stringer:
+			b.WriteString(v.String())
+		default:
+			_, _ = fmt.Fprintf(b, "%#v", value)
+		}
+	}
+	b.WriteByte('\n')
+}
+
+// Caller detection. We walk the stack ourselves rather than rely on logrus's
+// SetReportCaller because logrus would report our wrapper functions as the
+// caller. We skip frames in logrus and in this package.
+
+const (
+	logrusPackage       = "github.com/sirupsen/logrus"
+	logrusPackagePrefix = logrusPackage + "/"
+	thisPackage         = "github.com/projectcalico/calico/lib/std/log"
+	thisPackagePrefix   = thisPackage + "/"
+	maxCallerDepth      = 25
+	minimumCallerDepth  = 1
+)
+
+// pcsPool reuses the uintptr slice that backs runtime.Callers, so we don't
+// allocate maxCallerDepth*8 bytes per log emission under load.
+var pcsPool = sync.Pool{
+	New: func() any {
+		s := make([]uintptr, maxCallerDepth)
+		return &s
+	},
+}
+
+func findUserCaller() *runtime.Frame {
+	pcsPtr := pcsPool.Get().(*[]uintptr)
+	pcs := *pcsPtr
+	defer pcsPool.Put(pcsPtr)
+
+	n := runtime.Callers(minimumCallerDepth, pcs)
+	if n == 0 {
+		return nil
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		f, more := frames.Next()
+		pkg := getPackageName(f.Function)
+		if !isInternalPackage(pkg) {
+			frame := f
+			return &frame
+		}
+		if !more {
+			break
+		}
+	}
+	return nil
+}
+
+func isInternalPackage(pkg string) bool {
+	return pkg == logrusPackage ||
+		strings.HasPrefix(pkg, logrusPackagePrefix) ||
+		pkg == thisPackage ||
+		strings.HasPrefix(pkg, thisPackagePrefix)
+}
+
+// getPackageName extracts the package name from a fully qualified function name.
+// e.g. "github.com/x/y/pkg.Func" → "github.com/x/y/pkg".
+func getPackageName(f string) string {
+	for {
+		lastPeriod := strings.LastIndex(f, ".")
+		lastSlash := strings.LastIndex(f, "/")
+		if lastPeriod > lastSlash {
+			f = f[:lastPeriod]
+		} else {
+			break
+		}
+	}
+	return f
+}

--- a/lib/std/log/impl_logrus.go
+++ b/lib/std/log/impl_logrus.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// logrusLogger is the only Logger implementation. It wraps a *logrus.Entry.
+// New returns one of these; nothing in the public API exposes *logrus.Entry
+// directly.
+type logrusLogger struct {
+	entry *logrus.Entry
+}
+
+func newLogrusLogger(entry *logrus.Entry) *logrusLogger {
+	return &logrusLogger{entry: entry}
+}
+
+// New returns a Logger labelled with the given component name. The component
+// appears in every log line emitted via the returned Logger as a prefix on
+// the file name (e.g. "felix/calc_graph.go"). The per-logger component
+// overrides any component set via SetComponent or Configure.
+//
+// An empty component is treated as "no override": lines fall back to whatever
+// the global formatter carries.
+func New(component string) Logger {
+	entry := logrus.NewEntry(logrus.StandardLogger())
+	if component != "" {
+		entry = entry.WithField(fieldComponent, component)
+	}
+	return newLogrusLogger(entry)
+}
+
+// Emit methods. Each delegates to the underlying logrus entry.
+
+func (l *logrusLogger) Trace(args ...any)                   { l.entry.Trace(args...) }
+func (l *logrusLogger) Tracef(format string, args ...any)   { l.entry.Tracef(format, args...) }
+func (l *logrusLogger) Debug(args ...any)                   { l.entry.Debug(args...) }
+func (l *logrusLogger) Debugf(format string, args ...any)   { l.entry.Debugf(format, args...) }
+func (l *logrusLogger) Info(args ...any)                    { l.entry.Info(args...) }
+func (l *logrusLogger) Infof(format string, args ...any)    { l.entry.Infof(format, args...) }
+func (l *logrusLogger) Warn(args ...any)                    { l.entry.Warn(args...) }
+func (l *logrusLogger) Warnf(format string, args ...any)    { l.entry.Warnf(format, args...) }
+func (l *logrusLogger) Warning(args ...any)                 { l.entry.Warning(args...) }
+func (l *logrusLogger) Warningf(format string, args ...any) { l.entry.Warningf(format, args...) }
+func (l *logrusLogger) Error(args ...any)                   { l.entry.Error(args...) }
+func (l *logrusLogger) Errorf(format string, args ...any)   { l.entry.Errorf(format, args...) }
+
+// Fatal/Panic methods split logging from termination so static analyzers
+// (notably staticcheck SA5011) can see the terminating call in the wrapper
+// body and treat callers' nil-checks as guaranteed terminators. logrus's
+// Entry.Log/Logf/Logln explicitly do not exit/panic at Fatal/Panic level,
+// leaving us to call os.Exit / panic ourselves.
+
+func (l *logrusLogger) Fatal(args ...any) {
+	l.entry.Log(logrus.FatalLevel, args...)
+	os.Exit(1)
+}
+
+func (l *logrusLogger) Fatalf(format string, args ...any) {
+	l.entry.Logf(logrus.FatalLevel, format, args...)
+	os.Exit(1)
+}
+
+func (l *logrusLogger) Panic(args ...any) {
+	l.entry.Log(logrus.PanicLevel, args...)
+	panic(fmt.Sprint(args...))
+}
+
+func (l *logrusLogger) Panicf(format string, args ...any) {
+	l.entry.Logf(logrus.PanicLevel, format, args...)
+	panic(fmt.Sprintf(format, args...))
+}
+
+// Print/Printf/Println emit at Info level (logrus.Entry.Print* also do this).
+func (l *logrusLogger) Print(args ...any)                 { l.entry.Print(args...) }
+func (l *logrusLogger) Printf(format string, args ...any) { l.entry.Printf(format, args...) }
+func (l *logrusLogger) Println(args ...any)               { l.entry.Println(args...) }
+
+func (l *logrusLogger) Debugln(args ...any)   { l.entry.Debugln(args...) }
+func (l *logrusLogger) Infoln(args ...any)    { l.entry.Infoln(args...) }
+func (l *logrusLogger) Warnln(args ...any)    { l.entry.Warnln(args...) }
+func (l *logrusLogger) Warningln(args ...any) { l.entry.Warningln(args...) }
+func (l *logrusLogger) Errorln(args ...any)   { l.entry.Errorln(args...) }
+
+func (l *logrusLogger) Fatalln(args ...any) {
+	l.entry.Logln(logrus.FatalLevel, args...)
+	os.Exit(1)
+}
+
+func (l *logrusLogger) Panicln(args ...any) {
+	l.entry.Logln(logrus.PanicLevel, args...)
+	panic(fmt.Sprintln(args...))
+}
+
+func (l *logrusLogger) WithField(key string, value any) Logger {
+	return &logrusLogger{entry: l.entry.WithField(key, value)}
+}
+
+func (l *logrusLogger) WithFields(fields Fields) Logger {
+	return &logrusLogger{entry: l.entry.WithFields(logrus.Fields(fields))}
+}
+
+func (l *logrusLogger) WithError(err error) Logger {
+	return &logrusLogger{entry: l.entry.WithError(err)}
+}
+
+func (l *logrusLogger) Level() Level {
+	return Level(l.entry.Logger.GetLevel())
+}
+
+func (l *logrusLogger) IsLevelEnabled(level Level) bool {
+	return l.entry.Logger.IsLevelEnabled(logrus.Level(level))
+}

--- a/lib/std/log/internal_test.go
+++ b/lib/std/log/internal_test.go
@@ -1,0 +1,680 @@
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal tests covering the unexported destination/hook/formatter machinery.
+// These are the lib/std/log equivalents of the libcalico-go/lib/logutils test
+// suite, rewritten as standard testing.T tests so lib/std/go.mod doesn't need
+// Ginkgo/Gomega.
+
+package log
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// fixedTime is the synthetic timestamp used by the Formatter table tests.
+func fixedTime() time.Time {
+	t, err := time.Parse("2006-01-02 15:04:05.000", "2017-03-15 11:22:33.123")
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// TestFormatterTable exercises the formatter against fully-specified logrus
+// entries and asserts byte-exact output for both the main and syslog formats.
+// This locks in the format that operator dashboards and grep patterns expect.
+func TestFormatterTable(t *testing.T) {
+	cases := []struct {
+		name     string
+		entry    logrus.Entry
+		wantLog  string
+		wantSlog string
+	}{
+		// Note: the libcalico-go "empty" subtest expected `<nil> <nil>` for the
+		// file/line when entry.Caller was nil. In lib/std/log we always have
+		// fallback stack-walking, so an empty entry never produces `<nil>` —
+		// the formatter finds *something*. That subtest is omitted.
+		{
+			name: "basic",
+			entry: logrus.Entry{
+				Level: logrus.InfoLevel,
+				Time:  fixedTime(),
+				Caller: &runtime.Frame{
+					File: "biff.com/bar/foo.go",
+					Line: 123,
+				},
+				Data: logrus.Fields{
+					// Internal field; must be stripped from output.
+					fieldForceFlush: true,
+				},
+				Message: "The answer is 42.",
+			},
+			wantLog:  "2017-03-15 11:22:33.123 [INFO][<PID>] foo.go 123: The answer is 42.\n",
+			wantSlog: "INFO foo.go 123: The answer is 42.\n",
+		},
+		{
+			name: "with fields",
+			entry: logrus.Entry{
+				Level: logrus.WarnLevel,
+				Time:  fixedTime(),
+				Caller: &runtime.Frame{
+					File: "biff.com/bar/foo.go",
+					Line: 123,
+				},
+				Data: logrus.Fields{
+					"a":   10,
+					"b":   "foobar",
+					"c":   fixedTime(),
+					"err": errors.New("an error"),
+				},
+				Message: "The answer is 42.",
+			},
+			wantLog:  `2017-03-15 11:22:33.123 [WARNING][<PID>] foo.go 123: The answer is 42. a=10 b="foobar" c=2017-03-15 11:22:33.123 +0000 UTC err=an error` + "\n",
+			wantSlog: `WARNING foo.go 123: The answer is 42. a=10 b="foobar" c=2017-03-15 11:22:33.123 +0000 UTC err=an error` + "\n",
+		},
+	}
+
+	f := newFormatter("")
+	pid := fmt.Sprintf("%d", os.Getpid())
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			entry := c.entry
+			out, err := f.Format(&entry)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+			wantLog := strings.ReplaceAll(c.wantLog, "<PID>", pid)
+			if string(out) != wantLog {
+				t.Errorf("Format mismatch:\n  got:  %q\n  want: %q", string(out), wantLog)
+			}
+			gotSlog := formatForSyslog(&entry, "")
+			if gotSlog != c.wantSlog {
+				t.Errorf("Syslog mismatch:\n  got:  %q\n  want: %q", gotSlog, c.wantSlog)
+			}
+		})
+	}
+}
+
+// TestLogrusLevelsConsistent locks in the assumption that the indexes in
+// logrus.AllLevels match the numeric values of the level constants. The
+// formatter's pre-computed infix table relies on this.
+func TestLogrusLevelsConsistent(t *testing.T) {
+	for idx, level := range logrus.AllLevels {
+		if int(level) != idx {
+			t.Errorf("logrus.AllLevels[%d] = %v (int %d); want %d", idx, level, int(level), idx)
+		}
+	}
+}
+
+var (
+	testMsg1 = queuedLog{
+		Level:         logrus.InfoLevel,
+		Message:       []byte("Message"),
+		SyslogMessage: "syslog message",
+	}
+	testMsg2 = queuedLog{
+		Level:         logrus.InfoLevel,
+		Message:       []byte("Message2"),
+		SyslogMessage: "syslog message2",
+	}
+)
+
+// TestStreamDestinationDropCounter verifies that the destination tracks
+// dropped logs when the channel fills, then reports the drop count on the
+// next successfully-queued log.
+func TestStreamDestinationDropCounter(t *testing.T) {
+	c := make(chan queuedLog, 1)
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close() })
+	t.Cleanup(func() { _ = pw.Close() })
+	d := newStreamDestination(logrus.InfoLevel, pw, c, false, nil)
+
+	if ok := d.send(testMsg1); !ok {
+		t.Fatalf("first send should succeed")
+	}
+	// Channel is full; second send drops and increments the counter.
+	if ok := d.send(testMsg1); ok {
+		t.Fatalf("second send should have been dropped")
+	}
+	// Drain.
+	<-c
+	// Third send succeeds and carries NumSkippedLogs=1.
+	if ok := d.send(testMsg1); !ok {
+		t.Fatalf("third send should succeed")
+	}
+	got := <-c
+	if got.NumSkippedLogs != 1 {
+		t.Errorf("NumSkippedLogs = %d, want 1", got.NumSkippedLogs)
+	}
+	// Counter resets after being reported.
+	if ok := d.send(testMsg1); !ok {
+		t.Fatalf("fourth send should succeed")
+	}
+	got = <-c
+	if got.NumSkippedLogs != 0 {
+		t.Errorf("NumSkippedLogs not reset after reporting; got %d", got.NumSkippedLogs)
+	}
+}
+
+// TestStreamDestinationNoDropBlocks verifies that disableLogDropping makes
+// the destination block instead of dropping when the channel is full.
+func TestStreamDestinationNoDropBlocks(t *testing.T) {
+	c := make(chan queuedLog, 1)
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close() })
+	t.Cleanup(func() { _ = pw.Close() })
+	d := newStreamDestination(logrus.InfoLevel, pw, c, true, nil)
+
+	if ok := d.send(testMsg1); !ok {
+		t.Fatalf("first send should succeed")
+	}
+	done := make(chan bool, 1)
+	go func() {
+		done <- d.send(testMsg2)
+	}()
+	// Give the goroutine a chance to block.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatalf("second send should have blocked")
+	default:
+	}
+	// Drain to unblock.
+	if got := <-c; !bytes.Equal(got.Message, testMsg1.Message) {
+		t.Fatalf("got msg1=%q, want %q", got.Message, testMsg1.Message)
+	}
+	if got := <-c; !bytes.Equal(got.Message, testMsg2.Message) {
+		t.Fatalf("got msg2=%q, want %q", got.Message, testMsg2.Message)
+	}
+	if !<-done {
+		t.Fatalf("blocked send should ultimately succeed")
+	}
+}
+
+// TestStreamDestinationLoopWritesAndFlushes verifies that the background
+// writer drains the channel, propagates dropped-log markers, and signals
+// WaitGroups for flush-on-fatal flows.
+func TestStreamDestinationLoopWritesAndFlushes(t *testing.T) {
+	c := make(chan queuedLog, 4)
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close() })
+	d := newStreamDestination(logrus.InfoLevel, pw, c, false, nil)
+
+	go d.loopWritingLogs()
+	t.Cleanup(func() { close(c) })
+
+	readMsg := func() string {
+		b := make([]byte, 1024)
+		n, err := pr.Read(b)
+		if err != nil {
+			t.Fatalf("pipe read: %v", err)
+		}
+		return string(b[:n])
+	}
+
+	// Normal message.
+	c <- testMsg1
+	if got := readMsg(); got != "Message" {
+		t.Errorf("got %q, want %q", got, "Message")
+	}
+
+	// Skipped-logs marker emitted ahead of the message.
+	c <- queuedLog{
+		Level:          logrus.InfoLevel,
+		Message:        []byte("Message"),
+		NumSkippedLogs: 1,
+	}
+	if got := readMsg(); got != "... dropped 1 logs ...\n" {
+		t.Errorf("drop marker: got %q", got)
+	}
+	if got := readMsg(); got != "Message" {
+		t.Errorf("after-drop message: got %q", got)
+	}
+
+	// WaitGroup is signalled when the message is written.
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	c <- queuedLog{
+		Level:     logrus.InfoLevel,
+		Message:   []byte("Message"),
+		WaitGroup: wg,
+	}
+	_ = readMsg()
+	wg.Wait() // would block forever if not signalled
+}
+
+// mockSyslogWriter implements syslogWriter on top of an io.PipeWriter, with
+// a prefix per level so tests can verify level mapping.
+type mockSyslogWriter struct{ w *io.PipeWriter }
+
+func (s mockSyslogWriter) Debug(m string) error {
+	_, err := fmt.Fprintf(s.w, "DEBUG %s", m)
+	return err
+}
+func (s mockSyslogWriter) Info(m string) error { _, err := fmt.Fprintf(s.w, "INFO %s", m); return err }
+func (s mockSyslogWriter) Warning(m string) error {
+	_, err := fmt.Fprintf(s.w, "WARNING %s", m)
+	return err
+}
+func (s mockSyslogWriter) Err(m string) error { _, err := fmt.Fprintf(s.w, "ERROR %s", m); return err }
+func (s mockSyslogWriter) Crit(m string) error {
+	_, err := fmt.Fprintf(s.w, "CRITICAL %s", m)
+	return err
+}
+
+// TestSyslogDestinationLevelMapping verifies that each logrus level is
+// translated to the right syslog severity prefix.
+func TestSyslogDestinationLevelMapping(t *testing.T) {
+	cases := []struct {
+		level logrus.Level
+		want  string
+	}{
+		{logrus.DebugLevel, "DEBUG"},
+		{logrus.InfoLevel, "INFO"},
+		{logrus.WarnLevel, "WARNING"},
+		{logrus.ErrorLevel, "ERROR"},
+		{logrus.FatalLevel, "CRITICAL"},
+		{logrus.PanicLevel, "CRITICAL"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			ch := make(chan queuedLog, 1)
+			pr, pw := io.Pipe()
+			t.Cleanup(func() { _ = pr.Close() })
+			d := newSyslogDestination(c.level, mockSyslogWriter{w: pw}, ch, false, nil)
+			go d.loopWritingLogs()
+			t.Cleanup(func() { close(ch) })
+
+			ql := testMsg1
+			ql.Level = c.level
+			if ok := d.send(ql); !ok {
+				t.Fatalf("send should succeed")
+			}
+
+			b := make([]byte, 1024)
+			n, err := pr.Read(b)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			got := string(b[:n])
+			want := c.want + " syslog message"
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestBackgroundHookDebugRegexpFilter verifies that the debug-filename regex
+// filters debug logs based on the caller's source file.
+func TestBackgroundHookDebugRegexpFilter(t *testing.T) {
+	ch := make(chan queuedLog, 10)
+	d := &destination{level: logrus.DebugLevel, channel: ch}
+
+	re := regexp.MustCompile("another_caller_for_test")
+	bh := newBackgroundHook(logrus.AllLevels, logrus.DebugLevel, "", []*destination{d}, re, nil)
+
+	// Build a logger that runs through our hook with our formatter.
+	lg := logrus.New()
+	lg.SetFormatter(newFormatter(""))
+	lg.SetOutput(&nullWriter{})
+	lg.AddHook(bh)
+	lg.SetLevel(logrus.DebugLevel)
+
+	// Debug from THIS file (internal_test.go) should NOT match the regex.
+	lg.Debug("from this file")
+	select {
+	case ql := <-ch:
+		t.Errorf("debug from this file unexpectedly emitted: %s", string(ql.Message))
+	case <-time.After(20 * time.Millisecond):
+		// good
+	}
+
+	// Debug from the other test-helper file should match and pass through.
+	// We populate entry.Caller explicitly so the regex sees the test helper's
+	// file (the BackgroundHook's stack walk would otherwise skip past
+	// helpers that live inside the log package itself).
+	lg.SetReportCaller(true)
+	t.Cleanup(func() { lg.SetReportCaller(false) })
+	debugFromAnotherCaller(lg, "from other file")
+	lg.SetReportCaller(false)
+	select {
+	case ql := <-ch:
+		if !bytes.Contains(ql.Message, []byte("from other file")) {
+			t.Errorf("unexpected message: %s", string(ql.Message))
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("debug from matching file did not emit")
+	}
+
+	// Info should pass regardless of the debug regex.
+	lg.Info("info from this file")
+	select {
+	case ql := <-ch:
+		if !bytes.Contains(ql.Message, []byte("info from this file")) {
+			t.Errorf("info had wrong message: %s", string(ql.Message))
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("info was unexpectedly filtered")
+	}
+}
+
+// TestBackgroundHookFatalBlocksForFlush verifies that Panic/Fatal logs carry
+// a WaitGroup that callers can use to block until the log is written.
+func TestBackgroundHookFatalBlocksForFlush(t *testing.T) {
+	ch := make(chan queuedLog, 1)
+	d := &destination{level: logrus.DebugLevel, channel: ch}
+	bh := newBackgroundHook(logrus.AllLevels, logrus.DebugLevel, "", []*destination{d}, nil, nil)
+
+	lg := logrus.New()
+	lg.SetFormatter(newFormatter(""))
+	lg.SetOutput(&nullWriter{})
+	lg.AddHook(bh)
+	lg.ExitFunc = func(code int) {} // disable os.Exit on Fatal
+
+	emitted := make(chan struct{})
+	go func() {
+		defer close(emitted)
+		// Panic logs trigger the wait-group path; recover so the test stays alive.
+		defer func() { _ = recover() }()
+		lg.Panic("flush me")
+	}()
+
+	var ql queuedLog
+	select {
+	case ql = <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("hook did not deliver Panic log")
+	}
+	if ql.WaitGroup == nil {
+		t.Fatalf("Panic log should carry a WaitGroup for flush coordination")
+	}
+	// emitted goroutine should still be blocked waiting on WaitGroup.
+	select {
+	case <-emitted:
+		t.Fatalf("emitter unblocked before WaitGroup.Done")
+	case <-time.After(20 * time.Millisecond):
+		// good
+	}
+	ql.WaitGroup.Done()
+	select {
+	case <-emitted:
+	case <-time.After(time.Second):
+		t.Fatalf("emitter did not unblock after WaitGroup.Done")
+	}
+}
+
+// TestBackgroundHookForceFlushField verifies that the FieldForceFlush field
+// triggers the same flush-blocking behavior as Fatal/Panic, without escalating
+// the level.
+func TestBackgroundHookForceFlushField(t *testing.T) {
+	ch := make(chan queuedLog, 1)
+	d := &destination{level: logrus.DebugLevel, channel: ch}
+	bh := newBackgroundHook(logrus.AllLevels, logrus.DebugLevel, "", []*destination{d}, nil, nil)
+
+	lg := logrus.New()
+	lg.SetFormatter(newFormatter(""))
+	lg.SetOutput(&nullWriter{})
+	lg.AddHook(bh)
+
+	emitted := make(chan struct{})
+	go func() {
+		defer close(emitted)
+		lg.WithField(FieldForceFlush, true).Info("flush me")
+	}()
+
+	var ql queuedLog
+	select {
+	case ql = <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("hook did not deliver flush log")
+	}
+	if ql.WaitGroup == nil {
+		t.Fatalf("FieldForceFlush log should carry a WaitGroup")
+	}
+	select {
+	case <-emitted:
+		t.Fatalf("emitter unblocked before WaitGroup.Done")
+	case <-time.After(20 * time.Millisecond):
+	}
+	ql.WaitGroup.Done()
+	<-emitted
+}
+
+// TestBackgroundHookNoFlushByDefault verifies that ordinary Info logs do NOT
+// carry a WaitGroup and emitters do not block waiting for the destination.
+func TestBackgroundHookNoFlushByDefault(t *testing.T) {
+	ch := make(chan queuedLog, 1)
+	d := &destination{level: logrus.DebugLevel, channel: ch}
+	bh := newBackgroundHook(logrus.AllLevels, logrus.DebugLevel, "", []*destination{d}, nil, nil)
+
+	lg := logrus.New()
+	lg.SetFormatter(newFormatter(""))
+	lg.SetOutput(&nullWriter{})
+	lg.AddHook(bh)
+
+	emitted := make(chan struct{})
+	go func() {
+		defer close(emitted)
+		lg.Info("no flush")
+	}()
+	select {
+	case <-emitted:
+	case <-time.After(time.Second):
+		t.Fatalf("emitter blocked on Info log")
+	}
+	select {
+	case ql := <-ch:
+		if ql.WaitGroup != nil {
+			t.Errorf("ordinary Info should not carry a WaitGroup")
+		}
+	default:
+		t.Errorf("Info log was not delivered to destination")
+	}
+}
+
+// mockFormatter is a logrus.Formatter that just counts invocations and
+// captures the last entry; used by the rate-limited logger table tests.
+type mockFormatter struct {
+	count atomic.Int32
+	entry *logrus.Entry
+}
+
+func (m *mockFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	m.count.Add(1)
+	m.entry = e
+	return nil, nil
+}
+
+// TestRateLimitedLoggerComprehensive covers the full matrix of emit methods
+// against the throttling, burst, force, and field-propagation behavior of
+// the rate-limited logger. Equivalent to the libcalico-go DescribeTable.
+func TestRateLimitedLoggerComprehensive(t *testing.T) {
+	type entry struct {
+		name           string
+		expectedLevel  logrus.Level
+		testLevelGuard bool
+		fn             func(l Logger)
+	}
+	entries := []entry{
+		{"Debug", logrus.DebugLevel, true, func(l Logger) { l.Debug("log", "now") }},
+		{"Print", logrus.InfoLevel, false, func(l Logger) { l.Print("log", "now") }},
+		{"Info", logrus.InfoLevel, true, func(l Logger) { l.Info("log", "now") }},
+		{"Warn", logrus.WarnLevel, true, func(l Logger) { l.Warn("log", "now") }},
+		{"Warning", logrus.WarnLevel, true, func(l Logger) { l.Warning("log", "now") }},
+		{"Error", logrus.ErrorLevel, true, func(l Logger) { l.Error("log", "now") }},
+		{"Debugf", logrus.DebugLevel, true, func(l Logger) { l.Debugf("log %s", "hello") }},
+		{"Printf", logrus.InfoLevel, false, func(l Logger) { l.Printf("log %s", "hello") }},
+		{"Infof", logrus.InfoLevel, true, func(l Logger) { l.Infof("log %s", "hello") }},
+		{"Warnf", logrus.WarnLevel, true, func(l Logger) { l.Warnf("log %s", "hello") }},
+		{"Warningf", logrus.WarnLevel, true, func(l Logger) { l.Warningf("log %s", "hello") }},
+		{"Errorf", logrus.ErrorLevel, true, func(l Logger) { l.Errorf("log %s", "hello") }},
+		{"Debugln", logrus.DebugLevel, true, func(l Logger) { l.Debugln("log", "now") }},
+		{"Println", logrus.InfoLevel, false, func(l Logger) { l.Println("log", "now") }},
+		{"Infoln", logrus.InfoLevel, true, func(l Logger) { l.Infoln("log", "now") }},
+		{"Warnln", logrus.WarnLevel, true, func(l Logger) { l.Warnln("log", "now") }},
+		{"Warningln", logrus.WarnLevel, true, func(l Logger) { l.Warningln("log", "now") }},
+		{"Errorln", logrus.ErrorLevel, true, func(l Logger) { l.Errorln("log", "now") }},
+	}
+	for _, c := range entries {
+		t.Run(c.name, func(t *testing.T) {
+			counter := &mockFormatter{}
+			lr := &logrus.Logger{
+				Out:       os.Stderr,
+				Formatter: counter,
+				Hooks:     make(logrus.LevelHooks),
+				Level:     logrus.DebugLevel,
+			}
+			impl := &logrusLogger{entry: logrus.NewEntry(lr)}
+			rl := NewRateLimitedLogger(WithInterval(200*time.Millisecond), WithBaseLogger(impl))
+			rl = rl.WithError(errors.New("error"))
+			rl = rl.WithField("a", 1)
+			rl = rl.WithFields(Fields{"b": 2, "c": "3"})
+
+			// Level filtering: lowering the level below the call's level should
+			// suppress emission entirely.
+			if c.testLevelGuard {
+				for lvl := c.expectedLevel - 1; lvl > logrus.PanicLevel; lvl-- {
+					lr.SetLevel(lvl)
+					c.fn(rl)
+				}
+				lr.SetLevel(logrus.DebugLevel)
+			}
+
+			// First processed log emits.
+			c.fn(rl.WithError(errors.New("error")))
+			if got := counter.count.Load(); got != 1 {
+				t.Fatalf("count after first log = %d, want 1", got)
+			}
+			data := counter.entry.Data
+			for k, want := range map[string]any{"a": 1, "b": 2, "c": "3"} {
+				if data[k] != want {
+					t.Errorf("field %s = %v, want %v", k, data[k], want)
+				}
+			}
+			if _, ok := data["error"]; !ok {
+				t.Errorf("expected 'error' field on first emit")
+			}
+			if _, ok := data[fieldLogSkipped]; ok {
+				t.Errorf("first emit should not have %q field", fieldLogSkipped)
+			}
+			if _, ok := data[fieldLogNextLog]; !ok {
+				t.Errorf("first emit should have %q field", fieldLogNextLog)
+			}
+
+			// Next two within the interval are throttled.
+			c.fn(rl.WithField("a", 1))
+			c.fn(rl.WithField("a", 1))
+			if got := counter.count.Load(); got != 1 {
+				t.Fatalf("count after throttled = %d, want 1", got)
+			}
+
+			// After the interval, the next log emits and reports logsSkipped.
+			time.Sleep(220 * time.Millisecond)
+			c.fn(rl.WithFields(Fields{"b": 2, "c": "3"}))
+			if got := counter.count.Load(); got != 2 {
+				t.Fatalf("count after interval = %d, want 2", got)
+			}
+			if got, ok := counter.entry.Data[fieldLogSkipped]; !ok || got != 2 {
+				t.Errorf("logsSkipped = %v (ok=%v), want 2", got, ok)
+			}
+
+			// Force bypasses throttling on the immediate next emit.
+			c.fn(Force(rl))
+			if got := counter.count.Load(); got != 3 {
+				t.Fatalf("count after Force = %d, want 3", got)
+			}
+			if _, ok := counter.entry.Data[fieldLogSkipped]; ok {
+				t.Errorf("Force emit should not carry %q field", fieldLogSkipped)
+			}
+			if counter.entry.Level != c.expectedLevel {
+				t.Errorf("Force emit level = %v, want %v", counter.entry.Level, c.expectedLevel)
+			}
+
+			// Burst behavior.
+			counter.count.Store(0)
+			rl = NewRateLimitedLogger(
+				WithInterval(200*time.Millisecond),
+				WithBurst(2),
+				WithBaseLogger(impl),
+			)
+			c.fn(rl) // first emit, resets
+			c.fn(rl) // burst 1
+			c.fn(rl) // burst 2 (carries nextLog because burst remainder is now 0)
+			c.fn(rl) // throttled
+			c.fn(rl) // throttled
+			if got := counter.count.Load(); got != 3 {
+				t.Fatalf("burst count = %d, want 3", got)
+			}
+			time.Sleep(220 * time.Millisecond)
+			c.fn(rl) // resets again, reports logsSkipped=2
+			if got, ok := counter.entry.Data[fieldLogSkipped]; !ok || got != 2 {
+				t.Errorf("burst-reset logsSkipped = %v, want 2", got)
+			}
+		})
+	}
+}
+
+// FuzzAppendTime fuzzes the appendTime helper against the stdlib's
+// time.AppendFormat to ensure they agree byte-for-byte. This guards the
+// optimized hot-path formatter against drifts in RFC3339Nano internals.
+func FuzzAppendTime(f *testing.F) {
+	pool := sync.Pool{New: func() any { return &bytes.Buffer{} }}
+	const layout = "2006-01-02 15:04:05.000"
+
+	f.Add(int(time.Time{}.Unix()), int(time.Time{}.Nanosecond()))
+	f.Add(0, 0)
+	f.Add(1257894000, 0)
+	f.Add(1257894000, 1)
+	f.Add(1257894000, 100)
+	f.Add(1257894000, 1000)
+	f.Add(1257894000, 10000)
+	f.Add(1257894000, 100000)
+	f.Add(1257894000, 112345)
+
+	check := func(t *testing.T, tv time.Time) {
+		b1 := pool.Get().(*bytes.Buffer)
+		b2 := pool.Get().(*bytes.Buffer)
+		defer pool.Put(b1)
+		defer pool.Put(b2)
+		b1.Write(tv.AppendFormat(b1.AvailableBuffer(), layout))
+		appendTime(b2, tv)
+		if !bytes.Equal(b1.Bytes(), b2.Bytes()) {
+			t.Fatalf("mismatch at %v:\n  stdlib: %s\n  ours:   %s", tv, b1.String(), b2.String())
+		}
+		b1.Reset()
+		b2.Reset()
+	}
+
+	f.Fuzz(func(t *testing.T, secs, nanos int) {
+		tv := time.Unix(int64(secs), int64(nanos))
+		check(t, tv)
+		check(t, tv.UTC())
+	})
+}

--- a/lib/std/log/log_test.go
+++ b/lib/std/log/log_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/projectcalico/calico/lib/std/log"
+)
+
+// captureOutput swaps the package output to a bytes.Buffer for the duration
+// of the test and returns a function to read what was logged. Tests live in
+// package log_test so that caller detection correctly treats this file as
+// user code.
+func captureOutput(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetLevel(log.DebugLevel)
+	log.SetComponent("")
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetOutput(io.Discard)
+		log.SetOutput(os.Stdout)
+	})
+	return func() string { return buf.String() }
+}
+
+func TestFormatterMatchesLegacyShape(t *testing.T) {
+	read := captureOutput(t)
+	log.Info("hello")
+	out := read()
+	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} \[INFO\]\[\d+\] log_test\.go \d+: hello\n$`)
+	if !re.MatchString(out) {
+		t.Fatalf("log line did not match expected format:\nout: %q\nre:  %s", out, re.String())
+	}
+}
+
+func TestWithFieldEmitsSortedKVs(t *testing.T) {
+	read := captureOutput(t)
+	log.WithFields(log.Fields{"b": 2, "a": "one", "c": errors.New("boom")}).Info("msg")
+	out := read()
+	if !strings.Contains(out, ` a="one" b=2 c=boom`) {
+		t.Fatalf("fields not in sorted order or wrong rendering: %q", out)
+	}
+}
+
+func TestNewComponentPrefixesFilename(t *testing.T) {
+	read := captureOutput(t)
+	log.New("calc").Info("hi")
+	out := read()
+	if !strings.Contains(out, " calc/log_test.go ") {
+		t.Fatalf("expected component prefix on file name, got: %q", out)
+	}
+}
+
+func TestCallerSkipsWrapper(t *testing.T) {
+	read := captureOutput(t)
+	log.New("test-comp").WithField("k", "v").Info("through wrapper")
+	out := read()
+	if strings.Contains(out, "impl_logrus.go") || strings.Contains(out, "default.go") {
+		t.Fatalf("formatter reported wrapper as caller: %q", out)
+	}
+	if !strings.Contains(out, "log_test.go") {
+		t.Fatalf("formatter did not report user file as caller: %q", out)
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want log.Level
+	}{
+		{"panic", log.PanicLevel},
+		{"fatal", log.FatalLevel},
+		{"error", log.ErrorLevel},
+		{"warn", log.WarnLevel},
+		{"warning", log.WarnLevel},
+		{"info", log.InfoLevel},
+		{"debug", log.DebugLevel},
+		{"trace", log.TraceLevel},
+		{"INFO", log.InfoLevel},
+	}
+	for _, c := range cases {
+		got, err := log.ParseLevel(c.in)
+		if err != nil {
+			t.Errorf("ParseLevel(%q) errored: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseLevel(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+	if _, err := log.ParseLevel("nope"); err == nil {
+		t.Errorf("ParseLevel('nope') should have errored")
+	}
+}
+
+func TestRateLimitedLoggerThrottles(t *testing.T) {
+	read := captureOutput(t)
+	rl := log.NewRateLimitedLogger(log.WithInterval(time.Hour))
+	rl.Info("first")
+	rl.Info("second")
+	rl.Info("third")
+	out := read()
+	if strings.Count(out, "first") != 1 {
+		t.Errorf("first log should have emitted once:\n%s", out)
+	}
+	if strings.Contains(out, "second") || strings.Contains(out, "third") {
+		t.Errorf("throttled logs should not have emitted:\n%s", out)
+	}
+}
+
+func TestRateLimitedLoggerForceBypasses(t *testing.T) {
+	read := captureOutput(t)
+	rl := log.NewRateLimitedLogger(log.WithInterval(time.Hour))
+	rl.Info("first")
+	rl.Info("throttled")
+	log.Force(rl).Info("forced")
+	out := read()
+	if !strings.Contains(out, "first") || !strings.Contains(out, "forced") {
+		t.Fatalf("first and forced should both appear:\n%s", out)
+	}
+	if strings.Contains(out, "throttled") {
+		t.Fatalf("throttled message should not appear:\n%s", out)
+	}
+}
+
+func TestIsSensitiveParam(t *testing.T) {
+	for _, name := range []string{"Password", "API_TOKEN", "etcdKey", "AuthSecret", "kubeconfig"} {
+		if !log.IsSensitiveParam(name) {
+			t.Errorf("IsSensitiveParam(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"CertFile", "EtcdKeyFile", "KubeconfigPath", "Endpoints", "LogLevel"} {
+		if log.IsSensitiveParam(name) {
+			t.Errorf("IsSensitiveParam(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://user:secret@host.example/path", "https://user:xxxxx@host.example/path"},
+		{"https://host.example/path?token=abcdef", "https://host.example/path"},
+		{"https://host.example/p#frag", "https://host.example/p"},
+	}
+	for _, c := range cases {
+		if got := log.RedactURL(c.in); got != c.want {
+			t.Errorf("RedactURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/lib/std/log/logger.go
+++ b/lib/std/log/logger.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package log is the Calico standard logging package. Callers depend only on
+// the Logger interface defined here; the concrete implementation (currently
+// logrus) is hidden.
+//
+// See DESIGN.md for the package contract, configuration model, and migration plan.
+package log
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Logger is the primary interface for emitting log lines.
+type Logger interface {
+	Trace(args ...any)
+	Tracef(format string, args ...any)
+	Debug(args ...any)
+	Debugf(format string, args ...any)
+	Info(args ...any)
+	Infof(format string, args ...any)
+	Warn(args ...any)
+	Warnf(format string, args ...any)
+	// Warning is an alias of Warn for API compatibility with logrus call sites.
+	Warning(args ...any)
+	// Warningf is an alias of Warnf for API compatibility with logrus call sites.
+	Warningf(format string, args ...any)
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Panic(args ...any)
+	Panicf(format string, args ...any)
+
+	// Print/Printf/Println emit at Info level (stdlib-shaped API).
+	Print(args ...any)
+	Printf(format string, args ...any)
+	Println(args ...any)
+
+	// *ln variants match logrus's Println-style helpers.
+	Debugln(args ...any)
+	Infoln(args ...any)
+	Warnln(args ...any)
+	Warningln(args ...any)
+	Errorln(args ...any)
+	Fatalln(args ...any)
+	Panicln(args ...any)
+
+	// WithField returns a new Logger with the given field attached.
+	WithField(key string, value any) Logger
+	// WithFields returns a new Logger with the given fields attached.
+	WithFields(fields Fields) Logger
+	// WithError returns a new Logger with the error attached under a standard key.
+	WithError(err error) Logger
+
+	// Level returns the lowest severity this logger will emit.
+	Level() Level
+	// IsLevelEnabled reports whether logs at the given level will be emitted.
+	IsLevelEnabled(level Level) bool
+}
+
+// Fields is a set of key/value pairs attached to a log line.
+type Fields = map[string]any
+
+// Level is a log severity level. Values intentionally match logrus.Level ordering
+// so the internal implementation can cast between them; callers must not rely
+// on that fact.
+type Level uint32
+
+const (
+	PanicLevel Level = iota
+	FatalLevel
+	ErrorLevel
+	WarnLevel
+	InfoLevel
+	DebugLevel
+	TraceLevel
+)
+
+// String returns the lowercase name of the level.
+func (l Level) String() string {
+	switch l {
+	case PanicLevel:
+		return "panic"
+	case FatalLevel:
+		return "fatal"
+	case ErrorLevel:
+		return "error"
+	case WarnLevel:
+		return "warning"
+	case InfoLevel:
+		return "info"
+	case DebugLevel:
+		return "debug"
+	case TraceLevel:
+		return "trace"
+	}
+	return "unknown"
+}
+
+// ParseLevel parses a string into a Level. Accepts the same names used by logrus
+// ("panic", "fatal", "error", "warn"/"warning", "info", "debug", "trace").
+func ParseLevel(s string) (Level, error) {
+	switch strings.ToLower(s) {
+	case "panic":
+		return PanicLevel, nil
+	case "fatal":
+		return FatalLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	case "trace":
+		return TraceLevel, nil
+	}
+	return 0, fmt.Errorf("not a valid log level: %q", s)
+}
+
+// SafeParseLevel parses s as a Level. On parse failure it returns PanicLevel
+// and logs a warning. Mirrors libcalico-go's SafeParseLogLevel for migration
+// compatibility.
+func SafeParseLevel(s string) Level {
+	if s == "" {
+		return PanicLevel
+	}
+	level, err := ParseLevel(s)
+	if err != nil {
+		WithField("level", s).Warn("Invalid log level, defaulting to panic")
+		return PanicLevel
+	}
+	return level
+}

--- a/lib/std/log/ratelimited.go
+++ b/lib/std/log/ratelimited.go
@@ -1,0 +1,362 @@
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	fieldLogSkipped = "logsSkipped"
+	fieldLogNextLog = "nextLog"
+	defaultInterval = 5 * time.Minute
+)
+
+// NewRateLimitedLogger returns a Logger that throttles repeated emissions
+// to at most one per interval (default 5 minutes). Derived loggers from
+// WithField/WithFields/WithError share the throttle state with their
+// parent so that adding fields does not reset the throttle. Use Force to
+// bypass the throttle for a single emit.
+//
+// Fatal and Panic always emit — they are terminal, so the rate limit is
+// bypassed.
+//
+// Typical use:
+//
+//	logger := log.NewRateLimitedLogger().WithField("key", myKey)
+//	for !done {
+//	    logger.Infof("Checking some stuff: %s", myStuff)
+//	    done = doSomeStuff()
+//	}
+//	log.Force(logger).Info("Finished checking stuff")
+func NewRateLimitedLogger(opts ...RateLimitedOption) Logger {
+	r := &rateLimitedLogger{
+		data: &intervalData{
+			nextLog:  time.Now(),
+			interval: defaultInterval,
+		},
+		entry: logrus.NewEntry(logrus.StandardLogger()),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// RateLimitedOption configures the Logger returned by NewRateLimitedLogger.
+type RateLimitedOption func(*rateLimitedLogger)
+
+// WithInterval sets the minimum interval between emitted logs.
+// Default is 5 minutes.
+func WithInterval(d time.Duration) RateLimitedOption {
+	return func(r *rateLimitedLogger) { r.data.interval = d }
+}
+
+// WithBurst sets the number of logs that can be emitted in a row before
+// throttling kicks in. Default is 0 (no burst — only one log per interval).
+func WithBurst(n int) RateLimitedOption {
+	return func(r *rateLimitedLogger) {
+		r.data.burst = n
+		r.data.remainingBurst = n
+	}
+}
+
+// WithBaseLogger sets the underlying Logger used to emit. Default is the
+// package default. Useful when the caller has a per-component Logger they
+// want the rate-limited wrapper to inherit fields from.
+//
+// Only Loggers returned by this package (currently *logrusLogger) are
+// supported; passing any other Logger implementation panics. This is
+// deliberate: silently falling back to the package default would hide
+// the caller's intent.
+func WithBaseLogger(l Logger) RateLimitedOption {
+	impl, ok := l.(*logrusLogger)
+	if !ok {
+		panic(fmt.Sprintf("WithBaseLogger: unsupported Logger type %T; only Loggers returned by this package are accepted", l))
+	}
+	return func(r *rateLimitedLogger) {
+		r.entry = impl.entry
+	}
+}
+
+// Force returns a Logger whose next emission bypasses the rate limit if
+// l is a rate-limited logger; otherwise it returns l unchanged. Force
+// does not bypass level filtering.
+func Force(l Logger) Logger {
+	if rl, ok := l.(*rateLimitedLogger); ok {
+		return &rateLimitedLogger{data: rl.data, entry: rl.entry, force: true}
+	}
+	return l
+}
+
+type intervalData struct {
+	nextLog        time.Time
+	interval       time.Duration
+	burst          int
+	skipped        int
+	lock           sync.Mutex
+	remainingBurst int
+}
+
+type rateLimitedLogger struct {
+	data  *intervalData
+	force bool
+	entry *logrus.Entry
+}
+
+func (r *rateLimitedLogger) logEntry() *logrus.Entry {
+	now := time.Now()
+	r.data.lock.Lock()
+	defer r.data.lock.Unlock()
+
+	var shouldLog, shouldReset bool
+	if r.force || now.After(r.data.nextLog) {
+		shouldLog = true
+		shouldReset = true
+	}
+	if r.data.remainingBurst > 0 {
+		shouldLog = true
+		r.data.remainingBurst--
+	}
+
+	if !shouldLog {
+		r.data.skipped++
+		return nil
+	}
+
+	skipped := r.data.skipped
+	if shouldReset {
+		r.force = false
+		r.data.nextLog = now.Add(r.data.interval)
+		r.data.remainingBurst = r.data.burst
+		r.data.skipped = 0
+	}
+
+	entry := r.entry
+	if skipped > 0 || r.data.remainingBurst == 0 {
+		fields := logrus.Fields{}
+		if skipped > 0 {
+			fields[fieldLogSkipped] = skipped
+		}
+		if r.data.remainingBurst == 0 {
+			fields[fieldLogNextLog] = r.data.nextLog
+		}
+		entry = r.entry.WithFields(fields)
+	}
+	return entry
+}
+
+// WithError attaches an error to derived loggers.
+func (r *rateLimitedLogger) WithError(err error) Logger {
+	return &rateLimitedLogger{data: r.data, entry: r.entry.WithError(err)}
+}
+
+// WithField attaches a field to derived loggers.
+func (r *rateLimitedLogger) WithField(key string, value any) Logger {
+	return &rateLimitedLogger{data: r.data, entry: r.entry.WithField(key, value)}
+}
+
+// WithFields attaches fields to derived loggers.
+func (r *rateLimitedLogger) WithFields(fields Fields) Logger {
+	return &rateLimitedLogger{data: r.data, entry: r.entry.WithFields(logrus.Fields(fields))}
+}
+
+func (r *rateLimitedLogger) Trace(args ...any) {
+	if r.level() >= logrus.TraceLevel {
+		if e := r.logEntry(); e != nil {
+			e.Trace(args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Tracef(format string, args ...any) {
+	if r.level() >= logrus.TraceLevel {
+		if e := r.logEntry(); e != nil {
+			e.Tracef(format, args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Debug(args ...any) {
+	if r.level() >= logrus.DebugLevel {
+		if e := r.logEntry(); e != nil {
+			e.Debug(args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Debugf(format string, args ...any) {
+	if r.level() >= logrus.DebugLevel {
+		if e := r.logEntry(); e != nil {
+			e.Debugf(format, args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Info(args ...any) {
+	if r.level() >= logrus.InfoLevel {
+		if e := r.logEntry(); e != nil {
+			e.Info(args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Infof(format string, args ...any) {
+	if r.level() >= logrus.InfoLevel {
+		if e := r.logEntry(); e != nil {
+			e.Infof(format, args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Warn(args ...any) {
+	if r.level() >= logrus.WarnLevel {
+		if e := r.logEntry(); e != nil {
+			e.Warn(args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Warnf(format string, args ...any) {
+	if r.level() >= logrus.WarnLevel {
+		if e := r.logEntry(); e != nil {
+			e.Warnf(format, args...)
+		}
+	}
+}
+
+// Warning is an alias of Warn for API compatibility with logrus call sites.
+func (r *rateLimitedLogger) Warning(args ...any) { r.Warn(args...) }
+
+// Warningf is an alias of Warnf for API compatibility with logrus call sites.
+func (r *rateLimitedLogger) Warningf(format string, args ...any) { r.Warnf(format, args...) }
+
+func (r *rateLimitedLogger) Error(args ...any) {
+	if r.level() >= logrus.ErrorLevel {
+		if e := r.logEntry(); e != nil {
+			e.Error(args...)
+		}
+	}
+}
+
+func (r *rateLimitedLogger) Errorf(format string, args ...any) {
+	if r.level() >= logrus.ErrorLevel {
+		if e := r.logEntry(); e != nil {
+			e.Errorf(format, args...)
+		}
+	}
+}
+
+// Fatal emits and terminates the process. Always emits — rate limiting
+// is bypassed because Fatal is terminal.
+func (r *rateLimitedLogger) Fatal(args ...any) { r.entry.Fatal(args...) }
+
+// Fatalf emits and terminates the process. Always emits.
+func (r *rateLimitedLogger) Fatalf(format string, args ...any) { r.entry.Fatalf(format, args...) }
+
+// Panic emits and panics. Always emits — rate limiting is bypassed
+// because Panic is terminal.
+func (r *rateLimitedLogger) Panic(args ...any) { r.entry.Panic(args...) }
+
+// Panicf emits and panics. Always emits.
+func (r *rateLimitedLogger) Panicf(format string, args ...any) { r.entry.Panicf(format, args...) }
+
+// Print emits at Info level without applying level filtering; useful for
+// callers that integrate with the standard library's log.Logger contract.
+func (r *rateLimitedLogger) Print(args ...any) {
+	if e := r.logEntry(); e != nil {
+		e.Print(args...)
+	}
+}
+
+// Printf emits at Info level without applying level filtering.
+func (r *rateLimitedLogger) Printf(format string, args ...any) {
+	if e := r.logEntry(); e != nil {
+		e.Printf(format, args...)
+	}
+}
+
+// Println emits at Info level without applying level filtering.
+func (r *rateLimitedLogger) Println(args ...any) {
+	if e := r.logEntry(); e != nil {
+		e.Println(args...)
+	}
+}
+
+// Debugln matches logrus's Println-style emit at Debug level.
+func (r *rateLimitedLogger) Debugln(args ...any) {
+	if r.level() >= logrus.DebugLevel {
+		if e := r.logEntry(); e != nil {
+			e.Debugln(args...)
+		}
+	}
+}
+
+// Infoln matches logrus's Println-style emit at Info level.
+func (r *rateLimitedLogger) Infoln(args ...any) {
+	if r.level() >= logrus.InfoLevel {
+		if e := r.logEntry(); e != nil {
+			e.Infoln(args...)
+		}
+	}
+}
+
+// Warnln matches logrus's Println-style emit at Warn level.
+func (r *rateLimitedLogger) Warnln(args ...any) {
+	if r.level() >= logrus.WarnLevel {
+		if e := r.logEntry(); e != nil {
+			e.Warnln(args...)
+		}
+	}
+}
+
+// Warningln is an alias of Warnln for API compatibility with logrus.
+func (r *rateLimitedLogger) Warningln(args ...any) { r.Warnln(args...) }
+
+// Errorln matches logrus's Println-style emit at Error level.
+func (r *rateLimitedLogger) Errorln(args ...any) {
+	if r.level() >= logrus.ErrorLevel {
+		if e := r.logEntry(); e != nil {
+			e.Errorln(args...)
+		}
+	}
+}
+
+// Fatalln emits and terminates the process. Always emits.
+func (r *rateLimitedLogger) Fatalln(args ...any) { r.entry.Fatalln(args...) }
+
+// Panicln emits and panics. Always emits.
+func (r *rateLimitedLogger) Panicln(args ...any) { r.entry.Panicln(args...) }
+
+// Level returns the underlying logger's level.
+func (r *rateLimitedLogger) Level() Level {
+	return Level(r.level())
+}
+
+// IsLevelEnabled reports whether the given level would be emitted.
+func (r *rateLimitedLogger) IsLevelEnabled(level Level) bool {
+	return logrus.Level(level) <= r.level()
+}
+
+// level returns the underlying logger's level via an atomic read, mirroring
+// logrus's own non-exported helper.
+func (r *rateLimitedLogger) level() logrus.Level {
+	return logrus.Level(atomic.LoadUint32((*uint32)(&r.entry.Logger.Level)))
+}

--- a/lib/std/log/redact.go
+++ b/lib/std/log/redact.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"net/url"
+	"strings"
+)
+
+// sensitiveSubstrings are substrings that, when found in a lowercased config
+// parameter name, indicate the value may contain credentials.
+var sensitiveSubstrings = []string{
+	"password", "passwd", "passphrase",
+	"token", "bearer",
+	"secret",
+	"credential",
+	"authorization",
+	"cookie",
+	"private",
+}
+
+// sensitiveSuffixes are suffixes that indicate inline key/cert material (as
+// opposed to file paths like "keyfile" or "certpath").
+var sensitiveSuffixes = []string{"key", "cert", "kubeconfig", "kubeconfiginline"}
+
+// IsSensitiveParam reports whether a configuration parameter name suggests its
+// value may contain credentials or key material. Parameters whose names end
+// in "file" or "path" are assumed to be filesystem paths (not inline secrets)
+// and are excluded.
+func IsSensitiveParam(name string) bool {
+	lower := strings.ToLower(name)
+	if strings.HasSuffix(lower, "file") || strings.HasSuffix(lower, "path") {
+		return false
+	}
+	for _, sub := range sensitiveSubstrings {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	for _, suffix := range sensitiveSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactURL parses a URL string and returns a redacted form that masks any
+// userinfo password while preserving the scheme, host, port, and path.
+// Query strings and fragments are stripped because they may carry credentials
+// (e.g. ?token=, ?X-Amz-Signature=) that url.Redacted() does not handle.
+// Returns "<invalid-url>" if the URL cannot be parsed.
+func RedactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.Redacted()
+}

--- a/lib/std/log/rotating_file_linux.go
+++ b/lib/std/log/rotating_file_linux.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+// rotatingFile is an io.WriteCloser that follows external log rotation: when
+// the file at its path is renamed or deleted (e.g. by logrotate), the next
+// Write reopens at the original path so subsequent log lines land in the new
+// file rather than the now-detached inode.
+//
+// Detection is by inode comparison via stat() on each Write. That's one
+// extra syscall per log line — fine for the volumes log files see, and
+// avoids depending on inotify or external libraries.
+type rotatingFile struct {
+	path string
+	perm os.FileMode
+
+	mu  sync.Mutex
+	f   *os.File
+	ino uint64
+}
+
+func newRotatingFile(path string, perm os.FileMode) (*rotatingFile, error) {
+	r := &rotatingFile{path: path, perm: perm}
+	if err := r.open(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// open opens (or creates) the file at r.path and records its inode.
+// Caller must hold r.mu, or be in a constructor before the writer is shared.
+func (r *rotatingFile) open() error {
+	f, err := os.OpenFile(r.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, r.perm)
+	if err != nil {
+		return err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	r.f = f
+	r.ino = inodeOf(info)
+	return nil
+}
+
+// Write writes p to the underlying file, reopening first if the path now
+// points to a different inode (rotation happened) or no longer exists.
+func (r *rotatingFile) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info, err := os.Stat(r.path); err == nil {
+		if inodeOf(info) != r.ino {
+			_ = r.f.Close()
+			if err := r.open(); err != nil {
+				return 0, err
+			}
+		}
+	} else if os.IsNotExist(err) {
+		_ = r.f.Close()
+		if err := r.open(); err != nil {
+			return 0, err
+		}
+	}
+	// Other stat errors (permission, transient IO): write through the
+	// current handle and let the write itself surface the failure.
+
+	return r.f.Write(p)
+}
+
+// Close closes the underlying file handle.
+func (r *rotatingFile) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.f.Close()
+}
+
+// inodeOf extracts the inode number from a stat result. Linux always
+// returns *syscall.Stat_t from FileInfo.Sys(), so the type assertion is
+// safe; the fallback exists only for the impossible case of a stale info
+// object.
+func inodeOf(info os.FileInfo) uint64 {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return stat.Ino
+	}
+	return 0
+}

--- a/lib/std/log/rotating_file_linux_test.go
+++ b/lib/std/log/rotating_file_linux_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRotatingFileFollowsRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := newRotatingFile(path, 0644)
+	if err != nil {
+		t.Fatalf("newRotatingFile: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if _, err := w.Write([]byte("before-rotate\n")); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	// Simulate logrotate: rename current file aside.
+	rotated := path + ".1"
+	if err := os.Rename(path, rotated); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// Next write should reopen at the original path.
+	if _, err := w.Write([]byte("after-rotate\n")); err != nil {
+		t.Fatalf("post-rotate Write: %v", err)
+	}
+
+	// The rotated file should contain only the pre-rotate line.
+	got, err := os.ReadFile(rotated)
+	if err != nil {
+		t.Fatalf("read rotated: %v", err)
+	}
+	if string(got) != "before-rotate\n" {
+		t.Errorf("rotated file: want %q, got %q", "before-rotate\n", string(got))
+	}
+
+	// The original path should contain only the post-rotate line.
+	got, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read post-rotate: %v", err)
+	}
+	if string(got) != "after-rotate\n" {
+		t.Errorf("new file: want %q, got %q", "after-rotate\n", string(got))
+	}
+}
+
+func TestRotatingFileReopensWhenDeleted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := newRotatingFile(path, 0644)
+	if err != nil {
+		t.Fatalf("newRotatingFile: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if _, err := w.Write([]byte("before\n")); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := w.Write([]byte("after\n")); err != nil {
+		t.Fatalf("post-remove Write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "after\n" {
+		t.Errorf("post-remove file: want %q, got %q", "after\n", string(got))
+	}
+}

--- a/lib/std/log/summarizer.go
+++ b/lib/std/log/summarizer.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OpRecorder is the interface a Summarizer satisfies: code in a loop calls
+// RecordOperation as work happens, then EndOfIteration at the end.
+type OpRecorder interface {
+	RecordOperation(name string)
+}
+
+// Summarizer collects per-iteration operation names from a loop and
+// periodically emits one Info-level log line summarising what happened
+// (count of iterations, avg duration, longest iteration's operations).
+//
+// A summary is emitted at most once per minute under normal logging, and on
+// every iteration when debug logging is enabled.
+type Summarizer struct {
+	lock        sync.Mutex
+	lastLogTime time.Time
+
+	currentIteration *iteration
+	iterations       []*iteration
+	loopName         string
+}
+
+var _ OpRecorder = (*Summarizer)(nil)
+
+type iteration struct {
+	Operations []string
+	Duration   time.Duration
+}
+
+func (i *iteration) RecordOperation(name string) {
+	i.Operations = append(i.Operations, name)
+}
+
+// NewSummarizer constructs a Summarizer for the given loop name; the loop
+// name appears verbatim in summary log lines.
+func NewSummarizer(loopName string) *Summarizer {
+	return &Summarizer{
+		currentIteration: &iteration{},
+		lastLogTime:      time.Now(),
+		loopName:         loopName,
+	}
+}
+
+// RecordOperation records a named operation in the current iteration.
+func (s *Summarizer) RecordOperation(name string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.currentIteration.RecordOperation(name)
+}
+
+// EndOfIteration marks the end of one loop iteration. If enough time has
+// passed (or debug is enabled), a summary log line is emitted and the
+// accumulated iterations are reset.
+func (s *Summarizer) EndOfIteration(duration time.Duration) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.currentIteration.Duration = duration
+	s.iterations = append(s.iterations, s.currentIteration)
+	s.currentIteration = &iteration{}
+	if time.Since(s.lastLogTime) > time.Minute || IsLevelEnabled(DebugLevel) {
+		s.doLog()
+		s.iterations = s.iterations[:0]
+		s.lastLogTime = time.Now()
+	}
+}
+
+// DoLog emits a summary using the currently accumulated iterations.
+// Intended for tests; production callers use EndOfIteration, which resets
+// state on a cadence. Successive DoLog calls without an intervening
+// EndOfIteration on its cadence keep growing the elapsed-time window in
+// the emitted line — that's by design, mirroring master's behaviour, and
+// is fine because nothing in production actually calls DoLog.
+func (s *Summarizer) DoLog() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.doLog()
+}
+
+func (s *Summarizer) doLog() {
+	numUpdates := len(s.iterations)
+	var longestIteration *iteration
+	var sumOfDurations time.Duration
+	for _, it := range s.iterations {
+		sumOfDurations += it.Duration
+		if longestIteration == nil || it.Duration > longestIteration.Duration {
+			longestIteration = it
+		}
+	}
+	if longestIteration == nil {
+		return
+	}
+	avgDuration := (sumOfDurations / time.Duration(numUpdates)).Round(time.Millisecond)
+	longestOps := longestIteration.Operations
+	sort.Strings(longestOps)
+	Infof("Summarising %d %s over %v: avg=%v longest=%v (%v)",
+		numUpdates, s.loopName, time.Since(s.lastLogTime).Round(100*time.Millisecond), avgDuration,
+		longestIteration.Duration.Round(time.Millisecond),
+		strings.Join(longestOps, ","))
+}

--- a/lib/std/log/testing.go
+++ b/lib/std/log/testing.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// testingTBWriter adapts a testing.TB into an io.Writer so log output flows
+// into `go test`'s per-test buffer (and shows up only when the test fails
+// or runs with -v).
+type testingTBWriter struct {
+	tb testing.TB
+}
+
+func (w testingTBWriter) Write(p []byte) (int, error) {
+	w.tb.Helper()
+	w.tb.Log(strings.TrimRight(string(p), "\r\n"))
+	return len(p), nil
+}
+
+var testFormatterOnce sync.Once
+
+// RedirectTo configures the log package to write to the given testing.TB.
+// Intended to be called from a test's setup; registers a t.Cleanup() to
+// restore the previous output writer when the test ends.
+//
+// The "test" formatter is installed once per process to avoid clobbering the
+// production formatter between tests; the output writer is what gets swapped
+// per test.
+func RedirectTo(tb testing.TB) {
+	testFormatterOnce.Do(func() {
+		logrus.SetFormatter(newFormatter("test"))
+	})
+	old := logrus.StandardLogger().Out
+	logrus.SetOutput(testingTBWriter{tb: tb})
+	tb.Cleanup(func() {
+		logrus.SetOutput(old)
+	})
+}

--- a/lib/std/profile/profile.go
+++ b/lib/std/profile/profile.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package profile provides runtime profile dumping triggered by OS signals.
+//
+// On Linux, SIGUSR1 dumps a heap profile and SIGUSR2 dumps a 10-second CPU
+// profile, each to a configured path. On non-Linux platforms RegisterHandlers
+// is a no-op (the OS signals don't exist).
+package profile
+
+import (
+	"os"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	"github.com/projectcalico/calico/lib/std/log"
+)
+
+// Options configures the profiling signal handlers. An empty path for either
+// field disables that handler.
+type Options struct {
+	// HeapProfilePath is the destination file for SIGUSR1-triggered heap
+	// dumps. The literal substring "<timestamp>" is replaced with the
+	// current time when each profile is written.
+	HeapProfilePath string
+
+	// CPUProfilePath is the destination file for SIGUSR2-triggered
+	// 10-second CPU profiles. "<timestamp>" is replaced as above.
+	CPUProfilePath string
+}
+
+// DumpHeap writes a heap profile to fileName. "<timestamp>" in fileName is
+// replaced with the current time before opening the file.
+func DumpHeap(fileName string) {
+	logger := log.WithField("file", fileName)
+	logger.Info("Asked to create a memory profile.")
+	fileName = renderFileName(fileName)
+
+	f, err := os.Create(fileName)
+	if err != nil {
+		logger.WithError(err).Error("Could not create memory profile file")
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	logger.Info("Writing memory profile...")
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		logger.WithError(err).Error("Could not write memory profile")
+		return
+	}
+	logger.Info("Finished writing memory profile")
+}
+
+// DumpCPU writes a 10-second CPU profile to fileName. "<timestamp>" in
+// fileName is replaced with the current time before opening the file.
+func DumpCPU(fileName string) {
+	logger := log.WithField("file", fileName)
+	logger.Info("Asked to create a CPU profile.")
+	fileName = renderFileName(fileName)
+
+	f, err := os.Create(fileName)
+	if err != nil {
+		logger.WithError(err).Error("Could not create CPU profile file")
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	logger.Info("Writing CPU profile...")
+	if err := pprof.StartCPUProfile(f); err != nil {
+		logger.WithError(err).Error("Could not start CPU profile")
+		return
+	}
+	defer pprof.StopCPUProfile()
+	time.Sleep(10 * time.Second)
+	logger.Info("Finished writing CPU profile")
+}
+
+func renderFileName(template string) string {
+	if !strings.Contains(template, "<timestamp>") {
+		return template
+	}
+	return strings.Replace(template, "<timestamp>", time.Now().Format("2006-01-02-15:04:05"), 1)
+}

--- a/lib/std/profile/signals_linux.go
+++ b/lib/std/profile/signals_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// RegisterHandlers wires SIGUSR1 to DumpHeap and SIGUSR2 to DumpCPU using the
+// paths from opts. An empty path skips that handler.
+func RegisterHandlers(opts Options) {
+	if opts.HeapProfilePath != "" {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGUSR1)
+		go func() {
+			for range ch {
+				DumpHeap(opts.HeapProfilePath)
+			}
+		}()
+	}
+
+	if opts.CPUProfilePath != "" {
+		ch := make(chan os.Signal, 10)
+		signal.Notify(ch, syscall.SIGUSR2)
+		go func() {
+			for range ch {
+				DumpCPU(opts.CPUProfilePath)
+			}
+		}()
+	}
+}

--- a/lib/std/profile/signals_other.go
+++ b/lib/std/profile/signals_other.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+// RegisterHandlers is a no-op on non-Linux platforms. SIGUSR1/SIGUSR2 are not
+// available; callers needing on-demand profiling can call DumpHeap or DumpCPU
+// directly from their own signal/RPC plumbing.
+func RegisterHandlers(opts Options) {}


### PR DESCRIPTION
## Summary

Adds a new \`lib/std/log\` package that provides a fully abstract \`Logger\` interface, with logrus as the hidden implementation. This is the first of two PRs:

- **This PR**: adds the package. No callers migrated yet.
- **Follow-up PR (stacked on this)**: replaces \`github.com/sirupsen/logrus\` usage across the repo and deletes the now-superseded \`libcalico-go/lib/logutils\`, \`felix/logutils\`, and \`typha/pkg/logutils\` packages. See #12827.

The package lives in its own Go module (\`lib/std/go.mod\`) and depends only on logrus and \`golang.org/x/sys\`. No Prometheus dep tree — preserves the lightweight profile of Shaun's recent \`logformat\` extraction (#12840).

### What's in the package

- \`Logger\` interface with the full logrus emit/With surface, plus \`Print\`/\`Println\`/\`*ln\` variants for stdlib-compatible call sites.
- \`Configure(Options)\` with screen / file / syslog destinations, per-destination level, optional log dropping, and health counters via a one-method \`Counter\` interface.
- Background dispatch (loopWritingLogs goroutines) with a configurable channel size.
- Rate-limited logger that satisfies \`Logger\` (callers store \`log.Logger\`, never see the impl type). \`Force(Logger) Logger\` as a free function for bypassing the rate limit.
- Calico log line format preserved byte-for-byte from \`libcalico-go/lib/logutils\` so operator grep patterns keep working.
- Caller-walk that skips logrus and \`lib/std/log\` frames; pcs slice pooled.
- \`Summarizer\` (ported from \`felix/logutils\`).
- Secret-redaction helpers (\`IsSensitiveParam\`, \`RedactURL\`) ported from \`libcalico-go/lib/logutils\`.
- \`testing.TB\` redirect (\`RedirectTo\`) with auto-cleanup.
- Rotating-file writer for the file destination (in-tree, replaces \`github.com/mipearson/rfw\`).
- \`lib/std/profile\` sibling package: SIGUSR1 → heap profile, SIGUSR2 → CPU profile (Linux).

Defaults to stderr (matching logrus's default). Long-running daemons whose stdout is consumed by tests or kubelet opt in explicitly — see the follow-up PR for \`felix/daemon/logging.go\` and \`typha/pkg/daemon/logging.go\`.

## Test plan

- [x] Package builds (\`cd lib/std && go build ./...\`)
- [x] All package tests pass (\`cd lib/std && go test -count=1 ./log/...\` ✅)
- [x] Stress test passes (felix-FV-like load: 64 goroutines, sustained, slow consumer)
- [x] Fuzz parity test for time formatting against stdlib \`time.AppendFormat\`
- [x] Tested in the follow-up PR (#12827) which exercises this package across every component