### PR TITLE
Add KubeVirt e2e jobs to dataplane and release pipelines

### DIFF
--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -697,6 +697,26 @@ blocks:
       secrets:
         - name: dynamo-read-creds
 
+  - name: KubeVirt e2e tests
+    dependencies: []
+    task:
+      jobs:
+        - name: KubeVirt IP persistence and live migration
+          execution_time_limit:
+            hours: 4
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: K8S_VERSION
+              value: "stable-1.35"
+      env_vars:
+        - name: PROVISIONER
+          value: "gcp-kubeadm"
+        - name: NUM_KUBEVIRT_VMS
+          value: "2"
+        - name: E2E_TEST_CONFIG
+          value: "e2e/config/gcp-kubevirt.yaml"
+
 promotions:
   - name: Cleanup jobs
     pipeline_file: cleanup.yml

--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -794,6 +794,28 @@ blocks:
             - name: USE_HASH_RELEASE
               value: "true"
 
+  - name: KubeVirt e2e tests
+    dependencies: []
+    task:
+      jobs:
+        - name: KubeVirt IP persistence and live migration
+          execution_time_limit:
+            hours: 4
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: K8S_VERSION
+              value: "stable-1.35"
+      env_vars:
+        - name: PROVISIONER
+          value: "gcp-kubeadm"
+        - name: INSTALLER
+          value: "operator"
+        - name: NUM_KUBEVIRT_VMS
+          value: "2"
+        - name: E2E_TEST_CONFIG
+          value: "e2e/config/gcp-kubevirt.yaml"
+
 promotions:
   - name: Cleanup jobs
     pipeline_file: cleanup.yml

--- a/.semaphore/end-to-end/pipelines/nftables.yml
+++ b/.semaphore/end-to-end/pipelines/nftables.yml
@@ -202,6 +202,26 @@ blocks:
             - name: ENCAPSULATION_TYPE_V6
               value: "None"
 
+  - name: KubeVirt e2e tests
+    dependencies: []
+    task:
+      jobs:
+        - name: KubeVirt IP persistence and live migration
+          execution_time_limit:
+            hours: 4
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: K8S_VERSION
+              value: "stable-1.35"
+      env_vars:
+        - name: PROVISIONER
+          value: "gcp-kubeadm"
+        - name: NUM_KUBEVIRT_VMS
+          value: "2"
+        - name: E2E_TEST_CONFIG
+          value: "e2e/config/gcp-kubevirt.yaml"
+
 promotions:
   - name: Cleanup jobs
     pipeline_file: cleanup.yml

--- a/.semaphore/end-to-end/pipelines/patch-verification.yml
+++ b/.semaphore/end-to-end/pipelines/patch-verification.yml
@@ -498,6 +498,28 @@ blocks:
             # - name: ENABLE_NODE_LOCAL_DNS_CACHE # nodelocaldns - doesn't appear to work with RKE2
             #   value: "true"
 
+  - name: "KubeVirt e2e tests"
+    dependencies: []
+    task:
+      jobs:
+        - name: KubeVirt IP persistence and live migration
+          execution_time_limit:
+            hours: 4
+          commands:
+            - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
+          env_vars:
+            - name: K8S_VERSION
+              value: "stable-1.35"
+      env_vars:
+        - name: PROVISIONER
+          value: "gcp-kubeadm"
+        - name: INSTALLER
+          value: "operator"
+        - name: NUM_KUBEVIRT_VMS
+          value: "2"
+        - name: E2E_TEST_CONFIG
+          value: "e2e/config/gcp-kubevirt.yaml"
+
   # operator, calicocni, 4.18, amd64, bpf, ipv4, openshift, RHCOS, kdd, n/a, no-kube-proxy, autohep
   # Openshift needs f1-standard-2 (more disk) so it lives in its own block.
   - name: "Openshift"

