### PR TITLE
fix(felix): exclude LB-only IPPools from BPF in-pool route flag

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -645,9 +645,6 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 // to them should still be masqueraded (not exempted from SNAT via the
 // FlagInIPAMPool BPF route flag or the network-ip-pools ipset).
 func isLoadBalancerOnlyPool(pool *model.IPPool) bool {
-	if len(pool.AllowedUses) == 0 {
-		return false
-	}
 	return len(pool.AllowedUses) == 1 && slices.Contains(pool.AllowedUses, apiv3.IPPoolAllowedUseLoadBalancer)
 }
 

--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -644,6 +644,8 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 // their CIDRs do not represent workload/tunnel addresses and traffic destined
 // to them should still be masqueraded (not exempted from SNAT via the
 // FlagInIPAMPool BPF route flag or the network-ip-pools ipset).
+//
+// NOTE: keep in sync with isLoadBalancerOnly in felix/dataplane/linux/masq_mgr.go.
 func isLoadBalancerOnlyPool(pool *model.IPPool) bool {
 	return len(pool.AllowedUses) == 1 && slices.Contains(pool.AllowedUses, apiv3.IPPoolAllowedUseLoadBalancer)
 }

--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -17,9 +17,11 @@ package calc
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"time"
 
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/dispatcher"
@@ -588,12 +590,12 @@ func (c *L3RouteResolver) OnPoolUpdate(update api.Update) (_ bool) {
 	if update.Value != nil {
 		newPool = c.getPoolInfo(update)
 	}
-	if newPool != nil && newPool.PoolType != proto.IPPoolType_NONE {
+	if newPool != nil {
 		logrus.WithFields(logrus.Fields{
 			"oldType": oldPool.PoolType,
 			"newType": newPool.PoolType,
 			"newPool": *newPool,
-		}).Info("Pool is active")
+		}).Info("Pool update")
 		c.allPools[poolKey] = *newPool
 		c.trie.UpdatePool(newPool.CIDR, newPool.PoolType, newPool.NATOutgoing, newPool.CrossSubnet)
 	} else if oldPoolExists {
@@ -625,6 +627,9 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 	if pool == nil {
 		return proto.IPPoolType_NONE
 	}
+	if isLoadBalancerOnlyPool(pool) {
+		return proto.IPPoolType_NONE
+	}
 	if pool.VXLANMode != encap.Never {
 		return proto.IPPoolType_VXLAN
 	}
@@ -632,6 +637,18 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 		return proto.IPPoolType_IPIP
 	}
 	return proto.IPPoolType_NO_ENCAP
+}
+
+// isLoadBalancerOnlyPool returns true if the pool's AllowedUses contains only
+// "LoadBalancer". Such pools should not contribute to route pool type because
+// their CIDRs do not represent workload/tunnel addresses and traffic destined
+// to them should still be masqueraded (not exempted from SNAT via the
+// FlagInIPAMPool BPF route flag or the network-ip-pools ipset).
+func isLoadBalancerOnlyPool(pool *model.IPPool) bool {
+	if len(pool.AllowedUses) == 0 {
+		return false
+	}
+	return len(pool.AllowedUses) == 1 && slices.Contains(pool.AllowedUses, apiv3.IPPoolAllowedUseLoadBalancer)
 }
 
 // routesFromBlock returns a list of routes which should exist based on the provided

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -17,6 +17,7 @@ package calc
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/proto"
@@ -285,6 +286,111 @@ var _ = Describe("L3RouteResolver", func() {
 			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).NotTo(BeZero(),
 				"tunnel route in /32 block should have REMOTE_WORKLOAD")
 		})
