### PR TITLE
[BPF] Bump cali_v4_frags map version after in-place layout change

### DIFF
--- a/felix/bpf-gpl/ip_v4_fragment.h
+++ b/felix/bpf-gpl/ip_v4_fragment.h
@@ -31,13 +31,12 @@ struct frags4_value {
 	__u16 more_frags:1;
 	__u16 len;
 	__u32 __pad;
-	struct bpf_timer timer;
 	char data[MAX_FRAG];
 };
 
-CALI_MAP(cali_v4_frags, 2, BPF_MAP_TYPE_LRU_HASH, struct frags4_key, struct frags4_value, 10000, 0)
+CALI_MAP(cali_v4_frags, 3, BPF_MAP_TYPE_LRU_HASH, struct frags4_key, struct frags4_value, 10000, 0)
 
-CALI_MAP(cali_v4_frgtmp, 2,
+CALI_MAP(cali_v4_frgtmp, 3,
 		BPF_MAP_TYPE_PERCPU_ARRAY,
 		__u32, struct frags4_value,
 		1, 0)

--- a/felix/bpf/ipfrags/map.go
+++ b/felix/bpf/ipfrags/map.go
@@ -28,7 +28,7 @@ var MapParams = maps.MapParameters{
 	ValueSize:  ValueSize,
 	MaxEntries: 10000, // max number of nodes that can forward nodeports to a single node
 	Name:       "cali_v4_frags",
-	Version:    2,
+	Version:    3,
 }
 
 const (
@@ -48,7 +48,7 @@ var MapParameters = maps.MapParameters{
 	ValueSize:  ValueSize,
 	MaxEntries: 1,
 	Name:       "cali_v4_frgtmp",
-	Version:    2,
+	Version:    3,
 }
 
 func MapTmp() maps.Map {


### PR DESCRIPTION
### Description

An unused `struct bpf_timer` was added to `struct frags4_value`, growing the value of the `cali_v4_frags` and `cali_v4_frgtmp` maps from 1512 to 1528 bytes without bumping their version suffix. On a node that already had a pin from a build with the previous layout, libbpf refuses to reuse the mismatched pin (`parameter mismatch`, `-EINVAL`). Because these are global maps shared by the TC programs, the whole object fails to load for every endpoint, `BPFEndpointManager` never goes ready, and `calico-node` stays wedged at `0/1`.

The timer field was never used — only `frags4_fwd_value`'s timer is armed — so this removes it to restore the original layout, and bumps both maps to version 3. The new program looks up a fresh map name and sidesteps any incompatible pin left behind by an earlier build, in either the old (1512) or the briefly-shipped (1528) layout.

Fixes [CORE-12916](https://tigera.atlassian.net/browse/CORE-12916).

**Release note:**
```release-note
Fix BPF dataplane failing to program (calico-node stuck 0/1) after upgrade when a stale pinned cali_v4_frags map with an incompatible layout remained in bpffs.
```


[CORE-12916]: https://tigera.atlassian.net/browse/CORE-12916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