### PR TITLE
Use named IP set ID constants instead of string literals in rules/FV tests

### DIFF
--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ func newMasqManager(
 	// in sync, by which point we'll have added all our CIDRs into the sets.
 	ipsetsDataplane.AddOrReplaceIPSet(ipsets.IPSetMetadata{
 		MaxSize: maxIPSetSize,
-		SetID:   rules.IPSetIDAllPools,
+		SetID:   rules.IPSetIDNetworkPools,
 		Type:    ipsets.IPSetTypeHashNet,
 	}, []string{})
 	ipsetsDataplane.AddOrReplaceIPSet(ipsets.IPSetMetadata{
@@ -108,7 +108,7 @@ func (m *masqManager) OnUpdate(msg any) {
 		// same IP is a no-op anyway.
 		logCxt.Debug("Removing old pool.")
 		if !isLoadBalancerOnly(oldPool) {
-			m.ipsetsDataplane.RemoveMembers(rules.IPSetIDAllPools, []string{oldPool.Cidr})
+			m.ipsetsDataplane.RemoveMembers(rules.IPSetIDNetworkPools, []string{oldPool.Cidr})
 		}
 		if oldPool.Masquerade {
 			logCxt.Debug("Masquerade was enabled on pool.")
@@ -134,7 +134,7 @@ func (m *masqManager) OnUpdate(msg any) {
 			logCxt.Debug("Skipping LoadBalancer-only pool from network-ip-pools IP set.")
 		} else {
 			logCxt.Debug("Adding IPAM pool to network-ip-pools IP set.")
-			m.ipsetsDataplane.AddMembers(rules.IPSetIDAllPools, []string{newPool.Cidr})
+			m.ipsetsDataplane.AddMembers(rules.IPSetIDNetworkPools, []string{newPool.Cidr})
 		}
 		if newPool.Masquerade {
 			logCxt.Debug("IPAM has masquerade enabled.")

--- a/felix/fv/dscp_test.go
+++ b/felix/fv/dscp_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -156,9 +157,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 			if ipVersion == 6 {
 				binary = "ip6tables-save"
 			}
-			allPoolsIPSet := fmt.Sprintf("cali%v0network-ip-pools", ipVersion)
-			thisHostIPSet := fmt.Sprintf("cali%v0this-host", ipVersion)
-			dscpIPSet := fmt.Sprintf("cali%v0dscp-src-net", ipVersion)
+			allPoolsIPSet := utils.IPSetName(rules.IPSetIDNetworkPools, ipVersion)
+			thisHostIPSet := utils.IPSetName(rules.IPSetIDThisHostIPs, ipVersion)
+			dscpIPSet := utils.IPSetName(rules.IPSetIDDSCPEndpoints, ipVersion)
 			tmpl := "-m set --match-set %v src -m set ! --match-set %v dst -m set ! --match-set %v dst -j cali-egress-dscp"
 			expectedRule := fmt.Sprintf(tmpl, dscpIPSet, allPoolsIPSet, thisHostIPSet)
 			getRules := func() string {
@@ -174,9 +175,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 			if ipVersion == 6 {
 				ipFamily = "ip6"
 			}
-			allPoolsIPSet := fmt.Sprintf("@cali%v0network-ip-pools", ipVersion)
-			thisHostIPSet := fmt.Sprintf("@cali%v0this-host", ipVersion)
-			dscpIPSet := fmt.Sprintf("@cali%v0dscp-src-net", ipVersion)
+			allPoolsIPSet := utils.NFTSetName(rules.IPSetIDNetworkPools, ipVersion)
+			thisHostIPSet := utils.NFTSetName(rules.IPSetIDThisHostIPs, ipVersion)
+			dscpIPSet := utils.NFTSetName(rules.IPSetIDDSCPEndpoints, ipVersion)
 			tmpl := "%v saddr %v %v daddr != %v %v daddr != %v .* jump mangle-cali-egress-dscp"
 			pattern := fmt.Sprintf(tmpl, ipFamily, dscpIPSet, ipFamily, allPoolsIPSet, ipFamily, thisHostIPSet)
 			getRules := func() string {

--- a/felix/fv/dscp_test.go
+++ b/felix/fv/dscp_test.go
@@ -157,11 +157,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 			if ipVersion == 6 {
 				binary = "ip6tables-save"
 			}
-			allPoolsIPSet := utils.IPSetName(rules.IPSetIDNetworkPools, ipVersion)
+			networkPoolsIPSet := utils.IPSetName(rules.IPSetIDNetworkPools, ipVersion)
 			thisHostIPSet := utils.IPSetName(rules.IPSetIDThisHostIPs, ipVersion)
 			dscpIPSet := utils.IPSetName(rules.IPSetIDDSCPEndpoints, ipVersion)
 			tmpl := "-m set --match-set %v src -m set ! --match-set %v dst -m set ! --match-set %v dst -j cali-egress-dscp"
-			expectedRule := fmt.Sprintf(tmpl, dscpIPSet, allPoolsIPSet, thisHostIPSet)
+			expectedRule := fmt.Sprintf(tmpl, dscpIPSet, networkPoolsIPSet, thisHostIPSet)
 			getRules := func() string {
 				output, _ := felix.ExecOutput(binary, "-t", "mangle")
 				return output
@@ -175,11 +175,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ dscp tests", []apiconfig.Da
 			if ipVersion == 6 {
 				ipFamily = "ip6"
 			}
-			allPoolsIPSet := utils.NFTSetName(rules.IPSetIDNetworkPools, ipVersion)
+			networkPoolsIPSet := utils.NFTSetName(rules.IPSetIDNetworkPools, ipVersion)
 			thisHostIPSet := utils.NFTSetName(rules.IPSetIDThisHostIPs, ipVersion)
 			dscpIPSet := utils.NFTSetName(rules.IPSetIDDSCPEndpoints, ipVersion)
 			tmpl := "%v saddr %v %v daddr != %v %v daddr != %v .* jump mangle-cali-egress-dscp"
-			pattern := fmt.Sprintf(tmpl, ipFamily, dscpIPSet, ipFamily, allPoolsIPSet, ipFamily, thisHostIPSet)
+			pattern := fmt.Sprintf(tmpl, ipFamily, dscpIPSet, ipFamily, networkPoolsIPSet, ipFamily, thisHostIPSet)
 			getRules := func() string {
 				output, _ := felix.ExecOutput("nft", "list", "chain", ipFamily, "calico", "mangle-cali-POSTROUTING")
 				return output

--- a/felix/fv/routing_test.go
+++ b/felix/fv/routing_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
@@ -229,9 +230,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 								Eventually(f.BPFRoutes, "15s").Should(ContainSubstring(f.IP))
 								Consistently(f.BPFRoutes).ShouldNot(ContainSubstring(externalClient.IP))
 							} else if NFTMode() {
-								Eventually(f.NFTSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(len(felixes)))
+								Eventually(f.NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(len(felixes)))
 							} else {
-								Eventually(f.IPSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(len(felixes)))
+								Eventually(f.IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(len(felixes)))
 							}
 						}
 
@@ -267,12 +268,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 						for _, f := range tc.Felixes {
 							if BPFMode() {
 								Eventually(f.BPFRoutes, "15s").Should(ContainSubstring(externalClient.IP))
-								Expect(f.IPSetSize("cali40all-hosts-net")).To(BeZero(),
+								Expect(f.IPSetSize(utils.IPSetName(rules.IPSetIDAllHostNets, 4))).To(BeZero(),
 									"BPF mode shouldn't program IP sets")
 							} else if NFTMode() {
-								Eventually(f.NFTSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(len(felixes) + 1))
+								Eventually(f.NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(len(felixes) + 1))
 							} else {
-								Eventually(f.IPSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(len(felixes) + 1))
+								Eventually(f.IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(len(felixes) + 1))
 							}
 						}
 
@@ -707,9 +708,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 							}).Should(Equal(expectedNumRoutes),
 								fmt.Sprintf("Expected %v route per node, not: %v", expectedNumRoutes, f.BPFRoutes()))
 						} else if NFTMode() {
-							Eventually(f.NFTSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(ipsetLen))
+							Eventually(f.NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(ipsetLen))
 						} else {
-							Eventually(f.IPSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(ipsetLen))
+							Eventually(f.IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(ipsetLen))
 						}
 					}
 
@@ -743,9 +744,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 						}).Should(Equal(expectedNumRoutes),
 							fmt.Sprintf("Expected %v route per node, not: %v", expectedNumRoutes, felixes[0].BPFRoutes()))
 					} else if NFTMode() {
-						Eventually(felixes[0].NFTSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(ipsetLen))
+						Eventually(felixes[0].NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(ipsetLen))
 					} else {
-						Eventually(felixes[0].IPSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(ipsetLen))
+						Eventually(felixes[0].IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(ipsetLen))
 					}
 
 					cc.ExpectSome(w[0], w[1])
@@ -782,9 +783,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 					for _, f := range felixes {
 						// Wait for Felix to set up the allow list.
 						if NFTMode() {
-							Eventually(f.NFTSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(len(felixes)))
+							Eventually(f.NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(len(felixes)))
 						} else {
-							Eventually(f.IPSetSizeFn("cali40all-hosts-net"), "15s", "200ms").Should(Equal(len(felixes)))
+							Eventually(f.IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllHostNets, 4)), "15s", "200ms").Should(Equal(len(felixes)))
 						}
 					}
 
