### PR TITLE
felix: reclaim netkit WEP jump-map indices from the netkit allocator on restart

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1702,11 +1702,33 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 						iface.dpState.v6Readiness = ifaceIsReadyNotAssured
 					}
 				}
+				// Workload interfaces backed by netkit allocate their jump map
+				// indices from netkitJumpMapAllocs rather than jumpMapAllocs (see
+				// allocJumpIndicesForWEP / wepStateFillJumps). Determine the type
+				// here so that we reclaim each persisted index from the same
+				// allocator the apply path will use. If a netkit WEP's index were
+				// reclaimed into the regular allocator, the netkit allocator would
+				// believe that index is free and later hand it to another WEP,
+				// leaving two endpoints sharing one jump map slot and corrupting
+				// one of their policy programs.
+				isNetkit := false
+				if m.isWorkloadIface(netiface.Name) {
+					if link, err := m.dp.getIfaceLink(netiface.Name); err == nil {
+						if t := m.getIfaceTypeFromLink(link); t != IfaceTypeUnknown {
+							iface.info.ifaceType = t
+							isNetkit = t == IfaceTypeNetkit
+						}
+					}
+				}
 				checkAndReclaimIdx := func(idx int, h hook.Hook, indexMap []int) {
 					if idx < 0 {
 						return
 					}
-					if err := m.jumpMapAllocs[h].Assign(idx, netiface.Name); err != nil {
+					allocs := m.jumpMapAllocs
+					if isNetkit && h != hook.XDP {
+						allocs = m.netkitJumpMapAllocs
+					}
+					if err := allocs[h].Assign(idx, netiface.Name); err != nil {
 						// Conflict with another program; need to alloc a new index.
 						logrus.WithError(err).Error("Start of day resync found invalid jump map index, " +
 							"allocate a fresh one.")

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -1971,6 +1971,47 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			}))
 		})
 
+		It("should reclaim a netkit WEP's index into the netkit jump map allocator", func() {
+			// Regression test for the netkit jump-map index corruption on
+			// Felix restart (CORE-12937). A netkit workload allocates its
+			// policy indices from netkitJumpMapAllocs (see allocJumpIndicesForWEP
+			// / wepStateFillJumps), so start-of-day resync must reclaim its
+			// persisted indices from that same allocator. If they were reclaimed
+			// into the regular jumpMapAllocs instead, the netkit allocator would
+			// believe the index is free and later hand it to another netkit WEP,
+			// leaving two endpoints on one jump map slot and corrupting one of
+			// their policy programs.
+			err := dp.createIface("calinkit0", 50, "netkit")
+			Expect(err).NotTo(HaveOccurred())
+
+			dp.interfaceByIndexFn = func(ifindex int) (*net.Interface, error) {
+				if ifindex == 50 {
+					return &net.Interface{Name: "calinkit0", Index: 50, Flags: net.FlagUp}, nil
+				}
+				return nil, errors.New("no such network interface")
+			}
+
+			// Persisted ifstate from before the restart: a netkit WEP using
+			// policy index 2 on both hooks.
+			_ = ifStateMap.Update(
+				ifstate.NewKey(50).AsBytes(),
+				ifstate.NewValue(ifstate.FlgWEP|ifstate.FlgIPv4Ready, "calinkit0",
+					-1, 2, 2, -1, -1, -1, -1, -1).AsBytes(),
+			)
+			genWLUpdate("calinkit0")()
+
+			err = bpfEpMgr.CompleteDeferredWork()
+			Expect(err).NotTo(HaveOccurred())
+
+			// The persisted index must be reclaimed by the netkit allocator...
+			Expect(bpfEpMgr.netkitJumpMapAllocs[hook.Ingress].inUse).To(HaveKeyWithValue(2, "calinkit0"))
+			Expect(bpfEpMgr.netkitJumpMapAllocs[hook.Egress].inUse).To(HaveKeyWithValue(2, "calinkit0"))
+			// ...and must NOT land in the regular allocator (where the bug put it,
+			// leaving the netkit allocator free to hand index 2 out a second time).
+			Expect(bpfEpMgr.jumpMapAllocs[hook.Ingress].inUse).NotTo(HaveKey(2))
+			Expect(bpfEpMgr.jumpMapAllocs[hook.Egress].inUse).NotTo(HaveKey(2))
+		})
+
 		It("should handle jump map collision: single iface", func() {
 			// This test verifies that we recover if we're started with
 			// bad data in the ifstate map; in particular if two policy


### PR DESCRIPTION
## Description

In the BPF dataplane, when Felix restarts it re-establishes ownership of the persisted per-interface jump-map indices in `syncIfStateMap` → `checkAndReclaimIdx`. This always reclaimed indices into the regular `jumpMapAllocs`, but **netkit** workload endpoints allocate their policy and filter indices from a separate `netkitJumpMapAllocs` pool (see `allocJumpIndicesForWEP` / `wepStateFillJumps`).

After a restart, a netkit WEP's index was therefore reclaimed into the wrong allocator. The netkit allocator was left believing the index was free and would later hand the same index to another netkit WEP, so two endpoints ended up sharing one jump-map slot. One endpoint's policy program was overwritten, leaving it running the default-deny program — it dropped all of its traffic until the next reprogramming. The failure is intermittent (it depends on interface processing order) and only affects clusters using netkit devices.

It was observed as an intermittent failure of the `_BPF-SAFE_ Precise DNS logging [BeforeEach]` FV connectivity check (which restarts Felix mid-test): the destination workload's ingress policy program denied traffic that its allow-all profile should have permitted.

## Fix

Detect netkit workload interfaces during the start-of-day resync — the same way `onInterfaceUpdate` does, via `getIfaceLink`/`getIfaceTypeFromLink` — and reclaim their indices from `netkitJumpMapAllocs`, so the allocator's ownership matches the index each program actually uses after a restart. Determining the type from the live link (rather than persisting a flag in ifstate) is deliberate: it is robust across the upgrade boundary, where the first restart onto the fixed Felix still reads ifstate written by the old one.

## Testing

- New unit test `should reclaim a netkit WEP's index into the netkit jump map allocator`: seeds ifstate for a netkit WEP at policy index 2, runs the resync, and asserts the index is owned by `netkitJumpMapAllocs` and absent from `jumpMapAllocs`. It fails before the fix and passes after.
- Reproduced the original flake locally (BPF + netkit + nftables) and confirmed via debug logs that the allocator index and the attached program's index diverged; the full `BPF Endpoint Manager` UT suite passes with the change.

**Release note:**
```release-note
TBD
```
