### PR TITLE
wait for Azure VM extensions in Windows FV bring-up

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -342,8 +342,13 @@ blocks:
     # Publishing to Docker Hub happens in a separate post-build promotion
     # (push-images/nft-rpms.yml) so PR workflows never receive the push credential.
     #
-    # Consumers (untolerated gcloud cp): node, istio. Path forms cover the
-    # secondary-CHANGE_IN(istio) gap that misses istio/patches/*.
+    # Consumers (untolerated gcloud cp): "Build: node image" (10-prerequisites.yml),
+    # "Node: multi-arch build" (20-node.yml), "Istio" (20-istio.yml). This
+    # block's CHANGE_IN must be a superset of the union of all three consumer
+    # triggers — otherwise the consumer fires, the producer skips, and the
+    # consumer hard-fails on `gcloud storage cp: URL matched no objects`. The
+    # felix / process/testing / libcalico-stacktrace / 20-felix.yml triggers
+    # mirror "Build: node image" so a win-fv-only PR also rebuilds the RPMs.
     run:
       when: "true"
     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -342,8 +342,13 @@ blocks:
     # Publishing to Docker Hub happens in a separate post-build promotion
     # (push-images/nft-rpms.yml) so PR workflows never receive the push credential.
     #
-    # Consumers (untolerated gcloud cp): node, istio. Path forms cover the
-    # secondary-CHANGE_IN(istio) gap that misses istio/patches/*.
+    # Consumers (untolerated gcloud cp): "Build: node image" (10-prerequisites.yml),
+    # "Node: multi-arch build" (20-node.yml), "Istio" (20-istio.yml). This
+    # block's CHANGE_IN must be a superset of the union of all three consumer
+    # triggers — otherwise the consumer fires, the producer skips, and the
+    # consumer hard-fails on `gcloud storage cp: URL matched no objects`. The
+    # felix / process/testing / libcalico-stacktrace / 20-felix.yml triggers
+    # mirror "Build: node image" so a win-fv-only PR also rebuilds the RPMs.
     run:
       when: >-
         change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml',
@@ -352,6 +357,7 @@ blocks:
         '/.semaphore/semaphore.yml.d/09-blocks.yml',
         '/.semaphore/semaphore.yml.d/99-after_pipeline.yml',
         '/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml',
+        '/.semaphore/semaphore.yml.d/blocks/20-felix.yml',
         '/Makefile',
         '/api/pkg/apis/projectcalico/v3/*.go',
         '/api/pkg/defaults/*.go',
@@ -381,6 +387,7 @@ blocks:
         '/confd/pkg/resource/template/*.go',
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
+        '/felix/',
         '/felix/aws/*.go',
         '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
@@ -391,6 +398,7 @@ blocks:
         '/felix/bpf/asm/*.go',
         '/felix/bpf/bpfdefs/*.go',
         '/felix/bpf/bpfmap/*.go',
+        '/felix/bpf/cmd/*.go',
         '/felix/bpf/conntrack/*.go',
         '/felix/bpf/conntrack/cleanupv1/*.go',
         '/felix/bpf/conntrack/timeouts/*.go',
@@ -424,7 +432,10 @@ blocks:
         '/felix/bpf/xdp/*.go',
         '/felix/cachingmap/*.go',
         '/felix/calc/*.go',
+        '/felix/cmd/calico-bpf/*.go',
         '/felix/cmd/calico-bpf/commands/*.go',
+        '/felix/cmd/calico-felix-docgen/*.go',
+        '/felix/cmd/calico-felix/*.go',
         '/felix/collector/*.go',
         '/felix/collector/flowlog/*.go',
         '/felix/collector/goldmane/*.go',
@@ -450,14 +461,22 @@ blocks:
         '/felix/dispatcher/*.go',
         '/felix/environment/*.go',
         '/felix/ethtool/*.go',
+        '/felix/fv/cgroup/*.go',
+        '/felix/fv/connectivity/*.go',
+        '/felix/fv/pktgen/*.go',
+        '/felix/fv/test-connection/*.go',
+        '/felix/fv/test-workload/*.go',
+        '/felix/fv/utils/*.go',
         '/felix/generictables/*.go',
         '/felix/idalloc/*.go',
+        '/felix/idalloc/collision/*.go',
         '/felix/ifacemonitor/*.go',
         '/felix/ip/*.go',
         '/felix/ipsets/*.go',
         '/felix/iptables/*.go',
         '/felix/iptables/cmdshim/*.go',
         '/felix/jitter/*.go',
+        '/felix/k8sfv/*.go',
         '/felix/k8sutils/*.go',
         '/felix/labelindex/*.go',
         '/felix/labelindex/ipsetmember/*.go',
@@ -555,6 +574,7 @@ blocks:
         '/libcalico-go/lib/selector/parser/*.go',
         '/libcalico-go/lib/selector/tokenizer/*.go',
         '/libcalico-go/lib/set/*.go',
