### PR TITLE
Restore standard CNI plugins loopback etc in the combined calico image

### DIFF
--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -93,11 +93,19 @@ REGISTRAR_BIN = $(REPO_ROOT)/pod2daemon/bin/node-driver-registrar-$(ARCH)
 $(REGISTRAR_BIN):
 	$(MAKE) -C $(REPO_ROOT)/pod2daemon bin/node-driver-registrar-$(ARCH)
 
+# Standard CNI plugins (loopback, etc.) required by the install-cni init
+# container on platforms where the host does not ship its own CNI binaries
+# (e.g. RKE2 with cni: none).
+CNI_PLUGINS_DIR = $(REPO_ROOT)/cni-plugin/bin/$(ARCH)
+CNI_PLUGIN_BINS = $(CNI_PLUGINS_DIR)/loopback $(CNI_PLUGINS_DIR)/host-local $(CNI_PLUGINS_DIR)/portmap $(CNI_PLUGINS_DIR)/tuning $(CNI_PLUGINS_DIR)/flannel
+$(CNI_PLUGIN_BINS): | register
+	$(MAKE) -C $(REPO_ROOT)/cni-plugin build-cni-bins ARCH=$(ARCH)
+
 .PHONY: image image-all
 image: $(CONTAINER_MARKER)
 
-$(CONTAINER_MARKER): $(REPO_ROOT)/docker/calico/Dockerfile $(BINDIR)/calico-$(ARCH) $(BINDIR)/LICENSE $(REGISTRAR_BIN) | register
-	$(DOCKER_BUILD) --build-arg BIN_DIR=cmd/calico/$(BINDIR) --build-arg TARGETARCH=$(ARCH) -t $(CALICO_IMAGE):$(IMAGE_TAG)-$(ARCH) -f $(REPO_ROOT)/docker/calico/Dockerfile $(REPO_ROOT)
+$(CONTAINER_MARKER): $(REPO_ROOT)/docker/calico/Dockerfile $(BINDIR)/calico-$(ARCH) $(BINDIR)/LICENSE $(REGISTRAR_BIN) $(CNI_PLUGIN_BINS) | register
+	$(DOCKER_BUILD) --build-arg BIN_DIR=cmd/calico/$(BINDIR) --build-arg CNI_BIN_DIR=cni-plugin/bin/$(ARCH) --build-arg TARGETARCH=$(ARCH) -t $(CALICO_IMAGE):$(IMAGE_TAG)-$(ARCH) -f $(REPO_ROOT)/docker/calico/Dockerfile $(REPO_ROOT)
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=$(IMAGE_TAG) LATEST_IMAGE_TAG=$(IMAGE_TAG)
 	touch $@
 

--- a/docker/calico/Dockerfile
+++ b/docker/calico/Dockerfile
@@ -12,10 +12,20 @@ ARG BIN_DIR
 # The symlink has to be created in a stage that has a shell (scratch does
 # not) and the target has to resolve when BuildKit computes the COPY
 # checksum, so we stage both files together here under /shim.
-RUN mkdir -p /shim/usr/bin
+RUN mkdir -p /shim/usr/bin /shim/opt/cni/bin
 COPY ${BIN_DIR}/calico-${TARGETARCH} /shim/usr/bin/calico
 RUN ln -s calico /shim/usr/bin/calicoctl && \
     ln -s calico /shim/usr/bin/calico-ipam
+
+# Standard CNI plugins needed by the install-cni init container. Platforms
+# that set cni: none (e.g. RKE2) rely on Calico to supply loopback and
+# friends; without them every non-hostNetwork pod stays ContainerCreating.
+ARG CNI_BIN_DIR
+COPY ${CNI_BIN_DIR}/loopback    /shim/opt/cni/bin/
+COPY ${CNI_BIN_DIR}/host-local  /shim/opt/cni/bin/
+COPY ${CNI_BIN_DIR}/portmap     /shim/opt/cni/bin/
+COPY ${CNI_BIN_DIR}/tuning      /shim/opt/cni/bin/
+COPY ${CNI_BIN_DIR}/flannel     /shim/opt/cni/bin/
 
 # Stage all build-context files into a scratch layer so the final image gets
 # them in a single COPY. This keeps the CALICO_BASE layer hash stable across


### PR DESCRIPTION
Summary

  The image consolidation in #12225 dropped the standard CNI plugins (loopback, host-local, portmap, tuning, flannel) from the calico/calico image. This breaks all platforms where the host does not provide its own CNI plugins (e.g. RKE2 with cni: none).

  The old cni-plugin/Dockerfile copied all built binaries into /opt/cni/bin/:
  COPY ${BIN_DIR} /opt/cni/bin/
  
 The new docker/calico/Dockerfile only ships the combined binary at /usr/bin/calico. The install-cni init container still iterates /opt/cni/bin to copy plugins to the host (line 229 of install.go), but the directory no longer exists in the image so nothing gets installed.
Without loopback, kubelet cannot create pod sandboxes:
    Failed to create pod sandbox: plugin type="loopback" failed (add):
    failed to find plugin "loopback" in path [/opt/cni/bin]

  Every non-hostNetwork pod stays in ContainerCreating indefinitely.

  Impact

  - Broken since April 24 (#12225 merge date)
  - Affects every cni: none platform: RKE2, k3s without default CNI, bare-metal with external CNI
  - Failed RKE2 CIS Semaphore pipeline for 5 consecutive weekly runs (April 29 – May 27)
  https://tigera-delivery.semaphoreci.com/jobs/167d193b-653c-49cd-a616-f0045d20b64d

  - Verified on a RKE2 cluster (Ubuntu 22.04, kernel 6.8) — all calico-system pods stuck in ContainerCreating until fix applied

  Verification

  Built the fixed image locally, pushed to gcr.io/unique-caldron-775/cnx/tigera/calico:fix-cni-plugins, and deployed to a  RKE2 cluster with cni: none:

  Before fix — install-cni logs:
  Installed /host/opt/cni/bin/calico
  Installed /host/opt/cni/bin/calico-ipam
  Wrote Calico CNI binaries to /host/opt/cni/bin
  
  After fix — install-cni logs:
  Installed /host/opt/cni/bin/calico
  Installed /host/opt/cni/bin/calico-ipam
  Installed /host/opt/cni/bin/flannel
  Installed /host/opt/cni/bin/host-local
  Installed /host/opt/cni/bin/loopback
  Installed /host/opt/cni/bin/portmap
  Installed /host/opt/cni/bin/tuning
  Wrote Calico CNI binaries to /host/opt/cni/bin
  
  All pods progressed from ContainerCreating to Running, tigerastatus/apiserver became Available.