--- a/.semaphore/end-to-end/scripts/phases/configure.sh
+++ b/.semaphore/end-to-end/scripts/phases/configure.sh
@@ -2,14 +2,14 @@
 # configure.sh - configure test environment after cluster install.
 #
 # Sets PATH to include the bz-provisioned bin dir, exports external-node
-# credentials when ENABLE_EXTERNAL_NODE=true, propagates IPAM test config,
-# and applies the optional failsafe patch.
+# credentials when external_ip and external_key files exist in BZ_LOCAL_DIR
+# (written by bz install or gkm), propagates IPAM test config, and applies
+# the optional failsafe patch.
 #
 # Required env:
 #   BZ_LOCAL_DIR
 # Optional env:
-#   ENABLE_EXTERNAL_NODE, IPAM_TEST_POOL_SUBNET, FAILSAFE_443,
-#   K8S_E2E_DOCKER_EXTRA_FLAGS
+#   IPAM_TEST_POOL_SUBNET, FAILSAFE_443, K8S_E2E_DOCKER_EXTRA_FLAGS
 #
 # Exports consumed by later phases:
 #   PATH, EXT_USER, EXT_IP, EXT_KEY, K8S_E2E_DOCKER_EXTRA_FLAGS
@@ -20,7 +20,7 @@ if [[ -z "${BZ_LOCAL_DIR}" ]]; then echo "[ERROR] BZ_LOCAL_DIR is required but n
 
 export PATH=$PATH:${BZ_LOCAL_DIR}/bin
 
-if [[ "${ENABLE_EXTERNAL_NODE}" == "true" ]]; then
+if [[ -f "${BZ_LOCAL_DIR}/external_ip" ]] && [[ -f "${BZ_LOCAL_DIR}/external_key" ]]; then
   export EXT_USER=ubuntu
   EXT_IP=$(cat "${BZ_LOCAL_DIR}/external_ip")
   export EXT_IP

--- a/e2e/config/gcp-kubevirt.yaml
+++ b/e2e/config/gcp-kubevirt.yaml
@@ -1,0 +1,20 @@
+# gcp-kubevirt.yaml - GCP kubeadm with KubeVirt VMs.
+#
+# Referenced by KubeVirt e2e blocks in the per-dataplane and release
+# pipelines (iptables.yml, bpf.yml, nftables.yml, patch-verification.yml,
+# upgrade.yml, certification.yml). Runs Feature:KubeVirt tests on a GCP
+# kubeadm cluster with nested virtualization and KubeVirt.
+
+include:
+  - Feature:KubeVirt
+
+exclude:
+  labels:
+    - label: Slow
+      reason: "long-running tests not suitable for CI"
+
+    - label: Disruptive
+      reason: "breaks cluster state for other parallel tests"
+
+    - label: RequiresMockVirt
+      reason: "requires mock virtualization, not real KubeVirt"


### PR DESCRIPTION
Add Feature:KubeVirt e2e test blocks (IP persistence, live migration) to the per-dataplane and release pipelines

Each block provisions a GCP kubeadm cluster with nested virtualization and KubeVirt VMs, then runs the `Feature:KubeVirt` e2e tests. DATAPLANE is not set explicitly in the KubeVirt blocks — it inherits from each pipeline's global config (or defaults to `CalicoIptables` via the shared prologue).

**Pipelines updated:**
- `iptables.yml`
- `bpf.yml`
- `nftables.yml`
- `patch-verification.yml`


**Other changes:**
- New `e2e/config/gcp-kubevirt.yaml` test config (includes `Feature:KubeVirt`, excludes `Slow`, `Disruptive`, `RequiresMockVirt`)
- `configure.sh`: switch external-node credential detection from `ENABLE_EXTERNAL_NODE` env var to file-based detection (`external_ip`/`external_key` in `BZ_LOCAL_DIR`), which works with both `bz install` and `gkm` provisioners


**Release note:**
```release-note
None
```