### PR TITLE
Address Copilot review on PR #12770 (resync scale + perf-publishing)

### DIFF
--- a/hack/perf/index-templates/benchmark_data_neutron_resync.json
+++ b/hack/perf/index-templates/benchmark_data_neutron_resync.json
@@ -8,6 +8,7 @@
         "git_branch":       {"type": "keyword"},
         "code_version":     {"type": "keyword"},
         "ci_run_id":        {"type": "keyword"},
+        "pr_number":        {"type": "keyword"},
         "test_name":        {"type": "keyword"},
         "env":              {"type": "keyword"},
         "phase":            {"type": "keyword"},

--- a/networking-calico/devstack/resync_scale_test.py
+++ b/networking-calico/devstack/resync_scale_test.py
@@ -87,8 +87,12 @@ DEFAULT_SCALES = "100,1000,3000"
 # a port to a host.  Must match AGENT_TYPE_FELIX in mech_calico.py.
 AGENT_TYPE_FELIX = "Calico per-host agent (felix)"
 
-# How many ports to ask the Neutron API to create in one HTTP request.  Bulk create is
-# supported by the v2 API and is much faster than one-at-a-time.
+# Batch size for the port-create loop in ``create_ports``.  Each batch issues this
+# many *single-port* create_port calls in parallel across the thread pool.  We don't
+# use Neutron's bulk-create endpoint because the populate phase is just setup -- we
+# don't time it, and bulk vs single creates produce identical rows in the ports
+# table either way, so the later resync reads them identically.  Smaller batches
+# just mean more frequent progress logs.
 PORT_BULK_BATCH = 50
 
 # How many concurrent worker threads to use when populating resources.  Modest
@@ -139,9 +143,11 @@ def parse_db_connection(neutron_conf_path):
     conn_str = parser.get("database", "connection")
     parsed = urlparse(conn_str)
     if not parsed.username or not parsed.password:
+        # Don't include conn_str in the message -- it contains the DB password
+        # and would otherwise be echoed straight into CI logs.
         raise RuntimeError(
-            "Could not parse user/password from neutron.conf [database] connection=%s"
-            % conn_str
+            "Could not parse user/password from neutron.conf [database] "
+            "connection URL (host=%r scheme=%r)" % (parsed.hostname, parsed.scheme)
         )
     return {
         "host": parsed.hostname or "127.0.0.1",
@@ -363,16 +369,21 @@ def create_ports(conn, num_ports, networks, subnets, sgs, hosts):
             return None
 
     created = []
-    for batch_start in range(0, num_ports, PORT_BULK_BATCH):
-        batch = [
-            _build_port_spec(i)
-            for i in range(batch_start, min(batch_start + PORT_BULK_BATCH, num_ports))
-        ]
-        with concurrent.futures.ThreadPoolExecutor(max_workers=POPULATE_WORKERS) as ex:
+    # Reuse a single executor across all batches; otherwise the
+    # ThreadPoolExecutor setup/teardown cost dominates at small batch
+    # sizes, especially since at scale=3000 we have 60 batches.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=POPULATE_WORKERS) as ex:
+        for batch_start in range(0, num_ports, PORT_BULK_BATCH):
+            batch = [
+                _build_port_spec(i)
+                for i in range(
+                    batch_start, min(batch_start + PORT_BULK_BATCH, num_ports)
+                )
+            ]
             results = list(ex.map(_create_one, batch))
-        created.extend(p for p in results if p is not None)
-        if (batch_start // PORT_BULK_BATCH) % 10 == 0:
-            LOG.info("  ...created %d/%d ports", len(created), num_ports)
+            created.extend(p for p in results if p is not None)
+            if (batch_start // PORT_BULK_BATCH) % 10 == 0:
+                LOG.info("  ...created %d/%d ports", len(created), num_ports)
 
     LOG.info("Port creation done: %d ports", len(created))
     if len(created) != num_ports:


### PR DESCRIPTION
Four fixes covering the Copilot review at calico-private PR #12172 (mirror of merged PR #12770):

1. resync_scale_test.py: ``parse_db_connection`` no longer interpolates the full ``[database] connection`` URL into its RuntimeError message. The URL contains the DB password and would otherwise end up in CI logs verbatim.  Show only the host + scheme.

2. resync_scale_test.py: fix a misleading comment on PORT_BULK_BATCH. The constant was documented as "ports per HTTP bulk-create request", but ``create_ports`` actually issues single-port create calls in a thread pool -- the batching is just for progress logging and (with fix 3 below) executor lifetime.

3. resync_scale_test.py: reuse one ``ThreadPoolExecutor`` for the whole port-create loop, instead of constructing and tearing down a new one per batch.  At scale=3000 (60 batches) the setup/teardown cost adds up; sharing one executor is also closer to the model of "drive sustained concurrency through neutron-server" that the test is meant to exercise.

4. hack/perf/index-templates/benchmark_data_neutron_resync.json: pin ``pr_number`` as ``keyword``.  ``send-perf-results`` injects this field when ``SEMAPHORE_GIT_PR_NUMBER`` is set, and without pinning it the dynamic mapping could infer ``text`` on the first doc, leading to Kibana field-conflict warnings across yearly indices.