### PR TITLE
Retry transient apiserver errors in e2e ConfigureWithCleanup

### DIFF
--- a/e2e/pkg/utils/config.go
+++ b/e2e/pkg/utils/config.go
@@ -17,12 +17,25 @@ package utils
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// configRetry backs off long enough to ride out a calico-apiserver pod that's
+// briefly rolling or unreachable, which is where the transient errors that
+// retriableAPIError covers come from.
+var configRetry = wait.Backoff{
+	Steps:    8,
+	Duration: 100 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Cap:      10 * time.Second,
+}
 
 // ConfigureWithCleanup fetches an object by key, applies a mutation, and
 // returns a cleanup function that restores the original state. If the object
@@ -39,11 +52,16 @@ import (
 func ConfigureWithCleanup[T ctrlclient.Object](cli ctrlclient.Client, key ctrlclient.ObjectKey, obj T, mutate func(T)) (func(), error) {
 	ctx := context.Background()
 
-	if err := cli.Get(ctx, key, obj); apierrors.IsNotFound(err) {
+	err := retry.OnError(configRetry, retriableAPIError, func() error {
+		return cli.Get(ctx, key, obj)
+	})
+	if apierrors.IsNotFound(err) {
 		obj.SetName(key.Name)
 		obj.SetNamespace(key.Namespace)
 		mutate(obj)
-		if err := cli.Create(ctx, obj); err != nil {
+		if err := retry.OnError(configRetry, retriableAPIError, func() error {
+			return cli.Create(ctx, obj)
+		}); err != nil {
 			return nil, fmt.Errorf("failed to create %T: %w", obj, err)
 		}
 		return func() {
@@ -56,11 +74,11 @@ func ConfigureWithCleanup[T ctrlclient.Object](cli ctrlclient.Client, key ctrlcl
 	}
 
 	// Operator-reconciled resources (e.g. Installation) can be updated by a
-	// controller between our Get and Update, returning 409 Conflict. Wrap
-	// Get-mutate-Update in RetryOnConflict so we re-read the latest
-	// resourceVersion and re-apply our mutation on conflict.
+	// controller between our Get and Update, returning 409 Conflict. Re-read
+	// the latest resourceVersion and re-apply our mutation on conflict, and on
+	// the transient apiserver errors retriableAPIError covers.
 	var original T
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	if err := retry.OnError(configRetry, retriableAPIError, func() error {
 		if err := cli.Get(ctx, key, obj); err != nil {
 			return err
 		}
@@ -72,7 +90,7 @@ func ConfigureWithCleanup[T ctrlclient.Object](cli ctrlclient.Client, key ctrlcl
 	}
 
 	return func() {
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := retry.OnError(configRetry, retriableAPIError, func() error {
 			if err := cli.Get(context.Background(), key, obj); err != nil {
 				return err
 			}
@@ -82,4 +100,17 @@ func ConfigureWithCleanup[T ctrlclient.Object](cli ctrlclient.Client, key ctrlcl
 			framework.Logf("WARNING: failed to restore %T: %v", obj, err)
 		}
 	}, nil
+}
+
+// retriableAPIError reports whether err is worth retrying against the
+// aggregated projectcalico.org/v3 API server. Besides 409 Conflict, the
+// aggregation layer intermittently drops a request mid-flight when the backing
+// calico-apiserver pod is rolling. That surfaces as ServiceUnavailable
+// ("unexpected EOF") or a 500 InternalError, and clears on retry.
+func retriableAPIError(err error) bool {
+	return apierrors.IsConflict(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err)
 }

--- a/e2e/pkg/utils/config_test.go
+++ b/e2e/pkg/utils/config_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// A ServiceUnavailable from the aggregation layer (the "unexpected EOF" flake
+// when calico-apiserver is rolling) should be retried until it clears.
+func TestConfigureWithCleanupRetriesTransientUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Data:       map[string]string{"key": "original"},
+	}
+
+	updateCalls := 0
+	base := fake.NewClientBuilder().WithObjects(existing).Build()
+	cli := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, c ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCalls++
+			if updateCalls < 3 {
+				return apierrors.NewServiceUnavailable("error trying to reach service: unexpected EOF")
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	})
+
+	restore, err := ConfigureWithCleanup(cli, ctrlclient.ObjectKey{Name: "default"}, &corev1.ConfigMap{}, func(cm *corev1.ConfigMap) {
+		cm.Data["key"] = "mutated"
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(updateCalls).To(Equal(3), "transient ServiceUnavailable responses should be retried")
+
+	got := &corev1.ConfigMap{}
+	g.Expect(cli.Get(context.Background(), ctrlclient.ObjectKey{Name: "default"}, got)).To(Succeed())
+	g.Expect(got.Data["key"]).To(Equal("mutated"))
+	g.Expect(restore).NotTo(BeNil())
+}
+
+// A permanent error (e.g. Forbidden) is not retriable and should fail fast
+// rather than burning the whole backoff.
+func TestConfigureWithCleanupDoesNotRetryPermanentError(t *testing.T) {
+	g := NewWithT(t)
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Data:       map[string]string{"key": "original"},
+	}
+
+	updateCalls := 0
+	base := fake.NewClientBuilder().WithObjects(existing).Build()
+	cli := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, c ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			updateCalls++
+			return apierrors.NewForbidden(corev1.Resource("configmaps"), "default", nil)
+		},
+	})
+
+	_, err := ConfigureWithCleanup(cli, ctrlclient.ObjectKey{Name: "default"}, &corev1.ConfigMap{}, func(cm *corev1.ConfigMap) {
+		cm.Data["key"] = "mutated"
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(updateCalls).To(Equal(1), "a non-retriable error should not be retried")
+}


### PR DESCRIPTION
E2E specs intermittently fail in `BeforeEach` when the aggregated projectcalico.org/v3 API server drops a request mid-flight. When the backing calico-apiserver pod is rolling, the aggregation layer returns ServiceUnavailable ("unexpected EOF") or a 500, and `ConfigureWithCleanup` only retried on conflict, so a single blip failed the spec.

This retries Get, Create, and Update on those transient errors (in addition to conflict) with a backoff long enough to ride out a briefly-rolling apiserver.

```release-note
None
```
