### PR TITLE
Add workflow to DM PR authors on Slack when CI finishes

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -149,12 +149,32 @@ jobs:
           env.STATE != 'success'
         env:
           PR: ${{ steps.resolve.outputs.pr }}
+          # When CI finished, per GitHub (status events only; empty on a
+          # manual workflow_dispatch). Used as the freshness reference below.
+          EVENT_CREATED_AT: ${{ github.event.created_at }}
         run: |
           MARKER="<!-- sem-ai-ci-triage -->"
           COMMENT_URL=""
-          # Bound the query with `since` (filters by updated_at): triage
-          # always *creates or PATCHes* its comment for the current run, so
-          # its updated_at is recent. A 2h window keeps the result set to
+
+          # Freshness gate: triage upserts a single comment per PR, so a
+          # comment from an *earlier* failure can already exist. Accept it
+          # only if it was updated after this CI run finished — i.e. triage
+          # (which is triggered by the same status event) has rewritten it
+          # for the current run. Compare GitHub-server timestamps on both
+          # sides (event created_at vs comment updated_at); ISO-8601 UTC
+          # sorts lexicographically, so a string '>' is a time comparison.
+          # If triage lags we keep polling; if it skips the run entirely the
+          # comment never goes fresh and we correctly omit the link. On a
+          # manual run there is no event time, so skip the gate.
+          REF="$EVENT_CREATED_AT"
+          if [[ -n "$REF" ]]; then
+            FRESH="and (.updated_at > \"$REF\")"
+          else
+            FRESH=""
+          fi
+
+          # Bound the query with `since` (filters by updated_at): triage's
+          # comment is always recent, so a 2h window keeps the result to
           # ~1 page instead of walking every comment 12 times — avoids the
           # API churn/rate-limit risk of an unbounded --paginate in a loop.
           SINCE=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
@@ -162,7 +182,7 @@ jobs:
           # this; if not, we just omit the analysis link from the DM.
           for _ in $(seq 1 12); do
             COMMENT_URL=$(gh api "repos/$REPO/issues/$PR/comments?since=$SINCE&per_page=100" --paginate \
-              --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\")))][-1].html_url // empty")
+              --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\")) $FRESH)][-1].html_url // empty")
             [[ -n "$COMMENT_URL" ]] && break
             sleep 10
           done

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -118,10 +118,16 @@ jobs:
         run: |
           MARKER="<!-- sem-ai-ci-triage -->"
           COMMENT_URL=""
+          # Bound the query with `since` (filters by updated_at): triage
+          # always *creates or PATCHes* its comment for the current run, so
+          # its updated_at is recent. A 2h window keeps the result set to
+          # ~1 page instead of walking every comment 12 times — avoids the
+          # API churn/rate-limit risk of an unbounded --paginate in a loop.
+          SINCE=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
           # ~120s budget (12 x 10s). Triage typically comments well within
-          # this; if not, we fall back to a plain PR link in the DM.
+          # this; if not, we just omit the analysis link from the DM.
           for _ in $(seq 1 12); do
-            COMMENT_URL=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            COMMENT_URL=$(gh api "repos/$REPO/issues/$PR/comments?since=$SINCE&per_page=100" --paginate \
               --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\")))][-1].html_url // empty")
             [[ -n "$COMMENT_URL" ]] && break
             sleep 10
@@ -172,8 +178,11 @@ jobs:
             --data-binary @payload.json)
           set -e
 
