### PR TITLE
BPF FV: make host-IP tests robust to health/counter table wrapping

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -405,11 +405,22 @@ blocks:
     # producer for the "calico" build-cache group — every Go component block on
     # master restores the module + build cache populated here.
     #
-    # cmd/calico's Go closure already covers felix/typha (registered as
-    # subcommands); the non-go paths close the gap for Felix Build/UT, which
-    # does untolerated gcloud cp of calico-cgo/calico-race/libbpf. Other
-    # consumers use .semaphore/load-cached-images, which falls back to a local
-    # build on cache miss.
+    # felix MUST be the primary (first) CHANGE_IN arg so this producer is a strict
+    # superset of its consumers. The Felix Build/UT/FV and Windows FV blocks all
+    # trigger on CHANGE_IN(felix,...) and then do an untolerated gcloud cp of
+    # calico-cgo/calico-race/libbpf (or load the cached calico image), so this
+    # producer must run whenever they do — including on felix-test-only PRs.
+    #
+    # The deps tool (hack/cmd/deps) emits `/<primary>/**` for the FIRST arg with no
+    # test-file exclusion, but for every *secondary*/dependency package it adds a
+    # `/<pkg>/**/*_test.go` EXCLUSION. With cmd/calico primary, felix is only a
+    # dependency in cmd/calico's closure, so `/felix/**/*_test.go` was excluded and
+    # a PR touching only felix tests (e.g. felix/fv/*_test.go) ran the Felix blocks
+    # while skipping this producer — leaving the artifacts unuploaded. Putting felix
+    # first yields `/felix/**` with felix tests INCLUDED, matching the consumers.
+    # cmd/calico stays as a secondary so the calico image still rebuilds on changes
+    # to cmd/calico and any subcommand's Go closure (goldmane, guardian, typha, …).
+    #
     # The process/testing paths trigger this so the win-fv-felix block (which now
     # installs the locally-built calico image) has it cached in GCS. The libcalico
     # ipam/stacktrace paths and the 20-felix.yml self-trigger keep this block a

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -650,11 +650,22 @@ blocks:
     # producer for the "calico" build-cache group — every Go component block on
     # master restores the module + build cache populated here.
     #
-    # cmd/calico's Go closure already covers felix/typha (registered as
-    # subcommands); the non-go paths close the gap for Felix Build/UT, which
-    # does untolerated gcloud cp of calico-cgo/calico-race/libbpf. Other
-    # consumers use .semaphore/load-cached-images, which falls back to a local
-    # build on cache miss.
+    # felix MUST be the primary (first) CHANGE_IN arg so this producer is a strict
+    # superset of its consumers. The Felix Build/UT/FV and Windows FV blocks all
+    # trigger on CHANGE_IN(felix,...) and then do an untolerated gcloud cp of
+    # calico-cgo/calico-race/libbpf (or load the cached calico image), so this
+    # producer must run whenever they do — including on felix-test-only PRs.
+    #
+    # The deps tool (hack/cmd/deps) emits `/<primary>/**` for the FIRST arg with no
+    # test-file exclusion, but for every *secondary*/dependency package it adds a
+    # `/<pkg>/**/*_test.go` EXCLUSION. With cmd/calico primary, felix is only a
+    # dependency in cmd/calico's closure, so `/felix/**/*_test.go` was excluded and
+    # a PR touching only felix tests (e.g. felix/fv/*_test.go) ran the Felix blocks
+    # while skipping this producer — leaving the artifacts unuploaded. Putting felix
+    # first yields `/felix/**` with felix tests INCLUDED, matching the consumers.
+    # cmd/calico stays as a secondary so the calico image still rebuilds on changes
+    # to cmd/calico and any subcommand's Go closure (goldmane, guardian, typha, …).
+    #
     # The process/testing paths trigger this so the win-fv-felix block (which now
     # installs the locally-built calico image) has it cached in GCS. The libcalico
     # ipam/stacktrace paths and the 20-felix.yml self-trigger keep this block a
@@ -738,7 +749,7 @@ blocks:
         '/calicoctl/calicoctl/resourcemgr/*.go',
         '/calicoctl/calicoctl/util/*.go',
         '/calicoctl/calicoctl/util/yaml/*.go',
-        '/cmd/calico/**',
+        '/cmd/calico/*.go',
         '/cni-plugin/internal/pkg/azure/*.go',
         '/cni-plugin/internal/pkg/utils/*.go',
         '/cni-plugin/internal/pkg/utils/cri/*.go',
@@ -762,7 +773,7 @@ blocks:
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
         '/docker/calico/',
-        '/felix/',
+        '/felix/**',
         '/felix/aws/*.go',
         '/felix/bpf/*.go',
         '/felix/bpf/allowsources/*.go',
