### PR TITLE
Grant tigera-operator RBAC to manage envoy-gateway webhook in calico-system

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -370,9 +370,13 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     resourceNames:
+      - envoy-gateway-topology-injector.calico-system
+      # New install lives in calico-system; the .tigera-gateway entry is kept so the
+      # operator can also delete the legacy webhook on upgrade from 3.x.
       - envoy-gateway-topology-injector.tigera-gateway
     verbs:
       - update
+      - delete
   - apiGroups:
       - admissionregistration.k8s.io
     resources:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -370,9 +370,13 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     resourceNames:
+      - envoy-gateway-topology-injector.calico-system
+      # New install lives in calico-system; the .tigera-gateway entry is kept so the
+      # operator can also delete the legacy webhook on upgrade from 3.x.
       - envoy-gateway-topology-injector.tigera-gateway
     verbs:
       - update
+      - delete
   - apiGroups:
       - admissionregistration.k8s.io
     resources:

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -410,9 +410,13 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     resourceNames:
+      - envoy-gateway-topology-injector.calico-system
+      # New install lives in calico-system; the .tigera-gateway entry is kept so the
+      # operator can also delete the legacy webhook on upgrade from 3.x.
       - envoy-gateway-topology-injector.tigera-gateway
     verbs:
       - update
+      - delete
   - apiGroups:
       - admissionregistration.k8s.io
     resources:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -408,9 +408,13 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     resourceNames:
+      - envoy-gateway-topology-injector.calico-system
+      # New install lives in calico-system; the .tigera-gateway entry is kept so the
+      # operator can also delete the legacy webhook on upgrade from 3.x.
       - envoy-gateway-topology-injector.tigera-gateway
     verbs:
       - update
+      - delete
   - apiGroups:
       - admissionregistration.k8s.io
     resources:


### PR DESCRIPTION
- Gateway API namespaced mode moved the topology-injector MutatingWebhookConfiguration to envoy-gateway-topology-injector.calico-system; the operator role only allowed update on the legacy .tigera-gateway name, so reconcile looped on a forbidden error
- add the .calico-system resourceName and delete verb; keep .tigera-gateway so the legacy webhook can still be removed on upgrade from 3.x
- port of calico-private 59b3e0a09a (#11498)

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
