### PR TITLE
A new manifest for deploying Calico with Felix programming in-cluster routes

### DIFF
--- a/charts/calico/templates/calico-config.yaml
+++ b/charts/calico/templates/calico-config.yaml
@@ -41,6 +41,8 @@ data:
   # Configure the backend to use.
 {{- if or (.Values.flannel_migration) (.Values.vxlan) }}
   calico_backend: "vxlan"
+{{- else if eq .Values.cluster_routing_mode "felix" }}
+  calico_backend: "felix"
 {{- else }}
   calico_backend: "bird"
 {{- end }}

--- a/charts/crd.projectcalico.org.v1/templates/operator.tigera.io_installations.yaml
+++ b/charts/crd.projectcalico.org.v1/templates/operator.tigera.io_installations.yaml
@@ -9203,6 +9203,69 @@ spec:
                     prometheus metrics on. By default, metrics are not enabled.
                   format: int32
                   type: integer
+                typhaPodDisruptionBudget:
+                  description: |-
+                    TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                    Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                    selector is managed by the operator and cannot be overridden.
+                  properties:
+                    metadata:
+                      description:
+                        Metadata is a subset of a Kubernetes object's metadata
+                        that is added to the PodDisruptionBudget.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is a map of arbitrary non-identifying metadata. Each of these
+                            key/value pairs are added to the object's annotations provided the key does not
+                            already exist in the object's annotations.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Labels is a map of string keys and values that may match replicaset and
+                            service selectors. Each of these key/value pairs are added to the
+                            object's labels provided the key does not already exist in the object's labels.
+                          type: object
+                      type: object
+                    spec:
+                      description: Spec is the specification of the PodDisruptionBudget.
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                            can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                            If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                            default (MaxUnavailable=1 for calico-typha).
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MinAvailable is the minimum number of pods (as an integer or percentage) that
+                            must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                          x-kubernetes-int-or-string: true
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                            for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                            See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                          enum:
+                            - IfHealthyBudget
+                            - AlwaysAllow
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: minAvailable and maxUnavailable are mutually exclusive
+                          rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                  type: object
                 variant:
                   description: |-
                     Variant is the product to install - one of Calico or CalicoEnterprise.
@@ -18581,6 +18644,69 @@ spec:
                         serves prometheus metrics on. By default, metrics are not enabled.
                       format: int32
                       type: integer
+                    typhaPodDisruptionBudget:
+                      description: |-
+                        TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                        Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                        selector is managed by the operator and cannot be overridden.
+                      properties:
+                        metadata:
+                          description:
+                            Metadata is a subset of a Kubernetes object's
+                            metadata that is added to the PodDisruptionBudget.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations is a map of arbitrary non-identifying metadata. Each of these
+                                key/value pairs are added to the object's annotations provided the key does not
+                                already exist in the object's annotations.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Labels is a map of string keys and values that may match replicaset and
+                                service selectors. Each of these key/value pairs are added to the
+                                object's labels provided the key does not already exist in the object's labels.
+                              type: object
+                          type: object
+                        spec:
+                          description: Spec is the specification of the PodDisruptionBudget.
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                                can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                                If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                                default (MaxUnavailable=1 for calico-typha).
+                              x-kubernetes-int-or-string: true
+                            minAvailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MinAvailable is the minimum number of pods (as an integer or percentage) that
+                                must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                              x-kubernetes-int-or-string: true
+                            unhealthyPodEvictionPolicy:
+                              description: |-
+                                UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                                for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                                See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                              enum:
+                                - IfHealthyBudget
+                                - AlwaysAllow
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: minAvailable and maxUnavailable are mutually exclusive
+                              rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                      type: object
                     variant:
                       description: |-
                         Variant is the product to install - one of Calico or CalicoEnterprise.

--- a/charts/projectcalico.org.v3/templates/operator.tigera.io_installations.yaml
+++ b/charts/projectcalico.org.v3/templates/operator.tigera.io_installations.yaml
@@ -9203,6 +9203,69 @@ spec:
                     prometheus metrics on. By default, metrics are not enabled.
                   format: int32
                   type: integer
+                typhaPodDisruptionBudget:
+                  description: |-
+                    TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                    Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                    selector is managed by the operator and cannot be overridden.
+                  properties:
+                    metadata:
+                      description:
+                        Metadata is a subset of a Kubernetes object's metadata
+                        that is added to the PodDisruptionBudget.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is a map of arbitrary non-identifying metadata. Each of these
+                            key/value pairs are added to the object's annotations provided the key does not
+                            already exist in the object's annotations.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Labels is a map of string keys and values that may match replicaset and
+                            service selectors. Each of these key/value pairs are added to the
+                            object's labels provided the key does not already exist in the object's labels.
+                          type: object
+                      type: object
+                    spec:
+                      description: Spec is the specification of the PodDisruptionBudget.
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                            can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                            If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                            default (MaxUnavailable=1 for calico-typha).
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MinAvailable is the minimum number of pods (as an integer or percentage) that
+                            must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                          x-kubernetes-int-or-string: true
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                            for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                            See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                          enum:
+                            - IfHealthyBudget
+                            - AlwaysAllow
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: minAvailable and maxUnavailable are mutually exclusive
+                          rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                  type: object
                 variant:
                   description: |-
                     Variant is the product to install - one of Calico or CalicoEnterprise.
@@ -18581,6 +18644,69 @@ spec:
                         serves prometheus metrics on. By default, metrics are not enabled.
                       format: int32
                       type: integer
+                    typhaPodDisruptionBudget:
+                      description: |-
+                        TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                        Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                        selector is managed by the operator and cannot be overridden.
+                      properties:
+                        metadata:
+                          description:
+                            Metadata is a subset of a Kubernetes object's
+                            metadata that is added to the PodDisruptionBudget.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations is a map of arbitrary non-identifying metadata. Each of these
+                                key/value pairs are added to the object's annotations provided the key does not
+                                already exist in the object's annotations.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Labels is a map of string keys and values that may match replicaset and
+                                service selectors. Each of these key/value pairs are added to the
+                                object's labels provided the key does not already exist in the object's labels.
+                              type: object
+                          type: object
+                        spec:
+                          description: Spec is the specification of the PodDisruptionBudget.
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                                can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                                If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                                default (MaxUnavailable=1 for calico-typha).
+                              x-kubernetes-int-or-string: true
+                            minAvailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MinAvailable is the minimum number of pods (as an integer or percentage) that
+                                must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                              x-kubernetes-int-or-string: true
+                            unhealthyPodEvictionPolicy:
+                              description: |-
+                                UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                                for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                                See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                              enum:
+                                - IfHealthyBudget
+                                - AlwaysAllow
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: minAvailable and maxUnavailable are mutually exclusive
+                              rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                      type: object
                     variant:
                       description: |-
                         Variant is the product to install - one of Calico or CalicoEnterprise.

--- a/charts/values/calico-felix.yaml
+++ b/charts/values/calico-felix.yaml
@@ -1,0 +1,3 @@
+datastore: kubernetes
+network: calico
+cluster_routing_mode: felix