-          if [[ "$(printf '%s' "$RESP" | jq -r '.ok // false')" != "true" ]]; then
-            echo "::warning::Slack DM failed: $(printf '%s' "$RESP" | jq -r '.error // "unknown"')"
+          # jq stderr suppressed: an empty/non-JSON $RESP (Slack unreachable)
+          # is already non-fatal here — the [[ ]] just takes the warning
+          # branch — but silencing jq keeps a transient failure out of the log.
+          if [[ "$(printf '%s' "$RESP" | jq -r '.ok // false' 2>/dev/null)" != "true" ]]; then
+            echo "::warning::Slack DM failed: $(printf '%s' "$RESP" | jq -r '.error // "unknown"' 2>/dev/null)"
           else
             echo "DM sent to $SLACK_ID for PR #$PR ($STATE)"
           fi

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -1,0 +1,179 @@
+# DMs a PR author on Slack when their PR's Semaphore CI finishes.
+#
+# Opt-in is a repo *variable* (not a secret — Slack member IDs aren't
+# sensitive): CI_NOTIFY_MAP, a comma-separated list of
+#   <github-login>:<slack-member-id>
+# pairs, e.g.
+#   CI_NOTIFY_MAP = "tomastigera:U01ABCD2EFG, alice:U09ZYX8WVUT"
+# Set it with:  gh variable set CI_NOTIFY_MAP --body 'login:Uxxxx,...'
+#
+# Delivery uses the gh-pr-monitor Slack bot. Its token is a repo secret
+# GH_PR_MONITOR_BOT_TOKEN; the bot needs chat:write + im:write scopes so
+# chat.postMessage can open a DM to the author's Slack member ID.
+#
+# The workflow is a no-op (never fails noisily) if the variable/secret
+# are unset, the author hasn't opted in, or Slack is unreachable.
+
+name: CI finished Slack notify
+
+on:
+  status: {}
+
+# SHA-keyed: a force-push gets a new SHA in its own group, so a notify
+# for an earlier push is not cancelled by a later one.
+concurrency:
+  group: ci-notify-${{ github.event.sha || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  notify:
+    # Fire once when the aggregate Semaphore status reaches a terminal
+    # state. Skip 'pending' — that's CI starting/running, not finishing.
+    if: >-
+      github.event.context == 'ci/semaphoreci/pr: Calico' &&
+      (github.event.state == 'success' ||
+       github.event.state == 'failure' ||
+       github.event.state == 'error')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      CI_NOTIFY_MAP: ${{ vars.CI_NOTIFY_MAP }}
+      SLACK_BOT_TOKEN: ${{ secrets.GH_PR_MONITOR_BOT_TOKEN }}
+      STATE: ${{ github.event.state }}
+      SHA: ${{ github.event.sha }}
+      TARGET_URL: ${{ github.event.target_url }}
+    steps:
+      - name: Skip if not configured
+        id: gate
+        run: |
+          if [[ -z "${CI_NOTIFY_MAP}" || -z "${SLACK_BOT_TOKEN}" ]]; then
+            echo "::notice::CI_NOTIFY_MAP variable or GH_PR_MONITOR_BOT_TOKEN secret missing — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve PR + author from SHA
+        id: resolve
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          # Use the search API rather than repos/$REPO/commits/$SHA/pulls:
+          # the latter does not return PRs whose head commit lives on a
+          # fork, and projectcalico/calico PRs all come from forks.
+          PR=$(gh api "search/issues?q=sha:$SHA+is:pr+is:open+repo:$REPO" \
+                 --jq '.items[0].number // empty')
+          if [[ -z "$PR" ]]; then
+            echo "::notice::no open PR for sha=$SHA — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # pr.json holds the free-form title; it stays on the runner disk
+          # and is read with jq in later steps. It is never routed through
+          # GITHUB_OUTPUT or ${{ }} — those would be a script-injection
+          # vector for an attacker-chosen PR title.
+          gh api "repos/$REPO/pulls/$PR" \
+            --jq '{login: .user.login, title: .title, url: .html_url}' > pr.json
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Look up author's Slack ID
+        id: lookup
+        if: steps.gate.outputs.skip != 'true' && steps.resolve.outputs.skip != 'true'
+        run: |
+          # Read the login from pr.json (not a step output) — keep all
+          # PR-derived text off the ${{ }} interpolation path.
+          LOGIN=$(jq -r .login pr.json)
+          # CI_NOTIFY_MAP is "login:slackid, login:slackid, ...".
+          # Logins are [A-Za-z0-9-] and Slack IDs are [A-Z0-9], so ':'
+          # is an unambiguous delimiter.
+          SLACK_ID=$(printf '%s' "$CI_NOTIFY_MAP" \
+            | tr ',' '\n' | tr -d '[:space:]' \
+            | awk -F: -v u="$LOGIN" '$1==u {print $2; exit}')
+          if [[ -z "$SLACK_ID" ]]; then
+            echo "::notice::author '$LOGIN' not in CI_NOTIFY_MAP — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "slack_id=$SLACK_ID" >> "$GITHUB_OUTPUT"
+          fi
+
+      # On failure/error, sem-ai-ci-triage posts a failure-analysis comment
+      # — but it runs concurrently on the same status event and only after
+      # its LLM backend responds, so the comment usually isn't there yet.
+      # Poll briefly for it so the DM can deep-link to the analysis. Success
+      # never gets a triage comment, so we skip the poll entirely there.
+      - name: Wait for sem-ai-triage comment
+        id: triage
+        if: >-
+          steps.gate.outputs.skip != 'true' &&
+          steps.resolve.outputs.skip != 'true' &&
+          steps.lookup.outputs.skip != 'true' &&
+          github.event.state != 'success'
+        env:
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          MARKER="<!-- sem-ai-ci-triage -->"
+          COMMENT_URL=""
+          # ~120s budget (12 x 10s). Triage typically comments well within
+          # this; if not, we fall back to a plain PR link in the DM.
+          for _ in $(seq 1 12); do
+            COMMENT_URL=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+              --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\")))][-1].html_url // empty")
+            [[ -n "$COMMENT_URL" ]] && break
+            sleep 10
+          done
+          # html_url is a github.com URL (safe charset) — OK via GITHUB_OUTPUT.
+          echo "comment_url=$COMMENT_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack DM
+        if: >-
+          steps.gate.outputs.skip != 'true' &&
+          steps.resolve.outputs.skip != 'true' &&
+          steps.lookup.outputs.skip != 'true'
+        env:
+          SLACK_ID: ${{ steps.lookup.outputs.slack_id }}
+          PR: ${{ steps.resolve.outputs.pr }}
+          TRIAGE_COMMENT_URL: ${{ steps.triage.outputs.comment_url }}
+        run: |
+          # TITLE/URL come from pr.json via jq, never from ${{ }}.
+          TITLE=$(jq -r .title pr.json)
+          URL=$(jq -r .url pr.json)
+
+          case "$STATE" in
+            success) EMOJI=":white_check_mark:" WORD="passed" ;;
+            failure) EMOJI=":x:"                WORD="failed" ;;
+            error)   EMOJI=":warning:"          WORD="errored" ;;
+            *)       EMOJI=":grey_question:"     WORD="$STATE" ;;
+          esac
+
+          TEXT="$EMOJI CI $WORD on your PR #$PR: $TITLE"$'\n'"$URL"
+          if [[ -n "$TARGET_URL" ]]; then
+            TEXT="$TEXT"$'\n'"CI run: $TARGET_URL"
+          fi
+          # Failure-analysis link from sem-ai-triage, only when it actually
+          # posted one (it skips on PASS or backend hiccups — no promise made).
+          if [[ -n "$TRIAGE_COMMENT_URL" ]]; then
+            TEXT="$TEXT"$'\n'":mag: Failure analysis: $TRIAGE_COMMENT_URL"
+          fi
+
+          jq -n --arg c "$SLACK_ID" --arg t "$TEXT" \
+            '{channel: $c, text: $t, unfurl_links: false}' > payload.json
+
+          # Soft-fail: never break on a transient Slack issue.
+          set +e
+          RESP=$(curl -sS --max-time 30 -X POST \
+            https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            --data-binary @payload.json)
+          set -e
+
+          if [[ "$(printf '%s' "$RESP" | jq -r '.ok // false')" != "true" ]]; then
+            echo "::warning::Slack DM failed: $(printf '%s' "$RESP" | jq -r '.error // "unknown"')"
+          else
+            echo "DM sent to $SLACK_ID for PR #$PR ($STATE)"
+          fi

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -18,11 +18,28 @@ name: CI finished Slack notify
 
 on:
   status: {}
