### PR TITLE
Grant tigera-operator read access to Gateway resources (EV-6658)

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -671,6 +671,16 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
+  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
+  # CIG resources to.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - list
+      - get
+      - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.
   - apiGroups:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -648,6 +648,16 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
+  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
+  # CIG resources to.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - list
+      - get
+      - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.
   - apiGroups:

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -688,6 +688,16 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
+  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
+  # CIG resources to.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - list
+      - get
+      - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.
   - apiGroups:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -627,6 +627,16 @@ rules:
       - update
     resourceNames:
       - tigera-gateway-api-gateway-helm-certgen
+  # 4. The operator needs to be able to read Gateway resources to determine namespaces to apply
+  # CIG resources to.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - list
+      - get
+      - watch
   # For monitoring KubeVirt live migration.  The operator does not do this itself, but needs to
   # be able to assign this RBAC to Typha and calico-node.
   - apiGroups:


### PR DESCRIPTION
## Description

Adds `list`, `get`, and `watch` permissions on `gateway.networking.k8s.io/gateways`
to the tigera-operator ClusterRole. The operator needs to read Gateway resources
to determine which namespaces should receive CIG (Calico Ingress Gateway) resources.

Ref: EV-6658

## Changes

- `charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml` — added the rule
- `manifests/tigera-operator.yaml`, `manifests/ocp/02-role-tigera-operator.yaml`,
  `manifests/tigera-operator-ocp-upgrade.yaml` — regenerated via `make gen-manifests`


<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
