### PR TITLE
networking-calico: add resync-concurrency test for CORE-12037

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -235,14 +235,16 @@ python3 ../calico/networking-calico/devstack/qos_responsiveness_tests.py -v
 EOF
 
 # Run resync concurrency test.  Prints one RESYNC_CONCURRENCY_RESULT
-# line per scenario.
+# line per scenario.  Non-zero exit (any scenario over the 2x ratio
+# gate) propagates out of the heredoc and fails the bootstrap, so
+# regressions block CI.
 sudo -u stack -H -E bash -x <<'EOF'
 cd /opt/stack/devstack
 . openrc admin admin
 
 export ETCD_HOST=${SERVICE_HOST}
 export RESYNC_CALICO_RESYNC=${DEVSTACK_VENV:-/usr/local}/bin/calico-resync
-python3 ../calico/networking-calico/devstack/resync_concurrency_test.py || true
+python3 ../calico/networking-calico/devstack/resync_concurrency_test.py
 EOF
 
 # Run resync scale benchmark.  Prints one RESYNC_SCALE_RESULT line per

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -113,6 +113,12 @@ cd devstack-bootstrap
 sudo apt-get update
 sudo apt-get -y install git
 
+# crudini is used by resync_concurrency_test.py's `startup` scenario to
+# set/unset [calico] startup_resync_inject_per_item_delay_ms in neutron.conf
+# across a neutron-server restart.  Install it now so the test can use it
+# without needing a separate sudo block later.
+sudo apt-get -y install crudini
+
 # Enable IPv4 and IPv6 forwarding.
 sudo sysctl -w net.ipv4.ip_forward=1
 sudo sysctl -w net.ipv6.conf.all.forwarding=1
@@ -226,6 +232,17 @@ sudo pip install openstacksdk etcd3 pymysql
 
 export ETCD_HOST=${SERVICE_HOST}
 python3 ../calico/networking-calico/devstack/qos_responsiveness_tests.py -v
+EOF
+
+# Run resync concurrency test.  Prints one RESYNC_CONCURRENCY_RESULT
+# line per scenario.
+sudo -u stack -H -E bash -x <<'EOF'
+cd /opt/stack/devstack
+. openrc admin admin
+
+export ETCD_HOST=${SERVICE_HOST}
+export RESYNC_CALICO_RESYNC=${DEVSTACK_VENV:-/usr/local}/bin/calico-resync
+python3 ../calico/networking-calico/devstack/resync_concurrency_test.py || true
 EOF
 
 # Run resync scale benchmark.  Prints one RESYNC_SCALE_RESULT line per