@@ -954,6 +965,7 @@ blocks:
         '/libcalico-go/lib/hash/*.go',
         '/libcalico-go/lib/health/*.go',
         '/libcalico-go/lib/ipam/',
+        '/libcalico-go/lib/ipam/*.go',
         '/libcalico-go/lib/ipam/vmipam/*.go',
         '/libcalico-go/lib/kubevirt/*.go',
         '/libcalico-go/lib/logutils/*.go',
@@ -975,6 +987,7 @@ blocks:
         '/libcalico-go/lib/selector/tokenizer/*.go',
         '/libcalico-go/lib/set/*.go',
         '/libcalico-go/lib/testutils/stacktrace/',
+        '/libcalico-go/lib/testutils/stacktrace/*.go',
         '/libcalico-go/lib/validator/v1/*.go',
         '/libcalico-go/lib/validator/v3/*.go',
         '/libcalico-go/lib/watch/*.go',
@@ -1009,7 +1022,7 @@ blocks:
         '/process/testing/aso',
         '/process/testing/util',
         '/process/testing/winfv-felix',
-        '/typha/',
+        '/typha/cmd/typha-client/*.go',
         '/typha/cmd/typha/*.go',
         '/typha/pkg/calc/*.go',
         '/typha/pkg/config/*.go',
@@ -1032,7 +1045,13 @@ blocks:
         '/whisker-backend/cmd/whiskerbackend/*.go',
         '/whisker-backend/pkg/apis/v1/*.go',
         '/whisker-backend/pkg/config/*.go',