@@ -807,14 +808,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ cluster routing using Felix
 				if ipipMode == api.IPIPModeAlways && !BPFMode() {
 					It("after manually removing third node from allow list should have expected connectivity", func() {
 						if NFTMode() {
-							felixes[0].Exec("nft", "delete", "element", "ip", "calico", "cali40all-hosts-net", fmt.Sprintf("{ %s }", felixes[2].IP))
+							felixes[0].Exec("nft", "delete", "element", "ip", "calico", utils.IPSetName(rules.IPSetIDAllHostNets, 4), fmt.Sprintf("{ %s }", felixes[2].IP))
 							if enableIPv6 {
-								felixes[0].Exec("nft", "delete", "element", "ip6", "calico", "cali60all-hosts-net", fmt.Sprintf("{ %s }", felixes[2].IPv6))
+								felixes[0].Exec("nft", "delete", "element", "ip6", "calico", utils.IPSetName(rules.IPSetIDAllHostNets, 6), fmt.Sprintf("{ %s }", felixes[2].IPv6))
 							}
 						} else {
-							felixes[0].Exec("ipset", "del", "cali40all-hosts-net", felixes[2].IP)
+							felixes[0].Exec("ipset", "del", utils.IPSetName(rules.IPSetIDAllHostNets, 4), felixes[2].IP)
 							if enableIPv6 {
-								felixes[0].Exec("ipset", "del", "cali60all-hosts-net", felixes[2].IPv6)
+								felixes[0].Exec("ipset", "del", utils.IPSetName(rules.IPSetIDAllHostNets, 6), felixes[2].IPv6)
 							}
 						}
 

--- a/felix/fv/utils/utils.go
+++ b/felix/fv/utils/utils.go
@@ -246,10 +246,6 @@ func NFTSetNameForSelector(ipVersion int, rawSelector string) string {
 	return nftables.LegalizeSetName(base)
 }
 
-// IPSetName returns the dataplane name of the "main" IP set with the given ID
-// (e.g. rules.IPSetIDNetworkPools) for the given IP version, using the standard
-// "cali" prefix. For example, IPSetName(rules.IPSetIDNetworkPools, 4) returns
-// "cali40network-ip-pools".
 func IPSetName(ipSetID string, ipVersion uint8) string {
 	ipFamily := ipsets.IPFamilyV4
 	if ipVersion == 6 {
@@ -258,11 +254,6 @@ func IPSetName(ipSetID string, ipVersion uint8) string {
 	return ipsets.NewIPVersionConfig(ipFamily, rules.IPSetNamePrefix, nil, nil).NameForMainIPSet(ipSetID)
 }
 
-// NFTSetName returns the nftables set reference for the "main" IP set with the
-// given ID for the given IP version. It is the dataplane set name (see
-// IPSetName) prefixed with "@", as used in nftables rule expressions. For
-// example, NFTSetName(rules.IPSetIDNetworkPools, 4) returns
-// "@cali40network-ip-pools".
 func NFTSetName(ipSetID string, ipVersion uint8) string {
 	return "@" + IPSetName(ipSetID, ipVersion)
 }

--- a/felix/fv/utils/utils.go
+++ b/felix/fv/utils/utils.go
@@ -246,6 +246,27 @@ func NFTSetNameForSelector(ipVersion int, rawSelector string) string {
 	return nftables.LegalizeSetName(base)
 }
 
+// IPSetName returns the dataplane name of the "main" IP set with the given ID
+// (e.g. rules.IPSetIDNetworkPools) for the given IP version, using the standard
+// "cali" prefix. For example, IPSetName(rules.IPSetIDNetworkPools, 4) returns
+// "cali40network-ip-pools".
+func IPSetName(ipSetID string, ipVersion uint8) string {
+	ipFamily := ipsets.IPFamilyV4
+	if ipVersion == 6 {
+		ipFamily = ipsets.IPFamilyV6
+	}
+	return ipsets.NewIPVersionConfig(ipFamily, rules.IPSetNamePrefix, nil, nil).NameForMainIPSet(ipSetID)
+}
+
+// NFTSetName returns the nftables set reference for the "main" IP set with the
+// given ID for the given IP version. It is the dataplane set name (see
+// IPSetName) prefixed with "@", as used in nftables rule expressions. For
+// example, NFTSetName(rules.IPSetIDNetworkPools, 4) returns
+// "@cali40network-ip-pools".
+func NFTSetName(ipSetID string, ipVersion uint8) string {
+	return "@" + IPSetName(ipSetID, ipVersion)
+}
+
 // HasSyscallConn represents objects that can return a syscall.RawConn
 type HasSyscallConn interface {
 	SyscallConn() (syscall.RawConn, error)

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/felix/rules"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
@@ -550,9 +551,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 							}).Should(Equal(len(felixes)*2),
 								"Expected one host and one host tunneled route per node")
 						} else if NFTMode() {
-							Eventually(f.NFTSetSizeFn("cali40all-vxlan-net"), "10s", "200ms").Should(Equal(len(felixes) - 1))
+							Eventually(f.NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4)), "10s", "200ms").Should(Equal(len(felixes) - 1))
 						} else {
-							Eventually(f.IPSetSizeFn("cali40all-vxlan-net"), "10s", "200ms").Should(Equal(len(felixes) - 1))
+							Eventually(f.IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4)), "10s", "200ms").Should(Equal(len(felixes) - 1))
 						}
 					}
 
