### PR TITLE
Document separate CRD chart in helm install instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -367,6 +367,7 @@ the BPF dataplane).
 - After editing chart templates: `make gen-manifests`
 - This regenerates `manifests/` directory (mostly auto-generated)
 - Commit both chart changes and regenerated manifests
+- The install/upgrade instructions in `charts/tigera-operator/README.md` and `charts/crd.projectcalico.org.v1/README.md` are hand-written and drift silently. A chart change that alters how a user installs or upgrades Calico via Helm (moving resources between charts, adding/removing a manual step, renaming a chart, changing a documented values key or example command) must update the matching README in the same PR. See [`.github/instructions/helm-charts.instructions.md`](../.github/instructions/helm-charts.instructions.md).
 
 ### Working with eBPF Code
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -293,5 +293,9 @@ The eBPF dataplane design is split across the `bpf-*.md` files under [`felix/des
 
 Path-specific reviewer rules live in [`.github/instructions/bpf.instructions.md`](instructions/bpf.instructions.md) — a single thin pointer that scopes to all BPF paths and directs the agent to load the matching sub-design(s) from [`felix/DESIGN.md`](../felix/DESIGN.md)'s topic table, with `bpf-overview.md` as the always-read companion. The doc-update rule above applies; for BPF, "changes how it works" specifically means a new sub-program, CT flag, mark bit, map or map field, or any change to the packet path or forwarding decision.
 
+## Helm Chart Review
+
+The user-facing install and upgrade instructions are hand-written READMEs ([`charts/tigera-operator/README.md`](../charts/tigera-operator/README.md) and [`charts/crd.projectcalico.org.v1/README.md`](../charts/crd.projectcalico.org.v1/README.md)), not generated, so they drift silently when a chart change alters the steps a user has to run. [`.github/instructions/helm-charts.instructions.md`](instructions/helm-charts.instructions.md) scopes to `charts/**` and directs the reviewer to cross-check those READMEs against the change. The doc-update rule above applies; for charts, "changes how it works" means anything that alters how a user installs or upgrades Calico via Helm — moving resources between charts (CRDs especially), adding or removing a manual step, renaming a chart, or changing a documented values key or example command.
+
 ### Trust These Instructions
 These instructions are based on actual testing of the build system. Only search for additional information if you encounter specific errors not covered here or if the repository structure has changed significantly.

--- a/.github/instructions/helm-charts.instructions.md
+++ b/.github/instructions/helm-charts.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo:
+  - "charts/**"
+---
+
+# Helm charts
+
+The install and upgrade instructions users follow live in two
+README files, not in a `DESIGN.md`:
+
+- [`charts/tigera-operator/README.md`](../../charts/tigera-operator/README.md)
+  — the Installing and Upgrading flows for the operator chart.
+- [`charts/crd.projectcalico.org.v1/README.md`](../../charts/crd.projectcalico.org.v1/README.md)
+  — install/upgrade for the separately shipped CRD chart.
+
+These READMEs are hand-written, not generated. They drift silently
+when a chart change alters the steps a user has to run but the doc
+is left alone — that drift is what shipped a broken install in
+v3.32 (CRDs moved to their own chart, but the operator README still
+said `helm install` the operator chart directly). See #12860.
+
+Before reviewing a PR (Copilot code review) that touches any file
+matched by this instruction's `applyTo`, check whether the change
+affects how a user installs or upgrades Calico via Helm, and if so
+whether the two READMEs above still match. Things that change the
+user-facing steps include: moving resources between charts (CRDs
+especially), adding or removing a manual prerequisite step,
+renaming a chart or the repo, changing the namespace handling, or
+changing a documented values key or example command.
+
+## Update rule
+
+A chart PR that changes how a user installs or upgrades Calico via
+Helm must update the matching install/upgrade instructions in the
+same PR.
+
+**Exemption.** No README update is needed if the change does not
+alter any documented step — e.g. a values default that the README
+never mentions, a templating-only refactor, or a generated-CRD
+content bump. If in doubt, update the doc.
+
+## Amending the PR
+
+The Copilot automated code-review step is read-only with respect
+to the PR branch — it cannot push the doc amendment itself. When
+the review flags a missing update per the rule above, its comment
+should include a ready-to-paste `@copilot` prompt naming the README
+and the step that drifted, for example:
+
+> `@copilot update charts/tigera-operator/README.md Installing section to cover the new CRD install step — users must apply the crd.projectcalico.org.v1 chart before installing the operator chart.`
+
+The reviewer (or author) drops that into a new PR comment; the
+Copilot coding agent picks it up and pushes a commit with the
+amendment to the PR branch.

--- a/charts/crd.projectcalico.org.v1/README.md
+++ b/charts/crd.projectcalico.org.v1/README.md
@@ -1,6 +1,19 @@
 # Calico CRDs
 
-This chart contains the following Calico Custom Resource Definitions (CRDs), required for the tigera-operator helm chart to function properly:
+This chart contains the Calico Custom Resource Definitions (CRDs), required for the tigera-operator helm chart to function properly:
 
-- crd.projectalico.org/v1 API group
-- operator.tigera.io/v1 API group
+- `crd.projectcalico.org/v1` API group
+- `operator.tigera.io/v1` API group
+
+The CRDs live in their own chart because Helm does not upgrade or delete CRDs bundled in a chart's `crds/` directory. See [Helm's CRD best practices](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
+
+# Installing
+
+Install or upgrade the CRDs before installing or upgrading the `tigera-operator` chart:
+
+```
+helm repo add projectcalico https://docs.tigera.io/calico/charts
+helm template calico-crds projectcalico/crd.projectcalico.org.v1 | kubectl apply --server-side -f -
+```
+
+`helm template | kubectl apply --server-side` is used rather than `helm install` because some Calico CRDs exceed the size limit for client-side apply.

--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -24,6 +24,12 @@ Calico’s flexible architecture supports a wide range of deployment options, us
    helm repo add projectcalico https://docs.tigera.io/calico/charts
    ```
 
+1. Install the Calico CRDs. As of Calico v3.32, CRDs are no longer bundled in this chart and must be installed separately from the `crd.projectcalico.org.v1` chart. See [Custom Resource Definitions](#custom-resource-definitions) below for why.
+
+   ```
+   helm template calico-crds projectcalico/crd.projectcalico.org.v1 | kubectl apply --server-side -f -
+   ```
+
 1. Create the tigera-operator namespace.
 
    ```
@@ -35,6 +41,18 @@ Calico’s flexible architecture supports a wide range of deployment options, us
    ```
    helm install calico projectcalico/tigera-operator --namespace tigera-operator
    ```
+
+# Custom Resource Definitions
+
+This chart does not install the Calico CRDs (the `crd.projectcalico.org` and `operator.tigera.io` API groups). Helm does not upgrade or delete CRDs that live in a chart's `crds/` directory, which makes CRD lifecycle management awkward over the life of a cluster. Following [Helm's CRD best practices](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), the CRDs are shipped in a separate `crd.projectcalico.org.v1` chart that you install and upgrade yourself.
+
+To install or upgrade the CRDs:
+
+```
+helm template calico-crds projectcalico/crd.projectcalico.org.v1 | kubectl apply --server-side -f -
+```
+
+`helm template | kubectl apply --server-side` is used rather than `helm install` because some Calico CRDs exceed the size limit for client-side apply.
 
 # Upgrading
 
@@ -85,6 +103,12 @@ Starting in Calico v3.28, a change in the way UIDs are generated for projectcali
 > the output and then re-running the command without --dry-run to commit to the changes.
 
 ## All other upgrades
+
+1. Update the Calico CRDs. Helm will not do this for you (see [Custom Resource Definitions](#custom-resource-definitions)), so apply them before upgrading the operator chart.
+
+   ```bash
+   helm template calico-crds projectcalico/crd.projectcalico.org.v1 | kubectl apply --server-side -f -
+   ```
 
 1. Run the helm upgrade:
 


### PR DESCRIPTION
The tigera-operator chart README still told users to run `helm install projectcalico/tigera-operator` directly after the CRDs were moved into the separate `crd.projectcalico.org.v1` chart in v3.32. On a fresh cluster that fails, since the operator custom resources in the chart have no matching CRDs (`no matches for kind "Installation" in version "operator.tigera.io/v1"`).

Adds a CRD install step to the Installing section, a short section explaining why the CRDs ship separately, and a matching reminder in the upgrade flow. Also tidies up the `crd.projectcalico.org.v1` chart README (typo + install instructions).

Fixes #12860

```release-note
HELM: Fixes the tigera-operator chart install instructions, which omitted the step to install Calico CRDs from the separate crd.projectcalico.org.v1 chart.
```