### PR TITLE
E2E ambient policy label and affinity fix

### DIFF
--- a/e2e/config/gcp-bpf.yaml
+++ b/e2e/config/gcp-bpf.yaml
@@ -27,7 +27,7 @@ exclude:
     - label: NoEncap
       reason: "requires non-encapsulated routing, but this cluster uses VXLAN"
 
-    - label: Feature:Istio
+    - label: RequiresAmbientPolicyEnforcement
       reason: "Calico policy not enforced with Istio ambient on BPF dataplane"
 
     - label: RequiresXtables

--- a/e2e/pkg/describe/describe.go
+++ b/e2e/pkg/describe/describe.go
@@ -192,6 +192,16 @@ func RequiresXtables() any {
 	return framework.WithLabel("RequiresXtables")
 }
 
+// RequiresAmbientPolicyEnforcement marks Istio ambient-mode tests that assert
+// Calico NetworkPolicy is enforced on ambient (ztunnel-redirected) traffic. The
+// BPF dataplane's bpf_redirect bypasses the socket layer that ambient relies on,
+// so Calico policy is not enforced for ambient traffic there. BPF-mode clusters
+// skip these tests via a label exclusion entry in their e2e config (see
+// e2e/config/gcp-bpf.yaml).
+func RequiresAmbientPolicyEnforcement() any {
+	return framework.WithLabel("RequiresAmbientPolicyEnforcement")
+}
+
 // WithSmokeTest marks tests that are considered smoke tests.
 // A Smoke test must pass in under a minute, and is expected to pass on all platforms regardless of configuration.
 func WithSmokeTest() any {

--- a/e2e/pkg/tests/istio/istio.go
+++ b/e2e/pkg/tests/istio/istio.go
@@ -61,6 +61,7 @@ var _ = describe.CalicoDescribe(
 	describe.WithTeam(describe.Core),
 	describe.WithFeature("Istio"),
 	describe.WithCategory(describe.Networking),
+	describe.RequiresAmbientPolicyEnforcement(),
 	"Istio Ambient Mode",
 	func() {
 		f := utils.NewDefaultFramework("istio-ambient")

--- a/e2e/pkg/utils/conncheck/customizers.go
+++ b/e2e/pkg/utils/conncheck/customizers.go
@@ -42,22 +42,22 @@ func AvoidEachOther(pod *corev1.Pod) {
 	}
 	pod.Labels["e2e.projectcalico.org/anti-affinity"] = "true"
 
-	// Add the PodAntiAffinity rule to make sure Pods are scheduled on different nodes.
-	pod.Spec.Affinity = &corev1.Affinity{
-		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "e2e.projectcalico.org/anti-affinity",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"true"},
-							},
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &corev1.Affinity{}
+	}
+	pod.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "e2e.projectcalico.org/anti-affinity",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
 						},
 					},
-					TopologyKey: "kubernetes.io/hostname",
 				},
+				TopologyKey: "kubernetes.io/hostname",
 			},
 		},
 	}


### PR DESCRIPTION
Two E2E test fixes/improvements:

* Add a `RequiresAmbientPolicyEnforcement` label: This lets us specifically filter out tests that conflict between BPF and Istio Ambient Mode. There are other tests that *do* work with BPF and Istio that we want to run.
* `AvoidEachOther()` customizer: Don't clobber any existing Affinity information when setting the `pod.Spec.Affinity.PodAntiAffinity` field.