--- a/manifests/calico-felix.yaml
+++ b/manifests/calico-felix.yaml
@@ -1,0 +1,12742 @@
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+# This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+# Source: calico/templates/calico-config.yaml
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # Typha is disabled.
+  typha_service_name: "none"
+  # Configure the backend to use.
+  calico_backend: "felix"
+
+  # Configure the MTU to use for workload interfaces and tunnels.
+  # By default, MTU is auto-detected, and explicitly setting this field should not be required.
+  # You can override auto-detection by providing a non-zero value.
+  veth_mtu: "0"
+
+  # The CNI network configuration to install on each node. The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "log_file_path": "/var/log/calico/cni/cni.log",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: BGPConfiguration contains the configuration for any BGP routing.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPConfigurationSpec contains the values of the BGP configuration.
+              properties:
+                asNumber:
+                  description:
+                    "ASNumber is the default AS number used by a node. [Default:
+                    64512]"
+                  format: int32
+                  type: integer
+                bindMode:
+                  description: |-
+                    BindMode indicates whether to listen for BGP connections on all addresses (None)
+                    or only on the node's canonical IP address Node.Spec.BGP.IPvXAddress (NodeIP).
+                    Default behaviour is to listen for BGP connections on all addresses.
+                  enum:
+                    - None
+                    - NodeIP
+                  type: string
+                communities:
+                  description:
+                    Communities is a list of BGP community values and their
+                    arbitrary names for tagging routes.
+                  items:
+                    description:
+                      Community contains standard or large community value
+                      and its name.
+                    properties:
+                      name:
+                        description: Name given to community value.
+                        maxLength: 253
+                        type: string
+                      value:
+                        description: |-
+                          Value must be of format `aa:nn` or `aa:nn:mm`.
+                          For standard community use `aa:nn` format, where `aa` and `nn` are 16 bit number.
+                          For large community use `aa:nn:mm` format, where `aa`, `nn` and `mm` are 32 bit number.
+                          Where, `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                        maxLength: 40
+                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  maxItems: 500
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ignoredInterfaces:
+                  description:
+                    IgnoredInterfaces indicates the network interfaces that
+                    needs to be excluded when reading device routes.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                ipv4NormalRoutePriority:
+                  description: |-
+                    IPv4NormalRoutePriority is the normal route priority (metric) that Felix uses for IPv4
+                    workload routes. This must match the value configured in FelixConfiguration. BIRD uses
+                    this to identify elevated-priority routes during live migration and to override local
+                    workload routes with higher-priority BGP-learned routes. [Default: 1024]
+                  maximum: 2147483646
+                  minimum: 1
+                  type: integer
+                ipv6NormalRoutePriority:
+                  description: |-
+                    IPv6NormalRoutePriority is the normal route priority (metric) that Felix uses for IPv6
+                    workload routes. This must match the value configured in FelixConfiguration. BIRD uses
+                    this to identify elevated-priority routes during live migration and to override local
+                    workload routes with higher-priority BGP-learned routes. [Default: 1024]
+                  maximum: 2147483646
+                  minimum: 1
+                  type: integer
+                listenPort:
+                  description:
+                    ListenPort is the port where BGP protocol should listen.
+                    Defaults to 179
+                  maximum: 65535
+                  minimum: 1
+                  type: integer
+                localWorkloadPeeringIPV4:
+                  description: |-
+                    The virtual IPv4 address of the node with which its local workload is expected to peer.
+                    It is recommended to use a link-local address.
+                  type: string
+                localWorkloadPeeringIPV6:
+                  description: |-
+                    The virtual IPv6 address of the node with which its local workload is expected to peer.
+                    It is recommended to use a link-local address.
+                  type: string
+                logSeverityScreen:
+                  default: Info
+                  description:
+                    "LogSeverityScreen is the log severity above which logs
+                    are sent to the stdout. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                nodeMeshMaxRestartTime:
+                  description: |-
+                    Time to allow for software restart for node-to-mesh peerings.  When specified, this is configured
+                    as the graceful restart timeout.  When not specified, the BIRD default of 120s is used.
+                    This field can only be set on the default BGPConfiguration instance and requires that NodeMesh is enabled
+                  type: string
+                nodeMeshPassword:
+                  description: |-
+                    Optional BGP password for full node-to-mesh peerings.
+                    This field can only be set on the default BGPConfiguration instance and requires that NodeMesh is enabled
+                  properties:
+                    secretKeyRef:
+                      description: Selects a key of a secret in the node pod's namespace.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must be
+                            a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must be
+                            defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                nodeToNodeMeshEnabled:
+                  description:
+                    "NodeToNodeMeshEnabled sets whether full node to node
+                    BGP mesh is enabled. [Default: true]"
+                  type: boolean
+                prefixAdvertisements:
+                  description:
+                    PrefixAdvertisements contains per-prefix advertisement
+                    configuration.
+                  items:
+                    description:
+                      PrefixAdvertisement configures advertisement properties
+                      for the specified CIDR.
+                    properties:
+                      cidr:
+                        description: CIDR for which properties should be advertised.
+                        format: cidr
+                        type: string
+                      communities:
+                        description: |-
+                          Communities can be list of either community names already defined in `Specs.Communities` or community value of format `aa:nn` or `aa:nn:mm`.
+                          For standard community use `aa:nn` format, where `aa` and `nn` are 16 bit number.
+                          For large community use `aa:nn:mm` format, where `aa`, `nn` and `mm` are 32 bit number.
+                          Where,`aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                        items:
+                          type: string
+                        maxItems: 50
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  maxItems: 500
+                  type: array
+                  x-kubernetes-list-type: atomic
+                programClusterRoutes:
+                  description: |-
+                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
+                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Enabled,
+                    confd and BIRD program that route. When ProgramClusterRoutes is Disabled, it is expected that Felix will program that route.
+                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                serviceClusterIPs:
+                  description: |-
+                    ServiceClusterIPs are the CIDR blocks from which service cluster IPs are allocated.
+                    If specified, Calico will advertise these blocks, as well as any cluster IPs within them.
+                  items:
+                    description:
+                      ServiceClusterIPBlock represents a single allowed ClusterIP
+                      CIDR block.
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: atomic
+                serviceExternalIPs:
+                  description: |-
+                    ServiceExternalIPs are the CIDR blocks for Kubernetes Service External IPs.
+                    Kubernetes Service ExternalIPs will only be advertised if they are within one of these blocks.
+                  items:
+                    description:
+                      ServiceExternalIPBlock represents a single allowed
+                      External IP CIDR block.
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: atomic
+                serviceLoadBalancerAggregation:
+                  default: Enabled
+                  description: |-
+                    ServiceLoadBalancerAggregation controls how LoadBalancer service IPs are advertised.
+                    When set to "Disabled", individual /32 routes are advertised for each service instead of
+                    the full CIDR range. This is useful for anycast failover mechanisms where failed service
+                    routes need to be withdrawn. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                serviceLoadBalancerIPs:
+                  description: |-
+                    ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes Service LoadBalancer IPs.
+                    Kubernetes Service status.LoadBalancer.Ingress IPs will only be advertised if they are within one of these blocks.
+                  items:
+                    description:
+                      ServiceLoadBalancerIPBlock represents a single allowed
+                      LoadBalancer IP CIDR block.
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+              x-kubernetes-validations:
+                - message:
+                    nodeMeshPassword cannot be set when nodeToNodeMeshEnabled is
+                    false
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.nodeMeshPassword) || !has(self.nodeToNodeMeshEnabled)
+                    || self.nodeToNodeMeshEnabled == true"
+                - message:
+                    nodeMeshMaxRestartTime cannot be set when nodeToNodeMeshEnabled
+                    is false
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.nodeMeshMaxRestartTime) || !has(self.nodeToNodeMeshEnabled)
+                    || self.nodeToNodeMeshEnabled == true"
+                - message: communities are defined but not used in prefixAdvertisements
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.communities) || size(self.communities) == 0 || (has(self.prefixAdvertisements)
+                    && size(self.prefixAdvertisements) > 0)"
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                BGPFilterSpec contains the IPv4 and IPv6 filter rules of
+                the BGP Filter.
+              properties:
+                exportV4:
+                  description:
+                    The ordered set of IPv4 BGPFilter rules acting on exporting
+                    routes to a peer.
+                  items:
+                    description: |-
+                      BGPFilterRuleV4 defines a BGP filter rule consisting of match criteria, a terminal action,
+                      and optional operations to apply to matching routes.
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes whose AS path begins with the
+                          specified sequence of AS numbers.
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      cidr:
+                        description: |-
+                          If non-empty, this filter rule will only apply when the route being exported or imported
+                          "matches" the given CIDR - where the definition of "matches" is according to
+                          MatchOperator and PrefixLength.  CIDR should be in conventional CIDR notation,
+                          <prefix>/<length>.
+                        format: cidr
+                        maxLength: 18
+                        type: string
+                      communities:
+                        description: |-
+                          If set, this filter rule will only apply to routes that carry the specified BGP
+                          community.  On import, this matches communities set by the remote peer.  On export,
+                          this matches communities already present on the route, whether received from a BGP
+                          peer (e.g. on a route reflector re-advertising to an eBGP peer) or added locally
+                          by an import filter or an earlier export rule's AddCommunity operation.
+                        properties:
+                          values:
+                            description:
+                              Values is a list of BGP community values to
+                              match against. Exactly one value must be specified.
+                            items:
+                              description: |-
+                                BGPCommunityValue is a BGP community string in `aa:nn` (standard) or `aa:nn:mm` (large) format.
+                                For standard communities, each component must be a 16-bit value (0-65535).
+                                For large communities, each component must be a 32-bit value (0-4294967295).
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes with an outgoing interface that
+                          matches Interface.
+                        maxLength: 15
+                        type: string
+                      matchOperator:
+                        description: |-
+                          MatchOperator defines how the route's prefix is compared against CIDR.  "Equal" requires
+                          an exact prefix match, "In" requires the route to be contained within the CIDR (or equal),
+                          "NotEqual" and "NotIn" are their negations.  Only meaningful when CIDR is also specified.
+                          Required when CIDR is set.
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        description: |-
+                          Operations is an ordered list of route modifications to apply to matching routes before
+                          accepting them.  Only valid when Action is "Accept"; specifying operations with "Reject"
+                          is rejected by validation.  Each entry must set exactly one operation field.
+                        items:
+                          description: |-
+                            BGPFilterOperation is a discriminated union representing a single route modification.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              description:
+                                AddCommunity adds the specified BGP community
+                                to the route.
+                              properties:
+                                value:
+                                  description: Value is the BGP community to add.
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              description:
+                                PrependASPath prepends the specified AS numbers
+                                to the route's AS path.
+                              properties:
+                                prefix:
+                                  description: |-
+                                    Prefix is the sequence of AS numbers to prepend to the route's AS path.
+                                    The resulting path starts with these AS numbers in the order listed;
+                                    e.g. [65000, 65001] produces the path "65000 65001 <original>".
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              description: |-
+                                SetPriority sets the route's priority (metric), in the same units as the
+                                ...RoutePriority fields in FelixConfiguration.
+                              properties:
+                                value:
+                                  description: |-
+                                    Value is the priority to set, in the same units as FelixConfiguration's
+                                    ...RoutePriority fields.
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      peerType:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes being imported from or exported
+                          to a BGP peer of the specified type.  If empty, the rule applies to all peers.
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        description: |-
+                          PrefixLength further constrains the CIDR match by restricting the range of allowed
+                          prefix lengths.  For example, CIDR "10.0.0.0/8" with MatchOperator "In" and
+                          PrefixLength {min: 16, max: 24} matches any route within 10.0.0.0/8 whose prefix
+                          length is between /16 and /24.  Requires CIDR to be set; if CIDR is omitted,
+                          PrefixLength is ignored.  If PrefixLength is nil and CIDR is set, the CIDR's own
+                          prefix length is used as the minimum and /32 (for V4) as the maximum.
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        description: |-
+                          If set, this filter rule will only apply to routes with the given priority, in the
+                          same units as the ...RoutePriority fields in FelixConfiguration.
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        description: |-
+                          If set to "RemotePeers": for export rules, this filter rule will only apply to routes
+                          learned from BGP peers (i.e. re-advertised routes), not locally originated routes.
+                          For import rules, this field is redundant because imported routes are by definition
+                          from BGP peers.
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                  x-kubernetes-list-type: atomic
+                exportV6:
+                  description:
+                    The ordered set of IPv6 BGPFilter rules acting on exporting
+                    routes to a peer.
+                  items:
+                    description: |-
+                      BGPFilterRuleV6 defines a BGP filter rule consisting of match criteria, a terminal action,
+                      and optional operations to apply to matching routes.
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes whose AS path begins with the
+                          specified sequence of AS numbers.
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      cidr:
+                        description: |-
+                          If non-empty, this filter rule will only apply when the route being exported or imported
+                          "matches" the given CIDR - where the definition of "matches" is according to
+                          MatchOperator and PrefixLength.  CIDR should be in conventional CIDR notation,
+                          <prefix>/<length>.
+                        format: cidr
+                        maxLength: 43
+                        type: string
+                      communities:
+                        description: |-
+                          If set, this filter rule will only apply to routes that carry the specified BGP
+                          community.  On import, this matches communities set by the remote peer.  On export,
+                          this matches communities already present on the route, whether received from a BGP
+                          peer (e.g. on a route reflector re-advertising to an eBGP peer) or added locally
+                          by an import filter or an earlier export rule's AddCommunity operation.
+                        properties:
+                          values:
+                            description:
+                              Values is a list of BGP community values to
+                              match against. Exactly one value must be specified.
+                            items:
+                              description: |-
+                                BGPCommunityValue is a BGP community string in `aa:nn` (standard) or `aa:nn:mm` (large) format.
+                                For standard communities, each component must be a 16-bit value (0-65535).
+                                For large communities, each component must be a 32-bit value (0-4294967295).
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes with an outgoing interface that
+                          matches Interface.
+                        maxLength: 15
+                        type: string
+                      matchOperator:
+                        description: |-
+                          MatchOperator defines how the route's prefix is compared against CIDR.  "Equal" requires
+                          an exact prefix match, "In" requires the route to be contained within the CIDR (or equal),
+                          "NotEqual" and "NotIn" are their negations.  Only meaningful when CIDR is also specified.
+                          Required when CIDR is set.
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        description: |-
+                          Operations is an ordered list of route modifications to apply to matching routes before
+                          accepting them.  Only valid when Action is "Accept"; specifying operations with "Reject"
+                          is rejected by validation.  Each entry must set exactly one operation field.
+                        items:
+                          description: |-
+                            BGPFilterOperation is a discriminated union representing a single route modification.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              description:
+                                AddCommunity adds the specified BGP community
+                                to the route.
+                              properties:
+                                value:
+                                  description: Value is the BGP community to add.
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              description:
+                                PrependASPath prepends the specified AS numbers
+                                to the route's AS path.
+                              properties:
+                                prefix:
+                                  description: |-
+                                    Prefix is the sequence of AS numbers to prepend to the route's AS path.
+                                    The resulting path starts with these AS numbers in the order listed;
+                                    e.g. [65000, 65001] produces the path "65000 65001 <original>".
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              description: |-
+                                SetPriority sets the route's priority (metric), in the same units as the
+                                ...RoutePriority fields in FelixConfiguration.
+                              properties:
+                                value:
+                                  description: |-
+                                    Value is the priority to set, in the same units as FelixConfiguration's
+                                    ...RoutePriority fields.
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      peerType:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes being imported from or exported
+                          to a BGP peer of the specified type.  If empty, the rule applies to all peers.
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        description: |-
+                          PrefixLength further constrains the CIDR match by restricting the range of allowed
+                          prefix lengths.  For example, CIDR "fd00::/8" with MatchOperator "In" and
+                          PrefixLength {min: 48, max: 64} matches any route within fd00::/8 whose prefix
+                          length is between /48 and /64.  Requires CIDR to be set; if CIDR is omitted,
+                          PrefixLength is ignored.  If PrefixLength is nil and CIDR is set, the CIDR's own
+                          prefix length is used as the minimum and /128 (for V6) as the maximum.
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        description: |-
+                          If set, this filter rule will only apply to routes with the given priority, in the
+                          same units as the ...RoutePriority fields in FelixConfiguration.
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        description: |-
+                          If set to "RemotePeers": for export rules, this filter rule will only apply to routes
+                          learned from BGP peers (i.e. re-advertised routes), not locally originated routes.
+                          For import rules, this field is redundant because imported routes are by definition
+                          from BGP peers.
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                  x-kubernetes-list-type: atomic
+                importV4:
+                  description:
+                    The ordered set of IPv4 BGPFilter rules acting on importing
+                    routes from a peer.
+                  items:
+                    description: |-
+                      BGPFilterRuleV4 defines a BGP filter rule consisting of match criteria, a terminal action,
+                      and optional operations to apply to matching routes.
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes whose AS path begins with the
+                          specified sequence of AS numbers.
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      cidr:
+                        description: |-
+                          If non-empty, this filter rule will only apply when the route being exported or imported
+                          "matches" the given CIDR - where the definition of "matches" is according to
+                          MatchOperator and PrefixLength.  CIDR should be in conventional CIDR notation,
+                          <prefix>/<length>.
+                        format: cidr
+                        maxLength: 18
+                        type: string
+                      communities:
+                        description: |-
+                          If set, this filter rule will only apply to routes that carry the specified BGP
+                          community.  On import, this matches communities set by the remote peer.  On export,
+                          this matches communities already present on the route, whether received from a BGP
+                          peer (e.g. on a route reflector re-advertising to an eBGP peer) or added locally
+                          by an import filter or an earlier export rule's AddCommunity operation.
+                        properties:
+                          values:
+                            description:
+                              Values is a list of BGP community values to
+                              match against. Exactly one value must be specified.
+                            items:
+                              description: |-
+                                BGPCommunityValue is a BGP community string in `aa:nn` (standard) or `aa:nn:mm` (large) format.
+                                For standard communities, each component must be a 16-bit value (0-65535).
+                                For large communities, each component must be a 32-bit value (0-4294967295).
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes with an outgoing interface that
+                          matches Interface.
+                        maxLength: 15
+                        type: string
+                      matchOperator:
+                        description: |-
+                          MatchOperator defines how the route's prefix is compared against CIDR.  "Equal" requires
+                          an exact prefix match, "In" requires the route to be contained within the CIDR (or equal),
+                          "NotEqual" and "NotIn" are their negations.  Only meaningful when CIDR is also specified.
+                          Required when CIDR is set.
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        description: |-
+                          Operations is an ordered list of route modifications to apply to matching routes before
+                          accepting them.  Only valid when Action is "Accept"; specifying operations with "Reject"
+                          is rejected by validation.  Each entry must set exactly one operation field.
+                        items:
+                          description: |-
+                            BGPFilterOperation is a discriminated union representing a single route modification.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              description:
+                                AddCommunity adds the specified BGP community
+                                to the route.
+                              properties:
+                                value:
+                                  description: Value is the BGP community to add.
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              description:
+                                PrependASPath prepends the specified AS numbers
+                                to the route's AS path.
+                              properties:
+                                prefix:
+                                  description: |-
+                                    Prefix is the sequence of AS numbers to prepend to the route's AS path.
+                                    The resulting path starts with these AS numbers in the order listed;
+                                    e.g. [65000, 65001] produces the path "65000 65001 <original>".
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              description: |-
+                                SetPriority sets the route's priority (metric), in the same units as the
+                                ...RoutePriority fields in FelixConfiguration.
+                              properties:
+                                value:
+                                  description: |-
+                                    Value is the priority to set, in the same units as FelixConfiguration's
+                                    ...RoutePriority fields.
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      peerType:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes being imported from or exported
+                          to a BGP peer of the specified type.  If empty, the rule applies to all peers.
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        description: |-
+                          PrefixLength further constrains the CIDR match by restricting the range of allowed
+                          prefix lengths.  For example, CIDR "10.0.0.0/8" with MatchOperator "In" and
+                          PrefixLength {min: 16, max: 24} matches any route within 10.0.0.0/8 whose prefix
+                          length is between /16 and /24.  Requires CIDR to be set; if CIDR is omitted,
+                          PrefixLength is ignored.  If PrefixLength is nil and CIDR is set, the CIDR's own
+                          prefix length is used as the minimum and /32 (for V4) as the maximum.
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        description: |-
+                          If set, this filter rule will only apply to routes with the given priority, in the
+                          same units as the ...RoutePriority fields in FelixConfiguration.
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        description: |-
+                          If set to "RemotePeers": for export rules, this filter rule will only apply to routes
+                          learned from BGP peers (i.e. re-advertised routes), not locally originated routes.
+                          For import rules, this field is redundant because imported routes are by definition
+                          from BGP peers.
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                  x-kubernetes-list-type: atomic
+                importV6:
+                  description:
+                    The ordered set of IPv6 BGPFilter rules acting on importing
+                    routes from a peer.
+                  items:
+                    description: |-
+                      BGPFilterRuleV6 defines a BGP filter rule consisting of match criteria, a terminal action,
+                      and optional operations to apply to matching routes.
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes whose AS path begins with the
+                          specified sequence of AS numbers.
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      cidr:
+                        description: |-
+                          If non-empty, this filter rule will only apply when the route being exported or imported
+                          "matches" the given CIDR - where the definition of "matches" is according to
+                          MatchOperator and PrefixLength.  CIDR should be in conventional CIDR notation,
+                          <prefix>/<length>.
+                        format: cidr
+                        maxLength: 43
+                        type: string
+                      communities:
+                        description: |-
+                          If set, this filter rule will only apply to routes that carry the specified BGP
+                          community.  On import, this matches communities set by the remote peer.  On export,
+                          this matches communities already present on the route, whether received from a BGP
+                          peer (e.g. on a route reflector re-advertising to an eBGP peer) or added locally
+                          by an import filter or an earlier export rule's AddCommunity operation.
+                        properties:
+                          values:
+                            description:
+                              Values is a list of BGP community values to
+                              match against. Exactly one value must be specified.
+                            items:
+                              description: |-
+                                BGPCommunityValue is a BGP community string in `aa:nn` (standard) or `aa:nn:mm` (large) format.
+                                For standard communities, each component must be a 16-bit value (0-65535).
+                                For large communities, each component must be a 32-bit value (0-4294967295).
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes with an outgoing interface that
+                          matches Interface.
+                        maxLength: 15
+                        type: string
+                      matchOperator:
+                        description: |-
+                          MatchOperator defines how the route's prefix is compared against CIDR.  "Equal" requires
+                          an exact prefix match, "In" requires the route to be contained within the CIDR (or equal),
+                          "NotEqual" and "NotIn" are their negations.  Only meaningful when CIDR is also specified.
+                          Required when CIDR is set.
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        description: |-
+                          Operations is an ordered list of route modifications to apply to matching routes before
+                          accepting them.  Only valid when Action is "Accept"; specifying operations with "Reject"
+                          is rejected by validation.  Each entry must set exactly one operation field.
+                        items:
+                          description: |-
+                            BGPFilterOperation is a discriminated union representing a single route modification.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              description:
+                                AddCommunity adds the specified BGP community
+                                to the route.
+                              properties:
+                                value:
+                                  description: Value is the BGP community to add.
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              description:
+                                PrependASPath prepends the specified AS numbers
+                                to the route's AS path.
+                              properties:
+                                prefix:
+                                  description: |-
+                                    Prefix is the sequence of AS numbers to prepend to the route's AS path.
+                                    The resulting path starts with these AS numbers in the order listed;
+                                    e.g. [65000, 65001] produces the path "65000 65001 <original>".
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              description: |-
+                                SetPriority sets the route's priority (metric), in the same units as the
+                                ...RoutePriority fields in FelixConfiguration.
+                              properties:
+                                value:
+                                  description: |-
+                                    Value is the priority to set, in the same units as FelixConfiguration's
+                                    ...RoutePriority fields.
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      peerType:
+                        description: |-
+                          If non-empty, this filter rule will only apply to routes being imported from or exported
+                          to a BGP peer of the specified type.  If empty, the rule applies to all peers.
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        description: |-
+                          PrefixLength further constrains the CIDR match by restricting the range of allowed
+                          prefix lengths.  For example, CIDR "fd00::/8" with MatchOperator "In" and
+                          PrefixLength {min: 48, max: 64} matches any route within fd00::/8 whose prefix
+                          length is between /48 and /64.  Requires CIDR to be set; if CIDR is omitted,
+                          PrefixLength is ignored.  If PrefixLength is nil and CIDR is set, the CIDR's own
+                          prefix length is used as the minimum and /128 (for V6) as the maximum.
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        description: |-
+                          If set, this filter rule will only apply to routes with the given priority, in the
+                          same units as the ...RoutePriority fields in FelixConfiguration.
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        description: |-
+                          If set to "RemotePeers": for export rules, this filter rule will only apply to routes
+                          learned from BGP peers (i.e. re-advertised routes), not locally originated routes.
+                          For import rules, this field is redundant because imported routes are by definition
+                          from BGP peers.
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgppeers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPPeerSpec contains the specification for a BGPPeer resource.
+              properties:
+                asNumber:
+                  description: The AS Number of the peer.
+                  format: int32
+                  type: integer
+                filters:
+                  description: The ordered set of BGPFilters applied on this BGP peer.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                keepOriginalNextHop:
+                  description: |-
+                    Option to keep the original nexthop field when routes are sent to a BGP Peer.
+                    Setting "true" configures the selected BGP Peers node to use the "next hop keep;"
+                    instead of "next hop self;"(default) in the specific branch of the Node on "bird.cfg".
+                    Note: that this field is deprecated. Users should use the NextHopMode field to control
+                    the next hop attribute for a BGP peer.
+                  type: boolean
+                keepaliveTime:
+                  description: |-
+                    KeepaliveTime specifies the delay in seconds between sending consecutive Keepalive messages.
+                    When specified, this configures the BGP keepalive timer for the peerings generated by this BGPPeer resource.
+                    If not specified, BIRD uses its default keepalive time (one third of the hold time).
+                  type: string
+                localASNumber:
+                  description: |-
+                    The optional Local AS Number to use when peering with this remote peer.
+                    If not specified, the AS Number defined in default BGPConfiguration will be used.
+                  format: int32
+                  type: integer
+                localWorkloadSelector:
+                  description: |-
+                    Selector for the local workload that the node should peer with. When this is set, the peerSelector and peerIP fields must be empty,
+                    and the ASNumber must not be empty.
+                  maxLength: 1024
+                  type: string
+                maxRestartTime:
+                  description: |-
+                    Time to allow for software restart.  When specified, this is configured as the graceful
+                    restart timeout.  When not specified, the BIRD default of 120s is used.
+                  type: string
+                nextHopMode:
+                  description: |-
+                    NextHopMode defines the method of calculating the next hop attribute for received routes.
+                    This replaces and expands the deprecated KeepOriginalNextHop field.
+                    Users should use this setting to control the next hop attribute for a BGP peer.
+                    When this is set, the value of the KeepOriginalNextHop field is ignored.
+                    if neither keepOriginalNextHop or nextHopMode is specified, BGP's default behaviour is used.
+                    Set it to “Auto” to apply BGP’s default behaviour.
+                    Set it to "Self" to configure "next hop self;" in "bird.cfg".
+                    Set it to "Keep" to configure "next hop keep;" in "bird.cfg".
+                  enum:
+                    - Auto
+                    - Self
+                    - Keep
+                  type: string
+                node:
+                  description: |-
+                    The node name identifying the Calico node instance that is targeted by this peer.
+                    If this is not set, and no nodeSelector is specified, then this BGP peer selects all
+                    nodes in the cluster.
+                  maxLength: 253
+                  type: string
+                nodeSelector:
+                  description: |-
+                    Selector for the nodes that should have this peering.  When this is set, the Node
+                    field must be empty.
+                  maxLength: 1024
+                  type: string
+                numAllowedLocalASNumbers:
+                  description: |-
+                    Maximum number of local AS numbers that are allowed in the AS path for received routes.
+                    This removes BGP loop prevention and should only be used if absolutely necessary.
+                  format: int32
+                  type: integer
+                password:
+                  description:
+                    Optional BGP password for the peerings generated by this
+                    BGPPeer resource.
+                  properties:
+                    secretKeyRef:
+                      description: Selects a key of a secret in the node pod's namespace.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must be
+                            a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must be
+                            defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                peerIP:
+                  description: |-
+                    The IP address of the peer followed by an optional port number to peer with.
+                    If port number is given, format should be `[<IPv6>]:port` or `<IPv4>:<port>` for IPv4.
+                    If optional port number is not set, and this peer IP and ASNumber belongs to a calico/node
+                    with ListenPort set in BGPConfiguration, then we use that port to peer.
+                  maxLength: 64
+                  type: string
+                peerSelector:
+                  description: |-
+                    Selector for the remote nodes to peer with.  When this is set, the PeerIP and
+                    ASNumber fields must be empty.  For each peering between the local node and
+                    selected remote nodes, we configure an IPv4 peering if both ends have
+                    NodeBGPSpec.IPv4Address specified, and an IPv6 peering if both ends have
+                    NodeBGPSpec.IPv6Address specified.  The remote AS number comes from the remote
+                    node's NodeBGPSpec.ASNumber, or the global default if that is not set.
+                  maxLength: 1024
+                  type: string
+                reachableBy:
+                  description: |-
+                    Add an exact, i.e. /32, static route toward peer IP in order to prevent route flapping.
+                    ReachableBy contains the address of the gateway which peer can be reached by.
+                  maxLength: 64
+                  type: string
+                reversePeering:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Manual
+                    - enum:
+                        - Auto
+                        - Manual
+                  description: |-
+                    ReversePeering, for peerings between Calico nodes controls whether
+                    the reverse peering from nodes selected by peerSelector is generated
+                    automatically. If set to Manual, a separate BGPPeer must be created
+                    for the reverse peering. [Default: Auto]
+                  type: string
+                sourceAddress:
+                  description: |-
+                    Specifies whether and how to configure a source address for the peerings generated by
+                    this BGPPeer resource.  Default value "UseNodeIP" means to configure the node IP as the
+                    source address.  "None" means not to configure a source address.
+                  enum:
+                    - UseNodeIP
+                    - None
+                  type: string
+                ttlSecurity:
+                  description: |-
+                    TTLSecurity enables the generalized TTL security mechanism (GTSM) which protects against spoofed packets by
+                    ignoring received packets with a smaller than expected TTL value. The provided value is the number of hops
+                    (edges) between the peers.
+                  type: integer
+              type: object
+              x-kubernetes-validations:
+                - message: node and nodeSelector cannot both be set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.node) || size(self.node) == 0) || (!has(self.nodeSelector)
+                    || size(self.nodeSelector) == 0)
+                - message: peerIP and peerSelector cannot both be set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.peerIP) || size(self.peerIP) == 0) || (!has(self.peerSelector)
+                    || size(self.peerSelector) == 0)
+                - message: asNumber must be empty when peerSelector is set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.peerSelector) || size(self.peerSelector) == 0) || !has(self.asNumber)
+                    || self.asNumber == 0
+                - message: peerIP must be empty when localWorkloadSelector is set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.localWorkloadSelector) || size(self.localWorkloadSelector)
+                    == 0) || (!has(self.peerIP) || size(self.peerIP) == 0)
+                - message: peerSelector must be empty when localWorkloadSelector is set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.localWorkloadSelector) || size(self.localWorkloadSelector)
+                    == 0) || (!has(self.peerSelector) || size(self.peerSelector) == 0)
+                - message: asNumber is required when localWorkloadSelector is set
+                  reason: FieldValueInvalid
+                  rule:
+                    (!has(self.localWorkloadSelector) || size(self.localWorkloadSelector)
+                    == 0) || (has(self.asNumber) && self.asNumber != 0)
+                - message: reachableBy must be empty when peerIP is empty
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.reachableBy) || size(self.reachableBy) == 0 || (has(self.peerIP)
+                    && size(self.peerIP) > 0)"
+                - message:
+                    keepOriginalNextHop and nextHopMode cannot both be set; keepOriginalNextHop
+                    is deprecated, use nextHopMode instead
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.keepOriginalNextHop) || !self.keepOriginalNextHop ||
+                    !has(self.nextHopMode)"
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                BlockAffinitySpec contains the specification for a BlockAffinity
+                resource.
+              properties:
+                cidr:
+                  type: string
+                deleted:
+                  description: |-
+                    Deleted indicates that this block affinity is being deleted.
+                    This field is a string for compatibility with older releases that
+                    mistakenly treat this field as a string.
+                  type: string
+                node:
+                  type: string
+                state:
+                  type: string
+                type:
+                  type: string
+              required:
+                - cidr
+                - deleted
+                - node
+                - state
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: caliconodestatuses.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: CalicoNodeStatus
+    listKind: CalicoNodeStatusList
+    plural: caliconodestatuses
+    singular: caliconodestatus
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                CalicoNodeStatusSpec contains the specification for a CalicoNodeStatus
+                resource.
+              properties:
+                classes:
+                  description: |-
+                    Classes declares the types of information to monitor for this calico/node,
+                    and allows for selective status reporting about certain subsets of information.
+                  items:
+                    enum:
+                      - Agent
+                      - BGP
+                      - Routes
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                node:
+                  description:
+                    The node name identifies the Calico node instance for
+                    node status.
+                  type: string
+                updatePeriodSeconds:
+                  description: |-
+                    UpdatePeriodSeconds is the period at which CalicoNodeStatus should be updated.
+                    Set to 0 to disable CalicoNodeStatus refresh. Maximum update period is one day.
+                  format: int32
+                  type: integer
+              type: object
+            status:
+              description: |-
+                CalicoNodeStatusStatus defines the observed state of CalicoNodeStatus.
+                No validation needed for status since it is updated by Calico.
+              properties:
+                agent:
+                  description: Agent holds agent status on the node.
+                  properties:
+                    birdV4:
+                      description: BIRDV4 represents the latest observed status of bird4.
+                      properties:
+                        lastBootTime:
+                          description:
+                            LastBootTime holds the value of lastBootTime
+                            from bird.ctl output.
+                          type: string
+                        lastReconfigurationTime:
+                          description:
+                            LastReconfigurationTime holds the value of lastReconfigTime
+                            from bird.ctl output.
+                          type: string
+                        routerID:
+                          description: Router ID used by bird.
+                          type: string
+                        state:
+                          description: The state of the BGP Daemon.
+                          enum:
+                            - Ready
+                            - NotReady
+                          type: string
+                        version:
+                          description: Version of the BGP daemon
+                          type: string
+                      type: object
+                    birdV6:
+                      description: BIRDV6 represents the latest observed status of bird6.
+                      properties:
+                        lastBootTime:
+                          description:
+                            LastBootTime holds the value of lastBootTime
+                            from bird.ctl output.
+                          type: string
+                        lastReconfigurationTime:
+                          description:
+                            LastReconfigurationTime holds the value of lastReconfigTime
+                            from bird.ctl output.
+                          type: string
+                        routerID:
+                          description: Router ID used by bird.
+                          type: string
+                        state:
+                          description: The state of the BGP Daemon.
+                          enum:
+                            - Ready
+                            - NotReady
+                          type: string
+                        version:
+                          description: Version of the BGP daemon
+                          type: string
+                      type: object
+                  type: object
+                bgp:
+                  description: BGP holds node BGP status.
+                  properties:
+                    numberEstablishedV4:
+                      description: The total number of IPv4 established bgp sessions.
+                      type: integer
+                    numberEstablishedV6:
+                      description: The total number of IPv6 established bgp sessions.
+                      type: integer
+                    numberNotEstablishedV4:
+                      description: The total number of IPv4 non-established bgp sessions.
+                      type: integer
+                    numberNotEstablishedV6:
+                      description: The total number of IPv6 non-established bgp sessions.
+                      type: integer
+                    peersV4:
+                      description: PeersV4 represents IPv4 BGP peers status on the node.
+                      items:
+                        description:
+                          CalicoNodePeer contains the status of BGP peers
+                          on the node.
+                        properties:
+                          peerIP:
+                            description:
+                              IP address of the peer whose condition we are
+                              reporting.
+                            type: string
+                          since:
+                            description: Since the state or reason last changed.
+                            type: string
+                          state:
+                            description: State is the BGP session state.
+                            enum:
+                              - Idle
+                              - Connect
+                              - Active
+                              - OpenSent
+                              - OpenConfirm
+                              - Established
+                              - Close
+                            type: string
+                          type:
+                            description: |-
+                              Type indicates whether this peer is configured via the node-to-node mesh,
+                              or via an explicit global or per-node BGPPeer object.
+                            enum:
+                              - NodeMesh
+                              - NodePeer
+                              - GlobalPeer
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    peersV6:
+                      description: PeersV6 represents IPv6 BGP peers status on the node.
+                      items:
+                        description:
+                          CalicoNodePeer contains the status of BGP peers
+                          on the node.
+                        properties:
+                          peerIP:
+                            description:
+                              IP address of the peer whose condition we are
+                              reporting.
+                            type: string
+                          since:
+                            description: Since the state or reason last changed.
+                            type: string
+                          state:
+                            description: State is the BGP session state.
+                            enum:
+                              - Idle
+                              - Connect
+                              - Active
+                              - OpenSent
+                              - OpenConfirm
+                              - Established
+                              - Close
+                            type: string
+                          type:
+                            description: |-
+                              Type indicates whether this peer is configured via the node-to-node mesh,
+                              or via an explicit global or per-node BGPPeer object.
+                            enum:
+                              - NodeMesh
+                              - NodePeer
+                              - GlobalPeer
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                    - numberEstablishedV4
+                    - numberEstablishedV6
+                    - numberNotEstablishedV4
+                    - numberNotEstablishedV6
+                  type: object
+                lastUpdated:
+                  description: |-
+                    LastUpdated is a timestamp representing the server time when CalicoNodeStatus object
+                    last updated. It is represented in RFC3339 form and is in UTC.
+                  format: date-time
+                  nullable: true
+                  type: string
+                routes:
+                  description:
+                    Routes reports routes known to the Calico BGP daemon
+                    on the node.
+                  properties:
+                    routesV4:
+                      description: RoutesV4 represents IPv4 routes on the node.
+                      items:
+                        description:
+                          CalicoNodeRoute contains the status of BGP routes
+                          on the node.
+                        properties:
+                          destination:
+                            description: Destination of the route.
+                            type: string
+                          gateway:
+                            description: Gateway for the destination.
+                            type: string
+                          interface:
+                            description: Interface for the destination
+                            type: string
+                          learnedFrom:
+                            description:
+                              LearnedFrom contains information regarding
+                              where this route originated.
+                            properties:
+                              peerIP:
+                                description:
+                                  If sourceType is NodeMesh or BGPPeer, IP
+                                  address of the router that sent us this route.
+                                type: string
+                              sourceType:
+                                description:
+                                  Type of the source where a route is learned
+                                  from.
+                                enum:
+                                  - Kernel
+                                  - Static
+                                  - Direct
+                                  - NodeMesh
+                                  - BGPPeer
+                                type: string
+                            type: object
+                          type:
+                            description:
+                              Type indicates if the route is being used for
+                              forwarding or not.
+                            enum:
+                              - FIB
+                              - RIB
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    routesV6:
+                      description: RoutesV6 represents IPv6 routes on the node.
+                      items:
+                        description:
+                          CalicoNodeRoute contains the status of BGP routes
+                          on the node.
+                        properties:
+                          destination:
+                            description: Destination of the route.
+                            type: string
+                          gateway:
+                            description: Gateway for the destination.
+                            type: string
+                          interface:
+                            description: Interface for the destination
+                            type: string
+                          learnedFrom:
+                            description:
+                              LearnedFrom contains information regarding
+                              where this route originated.
+                            properties:
+                              peerIP:
+                                description:
+                                  If sourceType is NodeMesh or BGPPeer, IP
+                                  address of the router that sent us this route.
+                                type: string
+                              sourceType:
+                                description:
+                                  Type of the source where a route is learned
+                                  from.
+                                enum:
+                                  - Kernel
+                                  - Static
+                                  - Direct
+                                  - NodeMesh
+                                  - BGPPeer
+                                type: string
+                            type: object
+                          type:
+                            description:
+                              Type indicates if the route is being used for
+                              forwarding or not.
+                            enum:
+                              - FIB
+                              - RIB
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterInformation contains the cluster specific information.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                ClusterInformationSpec contains the values of describing the cluster.
+                This resource is managed automatically by Calico components and should not be modified manually.
+              properties:
+                calicoVersion:
+                  description:
+                    CalicoVersion is the version of Calico running on the
+                    cluster, set automatically by calico/node.
+                  type: string
+                clusterGUID:
+                  description:
+                    ClusterGUID is the unique identifier for this cluster,
+                    generated automatically at install time.
+                  type: string
+                clusterType:
+                  description: |-
+                    ClusterType describes the type of the cluster, e.g., "k8s,bgp,kubeadm".
+                    Set automatically based on the detected environment.
+                  type: string
+                datastoreReady:
+                  description: |-
+                    DatastoreReady is used during significant datastore migrations to signal to components
+                    such as Felix that it should wait before accessing the datastore.
+                  type: boolean
+                variant:
+                  description: Variant declares which variant of Calico is active.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Felix Configuration contains the configuration for Felix.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FelixConfigurationSpec contains the values of the Felix configuration.
+              properties:
+                allowIPIPPacketsFromWorkloads:
+                  description: |-
+                    AllowIPIPPacketsFromWorkloads controls whether Felix will add a rule to drop IPIP encapsulated traffic
+                    from workloads. [Default: false]
+                  type: boolean
+                allowVXLANPacketsFromWorkloads:
+                  description: |-
+                    AllowVXLANPacketsFromWorkloads controls whether Felix will add a rule to drop VXLAN encapsulated traffic
+                    from workloads. [Default: false]
+                  type: boolean
+                awsSrcDstCheck:
+                  description: |-
+                    AWSSrcDstCheck controls whether Felix will try to change the "source/dest check" setting on the EC2 instance
+                    on which it is running. A value of "Disable" will try to disable the source/dest check. Disabling the check
+                    allows for sending workload traffic without encapsulation within the same AWS subnet.
+                    [Default: DoNothing]
+                  enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                  type: string
+                bpfAttachType:
+                  description: |-
+                    BPFAttachType controls how are the BPF programs at the network interfaces attached.
+                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
+                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    [Default: TCX]
+                  enum:
+                    - TC
+                    - TCX
+                  type: string
+                bpfCTLBLogFilter:
+                  description: |-
+                    BPFCTLBLogFilter specifies, what is logged by connect time load balancer when BPFLogLevel is
+                    debug. Currently has to be specified as 'all' when BPFLogFilters is set
+                    to see CTLB logs.
+                    [Default: unset - means logs are emitted when BPFLogLevel id debug and BPFLogFilters not set.]
+                  type: string
+                bpfConnectTimeLoadBalancing:
+                  description: |-
+                    BPFConnectTimeLoadBalancing when in BPF mode, controls whether Felix installs the connect-time load
+                    balancer. The connect-time load balancer is required for the host to be able to reach Kubernetes services
+                    and it improves the performance of pod-to-service connections.When set to TCP, connect time load balancing
+                    is available only for services with TCP ports. [Default: TCP]
+                  enum:
+                    - TCP
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfConnectTimeLoadBalancingEnabled:
+                  description: |-
+                    BPFConnectTimeLoadBalancingEnabled when in BPF mode, controls whether Felix installs the connection-time load
+                    balancer.  The connect-time load balancer is required for the host to be able to reach Kubernetes services
+                    and it improves the performance of pod-to-service connections.  The only reason to disable it is for debugging
+                    purposes.
+
+                    Deprecated: Use BPFConnectTimeLoadBalancing [Default: true]
+                  type: boolean
+                bpfConntrackLogLevel:
+                  description: |-
+                    BPFConntrackLogLevel controls the log level of the BPF conntrack cleanup program, which runs periodically
+                    to clean up expired BPF conntrack entries.
+                    [Default: Off].
+                  enum:
+                    - "Off"
+                    - Debug
+                  type: string
+                bpfConntrackMode:
+                  description: |-
+                    BPFConntrackCleanupMode controls how BPF conntrack entries are cleaned up.  `Auto` will use a BPF program if supported,
+                    falling back to userspace if not.  `Userspace` will always use the userspace cleanup code.  `BPFProgram` will
+                    always use the BPF program (failing if not supported).
+
+                    /To be deprecated in future versions as conntrack map type changed to
+                    lru_hash and userspace cleanup is the only mode that is supported.
+                    [Default: Userspace]
+                  enum:
+                    - Auto
+                    - Userspace
+                    - BPFProgram
+                  type: string
+                bpfConntrackTimeouts:
+                  description: |-
+                    BPFConntrackTimers overrides the default values for the specified conntrack timer if
+                    set. Each value can be either a duration or `Auto` to pick the value from
+                    a Linux conntrack timeout.
+
+                    Configurable timers are: CreationGracePeriod, TCPSynSent,
+                    TCPEstablished, TCPFinsSeen, TCPResetSeen, UDPTimeout, GenericTimeout,
+                    ICMPTimeout.
+
+                    Unset values are replaced by the default values with a warning log for
+                    incorrect values.
+                  properties:
+                    creationGracePeriod:
+                      description: |-
+                        CreationGracePeriod gives a generic grace period to new connections
+                        before they are considered for cleanup [Default: 10s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    genericTimeout:
+                      description: |-
+                        GenericTimeout controls how long it takes before considering this
+                        entry for cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_generic_timeout is used. If nil, Calico uses its
+                        own default value. [Default: 10m].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    icmpTimeout:
+                      description: |-
+                        ICMPTimeout controls how long it takes before considering this
+                        entry for cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_icmp_timeout is used. If nil, Calico uses its
+                        own default value. [Default: 5s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpEstablished:
+                      description: |-
+                        TCPEstablished controls how long it takes before considering this entry for
+                        cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_established is used. If nil, Calico uses
+                        its own default value. [Default: 1h].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpFinsSeen:
+                      description: |-
+                        TCPFinsSeen controls how long it takes before considering this entry for
+                        cleanup after the connection was closed gracefully. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_time_wait is used. If nil, Calico uses
+                        its own default value. [Default: Auto].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpResetSeen:
+                      description: |-
+                        TCPResetSeen controls how long it takes before considering this entry for
+                        cleanup after the connection was aborted. If nil, Calico uses its own
+                        default value. [Default: 40s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpSynSent:
+                      description: |-
+                        TCPSynSent controls how long it takes before considering this entry for
+                        cleanup after the last SYN without a response. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_syn_sent is used. If nil, Calico uses
+                        its own default value. [Default: 20s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    udpTimeout:
+                      description: |-
+                        UDPTimeout controls how long it takes before considering this entry for
+                        cleanup after the connection became idle. If nil, Calico uses its own
+                        default value. [Default: 60s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                  type: object
+                bpfDSROptoutCIDRs:
+                  description: |-
+                    BPFDSROptoutCIDRs is a list of CIDRs which are excluded from DSR. That is, clients
+                    in those CIDRs will access service node ports as if BPFExternalServiceMode was set to
+                    Tunnel.
+                  items:
+                    type: string
+                  type: array
+                bpfDataIfacePattern:
+                  description: |-
+                    BPFDataIfacePattern is a regular expression that controls which interfaces Felix should attach BPF programs to
+                    in order to catch traffic to/from the network.  This needs to match the interfaces that Calico workload traffic
+                    flows over as well as any interfaces that handle incoming traffic to nodeports and services from outside the
+                    cluster.  It should not match the workload interfaces (usually named cali...) or any other special device managed
+                    by Calico itself (e.g., tunnels).
+                  type: string
+                bpfDisableGROForIfaces:
+                  description: |-
+                    BPFDisableGROForIfaces is a regular expression that controls which interfaces Felix should disable the
+                    Generic Receive Offload [GRO] option.  It should not match the workload interfaces (usually named cali...).
+                  type: string
+                bpfDisableUnprivileged:
+                  description: |-
+                    BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled sysctl to disable
+                    unprivileged use of BPF.  This ensures that unprivileged users cannot access Calico's BPF maps and
+                    cannot insert their own BPF programs to interfere with Calico's. [Default: true]
+                  type: boolean
+                bpfEnabled:
+                  description:
+                    "BPFEnabled, if enabled Felix will use the BPF dataplane.
+                    [Default: false]"
+                  type: boolean
+                bpfEnforceRPF:
+                  description: |-
+                    BPFEnforceRPF enforce strict RPF on all host interfaces with BPF programs regardless of
+                    what is the per-interfaces or global setting. Possible values are Disabled, Strict
+                    or Loose. [Default: Loose]
+                  pattern: ^(?i)(Disabled|Strict|Loose)?$
+                  type: string
+                bpfExcludeCIDRsFromNAT:
+                  description: |-
+                    BPFExcludeCIDRsFromNAT is a list of CIDRs that are to be excluded from NAT
+                    resolution so that host can handle them. A typical usecase is node local
+                    DNS cache.
+                  items:
+                    type: string
+                  type: array
+                bpfExportBufferSizeMB:
+                  description: |-
+                    BPFExportBufferSizeMB in BPF mode, controls the buffer size used for sending BPF events to felix.
+                    [Default: 1]
+                  type: integer
+                bpfExtToServiceConnmark:
+                  description: |-
+                    BPFExtToServiceConnmark in BPF mode, controls a 32bit mark that is set on connections from an
+                    external client to a local service. This mark allows us to control how packets of that
+                    connection are routed within the host and how is routing interpreted by RPF check. [Default: 0]
+                  type: integer
+                bpfExternalServiceMode:
+                  description: |-
+                    BPFExternalServiceMode in BPF mode, controls how connections from outside the cluster to services (node ports
+                    and cluster IPs) are forwarded to remote workloads.  If set to "Tunnel" then both request and response traffic
+                    is tunneled to the remote node.  If set to "DSR", the request traffic is tunneled but the response traffic
+                    is sent directly from the remote node.  In "DSR" mode, the remote node appears to use the IP of the ingress
+                    node; this requires a permissive L2 network.  [Default: Tunnel]
+                  pattern: ^(?i)(Tunnel|DSR)?$
+                  type: string
+                bpfForceTrackPacketsFromIfaces:
+                  description: |-
+                    BPFForceTrackPacketsFromIfaces in BPF mode, forces traffic from these interfaces
+                    to skip Calico's iptables NOTRACK rule, allowing traffic from those interfaces to be
+                    tracked by Linux conntrack.  Should only be used for interfaces that are not used for
+                    the Calico fabric.  For example, a docker bridge device for non-Calico-networked
+                    containers. [Default: docker+]
+                  items:
+                    type: string
+                  type: array
+                bpfHostConntrackBypass:
+                  description: |-
+                    BPFHostConntrackBypass Controls whether to bypass Linux conntrack in BPF mode for
+                    workloads and services. [Default: true - bypass Linux conntrack]
+                  type: boolean
+                bpfHostNetworkedNATWithoutCTLB:
+                  description: |-
+                    BPFHostNetworkedNATWithoutCTLB when in BPF mode, controls whether Felix does a NAT without CTLB. This along with BPFConnectTimeLoadBalancing
+                    determines the CTLB behavior. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfIPFragTimeout:
+                  description: |-
+                    BPFIPFragTimeout, in BPF mode, controls the timeout for IP fragment reassembly.
+                    This is the maximum time that the BPF dataplane will wait for all fragments of a
+                    fragmented IP packet to arrive before discarding them.  If left unset, the value
+                    is read from the Linux kernel sysctl net.ipv4.ipfrag_time (which defaults to 30
+                    seconds).
+                    [Default: unset - read from net.ipv4.ipfrag_time]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                bpfIPFragmentReassemblyEnabled:
+                  description: |-
+                    BPFIPFragmentReassemblyEnabled controls whether Felix loads the BPF program that
+                    reassembles out-of-order IP fragments from external networks. This program requires
+                    a kernel newer than 5.10. When enabled (the default) and the program fails to load,
+                    Felix reports not-ready until the user sets this to false. When false, fragmented
+                    packets from external sources are dropped. [Default: true]
+                  type: boolean
+                bpfJITHardening:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Strict
+                    - enum:
+                        - Auto
+                        - Strict
+                  description: |-
+                    BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
+                    if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
+                    Felix will not modify the JIT hardening setting. [Default: Auto]
+                  type: string
+                bpfKubeProxyHealthzPort:
+                  description: |-
+                    BPFKubeProxyHealthzPort, in BPF mode, controls the port that Felix's embedded kube-proxy health check server binds to.
+                    The health check server is used by external load balancers to determine if this node should receive traffic.
+                    Set to 0 to disable the health check server.  [Default: 10256]
+                  type: integer
+                bpfKubeProxyIptablesCleanupEnabled:
+                  description: |-
+                    BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF mode, Felix will proactively clean up the upstream
+                    Kubernetes kube-proxy's iptables chains.  Should only be enabled if kube-proxy is not running.  [Default: true]
+                  type: boolean
+                bpfKubeProxyMinSyncPeriod:
+                  description: |-
+                    BPFKubeProxyMinSyncPeriod, in BPF mode, controls the minimum time between updates to the dataplane for Felix's
+                    embedded kube-proxy.  Lower values give reduced set-up latency.  Higher values reduce Felix CPU usage by
+                    batching up more work.  [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                bpfL3IfacePattern:
+                  description: |-
+                    BPFL3IfacePattern is a regular expression that allows to list tunnel devices like wireguard or vxlan (i.e., L3 devices)
+                    in addition to BPFDataIfacePattern. That is, tunnel interfaces not created by Calico, that Calico workload traffic flows
+                    over as well as any interfaces that handle incoming traffic to nodeports and services from outside the cluster.
+                  type: string
+                bpfLogFilters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    BPFLogFilters is a map of key=values where the value is
+                    a pcap filter expression and the key is an interface name with 'all'
+                    denoting all interfaces, 'weps' all workload endpoints and 'heps' all host
+                    endpoints.
+
+                    When specified as an env var, it accepts a comma-separated list of
+                    key=values.
+                    [Default: unset - means all debug logs are emitted]
+                  type: object
+                bpfLogLevel:
+                  description: |-
+                    BPFLogLevel controls the log level of the BPF programs when in BPF dataplane mode.  One of "Off", "Info", or
+                    "Debug".  The logs are emitted to the BPF trace pipe, accessible with the command `tc exec bpf debug`.
+                    [Default: Off].
+                  pattern: ^(?i)(Off|Info|Debug)?$
+                  type: string
+                bpfMaglevMaxEndpointsPerService:
+                  description: |-
+                    BPFMaglevMaxEndpointsPerService is the maximum number of endpoints
+                    expected to be part of a single Maglev-enabled service.
+
+                    Influences the size of the per-service Maglev lookup-tables generated by Felix
+                    and thus the amount of memory reserved.
+
+                    [Default: 100]
+                  type: integer
+                bpfMaglevMaxServices:
+                  description: |-
+                    BPFMaglevMaxServices is the maximum number of expected Maglev-enabled
+                    services that Felix will allocate lookup-tables for.
+
+                    [Default: 100]
+                  type: integer
+                bpfMapSizeConntrack:
+                  description: |-
+                    BPFMapSizeConntrack sets the size for the conntrack map.  This map must be large enough to hold
+                    an entry for each active connection.  Warning: changing the size of the conntrack map can cause disruption.
+                  type: integer
+                bpfMapSizeConntrackCleanupQueue:
+                  description: |-
+                    BPFMapSizeConntrackCleanupQueue sets the size for the map used to hold NAT conntrack entries that are queued
+                    for cleanup.  This should be big enough to hold all the NAT entries that expire within one cleanup interval.
+                  minimum: 1
+                  type: integer
+                bpfMapSizeConntrackScaling:
+                  description: |-
+                    BPFMapSizeConntrackScaling controls whether and how we scale the conntrack map size depending
+                    on its usage. 'Disabled' make the size stay at the default or whatever is set by
+                    BPFMapSizeConntrack*. 'DoubleIfFull' doubles the size when the map is pretty much full even
+                    after cleanups. [Default: DoubleIfFull]
+                  pattern: ^(?i)(Disabled|DoubleIfFull)?$
+                  type: string
+                bpfMapSizeIPSets:
+                  description: |-
+                    BPFMapSizeIPSets sets the size for ipsets map.  The IP sets map must be large enough to hold an entry
+                    for each endpoint matched by every selector in the source/destination matches in network policy.  Selectors
+                    such as "all()" can result in large numbers of entries (one entry per endpoint in that case).
+                  type: integer
+                bpfMapSizeIfState:
+                  description: |-
+                    BPFMapSizeIfState sets the size for ifstate map.  The ifstate map must be large enough to hold an entry
+                    for each device (host + workloads) on a host.
+                  type: integer
+                bpfMapSizeNATAffinity:
+                  description: |-
+                    BPFMapSizeNATAffinity sets the size of the BPF map that stores the affinity of a connection (for services that
+                    enable that feature.
+                  type: integer
+                bpfMapSizeNATBackend:
+                  description: |-
+                    BPFMapSizeNATBackend sets the size for NAT back end map.
+                    This is the total number of endpoints. This is mostly
+                    more than the size of the number of services.
+                  type: integer
+                bpfMapSizeNATFrontend:
+                  description: |-
+                    BPFMapSizeNATFrontend sets the size for NAT front end map.
+                    FrontendMap should be large enough to hold an entry for each nodeport,
+                    external IP and each port in each service.
+                  type: integer
+                bpfMapSizePerCpuConntrack:
+                  description: |-
+                    BPFMapSizePerCPUConntrack determines the size of conntrack map based on the number of CPUs. If set to a
+                    non-zero value, overrides BPFMapSizeConntrack with `BPFMapSizePerCPUConntrack * (Number of CPUs)`.
+                    This map must be large enough to hold an entry for each active connection.  Warning: changing the size of the
+                    conntrack map can cause disruption.
+                  type: integer
+                bpfMapSizeRoute:
+                  description: |-
+                    BPFMapSizeRoute sets the size for the routes map.  The routes map should be large enough
+                    to hold one entry per workload and a handful of entries per host (enough to cover its own IPs and
+                    tunnel IPs).
+                  type: integer
+                bpfPSNATPorts:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
+                    collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
+                    preferably outside the  ephemeral ranges used by common operating systems. Linux uses
+                    32768–60999, while others mostly use the IANA defined range 49152–65535. It is not necessarily
+                    a problem if this range overlaps with the operating systems. Both ends of the range are
+                    inclusive. [Default: 20000:29999]
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                bpfPolicyDebugEnabled:
+                  description: |-
+                    BPFPolicyDebugEnabled when true, Felix records detailed information
+                    about the BPF policy programs, which can be examined with the calico-bpf command-line tool.
+                  type: boolean
+                bpfProfiling:
+                  description: |-
+                    BPFProfiling controls profiling of BPF programs. At the monent, it can be
+                    Disabled or Enabled. [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfRedirectToPeer:
+                  description: |-
+                    BPFRedirectToPeer controls whether traffic may be forwarded directly to the peer side of a workload’s device.
+                    Note that the legacy "L2Only" option is now deprecated and if set it is treated like "Enabled".
+                    Setting this option to "Enabled" allows direct redirection (including from L3 host devices such as IPIP tunnels or WireGuard),
+                    which can improve redirection performance but causes the redirected packets to bypass the host‑side ingress path.
+                    As a result, packet‑capture tools on the host side of the workload device (for example, tcpdump) will not see that traffic. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                cgroupV2Path:
+                  description:
+                    CgroupV2Path overrides the default location where to
+                    find the cgroup hierarchy.
+                  type: string
+                chainInsertMode:
+                  description: |-
+                    ChainInsertMode controls whether Felix hooks the kernel's top-level iptables chains by inserting a rule
+                    at the top of the chain or by appending a rule at the bottom. insert is the safe default since it prevents
+                    Calico's rules from being bypassed. If you switch to append mode, be sure that the other rules in the chains
+                    signal acceptance by falling through to the Calico rules, otherwise the Calico policy will be bypassed.
+                    [Default: insert]
+                  pattern: ^(?i)(Insert|Append)?$
+                  type: string
+                dataplaneDriver:
+                  description: |-
+                    DataplaneDriver filename of the external dataplane driver to use.  Only used if UseInternalDataplaneDriver
+                    is set to false.
+                  type: string
+                dataplaneWatchdogTimeout:
+                  description: |-
+                    DataplaneWatchdogTimeout is the readiness/liveness timeout used for Felix's (internal) dataplane driver.
+                    Deprecated: replaced by the generic HealthTimeoutOverrides.
+                  type: string
+                debugDisableLogDropping:
+                  description: |-
+                    DebugDisableLogDropping disables the dropping of log messages when the log buffer is full.  This can
+                    significantly impact performance if log write-out is a bottleneck. [Default: false]
+                  type: boolean
+                debugHost:
+                  description: |-
+                    DebugHost is the host IP or hostname to bind the debug port to.  Only used
+                    if DebugPort is set. [Default:localhost]
+                  type: string
+                debugMemoryProfilePath:
+                  description:
+                    DebugMemoryProfilePath is the path to write the memory
+                    profile to when triggered by signal.
+                  type: string
+                debugPort:
+                  description: |-
+                    DebugPort if set, enables Felix's debug HTTP port, which allows memory and CPU profiles
+                    to be retrieved.  The debug port is not secure, it should not be exposed to the internet.
+                  type: integer
+                debugSimulateCalcGraphHangAfter:
+                  description: |-
+                    DebugSimulateCalcGraphHangAfter is used to simulate a hang in the calculation graph after the specified duration.
+                    This is useful in tests of the watchdog system only!
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneApplyDelay:
+                  description: |-
+                    DebugSimulateDataplaneApplyDelay adds an artificial delay to every dataplane operation.  This is useful for
+                    simulating a heavily loaded system for test purposes only.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneHangAfter:
+                  description: |-
+                    DebugSimulateDataplaneHangAfter is used to simulate a hang in the dataplane after the specified duration.
+                    This is useful in tests of the watchdog system only!
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                defaultEndpointToHostAction:
+                  description: |-
+                    DefaultEndpointToHostAction controls what happens to traffic that goes from a workload endpoint to the host
+                    itself (after the endpoint's egress policy is applied). By default, Calico blocks traffic from workload
+                    endpoints to the host itself with an iptables "DROP" action. If you want to allow some or all traffic from
+                    endpoint to host, set this parameter to RETURN or ACCEPT. Use RETURN if you have your own rules in the iptables
+                    "INPUT" chain; Calico will insert its rules at the top of that chain, then "RETURN" packets to the "INPUT" chain
+                    once it has completed processing workload endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                    from workloads after processing workload endpoint egress policy. [Default: Drop]
+                  pattern: ^(?i)(Drop|Accept|Return)?$
+                  type: string
+                deviceRouteProtocol:
+                  description: |-
+                    DeviceRouteProtocol controls the protocol to set on routes programmed by Felix. The protocol is an 8-bit label
+                    used to identify the owner of the route.
+                  type: integer
+                deviceRouteSourceAddress:
+                  description: |-
+                    DeviceRouteSourceAddress IPv4 address to set as the source hint for routes programmed by Felix. When not set
+                    the source address for local traffic from host to workload will be determined by the kernel.
+                  maxLength: 45
+                  type: string
+                deviceRouteSourceAddressIPv6:
+                  description: |-
+                    DeviceRouteSourceAddressIPv6 IPv6 address to set as the source hint for routes programmed by Felix. When not set
+                    the source address for local traffic from host to workload will be determined by the kernel.
+                  maxLength: 45
+                  type: string
+                disableConntrackInvalidCheck:
+                  description: |-
+                    DisableConntrackInvalidCheck disables the check for invalid connections in conntrack. While the conntrack
+                    invalid check helps to detect malicious traffic, it can also cause issues with certain multi-NIC scenarios.
+                  type: boolean
+                endpointReportingDelay:
+                  description: |-
+                    EndpointReportingDelay is the delay before Felix reports endpoint status to the datastore. This is only used
+                    by the OpenStack integration. [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                endpointReportingEnabled:
+                  description: |-
+                    EndpointReportingEnabled controls whether Felix reports endpoint status to the datastore. This is only used
+                    by the OpenStack integration. [Default: false]
+                  type: boolean
+                endpointStatusPathPrefix:
+                  description: |-
+                    EndpointStatusPathPrefix is the path to the directory where endpoint status will be written. Endpoint status
+                    file reporting is disabled if field is left empty.
+
+                    Chosen directory should match the directory used by the CNI plugin for PodStartupDelay.
+                    [Default: /var/run/calico]
+                  type: string
+                externalNodesList:
+                  description: |-
+                    ExternalNodesCIDRList is a list of CIDR's of external, non-Calico nodes from which VXLAN/IPIP overlay traffic
+                    will be allowed.  By default, external tunneled traffic is blocked to reduce attack surface.
+                  items:
+                    type: string
+                  type: array
+                failsafeInboundHostPorts:
+                  description: |-
+                    FailsafeInboundHostPorts is a list of ProtoPort struct objects including UDP/TCP/SCTP ports and CIDRs that Felix will
+                    allow incoming traffic to host endpoints on irrespective of the security policy. This is useful to avoid accidentally
+                    cutting off a host with incorrect configuration. For backwards compatibility, if the protocol is not specified,
+                    it defaults to "tcp". If a CIDR is not specified, it will allow traffic from all addresses. To disable all inbound host ports,
+                    use the value "[]". The default value allows ssh access, DHCP, BGP, etcd and the Kubernetes API.
+                    [Default: tcp:22, udp:68, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666, tcp:6667 ]
+                  items:
+                    description:
+                      ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                failsafeOutboundHostPorts:
+                  description: |-
+                    FailsafeOutboundHostPorts is a list of PortProto struct objects including UDP/TCP/SCTP ports and CIDRs that Felix
+                    will allow outgoing traffic from host endpoints to irrespective of the security policy. This is useful to avoid accidentally
+                    cutting off a host with incorrect configuration. For backwards compatibility, if the protocol is not specified, it defaults
+                    to "tcp". If a CIDR is not specified, it will allow traffic from all addresses. To disable all outbound host ports,
+                    use the value "[]". The default value opens etcd's standard ports to ensure that Felix does not get cut off from etcd
+                    as well as allowing DHCP, DNS, BGP and the Kubernetes API.
+                    [Default: udp:53, udp:67, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666, tcp:6667 ]
+                  items:
+                    description:
+                      ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                featureDetectOverride:
+                  description: |-
+                    FeatureDetectOverride is used to override feature detection based on auto-detected platform
+                    capabilities.  Values are specified in a comma separated list with no spaces, example;
+                    "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=". A value of "true" or "false" will
+                    force enable/disable feature, empty or omitted values fall back to auto-detection.
+                  pattern: ^([a-zA-Z0-9-_]+=(true|false|),)*([a-zA-Z0-9-_]+=(true|false|))?$
+                  type: string
+                featureGates:
+                  description: |-
+                    FeatureGates is used to enable or disable tech-preview Calico features.
+                    Values are specified in a comma separated list with no spaces, example;
+                    "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false". This is
+                    used to enable features that are not fully production ready.
+                  pattern: ^([a-zA-Z0-9-_]+=([^=]+),)*([a-zA-Z0-9-_]+=([^=]+))?$
+                  type: string
+                floatingIPs:
+                  description: |-
+                    FloatingIPs configures whether or not Felix will program non-OpenStack floating IP addresses.  (OpenStack-derived
+                    floating IPs are always programmed, regardless of this setting.)
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                flowLogsCollectorDebugTrace:
+                  description: |-
+                    When FlowLogsCollectorDebugTrace is set to true, enables the logs in the collector to be
+                    printed in their entirety.
+                  type: boolean
+                flowLogsFlushInterval:
+                  description:
+                    FlowLogsFlushInterval configures the interval at which
+                    Felix exports flow logs.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                flowLogsGoldmaneServer:
+                  description:
+                    FlowLogGoldmaneServer is the flow server endpoint to
+                    which flow data should be published.
+                  type: string
+                flowLogsLocalReporter:
+                  description:
+                    "FlowLogsLocalReporter configures local unix socket for
+                    reporting flow data from each node. [Default: Disabled]"
+                  enum:
+                    - Disabled
+                    - Enabled
+                  type: string
+                flowLogsPolicyEvaluationMode:
+                  description: |-
+                    Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                    traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                    pending_policies field, offering a near-real-time view of policy changes across flows.
+                    None - Felix stops evaluating pending traces.
+                    [Default: Continuous]
+                  enum:
+                    - None
+                    - Continuous
+                  type: string
+                genericXDPEnabled:
+                  description: |-
+                    GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver
+                    modes can use XDP. This is not recommended since it doesn't provide better performance than
+                    iptables. [Default: false]
+                  type: boolean
+                goGCThreshold:
+                  description: |-
+                    GoGCThreshold Sets the Go runtime's garbage collection threshold.  I.e. the percentage that the heap is
+                    allowed to grow before garbage collection is triggered.  In general, doubling the value halves the CPU time
+                    spent doing GC, but it also doubles peak GC memory overhead.  A special value of -1 can be used
+                    to disable GC entirely; this should only be used in conjunction with the GoMemoryLimitMB setting.
+
+                    This setting is overridden by the GOGC environment variable.
+
+                    [Default: 40]
+                  type: integer
+                goMaxProcs:
+                  description: |-
+                    GoMaxProcs sets the maximum number of CPUs that the Go runtime will use concurrently.  A value of -1 means
+                    "use the system default"; typically the number of real CPUs on the system.
+
+                    this setting is overridden by the GOMAXPROCS environment variable.
+
+                    [Default: -1]
+                  type: integer
+                goMemoryLimitMB:
+                  description: |-
+                    GoMemoryLimitMB sets a (soft) memory limit for the Go runtime in MB.  The Go runtime will try to keep its memory
+                    usage under the limit by triggering GC as needed.  To avoid thrashing, it will exceed the limit if GC starts to
+                    take more than 50% of the process's CPU time.  A value of -1 disables the memory limit.
+
+                    Note that the memory limit, if used, must be considerably less than any hard resource limit set at the container
+                    or pod level.  This is because felix is not the only process that must run in the container or pod.
+
+                    This setting is overridden by the GOMEMLIMIT environment variable.
+
+                    [Default: -1]
+                  type: integer
+                healthEnabled:
+                  description: |-
+                    HealthEnabled if set to true, enables Felix's health port, which provides readiness and liveness endpoints.
+                    [Default: false]
+                  type: boolean
+                healthHost:
+                  description:
+                    "HealthHost is the host that the health server should
+                    bind to. [Default: localhost]"
+                  type: string
+                healthPort:
+                  description:
+                    "HealthPort is the TCP port that the health server should
+                    bind to. [Default: 9099]"
+                  type: integer
+                healthTimeoutOverrides:
+                  description: |-
+                    HealthTimeoutOverrides allows the internal watchdog timeouts of individual subcomponents to be
+                    overridden.  This is useful for working around "false positive" liveness timeouts that can occur
+                    in particularly stressful workloads or if CPU is constrained.  For a list of active
+                    subcomponents, see Felix's logs.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      timeout:
+                        type: string
+                    required:
+                      - name
+                      - timeout
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                interfaceExclude:
+                  description: |-
+                    InterfaceExclude A comma-separated list of interface names that should be excluded when Felix is resolving
+                    host endpoints. The default value ensures that Felix ignores Kubernetes' internal `kube-ipvs0` device. If you
+                    want to exclude multiple interface names using a single value, the list supports regular expressions. For
+                    regular expressions you must wrap the value with `/`. For example having values `/^kube/,veth1` will exclude
+                    all interfaces that begin with `kube` and also the interface `veth1`. [Default: kube-ipvs0]
+                  type: string
+                interfacePrefix:
+                  description: |-
+                    InterfacePrefix is the interface name prefix that identifies workload endpoints and so distinguishes
+                    them from host endpoint interfaces. Note: in environments other than bare metal, the orchestrators
+                    configure this appropriately. For example our Kubernetes and Docker integrations set the 'cali' value,
+                    and our OpenStack integration sets the 'tap' value. [Default: cali]
+                  type: string
+                interfaceRefreshInterval:
+                  description: |-
+                    InterfaceRefreshInterval is the period at which Felix rescans local interfaces to verify their state.
+                    The rescan can be disabled by setting the interval to 0.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                ipForwarding:
+                  description: |-
+                    IPForwarding controls whether Felix sets the host sysctls to enable IP forwarding.  IP forwarding is required
+                    when using Calico for workload networking.  This should be disabled only on hosts where Calico is used solely for
+                    host protection. In BPF mode, due to a kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                    must be disabled. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                ipipEnabled:
+                  description: |-
+                    IPIPEnabled overrides whether Felix should configure an IPIP interface on the host. Optional as Felix
+                    determines this based on the existing IP pools. [Default: nil (unset)]
+                  type: boolean
+                ipipMTU:
+                  description: |-
+                    IPIPMTU controls the MTU to set on the IPIP tunnel device.  Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                ipsetsRefreshInterval:
+                  description: |-
+                    IpsetsRefreshInterval controls the period at which Felix re-checks all IP sets to look for discrepancies.
+                    Set to 0 to disable the periodic refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesBackend:
+                  description: |-
+                    IptablesBackend controls which backend of iptables will be used. The default is `Auto`.
+
+                    Warning: changing this on a running system can leave "orphaned" rules in the "other" backend. These
+                    should be cleaned up to avoid confusing interactions.
+                  enum:
+                    - Legacy
+                    - NFT
+                    - Auto
+                  pattern: ^(?i)(Auto|Legacy|NFT)?$
+                  type: string
+                iptablesFilterAllowAction:
+                  description: |-
+                    IptablesFilterAllowAction controls what happens to traffic that is accepted by a Felix policy chain in the
+                    iptables filter table (which is used for "normal" policy). The default will immediately `Accept` the traffic. Use
+                    `Return` to send the traffic back up to the system chains for further processing.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                iptablesFilterDenyAction:
+                  description: |-
+                    IptablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default Calico blocks traffic
+                    with an iptables "DROP" action. If you want to use "REJECT" action instead you can configure it in here.
+                  pattern: ^(?i)(Drop|Reject)?$
+                  type: string
+                iptablesLockProbeInterval:
+                  description: |-
+                    IptablesLockProbeInterval configures the interval between attempts to claim
+                    the xtables lock.  Shorter intervals are more responsive but use more CPU.  [Default: 50ms]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesMangleAllowAction:
+                  description: |-
+                    IptablesMangleAllowAction controls what happens to traffic that is accepted by a Felix policy chain in the
+                    iptables mangle table (which is used for "pre-DNAT" policy). The default will immediately `Accept` the traffic.
+                    Use `Return` to send the traffic back up to the system chains for further processing.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                iptablesMarkMask:
+                  description: |-
+                    IptablesMarkMask is the mask that Felix selects its IPTables Mark bits from. Should be a 32 bit hexadecimal
+                    number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
+                    [Default: 0xffff0000]
+                  format: int32
+                  type: integer
+                iptablesNATOutgoingInterfaceFilter:
+                  description: |-
+                    This parameter can be used to limit the host interfaces on which Calico will apply SNAT to traffic leaving a
+                    Calico IPAM pool with "NAT outgoing" enabled. This can be useful if you have a main data interface, where
+                    traffic should be SNATted and a secondary device (such as the docker bridge) which is local to the host and
+                    doesn't require SNAT. This parameter uses the iptables interface matching syntax, which allows + as a
+                    wildcard. Most users will not need to set this. Example: if your data interfaces are eth0 and eth1 and you
+                    want to exclude the docker bridge, you could set this to eth+
+                  type: string
+                iptablesPostWriteCheckInterval:
+                  description: |-
+                    IptablesPostWriteCheckInterval is the period after Felix has done a write
+                    to the dataplane that it schedules an extra read back in order to check the write was not
+                    clobbered by another process. This should only occur if another application on the system
+                    doesn't respect the iptables lock. [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesRefreshInterval:
+                  description: |-
+                    IptablesRefreshInterval is the period at which Felix re-checks the IP sets
+                    in the dataplane to ensure that no other process has accidentally broken Calico's rules.
+                    Set to 0 to disable IP sets refresh. Note: the default for this value is lower than the
+                    other refresh intervals as a workaround for a Linux kernel bug that was fixed in kernel
+                    version 4.11. If you are using v4.11 or greater you may want to set this to, a higher value
+                    to reduce Felix CPU usage. [Default: 10s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                ipv4ElevatedRoutePriority:
+                  description: |-
+                    Route Priority value for an elevated priority Calico-programmed IPv4 route.  Note, higher
+                    values mean lower priority.  Elevated priority is used during VM live migration, and for
+                    optimal behaviour IPv4ElevatedRoutePriority must be less than IPv4NormalRoutePriority
+                    [Default: 512]
+                  type: integer
+                ipv4NormalRoutePriority:
+                  description: |-
+                    Route Priority value for a normal priority Calico-programmed IPv4 route.  Note, higher
+                    values mean lower priority. [Default: 1024]
+                  type: integer
+                ipv6ElevatedRoutePriority:
+                  description: |-
+                    Route Priority value for an elevated priority Calico-programmed IPv6 route.  Note, higher
+                    values mean lower priority.  Elevated priority is used during VM live migration, and for
+                    optimal behaviour IPv6ElevatedRoutePriority must be less than IPv6NormalRoutePriority
+                    [Default: 512]
+                  type: integer
+                ipv6NormalRoutePriority:
+                  description: |-
+                    Route Priority value for a normal priority Calico-programmed IPv6 route.  Note, higher
+                    values mean lower priority. [Default: 1024]
+                  type: integer
+                ipv6Support:
+                  description:
+                    IPv6Support controls whether Felix enables support for
+                    IPv6 (if supported by the in-use dataplane).
+                  type: boolean
+                istioAmbientMode:
+                  description: |-
+                    IstioAmbientMode configures Felix to work together with Tigera's Istio distribution.
+                    [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                istioDSCPMark:
+                  description: |-
+                    IstioDSCPMark sets the value to use when directing traffic to Istio ZTunnel, when Istio is enabled. The mark is set only on
+                    SYN packets at the final hop to avoid interference with other protocols. This value is reserved by Calico and must not be used
+                    with other Istio installation. [Default: 23]
+                  pattern: ^.*
+                  type: integer
+                  x-kubernetes-int-or-string: true
+                kubeNodePortRanges:
+                  description: |-
+                    KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
+                    Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
+                  items:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  maxItems: 7
+                  type: array
+                liveMigrationRouteConvergenceTime:
+                  description: |-
+                    LiveMigrationRouteConvergenceTime is the time to keep elevated route priority after a
+                    VM live migration completes.  This allows routes to converge across the cluster before
+                    reverting to normal priority. [Default: 30s]
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                logActionRateLimit:
+                  description: |-
+                    LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
+                    where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                  pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
+                  type: string
+                logActionRateLimitBurst:
+                  description:
+                    LogActionRateLimitBurst sets the rate limit burst of
+                    hitting a Log action when LogActionRateLimit is enabled.
+                  maximum: 9999
+                  minimum: 0
+                  type: integer
+                logDebugFilenameRegex:
+                  description: |-
+                    LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.
+                    Only logs from files with names that match the given regular expression are included.  The filter only applies
+                    to Debug level logs.
+                  type: string
+                logFilePath:
+                  description:
+                    "LogFilePath is the full path to the Felix log. Set to
+                    none to disable file logging. [Default: /var/log/calico/felix.log]"
+                  type: string
+                logPrefix:
+                  description: |-
+                    LogPrefix is the log prefix that Felix uses when rendering LOG rules. It is possible to use the following specifiers
+                    to include extra information in the log prefix.
+                    - %t: Tier name.
+                    - %k: Kind (short names).
+                    - %n: Policy or profile name.
+                    - %p: Policy or profile name (namespace/name for namespaced kinds or just name for non namespaced kinds).
+                    Calico includes ": " characters at the end of the generated log prefix.
+                    Note that iptables shows up to 29 characters for the log prefix and nftables up to 127 characters. Extra characters are truncated.
+                    [Default: calico-packet]
+                  pattern: "^([a-zA-Z0-9%: /_-])*$"
+                  type: string
+                logSeverityFile:
+                  description:
+                    "LogSeverityFile is the log severity above which logs
+                    are sent to the log file. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                logSeverityScreen:
+                  description:
+                    "LogSeverityScreen is the log severity above which logs
+                    are sent to the stdout. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                logSeveritySys:
+                  description: |-
+                    LogSeveritySys is the log severity above which logs are sent to the syslog. Set to None for no logging to syslog.
+                    [Default: Info]
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                maxIpsetSize:
+                  description: |-
+                    MaxIpsetSize is the maximum number of IP addresses that can be stored in an IP set. Not applicable
+                    if using the nftables backend.
+                  type: integer
+                metadataAddr:
+                  description: |-
+                    MetadataAddr is the IP address or domain name of the server that can answer VM queries for
+                    cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in
+                    Ubuntu, nova-api-metadata). A value of none (case-insensitive) means that Felix should not
+                    set up any NAT rule for the metadata path. [Default: 127.0.0.1]
+                  type: string
+                metadataPort:
+                  description: |-
+                    MetadataPort is the port of the metadata server. This, combined with global.MetadataAddr (if
+                    not 'None'), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                    In most cases this should not need to be changed [Default: 8775].
+                  type: integer
+                mtuIfacePattern:
+                  description: |-
+                    MTUIfacePattern is a regular expression that controls which interfaces Felix should scan in order
+                    to calculate the host's MTU.
+                    This should not match workload interfaces (usually named cali...).
+                  type: string
+                natOutgoingAddress:
+                  description: |-
+                    NATOutgoingAddress specifies an address to use when performing source NAT for traffic in a natOutgoing pool that
+                    is leaving the network. By default the address used is an address on the interface the traffic is leaving on
+                    (i.e. it uses the iptables MASQUERADE target).
+                  maxLength: 45
+                  type: string
+                natOutgoingExclusions:
+                  description: |-
+                    When a IP pool setting `natOutgoing` is true, packets sent from Calico networked containers in this IP pool to destinations will be masqueraded.
+                    Configure which type of destinations is excluded from being masqueraded.
+                    - IPPoolsOnly: destinations outside of this IP pool will be masqueraded.
+                    - IPPoolsAndHostIPs: destinations outside of this IP pool and all hosts will be masqueraded.
+                    [Default: IPPoolsOnly]
+                  enum:
+                    - IPPoolsOnly
+                    - IPPoolsAndHostIPs
+                  type: string
+                natPortRange:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
+                    network stack is used.
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                netlinkTimeout:
+                  description: |-
+                    NetlinkTimeout is the timeout when talking to the kernel over the netlink protocol, used for programming
+                    routes, rules, and other kernel objects. [Default: 10s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                nftablesFilterAllowAction:
+                  description: |-
+                    NftablesFilterAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict
+                    in the filter table. The default is to `ACCEPT` the traffic, which is a terminal action.  Alternatively,
+                    `RETURN` can be used to return the traffic back to the top-level chain for further processing by your rules.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                nftablesFilterDenyAction:
+                  description: |-
+                    NftablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default, Calico
+                    blocks traffic with a "drop" action. If you want to use a "reject" action instead you can configure it here.
+                  pattern: ^(?i)(Drop|Reject)?$
+                  type: string
+                nftablesMangleAllowAction:
+                  description: |-
+                    NftablesMangleAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict
+                    in the mangle table. The default is to `ACCEPT` the traffic, which is a terminal action.  Alternatively,
+                    `RETURN` can be used to return the traffic back to the top-level chain for further processing by your rules.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                nftablesMarkMask:
+                  description: |-
+                    NftablesMarkMask is the mask that Felix selects its nftables Mark bits from. Should be a 32 bit hexadecimal
+                    number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
+                    [Default: 0xffff0000]
+                  format: int32
+                  type: integer
+                nftablesMode:
+                  default: Auto
+                  description:
+                    "NFTablesMode configures nftables support in Felix. [Default:
+                    Auto]"
+                  enum:
+                    - Disabled
+                    - Enabled
+                    - Auto
+                  type: string
+                nftablesRefreshInterval:
+                  description:
+                    "NftablesRefreshInterval controls the interval at which
+                    Felix periodically refreshes the nftables rules. [Default: 90s]"
+                  type: string
+                nodeSelector:
+                  description: |-
+                    NodeSelector is an optional label selector that restricts this FelixConfiguration
+                    to apply only to nodes that match the given selector. This field is only valid
+                    on FelixConfiguration resources whose name is not "default" and does not start
+                    with "node.". For resources named "default", the configuration applies globally
+                    to all nodes. For resources named "node.<nodename>", the configuration applies to
+                    the named node only.
+
+                    At most one selector-scoped FelixConfiguration should match any given node.
+                    If multiple selector-scoped resources match, the oldest (by creation
+                    timestamp) is used and a warning is logged. This prevents an accidentally
+                    created conflicting resource from disrupting an existing, working
+                    configuration.
+                  maxLength: 1024
+                  type: string
+                openstackRegion:
+                  description: |-
+                    OpenstackRegion is the name of the region that a particular Felix belongs to. In a multi-region
+                    Calico/OpenStack deployment, this must be configured somehow for each Felix (here in the datamodel,
+                    or in felix.cfg or the environment on each compute node), and must match the [calico]
+                    openstack_region value configured in neutron.conf on each node. [Default: Empty]
+                  type: string
+                policySyncPathPrefix:
+                  description: |-
+                    PolicySyncPathPrefix is used to by Felix to communicate policy changes to external services,
+                    like Application layer policy. [Default: Empty]
+                  type: string
+                programClusterRoutes:
+                  description: |-
+                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
+                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
+                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                prometheusGoMetricsEnabled:
+                  description: |-
+                    PrometheusGoMetricsEnabled disables Go runtime metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                prometheusMetricsCAFile:
+                  description: |-
+                    PrometheusMetricsCAFile defines the absolute path to the TLS CA certificate file used for securing the /metrics endpoint.
+                    This certificate must be valid and accessible by the calico-node process.
+                  type: string
+                prometheusMetricsCertFile:
+                  description: |-
+                    PrometheusMetricsCertFile defines the absolute path to the TLS certificate file used for securing the /metrics endpoint.
+                    This certificate must be valid and accessible by the calico-node process.
+                  type: string
+                prometheusMetricsClientAuth:
+                  description: |-
+                    PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
+                    This determines how the server validates client certificates. Default is "RequireAndVerifyClientCert".
+                  type: string
+                prometheusMetricsEnabled:
+                  description:
+                    "PrometheusMetricsEnabled enables the Prometheus metrics
+                    server in Felix if set to true. [Default: false]"
+                  type: boolean
+                prometheusMetricsHost:
+                  description:
+                    "PrometheusMetricsHost is the host that the Prometheus
+                    metrics server should bind to. [Default: empty]"
+                  type: string
+                prometheusMetricsKeyFile:
+                  description: |-
+                    PrometheusMetricsKeyFile defines the absolute path to the private key file corresponding to the TLS certificate
+                    used for securing the /metrics endpoint. The private key must be valid and accessible by the calico-node process.
+                  type: string
+                prometheusMetricsPort:
+                  description:
+                    "PrometheusMetricsPort is the TCP port that the Prometheus
+                    metrics server should bind to. [Default: 9091]"
+                  type: integer
+                prometheusProcessMetricsEnabled:
+                  description: |-
+                    PrometheusProcessMetricsEnabled disables process metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                prometheusWireGuardMetricsEnabled:
+                  description: |-
+                    PrometheusWireGuardMetricsEnabled disables wireguard metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                removeExternalRoutes:
+                  description: |-
+                    RemoveExternalRoutes Controls whether Felix will remove unexpected routes to workload interfaces. Felix will
+                    always clean up expected routes that use the configured DeviceRouteProtocol.  To add your own routes, you must
+                    use a distinct protocol (in addition to setting this field to false).
+                  type: boolean
+                reportingInterval:
+                  description: |-
+                    ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.
+                    Must be non-zero in OpenStack deployments. [Default: 30s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                reportingTTL:
+                  description:
+                    "ReportingTTL is the time-to-live setting for process-wide
+                    status reports. [Default: 90s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                requireMTUFile:
+                  description: |-
+                    RequireMTUFile specifies whether mtu file is required to start the felix.
+                    Optional as to keep the same as previous behavior. [Default: false]
+                  type: boolean
+                routeRefreshInterval:
+                  description: |-
+                    RouteRefreshInterval is the period at which Felix re-checks the routes
+                    in the dataplane to ensure that no other process has accidentally broken Calico's rules.
+                    Set to 0 to disable route refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                routeSource:
+                  description: |-
+                    RouteSource configures where Felix gets its routing information.
+                    - WorkloadIPs: use workload endpoints to construct routes.
+                    - CalicoIPAM: the default - use IPAM data to construct routes.
+                  pattern: ^(?i)(WorkloadIPs|CalicoIPAM)?$
+                  type: string
+                routeSyncDisabled:
+                  description: |-
+                    RouteSyncDisabled will disable all operations performed on the route table. Set to true to
+                    run in network-policy mode only.
+                  type: boolean
+                routeTableRange:
+                  description: |-
+                    Deprecated in favor of RouteTableRanges.
+                    Calico programs additional Linux route tables for various purposes.
+                    RouteTableRange specifies the indices of the route tables that Calico should use.
+                  properties:
+                    max:
+                      type: integer
+                    min:
+                      type: integer
+                  required:
+                    - max
+                    - min
+                  type: object
+                  x-kubernetes-validations:
+                    - message: must be a range of route table indices within 1..250
+                      reason: FieldValueInvalid
+                      rule: self.min >= 1 && self.max >= self.min && self.max <= 250
+                routeTableRanges:
+                  description: |-
+                    Calico programs additional Linux route tables for various purposes.
+                    RouteTableRanges specifies a set of table index ranges that Calico should use.
+                    Deprecates`RouteTableRange`, overrides `RouteTableRange`.
+                  items:
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                      - max
+                      - min
+                    type: object
+                    x-kubernetes-validations:
+                      - message: min must be >= 1
+                        reason: FieldValueInvalid
+                        rule: self.min >= 1
+                      - message: min must not be greater than max
+                        reason: FieldValueInvalid
+                        rule: self.min <= self.max
+                  type: array
+                serviceLoopPrevention:
+                  description: |-
+                    When service IP advertisement is enabled, prevent routing loops to service IPs that are
+                    not in use, by dropping or rejecting packets that do not get DNAT'd by kube-proxy.
+                    Unless set to "Disabled", in which case such routing loops continue to be allowed.
+                    [Default: Drop]
+                  pattern: ^(?i)(Drop|Reject|Disabled)?$
+                  type: string
+                sidecarAccelerationEnabled:
+                  description:
+                    "SidecarAccelerationEnabled enables experimental sidecar
+                    acceleration [Default: false]"
+                  type: boolean
+                usageReportingEnabled:
+                  description: |-
+                    UsageReportingEnabled reports anonymous Calico version number and cluster size to projectcalico.org. Logs warnings returned by the usage
+                    server. For example, if a significant security vulnerability has been discovered in the version of Calico being used. [Default: true]
+                  type: boolean
+                usageReportingInitialDelay:
+                  description:
+                    "UsageReportingInitialDelay controls the minimum delay
+                    before Felix makes a report. [Default: 300s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                usageReportingInterval:
+                  description:
+                    "UsageReportingInterval controls the interval at which
+                    Felix makes reports. [Default: 86400s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                useInternalDataplaneDriver:
+                  description: |-
+                    UseInternalDataplaneDriver, if true, Felix will use its internal dataplane programming logic.  If false, it
+                    will launch an external dataplane driver and communicate with it over protobuf.
+                  type: boolean
+                vxlanEnabled:
+                  description: |-
+                    VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for IPv4 VXLAN networking.
+                    Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]
+                  type: boolean
+                vxlanMTU:
+                  description: |-
+                    VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel device.  Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                vxlanMTUV6:
+                  description: |-
+                    VXLANMTUV6 is the MTU to set on the IPv6 VXLAN tunnel device. Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                vxlanPort:
+                  description:
+                    "VXLANPort is the UDP port number to use for VXLAN traffic.
+                    [Default: 4789]"
+                  type: integer
+                vxlanVNI:
+                  description: |-
+                    VXLANVNI is the VXLAN VNI to use for VXLAN traffic.  You may need to change this if the default value is
+                    in use on your system. [Default: 4096]
+                  type: integer
+                windowsManageFirewallRules:
+                  description:
+                    "WindowsManageFirewallRules configures whether or not
+                    Felix will program Windows Firewall rules (to allow inbound access
+                    to its own metrics ports). [Default: Disabled]"
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                wireguardEnabled:
+                  description:
+                    "WireguardEnabled controls whether Wireguard is enabled
+                    for IPv4 (encapsulating IPv4 traffic over an IPv4 underlay network).
+                    [Default: false]"
+                  type: boolean
+                wireguardEnabledV6:
+                  description:
+                    "WireguardEnabledV6 controls whether Wireguard is enabled
+                    for IPv6 (encapsulating IPv6 traffic over an IPv6 underlay network).
+                    [Default: false]"
+                  type: boolean
+                wireguardHostEncryptionEnabled:
+                  description:
+                    "WireguardHostEncryptionEnabled controls whether Wireguard
+                    host-to-host encryption is enabled. [Default: false]"
+                  type: boolean
+                wireguardInterfaceName:
+                  description:
+                    "WireguardInterfaceName specifies the name to use for
+                    the IPv4 Wireguard interface. [Default: wireguard.cali]"
+                  type: string
+                wireguardInterfaceNameV6:
+                  description:
+                    "WireguardInterfaceNameV6 specifies the name to use for
+                    the IPv6 Wireguard interface. [Default: wg-v6.cali]"
+                  type: string
+                wireguardKeepAlive:
+                  description:
+                    "WireguardPersistentKeepAlive controls Wireguard PersistentKeepalive
+                    option. Set 0 to disable. [Default: 0]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                wireguardListeningPort:
+                  description:
+                    "WireguardListeningPort controls the listening port used
+                    by IPv4 Wireguard. [Default: 51820]"
+                  type: integer
+                wireguardListeningPortV6:
+                  description:
+                    "WireguardListeningPortV6 controls the listening port
+                    used by IPv6 Wireguard. [Default: 51821]"
+                  type: integer
+                wireguardMTU:
+                  description:
+                    "WireguardMTU controls the MTU on the IPv4 Wireguard
+                    interface. See Configuring MTU [Default: 1440]"
+                  type: integer
+                wireguardMTUV6:
+                  description:
+                    "WireguardMTUV6 controls the MTU on the IPv6 Wireguard
+                    interface. See Configuring MTU [Default: 1420]"
+                  type: integer
+                wireguardRoutingRulePriority:
+                  description:
+                    "WireguardRoutingRulePriority controls the priority value
+                    to use for the Wireguard routing rule. [Default: 99]"
+                  type: integer
+                wireguardThreadingEnabled:
+                  description: |-
+                    WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                    This increases the maximum number of packets a Wireguard interface can process.
+                    Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                    There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                    that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                    Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
+                  type: boolean
+                workloadSourceSpoofing:
+                  description: |-
+                    WorkloadSourceSpoofing controls whether pods can use the allowedSourcePrefixes annotation to send traffic with a source IP
+                    address that is not theirs. This is disabled by default. When set to "Any", pods can request any prefix.
+                  pattern: ^(?i)(Disabled|Any)?$
+                  type: string
+                xdpEnabled:
+                  description:
+                    "XDPEnabled enables XDP acceleration for suitable untracked
+                    incoming deny rules. [Default: true]"
+                  type: boolean
+                xdpRefreshInterval:
+                  description: |-
+                    XDPRefreshInterval is the period at which Felix re-checks all XDP state to ensure that no
+                    other process has accidentally broken Calico's BPF maps or attached programs. Set to 0 to
+                    disable XDP refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: routeTableRange and routeTableRanges cannot both be set
+                  reason: FieldValueForbidden
+                  rule: "!has(self.routeTableRange) || !has(self.routeTableRanges)"
+                - message: natOutgoingAddress must be a valid IPv4 address
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.natOutgoingAddress) || size(self.natOutgoingAddress)
+                    == 0 || (isIP(self.natOutgoingAddress) && ip(self.natOutgoingAddress).family()
+                    == 4)"
+                - message: deviceRouteSourceAddress must be a valid IPv4 address
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.deviceRouteSourceAddress) || size(self.deviceRouteSourceAddress)
+                    == 0 || (isIP(self.deviceRouteSourceAddress) && ip(self.deviceRouteSourceAddress).family()
+                    == 4)"
+                - message: deviceRouteSourceAddressIPv6 must be a valid IPv6 address
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.deviceRouteSourceAddressIPv6) || size(self.deviceRouteSourceAddressIPv6)
+                    == 0 || (isIP(self.deviceRouteSourceAddressIPv6) && ip(self.deviceRouteSourceAddressIPv6).family()
+                    == 6)"
+          type: object
+          x-kubernetes-validations:
+            - message:
+                nodeSelector must not be set on the 'default' or per-node ('node.*')
+                FelixConfiguration
+              reason: FieldValueForbidden
+              rule:
+                "self.metadata.name == 'default' || self.metadata.name.startsWith('node.')
+                ? !has(self.spec.nodeSelector) : true"
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  description: |-
+                    ApplyOnForward indicates to apply the rules in this policy on forward traffic.
+                    Must be set to true when DoNotTrack or PreDNAT is true.
+                  type: boolean
+                doNotTrack:
+                  description: |-
+                    DoNotTrack indicates whether packets matched by the rules in this policy should go through
+                    the data plane's connection tracking, such as Linux conntrack.  If True, the rules in
+                    this policy are applied before any data plane connection tracking, and packets allowed by
+                    this policy are marked as not to be tracked. Requires ApplyOnForward to be true.
+                  type: boolean
+                egress:
+                  description: |-
+                    The ordered set of egress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ingress:
+                  description: |-
+                    The ordered set of ingress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                namespaceSelector:
+                  description:
+                    NamespaceSelector is an optional field for an expression
+                    used to select a pod based on namespaces.
+                  maxLength: 1024
+                  type: string
+                order:
+                  description: |-
+                    Order is an optional field that specifies the order in which the policy is applied.
+                    Policies with higher "order" are applied after those with lower
+                    order within the same tier.  If the order is omitted, it may be considered to be "infinite" - i.e. the
+                    policy will be applied last.  Policies with identical order will be applied in
+                    alphanumerical order based on the Policy "Name" within the tier.
+                  type: number
+                performanceHints:
+                  description: |-
+                    PerformanceHints contains a list of hints to Calico's policy engine to
+                    help process the policy more efficiently.  Hints never change the
+                    enforcement behaviour of the policy.
+
+                    Currently, the only available hint is "AssumeNeededOnEveryNode".  When
+                    that hint is set on a policy, Felix will act as if the policy matches
+                    a local endpoint even if it does not. This is useful for "preloading"
+                    any large static policies that are known to be used on every node.
+                    If the policy is _not_ used on a particular node then the work
+                    done to preload the policy (and to maintain it) is wasted.
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                preDNAT:
+                  description: |-
+                    PreDNAT indicates to apply the rules in this policy before any DNAT.
+                    Requires ApplyOnForward to be true. Cannot be used with DoNotTrack, and the
+                    policy must not contain egress rules.
+                  type: boolean
+                selector:
+                  description:
+                    "The selector is an expression used to pick out the endpoints
+                    that the policy should\nbe applied to.\n\nSelector expressions follow
+                    this syntax:\n\n\tlabel == \"string_literal\"  ->  comparison, e.g.
+                    my_label == \"foo bar\"\n\tlabel != \"string_literal\"   ->  not
+                    equal; also matches if label is not present\n\tlabel in { \"a\",
+                    \"b\", \"c\", ... }  ->  true if the value of label X is one of
+                    \"a\", \"b\", \"c\"\n\tlabel not in { \"a\", \"b\", \"c\", ... }
+                    \ ->  true if the value of label X is not one of \"a\", \"b\", \"c\"\n\thas(label_name)
+                    \ -> True if that label is present\n\t! expr -> negation of expr\n\texpr
+                    && expr  -> Short-circuit and\n\texpr || expr  -> Short-circuit
+                    or\n\t( expr ) -> parens for grouping\n\tall() or the empty selector
+                    -> matches all endpoints.\n\nLabel names are allowed to contain
+                    alphanumerics, -, _ and /. String literals are more permissive\nbut
+                    they do not support escape characters.\n\nExamples (with made-up
+                    labels):\n\n\ttype == \"webserver\" && deployment == \"prod\"\n\ttype
+                    in {\"frontend\", \"backend\"}\n\tdeployment != \"dev\"\n\t! has(label_name)"
+                  maxLength: 1024
+                  type: string
+                serviceAccountSelector:
+                  description:
+                    ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  maxLength: 1024
+                  type: string
+                tier:
+                  default: default
+                  description: |-
+                    The name of the tier that this policy belongs to.  If this is omitted, the default
+                    tier (name is "default") is assumed.  The specified tier must exist in order to create
+                    security policies within the tier, the "default" tier is created automatically if it
+                    does not exist, this means for deployments requiring only a single Tier, the tier name
+                    may be omitted on all policy management requests.
+                  type: string
+                types:
+                  description: |-
+                    Types indicates whether this policy applies to ingress, or to egress, or to both.  When
+                    not explicitly specified (and so the value on creation is empty or nil), Calico defaults
+                    Types according to what Ingress and Egress rules are present in the policy.  The
+                    default is:
+
+                    - [ PolicyTypeIngress ], if there are no Egress rules (including the case where there are
+                      also no Ingress rules)
+
+                    - [ PolicyTypeEgress ], if there are Egress rules but no Ingress rules
+
+                    - [ PolicyTypeIngress, PolicyTypeEgress ], if there are both Ingress and Egress rules.
+
+                    When the policy is read back again, Types will always be one of these values, never empty
+                    or nil.
+                  items:
+                    description:
+                      PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: preDNAT and doNotTrack cannot both be true
+                  reason: FieldValueForbidden
+                  rule:
+                    "!((has(self.doNotTrack) && self.doNotTrack) && (has(self.preDNAT)
+                    && self.preDNAT))"
+                - message: preDNAT policy cannot have any egress rules
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.egress) ||
+                    size(self.egress) == 0
+                - message: preDNAT policy cannot have 'Egress' type
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.types) || !self.types.exists(t,
+                    t == 'Egress')
+                - message:
+                    applyOnForward must be true if either preDNAT or doNotTrack
+                    is true
+                  reason: FieldValueInvalid
+                  rule:
+                    (has(self.applyOnForward) && self.applyOnForward) || ((!has(self.doNotTrack)
+                    || !self.doNotTrack) && (!has(self.preDNAT) || !self.preDNAT))
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.selector) || !self.selector.contains('global(')"
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.serviceAccountSelector) || !self.serviceAccountSelector.contains('global(')"
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs that share labels to
+            allow rules to refer to them via selectors.  The labels of GlobalNetworkSet are not namespaced.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                GlobalNetworkSetSpec contains the specification for a NetworkSet
+                resource.
+              properties:
+                nets:
+                  description: |-
+                    The list of IP networks that belong to this set. Each entry must be in CIDR notation,
+                    e.g. "192.168.1.0/24". To include a single IP address, use a /32 (IPv4) or /128 (IPv6) mask.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                HostEndpointSpec contains the specification for a HostEndpoint
+                resource.
+              properties:
+                expectedIPs:
+                  description:
+                    "The expected IP addresses (IPv4 and IPv6) of the endpoint.\nIf
+                    \"InterfaceName\" is not present, Calico will look for an interface
+                    matching any\nof the IPs in the list and apply policy to that.\nNote:\n\tWhen
+                    using the selector match criteria in an ingress or egress security
+                    Policy\n\tor Profile, Calico converts the selector into a set of
+                    IP addresses. For host\n\tendpoints, the ExpectedIPs field is used
+                    for that purpose. (If only the interface\n\tname is specified, Calico
+                    does not learn the IPs of the interface for use in match\n\tcriteria.)"
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                interfaceName:
+                  description: |-
+                    Either "*", or the name of a specific Linux interface to apply policy to; or empty.  "*"
+                    indicates that this HostEndpoint governs all traffic to, from or through the default
+                    network namespace of the host named by the "Node" field; entering and leaving that
+                    namespace via any interface, including those from/to non-host-networked local workloads.
+
+                    If InterfaceName is not "*", this HostEndpoint only governs traffic that enters or leaves
+                    the host through the specific interface named by InterfaceName, or - when InterfaceName
+                    is empty - through the specific interface that has one of the IPs in ExpectedIPs.
+                    Therefore, when InterfaceName is empty, at least one expected IP must be specified.  Only
+                    external interfaces (such as "eth0") are supported here; it isn't possible for a
+                    HostEndpoint to protect traffic through a specific local workload interface.
+
+                    Note: Only some kinds of policy are implemented for "*" HostEndpoints; initially just
+                    pre-DNAT policy.  Please check Calico documentation for the latest position.
+                  maxLength: 15
+                  type: string
+                node:
+                  description: The node name identifying the Calico node instance.
+                  maxLength: 253
+                  type: string
+                ports:
+                  description:
+                    Ports contains the endpoint's named ports, which may
+                    be referenced in security policy rules.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                    required:
+                      - name
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                profiles:
+                  description: |-
+                    A list of identifiers of security Profile objects that apply to this endpoint. Each
+                    profile is applied in the order that they appear in this list.  Profile rules are applied
+                    after the selector-based security policy.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: at least one of interfaceName or expectedIPs must be specified
+                  reason: FieldValueInvalid
+                  rule:
+                    (has(self.interfaceName) && size(self.interfaceName) > 0) || (has(self.expectedIPs)
+                    && size(self.expectedIPs) > 0)
+                - message: node must be specified
+                  reason: FieldValueInvalid
+                  rule: has(self.node) && size(self.node) > 0
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                IPAMBlockSpec contains the specification for an IPAMBlock
+                resource.
+              properties:
+                affinity:
+                  description: |-
+                    Affinity of the block, if this block has one. If set, it will be of the form
+                    "host:<hostname>". If not set, this block is not affine to a host.
+                  type: string
+                affinityClaimTime:
+                  format: date-time
+                  type: string
+                allocations:
+                  description: |-
+                    Array of allocations in-use within this block. nil entries mean the allocation is free.
+                    For non-nil entries at index i, the index is the ordinal of the allocation within this block
+                    and the value is the index of the associated attributes in the Attributes array.
+                  items:
+                    type: integer
+                    # TODO: This nullable is manually added in. We should update controller-gen
+                    # to handle []*int properly itself.
+                    nullable: true
+                  type: array
+                attributes:
+                  description: |-
+                    Attributes is an array of arbitrary metadata associated with allocations in the block. To find
+                    attributes for a given allocation, use the value of the allocation's entry in the Allocations array
+                    as the index of the element in this array.
+                  items:
+                    properties:
+                      alternateOwnerAttrs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          AlternateOwnerAttrs contains attributes of the previous or potential owner
+                          (used during live migration to track the source or target pod).
+                        type: object
+                      handle_id:
+                        description: HandleID is the primary identifier for the allocation.
+                        type: string
+                      secondary:
+                        additionalProperties:
+                          type: string
+                        description:
+                          ActiveOwnerAttrs contains attributes of the active
+                          owner (the pod currently using the IP).
+                        type: object
+                    type: object
+                  type: array
+                cidr:
+                  description: The block's CIDR.
+                  type: string
+                deleted:
+                  description: |-
+                    Deleted is an internal boolean used to workaround a limitation in the Kubernetes API whereby
+                    deletion will not return a conflict error if the block has been updated. It should not be set manually.
+                  type: boolean
+                sequenceNumber:
+                  default: 0
+                  description: |-
+                    We store a sequence number that is updated each time the block is written.
+                    Each allocation will also store the sequence number of the block at the time of its creation.
+                    When releasing an IP, passing the sequence number associated with the allocation allows us
+                    to protect against a race condition and ensure the IP hasn't been released and re-allocated
+                    since the release request.
+                  format: int64
+                  type: integer
+                sequenceNumberForAllocation:
+                  additionalProperties:
+                    format: int64
+                    type: integer
+                  description: |-
+                    Map of allocated ordinal within the block to sequence number of the block at
+                    the time of allocation. Kubernetes does not allow numerical keys for maps, so
+                    the key is cast to a string.
+                  type: object
+                strictAffinity:
+                  description:
+                    StrictAffinity on the IPAMBlock is deprecated and no
+                    longer used by the code. Use IPAMConfig StrictAffinity instead.
+                  type: boolean
+                unallocated:
+                  description:
+                    Unallocated is an ordered list of allocations which are
+                    free in the block.
+                  items:
+                    type: integer
+                  type: array
+              required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                IPAMConfigSpec contains the specification for an IPAMConfig
+                resource.
+              properties:
+                autoAllocateBlocks:
+                  type: boolean
+                kubeVirtVMAddressPersistence:
+                  description: |-
+                    KubeVirtVMAddressPersistence controls whether KubeVirt VirtualMachine workloads
+                    maintain persistent IP addresses across VM lifecycle events.
+                    When set to VMAddressPersistenceEnabled, Calico automatically ensures that KubeVirt VMs retain their
+                    IP addresses when their underlying pods are recreated during VM operations such as
+                    reboot, live migration, or pod eviction. IP persistency is ensured when the
+                    VirtualMachineInstance (VMI) resource is deleted and recreated by the VM controller.
+                    When set to VMAddressPersistenceDisabled, VMs receive new IP addresses whenever their pods are recreated,
+                    following standard pod IP allocation behavior. Live migration target pods are not allowed
+                    when this is set to VMAddressPersistenceDisabled and will result in an error.
+                    If nil, defaults to VMAddressPersistenceEnabled (IP persistence enabled if not specified).
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                maxBlocksPerHost:
+                  description: |-
+                    MaxBlocksPerHost, if non-zero, is the max number of blocks that can be
+                    affine to each host.
+                  maximum: 2147483647
+                  minimum: 0
+                  type: integer
+                strictAffinity:
+                  type: boolean
+              required:
+                - autoAllocateBlocks
+                - strictAffinity
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                IPAMHandleSpec contains the specification for an IPAMHandle
+                resource.
+              properties:
+                block:
+                  additionalProperties:
+                    type: integer
+                  type: object
+                deleted:
+                  type: boolean
+                handleID:
+                  type: string
+              required:
+                - block
+                - handleID
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPPoolSpec contains the specification for an IPPool resource.
+              properties:
+                allowedUses:
+                  description: |-
+                    AllowedUses controls what the IP pool will be used for. If not specified or empty, defaults to
+                    ["Tunnel", "Workload"] for back-compatibility. Valid values: "Tunnel", "Workload", "LoadBalancer".
+                  items:
+                    description: |-
+                      IPPoolAllowedUse defines the allowed uses for an IP pool.
+                      It can be one of "Workload", "Tunnel", or "LoadBalancer".
+                      - "Workload" means the pool is used for workload IP addresses.
+                      - "Tunnel" means the pool is used for tunnel IP addresses.
+                      - "LoadBalancer" means the pool is used for load balancer IP addresses.
+                    enum:
+                      - Workload
+                      - Tunnel
+                      - LoadBalancer
+                    type: string
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: set
+                assignmentMode:
+                  default: Automatic
+                  description:
+                    Determines the mode how IP addresses should be assigned
+                    from this pool
+                  enum:
+                    - Automatic
+                    - Manual
+                  type: string
+                blockSize:
+                  description: |-
+                    The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 122 for IPv6.
+                    The block size must be between 0 and 32 for IPv4 and between 0 and 128 for IPv6. It must also be smaller than
+                    or equal to the size of the pool CIDR.
+                  maximum: 128
+                  minimum: 0
+                  type: integer
+                  x-kubernetes-validations:
+                    - message:
+                        Block size cannot be changed; follow IP pool migration
+                        guide to avoid corruption.
+                      reason: FieldValueInvalid
+                      rule: self == oldSelf
+                cidr:
+                  description: The pool CIDR.
+                  format: cidr
+                  maxLength: 48
+                  type: string
+                  x-kubernetes-validations:
+                    - message:
+                        CIDR cannot be changed; follow IP pool migration guide
+                        to avoid corruption.
+                      reason: FieldValueInvalid
+                      rule: self == oldSelf
+                disableBGPExport:
+                  description:
+                    "Disable exporting routes from this IP Pool's CIDR over
+                    BGP. [Default: false]"
+                  type: boolean
+                disabled:
+                  description:
+                    When disabled is true, Calico IPAM will not assign addresses
+                    from this pool.
+                  type: boolean
+                ipipMode:
+                  description: |-
+                    Contains configuration for IPIP tunneling for this pool.
+                    For IPv6 pools, IPIP tunneling must be disabled.
+                  enum:
+                    - Never
+                    - Always
+                    - CrossSubnet
+                  type: string
+                namespaceSelector:
+                  description: |-
+                    Allows IPPool to allocate for a specific namespace by label selector.
+                    If specified, both namespaceSelector and nodeSelector must match for the pool to be used.
+                  maxLength: 1024
+                  type: string
+                natOutgoing:
+                  description: |-
+                    When natOutgoing is true, packets sent from Calico networked containers in
+                    this pool to destinations outside of this pool will be masqueraded.
+                  type: boolean
+                nodeSelector:
+                  default: all()
+                  description:
+                    Allows IPPool to allocate for a specific node by label
+                    selector.
+                  maxLength: 1024
+                  type: string
+                vxlanMode:
+                  description: Contains configuration for VXLAN tunneling for this pool.
+                  enum:
+                    - Never
+                    - Always
+                    - CrossSubnet
+                  type: string
+              required:
+                - cidr
+              type: object
+              x-kubernetes-validations:
+                - message: ipipMode and vxlanMode cannot both be enabled
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.ipipMode) || !has(self.vxlanMode) || self.ipipMode
+                    == 'Never' || self.vxlanMode == 'Never' || size(self.ipipMode)
+                    == 0 || size(self.vxlanMode) == 0"
+                - message: LoadBalancer IP pool cannot have IPIP or VXLAN enabled
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'LoadBalancer')
+                    || (!has(self.ipipMode) || size(self.ipipMode) == 0 || self.ipipMode
+                    == 'Never') && (!has(self.vxlanMode) || size(self.vxlanMode) ==
+                    0 || self.vxlanMode == 'Never')"
+                - message:
+                    LoadBalancer cannot be combined with Workload or Tunnel allowed
+                    uses
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'LoadBalancer')
+                    || !self.allowedUses.exists(u, u == 'Workload' || u == 'Tunnel')"
+                - message: IPIP is not supported on IPv6 pools
+                  reason: FieldValueForbidden
+                  rule:
+                    cidr(self.cidr).ip().family() != 6 || !has(self.ipipMode) || self.ipipMode
+                    == 'Never' || size(self.ipipMode) == 0
+                - message: LoadBalancer IP pools cannot disable BGP export
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'LoadBalancer')
+                    || !has(self.disableBGPExport) || !self.disableBGPExport"
+                - message:
+                    IP Pool with AllowedUse LoadBalancer must have nodeSelector
+                    set to all()
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'LoadBalancer')
+                    || self.nodeSelector == 'all()'"
+                - message: IP Pool with AllowedUse Tunnel cannot have namespaceSelector
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'Tunnel')
+                    || !has(self.namespaceSelector) || size(self.namespaceSelector) ==
+                    0"
+                - message: global() selector is not valid for IPPool nodeSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.nodeSelector) || !self.nodeSelector.contains('global(')"
+                - message: global() selector is not valid for IPPool namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+            status:
+              properties:
+                conditions:
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipreservations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPReservation
+    listKind: IPReservationList
+    plural: ipreservations
+    singular: ipreservation
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                IPReservationSpec contains the specification for an IPReservation
+                resource.
+              properties:
+                reservedCIDRs:
+                  description: |-
+                    ReservedCIDRs is a list of CIDRs that Calico IPAM will exclude from new allocations.
+                    Each entry must be in CIDR notation (e.g., "10.0.0.0/24" or "10.0.0.1/32" for a single IP).
+                  format: cidr
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                KubeControllersConfigurationSpec contains the values of the
+                Kubernetes controllers configuration.
+              properties:
+                controllers:
+                  description:
+                    Controllers enables and configures individual Kubernetes
+                    controllers
+                  properties:
+                    loadBalancer:
+                      description:
+                        LoadBalancer enables and configures the LoadBalancer
+                        controller. Enabled by default, set to nil to disable.
+                      properties:
+                        assignIPs:
+                          default: AllServices
+                          description:
+                            AssignIPs controls which LoadBalancer Service
+                            gets IP assigned from Calico IPAM.
+                          enum:
+                            - AllServices
+                            - RequestedServicesOnly
+                          type: string
+                      type: object
+                    migration:
+                      description: Migration enables and configures migration controllers.
+                      properties:
+                        policyNameMigrator:
+                          default: Enabled
+                          description: |-
+                            PolicyNameMigrator enables or disables the Policy Name Migrator, which migrates
+                            old-style Calico backend policy names to use v3 style names.
+                          enum:
+                            - Disabled
+                            - Enabled
+                          type: string
+                      type: object
+                    namespace:
+                      description:
+                        Namespace enables and configures the namespace controller.
+                        Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation
+                            with the Calico datastore. [Default: 5m]"
+                          type: string
+                      type: object
+                    node:
+                      description:
+                        Node enables and configures the node controller.
+                        Enabled by default, set to nil to disable.
+                      properties:
+                        hostEndpoint:
+                          description:
+                            HostEndpoint controls syncing nodes to host endpoints.
+                            Disabled by default, set to nil to disable.
+                          properties:
+                            autoCreate:
+                              description: |-
+                                AutoCreate enables automatic creation of host endpoints for every node. [Default: Disabled]
+                                Valid values are: "Enabled", "Disabled".
+                              enum:
+                                - Enabled
+                                - Disabled
+                              type: string
+                            createDefaultHostEndpoint:
+                              description: |-
+                                DefaultHostEndpointMode controls whether a default host endpoint is created for each node.
+                                Valid values are: "Enabled", "Disabled".
+                              type: string
+                            templates:
+                              description:
+                                Templates contains definition for creating
+                                AutoHostEndpoints
+                              items:
+                                properties:
+                                  generateName:
+                                    description:
+                                      GenerateName is appended to the end
+                                      of the generated AutoHostEndpoint name
+                                    maxLength: 253
+                                    type: string
+                                  interfaceCIDRs:
+                                    description: |-
+                                      InterfaceCIDRs contains a list of CIDRs used for matching nodeIPs to the AutoHostEndpoint.
+                                      If specified, only addresses within these CIDRs will be included in the expected IPs.
+                                      At least one of InterfaceCIDRs and InterfacePattern must be specified.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  interfacePattern:
+                                    description: |-
+                                      InterfacePattern contains a regex string to match Node interface names. If specified, a HostEndpoint will be created for each matching interface on each selected node.
+                                      At least one of InterfaceCIDRs and InterfacePattern must be specified.
+                                    type: string
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Labels adds the specified labels to
+                                      the generated AutoHostEndpoint, labels from node
+                                      with the same name will be overwritten by values
+                                      from the template label
+                                    type: object
+                                  nodeSelector:
+                                    description:
+                                      NodeSelector allows the AutoHostEndpoint
+                                      to be created only for specific nodes
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        leakGracePeriod:
+                          description: |-
+                            LeakGracePeriod is the period used by the controller to determine if an IP address has been leaked.
+                            Set to 0 to disable IP garbage collection. [Default: 15m]
+                          type: string
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation
+                            with the Calico datastore. [Default: 5m]"
+                          type: string
+                        syncLabels:
+                          description: |-
+                            SyncLabels controls whether to copy Kubernetes node labels to Calico nodes. [Default: Enabled]
+                            Valid values are: "Enabled", "Disabled".
+                          enum:
+                            - Enabled
+                            - Disabled
+                          type: string
+                      type: object
+                    policy:
+                      description:
+                        Policy enables and configures the policy controller.
+                        Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation
+                            with the Calico datastore. [Default: 5m]"
+                          type: string
+                      type: object
+                    serviceAccount:
+                      description:
+                        ServiceAccount enables and configures the service
+                        account controller. Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation
+                            with the Calico datastore. [Default: 5m]"
+                          type: string
+                      type: object
+                    workloadEndpoint:
+                      description:
+                        WorkloadEndpoint enables and configures the workload
+                        endpoint controller. Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation
+                            with the Calico datastore. [Default: 5m]"
+                          type: string
+                      type: object
+                  type: object
+                debugProfilePort:
+                  description: |-
+                    DebugProfilePort configures the port to serve memory and cpu profiles on. If not specified, profiling
+                    is disabled.
+                    Valid values are: 0-65535.
+                  format: int32
+                  maximum: 65535
+                  minimum: 0
+                  type: integer
+                etcdV3CompactionPeriod:
+                  description:
+                    "EtcdV3CompactionPeriod is the period between etcdv3
+                    compaction requests. Set to 0 to disable. [Default: 10m]"
+                  type: string
+                healthChecks:
+                  default: Enabled
+                  description: |-
+                    HealthChecks enables or disables support for health checks [Default: Enabled]
+                    Valid values are: "Enabled", "Disabled".
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                logSeverityScreen:
+                  description: |-
+                    LogSeverityScreen is the log severity above which logs are sent to the stdout. [Default: Info]
+                    Valid values are: "None", "Debug", "Info", "Warning", "Error", "Fatal", "Panic".
+                  enum:
+                    - None
+                    - Debug
+                    - Info
+                    - Warning
+                    - Error
+                    - Fatal
+                    - Panic
+                  type: string
+                prometheusMetricsPort:
+                  description: |-
+                    PrometheusMetricsPort is the TCP port that the Prometheus metrics server should bind to. Set to 0 to disable. [Default: 9094]
+                    Valid values are: 0-65535.
+                  maximum: 65535
+                  minimum: 0
+                  type: integer
+              required:
+                - controllers
+              type: object
+            status:
+              description: |-
+                KubeControllersConfigurationStatus represents the status of the configuration. It's useful for admins to
+                be able to see the actual config that was applied, which can be modified by environment variables on the
+                kube-controllers process.
+              properties:
+                environmentVars:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    EnvironmentVars contains the environment variables on the kube-controllers that influenced
+                    the RunningConfig.
+                  type: object
+                runningConfig:
+                  description: |-
+                    RunningConfig contains the effective config that is running in the kube-controllers pod, after
+                    merging the API resource with any environment variables.
+                  properties:
+                    controllers:
+                      description:
+                        Controllers enables and configures individual Kubernetes
+                        controllers
+                      properties:
+                        loadBalancer:
+                          description:
+                            LoadBalancer enables and configures the LoadBalancer
+                            controller. Enabled by default, set to nil to disable.
+                          properties:
+                            assignIPs:
+                              default: AllServices
+                              description:
+                                AssignIPs controls which LoadBalancer Service
+                                gets IP assigned from Calico IPAM.
+                              enum:
+                                - AllServices
+                                - RequestedServicesOnly
+                              type: string
+                          type: object
+                        migration:
+                          description: Migration enables and configures migration controllers.
+                          properties:
+                            policyNameMigrator:
+                              default: Enabled
+                              description: |-
+                                PolicyNameMigrator enables or disables the Policy Name Migrator, which migrates
+                                old-style Calico backend policy names to use v3 style names.
+                              enum:
+                                - Disabled
+                                - Enabled
+                              type: string
+                          type: object
+                        namespace:
+                          description:
+                            Namespace enables and configures the namespace
+                            controller. Enabled by default, set to nil to disable.
+                          properties:
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation with the Calico datastore. [Default:
+                                5m]"
+                              type: string
+                          type: object
+                        node:
+                          description:
+                            Node enables and configures the node controller.
+                            Enabled by default, set to nil to disable.
+                          properties:
+                            hostEndpoint:
+                              description:
+                                HostEndpoint controls syncing nodes to host
+                                endpoints. Disabled by default, set to nil to disable.
+                              properties:
+                                autoCreate:
+                                  description: |-
+                                    AutoCreate enables automatic creation of host endpoints for every node. [Default: Disabled]
+                                    Valid values are: "Enabled", "Disabled".
+                                  enum:
+                                    - Enabled
+                                    - Disabled
+                                  type: string
+                                createDefaultHostEndpoint:
+                                  description: |-
+                                    DefaultHostEndpointMode controls whether a default host endpoint is created for each node.
+                                    Valid values are: "Enabled", "Disabled".
+                                  type: string
+                                templates:
+                                  description:
+                                    Templates contains definition for creating
+                                    AutoHostEndpoints
+                                  items:
+                                    properties:
+                                      generateName:
+                                        description:
+                                          GenerateName is appended to the
+                                          end of the generated AutoHostEndpoint name
+                                        maxLength: 253
+                                        type: string
+                                      interfaceCIDRs:
+                                        description: |-
+                                          InterfaceCIDRs contains a list of CIDRs used for matching nodeIPs to the AutoHostEndpoint.
+                                          If specified, only addresses within these CIDRs will be included in the expected IPs.
+                                          At least one of InterfaceCIDRs and InterfacePattern must be specified.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      interfacePattern:
+                                        description: |-
+                                          InterfacePattern contains a regex string to match Node interface names. If specified, a HostEndpoint will be created for each matching interface on each selected node.
+                                          At least one of InterfaceCIDRs and InterfacePattern must be specified.
+                                        type: string
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Labels adds the specified labels
+                                          to the generated AutoHostEndpoint, labels
+                                          from node with the same name will be overwritten
+                                          by values from the template label
+                                        type: object
+                                      nodeSelector:
+                                        description:
+                                          NodeSelector allows the AutoHostEndpoint
+                                          to be created only for specific nodes
+                                        type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            leakGracePeriod:
+                              description: |-
+                                LeakGracePeriod is the period used by the controller to determine if an IP address has been leaked.
+                                Set to 0 to disable IP garbage collection. [Default: 15m]
+                              type: string
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation with the Calico datastore. [Default:
+                                5m]"
+                              type: string
+                            syncLabels:
+                              description: |-
+                                SyncLabels controls whether to copy Kubernetes node labels to Calico nodes. [Default: Enabled]
+                                Valid values are: "Enabled", "Disabled".
+                              enum:
+                                - Enabled
+                                - Disabled
+                              type: string
+                          type: object
+                        policy:
+                          description:
+                            Policy enables and configures the policy controller.
+                            Enabled by default, set to nil to disable.
+                          properties:
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation with the Calico datastore. [Default:
+                                5m]"
+                              type: string
+                          type: object
+                        serviceAccount:
+                          description:
+                            ServiceAccount enables and configures the service
+                            account controller. Enabled by default, set to nil to disable.
+                          properties:
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation with the Calico datastore. [Default:
+                                5m]"
+                              type: string
+                          type: object
+                        workloadEndpoint:
+                          description:
+                            WorkloadEndpoint enables and configures the workload
+                            endpoint controller. Enabled by default, set to nil to disable.
+                          properties:
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation with the Calico datastore. [Default:
+                                5m]"
+                              type: string
+                          type: object
+                      type: object
+                    debugProfilePort:
+                      description: |-
+                        DebugProfilePort configures the port to serve memory and cpu profiles on. If not specified, profiling
+                        is disabled.
+                        Valid values are: 0-65535.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    etcdV3CompactionPeriod:
+                      description:
+                        "EtcdV3CompactionPeriod is the period between etcdv3
+                        compaction requests. Set to 0 to disable. [Default: 10m]"
+                      type: string
+                    healthChecks:
+                      default: Enabled
+                      description: |-
+                        HealthChecks enables or disables support for health checks [Default: Enabled]
+                        Valid values are: "Enabled", "Disabled".
+                      enum:
+                        - Enabled
+                        - Disabled
+                      type: string
+                    logSeverityScreen:
+                      description: |-
+                        LogSeverityScreen is the log severity above which logs are sent to the stdout. [Default: Info]
+                        Valid values are: "None", "Debug", "Info", "Warning", "Error", "Fatal", "Panic".
+                      enum:
+                        - None
+                        - Debug
+                        - Info
+                        - Warning
+                        - Error
+                        - Fatal
+                        - Panic
+                      type: string
+                    prometheusMetricsPort:
+                      description: |-
+                        PrometheusMetricsPort is the TCP port that the Prometheus metrics server should bind to. Set to 0 to disable. [Default: 9094]
+                        Valid values are: 0-65535.
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                  required:
+                    - controllers
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  description: |-
+                    The ordered set of egress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ingress:
+                  description: |-
+                    The ordered set of ingress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                order:
+                  description: |-
+                    Order is an optional field that specifies the order in which the policy is applied.
+                    Policies with higher "order" are applied after those with lower
+                    order within the same tier.  If the order is omitted, it may be considered to be "infinite" - i.e. the
+                    policy will be applied last.  Policies with identical order will be applied in
+                    alphanumerical order based on the Policy "Name" within the tier.
+                  type: number
+                performanceHints:
+                  description: |-
+                    PerformanceHints contains a list of hints to Calico's policy engine to
+                    help process the policy more efficiently.  Hints never change the
+                    enforcement behaviour of the policy.
+
+                    Currently, the only available hint is "AssumeNeededOnEveryNode".  When
+                    that hint is set on a policy, Felix will act as if the policy matches
+                    a local endpoint even if it does not. This is useful for "preloading"
+                    any large static policies that are known to be used on every node.
+                    If the policy is _not_ used on a particular node then the work
+                    done to preload the policy (and to maintain it) is wasted.
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                selector:
+                  description:
+                    "The selector is an expression used to pick out the endpoints
+                    that the policy should\nbe applied to.\n\nSelector expressions follow
+                    this syntax:\n\n\tlabel == \"string_literal\"  ->  comparison, e.g.
+                    my_label == \"foo bar\"\n\tlabel != \"string_literal\"   ->  not
+                    equal; also matches if label is not present\n\tlabel in { \"a\",
+                    \"b\", \"c\", ... }  ->  true if the value of label X is one of
+                    \"a\", \"b\", \"c\"\n\tlabel not in { \"a\", \"b\", \"c\", ... }
+                    \ ->  true if the value of label X is not one of \"a\", \"b\", \"c\"\n\thas(label_name)
+                    \ -> True if that label is present\n\t! expr -> negation of expr\n\texpr
+                    && expr  -> Short-circuit and\n\texpr || expr  -> Short-circuit
+                    or\n\t( expr ) -> parens for grouping\n\tall() or the empty selector
+                    -> matches all endpoints.\n\nLabel names are allowed to contain
+                    alphanumerics, -, _ and /. String literals are more permissive\nbut
+                    they do not support escape characters.\n\nExamples (with made-up
+                    labels):\n\n\ttype == \"webserver\" && deployment == \"prod\"\n\ttype
+                    in {\"frontend\", \"backend\"}\n\tdeployment != \"dev\"\n\t! has(label_name)"
+                  maxLength: 1024
+                  type: string
+                serviceAccountSelector:
+                  description:
+                    ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  maxLength: 1024
+                  type: string
+                tier:
+                  default: default
+                  description: |-
+                    The name of the tier that this policy belongs to.  If this is omitted, the default
+                    tier (name is "default") is assumed.  The specified tier must exist in order to create
+                    security policies within the tier, the "default" tier is created automatically if it
+                    does not exist, this means for deployments requiring only a single Tier, the tier name
+                    may be omitted on all policy management requests.
+                  type: string
+                types:
+                  description: |-
+                    Types indicates whether this policy applies to ingress, or to egress, or to both.  When
+                    not explicitly specified (and so the value on creation is empty or nil), Calico defaults
+                    Types according to what Ingress and Egress are present in the policy.  The
+                    default is:
+
+                    - [ PolicyTypeIngress ], if there are no Egress rules (including the case where there are
+                      also no Ingress rules)
+
+                    - [ PolicyTypeEgress ], if there are Egress rules but no Ingress rules
+
+                    - [ PolicyTypeIngress, PolicyTypeEgress ], if there are both Ingress and Egress rules.
+
+                    When the policy is read back again, Types will always be one of these values, never empty
+                    or nil.
+                  items:
+                    description:
+                      PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.selector) || !self.selector.contains('global(')"
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.serviceAccountSelector) || !self.serviceAccountSelector.contains('global(')"
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: networksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkSet
+    listKind: NetworkSetList
+    plural: networksets
+    singular: networkset
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                NetworkSetSpec contains the specification for a NetworkSet
+                resource.
+              properties:
+                nets:
+                  description: |-
+                    The list of IP networks that belong to this set. Each entry must be in CIDR notation,
+                    e.g. "192.168.1.0/24". To include a single IP address, use a /32 (IPv4) or /128 (IPv6) mask.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagedglobalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedGlobalNetworkPolicy
+    listKind: StagedGlobalNetworkPolicyList
+    plural: stagedglobalnetworkpolicies
+    singular: stagedglobalnetworkpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  description:
+                    ApplyOnForward indicates to apply the rules in this policy
+                    on forward traffic.
+                  type: boolean
+                doNotTrack:
+                  description: |-
+                    DoNotTrack indicates whether packets matched by the rules in this policy should go through
+                    the data plane's connection tracking, such as Linux conntrack.  If True, the rules in
+                    this policy are applied before any data plane connection tracking, and packets allowed by
+                    this policy are marked as not to be tracked.
+                  type: boolean
+                egress:
+                  description: |-
+                    The ordered set of egress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ingress:
+                  description: |-
+                    The ordered set of ingress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                namespaceSelector:
+                  description:
+                    NamespaceSelector is an optional field for an expression
+                    used to select a pod based on namespaces.
+                  maxLength: 1024
+                  type: string
+                order:
+                  description: |-
+                    Order is an optional field that specifies the order in which the policy is applied.
+                    Policies with higher "order" are applied after those with lower
+                    order within the same tier.  If the order is omitted, it may be considered to be "infinite" - i.e. the
+                    policy will be applied last.  Policies with identical order will be applied in
+                    alphanumerical order based on the Policy "Name" within the tier.
+                  type: number
+                performanceHints:
+                  description: |-
+                    PerformanceHints contains a list of hints to Calico's policy engine to
+                    help process the policy more efficiently.  Hints never change the
+                    enforcement behaviour of the policy.
+
+                    Currently, the only available hint is "AssumeNeededOnEveryNode".  When
+                    that hint is set on a policy, Felix will act as if the policy matches
+                    a local endpoint even if it does not. This is useful for "preloading"
+                    any large static policies that are known to be used on every node.
+                    If the policy is _not_ used on a particular node then the work
+                    done to preload the policy (and to maintain it) is wasted.
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                preDNAT:
+                  description:
+                    PreDNAT indicates to apply the rules in this policy before
+                    any DNAT.
+                  type: boolean
+                selector:
+                  description:
+                    "The selector is an expression used to pick out the endpoints
+                    that the policy should\nbe applied to.\n\nSelector expressions follow
+                    this syntax:\n\n\tlabel == \"string_literal\"  ->  comparison, e.g.
+                    my_label == \"foo bar\"\n\tlabel != \"string_literal\"   ->  not
+                    equal; also matches if label is not present\n\tlabel in { \"a\",
+                    \"b\", \"c\", ... }  ->  true if the value of label X is one of
+                    \"a\", \"b\", \"c\"\n\tlabel not in { \"a\", \"b\", \"c\", ... }
+                    \ ->  true if the value of label X is not one of \"a\", \"b\", \"c\"\n\thas(label_name)
+                    \ -> True if that label is present\n\t! expr -> negation of expr\n\texpr
+                    && expr  -> Short-circuit and\n\texpr || expr  -> Short-circuit
+                    or\n\t( expr ) -> parens for grouping\n\tall() or the empty selector
+                    -> matches all endpoints.\n\nLabel names are allowed to contain
+                    alphanumerics, -, _ and /. String literals are more permissive\nbut
+                    they do not support escape characters.\n\nExamples (with made-up
+                    labels):\n\n\ttype == \"webserver\" && deployment == \"prod\"\n\ttype
+                    in {\"frontend\", \"backend\"}\n\tdeployment != \"dev\"\n\t! has(label_name)"
+                  maxLength: 1024
+                  type: string
+                serviceAccountSelector:
+                  description:
+                    ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  maxLength: 1024
+                  type: string
+                stagedAction:
+                  default: Set
+                  description:
+                    The staged action. If this is omitted, the default is
+                    Set.
+                  enum:
+                    - Set
+                    - Delete
+                    - Learn
+                    - Ignore
+                  type: string
+                tier:
+                  default: default
+                  description: |-
+                    The name of the tier that this policy belongs to.  If this is omitted, the default
+                    tier (name is "default") is assumed.  The specified tier must exist in order to create
+                    security policies within the tier, the "default" tier is created automatically if it
+                    does not exist, this means for deployments requiring only a single Tier, the tier name
+                    may be omitted on all policy management requests.
+                  type: string
+                types:
+                  description: |-
+                    Types indicates whether this policy applies to ingress, or to egress, or to both.  When
+                    not explicitly specified (and so the value on creation is empty or nil), Calico defaults
+                    Types according to what Ingress and Egress rules are present in the policy.  The
+                    default is:
+
+                    - [ PolicyTypeIngress ], if there are no Egress rules (including the case where there are
+                      also no Ingress rules)
+
+                    - [ PolicyTypeEgress ], if there are Egress rules but no Ingress rules
+
+                    - [ PolicyTypeIngress, PolicyTypeEgress ], if there are both Ingress and Egress rules.
+
+                    When the policy is read back again, Types will always be one of these values, never empty
+                    or nil.
+                  items:
+                    description:
+                      PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: preDNAT and doNotTrack cannot both be true
+                  reason: FieldValueForbidden
+                  rule:
+                    "!((has(self.doNotTrack) && self.doNotTrack) && (has(self.preDNAT)
+                    && self.preDNAT))"
+                - message: preDNAT policy cannot have any egress rules
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.egress) ||
+                    size(self.egress) == 0
+                - message: preDNAT policy cannot have 'Egress' type
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.types) || !self.types.exists(t,
+                    t == 'Egress')
+                - message:
+                    applyOnForward must be true if either preDNAT or doNotTrack
+                    is true
+                  reason: FieldValueInvalid
+                  rule:
+                    (has(self.applyOnForward) && self.applyOnForward) || ((!has(self.doNotTrack)
+                    || !self.doNotTrack) && (!has(self.preDNAT) || !self.preDNAT))
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.selector) || !self.selector.contains('global(')"
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.serviceAccountSelector) || !self.serviceAccountSelector.contains('global(')"
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedKubernetesNetworkPolicy
+    listKind: StagedKubernetesNetworkPolicyList
+    plural: stagedkubernetesnetworkpolicies
+    singular: stagedkubernetesnetworkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  description: |-
+                    List of egress rules to be applied to the selected pods. Outgoing traffic is
+                    allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                    otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                    across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                    this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                    solely to ensure that the pods it selects are isolated by default).
+                    This field is beta-level in 1.8
+                  items:
+                    description: |-
+                      NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                      matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                      This type is beta-level in 1.8
+                    properties:
+                      ports:
+                        description: |-
+                          ports is a list of destination ports for outgoing traffic.
+                          Each item in this list is combined using a logical OR. If this field is
+                          empty or missing, this rule matches all ports (traffic not restricted by port).
+                          If this field is present and contains at least one item, then this rule allows
+                          traffic only if the traffic matches at least one port in the list.
+                        items:
+                          description:
+                            NetworkPolicyPort describes a port to allow traffic
+                            on
+                          properties:
+                            endPort:
+                              description: |-
+                                endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                should be allowed by the policy. This field cannot be defined if the port field
+                                is not defined or if the port field is defined as a named (string) port.
+                                The endPort must be equal or greater than port.
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                port represents the port on the given protocol. This can either be a numerical or named
+                                port on a pod. If this field is not provided, this matches all port names and
+                                numbers.
+                                If present, only traffic on the specified protocol AND port will be matched.
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              description: |-
+                                protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                If not specified, this field defaults to TCP.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      to:
+                        description: |-
+                          to is a list of destinations for outgoing traffic of pods selected for this rule.
+                          Items in this list are combined using a logical OR operation. If this field is
+                          empty or missing, this rule matches all destinations (traffic not restricted by
+                          destination). If this field is present and contains at least one item, this rule
+                          allows traffic only if the traffic matches at least one item in the to list.
+                        items:
+                          description: |-
+                            NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                            fields are allowed
+                          properties:
+                            ipBlock:
+                              description: |-
+                                ipBlock defines policy on a particular IPBlock. If this field is set then
+                                neither of the other fields can be.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    cidr is a string representing the IPBlock
+                                    Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                  type: string
+                                except:
+                                  description: |-
+                                    except is a slice of CIDRs that should not be included within an IPBlock
+                                    Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    Except values will be rejected if they are outside the cidr range
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - cidr
+                              type: object
+                            namespaceSelector:
+                              description: |-
+                                namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            podSelector:
+                              description: |-
+                                podSelector is a label selector which selects pods. This field follows standard label
+                                selector semantics; if present but empty, it selects all pods.
+
+                                If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ingress:
+                  description: |-
+                    List of ingress rules to be applied to the selected pods. Traffic is allowed to
+                    a pod if there are no NetworkPolicies selecting the pod
+                    (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                    the pod's local node, OR if the traffic matches at least one ingress rule
+                    across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                    this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                    solely to ensure that the pods it selects are isolated by default)
+                  items:
+                    description: |-
+                      NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                      matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                    properties:
+                      from:
+                        description: |-
+                          from is a list of sources which should be able to access the pods selected for this rule.
+                          Items in this list are combined using a logical OR operation. If this field is
+                          empty or missing, this rule matches all sources (traffic not restricted by
+                          source). If this field is present and contains at least one item, this rule
+                          allows traffic only if the traffic matches at least one item in the from list.
+                        items:
+                          description: |-
+                            NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                            fields are allowed
+                          properties:
+                            ipBlock:
+                              description: |-
+                                ipBlock defines policy on a particular IPBlock. If this field is set then
+                                neither of the other fields can be.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    cidr is a string representing the IPBlock
+                                    Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                  type: string
+                                except:
+                                  description: |-
+                                    except is a slice of CIDRs that should not be included within an IPBlock
+                                    Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    Except values will be rejected if they are outside the cidr range
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - cidr
+                              type: object
+                            namespaceSelector:
+                              description: |-
+                                namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            podSelector:
+                              description: |-
+                                podSelector is a label selector which selects pods. This field follows standard label
+                                selector semantics; if present but empty, it selects all pods.
+
+                                If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ports:
+                        description: |-
+                          ports is a list of ports which should be made accessible on the pods selected for
+                          this rule. Each item in this list is combined using a logical OR. If this field is
+                          empty or missing, this rule matches all ports (traffic not restricted by port).
+                          If this field is present and contains at least one item, then this rule allows
+                          traffic only if the traffic matches at least one port in the list.
+                        items:
+                          description:
+                            NetworkPolicyPort describes a port to allow traffic
+                            on
+                          properties:
+                            endPort:
+                              description: |-
+                                endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                should be allowed by the policy. This field cannot be defined if the port field
+                                is not defined or if the port field is defined as a named (string) port.
+                                The endPort must be equal or greater than port.
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                port represents the port on the given protocol. This can either be a numerical or named
+                                port on a pod. If this field is not provided, this matches all port names and
+                                numbers.
+                                If present, only traffic on the specified protocol AND port will be matched.
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              description: |-
+                                protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                If not specified, this field defaults to TCP.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                podSelector:
+                  description: |-
+                    Selects the pods to which this NetworkPolicy object applies. The array of
+                    ingress rules is applied to any pods selected by this field. Multiple network
+                    policies can select the same set of pods. In this case, the ingress rules for
+                    each are combined additively. This field is NOT optional and follows standard
+                    label selector semantics. An empty podSelector matches all pods in this
+                    namespace.
+                  properties:
+                    matchExpressions:
+                      description:
+                        matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description:
+                              key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                policyTypes:
+                  description: |-
+                    List of rule types that the NetworkPolicy relates to.
+                    Valid options are Ingress, Egress, or Ingress,Egress.
+                    If this field is not specified, it will default based on the existence of Ingress or Egress rules;
+                    policies that contain an Egress section are assumed to affect Egress, and all policies
+                    (whether or not they contain an Ingress section) are assumed to affect Ingress.
+                    If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                    Likewise, if you want to write a policy that specifies that no egress is allowed,
+                    you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                    an Egress section and would otherwise default to just [ "Ingress" ]).
+                    This field is beta-level in 1.8
+                  items:
+                    description: |-
+                      PolicyType string describes the NetworkPolicy type
+                      This type is beta-level in 1.8
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+                stagedAction:
+                  default: Set
+                  description:
+                    The staged action. If this is omitted, the default is
+                    Set.
+                  enum:
+                    - Set
+                    - Delete
+                    - Learn
+                    - Ignore
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagednetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedNetworkPolicy
+    listKind: StagedNetworkPolicyList
+    plural: stagednetworkpolicies
+    singular: stagednetworkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  description: |-
+                    The ordered set of egress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ingress:
+                  description: |-
+                    The ordered set of ingress rules.  Each rule contains a set of packet match criteria and
+                    a corresponding action to apply. Limited to 1024 rules per policy.
+                  items:
+                    description: |-
+                      A Rule encapsulates a set of match criteria and an action.  Both selector-based security Policy
+                      and security Profiles reference rules - separated out as a list of rules for both
+                      ingress and egress packet matching.
+
+                      Each positive match criteria has a negated version, prefixed with "Not". All the match
+                      criteria within a rule must be satisfied for a packet to match. A single rule can contain
+                      the positive and negative version of a match and both must be satisfied for the rule to match.
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        description:
+                          Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                      http:
+                        description:
+                          HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: |-
+                              Methods is an optional field that restricts the rule to apply only to HTTP requests that use one of the listed
+                              HTTP Methods (e.g. GET, PUT, etc.)
+                              Multiple methods are OR'd together.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          paths:
+                            description: |-
+                              Paths is an optional field that restricts the rule to apply to HTTP requests that use one of the listed
+                              HTTP Paths.
+                              Multiple paths are OR'd together.
+                              e.g:
+                              - exact: /foo
+                              - prefix: /bar
+                              NOTE: Each entry may ONLY specify either a `exact` or a `prefix` match. The validator will check for it.
+                            items:
+                              description: |-
+                                HTTPPath specifies an HTTP path to match. It may be either of the form:
+                                exact: <path>: which matches the path exactly or
+                                prefix: <path-prefix>: which matches the path prefix
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      icmp:
+                        description: |-
+                          ICMP is an optional field that restricts the rule to apply to a specific type and
+                          code of ICMP traffic.  This should only be specified if the Protocol field is set to
+                          "ICMP" or "ICMPv6".
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        description: |-
+                          IPVersion is an optional field that restricts the rule to only match a specific IP
+                          version.
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        description:
+                          Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description:
+                              Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: |-
+                              Match on a specific ICMP code.  If specified, the Type value must also be specified.
+                              This is a technical limitation imposed by the kernel's iptables firewall, which
+                              Calico uses to enforce the rule.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+                              (i.e. pings).
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description:
+                          NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          Protocol is an optional field that restricts the rule to only apply to traffic of
+                          a specific IP protocol. Required if any of the EntityRules contain Ports
+                          (because ports only apply to certain protocols).
+
+                          Must be one of these string values: "TCP", "UDP", "ICMP", "ICMPv6", "SCTP", "UDPLite"
+                          or an integer in the range 1-255.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description:
+                          Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: |-
+                              NamespaceSelector is an optional field that contains a selector expression. Only traffic
+                              that originates from (or terminates at) endpoints within the selected namespaces will be
+                              matched. When both NamespaceSelector and another selector are defined on the same rule, then only
+                              workload endpoints that are matched by both selectors will be selected by the rule.
+
+                              For NetworkPolicy, an empty NamespaceSelector implies that the Selector is limited to selecting
+                              only workload endpoints in the same namespace as the NetworkPolicy.
+
+                              For NetworkPolicy, `global()` NamespaceSelector implies that the Selector is limited to selecting
+                              only GlobalNetworkSet or HostEndpoint.
+
+                              For GlobalNetworkPolicy, an empty NamespaceSelector implies the Selector applies to workload
+                              endpoints across all namespaces.
+                            maxLength: 1024
+                            type: string
+                          nets:
+                            description: |-
+                              Nets is an optional field that restricts the rule to only apply to traffic that
+                              originates from (or terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            description:
+                              NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            maxItems: 256
+                            type: array
+                            x-kubernetes-list-type: set
+                          notPorts:
+                            description: |-
+                              NotPorts is the negated version of the Ports field.
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          notSelector:
+                            description: |-
+                              NotSelector is the negated version of the Selector field.  See Selector field for
+                              subtleties with negated selectors.
+                            maxLength: 1024
+                            type: string
+                          ports:
+                            description: |-
+                              Ports is an optional field that restricts the rule to only apply to traffic that has a
+                              source (destination) port that matches one of these ranges/values. This value is a
+                              list of integers or strings that represent ranges of ports.
+
+                              Since only some protocols have ports, if any ports are specified it requires the
+                              Protocol match in the Rule to be set to "TCP", "UDP", or "SCTP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            maxItems: 50
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          selector:
+                            description:
+                              "Selector is an optional field that contains
+                              a selector expression (see Policy for\nsample syntax).
+                              \ Only traffic that originates from (terminates at) endpoints
+                              matching\nthe selector will be matched.\n\nNote that:
+                              in addition to the negated version of the Selector (see
+                              NotSelector below), the\nselector expression syntax itself
+                              supports negation.  The two types of negation are subtly\ndifferent.
+                              One negates the set of matched endpoints, the other negates
+                              the whole match:\n\n\tSelector = \"!has(my_label)\" matches
+                              packets that are from other Calico-controlled\n\tendpoints
+                              that do not have the label \"my_label\".\n\n\tNotSelector
+                              = \"has(my_label)\" matches packets that are not from
+                              Calico-controlled\n\tendpoints that do have the label
+                              \"my_label\".\n\nThe effect is that the latter will accept
+                              packets from non-Calico sources whereas the\nformer is
+                              limited to packets from Calico-controlled endpoints."
+                            maxLength: 1024
+                            type: string
+                          serviceAccounts:
+                            description: |-
+                              ServiceAccounts is an optional field that restricts the rule to only apply to traffic that originates from (or
+                              terminates at) a pod running as a matching service account.
+                            properties:
+                              names:
+                                description: |-
+                                  Names is an optional field that restricts the rule to only apply to traffic that originates from (or terminates
+                                  at) a pod running as a service account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                description: |-
+                                  Selector is an optional field that restricts the rule to only apply to traffic that originates from
+                                  (or terminates at) a pod running as a service account that matches the given label selector.
+                                  If both Names and Selector are specified then they are AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: |-
+                              Services is an optional field that contains options for matching Kubernetes Services.
+                              If specified, only traffic that originates from or terminates at endpoints within the selected
+                              service(s) will be matched, and only to/from each endpoint's port.
+
+                              Services cannot be specified on the same rule as Selector, NotSelector, NamespaceSelector, Nets,
+                              NotNets or ServiceAccounts.
+
+                              Ports and NotPorts can only be specified with Services on ingress rules.
+                            properties:
+                              name:
+                                description:
+                                  Name specifies the name of a Kubernetes
+                                  Service to match.
+                                maxLength: 253
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the namespace of the given Service. If left empty, the rule
+                                  will match within this policy's namespace.
+                                maxLength: 253
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: global() can only be used in an EntityRule namespaceSelector
+                            reason: FieldValueInvalid
+                            rule: "!has(self.selector) || !self.selector.contains('global(')"
+                          - message:
+                              cannot specify NamespaceSelector and Services on
+                              the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || !has(self.namespaceSelector)
+                              || size(self.namespaceSelector) == 0"
+                          - message:
+                              cannot specify ServiceAccounts and Services on the
+                              same rule
+                            reason: FieldValueForbidden
+                            rule: "!has(self.services) || !has(self.serviceAccounts)"
+                          - message: services must specify a service name
+                            reason: FieldValueRequired
+                            rule: "!has(self.services) || size(self.services.name) > 0"
+                          - message:
+                              cannot specify Selector/NotSelector and Services
+                              on the same rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.selector) || size(self.selector)
+                              == 0) && (!has(self.notSelector) || size(self.notSelector)
+                              == 0)"
+                          - message:
+                              cannot specify Nets/NotNets and Services on the same
+                              rule
+                            reason: FieldValueForbidden
+                            rule:
+                              "!has(self.services) || (!has(self.nets) || size(self.nets)
+                              == 0) && (!has(self.notNets) || size(self.notNets) == 0)"
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                      - message: ICMP fields require protocol to be ICMP or ICMPv6
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.icmp) || (has(self.protocol) && (self.protocol
+                          == 'ICMP' || self.protocol == 'ICMPv6' || self.protocol
+                          == 1 || self.protocol == 58))"
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMP' && self.protocol
+                          != 1)) || !has(self.ipVersion) || self.ipVersion == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.protocol) || (self.protocol != 'ICMPv6' && self.protocol
+                          != 58)) || !has(self.ipVersion) || self.ipVersion == 6
+                      - message: protocol ICMP requires ipVersion 4
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMP' &&
+                          self.notProtocol != 1)) || !has(self.ipVersion) || self.ipVersion
+                          == 4
+                      - message: protocol ICMPv6 requires ipVersion 6
+                        reason: FieldValueInvalid
+                        rule:
+                          (!has(self.notProtocol) || (self.notProtocol != 'ICMPv6'
+                          && self.notProtocol != 58)) || !has(self.ipVersion) || self.ipVersion
+                          == 6
+                  maxItems: 1024
+                  type: array
+                  x-kubernetes-list-type: atomic
+                order:
+                  description: |-
+                    Order is an optional field that specifies the order in which the policy is applied.
+                    Policies with higher "order" are applied after those with lower
+                    order within the same tier.  If the order is omitted, it may be considered to be "infinite" - i.e. the
+                    policy will be applied last.  Policies with identical order will be applied in
+                    alphanumerical order based on the Policy "Name" within the tier.
+                  type: number
+                performanceHints:
+                  description: |-
+                    PerformanceHints contains a list of hints to Calico's policy engine to
+                    help process the policy more efficiently.  Hints never change the
+                    enforcement behaviour of the policy.
+
+                    Currently, the only available hint is "AssumeNeededOnEveryNode".  When
+                    that hint is set on a policy, Felix will act as if the policy matches
+                    a local endpoint even if it does not. This is useful for "preloading"
+                    any large static policies that are known to be used on every node.
+                    If the policy is _not_ used on a particular node then the work
+                    done to preload the policy (and to maintain it) is wasted.
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                selector:
+                  description:
+                    "The selector is an expression used to pick out the endpoints
+                    that the policy should\nbe applied to.\n\nSelector expressions follow
+                    this syntax:\n\n\tlabel == \"string_literal\"  ->  comparison, e.g.
+                    my_label == \"foo bar\"\n\tlabel != \"string_literal\"   ->  not
+                    equal; also matches if label is not present\n\tlabel in { \"a\",
+                    \"b\", \"c\", ... }  ->  true if the value of label X is one of
+                    \"a\", \"b\", \"c\"\n\tlabel not in { \"a\", \"b\", \"c\", ... }
+                    \ ->  true if the value of label X is not one of \"a\", \"b\", \"c\"\n\thas(label_name)
+                    \ -> True if that label is present\n\t! expr -> negation of expr\n\texpr
+                    && expr  -> Short-circuit and\n\texpr || expr  -> Short-circuit
+                    or\n\t( expr ) -> parens for grouping\n\tall() or the empty selector
+                    -> matches all endpoints.\n\nLabel names are allowed to contain
+                    alphanumerics, -, _ and /. String literals are more permissive\nbut
+                    they do not support escape characters.\n\nExamples (with made-up
+                    labels):\n\n\ttype == \"webserver\" && deployment == \"prod\"\n\ttype
+                    in {\"frontend\", \"backend\"}\n\tdeployment != \"dev\"\n\t! has(label_name)"
+                  maxLength: 1024
+                  type: string
+                serviceAccountSelector:
+                  description:
+                    ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  maxLength: 1024
+                  type: string
+                stagedAction:
+                  default: Set
+                  description:
+                    The staged action. If this is omitted, the default is
+                    Set.
+                  enum:
+                    - Set
+                    - Delete
+                    - Learn
+                    - Ignore
+                  type: string
+                tier:
+                  default: default
+                  description: |-
+                    The name of the tier that this policy belongs to.  If this is omitted, the default
+                    tier (name is "default") is assumed.  The specified tier must exist in order to create
+                    security policies within the tier, the "default" tier is created automatically if it
+                    does not exist, this means for deployments requiring only a single Tier, the tier name
+                    may be omitted on all policy management requests.
+                  type: string
+                types:
+                  description: |-
+                    Types indicates whether this policy applies to ingress, or to egress, or to both.  When
+                    not explicitly specified (and so the value on creation is empty or nil), Calico defaults
+                    Types according to what Ingress and Egress are present in the policy.  The
+                    default is:
+
+                    - [ PolicyTypeIngress ], if there are no Egress rules (including the case where there are
+                      also no Ingress rules)
+
+                    - [ PolicyTypeEgress ], if there are Egress rules but no Ingress rules
+
+                    - [ PolicyTypeIngress, PolicyTypeEgress ], if there are both Ingress and Egress rules.
+
+                    When the policy is read back again, Types will always be one of these values, never empty
+                    or nil.
+                  items:
+                    description:
+                      PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.selector) || !self.selector.contains('global(')"
+                - message: global() can only be used in an EntityRule namespaceSelector
+                  reason: FieldValueInvalid
+                  rule: "!has(self.serviceAccountSelector) || !self.serviceAccountSelector.contains('global(')"
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tiers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: Tier
+    listKind: TierList
+    plural: tiers
+    singular: tier
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                TierSpec contains the specification for a security policy
+                tier resource.
+              properties:
+                defaultAction:
+                  allOf:
+                    - enum:
+                        - Allow
+                        - Deny
+                        - Log
+                        - Pass
+                    - enum:
+                        - Pass
+                        - Deny
+                  default: Deny
+                  description: |-
+                    DefaultAction specifies the action applied to traffic that matches a policy in the tier
+                    but does not match any rule within that policy.
+                    [Default: Deny]
+                  type: string
+                order:
+                  description: |-
+                    Order is an optional field that specifies the order in which the tier is applied.
+                    Tiers with higher "order" are applied after those with lower order.  If the order
+                    is omitted, it may be considered to be "infinite" - i.e. the tier will be applied
+                    last.  Tiers with identical order will be applied in alphanumerical order based
+                    on the Tier "Name".
+                  type: number
+              type: object
+            status:
+              description: TierStatus contains the status of a Tier resource.
+              properties:
+                conditions:
+                  description: |-
+                    Conditions represents the latest observed set of conditions for the resource. A tier with a
+                    "Ready" condition set to "True" is operating as expected.
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+          x-kubernetes-validations:
+            - message: The 'kube-admin' tier must have default action 'Pass'
+              reason: FieldValueInvalid
+              rule:
+                "self.metadata.name == 'kube-admin' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
+            - message: The 'kube-baseline' tier must have default action 'Pass'
+              reason: FieldValueInvalid
+              rule:
+                "self.metadata.name == 'kube-baseline' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Pass') : true"
+            - message: The 'default' tier must have default action 'Deny'
+              reason: FieldValueInvalid
+              rule:
+                "self.metadata.name == 'default' ? (has(self.spec.defaultAction)
+                && self.spec.defaultAction == 'Deny') : true"
+            - message: default tier order must be 1000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'default' || (has(self.spec.order) && self.spec.order
+                == 1000000.0)
+            - message: kube-admin tier order must be 1000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-admin' || (has(self.spec.order) && self.spec.order
+                == 1000.0)
+            - message: kube-baseline tier order must be 10000000
+              reason: FieldValueInvalid
+              rule:
+                self.metadata.name != 'kube-baseline' || (has(self.spec.order) &&
+                self.spec.order == 10000000.0)
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/347
+    policy.networking.k8s.io/bundle-version: v0.2.0
+    policy.networking.k8s.io/channel: standard
+  name: clusternetworkpolicies.policy.networking.k8s.io
+spec:
+  group: policy.networking.k8s.io
+  names:
+    kind: ClusterNetworkPolicy
+    listKind: ClusterNetworkPolicyList
+    plural: clusternetworkpolicies
+    shortNames:
+      - cnp
+    singular: clusternetworkpolicy
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - jsonPath: .spec.priority
+          name: Priority
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: ClusterNetworkPolicy is a cluster-wide network policy resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired behavior of ClusterNetworkPolicy.
+              properties:
+                egress:
+                  description: |-
+                    Egress is the list of Egress rules to be applied to the selected pods.
+
+                    A maximum of 25 rules is allowed in this block.
+
+                    The relative precedence of egress rules within a single CNP object
+                    (all of which share the priority) will be determined by the order
+                    in which the rule is written.
+                    Thus, a rule that appears at the top of the egress rules
+                    would take the highest precedence.
+                    CNPs with no egress rules do not affect egress traffic.
+                  items:
+                    description: |-
+                      ClusterNetworkPolicyEgressRule describes an action to take on a particular
+                      set of traffic originating from pods selected by a ClusterNetworkPolicy's
+                      Subject field.
+
+                      <network-policy-api:experimental:validation>
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching
+                          traffic.  Currently the following actions are supported:
+
+                          - Accept: Accepts the selected traffic, allowing it to
+                            egress. No further ClusterNetworkPolicy or NetworkPolicy
+                            rules will be processed.
+
+                          - Deny: Drops the selected traffic. No further
+                            ClusterNetworkPolicy or NetworkPolicy rules will be
+                            processed.
+
+                          - Pass: Skips all further ClusterNetworkPolicy rules in the
+                            current tier for the selected traffic, and passes
+                            evaluation to the next tier.
+                        enum:
+                          - Accept
+                          - Deny
+                          - Pass
+                        type: string
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than
+                          100 characters in length. This field should be used by the implementation
+                          to help improve observability, readability and error-reporting
+                          for any applied policies.
+                        maxLength: 100
+                        type: string
+                      protocols:
+                        description: |-
+                          Protocols allows for more fine-grain matching of traffic on
+                          protocol-specific attributes such as the port. If
+                          unspecified, protocol-specific attributes will not be used
+                          to match traffic.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyProtocol describes additional protocol-specific match rules.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            destinationNamedPort:
+                              description: |-
+                                DestinationNamedPort selects a destination port on a pod based on the
+                                ContainerPort name. You can't use this in a rule that targets resources
+                                without named ports (e.g. Nodes or Networks).
+                              type: string
+                            sctp:
+                              description: SCTP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            tcp:
+                              description: TCP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            udp:
+                              description: UDP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                      to:
+                        description: |-
+                          To is the list of destinations whose traffic this rule applies to. If any
+                          element matches the destination of outgoing traffic then the specified
+                          action is applied. This field must be defined and contain at least one
+                          item.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyEgressPeer defines a peer to allow traffic to.
+
+                            Exactly one of the fields must be set for a given peer and this is enforced
+                            by the validation rules on the CRD. If an implementation sees no fields are
+                            set then it can infer that the deployed CRD is of an incompatible version
+                            with an unknown field.  In that case it should fail closed.
+
+                            For "Accept" rules, "fail closed" means: "treat the rule as matching no
+                            traffic". For "Deny" and "Pass" rules, "fail closed" means: "treat the rule
+                            as a 'Deny all' rule".
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            networks:
+                              description: |-
+                                Networks defines a way to select peers via CIDR blocks.
+                                This is intended for representing entities that live outside the cluster,
+                                which can't be selected by pods, namespaces and nodes peers, but note
+                                that cluster-internal traffic will be checked against the rule as
+                                well. So if you Accept or Deny traffic to `"0.0.0.0/0"`, that will allow
+                                or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                                add a rule that Passes all pod traffic before the Networks rule.
+
+                                Each item in Networks should be provided in the CIDR format and should be
+                                IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+                                Networks can have up to 25 CIDRs specified.
+                              items:
+                                description: |-
+                                  CIDR is an IP address range in CIDR notation
+                                  (for example, "10.0.0.0/8" or "fd00::/8").
+                                maxLength: 43
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: Invalid CIDR format provided
+                                    rule: isCIDR(self)
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: set
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector
+                                    semantics; if empty, it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace;
+                                    if empty, it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - to
+                    type: object
+                  maxItems: 25
+                  type: array
+                ingress:
+                  description: |-
+                    Ingress is the list of Ingress rules to be applied to the selected pods.
+
+                    A maximum of 25 rules is allowed in this block.
+
+                    The relative precedence of ingress rules within a single CNP object
+                    (all of which share the priority) will be determined by the order
+                    in which the rule is written.
+                    Thus, a rule that appears at the top of the ingress rules
+                    would take the highest precedence.
+                    CNPs with no ingress rules do not affect ingress traffic.
+                  items:
+                    description: |-
+                      ClusterNetworkPolicyIngressRule describes an action to take on a particular
+                      set of traffic destined for pods selected by a ClusterNetworkPolicy's
+                      Subject field.
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching
+                          traffic. Currently the following actions are supported:
+
+                          - Accept: Accepts the selected traffic, allowing it into
+                            the destination. No further ClusterNetworkPolicy or
+                            NetworkPolicy rules will be processed.
+
+                            Note: while Accept ensures traffic is accepted by
+                            Kubernetes network policy, it is still possible that the
+                            packet is blocked in other ways: custom nftable rules,
+                            high-layers e.g. service mesh.
+
+                          - Deny: Drops the selected traffic. No further
+                            ClusterNetworkPolicy or NetworkPolicy rules will be
+                            processed.
+
+                          - Pass: Skips all further ClusterNetworkPolicy rules in the
+                            current tier for the selected traffic, and passes
+                            evaluation to the next tier.
+                        enum:
+                          - Accept
+                          - Deny
+                          - Pass
+                        type: string
+                      from:
+                        description: |-
+                          From is the list of sources whose traffic this rule applies to.
+                          If any element matches the source of incoming
+                          traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyIngressPeer defines a peer to allow traffic from.
+
+                            Exactly one of the fields must be set for a given peer and this is enforced
+                            by the validation rules on the CRD. If an implementation sees no fields are
+                            set then it can infer that the deployed CRD is of an incompatible version
+                            with an unknown field.  In that case it should fail closed.
+
+                            For "Accept" rules, "fail closed" means: "treat the rule as matching no
+                            traffic". For "Deny" and "Pass" rules, "fail closed" means: "treat the rule
+                            as a 'Deny all' rule".
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector
+                                    semantics; if empty, it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace;
+                                    if empty, it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than
+                          100 characters in length. This field should be used by the implementation
+                          to help improve observability, readability and error-reporting
+                          for any applied policies.
+                        maxLength: 100
+                        type: string
+                      protocols:
+                        description: |-
+                          Protocols allows for more fine-grain matching of traffic on
+                          protocol-specific attributes such as the port. If
+                          unspecified, protocol-specific attributes will not be used
+                          to match traffic.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyProtocol describes additional protocol-specific match rules.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            destinationNamedPort:
+                              description: |-
+                                DestinationNamedPort selects a destination port on a pod based on the
+                                ContainerPort name. You can't use this in a rule that targets resources
+                                without named ports (e.g. Nodes or Networks).
+                              type: string
+                            sctp:
+                              description: SCTP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            tcp:
+                              description: TCP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            udp:
+                              description: UDP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - from
+                    type: object
+                  maxItems: 25
+                  type: array
+                priority:
+                  description: |-
+                    Priority is a value from 0 to 1000 indicating the precedence of
+                    the policy within its tier. Policies with lower priority values have
+                    higher precedence, and are checked before policies with higher priority
+                    values in the same tier. All Admin tier rules have higher precedence than
+                    NetworkPolicy or Baseline tier rules.
+                    If two (or more) policies in the same tier with the same priority
+                    could match a connection, then the implementation can apply any of the
+                    matching policies to the connection, and there is no way for the user to
+                    reliably determine which one it will choose. Administrators must be
+                    careful about assigning the priorities for policies with rules that will
+                    match many connections, and ensure that policies have unique priority
+                    values in cases where ambiguity would be unacceptable.
+                  format: int32
+                  maximum: 1000
+                  minimum: 0
+                  type: integer
+                subject:
+                  description:
+                    Subject defines the pods to which this ClusterNetworkPolicy
+                    applies.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    namespaces:
+                      description: Namespaces is used to select pods via namespace selectors.
+                      properties:
+                        matchExpressions:
+                          description:
+                            matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description:
+                                  key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    pods:
+                      description:
+                        Pods is used to select pods via namespace AND pod
+                        selectors.
+                      properties:
+                        namespaceSelector:
+                          description: |-
+                            NamespaceSelector follows standard label selector
+                            semantics; if empty, it selects all Namespaces.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        podSelector:
+                          description: |-
+                            PodSelector is used to explicitly select pods within a namespace;
+                            if empty, it selects all Pods.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - podSelector
+                      type: object
+                  type: object
+                tier:
+                  description: |-
+                    Tier is used as the top-level grouping for network policy prioritization.
+
+                    Policy tiers are evaluated in the following order:
+                    * Admin tier
+                    * NetworkPolicy tier
+                    * Baseline tier
+
+                    ClusterNetworkPolicy can use 2 of these tiers: Admin and Baseline.
+
+                    The Admin tier takes precedence over all other policies. Policies
+                    defined in this tier are used to set cluster-wide security rules
+                    that cannot be overridden in the other tiers. If Admin tier has
+                    made a final decision (Accept or Deny) on a connection, then no
+                    further evaluation is done.
+
+                    NetworkPolicy tier is the tier for the namespaced v1.NetworkPolicy.
+                    These policies are intended for the application developer to describe
+                    the security policy associated with their deployments inside their
+                    namespace. v1.NetworkPolicy always makes a final decision for selected
+                    pods. Further evaluation only happens for Pods not selected by a
+                    v1.NetworkPolicy.
+
+                    Baseline tier is a cluster-wide policy that can be overridden by the
+                    v1.NetworkPolicy. If Baseline tier has made a final decision (Accept or
+                    Deny) on a connection, then no further evaluation is done.
+
+                    If a given connection wasn't allowed or denied by any of the tiers,
+                    the default kubernetes policy is applied, which says that
+                    all pods can communicate with each other.
+                  enum:
+                    - Admin
+                    - Baseline
+                  type: string
+              required:
+                - priority
+                - subject
+                - tier
+              type: object
+            status:
+              description: Status is the status to be reported by the implementation.
+              properties:
+                conditions:
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              required:
+                - conditions
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+# Source: calico/templates/calico-kube-controllers-rbac.yaml
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+rules:
+  # Nodes are watched to monitor for deletions.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - watch
+      - list
+      - get
+  # Pods are watched to check for existence as part of IPAM controller.
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  # Namespaces are watched for LoadBalancer IP allocation with namespace selector support
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  # Services are monitored for service LoadBalancer IP allocation
+  - apiGroups: [""]
+    resources:
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - ipreservations
+    verbs:
+      - list
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - ipamconfigurations
+      - ipamconfigs
+      - tiers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  # Pools are watched to maintain a mapping of blocks to IP pools.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
+      - watch
+  # kube-controllers manages hostendpoints.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - hostendpoints
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  # Needs access to update clusterinformations.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - clusterinformations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+  # KubeControllersConfiguration is where it gets its config
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - kubecontrollersconfigurations
+    verbs:
+      # read its own config
+      - get
+      - list
+      # create a default if none exists
+      - create
+      # update status
+      - update
+      # watch for changes
+      - watch
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - kubecontrollersconfigurations/status
+    verbs:
+      - get
+      - update
+  # Needed for policy name migrator.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - networkpolicies
+      - stagednetworkpolicies
+      - globalnetworkpolicies
+      - stagedglobalnetworkpolicies
+    verbs:
+      - watch
+      - list
+      - get
+      - create
+      - update
+      - delete
+  # Needed for migration controller to watch calico-node and calico-typha status.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  # Migration controller: manage DatastoreMigration CRs.
+  - apiGroups: ["migration.projectcalico.org"]
+    resources:
+      - datastoremigrations
+      - datastoremigrations/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  # Migration controller: read, watch, and delete CRDs during migration.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  # Migration controller: manage API services during migration.
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources:
+      - apiservices
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  # Migration controller: read v1 resources and write v3 resources.
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: calico/templates/calico-node-rbac.yaml
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-node
+rules:
+  # Used for creating service account tokens to be used by the CNI plugin
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - calico-cni-plugin
+    verbs:
+      - create
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch
+      - list
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+      # Used to discover Typhas.
+      - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  # Watch for changes to Kubernetes ClusterNetworkPolicies.
+  - apiGroups: ["policy.networking.k8s.io"]
+    resources:
+      - clusternetworkpolicies
+    verbs:
+      - watch
+      - list
+  # Used by Calico for policy information.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # The CNI plugin patches pods/status.
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  # Calico monitors various CRDs for config.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - globalbgpconfigs
+      - felixconfigurations
+      - bgppeers
+      - bgpfilters
+      - bgpconfigurations
+      - ippools
+      - ipreservations
+      - ipamblocks
+      - globalnetworkpolicies
+      - stagedglobalnetworkpolicies
+      - networkpolicies
+      - stagednetworkpolicies
+      - stagedkubernetesnetworkpolicies
+      - globalnetworksets
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      - caliconodestatuses
+      - tiers
+    verbs:
+      - get
+      - list
+      - watch
+  # Calico creates some tiers on startup.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
+  # Calico must create and update some CRDs on startup.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - ippools
+      - felixconfigurations
+      - bgpconfigurations
+      - clusterinformations
+    verbs:
+      - create
+      - update
+  # Calico must update some CRDs.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - caliconodestatuses
+    verbs:
+      - update
+  # Calico stores some configuration information on the node.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  # These permissions are only required for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  # The CNI plugin and calico/node need to be able to create a default
+  # IPAMConfiguration
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - ipamconfigurations
+      - ipamconfigs
+    verbs:
+      - get
+      - create
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+  # For monitoring KubeVirt live migration.
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - virtualmachineinstancemigrations
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: calico/templates/calico-node-rbac.yaml
+# CNI cluster role
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-cni-plugin
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups: ["projectcalico.org", "crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - clusterinformations
+      - ippools
+      - ipreservations
+      - ipamconfigurations
+      - ipamconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+---
+# Source: calico/templates/tier-getter.yaml
+# Implements the necessary permissions for the kube-controller-manager to interact with
+# Tiers and Tiered Policies for GC.
+#
+# https://github.com/tigera/operator/blob/v1.37.0/pkg/render/apiserver.go#L1505-L1545
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-tier-getter
+rules:
+  - apiGroups:
+      - "projectcalico.org"
+    resources:
+      - "tiers"
+    verbs:
+      - "get"
+---
+# Source: calico/templates/calico-kube-controllers-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+  - kind: ServiceAccount
+    name: calico-kube-controllers
+    namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+  - kind: ServiceAccount
+    name: calico-node
+    namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+  - kind: ServiceAccount
+    name: calico-cni-plugin
+    namespace: kube-system
+---
+# Source: calico/templates/tier-getter.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-tier-getter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-tier-getter
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: system:kube-controller-manager
+---
+# Source: calico/templates/calico-node.yaml
+# This manifest installs the calico-node container, as well
+# as the CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
+      initContainers:
+        # This container performs upgrade from host-local IPAM to calico-ipam.
+        # It can be deleted if this is a fresh installation, or if you have already
+        # upgraded to use calico-ipam.
+        - name: upgrade-ipam
+          image: quay.io/calico/calico:master
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/bin/calico-ipam", "-upgrade"]
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+          volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          securityContext:
+            privileged: true
+        # This container installs the CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/calico:master
+          imagePullPolicy: IfNotPresent
+          args: ["cni", "install"]
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          securityContext:
+            privileged: true
+        # This init container mounts the necessary filesystems needed by the BPF data plane
+        # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
+        # networking to allow communication with the API Server. Calico-node initialization is executed
+        # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptables mode.
+        - name: "ebpf-bootstrap"
+          image: quay.io/calico/node:master
+          imagePullPolicy: IfNotPresent
+          command: ["calico", "component", "node", "init", "--best-effort"]
+          volumeMounts:
+            - mountPath: /sys/fs
+              name: sys-fs
+              # Bidirectional is required to ensure that the new mount we make at /sys/fs/bpf propagates to the host
+              # so that it outlives the init container.
+              mountPropagation: Bidirectional
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              # Bidirectional is required to ensure that the new mount we make at /run/calico/cgroup propagates to the host
+              # so that it outlives the init container.
+              mountPropagation: Bidirectional
+            # Mount /proc/ from host which usually is an init program at /nodeproc. It's needed by mountns binary,
+            # executed by calico-node, to mount root cgroup2 fs at /run/calico/cgroup to attach CTLB programs correctly.
+            - mountPath: /nodeproc
+              name: nodeproc
+              readOnly: true
+          securityContext:
+            privileged: true
+      containers:
+        # Runs calico-node container on each Kubernetes node. This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:master
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Enable or Disable VXLAN on the default IP pool.
+            - name: CALICO_IPV4POOL_VXLAN
+              value: "Never"
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "Never"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Set MTU for the VXLAN tunnel device.
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Set MTU for the Wireguard tunnel device.
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # - name: CALICO_IPV4POOL_CIDR
+            #   value: "192.168.0.0/16"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - calico
+                  - component
+                  - node
+                  - shutdown
+          livenessProbe:
+            exec:
+              command:
+                - calico
+                - component
+                - node
+                - health
+                - --felix-live
+                - --bird-live
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - calico
+                - component
+                - node
+                - health
+                - --felix-ready
+                - --bird-ready
+            periodSeconds: 10
+            timeoutSeconds: 10
+          volumeMounts:
+            # For maintaining CNI plugin API credentials.
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - name: policysync
+              mountPath: /var/run/nodeagent
+            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
+            # parent directory.
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+            - name: cni-log-dir
+              mountPath: /var/log/calico/cni
+              readOnly: true
+      volumes:
+        # Used by calico-node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+            type: DirectoryOrCreate
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+            type: DirectoryOrCreate
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs/
+            type: DirectoryOrCreate
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory
+        # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
+        - name: nodeproc
+          hostPath:
+            path: /proc
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Used to access CNI logs.
+        - name: cni-log-dir
+          hostPath:
+            path: /var/log/calico/cni
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
+        # Used to create per-pod Unix Domain Sockets
+        - name: policysync
+          hostPath:
+            type: DirectoryOrCreate
+            path: /var/run/nodeagent
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: calico-kube-controllers
+          image: quay.io/calico/calico:master
+          imagePullPolicy: IfNotPresent
+          args: ["component", "kube-controllers"]
+          env:
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: node,loadbalancer
+            - name: DATASTORE_TYPE
+              value: kubernetes
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/calico
+                - component
+                - kube-controllers
+                - kube-controllers-health
+                - -l
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/calico
+                - component
+                - kube-controllers
+                - kube-controllers-health
+                - -r
+            periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -19618,6 +19618,69 @@ spec:
                     prometheus metrics on. By default, metrics are not enabled.
                   format: int32
                   type: integer
+                typhaPodDisruptionBudget:
+                  description: |-
+                    TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                    Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                    selector is managed by the operator and cannot be overridden.
+                  properties:
+                    metadata:
+                      description:
+                        Metadata is a subset of a Kubernetes object's metadata
+                        that is added to the PodDisruptionBudget.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is a map of arbitrary non-identifying metadata. Each of these
+                            key/value pairs are added to the object's annotations provided the key does not
+                            already exist in the object's annotations.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Labels is a map of string keys and values that may match replicaset and
+                            service selectors. Each of these key/value pairs are added to the
+                            object's labels provided the key does not already exist in the object's labels.
+                          type: object
+                      type: object
+                    spec:
+                      description: Spec is the specification of the PodDisruptionBudget.
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                            can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                            If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                            default (MaxUnavailable=1 for calico-typha).
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MinAvailable is the minimum number of pods (as an integer or percentage) that
+                            must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                          x-kubernetes-int-or-string: true
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                            for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                            See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                          enum:
+                            - IfHealthyBudget
+                            - AlwaysAllow
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: minAvailable and maxUnavailable are mutually exclusive
+                          rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                  type: object
                 variant:
                   description: |-
                     Variant is the product to install - one of Calico or CalicoEnterprise.
@@ -28996,6 +29059,69 @@ spec:
                         serves prometheus metrics on. By default, metrics are not enabled.
                       format: int32
                       type: integer
+                    typhaPodDisruptionBudget:
+                      description: |-
+                        TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                        Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                        selector is managed by the operator and cannot be overridden.
+                      properties:
+                        metadata:
+                          description:
+                            Metadata is a subset of a Kubernetes object's
+                            metadata that is added to the PodDisruptionBudget.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations is a map of arbitrary non-identifying metadata. Each of these
+                                key/value pairs are added to the object's annotations provided the key does not
+                                already exist in the object's annotations.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Labels is a map of string keys and values that may match replicaset and
+                                service selectors. Each of these key/value pairs are added to the
+                                object's labels provided the key does not already exist in the object's labels.
+                              type: object
+                          type: object
+                        spec:
+                          description: Spec is the specification of the PodDisruptionBudget.
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                                can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                                If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                                default (MaxUnavailable=1 for calico-typha).
+                              x-kubernetes-int-or-string: true
+                            minAvailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MinAvailable is the minimum number of pods (as an integer or percentage) that
+                                must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                              x-kubernetes-int-or-string: true
+                            unhealthyPodEvictionPolicy:
+                              description: |-
+                                UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                                for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                                See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                              enum:
+                                - IfHealthyBudget
+                                - AlwaysAllow
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: minAvailable and maxUnavailable are mutually exclusive
+                              rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                      type: object
                     variant:
                       description: |-
                         Variant is the product to install - one of Calico or CalicoEnterprise.

--- a/manifests/v1_crd_projectcalico_org.yaml
+++ b/manifests/v1_crd_projectcalico_org.yaml
@@ -19618,6 +19618,69 @@ spec:
                     prometheus metrics on. By default, metrics are not enabled.
                   format: int32
                   type: integer
+                typhaPodDisruptionBudget:
+                  description: |-
+                    TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                    Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                    selector is managed by the operator and cannot be overridden.
+                  properties:
+                    metadata:
+                      description:
+                        Metadata is a subset of a Kubernetes object's metadata
+                        that is added to the PodDisruptionBudget.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is a map of arbitrary non-identifying metadata. Each of these
+                            key/value pairs are added to the object's annotations provided the key does not
+                            already exist in the object's annotations.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Labels is a map of string keys and values that may match replicaset and
+                            service selectors. Each of these key/value pairs are added to the
+                            object's labels provided the key does not already exist in the object's labels.
+                          type: object
+                      type: object
+                    spec:
+                      description: Spec is the specification of the PodDisruptionBudget.
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                            can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                            If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                            default (MaxUnavailable=1 for calico-typha).
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MinAvailable is the minimum number of pods (as an integer or percentage) that
+                            must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                          x-kubernetes-int-or-string: true
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                            for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                            See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                          enum:
+                            - IfHealthyBudget
+                            - AlwaysAllow
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: minAvailable and maxUnavailable are mutually exclusive
+                          rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                  type: object
                 variant:
                   description: |-
                     Variant is the product to install - one of Calico or CalicoEnterprise.
@@ -28996,6 +29059,69 @@ spec:
                         serves prometheus metrics on. By default, metrics are not enabled.
                       format: int32
                       type: integer
+                    typhaPodDisruptionBudget:
+                      description: |-
+                        TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                        Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                        selector is managed by the operator and cannot be overridden.
+                      properties:
+                        metadata:
+                          description:
+                            Metadata is a subset of a Kubernetes object's
+                            metadata that is added to the PodDisruptionBudget.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations is a map of arbitrary non-identifying metadata. Each of these
+                                key/value pairs are added to the object's annotations provided the key does not
+                                already exist in the object's annotations.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Labels is a map of string keys and values that may match replicaset and
+                                service selectors. Each of these key/value pairs are added to the
+                                object's labels provided the key does not already exist in the object's labels.
+                              type: object
+                          type: object
+                        spec:
+                          description: Spec is the specification of the PodDisruptionBudget.
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                                can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                                If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                                default (MaxUnavailable=1 for calico-typha).
+                              x-kubernetes-int-or-string: true
+                            minAvailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MinAvailable is the minimum number of pods (as an integer or percentage) that
+                                must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                              x-kubernetes-int-or-string: true
+                            unhealthyPodEvictionPolicy:
+                              description: |-
+                                UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                                for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                                See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                              enum:
+                                - IfHealthyBudget
+                                - AlwaysAllow
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: minAvailable and maxUnavailable are mutually exclusive
+                              rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                      type: object
                     variant:
                       description: |-
                         Variant is the product to install - one of Calico or CalicoEnterprise.

--- a/manifests/v3_projectcalico_org.yaml
+++ b/manifests/v3_projectcalico_org.yaml
@@ -19618,6 +19618,69 @@ spec:
                     prometheus metrics on. By default, metrics are not enabled.
                   format: int32
                   type: integer
+                typhaPodDisruptionBudget:
+                  description: |-
+                    TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                    Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                    selector is managed by the operator and cannot be overridden.
+                  properties:
+                    metadata:
+                      description:
+                        Metadata is a subset of a Kubernetes object's metadata
+                        that is added to the PodDisruptionBudget.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is a map of arbitrary non-identifying metadata. Each of these
+                            key/value pairs are added to the object's annotations provided the key does not
+                            already exist in the object's annotations.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Labels is a map of string keys and values that may match replicaset and
+                            service selectors. Each of these key/value pairs are added to the
+                            object's labels provided the key does not already exist in the object's labels.
+                          type: object
+                      type: object
+                    spec:
+                      description: Spec is the specification of the PodDisruptionBudget.
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                            can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                            If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                            default (MaxUnavailable=1 for calico-typha).
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            MinAvailable is the minimum number of pods (as an integer or percentage) that
+                            must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                          x-kubernetes-int-or-string: true
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                            for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                            See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                          enum:
+                            - IfHealthyBudget
+                            - AlwaysAllow
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: minAvailable and maxUnavailable are mutually exclusive
+                          rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                  type: object
                 variant:
                   description: |-
                     Variant is the product to install - one of Calico or CalicoEnterprise.
@@ -28996,6 +29059,69 @@ spec:
                         serves prometheus metrics on. By default, metrics are not enabled.
                       format: int32
                       type: integer
+                    typhaPodDisruptionBudget:
+                      description: |-
+                        TyphaPodDisruptionBudget configures the PodDisruptionBudget for the calico-typha
+                        Deployment. Fields left unset fall back to the operator's defaults. The PDB's
+                        selector is managed by the operator and cannot be overridden.
+                      properties:
+                        metadata:
+                          description:
+                            Metadata is a subset of a Kubernetes object's
+                            metadata that is added to the PodDisruptionBudget.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Annotations is a map of arbitrary non-identifying metadata. Each of these
+                                key/value pairs are added to the object's annotations provided the key does not
+                                already exist in the object's annotations.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Labels is a map of string keys and values that may match replicaset and
+                                service selectors. Each of these key/value pairs are added to the
+                                object's labels provided the key does not already exist in the object's labels.
+                              type: object
+                          type: object
+                        spec:
+                          description: Spec is the specification of the PodDisruptionBudget.
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MaxUnavailable is the maximum number of pods (as an integer or percentage) that
+                                can be unavailable during a disruption. Mutually exclusive with MinAvailable.
+                                If neither MinAvailable nor MaxUnavailable is set, the operator applies its
+                                default (MaxUnavailable=1 for calico-typha).
+                              x-kubernetes-int-or-string: true
+                            minAvailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                MinAvailable is the minimum number of pods (as an integer or percentage) that
+                                must remain available during a disruption. Mutually exclusive with MaxUnavailable.
+                              x-kubernetes-int-or-string: true
+                            unhealthyPodEvictionPolicy:
+                              description: |-
+                                UnhealthyPodEvictionPolicy defines when unhealthy pods should be considered
+                                for eviction. Defaults to IfHealthyBudget (the Kubernetes default) when unset.
+                                See https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy.
+                              enum:
+                                - IfHealthyBudget
+                                - AlwaysAllow
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: minAvailable and maxUnavailable are mutually exclusive
+                              rule: "!(has(self.minAvailable) && has(self.maxUnavailable))"
+                      type: object
                     variant:
                       description: |-
                         Variant is the product to install - one of Calico or CalicoEnterprise.

--- a/node/filesystem/etc/rc.local
+++ b/node/filesystem/etc/rc.local
@@ -51,6 +51,11 @@ case "$CALICO_NETWORKING_BACKEND" in
 	# If running in VXLAN-only mode, we don't need to run BIRD / Confd.
 	echo "CALICO_NETWORKING_BACKEND is vxlan - no need to run a BGP daemon"
 	;;
+	"felix" )
+	# If running with Felix programming all in-cluster routes, BGP is
+	# disabled (like vxlan) and we don't need to run BIRD / Confd.
+	echo "CALICO_NETWORKING_BACKEND is felix - no need to run a BGP daemon"
+	;;
 	* )
 
 	# Enable the confd and bird services

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -153,6 +153,7 @@ var _ = DescribeTable("Node IP detection failure cases",
 	},
 
 	Entry("startup should terminate if IP is set to none and Calico is used for networking", "bird", 1, "", false),
+	Entry("startup should terminate if IP is set to none and Felix programs in-cluster routes", "felix", 1, "", false),
 	Entry("startup should NOT terminate if IP is set to none and Calico is policy-only", "none", 0, "", false),
 	Entry("startup should NOT terminate and BGPSpec shouldn't be set", "none", 0, "rrClusterID", false),
 )


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Adding a new manifest for deploying clusters with Felix programming cluster routes, and BGP/BIRD disabled.

This is done by introducing a new variable for helm, named `cluster_routing_mode`. If set to `felix`, Felix will be responsible for programming. Any other value (default), BIRD would program those routes.

 
<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Adding a new manifest for deploying Calico with Felix programming all in-cluster routes, and BIRD disabled. 
```