+  # Manual test path: simulate a finished-CI status for a given PR, so the
+  # full chain (resolve -> opt-in lookup -> DM) can be exercised on demand
+  # without waiting for real CI. Dispatchable only once this file is on the
+  # default branch (a GitHub limitation), so it's for post-merge sanity
+  # checks, not pre-merge testing.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to notify about"
+        required: true
+        type: string
+      state:
+        description: "Simulated CI outcome"
+        required: false
+        default: success
+        type: choice
+        options: [success, failure, error]
 
-# SHA-keyed: a force-push gets a new SHA in its own group, so a notify
-# for an earlier push is not cancelled by a later one.
+# SHA-keyed for status events; PR-keyed for manual runs. A force-push gets a
+# new SHA in its own group, so a notify for an earlier push is not cancelled.
 concurrency:
-  group: ci-notify-${{ github.event.sha || github.run_id }}
+  group: ci-notify-${{ github.event.sha || inputs.pr_number || github.run_id }}
   cancel-in-progress: false
 
 permissions:
@@ -33,11 +50,13 @@ jobs:
   notify:
     # Fire once when the aggregate Semaphore status reaches a terminal
     # state. Skip 'pending' — that's CI starting/running, not finishing.
+    # Manual workflow_dispatch runs always proceed (state comes from input).
     if: >-