@@ -579,9 +580,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						}).Should(Equal((len(felixes)-1)*2),
 							"Expected one host and one host tunneled route per node, not: "+felixes[0].BPFRoutes())
 					} else if NFTMode() {
-						Eventually(felixes[0].NFTSetSizeFn("cali40all-vxlan-net"), "5s", "200ms").Should(Equal(len(felixes) - 2))
+						Eventually(felixes[0].NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4)), "5s", "200ms").Should(Equal(len(felixes) - 2))
 					} else {
-						Eventually(felixes[0].IPSetSizeFn("cali40all-vxlan-net"), "5s", "200ms").Should(Equal(len(felixes) - 2))
+						Eventually(felixes[0].IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4)), "5s", "200ms").Should(Equal(len(felixes) - 2))
 					}
 
 					cc.ExpectSome(w[0], w[1])
@@ -618,9 +619,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					for _, f := range felixes {
 						// Wait for Felix to set up the allow list.
 						if NFTMode() {
-							Eventually(f.NFTSetSizeFn("cali40all-vxlan-net"), "5s", "200ms").Should(Equal(len(felixes) - 1))
+							Eventually(f.NFTSetSizeFn(utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4)), "5s", "200ms").Should(Equal(len(felixes) - 1))
 						} else {
-							Eventually(f.IPSetSizeFn("cali40all-vxlan-net"), "5s", "200ms").Should(Equal(len(felixes) - 1))
+							Eventually(f.IPSetSizeFn(utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4)), "5s", "200ms").Should(Equal(len(felixes) - 1))
 						}
 					}
 