+        '/libcalico-go/lib/testutils/stacktrace/',
         '/libcalico-go/lib/validator/v1/*.go',
         '/libcalico-go/lib/validator/v3/*.go',
         '/libcalico-go/lib/watch/*.go',
@@ -562,13 +582,20 @@ blocks:
         '/metadata.mk',
         '/node/',
         '/node/**',
+        '/node/pkg/lifecycle/utils/*.go',
         '/pkg/buildinfo/*.go',
         '/pod2daemon/binder/*.go',
+        '/process/testing/aso',
+        '/process/testing/util',
+        '/process/testing/winfv-felix',
         '/typha/pkg/discovery/*.go',
         '/typha/pkg/syncclient/*.go',
         '/typha/pkg/syncclientutils/*.go',
         '/typha/pkg/syncproto/*.go',
         '/typha/pkg/tlsutils/*.go',
+        'felix/**/*Dockerfile*',
+        'felix/Makefile',
+        'felix/deps.txt',
         'istio/**/*Dockerfile*',
         'istio/Makefile',
         'istio/deps.txt'],

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -137,10 +137,15 @@
   # Publishing to Docker Hub happens in a separate post-build promotion
   # (push-images/nft-rpms.yml) so PR workflows never receive the push credential.
   #
-  # Consumers (untolerated gcloud cp): node, istio. Path forms cover the
-  # secondary-CHANGE_IN(istio) gap that misses istio/patches/*.
+  # Consumers (untolerated gcloud cp): "Build: node image" (10-prerequisites.yml),
+  # "Node: multi-arch build" (20-node.yml), "Istio" (20-istio.yml). This
+  # block's CHANGE_IN must be a superset of the union of all three consumer
+  # triggers — otherwise the consumer fires, the producer skips, and the
+  # consumer hard-fails on `gcloud storage cp: URL matched no objects`. The
+  # felix / process/testing / libcalico-stacktrace / 20-felix.yml triggers
+  # mirror "Build: node image" so a win-fv-only PR also rebuilds the RPMs.
   run:
-    when: "${CHANGE_IN(node,istio,non-go:/node/,non-go:/istio/,non-go:/hack/rpms/nftables/)}"
+    when: "${CHANGE_IN(node,istio,felix,non-go:/node/,non-go:/istio/,non-go:/felix/,non-go:/hack/rpms/nftables/,non-go:/libcalico-go/lib/testutils/stacktrace/,non-go:/.semaphore/semaphore.yml.d/blocks/20-felix.yml,non-go:/process/testing/aso,non-go:/process/testing/util,non-go:/process/testing/winfv-felix)}"
   dependencies: []
   task:
     agent:

--- a/process/testing/aso/infra/templates/vmss-linux.yaml
+++ b/process/testing/aso/infra/templates/vmss-linux.yaml
@@ -66,17 +66,41 @@ spec:
       set -eu -o pipefail
       echo "Installing containerd..."
 
+      # Wait for cloud-init to fully finish before touching apt — on first
+      # boot, cloud-init / unattended-upgrades hold /var/lib/dpkg/lock-frontend
+      # and trip an apt lock-timeout that aborts the rest of this script.
+      cloud-init status --wait || true
+
+      # Stop and mask the apt timers and unattended-upgrades so they cannot
+      # re-acquire the dpkg lock mid-install. Lenient: missing units on
+      # leaner images must not abort set -e.
+      systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service 2>/dev/null || true
+      systemctl mask apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service 2>/dev/null || true
+
+      # Retry apt phases. Azure CustomScript extensions do not auto-retry,
+      # and set -e makes a single transient apt/network failure terminal.
+      apt_retry() {
+        local n=3 i
+        for i in $(seq 1 $n); do
+          if "$@"; then return 0; fi
+          echo "Command failed (attempt $i/$n): $* - retrying in 20s..."
+          sleep 20
+        done
+        echo "Command failed after $n attempts: $*"
+        return 1
+      }
+
       # Update package list
-      apt-get -o DPkg::Lock::Timeout=60 update
+      apt_retry apt-get -o DPkg::Lock::Timeout=180 update
 
       # Install prerequisites
-      apt-get -o DPkg::Lock::Timeout=60 install -y apt-transport-https ca-certificates curl gnupg lsb-release
+      apt_retry apt-get -o DPkg::Lock::Timeout=180 install -y apt-transport-https ca-certificates curl gnupg lsb-release
 
       # Install containerd from the Docker repo
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --no-tty --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-      apt-get -o DPkg::Lock::Timeout=60 update
-      apt-get -o DPkg::Lock::Timeout=60 install -y containerd.io
+      apt_retry apt-get -o DPkg::Lock::Timeout=180 update
+      apt_retry apt-get -o DPkg::Lock::Timeout=180 install -y containerd.io
 
       # Configure containerd for Kubernetes
       mkdir -p /etc/containerd

