### PR TITLE
Detect served MutatingAdmissionPolicy API version in the helm chart (v3.32)

### DIFF
--- a/charts/calico/templates/admission-policies.yaml
+++ b/charts/calico/templates/admission-policies.yaml
@@ -1,6 +1,14 @@
 {{- if .Values.useV3CRDs }}
+{{- $apiVersion := "admissionregistration.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1beta1" -}}
+{{- else if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1alpha1/MutatingAdmissionPolicy" -}}
+{{- $apiVersion = "admissionregistration.k8s.io/v1alpha1" -}}
+{{- end }}
 {{ range $path, $_ := .Files.Glob "admission/*" }}
 ---
-{{ $.Files.Get $path }}
+{{ $.Files.Get $path | replace "admissionregistration.k8s.io/v1beta1" $apiVersion }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Backport of the MutatingAdmissionPolicy apiVersion detection from master (https://github.com/projectcalico/calico/pull/12833 and https://github.com/projectcalico/calico/pull/12875) to release-v3.32.

The one difference from master: v3.32 keeps v1beta1 as the default when the served version can't be detected, so the generated static manifests stay v1beta1 (master forces v1 via `generate.sh --api-versions`, which we deliberately don't do here). On a live cluster the chart still detects and renders v1 (k8s 1.36+) or v1alpha1 (k8s 1.32-1.33 with the feature gate) when that's what's served.

Verified the generated `manifests/calico-v3-crds.yaml` is byte-identical after the change, and that `helm template` renders v1/v1beta1/v1alpha1 correctly per `--api-versions`.

```release-note
HELM: Detect the served MutatingAdmissionPolicy API version and render MutatingAdmissionPolicy/MutatingAdmissionPolicyBinding accordingly (v1 on Kubernetes 1.36+, v1alpha1 when only the alpha API is served), defaulting to v1beta1.
```
