### PR TITLE
libcalico-go: fix flaky watch-event test harness wait

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -412,9 +412,14 @@ blocks:
     # build on cache miss.
     # The process/testing paths trigger this so the win-fv-felix block (which now
     # installs the locally-built calico image) has it cached in GCS. The libcalico
-    # ipam/stacktrace paths and the 20-felix.yml self-trigger keep this block a
+    # ipam/testutils paths and the 20-felix.yml self-trigger keep this block a
     # superset of the win-fv-felix block's trigger (felix's full test closure plus
     # its own CI block), so win-fv-felix never runs without this image in GCS.
+    # libcalico-go/lib/testutils is covered in full (not just its stacktrace
+    # subdirectory): it is a test-only dependency of several component blocks
+    # (e.g. kube-controllers, whose ci-no-prereqs requires the cached image), so
+    # it triggers those blocks via their Go test closure without being in
+    # cmd/calico's production closure.
     run:
       when: "true"
     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -382,6 +382,7 @@ blocks:
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
         '/felix/bpf-gpl',
         '/felix/bpf/*.go',
@@ -657,9 +658,14 @@ blocks:
     # build on cache miss.
     # The process/testing paths trigger this so the win-fv-felix block (which now
     # installs the locally-built calico image) has it cached in GCS. The libcalico
-    # ipam/stacktrace paths and the 20-felix.yml self-trigger keep this block a
+    # ipam/testutils paths and the 20-felix.yml self-trigger keep this block a
     # superset of the win-fv-felix block's trigger (felix's full test closure plus
     # its own CI block), so win-fv-felix never runs without this image in GCS.
