### PR TITLE
e2e: fix Tiered-RBAC test failures on gcp-bpf CI

### DIFF
--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -32,3 +32,6 @@ exclude:
 
     - label: RequiresXtables
       reason: "requires iptables or nftables dataplane, but this cluster uses BPF"
+
+    - label: RequiresCalicoAPIServer
+      reason: "USE_API_SERVER is false on this pipeline; aggregated apiserver is not deployed"

--- a/e2e/pkg/tests/policy/tiered_rbac.go
+++ b/e2e/pkg/tests/policy/tiered_rbac.go
@@ -354,7 +354,8 @@ var _ = describe.CalicoDescribe(
 		// Even an admin cannot update or delete it. Each test includes a
 		// DeferCleanup safety net that restores the default tier if the
 		// operation unexpectedly succeeds, so we don't leave the cluster broken.
-		Context("default tier", func() {
+		framework.Context("default tier", describe.RequiresCalicoAPIServer(), func() {
+			BeforeEach(func() { requireCalicoAPIServer(f.ClientConfig()) })
 			// restoreDefaultTier is a safety net for default tier tests. If the
 			// tier was modified (ResourceVersion changed) it restores the saved
 			// spec; if it was deleted it recreates it.


### PR DESCRIPTION
## Description

The Tiered-RBAC test suite has been failing on the gcp-bpf CI pipeline because:

1. The gcp-bpf CI pipeline runs with USE_API_SERVER=false (aggregated Calico API server is not deployed). The kind.yaml and kind-felix-routing.yaml configs already exclude RequiresCalicoAPIServer tests for the same reason, but gcp-bpf.yaml was missing the exclude. Every RequiresCalicoAPIServer test failed BeforeEach with the existing helpful message.

2. The default-tier tests (should not allow updating/deleting the default tier) rely on the aggregated apiserver's storage-layer protection but lacked the RequiresCalicoAPIServer label. They ran in CRD mode, the protection wasn't there, and the assertions failed in-It.

This PR:
- Adds RequiresCalicoAPIServer to gcp-bpf.yaml's exclude list, matching the kind configs.
- Tags the default-tier Context with RequiresCalicoAPIServer plus the standard BeforeEach gate (matching the pattern of the three other apiserver-dependent contexts in tiered_rbac.go).

## Release Note

\`\`\`release-note
None
\`\`\`