### PR TITLE
Remove FIPS build support

### DIFF
--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -70,10 +70,6 @@ installation:
   # Run Calico in non-privileged mode (Rootless)
   nonPrivileged: "Disabled"
 
-  # Enable FIPS compliance mode (Requires FIPS compliant cluster/images)
-  # Only supported for Variant=Calico.
-  # fipsMode: "Disabled"
-
   # Configure log severity (Info, Debug, Warning, Error, Fatal)
   # logging:
   #   cni:

--- a/cmd/calico/Makefile
+++ b/cmd/calico/Makefile
@@ -27,17 +27,9 @@ CGO_LDFLAGS = "-L$(LIBBPF_CONTAINER_PATH)/$(ARCH) $(CROSS_CGO_LDFLAGS) -lbpf -le
 CGO_CFLAGS = "-I$(LIBBPF_CONTAINER_PATH) -I$(BPFGPL_CONTAINER_PATH)"
 endif
 
-FIPS ?= false
-ifeq ($(FIPS),true)
-BINDIR = bin/$(ARCH)-fips
-CONTAINER_MARKER = .image.created-$(ARCH)-fips
-IMAGE_TAG = latest-fips
-VALIDARCHES=amd64
-else
 BINDIR = bin
 CONTAINER_MARKER = .image.created-$(ARCH)
 IMAGE_TAG = latest
-endif
 
 .PHONY: clean
 clean:
@@ -53,20 +45,11 @@ build: $(BINDIR)/calico-$(ARCH)
 build-cgo: $(BINDIR)/calico-cgo-$(ARCH)
 build-race: $(BINDIR)/calico-race-$(ARCH)
 
-ifeq ($(FIPS),true)
-# The FIPS binary is cgo-linked via build_cgo_boring_binary, so it needs libbpf
-# available in the build container for transitive felix/bpf/libbpf imports.
-$(BINDIR)/calico-$(ARCH): $(LIBBPF_A) $(SRC_FILES)
-	$(call build_cgo_boring_binary, ./, $@)
-else
 $(BINDIR)/calico-$(ARCH): $(SRC_FILES)
 	$(call build_binary, ./, $@)
-endif
 
 $(BINDIR)/calico-cgo-$(ARCH): $(LIBBPF_A) $(SRC_FILES)
-ifeq ($(FIPS),true)
-	$(call build_cgo_boring_binary, ./, $@)
-else ifeq ($(ARCH),$(filter $(ARCH),amd64 arm64))
+ifeq ($(ARCH),$(filter $(ARCH),amd64 arm64))
 	$(call build_cgo_binary, ./, $@)
 else
 	$(call build_binary, ./, $@)
@@ -101,11 +84,9 @@ $(CONTAINER_MARKER): $(REPO_ROOT)/docker/calico/Dockerfile $(BINDIR)/calico-$(AR
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=$(IMAGE_TAG) LATEST_IMAGE_TAG=$(IMAGE_TAG)
 	touch $@
 
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
 
 ###############################################################################
 # CI/CD
@@ -124,8 +105,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) clean image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
-	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)-fips LATEST_IMAGE_TAG=latest-fips
-	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
 ## Pushes the combined calico image to the registries.
@@ -133,5 +112,4 @@ release-build: .release-$(VERSION).created
 release-publish: release-prereqs .release-$(VERSION).published
 .release-$(VERSION).published:
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	$(MAKE) FIPS=true push-images-to-registries push-manifests IMAGETAG=$(VERSION)-fips RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	touch $@

--- a/confd/Makefile
+++ b/confd/Makefile
@@ -28,11 +28,7 @@ sub-build-%:
 	$(MAKE) build ARCH=$*
 
 bin/confd-$(ARCH): $(SRC_FILES)
-ifeq ($(FIPS),true)
-	$(call build_cgo_boring_binary, $(PACKAGE_NAME), $@)
-else
 	$(call build_binary, $(PACKAGE_NAME), $@)
-endif
 	ln -sf confd-$(ARCH) bin/confd
 
 ###############################################################################

--- a/crypto/pkg/tls/tls.go
+++ b/crypto/pkg/tls/tls.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,8 +109,7 @@ func ParseTLSVersion(version string) (uint16, error) {
 	}
 }
 