+    # libcalico-go/lib/testutils is covered in full (not just its stacktrace
+    # subdirectory): it is a test-only dependency of several component blocks
+    # (e.g. kube-controllers, whose ci-no-prereqs requires the cached image), so
+    # it triggers those blocks via their Go test closure without being in
+    # cmd/calico's production closure.
     run:
       when: >-
         change_in(['/.semaphore/semaphore.yml.d/01-preamble.yml',
@@ -764,6 +770,7 @@ blocks:
         '/docker/calico/',
         '/felix/',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf/*.go',
         '/felix/bpf/allowsources/*.go',
         '/felix/bpf/arp/*.go',
@@ -974,7 +981,7 @@ blocks:
         '/libcalico-go/lib/selector/parser/*.go',
         '/libcalico-go/lib/selector/tokenizer/*.go',
         '/libcalico-go/lib/set/*.go',
-        '/libcalico-go/lib/testutils/stacktrace/',
+        '/libcalico-go/lib/testutils/',
         '/libcalico-go/lib/validator/v1/*.go',
         '/libcalico-go/lib/validator/v3/*.go',
         '/libcalico-go/lib/watch/*.go',
@@ -1162,6 +1169,7 @@ blocks:
         '/crypto/pkg/tls/*.go',
         '/felix/',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
         '/felix/bpf-gpl',
         '/felix/bpf/*.go',
@@ -1860,6 +1868,7 @@ blocks:
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf/*.go',
         '/felix/bpf/allowsources/*.go',
         '/felix/bpf/arp/*.go',
@@ -2641,6 +2650,7 @@ blocks:
         '/crypto/pkg/tls/*.go',
         '/e2e/**',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
         '/felix/bpf-gpl',
         '/felix/bpf/*.go',
@@ -4449,6 +4459,7 @@ blocks:
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
         '/felix/bpf-gpl',
         '/felix/bpf/*.go',
@@ -4726,6 +4737,7 @@ blocks:
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
         '/felix/bpf-gpl',
         '/felix/bpf/*.go',
@@ -5069,6 +5081,7 @@ blocks:
         '/confd/pkg/run/*.go',
         '/crypto/pkg/tls/*.go',
         '/felix/aws/*.go',
+        '/felix/aws/ec2query/*.go',
         '/felix/bpf-apache',
         '/felix/bpf-gpl',
         '/felix/bpf/*.go',

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -208,11 +208,16 @@
   # build on cache miss.
   # The process/testing paths trigger this so the win-fv-felix block (which now
   # installs the locally-built calico image) has it cached in GCS. The libcalico
-  # ipam/stacktrace paths and the 20-felix.yml self-trigger keep this block a
+  # ipam/testutils paths and the 20-felix.yml self-trigger keep this block a
   # superset of the win-fv-felix block's trigger (felix's full test closure plus
   # its own CI block), so win-fv-felix never runs without this image in GCS.
+  # libcalico-go/lib/testutils is covered in full (not just its stacktrace
+  # subdirectory): it is a test-only dependency of several component blocks
+  # (e.g. kube-controllers, whose ci-no-prereqs requires the cached image), so
+  # it triggers those blocks via their Go test closure without being in
+  # cmd/calico's production closure.
   run:
-    when: "${CHANGE_IN(cmd/calico,non-go:/felix/,non-go:/typha/,non-go:/.semaphore/vms/,non-go:/docker/calico/,non-go:/libcalico-go/lib/ipam/,non-go:/libcalico-go/lib/testutils/stacktrace/,non-go:/.semaphore/semaphore.yml.d/blocks/20-felix.yml,non-go:/process/testing/aso,non-go:/process/testing/util,non-go:/process/testing/winfv-felix)}"
+    when: "${CHANGE_IN(cmd/calico,non-go:/felix/,non-go:/typha/,non-go:/.semaphore/vms/,non-go:/docker/calico/,non-go:/libcalico-go/lib/ipam/,non-go:/libcalico-go/lib/testutils/,non-go:/.semaphore/semaphore.yml.d/blocks/20-felix.yml,non-go:/process/testing/aso,non-go:/process/testing/util,non-go:/process/testing/winfv-felix)}"
   dependencies: []
   task:
     env_vars:

--- a/libcalico-go/lib/testutils/resources.go
+++ b/libcalico-go/lib/testutils/resources.go
@@ -178,7 +178,14 @@ type testResourceWatcher struct {
 func (t *testResourceWatcher) run() {
 	for {
 		select {
-		case event := <-t.watch.ResultChan():
+		case event, ok := <-t.watch.ResultChan():
+			if !ok {
+				// The watcher closed its result channel (the watch.Interface
+				// Stop() contract).  Treat it as end-of-stream rather than
+				// spinning on zero-value events.
+				log.Info("Watch result channel closed; exiting test watch loop")
+				return
+			}
 			if t.ignored(event) {
 				continue
 			}

--- a/libcalico-go/lib/testutils/resources.go
+++ b/libcalico-go/lib/testutils/resources.go
@@ -35,6 +35,12 @@ import (
 
 const ExpectNoNamespace = ""
 
+// watchEventTimeout bounds how long ExpectEvents waits for the expected watch
+// events to arrive.  It is generous on purpose: watch-event delivery can lag
+// under a loaded apiserver, and waiting longer only slows the rare genuine
+// failure rather than flaking the common success path.
+const watchEventTimeout = 20 * time.Second
+
 type resourceMatcher struct {
 	kind, namespace, name string
 	spec                  any
@@ -238,19 +244,23 @@ func (t *testResourceWatcher) ExpectEventsAnyOrder(kind string, expectedEvents [
 func (t *testResourceWatcher) expectEvents(kind string, anyOrder bool, expectedEvents []watch.Event) {
 	By("Waiting for the correct number of events")
 	log.Infof("Start waiting at %s", time.Now())
-	t.lock.Lock()
-	cur := len(t.events)
-	t.lock.Unlock()
-	for ii := 0; ii < 10 && cur != len(expectedEvents); ii++ {
-		time.Sleep(100 * time.Millisecond)
+	// Poll until we have received at least the expected number of events, or a
+	// generous deadline elapses.  This previously gave up after only ~1s of
+	// quiescence (10 x 100ms with no new event), which flaked when watch-event
+	// delivery lagged under a loaded apiserver - the watcher bailed with too few
+	// events and failed.  We deliberately do not assert here: the block below
+	// logs the received events and produces a precise failure message if the
+	// count is wrong.  Stopping as soon as the count is reached preserves the
+	// original behaviour of catching a too-many-events bug downstream.
+	deadline := time.Now().Add(watchEventTimeout)
+	for {
 		t.lock.Lock()
-		newcur := len(t.events)
+		cur := len(t.events)
 		t.lock.Unlock()
-		if newcur != cur {
-			// We've got new events, so reset the counter.
-			ii = 0
-			cur = newcur
+		if cur >= len(expectedEvents) || !time.Now().Before(deadline) {
+			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	log.Infof("Finish waiting at %s", time.Now())
 

--- a/libcalico-go/lib/testutils/resources_suite_test.go
+++ b/libcalico-go/lib/testutils/resources_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTestutils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "libcalico-go/lib/testutils Suite")
+}

--- a/libcalico-go/lib/testutils/resources_watch_test.go
+++ b/libcalico-go/lib/testutils/resources_watch_test.go
@@ -29,21 +29,50 @@ import (
 // slowWatch is a watch.Interface whose events are delivered on a caller-controlled
 // schedule.  It is used to simulate watch-event delivery lagging under a loaded
 // apiserver, which is what made the clientv3 *_e2e_test.go watch specs flaky.
+//
+// A forwarder goroutine is the sole sender on the result channel, so it can
+// safely close that channel on Stop() as required by the watch.Interface
+// contract without racing an in-flight send.
 type slowWatch struct {
+	in       chan watch.Event
 	ch       chan watch.Event
 	stopOnce sync.Once
 	stopped  chan struct{}
 }
 
+var _ watch.Interface = (*slowWatch)(nil)
+
 func newSlowWatch() *slowWatch {
-	return &slowWatch{
+	w := &slowWatch{
+		in:      make(chan watch.Event),
 		ch:      make(chan watch.Event),
 		stopped: make(chan struct{}),
+	}
+	go w.loop()
+	return w
+}
+
+// loop forwards events from send to the result channel until the watch is
+// stopped, then closes the result channel.
+func (w *slowWatch) loop() {
+	defer close(w.ch)
+	for {
+		select {
+		case e := <-w.in:
+			select {
+			case w.ch <- e:
+			case <-w.stopped:
+				return
+			}
+		case <-w.stopped:
+			return
+		}
 	}
 }
 
 func (w *slowWatch) ResultChan() <-chan watch.Event { return w.ch }
 
+// Stop terminates the watch; the forwarder goroutine closes the result channel.
 func (w *slowWatch) Stop() {
 	w.stopOnce.Do(func() { close(w.stopped) })
 }
@@ -51,7 +80,7 @@ func (w *slowWatch) Stop() {
 // send delivers an event, abandoning the send if the watcher has been stopped.
 func (w *slowWatch) send(e watch.Event) {
 	select {
-	case w.ch <- e:
+	case w.in <- e:
 	case <-w.stopped:
 	}
 }
@@ -92,5 +121,29 @@ var _ = Describe("TestResourceWatch event waiting", func() {
 			{Type: watch.Added, Object: res1},
 			{Type: watch.Added, Object: res2},
 		})
+	})
+
+	It("treats a closed result channel as end-of-stream", func() {
+		w := newSlowWatch()
+		tw := testutils.NewTestResourceWatch(apiconfig.EtcdV3, w)
+		defer tw.Stop()
+
+		res1 := tier("tier-1")
+		go func() {
+			defer GinkgoRecover()
+			w.send(watch.Event{Type: watch.Added, Object: res1})
+		}()
+		tw.ExpectEvents(apiv3.KindTier, []watch.Event{
+			{Type: watch.Added, Object: res1},
+		})
+
+		// Stop the watch directly; per the watch.Interface contract this
+		// closes the result channel.  The event-collection loop must treat
+		// that as end-of-stream - it used to spin on the closed channel,
+		// appending zero-value events.  ExpectEvents consumed the event
+		// above, so no further events should be observed.
+		w.Stop()
+		time.Sleep(200 * time.Millisecond)
+		tw.ExpectEvents(apiv3.KindTier, []watch.Event{})
 	})
 })

--- a/libcalico-go/lib/testutils/resources_watch_test.go
+++ b/libcalico-go/lib/testutils/resources_watch_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils_test
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/calico/libcalico-go/lib/watch"
+)
+
+// slowWatch is a watch.Interface whose events are delivered on a caller-controlled
+// schedule.  It is used to simulate watch-event delivery lagging under a loaded
+// apiserver, which is what made the clientv3 *_e2e_test.go watch specs flaky.
+type slowWatch struct {
+	ch       chan watch.Event
+	stopOnce sync.Once
+	stopped  chan struct{}
+}
+
+func newSlowWatch() *slowWatch {
+	return &slowWatch{
+		ch:      make(chan watch.Event),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (w *slowWatch) ResultChan() <-chan watch.Event { return w.ch }
+
+func (w *slowWatch) Stop() {
+	w.stopOnce.Do(func() { close(w.stopped) })
+}
+
+// send delivers an event, abandoning the send if the watcher has been stopped.
+func (w *slowWatch) send(e watch.Event) {
+	select {
+	case w.ch <- e:
+	case <-w.stopped:
+	}
+}
+
+// tier returns a minimally-populated Tier that satisfies the resource matcher
+// (correct GVK and a non-empty resource version).
+func tier(name string) *apiv3.Tier {
+	t := apiv3.NewTier()
+	t.Name = name
+	t.ResourceVersion = "1"
+	return t
+}
+
+var _ = Describe("TestResourceWatch event waiting", func() {
+	// Regression test for the flaky clientv3 watch specs ("should handle watch
+	// events for different resource versions and event types").  The shared
+	// ExpectEvents helper used to give up after ~1s of quiescence; when watch
+	// events were delivered more slowly than that under CI load it bailed with
+	// too few events and failed.  Deliver each event after a delay longer than
+	// that former 1s window and assert the helper still receives them all.
+	It("waits past the old 1s quiescence window for slowly-delivered events", func() {
+		w := newSlowWatch()
+		tw := testutils.NewTestResourceWatch(apiconfig.EtcdV3, w)
+		defer tw.Stop()
+
+		res1 := tier("tier-1")
+		res2 := tier("tier-2")
+
+		go func() {
+			defer GinkgoRecover()
+			time.Sleep(1200 * time.Millisecond)
+			w.send(watch.Event{Type: watch.Added, Object: res1})
+			time.Sleep(1200 * time.Millisecond)
+			w.send(watch.Event{Type: watch.Added, Object: res2})
+		}()
+
+		tw.ExpectEvents(apiv3.KindTier, []watch.Event{
+			{Type: watch.Added, Object: res1},
+			{Type: watch.Added, Object: res2},
+		})
+	})
+})

--- a/libcalico-go/lib/testutils/resources_watch_test.go
+++ b/libcalico-go/lib/testutils/resources_watch_test.go
@@ -52,8 +52,8 @@ func newSlowWatch() *slowWatch {
 	return w
 }
 
-// loop forwards events from send to the result channel until the watch is
-// stopped, then closes the result channel.
+// loop forwards events queued via send() to the result channel until the
+// watch is stopped, then closes the result channel.
 func (w *slowWatch) loop() {
 	defer close(w.ch)
 	for {
@@ -78,6 +78,8 @@ func (w *slowWatch) Stop() {
 }
 
 // send delivers an event, abandoning the send if the watcher has been stopped.
+// It cannot block forever: loop() only exits after stopped is closed, and once
+// stopped is closed the second select case is always ready.
 func (w *slowWatch) send(e watch.Event) {
 	select {
 	case w.in <- e:
@@ -142,6 +144,12 @@ var _ = Describe("TestResourceWatch event waiting", func() {
 		// that as end-of-stream - it used to spin on the closed channel,
 		// appending zero-value events.  ExpectEvents consumed the event
 		// above, so no further events should be observed.
+		//
+		// The sleep cannot make this test flake: with a correct collection
+		// loop nothing can deliver events after Stop(), so the final check
+		// is deterministic.  It only gives a regressed (spinning) loop time
+		// to append events before the check; the loop is internal to the
+		// harness, so there is nothing to synchronize on instead.
 		w.Stop()
 		time.Sleep(200 * time.Millisecond)
 		tw.ExpectEvents(apiv3.KindTier, []watch.Event{})


### PR DESCRIPTION
## Description

Fixes a long-standing flake in the `clientv3` watch e2e specs ("should handle watch events for different resource versions and event types") caused by the shared watch-event test harness in `libcalico-go/lib/testutils`.

**Bug fix (flake):** `testResourceWatcher.expectEvents` used to give up after ~1s of quiescence (10 x 100ms polls with no new event). When watch-event delivery lagged under a loaded apiserver in CI, the helper bailed with too few events and the spec failed. The wait is now a generous 20s deadline that stops as soon as the expected event count is reached — preserving the existing too-many-events detection downstream while no longer flaking on slow delivery.

**Hardening (watch.Interface Stop() contract):** `testResourceWatcher.run()` now treats a closed result channel as end-of-stream (`event, ok := <-ch`). Previously a closed channel made the loop spin hot, appending zero-value events (and the diagnostic logging would nil-panic on them). The new `slowWatch` test fake honors the `watch.Interface` contract by closing its result channel on `Stop()`, via a forwarder goroutine that is the channel's sole sender so the close cannot race an in-flight send.

## Testing

- New regression tests in `libcalico-go/lib/testutils/resources_watch_test.go`:
  - delayed-delivery test fails under the old ~1s quiescence wait, passes with the deadline-based wait
  - closed-channel test panics/fails under the old `run()` loop, passes with the fix (verified by temporarily reverting each fix)
- `go test -race ./libcalico-go/lib/testutils/` passes

**Release note:**
```release-note
TBD
```