--- a/process/testing/aso/vmss.sh
+++ b/process/testing/aso/vmss.sh
@@ -197,6 +197,38 @@ EOF
     return 1
   fi
 
+  # VirtualMachine Ready means Azure provisioned the VM — NOT that the
+  # CustomScript extensions that install containerd (Linux) or configure
+  # OpenSSH / runtime (Windows) have finished. Without an explicit gate
+  # here, downstream scripts race the extension and time out 5+ minutes
+  # later inside the VM with no useful diagnostic.
+  log_info "Waiting for VM extensions to finish reconciling..."
+  local ext_resources=()
+  for ((i=1; i<=${LINUX_NODE_COUNT}; i++)); do
+    ext_resources+=("vm-linux-${i}-containerd")
+  done
+  for ((i=1; i<=${WINDOWS_NODE_COUNT}; i++)); do
+    ext_resources+=("vm-windows-${i}-openssh")
+    ext_resources+=("vm-windows-${i}-customextension")
+  done
+
+  local failed_exts=()
+  for ext in "${ext_resources[@]}"; do
+    if ! wait_for_aso_resource "virtualmachinesextension" "$ext" "aso" "$ASO_TIMEOUT_DEFAULT"; then
+      log_error "VirtualMachinesExtension $ext failed to become ready"
+      failed_exts+=("$ext")
+      ${KUBECTL} describe virtualmachinesextension "$ext" -n aso | tail -30
+    else
+      log_info "VirtualMachinesExtension $ext is ready"
+    fi
+  done
+
+  if [[ ${#failed_exts[@]} -gt 0 ]]; then
+    log_error "Failed VirtualMachinesExtension resources: ${failed_exts[*]}"
+    log_info "Use '${KUBECTL} describe virtualmachinesextension <name> -n aso' for more details"
+    return 1
+  fi
+
   log_info "All ASO v2 resources applied and reconciled successfully"
 }
 
@@ -693,6 +725,29 @@ function diagnose_aso_resources() {
       if ${KUBECTL} get virtualmachine $vm -n aso &>/dev/null; then
         echo "--- VirtualMachine: $vm ---"
         ${KUBECTL} get virtualmachine $vm -n aso -o yaml | grep -A 20 "status:" | grep -E "(conditions|ready|message|reason)"
+      fi
+    done
+
+    # Per-extension health. The summary above only shows finalizers, which
+    # tells us the resources exist but NOT whether the CustomScript
+    # extensions on each VM actually finished (Ready/provisioningState).
+    # That's what we need to debug "containerd not ready" style timeouts.
+    log_info "Detailed VirtualMachinesExtension status:"
+    local ext_names=()
+    for ((i=1; i<=${LINUX_NODE_COUNT}; i++)); do
+      ext_names+=("vm-linux-${i}-containerd")
+    done
+    for ((i=1; i<=${WINDOWS_NODE_COUNT}; i++)); do
+      ext_names+=("vm-windows-${i}-openssh")
+      ext_names+=("vm-windows-${i}-customextension")
+    done
+    for ext in "${ext_names[@]}"; do
+      if ${KUBECTL} get virtualmachinesextension "$ext" -n aso &>/dev/null; then
+        echo "--- VirtualMachinesExtension: $ext ---"
+        ${KUBECTL} get virtualmachinesextension "$ext" -n aso \
+          -o jsonpath='{range .status.conditions[*]}  type={.type} status={.status} reason={.reason} message={.message}{"\n"}{end}' 2>/dev/null
+        ${KUBECTL} get virtualmachinesextension "$ext" -n aso \
+          -o jsonpath='  provisioningState={.status.provisioningState}{"\n"}' 2>/dev/null
       fi
     done
   else


### PR DESCRIPTION
vmss.sh waited for the Azure VirtualMachine to be Ready but not for the CustomScript extensions that actually install containerd (Linux) and configure OpenSSH / runtime (Windows). The harness then raced the extension and would time out 5+ minutes later deep inside setup-node.sh ("ERROR: containerd was not ready after 5 minutes") with no useful diagnostic — diagnose_aso_resources() only printed extension finalizers, not their Ready condition or provisioningState.

Add an explicit wait_for_aso_resource gate on
vm-linux-N-containerd / vm-windows-N-{openssh,customextension} after the VM-Ready gate, and extend the diagnostic dump to print each extension's status.conditions and provisioningState via jsonpath.

Harden the Linux containerd extension's inline bash against first-boot apt-lock contention with cloud-init / unattended-upgrades:
  - cloud-init status --wait before touching apt
  - stop and mask apt-daily{,-upgrade} timers + unattended-upgrades
  - raise DPkg::Lock::Timeout from 60 to 180
  - inline apt_retry() (3 attempts, 20s backoff) around all apt phases

No Windows-side bash changes (PowerShell, no apt). No setup-node.sh changes (its containerd polling is correct; the upstream gate makes its 5-min fallback moot in the happy path).

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