-        '/whisker-backend/pkg/handlers/v1/*.go'],
+        '/whisker-backend/pkg/handlers/v1/*.go',
+        'cmd/calico/**/*Dockerfile*',
+        'cmd/calico/Makefile',
+        'cmd/calico/deps.txt',
+        'typha/**/*Dockerfile*',
+        'typha/Makefile',
+        'typha/deps.txt'],
         {pipeline_file: 'ignore', exclude: ['/**/*.md',
         '/**/.gitignore',
         '/**/AUTHORS*',
@@ -1045,10 +1064,10 @@ blocks:
         '/apiserver/**/*_test.go',
         '/app-policy/**/*_test.go',
         '/calicoctl/**/*_test.go',
+        '/cmd/**/*_test.go',
         '/cni-plugin/**/*_test.go',
         '/confd/**/*_test.go',
         '/crypto/**/*_test.go',
-        '/felix/**/*_test.go',
         '/goldmane/**/*_test.go',
         '/guardian/**/*_test.go',
         '/key-cert-provisioner/**/*_test.go',

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -201,18 +201,29 @@
   # producer for the "calico" build-cache group — every Go component block on
   # master restores the module + build cache populated here.
   #
-  # cmd/calico's Go closure already covers felix/typha (registered as
-  # subcommands); the non-go paths close the gap for Felix Build/UT, which
-  # does untolerated gcloud cp of calico-cgo/calico-race/libbpf. Other
-  # consumers use .semaphore/load-cached-images, which falls back to a local
-  # build on cache miss.
+  # felix MUST be the primary (first) CHANGE_IN arg so this producer is a strict
+  # superset of its consumers. The Felix Build/UT/FV and Windows FV blocks all
+  # trigger on CHANGE_IN(felix,...) and then do an untolerated gcloud cp of
+  # calico-cgo/calico-race/libbpf (or load the cached calico image), so this
+  # producer must run whenever they do — including on felix-test-only PRs.
+  #
+  # The deps tool (hack/cmd/deps) emits `/<primary>/**` for the FIRST arg with no
+  # test-file exclusion, but for every *secondary*/dependency package it adds a
+  # `/<pkg>/**/*_test.go` EXCLUSION. With cmd/calico primary, felix is only a
+  # dependency in cmd/calico's closure, so `/felix/**/*_test.go` was excluded and
+  # a PR touching only felix tests (e.g. felix/fv/*_test.go) ran the Felix blocks
+  # while skipping this producer — leaving the artifacts unuploaded. Putting felix
+  # first yields `/felix/**` with felix tests INCLUDED, matching the consumers.
+  # cmd/calico stays as a secondary so the calico image still rebuilds on changes
+  # to cmd/calico and any subcommand's Go closure (goldmane, guardian, typha, …).
+  #
   # The process/testing paths trigger this so the win-fv-felix block (which now
   # installs the locally-built calico image) has it cached in GCS. The libcalico
   # ipam/stacktrace paths and the 20-felix.yml self-trigger keep this block a
   # superset of the win-fv-felix block's trigger (felix's full test closure plus
   # its own CI block), so win-fv-felix never runs without this image in GCS.
   run:
-    when: "${CHANGE_IN(cmd/calico,non-go:/felix/,non-go:/typha/,non-go:/.semaphore/vms/,non-go:/docker/calico/,non-go:/libcalico-go/lib/ipam/,non-go:/libcalico-go/lib/testutils/stacktrace/,non-go:/.semaphore/semaphore.yml.d/blocks/20-felix.yml,non-go:/process/testing/aso,non-go:/process/testing/util,non-go:/process/testing/winfv-felix)}"
+    when: "${CHANGE_IN(felix,cmd/calico,typha,non-go:/.semaphore/vms/,non-go:/docker/calico/,non-go:/libcalico-go/lib/ipam/,non-go:/libcalico-go/lib/testutils/stacktrace/,non-go:/.semaphore/semaphore.yml.d/blocks/20-felix.yml,non-go:/process/testing/aso,non-go:/process/testing/util,non-go:/process/testing/winfv-felix)}"
   dependencies: []
   task:
     env_vars:

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -524,8 +524,13 @@ func readDroppedNoHostIPCounter(g Gomega, felix *infrastructure.Felix, ifName st
 		if strings.TrimSpace(strings.ToLower(fields[0])) == "dropped" {
 			inDropped = true
 		}
-		if inDropped && strings.TrimSpace(strings.ToLower(fields[1])) ==
-			"vxlan encap when host ip unknown" {
+		// The counter name "VXLAN encap when host IP unknown" exceeds the
+		// counters-dump TYPE column width and wraps onto a second line
+		// ("...host IP" / "unknown"), so match on the unique prefix that
+		// survives on the first line — the counts live on that first line
+		// either way. HasPrefix also matches the unwrapped (wide-table) form.
+		if inDropped && strings.HasPrefix(strings.TrimSpace(strings.ToLower(fields[1])),
+			"vxlan encap when host ip") {
 			iCount, _ = strconv.Atoi(strings.TrimSpace(fields[2]))
 			eCount, _ = strconv.Atoi(strings.TrimSpace(fields[3]))
 			return iCount, eCount

--- a/felix/fv/bpf_node_delete_test.go
+++ b/felix/fv/bpf_node_delete_test.go
@@ -162,7 +162,10 @@ var _ = infrastructure.DatastoreDescribe(
 				ContainSubstring("BPFHostIP"),
 				ContainSubstring("status=503"),
 				ContainSubstring("Host IP unknown"),
-				ContainSubstring("IPv4 unknown since"),
+				// The readiness detail wraps across table lines, so the
+				// "IPv4 unknown" and "since <ts>" halves can be split by
+				// padding and "|" borders — tolerate that between them.
+				MatchRegexp(`IPv4 unknown[\s|]*since`),
 			))
 		})
 
@@ -318,7 +321,10 @@ var _ = infrastructure.DatastoreDescribe(
 			Eventually(readinessReport, "10s", "500ms").Should(SatisfyAll(
 				ContainSubstring("BPFHostIP"),
 				ContainSubstring("status=503"),
-				ContainSubstring("IPv4 unknown since"),
+				// The readiness detail wraps across table lines, so the
+				// "IPv4 unknown" and "since <ts>" halves can be split by
+				// padding and "|" borders — tolerate that between them.
+				MatchRegexp(`IPv4 unknown[\s|]*since`),
 			))
 
 			By("Restoring the Node IP and confirming readiness recovers")


### PR DESCRIPTION
Makes two BPF host-IP FV tests robust to ASCII-table line wrapping.

The node-delete and dual-stack host-IP FV tests (added in #12810) assert on substrings that the health/CLI tables can wrap across lines depending on the rendered column widths:

- `bpf_node_delete_test.go` matched the contiguous `"IPv4 unknown since"`, but the `/readiness` health table can wrap the long `BPFHostIP` detail between `"IPv4 unknown"` and `"since <timestamp>"`. Now matched with a regex that tolerates the intervening padding and `|` borders.
- `readDroppedNoHostIPCounter` required an exact match of the 32-char `"VXLAN encap when host IP unknown"` counter name, which wraps in the `calico-bpf counters dump` TYPE column. Now matched on the unique prefix that survives on the first line (where the counts are); this also matches the unwrapped form.

No product behaviour change — only the test parsing is made robust. These assertions fail deterministically on the release-v3.32 cherry-pick CI's table widths (projectcalico/calico#12874); this is the same fix, ported to master so the fragility can't resurface here.

Verified by building the FV test binary (`make -C felix fv/fv.test`); the underlying behaviour was confirmed correct by running the affected BPF FVs locally on the v3.32 branch.

**Release note:**
```release-note
None
```