### PR TITLE
Re-enable publication of OpenStack packages for master branch

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -182,6 +182,8 @@ promotions:
     pipeline_file: push-images/envoy.yml
   - name: Publish openstack packages
     pipeline_file: push-images/packaging.yaml
+    auto_promote:
+      when: "branch =~ 'master'"
   - name: Run Fossa scans
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -183,7 +183,7 @@ promotions:
   - name: Publish openstack packages
     pipeline_file: push-images/packaging.yaml
     auto_promote:
-      when: "branch =~ 'master'"
+      when: "branch = 'master'"
   - name: Run Fossa scans
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -182,6 +182,8 @@ promotions:
     pipeline_file: push-images/envoy.yml
   - name: Publish openstack packages
     pipeline_file: push-images/packaging.yaml
+    auto_promote:
+      when: "branch =~ 'master'"
   - name: Run Fossa scans
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -183,7 +183,7 @@ promotions:
   - name: Publish openstack packages
     pipeline_file: push-images/packaging.yaml
     auto_promote:
-      when: "branch =~ 'master'"
+      when: "branch = 'master'"
   - name: Run Fossa scans
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -55,7 +55,7 @@ promotions:
   - name: Publish openstack packages
     pipeline_file: push-images/packaging.yaml
     auto_promote:
-      when: "branch =~ 'master'"
+      when: "branch = 'master'"
   - name: Run Fossa scans
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -54,6 +54,8 @@ promotions:
     pipeline_file: push-images/envoy.yml
   - name: Publish openstack packages
     pipeline_file: push-images/packaging.yaml
+    auto_promote:
+      when: "branch =~ 'master'"
   - name: Run Fossa scans
     pipeline_file: license-scanning/fossa-scan.yml
     auto_promote:


### PR DESCRIPTION
This was disabled as part of #12786, but the argument for needing packages for OpenStack is different from that for hashrelease images.  Our Calico/OpenStack ST (in tigera/calico-test) depends on those packages being up to date, and we don't have an analogue of the hashrelease build building its own images.