+	})
+
+	It("should not set IpPoolType but still propagate NatOutgoing for LoadBalancer-only pools", func() {
+		eventBuf := make(rtEventsMock, 100)
+		l3RR := NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+		l3RR.OnAlive = func() {}
+
+		lbPoolCIDR, _ := ip.CIDRFromString("10.96.0.0/16")
+		l3RR.OnPoolUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(net.IPNet{IPNet: lbPoolCIDR.ToIPNet()})},
+				Value: &model.IPPool{
+					CIDR:        net.IPNet{IPNet: lbPoolCIDR.ToIPNet()},
+					Masquerade:  true,
+					AllowedUses: []v3.IPPoolAllowedUse{v3.IPPoolAllowedUseLoadBalancer},
+				},
+			},
+		})
+
+		remoteAffinity := "host:remote-host"
+		blockCIDR := net.MustParseCIDR("10.96.1.0/26")
+		l3RR.OnBlockUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+				Value: &model.AllocationBlock{
+					CIDR:        blockCIDR,
+					Affinity:    &remoteAffinity,
+					Allocations: make([]*int, 64),
+					Unallocated: []int{0},
+				},
+			},
+		})
+
+		l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{V4Addr: ip.FromString("192.168.0.2").(ip.V4Addr)})
+		l3RR.flush()
+
+		var routes []*proto.RouteUpdate
+		for len(eventBuf) > 0 {
+			if rt, ok := (<-eventBuf).(*proto.RouteUpdate); ok {
+				routes = append(routes, rt)
+			}
+		}
+		var blockRoute *proto.RouteUpdate
+		for _, rt := range routes {
+			if rt.Dst == "10.96.1.0/26" {
+				blockRoute = rt
+			}
+		}
+		Expect(blockRoute).NotTo(BeNil(), "expected a route for 10.96.1.0/26")
+		Expect(blockRoute.IpPoolType).To(Equal(proto.IPPoolType_NONE))
+		Expect(blockRoute.NatOutgoing).To(BeTrue())
+	})
+
+	It("should set IpPoolType for pools with Workload and LoadBalancer uses", func() {
+		eventBuf := make(rtEventsMock, 100)
+		l3RR := NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+		l3RR.OnAlive = func() {}
+
+		mixedPoolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+		l3RR.OnPoolUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()})},
+				Value: &model.IPPool{
+					CIDR:        net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()},
+					VXLANMode:   encap.Always,
+					Masquerade:  true,
+					AllowedUses: []v3.IPPoolAllowedUse{v3.IPPoolAllowedUseWorkload, v3.IPPoolAllowedUseLoadBalancer},
+				},
+			},
+		})
+
+		remoteAffinity := "host:remote-host"
+		blockCIDR := net.MustParseCIDR("10.0.1.0/26")
+		l3RR.OnBlockUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+				Value: &model.AllocationBlock{
+					CIDR:        blockCIDR,
+					Affinity:    &remoteAffinity,
+					Allocations: make([]*int, 64),
+					Unallocated: []int{0},
+				},
+			},
+		})
+
+		l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+			V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
+			VXLANAddr: ip.FromString("10.0.1.1"),
+		})
+		l3RR.flush()
+
+		var routes []*proto.RouteUpdate
+		for len(eventBuf) > 0 {
+			if rt, ok := (<-eventBuf).(*proto.RouteUpdate); ok {
+				routes = append(routes, rt)
+			}
+		}
+		var blockRoute *proto.RouteUpdate
+		for _, rt := range routes {
+			if rt.Dst == "10.0.1.0/26" {
+				blockRoute = rt
+			}
+		}
+		Expect(blockRoute).NotTo(BeNil(), "expected a route for 10.0.1.0/26")
+		Expect(blockRoute.IpPoolType).To(Equal(proto.IPPoolType_VXLAN))
 	})
 
 	Describe("l3rrNodeInfo UTs", func() {

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -305,7 +305,7 @@ var _ = Describe("L3RouteResolver", func() {
 			},
 		})
 
-		remoteAffinity := "host:remote-host"
+		remoteAffinity := "virtual:loadbalancer"
 		blockCIDR := net.MustParseCIDR("10.96.1.0/26")
 		l3RR.OnBlockUpdate(api.Update{
 			KVPair: model.KVPair{


### PR DESCRIPTION
## Description

IPPools with `allowedUses: [LoadBalancer]` caused `poolTypeForPool()` to return `NO_ENCAP`, which set `FlagInIPAMPool` on BPF routes and exempted traffic to LB VIPs from SNAT masquerading. This broke cross-cluster connectivity when a shared LB pool was used across clusters.

### Changes

1. **Return `IPPoolType_NONE` for LB-only pools** in `poolTypeForPool()` via a new `isLoadBalancerOnlyPool()` helper, preventing `FlagInIPAMPool` from being set on BPF routes.

2. **Remove the stale `PoolType != NONE` guard** from the pool update path. This was previously dead code (a non-nil pool never resolved to `NONE`). With the new LB-only check it must be removed to keep LB-only pools in the trie so `NATOutgoing` and `CrossSubnet` continue to propagate correctly.

3. **Unit tests** covering:
   - LB-only pool → `IpPoolType == NONE` and `NatOutgoing` still propagated
   - Mixed-use pool (Workload + LoadBalancer) → `IpPoolType == VXLAN` (not excluded)

### Context

Complements PR #12769 which fixed the iptables/ipset path (`network-ip-pools` ipset). This PR fixes the BPF dataplane path (route map `FlagInIPAMPool` flag).

Fixes: https://github.com/projectcalico/calico/issues/12767