--- a/networking-calico/devstack/resync_concurrency_test.py
+++ b/networking-calico/devstack/resync_concurrency_test.py
@@ -257,6 +257,7 @@ def scenario_on_demand(
     try:
         if not wait_for_endpoints_phase(log_file, deadline_secs=60):
             proc.kill()
+            proc.wait()
             raise RuntimeError(
                 "calico-resync did not reach the endpoints phase within 60s"
             )
@@ -289,6 +290,7 @@ def scenario_on_demand(
     finally:
         if proc.poll() is None:
             proc.kill()
+            proc.wait()
         try:
             os.unlink(output_file.name)
         except OSError:

--- a/networking-calico/devstack/resync_concurrency_test.py
+++ b/networking-calico/devstack/resync_concurrency_test.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Resync concurrency test: does a long-running resync block dynamic port creation?
+
+Resync runs in its own OS process - equally whether it is the
+``CalicoStartupResyncWorker`` for start-of-day resync within the Neutron server, or a
+``calico-resync`` invocation for on-demand - separate from the API workers.  So in
+principle a long resync should not block dynamic operations: the only ways it could
+would be through shared external resources -- Neutron DB lock contention, etcd's
+serialised transaction queue, or, on a single-host test box, CPU contention.
+
+This test demonstrates that, in practice, dynamic port creation latency does not regress
+meaningfully while a long resync is alive.  Two scenarios:
+
+* **on_demand**: run ``calico-resync`` with the ``--inject-per-item-delay-ms``
+  hidden flag so it stretches the endpoints phase to a known duration; create
+  test ports during that window; compare median latency to a baseline with no
+  concurrent resync.
+
+* **startup**: set ``[calico] startup_resync_inject_per_item_delay_ms`` in
+  ``neutron.conf``, restart neutron-server, and create test ports during the
+  ``CalicoStartupResyncWorker``'s stretched endpoints phase.
+
+Both scenarios assert that the in-resync median latency is at most ``2x`` the baseline
+median; both emit a timing summary that puts each port-create timestamp alongside the
+resync's own ``started_at`` / ``finished_at``, so a reviewer can see the overlap
+directly.
+
+Run as the ``stack`` user with the admin openrc sourced.  Environment vars:
+
+    ETCD_HOST=<ip>         (default localhost)
+    ETCD_PORT=<port>       (default 2379)
+    NEUTRON_CONF=<path>    (default /etc/neutron/neutron.conf)
+    RESYNC_CONCURRENCY_POPULATE_SCALE=<n>     (default 1000)
+    RESYNC_CONCURRENCY_TEST_PORTS=<n>         (default 5)
+    RESYNC_CONCURRENCY_PER_ITEM_DELAY_MS=<n>  (default 50)
+    RESYNC_CONCURRENCY_RATIO_LIMIT=<f>        (default 2.0)
+    RESYNC_CALICO_RESYNC=calico-resync        (path to the CLI)
+    RESYNC_CONCURRENCY_SCENARIOS=on_demand,startup  (which to run)
+
+The scenarios share their populate / cleanup with ``resync_scale_test.py`` -- the same
+fake-agent rows, networks, SGs and ports.
+"""
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+# Reuse all populate / cleanup machinery from the scale test.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import resync_scale_test as scale
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+LOG = logging.getLogger("resync-concurrency")
+
+
+# ---------------------------------------------------------------------------
+# Measurement.
+# ---------------------------------------------------------------------------
+
+
+def time_port_create(conn, network, subnet, sg, host, label):
+    """Create one port via the Neutron REST API.
+
+    Returns (port_id, elapsed_secs, started_at_iso).  ``label`` ends up in the port
+    name so the per-iteration log lines and the Neutron DB rows can be correlated.
+    """
+    # Prefix the port name with scale.TEST_TAG so scale.cleanup_neutron()
+    # picks it up at the end of the run (it deletes only ports whose name
+    # starts with TEST_TAG).  Without this, our test ports outlive cleanup
+    # and block the subsequent network-delete pass.
+    spec = {
+        "name": "%s-concurrency-%s-%s" % (scale.TEST_TAG, label, uuid.uuid4().hex[:8]),
+        "network_id": network.id,
+        "fixed_ips": [{"subnet_id": subnet.id}],
+        "security_groups": [sg.id],
+        "device_id": "concurrency-inst-%s" % uuid.uuid4().hex[:8],
+        "device_owner": "compute:fake",
+        "binding_host_id": host,
+    }
+    started_at = datetime.datetime.utcnow().isoformat() + "Z"
+    t0 = time.monotonic()
+    port = conn.network.create_port(**spec)
+    elapsed = time.monotonic() - t0
+    return port.id, elapsed, started_at
+
+
+def measure_port_create_burst(conn, network, subnet, sg, host, count, label):
+    """Create ``count`` ports back-to-back, return list of measurement dicts."""
+    out = []
+    for i in range(count):
+        port_id, elapsed_secs, started_at = time_port_create(
+            conn, network, subnet, sg, host, label
+        )
+        LOG.info(
+            "  %s port %d/%d: id=%s elapsed=%.3fs",
+            label,
+            i + 1,
+            count,
+            port_id,
+            elapsed_secs,
+        )
+        out.append(
+            {
+                "label": label,
+                "iter": i,
+                "port_id": port_id,
+                "elapsed_secs": elapsed_secs,
+                "started_at": started_at,
+            }
+        )
+    return out
+
+
+def median(measurements):
+    if not measurements:
+        return -1
+    return statistics.median(m["elapsed_secs"] for m in measurements)
+
+
+def _take_warmup_then_measure(conn, network, subnet, sg, host, count):
+    """Create one warm-up port (discarded from the median) then ``count``
+    measured ports.  Returns ``(warmup_list, measured_list)``.
+
+    Discarding one warm-up sample matters most in the startup scenario,
+    where the API workers have just come back up after a neutron-server
+    restart and the first port-create pays for cold DB-connection pools
+    and plugin caches.  We do it consistently in both scenarios so the
+    reported medians remain directly comparable.  The warm-up sample is
+    still included in the timing summary so a reviewer can see what it
+    cost.
+    """
+    warmup = measure_port_create_burst(
+        conn, network, subnet, sg, host, 1, "in_resync_warmup"
+    )
+    LOG.info(
+        "In-resync warm-up port (discarded from median): %.3fs",
+        warmup[0]["elapsed_secs"],
+    )
+    measured = measure_port_create_burst(
+        conn, network, subnet, sg, host, count, "in_resync"
+    )
+    return warmup, measured
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: on-demand calico-resync.
+# ---------------------------------------------------------------------------
+
+
+# Marker logged by ResourceSyncer when the endpoints phase begins.  Test waits
+# for this in the calico-resync log file before firing the in-resync burst,
+# so we know the per-item delay loop is actively running.
+_ENDPOINTS_PHASE_MARKER = "Starting resync for WorkloadEndpoint"
+
+
+def wait_for_endpoints_phase(log_path, deadline_secs):
+    """Tail ``log_path`` until the endpoints-phase start marker appears."""
+    t_end = time.monotonic() + deadline_secs
+    while time.monotonic() < t_end:
+        try:
+            with open(log_path) as f:
+                if _ENDPOINTS_PHASE_MARKER in f.read():
+                    return True
+        except FileNotFoundError:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def scenario_on_demand(
+    conn,
+    network,
+    subnet,
+    sg,
+    host,
+    neutron_conf,
+    extra_conf,
+    log_file,
+    test_ports,
+    per_item_delay_ms,
+):
+    """Scenario A: on-demand calico-resync."""
+    LOG.info("=" * 60)
+    LOG.info("Scenario: on_demand calico-resync")
+    LOG.info("=" * 60)
+
+    # Truncate the log file so the marker poll starts from a known state.
+    open(log_file, "w").close()
+
+    # Baseline: measure without a concurrent resync.
+    LOG.info("Baseline: creating %d ports, no concurrent resync", test_ports)
+    baseline = measure_port_create_burst(
+        conn, network, subnet, sg, host, test_ports, "baseline"
+    )
+    baseline_median = median(baseline)
+    LOG.info("Baseline median: %.3fs", baseline_median)
+
+    # Run calico-resync with the per-item delay.  Capture its JSON output for
+    # the timing summary.
+    output_file = tempfile.NamedTemporaryFile(
+        mode="r", suffix=".json", prefix="calico-resync-conc-", delete=False
+    )
+    output_file.close()
+    cmd = [
+        os.environ.get("RESYNC_CALICO_RESYNC", "calico-resync"),
+        "--config-file",
+        neutron_conf,
+        "--config-file",
+        extra_conf,
+        "--output",
+        output_file.name,
+        "--inject-per-item-delay-ms",
+        str(per_item_delay_ms),
+    ]
+    LOG.info("Starting calico-resync (per-item delay=%dms)", per_item_delay_ms)
+    LOG.info("  %s", " ".join(cmd))
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    try:
+        if not wait_for_endpoints_phase(log_file, deadline_secs=60):
+            proc.kill()
+            raise RuntimeError(
+                "calico-resync did not reach the endpoints phase within 60s"
+            )
+        LOG.info("Resync confirmed in endpoints phase -- starting in-resync burst")
+
+        # In-resync: measure while the resync is in the stretched endpoints
+        # phase.  We always discard the first sample as a warm-up (see
+        # _take_warmup_then_measure for rationale).
+        warmup, in_resync_main = _take_warmup_then_measure(
+            conn, network, subnet, sg, host, test_ports
+        )
+        in_resync = warmup + in_resync_main
+        in_resync_median = median(in_resync_main)
+        LOG.info("In-resync median: %.3fs", in_resync_median)
+
+        # Wait for resync to actually complete so the timing summary can pair
+        # each test port's timestamp with the resync's own started_at /
+        # finished_at.
+        LOG.info("Waiting for resync to complete...")
+        rc = proc.wait()
+        with open(output_file.name) as f:
+            result = json.load(f)
+        LOG.info(
+            "Resync finished rc=%d, started_at=%s, finished_at=%s, total_ms=%d",
+            rc,
+            result["started_at"],
+            result["finished_at"],
+            result["total_ms"],
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        try:
+            os.unlink(output_file.name)
+        except OSError:
+            pass
+
+    return {
+        "scenario": "on_demand",
+        "baseline": baseline,
+        "baseline_median_secs": baseline_median,
+        "in_resync": in_resync,
+        "in_resync_median_secs": in_resync_median,
+        "ratio": (in_resync_median / baseline_median if baseline_median > 0 else -1),
+        "resync_started_at": result["started_at"],
+        "resync_finished_at": result["finished_at"],
+        "resync_total_ms": result["total_ms"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: start-of-day resync via neutron-server restart.
+# ---------------------------------------------------------------------------
+
+
+def neutron_conf_set(path, section, key, value):
+    """``crudini``-style edit: set [section] key=value in a config file."""
+    subprocess.check_call(["sudo", "crudini", "--set", path, section, key, str(value)])
+
+
+def neutron_conf_unset(path, section, key):
+    subprocess.run(["sudo", "crudini", "--del", path, section, key], check=False)
+
+
+def neutron_server_restart_and_wait(conn, deadline_secs=60):
+    """Restart neutron-server and poll until its API is responsive."""
+    LOG.info("Restarting neutron-server (systemctl restart devstack@q-svc)")
+    subprocess.check_call(["sudo", "systemctl", "restart", "devstack@q-svc"])
+    t_end = time.monotonic() + deadline_secs
+    while time.monotonic() < t_end:
+        try:
+            list(conn.network.networks(limit=1))
+            LOG.info("Neutron API responsive again")
+            return
+        except Exception as exc:
+            LOG.debug("Neutron API not yet ready: %s", exc)
+            time.sleep(1)
+    raise RuntimeError(
+        "neutron-server did not become API-responsive within %ds" % deadline_secs
+    )
+
+
+def wait_for_log_text_in_journal(text, since_dt, deadline_secs):
+    """Poll ``journalctl -u devstack@q-svc`` until ``text`` appears.
+
+    ``since_dt`` is a naive ``datetime.datetime`` in UTC; we format it as
+    ``YYYY-MM-DD HH:MM:SS`` for ``journalctl --since``, which doesn't
+    accept ISO 8601's ``T``/``Z`` punctuation.
+    """
+    since_journal = since_dt.strftime("%Y-%m-%d %H:%M:%S")
+    t_end = time.monotonic() + deadline_secs
+    while time.monotonic() < t_end:
+        tail = subprocess.run(
+            [
+                "sudo",
+                "journalctl",
+                "-u",
+                "devstack@q-svc",
+                "--since",
+                since_journal,
+                "-q",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if text in tail.stdout:
+            return True
+        time.sleep(2)
+    return False
+
+
+def scenario_startup(
+    conn,
+    network,
+    subnet,
+    sg,
+    host,
+    neutron_conf,
+    test_ports,
+    per_item_delay_ms,
+    populate_scale,
+):
+    """Scenario B: start-of-day resync."""
+    LOG.info("=" * 60)
+    LOG.info("Scenario: startup resync")
+    LOG.info("=" * 60)
+
+    # Set the per-item-delay knob on [calico] and restart neutron-server.
+    # After the restart, CalicoStartupResyncWorker handles the resync in its
+    # own process while the API workers stay alive and handle requests.
+    neutron_conf_set(
+        neutron_conf,
+        "calico",
+        "startup_resync_inject_per_item_delay_ms",
+        per_item_delay_ms,
+    )
+    try:
+        t_restart_dt = datetime.datetime.utcnow()
+        t_restart_iso = t_restart_dt.isoformat() + "Z"
+        neutron_server_restart_and_wait(conn)
+
+        # Wait for the endpoints phase to begin in the resync worker's log.
+        # Once it starts, we have populate_scale * per_item_delay_ms of
+        # window to fire the in-resync burst.
+        LOG.info("Waiting for start-of-day endpoints phase to begin...")
+        if not wait_for_log_text_in_journal(
+            _ENDPOINTS_PHASE_MARKER, t_restart_dt, deadline_secs=60
+        ):
+            raise RuntimeError(
+                "Start-of-day resync did not reach the endpoints phase "
+                "within 60s of restart"
+            )
+        LOG.info("Resync confirmed in endpoints phase -- starting in-resync burst")
+
+        # In-resync: measure while the resync worker is in the stretched
+        # endpoints phase.  We always discard the first sample as a warm-up
+        # (see _take_warmup_then_measure for rationale).
+        warmup, in_resync_main = _take_warmup_then_measure(
+            conn, network, subnet, sg, host, test_ports
+        )
+        in_resync = warmup + in_resync_main
+        in_resync_median = median(in_resync_main)
+        LOG.info("In-resync median: %.3fs", in_resync_median)
+
+        # Wait for the resync to actually complete.  Total time is bounded
+        # by populate_scale * per_item_delay_ms plus etcd-read /
+        # neutron-read overhead.
+        expected_endpoints_secs = (populate_scale * per_item_delay_ms) / 1000.0
+        budget_secs = int(expected_endpoints_secs * 2) + 120
+        LOG.info(
+            "Waiting up to %ds for start-of-day resync to complete...",
+            budget_secs,
+        )
+        if not wait_for_log_text_in_journal(
+            "One-shot resync done", t_restart_dt, deadline_secs=budget_secs
+        ):
+            raise RuntimeError("Start-of-day resync did not complete within the window")
+        t_resync_done_iso = datetime.datetime.utcnow().isoformat() + "Z"
+        LOG.info("Resync completed")
+    finally:
+        # Restore neutron.conf so future test runs aren't perturbed.
+        neutron_conf_unset(
+            neutron_conf,
+            "calico",
+            "startup_resync_inject_per_item_delay_ms",
+        )
+
+    # Baseline AFTER the resync has finished -- the cleanest "no concurrent
+    # resync" state we can get without another restart.
+    LOG.info("Baseline: creating %d ports, no concurrent resync", test_ports)
+    baseline = measure_port_create_burst(
+        conn, network, subnet, sg, host, test_ports, "baseline"
+    )
+    baseline_median = median(baseline)
+    LOG.info("Baseline median: %.3fs", baseline_median)
+
+    return {
+        "scenario": "startup",
+        "baseline": baseline,
+        "baseline_median_secs": baseline_median,
+        "in_resync": in_resync,
+        "in_resync_median_secs": in_resync_median,
+        "ratio": (in_resync_median / baseline_median if baseline_median > 0 else -1),
+        # No JSON-level resync timestamps for the start-of-day case, so we
+        # use the closest observable proxies.
+        "resync_started_at": t_restart_iso,
+        "resync_finished_at": t_resync_done_iso,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+
+
+def print_summary(result, ratio_limit):
+    """Print a reviewer-friendly summary showing the overlap between the
+    resync's lifetime and each test port's API call."""
+    LOG.info("")
+    LOG.info("===== Concurrency summary: scenario=%s =====", result["scenario"])
+    LOG.info("Resync started:  %s", result.get("resync_started_at", "?"))
+    for m in result["in_resync"]:
+        # Match the 1-based numbering and label used by the burst log
+        # ("in_resync port 3/5") so the per-port lines printed live and the
+        # summary at the end refer to the same ports the same way.  The
+        # warmup is logged as ``in_resync_warmup port 1`` and the measured
+        # ports as ``in_resync port 1`` ... ``port N``.
+        LOG.info(
+            "  %s port %d at %s, API took %.3fs",
+            m["label"],
+            m["iter"] + 1,
+            m["started_at"],
+            m["elapsed_secs"],
+        )
+    LOG.info("Resync finished: %s", result.get("resync_finished_at", "?"))
+    LOG.info("")
+    LOG.info("Baseline median: %.3fs", result["baseline_median_secs"])
+    LOG.info("In-resync median: %.3fs", result["in_resync_median_secs"])
+    LOG.info("Ratio: %.2fx (limit: %.2fx)", result["ratio"], ratio_limit)
+
+    passed = result["ratio"] <= ratio_limit and result["ratio"] > 0
+    LOG.info(
+        "RESYNC_CONCURRENCY_RESULT scenario=%s ratio=%.3f passed=%s",
+        result["scenario"],
+        result["ratio"],
+        passed,
+    )
+    sys.stdout.flush()
+    return passed
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers (thin wrappers around scale-test code).
+# ---------------------------------------------------------------------------
+
+
+def populate(conn, db_args, populate_scale):
+    """Provision fake agents + networks + SGs + populate-scale base ports.
+
+    Returns (network, subnet, sg, host) for the test to use when creating
+    additional ports.
+    """
+    num_hosts = scale.hosts_for_scale(populate_scale)
+    num_networks = max(1, populate_scale // 100)
+    num_sgs = max(1, num_networks * 2)
+    hosts = ["concurrency-fake-%05d" % i for i in range(num_hosts)]
+
+    LOG.info(
+        "Populating %d ports across %d networks / %d SGs / %d hosts...",
+        populate_scale,
+        num_networks,
+        num_sgs,
+        num_hosts,
+    )
+    scale.insert_fake_agents(db_args, hosts)
+    nets, subs = scale.create_networks_and_subnets(conn, num_networks)
+    sgs = scale.create_security_groups(conn, num_sgs)
+    scale.create_ports(conn, populate_scale, nets, subs, sgs, hosts)
+
+    # Test ports go on the first network/subnet/SG, with the first fake
+    # host.  Each test port is one more port on top of the populate-scale
+    # baseline.
+    return nets[0], subs[0], sgs[0], hosts[0]
+
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--neutron-conf",
+        default=os.environ.get("NEUTRON_CONF", "/etc/neutron/neutron.conf"),
+        help=(
+            "Path to neutron.conf to read [database] from and to mutate for "
+            "the startup scenario."
+        ),
+    )
+    args = parser.parse_args()
+
+    populate_scale = scale.env_int("RESYNC_CONCURRENCY_POPULATE_SCALE", 1000)
+    test_ports = scale.env_int("RESYNC_CONCURRENCY_TEST_PORTS", 5)
+    per_item_delay_ms = scale.env_int("RESYNC_CONCURRENCY_PER_ITEM_DELAY_MS", 50)
+    ratio_limit = float(os.environ.get("RESYNC_CONCURRENCY_RATIO_LIMIT", "2.0"))
+    scenarios = os.environ.get(
+        "RESYNC_CONCURRENCY_SCENARIOS", "on_demand,startup"
+    ).split(",")
+    scenarios = [s.strip() for s in scenarios if s.strip()]
+
+    db_args = scale.parse_db_connection(args.neutron_conf)
+    LOG.info(
+        "DB: %s@%s:%d/%s",
+        db_args["user"],
+        db_args["host"],
+        db_args["port"],
+        db_args["database"],
+    )
+
+    etcd_host = os.environ.get("ETCD_HOST", "localhost")
+    etcd_port = int(os.environ.get("ETCD_PORT", "2379"))
+    etcd_client = scale.etcd3.client(host=etcd_host, port=etcd_port)
+    LOG.info("etcd %s:%d", etcd_host, etcd_port)
+
+    conn = scale.connect_openstack()
+    scale.bump_quotas(conn)
+
+    # Layered calico-resync config: route logs to a file we can tail for
+    # the endpoints-phase marker, and bump the DB connection pool so the
+    # large populated baseline doesn't exhaust the default.
+    extra_conf = os.environ.get(
+        "RESYNC_CALICO_RESYNC_CONF", "/tmp/calico-resync-conc.ini"
+    )
+    log_file = os.environ.get("RESYNC_CALICO_RESYNC_LOG", "/tmp/calico-resync-conc.log")
+    with open(extra_conf, "w") as f:
+        f.write("[DEFAULT]\n")
+        f.write("log_file = %s\n" % log_file)
+        f.write("use_stderr = False\n")
+        f.write("[database]\n")
+        f.write("max_pool_size = 50\n")
+        f.write("max_overflow = 200\n")
+
+    failed = False
+    network = subnet = sg = host = None
+    try:
+        network, subnet, sg, host = populate(conn, db_args, populate_scale)
+        for scen in scenarios:
+            try:
+                if scen == "on_demand":
+                    result = scenario_on_demand(
+                        conn,
+                        network,
+                        subnet,
+                        sg,
+                        host,
+                        args.neutron_conf,
+                        extra_conf,
+                        log_file,
+                        test_ports,
+                        per_item_delay_ms,
+                    )
+                elif scen == "startup":
+                    result = scenario_startup(
+                        conn,
+                        network,
+                        subnet,
+                        sg,
+                        host,
+                        args.neutron_conf,
+                        test_ports,
+                        per_item_delay_ms,
+                        populate_scale,
+                    )
+                else:
+                    LOG.warning("Unknown scenario %r, skipping", scen)
+                    continue
+                passed = print_summary(result, ratio_limit)
+                if not passed:
+                    failed = True
+            except Exception:
+                LOG.exception("Scenario %s failed with exception", scen)
+                failed = True
+    finally:
+        scale.cleanup_neutron(conn)
+        scale.delete_fake_agents(db_args)
+        scale.cleanup_etcd(etcd_client)
+
+    LOG.info(
+        "Resync concurrency test finished at %s",
+        datetime.datetime.utcnow().isoformat(),
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/networking-calico/devstack/resync_concurrency_test.py
+++ b/networking-calico/devstack/resync_concurrency_test.py
@@ -143,28 +143,28 @@ def median(measurements):
     return statistics.median(m["elapsed_secs"] for m in measurements)
 
 
-def _take_warmup_then_measure(conn, network, subnet, sg, host, count):
+def _take_warmup_then_measure(conn, network, subnet, sg, host, count, label):
     """Create one warm-up port (discarded from the median) then ``count``
-    measured ports.  Returns ``(warmup_list, measured_list)``.
+    measured ports under ``label``.  Returns ``(warmup_list, measured_list)``.
 
-    Discarding one warm-up sample matters most in the startup scenario,
-    where the API workers have just come back up after a neutron-server
-    restart and the first port-create pays for cold DB-connection pools
-    and plugin caches.  We do it consistently in both scenarios so the
-    reported medians remain directly comparable.  The warm-up sample is
-    still included in the timing summary so a reviewer can see what it
-    cost.
+    Warm-up discard matters most in the startup scenario, where the API
+    workers have just come back up after a neutron-server restart and the
+    first port-create pays for cold DB-connection pools and plugin caches.
+    Applied symmetrically to both baseline and in-resync bursts so the two
+    medians come from comparably-trimmed samples -- trimming only one side
+    would bias the ``in_resync / baseline`` ratio (typically toward making
+    the test more lenient, since the first sample is usually the slowest).
+    The warm-up sample is still included in the timing summary so a
+    reviewer can see what it cost.
     """
-    warmup = measure_port_create_burst(
-        conn, network, subnet, sg, host, 1, "in_resync_warmup"
-    )
+    warmup_label = "%s_warmup" % label
+    warmup = measure_port_create_burst(conn, network, subnet, sg, host, 1, warmup_label)
     LOG.info(
-        "In-resync warm-up port (discarded from median): %.3fs",
+        "%s warm-up port (discarded from median): %.3fs",
+        label,
         warmup[0]["elapsed_secs"],
     )
-    measured = measure_port_create_burst(
-        conn, network, subnet, sg, host, count, "in_resync"
-    )
+    measured = measure_port_create_burst(conn, network, subnet, sg, host, count, label)
     return warmup, measured
 
 
@@ -173,10 +173,14 @@ def _take_warmup_then_measure(conn, network, subnet, sg, host, count):
 # ---------------------------------------------------------------------------
 
 
-# Marker logged by ResourceSyncer when the endpoints phase begins.  Test waits
-# for this in the calico-resync log file before firing the in-resync burst,
-# so we know the per-item delay loop is actively running.
-_ENDPOINTS_PHASE_MARKER = "Starting resync for WorkloadEndpoint"
+# Marker logged by ResourceSyncer at the top of the WorkloadEndpoint resync's
+# compare loop -- i.e. AFTER the etcd read and the CONTEXT_WRITER-held neutron
+# read, immediately before the per-item delay loop begins.  The test waits for
+# this line so the in-resync burst lands inside the stretched delay window,
+# not during the (held writer) neutron read that precedes it.  Pinning the
+# marker to the compare-loop start is what lets the in-resync median actually
+# reflect the stretched phase the test is trying to measure.
+_ENDPOINTS_PHASE_MARKER = "Resync for WorkloadEndpoint: starting compare loop"
 
 
 def wait_for_endpoints_phase(log_path, deadline_secs):
@@ -213,12 +217,15 @@ def scenario_on_demand(
     # Truncate the log file so the marker poll starts from a known state.
     open(log_file, "w").close()
 
-    # Baseline: measure without a concurrent resync.
+    # Baseline: measure without a concurrent resync.  Take a warm-up port
+    # first and discard it from the median, so the baseline is trimmed the
+    # same way the in-resync burst is (see _take_warmup_then_measure).
     LOG.info("Baseline: creating %d ports, no concurrent resync", test_ports)
-    baseline = measure_port_create_burst(
+    baseline_warmup, baseline_main = _take_warmup_then_measure(
         conn, network, subnet, sg, host, test_ports, "baseline"
     )
-    baseline_median = median(baseline)
+    baseline = baseline_warmup + baseline_main
+    baseline_median = median(baseline_main)
     LOG.info("Baseline median: %.3fs", baseline_median)
 
     # Run calico-resync with the per-item delay.  Capture its JSON output for
@@ -240,7 +247,12 @@ def scenario_on_demand(
     ]
     LOG.info("Starting calico-resync (per-item delay=%dms)", per_item_delay_ms)
     LOG.info("  %s", " ".join(cmd))
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # Discard stdout/stderr rather than piping them: with PIPE and no reader,
+    # a Python warning or stray traceback could fill the ~64KB OS pipe buffer
+    # and deadlock proc.wait().  All oslo logging is routed to log_file via
+    # extra_conf, and the JSON ResyncResult is written to --output, so nothing
+    # we care about is being thrown away.
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     try:
         if not wait_for_endpoints_phase(log_file, deadline_secs=60):
@@ -254,7 +266,7 @@ def scenario_on_demand(
         # phase.  We always discard the first sample as a warm-up (see
         # _take_warmup_then_measure for rationale).
         warmup, in_resync_main = _take_warmup_then_measure(
-            conn, network, subnet, sg, host, test_ports
+            conn, network, subnet, sg, host, test_ports, "in_resync"
         )
         in_resync = warmup + in_resync_main
         in_resync_median = median(in_resync_main)
@@ -332,7 +344,12 @@ def wait_for_log_text_in_journal(text, since_dt, deadline_secs):
 
     ``since_dt`` is a naive ``datetime.datetime`` in UTC; we format it as
     ``YYYY-MM-DD HH:MM:SS`` for ``journalctl --since``, which doesn't
-    accept ISO 8601's ``T``/``Z`` punctuation.
+    accept ISO 8601's ``T``/``Z`` punctuation.  ``--utc`` tells journalctl
+    to interpret ``--since`` (and display its output) in UTC, so the test
+    runs identically on UTC and non-UTC hosts -- without ``--utc`` the
+    bare timestamp is interpreted as local time, which off a non-UTC box
+    would either match nothing (timestamp in the future) or a prior run's
+    marker (timestamp too far back).
     """
     since_journal = since_dt.strftime("%Y-%m-%d %H:%M:%S")
     t_end = time.monotonic() + deadline_secs
@@ -343,6 +360,7 @@ def wait_for_log_text_in_journal(text, since_dt, deadline_secs):
                 "journalctl",
                 "-u",
                 "devstack@q-svc",
+                "--utc",
                 "--since",
                 since_journal,
                 "-q",
@@ -403,7 +421,7 @@ def scenario_startup(
         # endpoints phase.  We always discard the first sample as a warm-up
         # (see _take_warmup_then_measure for rationale).
         warmup, in_resync_main = _take_warmup_then_measure(
-            conn, network, subnet, sg, host, test_ports
+            conn, network, subnet, sg, host, test_ports, "in_resync"
         )
         in_resync = warmup + in_resync_main
         in_resync_median = median(in_resync_main)
@@ -433,12 +451,14 @@ def scenario_startup(
         )
 
     # Baseline AFTER the resync has finished -- the cleanest "no concurrent
-    # resync" state we can get without another restart.
+    # resync" state we can get without another restart.  Symmetric warm-up
+    # with the in-resync burst (see _take_warmup_then_measure).
     LOG.info("Baseline: creating %d ports, no concurrent resync", test_ports)
-    baseline = measure_port_create_burst(
+    baseline_warmup, baseline_main = _take_warmup_then_measure(
         conn, network, subnet, sg, host, test_ports, "baseline"
     )
-    baseline_median = median(baseline)
+    baseline = baseline_warmup + baseline_main
+    baseline_median = median(baseline_main)
     LOG.info("Baseline median: %.3fs", baseline_median)
 
     return {

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/endpoints.py
@@ -80,8 +80,12 @@ NETWORK_NAME_MAX_LENGTH = datamodel_v3.SANITIZE_LABEL_MAX_LENGTH
 
 
 class WorkloadEndpointSyncer(ResourceSyncer):
-    def __init__(self, db, policy_syncer):
-        super(WorkloadEndpointSyncer, self).__init__(db, "WorkloadEndpoint")
+    def __init__(self, db, policy_syncer, inject_per_item_delay_ms=0):
+        super(WorkloadEndpointSyncer, self).__init__(
+            db,
+            "WorkloadEndpoint",
+            inject_per_item_delay_ms=inject_per_item_delay_ms,
+        )
         self.policy_syncer = policy_syncer
         self.keystone = make_keystone_client()
         self.proj_data_cache = {}

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -161,6 +161,7 @@ calico_opts = [
     cfg.IntOpt(
         "startup_resync_inject_per_item_delay_ms",
         default=0,
+        min=0,
         help=(
             "TEST-ONLY: when non-zero, the start-of-day resync sleeps "
             "this many milliseconds between every step of its endpoints "

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -158,6 +158,18 @@ calico_opts = [
         ),
         help="Deprecated and unused.  Retained to avoid neutron.conf errors.",
     ),
+    cfg.IntOpt(
+        "startup_resync_inject_per_item_delay_ms",
+        default=0,
+        help=(
+            "TEST-ONLY: when non-zero, the start-of-day resync sleeps "
+            "this many milliseconds between every step of its endpoints "
+            "compare loop.  Used by the resync-concurrency test "
+            "(CORE-12037) to stretch the resync to a known duration "
+            "while dynamic operations are timed against it.  Never set "
+            "this in production."
+        ),
+    ),
 ]
 cfg.CONF.register_opts(calico_opts, "calico")
 
@@ -1268,7 +1280,12 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         self.db = None
         self._get_db()
 
-        result = resync.Scope(self.db).run()
+        result = resync.Scope(
+            self.db,
+            inject_per_item_delay_ms=(
+                cfg.CONF.calico.startup_resync_inject_per_item_delay_ms
+            ),
+        ).run()
         if result.ok:
             LOG.info("One-shot resync done: %s", result.to_dict())
         else:

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
@@ -88,9 +88,13 @@ class ResourceSyncer(object):
     when the syncer read the incorrect data.
     """
 
-    def __init__(self, db, resource_kind):
+    def __init__(self, db, resource_kind, inject_per_item_delay_ms=0):
         self.db = db
         self.resource_kind = resource_kind
+        # Test-only: when non-zero, sleep this many ms after each
+        # iteration of the compare loop below.  Used by the resync-
+        # concurrency test (CORE-12037).  Always 0 in production.
+        self._inject_per_item_delay_secs = inject_per_item_delay_ms / 1000.0
 
     def resync(self, context, scope):
         """Reconcile this resource type's etcd state with Neutron.
@@ -243,6 +247,8 @@ class ResourceSyncer(object):
                         name,
                     )
             # else: name was in scope but neither side has it -- nothing to do.
+            if self._inject_per_item_delay_secs:
+                time.sleep(self._inject_per_item_delay_secs)
         t_compare = time.monotonic()
 
         # Delete any legacy etcd data for this kind of resource.  Only makes sense in

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
@@ -91,10 +91,16 @@ class ResourceSyncer(object):
     def __init__(self, db, resource_kind, inject_per_item_delay_ms=0):
         self.db = db
         self.resource_kind = resource_kind
-        # Test-only: when non-zero, sleep this many ms after each
+        # Test-only: when positive, sleep this many ms after each
         # iteration of the compare loop below.  Used by the resync-
-        # concurrency test (CORE-12037).  Always 0 in production.
-        self._inject_per_item_delay_secs = inject_per_item_delay_ms / 1000.0
+        # concurrency test (CORE-12037).  Always 0 in production.  Clamp
+        # to 0 defensively: time.sleep() raises ValueError on a negative
+        # argument, which would silently turn a misconfigured test knob
+        # into a resync failure.  The two call sites (mech_calico's
+        # IntOpt and the calico-resync --inject-per-item-delay-ms flag)
+        # both have their own non-negativity checks, but a single guard
+        # here covers any future caller too.
+        self._inject_per_item_delay_secs = max(0, inject_per_item_delay_ms) / 1000.0
 
     def resync(self, context, scope):
         """Reconcile this resource type's etcd state with Neutron.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/syncer.py
@@ -179,6 +179,12 @@ class ResourceSyncer(object):
         def _iter_order(n):
             return (0 if n.startswith("lm ") else 1, n)
 
+        # Compare-loop marker.  The resync-concurrency test (CORE-12037) waits
+        # for this line in the resync log before firing its in-resync burst, so
+        # the burst lands inside the test-injected per-item delay window rather
+        # than during the etcd read or the CONTEXT_WRITER-held neutron read.
+        LOG.info("Resync for %s: starting compare loop", self.resource_kind)
+
         for name in sorted(set(etcd_map) | set(neutron_map), key=_iter_order):
             in_etcd = name in etcd_map
             in_neutron = name in neutron_map

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -368,6 +368,14 @@ class TestPluginEtcdBase(_TestEtcdBase):
         lib.m_oslo_config.cfg.CONF.calico.ingress_burst_packets = 0
         lib.m_oslo_config.cfg.CONF.calico.egress_burst_packets = 0
         lib.m_oslo_config.cfg.CONF.calico.startup_resync = "always"
+        # Set the resync-concurrency injection knob explicitly to 0 so the
+        # syncer's ``max(0, inject_per_item_delay_ms)`` clamp gets a real
+        # int -- without this, the attribute is the default MagicMock,
+        # which raises TypeError on `>` comparison with int.  (Before the
+        # clamp landed, the auto-generated MagicMock.__float__ silently
+        # coerced this into a real time.sleep(1.0) per compare-loop item,
+        # adding ~70s of dead sleep to the suite.)
+        lib.m_oslo_config.cfg.CONF.calico.startup_resync_inject_per_item_delay_ms = 0
         calico_config._reset_globals()
         datamodel_v2._reset_globals()
 

--- a/networking-calico/networking_calico/resync/cli.py
+++ b/networking-calico/networking_calico/resync/cli.py
@@ -125,6 +125,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "harder to parse cleanly."
         ),
     )
+    parser.add_argument(
+        "--inject-per-item-delay-ms",
+        type=int,
+        default=0,
+        metavar="MS",
+        help=argparse.SUPPRESS,  # test-only knob; CORE-12037
+    )
     return parser
 
 
@@ -185,6 +192,7 @@ def main(argv=None) -> int:
         ports=args.ports,
         security_groups=args.security_groups,
         include_security_groups_for_ports=args.include_sgs_for_ports,
+        inject_per_item_delay_ms=args.inject_per_item_delay_ms,
     ).run()
 
     if args.output:

--- a/networking-calico/networking_calico/resync/cli.py
+++ b/networking-calico/networking_calico/resync/cli.py
@@ -127,12 +127,21 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--inject-per-item-delay-ms",
-        type=int,
+        type=_non_negative_int,
         default=0,
         metavar="MS",
         help=argparse.SUPPRESS,  # test-only knob; CORE-12037
     )
     return parser
+
+
+def _non_negative_int(s):
+    """argparse type: reject negative values up-front rather than letting
+    them flow into the ``time.sleep`` call in the syncer's compare loop."""
+    v = int(s)
+    if v < 0:
+        raise argparse.ArgumentTypeError("must be >= 0, got %d" % v)
+    return v
 
 
 def main(argv=None) -> int:

--- a/networking-calico/networking_calico/resync/scope.py
+++ b/networking-calico/networking_calico/resync/scope.py
@@ -107,6 +107,7 @@ class Scope:
         ports=None,
         security_groups=None,
         include_security_groups_for_ports=False,
+        inject_per_item_delay_ms=0,
     ):
         self.db = db
         self.driver = driver
@@ -116,6 +117,12 @@ class Scope:
         self.ports = set(ports or [])
         self.security_groups = set(security_groups or [])
         self.include_security_groups_for_ports = include_security_groups_for_ports
+        # Test-only: when non-zero, sleep this many ms between every step of
+        # the endpoints-phase compare loop.  Used by the resync-concurrency
+        # test (CORE-12037) to stretch the endpoints phase to a known
+        # duration so dynamic operations can be timed against it.  Always 0
+        # in production.
+        self.inject_per_item_delay_ms = inject_per_item_delay_ms
 
     def all(self):
         return not (self.networks or self.subnets or self.ports or self.security_groups)
@@ -147,7 +154,11 @@ class Scope:
             else:
                 subnet_syncer = SubnetSyncer(self.db)
                 policy_syncer = PolicySyncer(self.db)
-                endpoint_syncer = WorkloadEndpointSyncer(self.db, policy_syncer)
+                endpoint_syncer = WorkloadEndpointSyncer(
+                    self.db,
+                    policy_syncer,
+                    inject_per_item_delay_ms=self.inject_per_item_delay_ms,
+                )
 
             phases["expand"] = _run_phase(self.expand)
             phases["subnets"] = _run_phase(


### PR DESCRIPTION
Add a DevStack-side test that demonstrates a long-running resync does not meaningfully block dynamic port creation, plus the test-only driver knobs it needs to drive a deterministic test window.

Driver-side knobs (production code, default 0, never set in production):

* ``--inject-per-item-delay-ms`` hidden flag on ``calico-resync``.
* ``[calico] startup_resync_inject_per_item_delay_ms`` config option for the start-of-day resync.

Both flow through to ``Scope.__init__``, which passes the value to ``WorkloadEndpointSyncer``'s constructor.  ``ResourceSyncer`` then sleeps that many milliseconds after every iteration of its compare loop -- so the endpoints phase (which dominates real resync time anyway) is stretched out to a known duration of ``populate_scale * per_item_delay_ms``, giving the test a stable in-resync window.

Test script (``devstack/resync_concurrency_test.py``):

* Reuses ``resync_scale_test.py``'s populate / cleanup helpers via ``import resync_scale_test as scale``.
* Two scenarios:
  - ``on_demand`` runs ``calico-resync`` with the inject flag, polls its log file for the ``"Starting resync for WorkloadEndpoint"`` marker, then creates ``test_ports`` ports back-to-back through the Neutron REST API and times each API call.  Compares the in-resync median against a baseline median measured before the resync started.
  - ``startup`` writes the inject knob into ``[calico]`` via ``crudini``, restarts neutron-server with ``systemctl restart devstack@q-svc``, polls ``journalctl`` for the same endpoints-phase marker, then fires the same in-resync burst against the API workers while the resync worker is busy in its stretched endpoints phase.  Baseline runs after the resync completes.

* Each scenario asserts ``in_resync_median <= baseline_median * 2.0`` (configurable via ``RESYNC_CONCURRENCY_RATIO_LIMIT``).  The summary prints each in-resync port's timestamp between the resync's own ``started_at`` and ``finished_at``, so the overlap is visible directly to a reviewer.

* Tunable via ``RESYNC_CONCURRENCY_POPULATE_SCALE`` (default 1000), ``RESYNC_CONCURRENCY_TEST_PORTS`` (5), ``RESYNC_CONCURRENCY_PER_ITEM_DELAY_MS`` (50), ``RESYNC_CONCURRENCY_RATIO_LIMIT`` (2.0), and ``RESYNC_CONCURRENCY_SCENARIOS`` (default ``on_demand,startup``).

The startup scenario relies on the ``stack`` user having passwordless sudo for ``systemctl restart devstack@q-svc``, ``journalctl``, and ``crudini``, which DevStack's ``create-stack-user.sh`` already sets up.