### PR TITLE
Render MutatingAdmissionPolicy as v1alpha1 when that's all the cluster serves

### DIFF
--- a/charts/calico/templates/admission-policies.yaml
+++ b/charts/calico/templates/admission-policies.yaml
@@ -2,6 +2,10 @@
 {{- $apiVersion := "admissionregistration.k8s.io/v1beta1" -}}
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/MutatingAdmissionPolicy" -}}
 {{- $apiVersion = "admissionregistration.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1beta1" -}}
+{{- else if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1alpha1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1alpha1" -}}
 {{- end }}
 {{ range $path, $_ := .Files.Glob "admission/*" }}
 ---


### PR DESCRIPTION
https://github.com/projectcalico/calico/pull/12833 added v1/v1beta1 toggling for MutatingAdmissionPolicy. This extends it to also cover v1alpha1, which is the only version served on Kubernetes 1.32-1.33 when the MutatingAdmissionPolicy feature gate is enabled. The preference order is now v1 -> v1beta1 -> v1alpha1, with v1beta1 staying the default for `helm template` when capabilities aren't reported (so the generated `manifests/calico-v3-crds.yaml` is unchanged).

The companion operator-side change is https://github.com/tigera/operator/pull/4837.

Verified rendering: v1 served -> v1, v1beta1 served -> v1beta1, v1alpha1 served -> v1alpha1, nothing reported -> v1beta1.

```release-note
HELM: Render MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding as admissionregistration.k8s.io/v1alpha1 when the cluster only serves the alpha API (Kubernetes 1.32-1.33 with the feature gate enabled).
```