-      github.event.context == 'ci/semaphoreci/pr: Calico' &&
-      (github.event.state == 'success' ||
-       github.event.state == 'failure' ||
-       github.event.state == 'error')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.context == 'ci/semaphoreci/pr: Calico' &&
+       (github.event.state == 'success' ||
+        github.event.state == 'failure' ||
+        github.event.state == 'error'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -45,7 +64,9 @@ jobs:
       REPO: ${{ github.repository }}
       CI_NOTIFY_MAP: ${{ vars.CI_NOTIFY_MAP }}
       SLACK_BOT_TOKEN: ${{ secrets.GH_PR_MONITOR_BOT_TOKEN }}
-      STATE: ${{ github.event.state }}
+      # On a status event these come from the event; on workflow_dispatch
+      # STATE falls through to the input and SHA/TARGET_URL are empty.
+      STATE: ${{ github.event.state || inputs.state }}
       SHA: ${{ github.event.sha }}
       TARGET_URL: ${{ github.event.target_url }}
     steps:
@@ -59,19 +80,32 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve PR + author from SHA
+      - name: Resolve PR + author
         id: resolve
         if: steps.gate.outputs.skip != 'true'
+        env:
+          INPUT_PR: ${{ inputs.pr_number }}
         run: |
-          # Use the search API rather than repos/$REPO/commits/$SHA/pulls:
-          # the latter does not return PRs whose head commit lives on a
-          # fork, and projectcalico/calico PRs all come from forks.
-          PR=$(gh api "search/issues?q=sha:$SHA+is:pr+is:open+repo:$REPO" \
-                 --jq '.items[0].number // empty')
-          if [[ -z "$PR" ]]; then
-            echo "::notice::no open PR for sha=$SHA — skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ -n "$INPUT_PR" ]]; then
+            # Manual run: trust only a numeric PR number (guards against
+            # injection via the free-form dispatch input).
+            if [[ ! "$INPUT_PR" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be numeric, got '$INPUT_PR'"
+              exit 1
+            fi
+            PR="$INPUT_PR"
+          else
+            # Status event: resolve PR from SHA. Use the search API rather
+            # than repos/$REPO/commits/$SHA/pulls — the latter does not
+            # return PRs whose head commit lives on a fork, and
+            # projectcalico/calico PRs all come from forks.
+            PR=$(gh api "search/issues?q=sha:$SHA+is:pr+is:open+repo:$REPO" \
+                   --jq '.items[0].number // empty')
+            if [[ -z "$PR" ]]; then
+              echo "::notice::no open PR for sha=$SHA — skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
           # pr.json holds the free-form title; it stays on the runner disk
           # and is read with jq in later steps. It is never routed through
@@ -112,7 +146,7 @@ jobs:
           steps.gate.outputs.skip != 'true' &&
           steps.resolve.outputs.skip != 'true' &&
           steps.lookup.outputs.skip != 'true' &&
-          github.event.state != 'success'
+          env.STATE != 'success'
         env:
           PR: ${{ steps.resolve.outputs.pr }}
         run: |

--- a/.github/workflows/sem-ai-ci-triage.yml
+++ b/.github/workflows/sem-ai-ci-triage.yml
@@ -187,3 +187,52 @@ jobs:
             echo "posting new comment on PR #$PR"
             gh api -X POST "repos/$REPO/issues/$PR/comments" --input - <<<"$PAYLOAD"
           fi
+
+  # When CI goes green, delete any stale failure-analysis comment left by an
+  # earlier failed run. The triage job only ever upserts on failure/error, so
+  # without this a now-passing PR keeps showing an obsolete failure report.
+  # Mutually exclusive with `triage`: that job requires failure/error, this
+  # one requires success, so exactly one runs per status event.
+  cleanup:
+    if: >-
+      github.event_name == 'status' &&
+      github.event.context == 'ci/semaphoreci/pr: Calico' &&
+      github.event.state == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      SHA: ${{ github.event.sha }}
+    steps:
+      - name: Resolve PR from SHA
+        id: resolve
+        run: |
+          # Fork-aware lookup — see the triage job for the rationale.
+          PR=$(gh api "search/issues?q=sha:$SHA+is:pr+is:open+repo:$REPO" \
+                 --jq '.items[0].number // empty')
+          if [[ -z "$PR" ]]; then
+            echo "::notice::no open PR for sha=$SHA — nothing to clean up"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Delete stale sem-ai-triage comment
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          MARKER="<!-- sem-ai-ci-triage -->"
+          IDS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\")))][].id")
+          if [[ -z "$IDS" ]]; then
+            echo "no sem-ai-triage comment on PR #$PR — nothing to delete"
+            exit 0
+          fi
+          # Best-effort: a transient delete failure must not fail the workflow.
+          for ID in $IDS; do
+            echo "deleting stale triage comment $ID on PR #$PR"
+            gh api -X DELETE "repos/$REPO/issues/comments/$ID" \
+              || echo "::warning::failed to delete comment $ID (continuing)"
+          done

--- a/.github/workflows/sem-ai-ci-triage.yml
+++ b/.github/workflows/sem-ai-ci-triage.yml
@@ -1,4 +1,3 @@
-# Drop this into the target repo at: .github/workflows/sem-ai-ci-triage.yml
 # Required repo secrets:
 #   SEM_AI_TRIAGE_URL   — endpoint of the triage service
 #   SEM_AI_TRIAGE_TOKEN — bearer token expected by the endpoint


### PR DESCRIPTION
## Description

Adds `.github/workflows/ci-notify.yml`, which DMs a PR author on Slack when their PR's Semaphore CI finishes.

It piggybacks on the same GitHub `status` event that `sem-ai-ci-triage.yml` uses (Semaphore reports CI as commit statuses on the aggregate context `ci/semaphoreci/pr: Calico`), reusing its fork-aware PR/author resolution. Notifications fire on all terminal outcomes (success/failure/error).

**Opt-in** is the `CI_NOTIFY_MAP` repo variable — a comma-separated list of `<github-login>:<slack-member-id>` pairs (Slack member IDs aren't secret). Delivery uses the gh-pr-monitor Slack bot via `chat.postMessage`; its token is the `GH_PR_MONITOR_BOT_TOKEN` repo secret (needs `chat:write` + `im:write`).

On failure/error it briefly polls (~120s) for the `sem-ai-ci-triage` failure-analysis comment and deep-links to it when present, gated on the comment's `updated_at` being newer than the status event so it never links a previous run's stale analysis. A manual `workflow_dispatch` path (pr_number + simulated state) allows post-merge end-to-end testing. The workflow is a no-op (never fails noisily) when the variable/secret are unset, the author hasn't opted in, or Slack is unreachable. PR-derived free-form text (title) is kept off the `${{ }}`/`GITHUB_OUTPUT` interpolation path to avoid script injection.

### Also: clean up stale triage comments on green

`sem-ai-ci-triage.yml` only ever upserts its failure-analysis comment on failure/error and never removed it, so a PR that later passed kept showing an obsolete failure report. This PR adds a `cleanup` job to that workflow which, on a `success` status, deletes any lingering `sem-ai-ci-triage` comment. It is mutually exclusive with the existing triage job (success vs failure/error) and best-effort.

### Setup (one-time, by a maintainer)

```
gh variable set CI_NOTIFY_MAP --repo projectcalico/calico --body 'login:Uxxxx, ...'
gh secret   set GH_PR_MONITOR_BOT_TOKEN --repo projectcalico/calico --body 'xoxb-...'
```

## Release Note

```release-note
TBD
```