@@ -642,14 +643,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 				if vxlanMode == api.VXLANModeAlways && !BPFMode() {
 					It("after manually removing third node from allow list should have expected connectivity", func() {
 						if NFTMode() {
-							felixes[0].Exec("nft", "delete", "element", "ip", "calico", "cali40all-vxlan-net", fmt.Sprintf("{ %s }", felixes[2].IP))
+							felixes[0].Exec("nft", "delete", "element", "ip", "calico", utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4), fmt.Sprintf("{ %s }", felixes[2].IP))
 							if enableIPv6 {
-								felixes[0].Exec("nft", "delete", "element", "ip6", "calico", "cali60all-vxlan-net", fmt.Sprintf("{ %s }", felixes[2].IPv6))
+								felixes[0].Exec("nft", "delete", "element", "ip6", "calico", utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 6), fmt.Sprintf("{ %s }", felixes[2].IPv6))
 							}
 						} else {
-							felixes[0].Exec("ipset", "del", "cali40all-vxlan-net", felixes[2].IP)
+							felixes[0].Exec("ipset", "del", utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 4), felixes[2].IP)
 							if enableIPv6 {
-								felixes[0].Exec("ipset", "del", "cali60all-vxlan-net", felixes[2].IPv6)
+								felixes[0].Exec("ipset", "del", utils.IPSetName(rules.IPSetIDAllVXLANSourceNets, 6), felixes[2].IPv6)
 							}
 						}
 

