### PR TITLE
Bump container-storage-interface/spec to v1.12.0

### DIFF
--- a/cmd/deps.txt
+++ b/cmd/deps.txt
@@ -30,7 +30,7 @@ github.com/cespare/xxhash/v2 v2.3.0
 github.com/chai2010/gettext-go v1.0.2
 github.com/clipperhouse/uax29/v2 v2.6.0
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5
-github.com/container-storage-interface/spec v1.9.0
+github.com/container-storage-interface/spec v1.12.0
 github.com/containernetworking/cni v1.3.0
 github.com/containernetworking/plugins v1.9.1
 github.com/coreos/go-iptables v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/smithy-go v1.25.0
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/buger/jsonparser v1.1.2
-	github.com/container-storage-interface/spec v1.9.0
+	github.com/container-storage-interface/spec v1.12.0
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/container-storage-interface/spec v1.9.0 h1:zKtX4STsq31Knz3gciCYCi1SXtO2HJDecIjDVboYavY=
-github.com/container-storage-interface/spec v1.9.0/go.mod h1:ZfDu+3ZRyeVqxZM0Ds19MVLkN2d1XJ5MAfi1L3VjlT0=
+github.com/container-storage-interface/spec v1.12.0 h1:zrFOEqpR5AghNaaDG4qyedwPBqU2fU0dWjLQMP/azK0=
+github.com/container-storage-interface/spec v1.12.0/go.mod h1:txsm+MA2B2WDa5kW69jNbqPnvTtfvZma7T/zsAZ9qX8=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5lMcWspGIg0=

--- a/pod2daemon/csidriver/driver/driver.go
+++ b/pod2daemon/csidriver/driver/driver.go
@@ -67,6 +67,7 @@ type ConfigurationOptions struct {
 }
 
 type Driver struct {
+	csi.UnimplementedIdentityServer
 	nodeService
 
 	server  *grpc.Server

--- a/pod2daemon/csidriver/driver/driver_test.go
+++ b/pod2daemon/csidriver/driver/driver_test.go
@@ -8,7 +8,17 @@ import (
 	"os"
 	"testing"
 
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	. "github.com/onsi/gomega"
+)
+
+// Compile-time assertions that the driver satisfies the CSI server interfaces.
+// Since CSI spec v1.10.0 these interfaces require embedding the generated
+// Unimplemented*Server structs (forward compatibility), so these guard against
+// a regression where that embedding is dropped.
+var (
+	_ csi.IdentityServer = (*Driver)(nil)
+	_ csi.NodeServer     = (*Driver)(nil)
 )
 
 func testRetrievePodInfoFromFile(g *WithT, setup podInfoTestSetup, volumeID, credsJSON string, checkErr validateReturnError) {
@@ -18,7 +28,7 @@ func testRetrievePodInfoFromFile(g *WithT, setup podInfoTestSetup, volumeID, cre
 	nodeServiceConfig := ConfigurationOptions{
 		NodeAgentCredentialsHomeDir: "/tmp",
 	}
-	nodeService := &nodeService{&nodeServiceConfig}
+	nodeService := &nodeService{config: &nodeServiceConfig}
 	_, err = nodeService.retrievePodInfoFromFile(volumeID)
 	g.Expect(checkErr(err)).NotTo(HaveOccurred(), "Error check failed")
 }

--- a/pod2daemon/csidriver/driver/node.go
+++ b/pod2daemon/csidriver/driver/node.go
@@ -36,6 +36,7 @@ import (
 
 // Define the nodeService as per the CSI spec.
 type nodeService struct {
+	csi.UnimplementedNodeServer
 	config *ConfigurationOptions
 }
 

--- a/pod2daemon/deps.txt
+++ b/pod2daemon/deps.txt
@@ -4,8 +4,7 @@ Run 'make gen-deps-files' to regenerate.
 go 1.26.3
 github.com/beorn7/perks v1.0.1
 github.com/cespare/xxhash/v2 v2.3.0
-github.com/container-storage-interface/spec v1.9.0
-github.com/golang/protobuf v1.5.4
+github.com/container-storage-interface/spec v1.12.0
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/projectcalico/calico
 github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
CSI spec regenerated its gRPC stubs (since v1.10.0) so that the IdentityServer and NodeServer interfaces require embedding the generated Unimplemented*Server structs for forward compatibility. Embed csi.UnimplementedIdentityServer in Driver and csi.UnimplementedNodeServer in nodeService so the csidriver builds against the bumped dependency.

Add compile-time interface assertions to guard against the embedding being dropped, and switch the nodeService test literal to a keyed field.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Bump container-storage-interface/spec to v1.12.0.
```
