### PR TITLE
fix: Fix bug in most verbose log level logic

### DIFF
--- a/felix/logutils/logutils.go
+++ b/felix/logutils/logutils.go
@@ -89,9 +89,8 @@ func ConfigureLogging(configParams *config.Config) {
 
 	// Work out the most verbose level that is being logged.
 	mostVerboseLevel := max(logLevelFile, logLevelScreen)
-	if logLevelSyslog > mostVerboseLevel {
-		mostVerboseLevel = logLevelScreen
-	}
+	mostVerboseLevel = max(logLevelSyslog, mostVerboseLevel)
+
 	// Disable all more-verbose levels using the global setting, this ensures that debug logs
 	// are filtered out as early as possible.
 	log.SetLevel(mostVerboseLevel)


### PR DESCRIPTION
## WHY, WHAT

I'm unsure whether this is intentional but it is definitely breaking a valid use case imo.

With the current logic, if syslog's level is greater than file's level or stdout's level, then `felix` will choose stdout's level. In other words, if one specifies the following in `felix.cfg`:

```sh
LogSeverityScreen = none
LogFilePath = none
LogSeverityFile = none
LogSeveritySys = Info
```

Then nothing will be logged. This is because `LogSeverityScreen` and `LogSeverityFile` will be set to `PanicLevel=0` by default, while `LogSeveritySys` will be set to `InfoLevel=4`, and by the current logic, if syslog's level is greater than both file's level and stdout's level, `mostVerboseLevel = logLevelScreen`, which is `PanicLevel=0` in this case.

A user of `felix`, when specifying configs like this, expects `felix` logs info and above into syslog only.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Bugfix: Felix did not emit the requested logging when configured to log to syslog at a more detailed level than to any other logging destination.
```
