### PR TITLE
ci(sem-ai-triage): look up PR via search API to find fork PRs

### DIFF
--- a/.github/workflows/sem-ai-ci-triage.yml
+++ b/.github/workflows/sem-ai-ci-triage.yml
@@ -76,8 +76,11 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
-                   --jq '[.[] | select(.state == "open")] | .[0].number // empty')
+            # Use the search API rather than repos/$REPO/commits/$SHA/pulls:
+            # the latter does not return PRs whose head commit lives on a
+            # fork, and projectcalico/calico PRs all come from forks.
+            PR=$(gh api "search/issues?q=sha:$SHA+is:pr+is:open+repo:$REPO" \
+                   --jq '.items[0].number // empty')
             if [[ -z "$PR" ]]; then
               echo "::warning::no open PR for sha=$SHA — skipping (commit is likely on a branch with no open PR)"
               echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- `sem-ai CI triage` was soft-skipping on every `status` event with `no open PR for sha=...` because `repos/$REPO/commits/$SHA/pulls` returns `[]` for commits whose head branch lives on a fork. All projectcalico/calico PRs come from forks, so the workflow was effectively no-op for real status triggers.
- Swap the PR lookup to `search/issues?q=sha:$SHA+is:pr+is:open+repo:$REPO`. The search API does index commits across forks.

Verified against the most recent retrigger of #12854 (fork `mazdakn/calico`, head `8396b418`): `commits/$SHA/pulls` returns `[]`, `search/issues` returns `12854`.

## Test plan

- [x] Confirmed the new query returns the PR number against a live fork-PR commit.
- [ ] After merge, retrigger CI on an open fork PR and confirm the workflow proceeds past the resolve step (look for `Fetch PR title + body` running rather than skipped).

### Release Note

```release-note
None
```