--- a/felix/rules/nat.go
+++ b/felix/rules/nat.go
@@ -54,12 +54,12 @@ func (r *DefaultRuleRenderer) makeNATOutgoingRuleBPF(version uint8, protocol str
 
 func (r *DefaultRuleRenderer) makeNATOutgoingRuleIPTables(ipVersion uint8, protocol string, action generictables.Action) generictables.Rule {
 	ipConf := r.ipSetConfig(ipVersion)
-	allIPsSetName := ipConf.NameForMainIPSet(IPSetIDAllPools)
+	networkIPsSetName := ipConf.NameForMainIPSet(IPSetIDNetworkPools)
 	masqIPsSetName := ipConf.NameForMainIPSet(IPSetIDNATOutgoingMasqPools)
 
 	match := r.NewMatch().
 		SourceIPSet(masqIPsSetName).
-		NotDestIPSet(allIPsSetName)
+		NotDestIPSet(networkIPsSetName)
 
 	if r.NATOutgoingExclusions == string(apiv3.NATOutgoingExclusionsIPPoolsAndHostIPs) {
 		allHostsIPsSetName := ipConf.NameForMainIPSet(IPSetIDAllHostNets)

--- a/felix/rules/nat_test.go
+++ b/felix/rules/nat_test.go
@@ -54,8 +54,8 @@ var _ = Describe("NAT", func() {
 				{
 					Action: MasqAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)),
 				},
 			},
 		}))
@@ -71,9 +71,9 @@ var _ = Describe("NAT", func() {
 				{
 					Action: MasqAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").
-						NotDestIPSet("cali40all-hosts-net"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDAllHostNets, 4)),
 				},
 			},
 		}))
@@ -90,8 +90,8 @@ var _ = Describe("NAT", func() {
 				{
 					Action: SNATAction{ToAddr: snatAddress},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)),
 				},
 			},
 		}))
@@ -108,32 +108,32 @@ var _ = Describe("NAT", func() {
 				{
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("tcp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("tcp"),
 				},
 				{
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("udp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("udp"),
 				},
 				{
 					Action: MasqAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)),
 				},
 			},
 		}))
@@ -151,36 +151,36 @@ var _ = Describe("NAT", func() {
 				{
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("tcp").
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("tcp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("tcp").
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("tcp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: MasqAction{ToPorts: "99-100"},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("udp").
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("udp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("udp").
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("udp").
 						OutInterface("cali-123"),
 				},
 				{
 					Action: MasqAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).
 						OutInterface("cali-123"),
 				},
 			},
@@ -202,32 +202,32 @@ var _ = Describe("NAT", func() {
 				{
 					Action: SNATAction{ToAddr: expectedAddress},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("tcp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("tcp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("tcp"),
 				},
 				{
 					Action: SNATAction{ToAddr: expectedAddress},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("udp"),
 				},
 				{
 					Action: ReturnAction{},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools").Protocol("udp"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)).Protocol("udp"),
 				},
 				{
 					Action: SNATAction{ToAddr: snatAddress},
 					Match: Match().
-						SourceIPSet("cali40masq-ipam-pools").
-						NotDestIPSet("cali40network-ip-pools"),
+						SourceIPSet(ipSetName(IPSetIDNATOutgoingMasqPools, 4)).
+						NotDestIPSet(ipSetName(IPSetIDNetworkPools, 4)),
 				},
 			},
 		}))

--- a/felix/rules/nat_test.go
+++ b/felix/rules/nat_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -239,3 +239,11 @@ var _ = Describe("NAT", func() {
 		}))
 	})
 })
+
+func ipSetName(ipSetID string, ipVersion uint8) string {
+	family := ipsets.IPFamilyV4
+	if ipVersion == 6 {
+		family = ipsets.IPFamilyV6
+	}
+	return ipsets.NewIPVersionConfig(family, ipsets.IPSetNamePrefix, nil, nil).NameForMainIPSet(ipSetID)
+}

