### PR TITLE
Add KubeVirt e2e pipeline for Semaphore CI

### DIFF
--- a/.semaphore/end-to-end/pipelines/kubevirt.yml
+++ b/.semaphore/end-to-end/pipelines/kubevirt.yml
@@ -1,0 +1,70 @@
+version: v1.0
+
+name: KubeVirt
+
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+
+execution_time_limit:
+  hours: 12
+
+global_job_config:
+  prologue:
+    commands_file: ../scripts/global_prologue.sh
+  epilogue:
+    always:
+      commands:
+        - ~/calico/.semaphore/end-to-end/scripts/global_epilogue.sh
+  secrets:
+    - name: marvin-github-ssh-private-key
+    - name: banzai-secrets
+  env_vars:
+    - name: FUNCTIONAL_AREA
+      value: "kubevirt.yml"
+    - name: PROVISIONER
+      value: "gcp-kubeadm"
+    - name: INSTALLER
+      value: "operator"
+    - name: DATAPLANE
+      value: "Default"
+    - name: NUM_KUBEVIRT_VMS
+      value: "2"
+    - name: RUN_LOCAL_TESTS
+      value: "true"
+    - name: E2E_TEST_CONFIG
+      value: "e2e/config/gcp-kubevirt.yaml"
+    - name: BANZAI_CORE_BRANCH
+      value: "song-gkm-fix"
+    - name: USE_PRIVATE_REGISTRY
+      value: "true"
+    - name: PRIVATE_REGISTRY
+      value: "quay.io/" # Pull from quay to avoid Docker Hub rate limits
+
+blocks:
+  - name: KubeVirt e2e tests
+    dependencies: []
+    task:
+      jobs:
+        - name: KubeVirt IP persistence and live migration
+          execution_time_limit:
+            hours: 7
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: K8S_VERSION
+              value: "stable-1.35"
+
+promotions:
+  - name: Cleanup jobs
+    pipeline_file: cleanup.yml
+    auto_promote:
+      when: "result = 'stopped'"
+
+after_pipeline:
+  task:
+    jobs:
+      - name: Reports
+        commands:
+          - test-results gen-pipeline-report --force

--- a/.semaphore/end-to-end/scripts/phases/configure.sh
+++ b/.semaphore/end-to-end/scripts/phases/configure.sh
@@ -2,14 +2,14 @@
 # configure.sh - configure test environment after cluster install.
 #
 # Sets PATH to include the bz-provisioned bin dir, exports external-node
-# credentials when ENABLE_EXTERNAL_NODE=true, propagates IPAM test config,
-# and applies the optional failsafe patch.
+# credentials when external_ip and external_key files exist in BZ_LOCAL_DIR
+# (written by bz install or gkm), propagates IPAM test config, and applies
+# the optional failsafe patch.
 #
 # Required env:
 #   BZ_LOCAL_DIR
 # Optional env:
-#   ENABLE_EXTERNAL_NODE, IPAM_TEST_POOL_SUBNET, FAILSAFE_443,
-#   K8S_E2E_DOCKER_EXTRA_FLAGS
+#   IPAM_TEST_POOL_SUBNET, FAILSAFE_443, K8S_E2E_DOCKER_EXTRA_FLAGS
 #
 # Exports consumed by later phases:
 #   PATH, EXT_USER, EXT_IP, EXT_KEY, K8S_E2E_DOCKER_EXTRA_FLAGS
@@ -20,7 +20,7 @@ if [[ -z "${BZ_LOCAL_DIR}" ]]; then echo "[ERROR] BZ_LOCAL_DIR is required but n
 
 export PATH=$PATH:${BZ_LOCAL_DIR}/bin
 
-if [[ "${ENABLE_EXTERNAL_NODE}" == "true" ]]; then
+if [[ -f "${BZ_LOCAL_DIR}/external_ip" ]] && [[ -f "${BZ_LOCAL_DIR}/external_key" ]]; then
   export EXT_USER=ubuntu
   EXT_IP=$(cat "${BZ_LOCAL_DIR}/external_ip")
   export EXT_IP

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -73,6 +73,14 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # the container, and we prepend that to PATH inside the bash -c below.
   make kubectl
 
+  # Optional debug pause: touch /home/semaphore/pause before this point to
+  # hold execution so you can SSH in and inspect the environment.  Remove
+  # the file to continue.
+  while [[ -f /home/semaphore/pause ]]; do
+    echo "[DEBUG] /home/semaphore/pause exists — waiting (remove it to continue)..."
+    sleep 15
+  done
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0

--- a/e2e/config/gcp-kubevirt.yaml
+++ b/e2e/config/gcp-kubevirt.yaml
@@ -1,0 +1,16 @@
+# gcp-kubevirt.yaml - GCP kubeadm with KubeVirt VMs.
+#
+# Used by the kubevirt.yml e2e pipeline. Runs Feature:KubeVirt tests on a
+# GCP kubeadm cluster with nested virtualization, KubeVirt, and external
+# L2TP/BGP nodes.
+
+include:
+  - Feature:KubeVirt
+
+exclude:
+  labels:
+    - label: Slow
+      reason: "long-running tests not suitable for CI"
+
+    - label: Disruptive
+      reason: "breaks cluster state for other parallel tests"


### PR DESCRIPTION
Add a standalone Semaphore pipeline that provisions a GCP kubeadm cluster with nested virtualization and KubeVirt, then runs the Feature:KubeVirt e2e tests (IP persistence + live migration).

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->