-// NewTLSConfig returns a tls.Config with the recommended default settings for Calico components. Based on build flags,
-// boringCrypto may be used and fips strict mode may be enforced, which can override the parameters defined in this func.
+// NewTLSConfig returns a tls.Config with the recommended default settings for Calico components.
 func NewTLSConfig() (*tls.Config, error) {
 	env := os.Getenv("TLS_CIPHER_SUITES")
 	ciphers, err := ParseTLSCiphers(env)

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -174,14 +174,10 @@ DOCKER_GO_BUILD_CGO=$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(if $(CROSS_CC)
 LIBBPF_DEP=$(if $(filter 1,$(CGO_ENABLED)),$(LIBBPF_A))
 bin/calico-felix-$(ARCH): $(LIBBPF_DEP) $(SRC_FILES)
 	@echo Building felix for $(ARCH) on $(BUILDARCH)
-ifeq ($(FIPS),true)
-	$(call build_cgo_boring_binary, $(PACKAGE_NAME)/cmd/calico-felix, $@)
-else
 ifeq ($(ARCH),$(filter $(ARCH),amd64 arm64 ppc64le ))
 	$(call build_cgo_binary, $(PACKAGE_NAME)/cmd/calico-felix, $@)
 else
 	$(call build_binary, $(PACKAGE_NAME)/cmd/calico-felix, $@)
-endif
 endif
 
 bin/calico-felix-race-$(ARCH):  $(LIBBPF_A) $(SRC_FILES) ../go.mod

--- a/hack/check-images-availability.sh
+++ b/hack/check-images-availability.sh
@@ -49,8 +49,7 @@ manifest_dir="${SCRIPT_DIR}/../manifests"
 
 manifest_images_raw=$(
   grep -rhoE 'image:\s*["'\''"]?[a-z0-9./_-]+:[a-zA-Z0-9._-]+' "$manifest_dir" \
-  | sed -E 's/image:\s*["'\''"]?//' \
-  | grep -v -- '-fips'
+  | sed -E 's/image:\s*["'\''"]?//'
 )
 
 # Step 1.1: Normalize and adjust image paths
@@ -84,7 +83,7 @@ manifest_images=$(
 )
 
 count=$(echo "$manifest_images" | wc -l)
-echo "Total unique images (excluding -fips): ${count}"
+echo "Total unique images: ${count}"
 
 #########################################
 # Step 2: Check availability with retries

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -151,10 +151,10 @@ CALICO_BUILD    = $(GO_BUILD_IMAGE):$(GO_BUILD_VER)
 RUST_BUILD_IMAGE ?= calico/rust-build
 CALICO_RUST_BUILD = $(RUST_BUILD_IMAGE):$(RUST_BUILD_VER)
 
-# We use BoringCrypto as FIPS validated cryptography in order to allow users to run in FIPS Mode (amd64 only).
+# On amd64 we build with CGO enabled (libbpf and other cgo deps require it);
+# other architectures default to pure-Go builds.
 ifeq ($(ARCH), $(filter $(ARCH),amd64))
-GOEXPERIMENT?=boringcrypto
-TAGS?=boringcrypto,osusergo,netgo
+TAGS?=osusergo,netgo
 CGO_ENABLED?=1
 else
 CGO_ENABLED?=0
@@ -188,25 +188,7 @@ endif
 endif
 endif
 
-# Build a binary with boring crypto support.
-# This function expects you to pass in two arguments:
-#   1st arg: path/to/input/package(s)
-#   2nd arg: path/to/output/binary
-# Only when arch = amd64 it will use boring crypto to build the binary.
-# Uses LDFLAGS, CGO_LDFLAGS, CGO_CFLAGS when set.
-# Tests that the resulting binary contains boringcrypto symbols.
-define build_cgo_boring_binary
-	$(DOCKER_RUN) \
-		-e CGO_ENABLED=1 \
-		$(if $(CROSS_CC),-e CC="$(CROSS_CC)") \
-		-e CGO_CFLAGS=$(CGO_CFLAGS) \
-		-e CGO_LDFLAGS=$(CGO_LDFLAGS) \
-		$(CALICO_BUILD) \
-		sh -c '$(GIT_CONFIG_SSH) GOEXPERIMENT=boringcrypto go build -o $(2) -tags fipsstrict -v -buildvcs=false -ldflags "$(LDFLAGS)" $(1) \
-			&& go tool nm $(2) | grep '_Cfunc__goboringcrypto_' 1> /dev/null'
-endef
-
-# Use this when building binaries that need cgo, but have no crypto and therefore would not contain any boring symbols.
+# Use this when building binaries that need cgo (e.g. for libbpf).
 define build_cgo_binary
 	$(DOCKER_RUN) \
 		-e CGO_ENABLED=1 \
@@ -217,7 +199,7 @@ define build_cgo_binary
 		sh -c '$(GIT_CONFIG_SSH) go build -o $(2) -v -buildvcs=false -ldflags "$(LDFLAGS)" $(1)'
 endef
 
-# For binaries that do not require boring crypto.
+# For binaries that do not require cgo.
 define build_binary
 	$(DOCKER_RUN) \
 		-e CGO_ENABLED=0 \

--- a/node/Makefile
+++ b/node/Makefile
@@ -39,16 +39,8 @@ CALICO_API_GROUP ?= projectcalico.org/v3
 ###############################################################################
 include ../lib.Makefile
 
-FIPS ?= false
-
-ifeq ($(FIPS),true)
-NODE_CONTAINER_BIN_DIR=./dist/bin/$(ARCH)-fips
-NODE_CONTAINER_MARKER=$(NODE_CONTAINER_FIPS_CREATED)
-VALIDARCHES=amd64
-else
 NODE_CONTAINER_BIN_DIR=dist/bin
 NODE_CONTAINER_MARKER=$(NODE_CONTAINER_CREATED)
-endif
 
 # The node image uses the combined calico binary built with CGO for BPF support.
 NODE_CONTAINER_BINARY = $(NODE_CONTAINER_BIN_DIR)/calico-$(ARCH)
@@ -74,7 +66,6 @@ TEST_CONTAINER_FILES=$(shell find tests/ -type f ! -name '*.created')
 
 # Variables controlling the image
 NODE_CONTAINER_CREATED=.calico_node.created-$(ARCH)
-NODE_CONTAINER_FIPS_CREATED=.calico_node.created-$(ARCH)-fips
 WINDOWS_BINARY = $(NODE_CONTAINER_BIN_DIR)/calico-node.exe
 TOOLS_MOUNTNS_BINARY = $(NODE_CONTAINER_BIN_DIR)/mountns-$(ARCH)
 
@@ -217,15 +208,10 @@ CGO_CFLAGS=""
 endif
 
 # The node image uses the combined calico binary built with CGO for BPF support.
-# Forward FIPS so the sub-make produces a boringcrypto-linked binary and writes
-# it to bin/$(ARCH)-fips, which is where we pick it up from below.
 CMD_CALICO_BINDIR = ../cmd/calico/bin
-ifeq ($(FIPS),true)
-CMD_CALICO_BINDIR = ../cmd/calico/bin/$(ARCH)-fips
-endif
 
 $(NODE_CONTAINER_BINARY): filesystem/usr/lib/calico/bpf $(LIBBPF_A) $(SRC_FILES) ../go.mod
-	$(MAKE) -C ../cmd/calico build-cgo ARCH=$(ARCH) FIPS=$(FIPS)
+	$(MAKE) -C ../cmd/calico build-cgo ARCH=$(ARCH)
 	mkdir -p $(NODE_CONTAINER_BIN_DIR)
 	cp $(CMD_CALICO_BINDIR)/calico-cgo-$(ARCH) $@
 
@@ -250,11 +236,9 @@ endif
 # Building the image
 ###############################################################################
 ## Create the images for all supported ARCHes
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
 
 dist/LICENSE: ../LICENSE.md
 	mkdir -p dist
@@ -277,7 +261,7 @@ nft-rpms-image: | register
 # as a registry pull and fails when that tag hasn't been pushed yet (PR
 # builds, fresh local builds). Other base images (UBI_IMAGE, BIRD_IMAGE,
 # BPFTOOL_IMAGE) are pinned by tag so cache freshness is fine without --pull.
-$(NODE_CONTAINER_CREATED) $(NODE_CONTAINER_FIPS_CREATED): DOCKER_PULL :=
+$(NODE_CONTAINER_CREATED): DOCKER_PULL :=
 
 $(NODE_CONTAINER_CREATED): $(IMAGE_DEPS) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) $(NODE_CONTAINER_FILES) $(TOOLS_MOUNTNS_BINARY) dist/LICENSE | register nft-rpms-image
 	$(DOCKER_BUILD) \
@@ -288,17 +272,6 @@ $(NODE_CONTAINER_CREATED): $(IMAGE_DEPS) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOU
 		--build-arg GIT_VERSION=$(GIT_VERSION) \
 		-t $(NODE_IMAGE):latest-$(ARCH) -f ./Dockerfile .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-	touch $@
-
-$(NODE_CONTAINER_FIPS_CREATED): $(IMAGE_DEPS) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) $(NODE_CONTAINER_FILES) $(TOOLS_MOUNTNS_BINARY) dist/LICENSE | register nft-rpms-image
-	$(DOCKER_BUILD) \
-		--build-arg BIN_DIR=$(NODE_CONTAINER_BIN_DIR) \
-		--build-arg BIRD_IMAGE=$(BIRD_IMAGE) \
-		--build-arg BPFTOOL_IMAGE=$(BPFTOOL_IMAGE) \
-		--build-context nft-rpms=docker-image://$(NFT_RPMS_IMAGE) \
-		--build-arg GIT_VERSION=$(GIT_VERSION) \
-		-t $(NODE_IMAGE):latest-fips-$(ARCH) -f ./Dockerfile .
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
 # download BIRD source to include in image.