--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -64,7 +64,7 @@ const (
 	ChainEgressDSCP      = ChainNamePrefix + "egress-dscp"
 	IPSetIDDSCPEndpoints = "dscp-src-net"
 
-	IPSetIDAllPools             = "network-ip-pools"
+	IPSetIDNetworkPools         = "network-ip-pools"
 	IPSetIDNATOutgoingMasqPools = "masq-ipam-pools"
 
 	IPSetIDAllHostNets        = "all-hosts-net"

--- a/felix/rules/rules_suite_test.go
+++ b/felix/rules/rules_suite_test.go
@@ -20,24 +20,11 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
 func init() {
 	testutils.HookLogrusForGinkgo()
-}
-
-// ipSetName returns the dataplane name of the "main" IP set with the given ID
-// (e.g. IPSetIDNetworkPools) for the given IP version, using the standard "cali"
-// prefix used throughout these tests. For example,
-// ipSetName(IPSetIDNetworkPools, 4) returns "cali40network-ip-pools".
-func ipSetName(ipSetID string, ipVersion uint8) string {
-	family := ipsets.IPFamilyV4
-	if ipVersion == 6 {
-		family = ipsets.IPFamilyV6
-	}
-	return ipsets.NewIPVersionConfig(family, ipsets.IPSetNamePrefix, nil, nil).NameForMainIPSet(ipSetID)
 }
 
 func TestRules(t *testing.T) {

--- a/felix/rules/rules_suite_test.go
+++ b/felix/rules/rules_suite_test.go
@@ -20,11 +20,24 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
 func init() {
 	testutils.HookLogrusForGinkgo()
+}
+
+// ipSetName returns the dataplane name of the "main" IP set with the given ID
+// (e.g. IPSetIDNetworkPools) for the given IP version, using the standard "cali"
+// prefix used throughout these tests. For example,
+// ipSetName(IPSetIDNetworkPools, 4) returns "cali40network-ip-pools".
+func ipSetName(ipSetID string, ipVersion uint8) string {
+	family := ipsets.IPFamilyV4
+	if ipVersion == 6 {
+		family = ipsets.IPFamilyV6
+	}
+	return ipsets.NewIPVersionConfig(family, ipsets.IPSetNamePrefix, nil, nil).NameForMainIPSet(ipSetID)
 }
 
 func TestRules(t *testing.T) {

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1088,14 +1088,14 @@ func (r *DefaultRuleRenderer) StaticManglePostroutingChain(ipVersion uint8) *gen
 
 	if !r.BPFEnabled {
 		ipConf := r.ipSetConfig(ipVersion)
-		allIPsSetName := ipConf.NameForMainIPSet(IPSetIDAllPools)
+		networkIPsSetName := ipConf.NameForMainIPSet(IPSetIDNetworkPools)
 		localHostSetName := ipConf.NameForMainIPSet(IPSetIDThisHostIPs)
 		dscpSetName := ipConf.NameForMainIPSet(IPSetIDDSCPEndpoints)
 		rules = append(
 			rules, generictables.Rule{
 				Match: r.NewMatch().
 					SourceIPSet(dscpSetName).
-					NotDestIPSet(allIPsSetName).
+					NotDestIPSet(networkIPsSetName).
 					NotDestIPSet(localHostSetName),
 				Action:  r.Jump(ChainEgressDSCP),
 				Comment: []string{"set dscp for traffic leaving cluster."},

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -43,14 +43,14 @@ var _ = Describe("Static", func() {
 		It("should generate expected cali-POSTROUTING chain in the mangle table", func() {
 			expRules := []generictables.Rule{}
 			if !rr.BPFEnabled {
-				allPoolSetName := ipSetName(IPSetIDNetworkPools, ipVersion)
+				networkPoolSetName := ipSetName(IPSetIDNetworkPools, ipVersion)
 				thisHostSetName := ipSetName(IPSetIDThisHostIPs, ipVersion)
 				dscpSetName := ipSetName(IPSetIDDSCPEndpoints, ipVersion)
 				expRules = append(expRules, generictables.Rule{
 					// DSCP rule.
 					Match: iptables.Match().
 						SourceIPSet(dscpSetName).
-						NotDestIPSet(allPoolSetName).
+						NotDestIPSet(networkPoolSetName).
 						NotDestIPSet(thisHostSetName),
 					Action:  iptables.JumpAction{Target: ChainEgressDSCP},
 					Comment: []string{"set dscp for traffic leaving cluster."},

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -43,9 +43,9 @@ var _ = Describe("Static", func() {
 		It("should generate expected cali-POSTROUTING chain in the mangle table", func() {
 			expRules := []generictables.Rule{}
 			if !rr.BPFEnabled {
-				allPoolSetName := fmt.Sprintf("cali%v0network-ip-pools", ipVersion)
-				thisHostSetName := fmt.Sprintf("cali%v0this-host", ipVersion)
-				dscpSetName := fmt.Sprintf("cali%v0dscp-src-net", ipVersion)
+				allPoolSetName := ipSetName(IPSetIDNetworkPools, ipVersion)
+				thisHostSetName := ipSetName(IPSetIDThisHostIPs, ipVersion)
+				dscpSetName := ipSetName(IPSetIDDSCPEndpoints, ipVersion)
 				expRules = append(expRules, generictables.Rule{
 					// DSCP rule.
 					Match: iptables.Match().
@@ -200,7 +200,7 @@ var _ = Describe("Static", func() {
 				Describe(fmt.Sprintf("IPv%d", ipVersion), func() {
 					// Capture current value of ipVersion.
 					ipVersion := ipVersion
-					ipSetThisHost := fmt.Sprintf("cali%d0this-host", ipVersion)
+					ipSetThisHost := ipSetName(IPSetIDThisHostIPs, ipVersion)
 
 					var portRanges []*proto.PortRange
 					portRange := &proto.PortRange{
@@ -730,7 +730,7 @@ var _ = Describe("Static", func() {
 					{
 						Match: iptables.Match().
 							ProtocolNum(4).
-							SourceIPSet("cali40all-hosts-net").
+							SourceIPSet(ipSetName(IPSetIDAllHostNets, 4)).
 							DestAddrType("LOCAL"),
 
 						Action:  iptables.AcceptAction{},
@@ -781,7 +781,7 @@ var _ = Describe("Static", func() {
 					{
 						Match: iptables.Match().
 							ProtocolNum(4).
-							SourceIPSet("cali40all-hosts-net").
+							SourceIPSet(ipSetName(IPSetIDAllHostNets, 4)).
 							DestAddrType("LOCAL"),
 
 						Action:  iptables.AcceptAction{},
@@ -900,7 +900,7 @@ var _ = Describe("Static", func() {
 					// Auto-allow IPIP traffic to other Calico hosts.
 					{
 						Match: iptables.Match().ProtocolNum(4).
-							DestIPSet("cali40all-hosts-net").
+							DestIPSet(ipSetName(IPSetIDAllHostNets, 4)).
 							SrcAddrType(generictables.AddrTypeLocal, false),
 						Action:  iptables.AcceptAction{},
 						Comment: []string{"Allow IPIP packets to other Calico hosts"},
@@ -935,7 +935,7 @@ var _ = Describe("Static", func() {
 					// Auto-allow IPIP traffic to other Calico hosts.
 					{
 						Match: iptables.Match().ProtocolNum(4).
-							DestIPSet("cali40all-hosts-net").
+							DestIPSet(ipSetName(IPSetIDAllHostNets, 4)).
 							SrcAddrType(generictables.AddrTypeLocal, false),
 						Action:  iptables.AcceptAction{},
 						Comment: []string{"Allow IPIP packets to other Calico hosts"},
@@ -1315,7 +1315,7 @@ var _ = Describe("Static", func() {
 		})
 		for _, ipVersion := range []uint8{4, 6} {
 			// Capture current value of ipVersion.
-			ipSetThisHost := fmt.Sprintf("cali%d0this-host", ipVersion)
+			ipSetThisHost := ipSetName(IPSetIDThisHostIPs, ipVersion)
 
 			portRanges1 := []*proto.PortRange{
 				{First: 30030, Last: 30040},
@@ -1877,12 +1877,7 @@ var _ = Describe("Static", func() {
 					Expect(chain).NotTo(BeNil())
 					Expect(chain.Name).To(Equal("cali-POSTROUTING"))
 
-					var expectedMeshIPSet string
-					if ipVersion == 4 {
-						expectedMeshIPSet = "cali40all-istio-weps"
-					} else {
-						expectedMeshIPSet = "cali60all-istio-weps"
-					}
+					expectedMeshIPSet := ipSetName(IPSetIDAllIstioWEPs, ipVersion)
 
 					// Look for the Istio DSCP marking rule
 					found := false


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Adding a few utility functions to use for ipset names in tests instead of using string literals in the tests.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
