### PR TITLE
feat(release): idempotent tag and GitHub release operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ release: release/bin/release
 	@release/bin/release release build
 
 # Publish an already built release.
-release-publish: release/bin/release bin/ghr bin/helm
+release-publish: release/bin/release bin/gh bin/ghr bin/helm
 	@release/bin/release release publish
 
 release-public: bin/gh release/bin/release

--- a/Makefile
+++ b/Makefile
@@ -464,7 +464,7 @@ release: release/bin/release
 	@release/bin/release release build
 
 # Publish an already built release.
-release-publish: release/bin/release bin/ghr bin/helm
+release-publish: release/bin/release bin/gh bin/ghr bin/helm
 	@release/bin/release release publish
 
 release-public: bin/gh release/bin/release

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -15,6 +15,7 @@
 package calico
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -174,6 +175,9 @@ type CalicoManager struct {
 	awsProfile    string
 	s3Bucket      string
 	githubToken   string
+
+	// tagAtHEAD memoizes tagExistsAtHEAD so the rev-parse runs once per release.
+	tagAtHEAD *tagCheck
 
 	// imageRegistries is the list of imageRegistries to which we should publish images.
 	imageRegistries []string
@@ -516,11 +520,56 @@ func (r *CalicoManager) TagRelease(ver string) error {
 		return fmt.Errorf("failed to determine branch: %s", err)
 	}
 	logrus.WithFields(logrus.Fields{"branch": branch, "version": ver}).Infof("Creating Calico release from branch")
-	_, err = r.git("tag", ver)
-	if err != nil {
+
+	tc := r.tagState(ver)
+	if tc.err != nil {
+		return fmt.Errorf("checking %s tag matches HEAD: %w", ver, tc.err)
+	}
+	if tc.atHEAD {
+		logrus.WithField("version", ver).Info("Tag already exists at HEAD, skipping tag creation")
+		return nil
+	}
+
+	if _, err = r.git("tag", ver); err != nil {
 		return fmt.Errorf("failed to tag release: %s", err)
 	}
 	return nil
+}
+
+type tagCheck struct {
+	atHEAD bool
+	err    error
+}
+
+// tagState reports whether the tag already exists and points at HEAD.
+// A tag at a different commit is a conflict, surfaced via err.
+// The result is memoized as both releasePrereqs and TagRelease consult it.
+func (r *CalicoManager) tagState(ver string) *tagCheck {
+	if r.tagAtHEAD != nil {
+		return r.tagAtHEAD
+	}
+	tc := &tagCheck{}
+	tagCommit, err := r.git("rev-parse", "-q", "--verify", "refs/tags/"+ver+"^{commit}")
+	if err != nil || strings.TrimSpace(tagCommit) == "" {
+		r.tagAtHEAD = tc
+		return tc
+	}
+	tagCommit = strings.TrimSpace(tagCommit)
+	headCommit, err := r.git("rev-parse", "HEAD")
+	if err != nil {
+		tc.err = fmt.Errorf("resolve HEAD: %w", err)
+		r.tagAtHEAD = tc
+		return tc
+	}
+	headCommit = strings.TrimSpace(headCommit)
+	if tagCommit != headCommit {
+		tc.err = fmt.Errorf("tag %s already exists at %s but HEAD is %s", ver, tagCommit, headCommit)
+		r.tagAtHEAD = tc
+		return tc
+	}
+	tc.atHEAD = true
+	r.tagAtHEAD = tc
+	return tc
 }
 
 // modifyHelmChartsValues modifies values in helm charts to use the correct version.
@@ -777,6 +826,11 @@ func (r *CalicoManager) releasePrereqs() error {
 		if !reflect.DeepEqual(r.imageRegistries, defaultRegistries) {
 			return fmt.Errorf("image registries cannot be different from default registries for a release")
 		}
+	}
+
+	// Check if the tag exist and that it does not point at a different commit.
+	if tc := r.tagState(r.calicoVersion); tc.err != nil {
+		return fmt.Errorf("checking %s tag matches HEAD: %w", r.calicoVersion, tc.err)
 	}
 
 	return nil
@@ -1275,11 +1329,52 @@ func (r *CalicoManager) publishGitTag() error {
 		logrus.Info("Skipping git tag")
 		return nil
 	}
-	_, err := r.git("push", r.remote, r.calicoVersion)
+
+	lsRemote, err := r.git("ls-remote", "--tags", r.remote, "refs/tags/"+r.calicoVersion)
 	if err != nil {
+		return fmt.Errorf("query remote tag: %w", err)
+	}
+	if remoteSHA := remoteTagCommit(lsRemote, r.calicoVersion); remoteSHA != "" {
+		localSHA, err := r.git("rev-list", "-n1", r.calicoVersion)
+		if err != nil {
+			return fmt.Errorf("resolve local tag %s: %w", r.calicoVersion, err)
+		}
+		localSHA = strings.TrimSpace(localSHA)
+		if remoteSHA == localSHA {
+			logrus.WithField("version", r.calicoVersion).Info("Remote tag already exists and matches, skipping push")
+			return nil
+		}
+		return fmt.Errorf("remote tag %s already exists at %s but local tag is %s", r.calicoVersion, remoteSHA, localSHA)
+	}
+
+	if _, err := r.git("push", r.remote, r.calicoVersion); err != nil {
 		return fmt.Errorf("failed to push git tag: %w", err)
 	}
 	return nil
+}
+
+// remoteTagCommit returns the commit a remote tag points at
+// For annotated tags, used the peeled reference (refs/tags/<tag>^{}) to get the commit SHA.
+func remoteTagCommit(lsRemoteOutput, ver string) string {
+	tagRef := "refs/tags/" + ver
+	peeledRef := tagRef + "^{}"
+	var tagObjSHA, peeledSHA string
+	for _, line := range strings.Split(lsRemoteOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		switch fields[1] {
+		case peeledRef:
+			peeledSHA = fields[0]
+		case tagRef:
+			tagObjSHA = fields[0]
+		}
+	}
+	if peeledSHA != "" {
+		return peeledSHA
+	}
+	return tagObjSHA
 }
 
 func (r *CalicoManager) publishGithubRelease() error {
@@ -1322,6 +1417,13 @@ Additional links:
 	replacer := strings.NewReplacer(formatters...)
 	releaseNote := replacer.Replace(releaseNoteTemplate)
 
+	// if a release is already published, stop instead.
+	if published, err := r.publishedReleaseExists(); err != nil {
+		return fmt.Errorf("publishing github release: %w", err)
+	} else if published {
+		return fmt.Errorf("github release %s is already published; refusing to modify it", r.calicoVersion)
+	}
+
 	args := []string{
 		"-username", r.githubOrg,
 		"-repository", r.repo,
@@ -1336,6 +1438,28 @@ Additional links:
 		return fmt.Errorf("failed to publish github release: %w", err)
 	}
 	return nil
+}
+
+// publishedReleaseExists reports whether a non-draft GitHub release exists for the tag.
+func (r *CalicoManager) publishedReleaseExists() (bool, error) {
+	out, err := r.runner.RunInDir(r.repoRoot, "./bin/gh", []string{
+		"release", "view", r.calicoVersion,
+		"--repo", fmt.Sprintf("%s/%s", r.githubOrg, r.repo),
+		"--json", "isDraft",
+	}, nil)
+	if err != nil {
+		if strings.Contains(out, "release not found") || strings.Contains(err.Error(), "release not found") {
+			return false, nil
+		}
+		return false, fmt.Errorf("query github release: %w", err)
+	}
+	var rel struct {
+		IsDraft bool `json:"isDraft"`
+	}
+	if err := json.Unmarshal([]byte(out), &rel); err != nil {
+		return false, fmt.Errorf("parse github release: %w", err)
+	}
+	return !rel.IsDraft, nil
 }
 
 func (r *CalicoManager) publishContainerImages() error {

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -530,8 +530,8 @@ func (r *CalicoManager) TagRelease(ver string) error {
 		return nil
 	}
 
-	if _, err = r.git("tag", ver); err != nil {
-		return fmt.Errorf("failed to tag release: %s", err)
+	if _, err = r.git("tag", "-a", "-m", "Release "+ver, ver); err != nil {
+		return fmt.Errorf("tag release: %w", err)
 	}
 	return nil
 }

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -288,7 +288,7 @@ func (r *CalicoManager) Build() error {
 	if !r.isHashRelease {
 		// Only tag release if this is not a hashrelease.
 		// TODO: Option to skip producing a tag, for development.
-		if err = r.TagRelease(ver); err != nil {
+		if err = r.TagRelease(); err != nil {
 			return err
 		}
 
@@ -514,14 +514,15 @@ func (r *CalicoManager) DeleteTag(ver string) error {
 	return nil
 }
 
-func (r *CalicoManager) TagRelease(ver string) error {
+func (r *CalicoManager) TagRelease() error {
+	ver := r.calicoVersion
 	branch, err := r.determineBranch()
 	if err != nil {
-		return fmt.Errorf("failed to determine branch: %s", err)
+		return fmt.Errorf("failed to determine branch: %w", err)
 	}
 	logrus.WithFields(logrus.Fields{"branch": branch, "version": ver}).Infof("Creating Calico release from branch")
 
-	tc := r.tagState(ver)
+	tc := r.tagState()
 	if tc.err != nil {
 		return fmt.Errorf("checking %s tag matches HEAD: %w", ver, tc.err)
 	}
@@ -541,15 +542,15 @@ type tagCheck struct {
 	err    error
 }
 
-// tagState reports whether the tag already exists and points at HEAD.
+// tagState reports whether the release tag already exists and points at HEAD.
 // A tag at a different commit is a conflict, surfaced via err.
 // The result is memoized as both releasePrereqs and TagRelease consult it.
-func (r *CalicoManager) tagState(ver string) *tagCheck {
+func (r *CalicoManager) tagState() *tagCheck {
 	if r.tagAtHEAD != nil {
 		return r.tagAtHEAD
 	}
 	tc := &tagCheck{}
-	tagCommit, err := r.git("rev-parse", "-q", "--verify", "refs/tags/"+ver+"^{commit}")
+	tagCommit, err := r.git("rev-parse", "-q", "--verify", "refs/tags/"+r.calicoVersion+"^{commit}")
 	if err != nil || strings.TrimSpace(tagCommit) == "" {
 		r.tagAtHEAD = tc
 		return tc
@@ -563,7 +564,7 @@ func (r *CalicoManager) tagState(ver string) *tagCheck {
 	}
 	headCommit = strings.TrimSpace(headCommit)
 	if tagCommit != headCommit {
-		tc.err = fmt.Errorf("tag %s already exists at %s but HEAD is %s", ver, tagCommit, headCommit)
+		tc.err = fmt.Errorf("tag %s already exists at %s but HEAD is %s", r.calicoVersion, tagCommit, headCommit)
 		r.tagAtHEAD = tc
 		return tc
 	}
@@ -829,7 +830,7 @@ func (r *CalicoManager) releasePrereqs() error {
 	}
 
 	// Check if the tag exist and that it does not point at a different commit.
-	if tc := r.tagState(r.calicoVersion); tc.err != nil {
+	if tc := r.tagState(); tc.err != nil {
 		return fmt.Errorf("checking %s tag matches HEAD: %w", r.calicoVersion, tc.err)
 	}
 
@@ -1353,8 +1354,8 @@ func (r *CalicoManager) publishGitTag() error {
 	return nil
 }
 
-// remoteTagCommit returns the commit a remote tag points at
-// For annotated tags, used the peeled reference (refs/tags/<tag>^{}) to get the commit SHA.
+// remoteTagCommit returns the commit a remote tag points at.
+// For annotated tags, use the peeled reference (refs/tags/<tag>^{}) to get the commit SHA.
 func remoteTagCommit(lsRemoteOutput, ver string) string {
 	tagRef := "refs/tags/" + ver
 	peeledRef := tagRef + "^{}"

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -147,7 +147,7 @@ func TestTagRelease(t *testing.T) {
 			f.on("git rev-parse --abbrev-ref HEAD", "release-v3.30", nil)
 			f.on("git rev-parse HEAD", headSHA, nil)
 			f.on(fmt.Sprintf("git rev-parse -q --verify refs/tags/%s^{commit}", ver), tt.tagCommit, tt.tagErr)
-			f.on(fmt.Sprintf("git tag %s", ver), "", nil)
+			f.on(fmt.Sprintf("git tag -a -m Release %s %s", ver, ver), "", nil)
 
 			r := &CalicoManager{runner: f}
 			err := r.TagRelease(ver)
@@ -166,7 +166,7 @@ func TestTagRelease(t *testing.T) {
 			if err != nil {
 				t.Fatalf("TagRelease(%q) unexpected error: %v", ver, err)
 			}
-			if got := f.ran("git tag " + ver); got != tt.wantTag {
+			if got := f.ran("git tag -a "); got != tt.wantTag {
 				t.Errorf("git tag issued = %v, want %v (calls: %v)", got, tt.wantTag, f.calls)
 			}
 		})

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -14,7 +14,375 @@
 
 package calico
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeResult is the canned response for a matched command.
+type fakeResult struct {
+	stdout string
+	err    error
+}
+
+// fakeRunner is a command.CommandRunner that returns canned output per command
+// and records every invocation so tests can assert what was (and was not) run.
+type fakeRunner struct {
+	// responses maps a command key ("name arg1 arg2 ...") to its canned result.
+	// A key that is a prefix of the invoked command also matches (longest-prefix
+	// wins), so tests can match on a stable command head without spelling out
+	// variable trailing args (a temp-file path, an enumerated asset list).
+	responses map[string]fakeResult
+
+	// calls records every command invoked, as "name arg1 arg2 ...".
+	calls []string
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{responses: map[string]fakeResult{}}
+}
+
+// on registers a canned result for a command key.
+func (f *fakeRunner) on(key, stdout string, err error) *fakeRunner {
+	f.responses[key] = fakeResult{stdout: stdout, err: err}
+	return f
+}
+
+func (f *fakeRunner) record(name string, args []string) (string, error) {
+	cmd := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	f.calls = append(f.calls, cmd)
+	if res, ok := f.responses[cmd]; ok {
+		return res.stdout, res.err
+	}
+	var bestKey string
+	for key := range f.responses {
+		if strings.HasPrefix(cmd, key) && len(key) > len(bestKey) {
+			bestKey = key
+		}
+	}
+	if bestKey != "" {
+		res := f.responses[bestKey]
+		return res.stdout, res.err
+	}
+	return "", nil
+}
+
+func (f *fakeRunner) Run(name string, args, env []string) (string, error) {
+	return f.record(name, args)
+}
+
+func (f *fakeRunner) RunNoCapture(name string, args, env []string) error {
+	_, err := f.record(name, args)
+	return err
+}
+
+func (f *fakeRunner) RunInDir(dir, name string, args, env []string) (string, error) {
+	return f.record(name, args)
+}
+
+func (f *fakeRunner) RunInDirNoCapture(dir, name string, args, env []string) error {
+	_, err := f.record(name, args)
+	return err
+}
+
+func (f *fakeRunner) RunInDirToFile(dir, name string, args, env []string, logPath string) (string, error) {
+	return f.record(name, args)
+}
+
+// ran reports whether any recorded call starts with the given command prefix.
+func (f *fakeRunner) ran(prefix string) bool {
+	return f.count(prefix) > 0
+}
+
+// count returns how many recorded calls start with the given command prefix.
+func (f *fakeRunner) count(prefix string) int {
+	n := 0
+	for _, c := range f.calls {
+		if strings.HasPrefix(c, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestTagRelease(t *testing.T) {
+	const (
+		ver      = "v3.30.0"
+		headSHA  = "1111111111111111111111111111111111111111"
+		otherSHA = "2222222222222222222222222222222222222222"
+	)
+
+	tests := []struct {
+		name        string
+		tagCommit   string // canned `rev-parse refs/tags/<ver>^{commit}`; empty => tag missing
+		tagErr      error  // canned error for that lookup
+		wantTag     bool   // expect `git tag <ver>` to be issued
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:      "tag does not exist creates it",
+			tagCommit: "",
+			tagErr:    fmt.Errorf("exit status 1"),
+			wantTag:   true,
+		},
+		{
+			name:      "tag exists at HEAD skips",
+			tagCommit: headSHA,
+			wantTag:   false,
+		},
+		{
+			name:        "tag exists at different commit errors",
+			tagCommit:   otherSHA,
+			wantTag:     false,
+			wantErr:     true,
+			errContains: []string{otherSHA, headSHA},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeRunner()
+			f.on("git rev-parse --abbrev-ref HEAD", "release-v3.30", nil)
+			f.on("git rev-parse HEAD", headSHA, nil)
+			f.on(fmt.Sprintf("git rev-parse -q --verify refs/tags/%s^{commit}", ver), tt.tagCommit, tt.tagErr)
+			f.on(fmt.Sprintf("git tag %s", ver), "", nil)
+
+			r := &CalicoManager{runner: f}
+			err := r.TagRelease(ver)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("TagRelease(%q) = nil, want error", ver)
+				}
+				for _, sub := range tt.errContains {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q does not contain %q", err.Error(), sub)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TagRelease(%q) unexpected error: %v", ver, err)
+			}
+			if got := f.ran("git tag " + ver); got != tt.wantTag {
+				t.Errorf("git tag issued = %v, want %v (calls: %v)", got, tt.wantTag, f.calls)
+			}
+		})
+	}
+}
+
+// The tag/HEAD comparison is consulted by both releasePrereqs (fail-fast) and
+// TagRelease (authoritative), but the rev-parse must run only once per release.
+func TestTagStateMemoized(t *testing.T) {
+	const ver = "v3.30.0"
+	f := newFakeRunner()
+	f.on(fmt.Sprintf("git rev-parse -q --verify refs/tags/%s^{commit}", ver), "", fmt.Errorf("exit status 1"))
+
+	r := &CalicoManager{runner: f, calicoVersion: ver}
+	if tc := r.tagState(ver); tc.err != nil {
+		t.Fatal(tc.err)
+	}
+	if tc := r.tagState(ver); tc.err != nil {
+		t.Fatal(tc.err)
+	}
+	if got := f.count("git rev-parse -q --verify refs/tags/" + ver); got != 1 {
+		t.Errorf("tag rev-parse ran %d times, want 1 (calls: %v)", got, f.calls)
+	}
+}
+
+// releasePrereqs fails fast when the tag points at a different commit, before
+// the build runs.
+func TestReleasePrereqsTagConflict(t *testing.T) {
+	const (
+		ver      = "v3.30.0"
+		headSHA  = "1111111111111111111111111111111111111111"
+		otherSHA = "2222222222222222222222222222222222222222"
+	)
+	f := newFakeRunner()
+	f.on("git rev-parse --abbrev-ref HEAD", "release-v3.30", nil)
+	f.on("git rev-parse HEAD", headSHA, nil)
+	f.on(fmt.Sprintf("git rev-parse -q --verify refs/tags/%s^{commit}", ver), otherSHA, nil)
+
+	r := &CalicoManager{runner: f, calicoVersion: ver, githubOrg: "myfork", repo: "calico"}
+	err := r.releasePrereqs()
+	if err == nil {
+		t.Fatal("releasePrereqs() = nil, want conflict error")
+	}
+	for _, sub := range []string{otherSHA, headSHA} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not contain %q", err.Error(), sub)
+		}
+	}
+}
+
+func TestPublishGitTag(t *testing.T) {
+	const (
+		ver       = "v3.30.0"
+		remote    = "origin"
+		localSHA  = "1111111111111111111111111111111111111111"
+		remoteSHA = "2222222222222222222222222222222222222222"
+		tagObjSHA = "3333333333333333333333333333333333333333"
+	)
+
+	tests := []struct {
+		name        string
+		gitRef      bool
+		lsRemote    string // canned `git ls-remote --tags <remote> refs/tags/<ver>`
+		wantPush    bool
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:     "skip flag disabled does nothing",
+			gitRef:   false,
+			wantPush: false,
+		},
+		{
+			name:     "remote tag missing pushes",
+			gitRef:   true,
+			lsRemote: "",
+			wantPush: true,
+		},
+		{
+			name:     "remote tag matches local skips",
+			gitRef:   true,
+			lsRemote: fmt.Sprintf("%s\trefs/tags/%s", localSHA, ver),
+			wantPush: false,
+		},
+		{
+			name:        "remote tag differs errors",
+			gitRef:      true,
+			lsRemote:    fmt.Sprintf("%s\trefs/tags/%s", remoteSHA, ver),
+			wantPush:    false,
+			wantErr:     true,
+			errContains: []string{localSHA, remoteSHA},
+		},
+		{
+			name:     "annotated tag peeled line matches local skips",
+			gitRef:   true,
+			lsRemote: fmt.Sprintf("%s\trefs/tags/%s\n%s\trefs/tags/%s^{}", tagObjSHA, ver, localSHA, ver),
+			wantPush: false,
+		},
+		{
+			name:        "annotated tag peeled line differs errors",
+			gitRef:      true,
+			lsRemote:    fmt.Sprintf("%s\trefs/tags/%s\n%s\trefs/tags/%s^{}", tagObjSHA, ver, remoteSHA, ver),
+			wantPush:    false,
+			wantErr:     true,
+			errContains: []string{localSHA, remoteSHA},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeRunner()
+			f.on(fmt.Sprintf("git ls-remote --tags %s refs/tags/%s", remote, ver), tt.lsRemote, nil)
+			f.on(fmt.Sprintf("git rev-list -n1 %s", ver), localSHA, nil)
+			f.on(fmt.Sprintf("git push %s %s", remote, ver), "", nil)
+
+			r := &CalicoManager{runner: f, gitRef: tt.gitRef, remote: remote, calicoVersion: ver}
+			err := r.publishGitTag()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("publishGitTag() = nil, want error")
+				}
+				for _, sub := range tt.errContains {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q does not contain %q", err.Error(), sub)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("publishGitTag() unexpected error: %v", err)
+			}
+			if got := f.ran(fmt.Sprintf("git push %s %s", remote, ver)); got != tt.wantPush {
+				t.Errorf("git push issued = %v, want %v (calls: %v)", got, tt.wantPush, f.calls)
+			}
+		})
+	}
+}
+
+func TestPublishGithubRelease(t *testing.T) {
+	const (
+		ver  = "v3.30.0"
+		org  = "projectcalico"
+		repo = "calico"
+	)
+	repoFlag := fmt.Sprintf("--repo %s/%s", org, repo)
+	notFound := fmt.Errorf("release not found")
+
+	tests := []struct {
+		name          string
+		githubRelease bool
+		viewOut       string
+		viewErr       error
+		wantGhr       bool
+		wantErr       bool
+	}{
+		{
+			name:          "skip flag disabled does nothing",
+			githubRelease: false,
+		},
+		{
+			name:          "no release runs ghr",
+			githubRelease: true,
+			viewOut:       "release not found",
+			viewErr:       notFound,
+			wantGhr:       true,
+		},
+		{
+			name:          "draft release runs ghr",
+			githubRelease: true,
+			viewOut:       `{"isDraft":true}`,
+			wantGhr:       true,
+		},
+		{
+			name:          "published release errors without running ghr",
+			githubRelease: true,
+			viewOut:       `{"isDraft":false}`,
+			wantGhr:       false,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeRunner()
+			f.on(fmt.Sprintf("./bin/gh release view %s %s --json isDraft", ver, repoFlag), tt.viewOut, tt.viewErr)
+			f.on("./bin/ghr", "", nil)
+
+			r := &CalicoManager{
+				runner:        f,
+				githubRelease: tt.githubRelease,
+				calicoVersion: ver,
+				githubOrg:     org,
+				repo:          repo,
+				outputDir:     t.TempDir(),
+			}
+			err := r.publishGithubRelease()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("publishGithubRelease() = nil, want error")
+				}
+				if f.ran("./bin/ghr") {
+					t.Errorf("ghr was invoked for a published release (calls: %v)", f.calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("publishGithubRelease() unexpected error: %v", err)
+			}
+			if got := f.ran("./bin/ghr"); got != tt.wantGhr {
+				t.Errorf("ghr issued = %v, want %v (calls: %v)", got, tt.wantGhr, f.calls)
+			}
+		})
+	}
+}
 
 func TestOwnerFromRemoteURL(t *testing.T) {
 	tests := []struct {

--- a/release/pkg/manager/calico/manager_test.go
+++ b/release/pkg/manager/calico/manager_test.go
@@ -149,12 +149,12 @@ func TestTagRelease(t *testing.T) {
 			f.on(fmt.Sprintf("git rev-parse -q --verify refs/tags/%s^{commit}", ver), tt.tagCommit, tt.tagErr)
 			f.on(fmt.Sprintf("git tag -a -m Release %s %s", ver, ver), "", nil)
 
-			r := &CalicoManager{runner: f}
-			err := r.TagRelease(ver)
+			r := &CalicoManager{runner: f, calicoVersion: ver}
+			err := r.TagRelease()
 
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("TagRelease(%q) = nil, want error", ver)
+					t.Fatalf("TagRelease() = nil, want error")
 				}
 				for _, sub := range tt.errContains {
 					if !strings.Contains(err.Error(), sub) {
@@ -164,7 +164,7 @@ func TestTagRelease(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Fatalf("TagRelease(%q) unexpected error: %v", ver, err)
+				t.Fatalf("TagRelease() unexpected error: %v", err)
 			}
 			if got := f.ran("git tag -a "); got != tt.wantTag {
 				t.Errorf("git tag issued = %v, want %v (calls: %v)", got, tt.wantTag, f.calls)
@@ -181,10 +181,10 @@ func TestTagStateMemoized(t *testing.T) {
 	f.on(fmt.Sprintf("git rev-parse -q --verify refs/tags/%s^{commit}", ver), "", fmt.Errorf("exit status 1"))
 
 	r := &CalicoManager{runner: f, calicoVersion: ver}
-	if tc := r.tagState(ver); tc.err != nil {
+	if tc := r.tagState(); tc.err != nil {
 		t.Fatal(tc.err)
 	}
-	if tc := r.tagState(ver); tc.err != nil {
+	if tc := r.tagState(); tc.err != nil {
 		t.Fatal(tc.err)
 	}
 	if got := f.count("git rev-parse -q --verify refs/tags/" + ver); got != 1 {


### PR DESCRIPTION
Make tag creation, tag push, and GitHub release publishing safe to re-run.

Also switches `git tag` to annotated.

**Release note:**
```release-note
TBD
```