@@ -425,8 +398,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	# Generate the `latest` node images.
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
-	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)-fips LATEST_IMAGE_TAG=latest-fips
-	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	# Generate the Windows zip archives.
 	$(MAKE) release-windows-archive
 	$(MAKE) $(WINDOWS_INSTALL_SCRIPT)
@@ -441,7 +412,6 @@ release-publish: release-prereqs .release-$(VERSION).published
 .release-$(VERSION).published:
 	# Push node images.
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
-	$(MAKE) FIPS=true push-images-to-registries push-manifests IMAGETAG=$(VERSION)-fips RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 
 	# Push Windows images.
 	$(MAKE) release-windows IMAGETAG=$(VERSION) CONFIRM=$(CONFIRM)

--- a/node/clean-up-filesystem.sh
+++ b/node/clean-up-filesystem.sh
@@ -225,16 +225,6 @@ while read -r path; do
     libs_to_keep[$path]=true
     continue
   fi
-  # These libraries and hmac files under /usr/lib64 are needed when ubi container
-  # is running in FIPS mode. They are not directly linked by the allowed binaries.
-  # * /usr/lib64/.libcrypto.so.x.y.z.hmac
-  # * /usr/lib64/.libssl.so.x.y.z.hmac
-  # * /usr/lib64/libssl.so.x.y.z
-  if [[ "$path" =~ .libcrypto|.libssl|libssl ]]; then
-    echo "FIPS PLUGIN: $path"
-    libs_to_keep[$path]=true
-    continue
-  fi
 done < <(find /usr/lib64 \( -type f -or -type l \))
 
 # Now remove all but a keep-list of RPM packages.  Cleaning up packages with rpm itself updates the

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -49,12 +49,7 @@ REGISTRAR_TIGERA_BUILD_CMD="cd /go/src/github.com/$(UPSTREAM_REGISTRAR_PROJECT) 
 	go build -tags $(TAGS) -buildvcs=false -v -o $(BINDIR)/csi-node-driver-registrar cmd/csi-node-driver-registrar/*.go"
 REGISTRAR_UPSTREAM_BUILD_CMD="cd /go/src/github.com/$(UPSTREAM_REGISTRAR_PROJECT) && make build BUILD_PLATFORMS=$(BUILD_PLATFORMS)"
 
-ifeq ($(ARCH), $(filter $(ARCH),amd64))
-# We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
-REGISTRAR_BUILD_CMD=$(REGISTRAR_TIGERA_BUILD_CMD)
-CGO_ENABLED=1
-GOEXPERIMENT=""
-else ifeq ($(ARCH), $(filter $(ARCH),arm64))
+ifeq ($(ARCH), $(filter $(ARCH),amd64 arm64))
 CGO_ENABLED=0
 REGISTRAR_BUILD_CMD=$(REGISTRAR_TIGERA_BUILD_CMD)
 else ifeq ($(ARCH), $(filter $(ARCH),ppc64le))
@@ -72,7 +67,7 @@ REGISTRAR_BUILD_CMD=$(REGISTRAR_UPSTREAM_BUILD_CMD)
 endif
 
 $(BINDIR)/node-driver-registrar-%: clone-registrar-upstream
-	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) -e GOEXPERIMENT=$(GOEXPERIMENT) \
+	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) \
 			-v $(REPO_ROOT)/pod2daemon/$(REGISTRAR_IMAGE):/go/src/github.com/$(UPSTREAM_REGISTRAR_PROJECT):rw \
 			$(CALICO_BUILD) \
 			/bin/bash -c $(REGISTRAR_BUILD_CMD)

--- a/test-tools/mocknode/mock-node.yaml
+++ b/test-tools/mocknode/mock-node.yaml
@@ -26,8 +26,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: FIPS_MODE_ENABLED
-              value: "false"
           image: quay.io/calico/mock-node:master
           imagePullPolicy: IfNotPresent
           name: mock-calico-node


### PR DESCRIPTION
Removes FIPS build support from the OSS repo. We no longer produce boringcrypto/fipsstrict binaries or the `-fips` image variants, and this drops the remaining FIPS references (the FIPS build flags, the FIPS env var on the mock node, and the libssl/libcrypto carve-outs in the node filesystem cleanup).

Note that the `fipsMode` field on the operator Installation API is owned by tigera/operator and syncs into the CRDs here, so removing it is a separate operator change. FIPS references in the docs are also a separate follow-up.

```release-note
Removes the FIPS image variants ("-fips" tagged images) and FIPS build support from Calico, as it was outdated and no longer maintained. 
```
