### PR TITLE
libcalico-go: address review feedback from #12047

### DIFF
--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -118,7 +118,7 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 }
 
 // ClientOptions provides pre-built clients for constructing a KubeClient.
-// ClientSet and RESTClient are required; the rest are optional.
+// ClientSet, RESTClient, and Group are required; the rest are optional.
 type ClientOptions struct {
 	ClientSet                  kubernetes.Interface
 	RESTClient                 rest.Interface
@@ -132,10 +132,16 @@ type ClientOptions struct {
 // to be injected for testing.
 func NewWithOptions(opts ClientOptions) (api.Client, error) {
 	if opts.ClientSet == nil {
-		return nil, fmt.Errorf("ClientSet is required")
+		return nil, fmt.Errorf("a ClientSet is required")
 	}
 	if opts.RESTClient == nil {
-		return nil, fmt.Errorf("RESTClient is required")
+		return nil, fmt.Errorf("a RESTClient is required")
+	}
+	switch opts.Group {
+	case resources.BackingAPIGroupV1, resources.BackingAPIGroupV3:
+	default:
+		return nil, fmt.Errorf("group must be %s or %s, got %q",
+			resources.BackingAPIGroupV1, resources.BackingAPIGroupV3, opts.Group)
 	}
 
 	c := &KubeClient{

--- a/libcalico-go/lib/clientv3/client.go
+++ b/libcalico-go/lib/clientv3/client.go
@@ -66,15 +66,16 @@ func New(config apiconfig.CalicoAPIConfig) (Interface, error) {
 		validator.SetCRDValidationEnabled(true)
 	}
 
-	c := NewFromBackend(be).(client)
-	c.config = config
-	return c, nil
+	return NewFromBackend(config, be), nil
 }
 
 // NewFromBackend wraps an existing backend client (e.g. one backed by fakes
-// in tests) in a clientv3 Interface.
-func NewFromBackend(be bapi.Client) Interface {
+// in tests) in a clientv3 Interface. config drives behavior that depends on
+// the datastore type (e.g. ensureClusterInformation tagging clusters with a
+// "kdd"/"k8s" suffix); pass the same CalicoAPIConfig that produced be.
+func NewFromBackend(config apiconfig.CalicoAPIConfig, be bapi.Client) Interface {
 	return client{
+		config:    config,
 		backend:   be,
 		resources: &resources{backend: be},
 	}


### PR DESCRIPTION
Three small follow-ups to PR #12047 (Make k8s backend support injectable
clients for testing), raised by Copilot on the auto-cherry-pick:

- `NewFromBackend` now takes a `CalicoAPIConfig`. The previous signature
  left `c.config` as the zero value, which would feed an incorrect
  `Spec.DatastoreType` to callsites like `ensureClusterInformation` that
  branch on it for the "kdd"/"k8s" clusterType suffix.
- `NewWithOptions` validates that `Group` is `BackingAPIGroupV1` or
  `BackingAPIGroupV3`. It's required by every CRD-backed resource
  client, and an empty value would only show up as a confusing runtime
  error later.
- Lower-case the leading word in the two existing error strings to match
  Go convention.

### Release Note
None.