### PR TITLE
Use mocked netlink in netlinkshim for ipip/vxlan/noencap UTs

### DIFF
--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -16,18 +16,17 @@ package intdataplane
 
 import (
 	"context"
-	"errors"
 	"net"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
 	"github.com/projectcalico/calico/felix/dataplane/linux/dataplanedefs"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/netlinkshim/mocknetlink"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/routetable"
 	"github.com/projectcalico/calico/felix/rules"
@@ -37,7 +36,7 @@ var _ = Describe("IPIPManager", func() {
 	var (
 		ipipMgr   *ipipManager
 		rt        *mockRouteTable
-		dataplane *mockTunnelDataplane
+		dataplane *mocknetlink.MockNetlinkDataplane
 	)
 
 	BeforeEach(func() {
@@ -45,14 +44,19 @@ var _ = Describe("IPIPManager", func() {
 			currentRoutes: map[string][]routetable.Target{},
 		}
 
-		la := netlink.NewLinkAttrs()
-		la.Name = "eth0"
 		opRecorder := logutils.NewSummarizer("test")
 
-		dataplane = &mockTunnelDataplane{
-			links:          []netlink.Link{&mockLink{attrs: la}},
-			tunnelLinkName: dataplanedefs.IPIPIfaceName,
-		}
+		// Mark the mock netlink connection as open (the manager is handed the
+		// handle directly rather than connecting via a factory function) and
+		// seed an "eth0" parent device carrying the host address.
+		dataplane = mocknetlink.New()
+		_, err := dataplane.NewMockNetlink()
+		Expect(err).NotTo(HaveOccurred())
+		dataplane.ImmediateLinkUp = true
+		eth0 := dataplane.AddIface(2, "eth0", true, true)
+		Expect(dataplane.AddrAdd(eth0, &netlink.Addr{IPNet: &net.IPNet{IP: net.IPv4(172, 0, 0, 2)}})).To(Succeed())
+		dataplane.ResetDeltas()
+
 		ipipMgr = newIPIPManagerWithShims(
 			rt, dataplanedefs.IPIPIfaceName,
 			4,
@@ -96,40 +100,42 @@ var _ = Describe("IPIPManager", func() {
 		Expect(noEncapDev).NotTo(BeNil())
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(dataplane.tunnelLink).ToNot(BeNil())
-		Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1400))
-		Expect(dataplane.tunnelLinkAttrs.Flags).To(Equal(net.FlagUp))
-		Expect(dataplane.addrs).To(HaveLen(1))
-		Expect(dataplane.addrs[0].IP.String()).To(Equal("192.168.0.1"))
+		tunnelLink := dataplane.NameToLink[dataplanedefs.IPIPIfaceName]
+		Expect(tunnelLink).ToNot(BeNil())
+		Expect(tunnelLink.LinkAttrs.MTU).To(Equal(1400))
+		Expect(tunnelLink.LinkAttrs.Flags).To(Equal(net.FlagUp))
+		Expect(tunnelLink.Addrs).To(HaveLen(1))
+		Expect(tunnelLink.Addrs[0].IP.String()).To(Equal("192.168.0.1"))
 
-		dataplane.ResetCalls()
+		dataplane.ResetDeltas()
 		err = ipipMgr.routeMgr.configureTunnelDevice(link, addr, 50, false)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dataplane.LinkAddCalled).To(BeFalse())
-		Expect(dataplane.LinkSetUpCalled).To(BeFalse())
-		Expect(dataplane.LinkSetMTUCalled).To(BeTrue())
-		Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(50))
-		Expect(dataplane.AddrUpdated).To(BeFalse())
+		Expect(dataplane.NumLinkAddCalls).To(BeZero())
+		Expect(dataplane.NumLinkSetUpCalls).To(BeZero())
+		Expect(dataplane.NumLinkSetMTUCalls).To(Equal(1))
+		Expect(tunnelLink.LinkAttrs.MTU).To(Equal(50))
+		Expect(dataplane.AddedAddrs.Len()).To(BeZero())
+		Expect(dataplane.DeletedAddrs.Len()).To(BeZero())
 
-		dataplane.ResetCalls()
+		dataplane.ResetDeltas()
 		err = ipipMgr.routeMgr.configureTunnelDevice(link, addr, 1500, false)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(dataplane.LinkAddCalled).To(BeFalse())
-		Expect(dataplane.LinkSetUpCalled).To(BeFalse())
-		Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1500))
-		Expect(dataplane.addrs).To(HaveLen(1))
-		Expect(dataplane.addrs[0].IP.String()).To(Equal("192.168.0.1"))
+		Expect(dataplane.NumLinkAddCalls).To(BeZero())
+		Expect(dataplane.NumLinkSetUpCalls).To(BeZero())
+		Expect(tunnelLink.LinkAttrs.MTU).To(Equal(1500))
+		Expect(tunnelLink.Addrs).To(HaveLen(1))
+		Expect(tunnelLink.Addrs[0].IP.String()).To(Equal("192.168.0.1"))
 
-		dataplane.ResetCalls()
+		dataplane.ResetDeltas()
 		err = ipipMgr.routeMgr.configureTunnelDevice(link, "", 1500, false)
 		Expect(err).To(HaveOccurred())
-		Expect(dataplane.tunnelLink).ToNot(BeNil())
-		Expect(dataplane.LinkAddCalled).To(BeFalse())
-		Expect(dataplane.LinkSetUpCalled).To(BeFalse())
-		Expect(dataplane.tunnelLinkAttrs.MTU).To(Equal(1500))
-		Expect(dataplane.tunnelLinkAttrs.Flags).To(Equal(net.FlagUp))
-		Expect(dataplane.addrs).To(HaveLen(1))
-		Expect(dataplane.addrs[0].IP.String()).To(Equal("192.168.0.1"))
+		Expect(dataplane.NameToLink[dataplanedefs.IPIPIfaceName]).ToNot(BeNil())
+		Expect(dataplane.NumLinkAddCalls).To(BeZero())
+		Expect(dataplane.NumLinkSetUpCalls).To(BeZero())
+		Expect(tunnelLink.LinkAttrs.MTU).To(Equal(1500))
+		Expect(tunnelLink.LinkAttrs.Flags).To(Equal(net.FlagUp))
+		Expect(tunnelLink.Addrs).To(HaveLen(1))
+		Expect(tunnelLink.Addrs[0].IP.String()).To(Equal("192.168.0.1"))
 	})
 
 	It("successfully adds a route to the noEncap interface", func() {
@@ -414,165 +420,3 @@ var _ = Describe("IPIPManager", func() {
 		Expect(rt.currentRoutes[dataplanedefs.IPIPIfaceName]).To(HaveLen(0))
 	})
 })
-
-const (
-	mockedTunnelIndex = 6
-)
-
-var (
-	errNotFound    = errors.New("not found")
-	errMockFailure = errors.New("mock failure")
-)
-
-type mockTunnelDataplane struct {
-	tunnelLink      netlink.Link
-	tunnelLinkAttrs *netlink.LinkAttrs
-	tunnelLinkName  string
-	addrs           []netlink.Addr
-
-	LinkAddCalled    bool
-	LinkSetMTUCalled bool
-	LinkSetUpCalled  bool
-	AddrUpdated      bool
-
-	NumCalls    int
-	ErrorAtCall int
-
-	ipVersion uint8
-	links     []netlink.Link
-}
-
-func (d *mockTunnelDataplane) ResetCalls() {
-	d.LinkAddCalled = false
-	d.LinkSetMTUCalled = false
-	d.LinkSetUpCalled = false
-	d.AddrUpdated = false
-}
-
-func (d *mockTunnelDataplane) incCallCount() error {
-	d.NumCalls += 1
-	if d.NumCalls == d.ErrorAtCall {
-		logrus.Warn("Simulating an error due to call count")
-		return errMockFailure
-	}
-	return nil
-}
-
-func (d *mockTunnelDataplane) LinkByName(name string) (netlink.Link, error) {
-	logrus.WithField("name", name).Info("LinkByName called")
-
-	if err := d.incCallCount(); err != nil {
-		return nil, err
-	}
-
-	Expect(name).To(Equal(d.tunnelLinkName))
-	if d.tunnelLink == nil {
-		return nil, errNotFound
-	}
-	return d.tunnelLink, nil
-}
-
-func (d *mockTunnelDataplane) LinkSetMTU(link netlink.Link, mtu int) error {
-	d.LinkSetMTUCalled = true
-	if err := d.incCallCount(); err != nil {
-		return err
-	}
-	Expect(link.Attrs().Name).To(Equal(d.tunnelLinkName))
-	d.tunnelLinkAttrs.MTU = mtu
-	return nil
-}
-
-func (d *mockTunnelDataplane) LinkSetUp(link netlink.Link) error {
-	d.LinkSetUpCalled = true
-	if err := d.incCallCount(); err != nil {
-		return err
-	}
-	Expect(link.Attrs().Name).To(Equal(d.tunnelLinkName))
-	d.tunnelLinkAttrs.Flags |= net.FlagUp
-	return nil
-}
-
-func (d *mockTunnelDataplane) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
-	if err := d.incCallCount(); err != nil {
-		return nil, err
-	}
-
-	name := link.Attrs().Name
-	Expect(name).Should(BeElementOf(d.tunnelLinkName, "eth0"))
-	if name == "eth0" {
-		if d.ipVersion == 6 {
-			return []netlink.Addr{{
-				IPNet: &net.IPNet{
-					IP: net.ParseIP("fc00:10:96::2"),
-				}},
-			}, nil
-		}
-		return []netlink.Addr{{
-			IPNet: &net.IPNet{
-				IP: net.IPv4(172, 0, 0, 2),
-			}},
-		}, nil
-	}
-	return d.addrs, nil
-}
-
-func (d *mockTunnelDataplane) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
-	d.AddrUpdated = true
-	if err := d.incCallCount(); err != nil {
-		return err
-	}
-	Expect(d.addrs).NotTo(ContainElement(*addr))
-	d.addrs = append(d.addrs, *addr)
-	return nil
-}
-
-func (d *mockTunnelDataplane) AddrDel(link netlink.Link, addr *netlink.Addr) error {
-	d.AddrUpdated = true
-	if err := d.incCallCount(); err != nil {
-		return err
-	}
-	Expect(d.addrs).To(HaveLen(1))
-	Expect(d.addrs[0].IP.String()).To(Equal(addr.IP.String()))
-	d.addrs = nil
-	return nil
-}
-
-func (d *mockTunnelDataplane) LinkList() ([]netlink.Link, error) {
-	return d.links, nil
-}
-
-func (d *mockTunnelDataplane) LinkAdd(l netlink.Link) error {
-	d.LinkAddCalled = true
-	if err := d.incCallCount(); err != nil {
-		return err
-	}
-	Expect(l.Attrs().Name).To(Equal(d.tunnelLinkName))
-	if d.tunnelLink == nil {
-		logrus.Info("Creating tunnel link")
-		l.Attrs().Index = mockedTunnelIndex
-		d.tunnelLinkAttrs = l.Attrs()
-		d.tunnelLink = l
-	}
-	return nil
-}
-
-func (d *mockTunnelDataplane) LinkDel(_ netlink.Link) error {
-	return nil
-}
-
-type mockLink struct {
-	attrs netlink.LinkAttrs
-	typ   string
-}
-
-func (l *mockLink) Attrs() *netlink.LinkAttrs {
-	return &l.attrs
-}
-
-func (l *mockLink) Type() string {
-	if l.typ == "" {
-		return "not implemented"
-	}
-
-	return l.typ
-}

--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -46,9 +46,6 @@ var _ = Describe("IPIPManager", func() {
 
 		opRecorder := logutils.NewSummarizer("test")
 
-		// Mark the mock netlink connection as open (the manager is handed the
-		// handle directly rather than connecting via a factory function) and
-		// seed an "eth0" parent device carrying the host address.
 		dataplane = mocknetlink.New()
 		_, err := dataplane.NewMockNetlink()
 		Expect(err).NotTo(HaveOccurred())

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -46,9 +46,6 @@ var _ = Describe("NoEncap Manager", func() {
 
 		opRecorder := logutils.NewSummarizer("test")
 
-		// Mark the mock netlink connections as open (the managers are handed
-		// the handles directly rather than connecting via a factory function)
-		// and seed an "eth0" parent device carrying the host address.
 		dataplane := mocknetlink.New()
 		_, err := dataplane.NewMockNetlink()
 		Expect(err).NotTo(HaveOccurred())

--- a/felix/dataplane/linux/noencap_mgr_test.go
+++ b/felix/dataplane/linux/noencap_mgr_test.go
@@ -15,6 +15,8 @@
 package intdataplane
 
 import (
+	"net"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
@@ -22,6 +24,7 @@ import (
 	"github.com/projectcalico/calico/felix/dataplane/linux/dataplanedefs"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/netlinkshim/mocknetlink"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/routetable"
 )
@@ -41,9 +44,24 @@ var _ = Describe("NoEncap Manager", func() {
 			currentRoutes: map[string][]routetable.Target{},
 		}
 
-		la := netlink.NewLinkAttrs()
-		la.Name = "eth0"
 		opRecorder := logutils.NewSummarizer("test")
+
+		// Mark the mock netlink connections as open (the managers are handed
+		// the handles directly rather than connecting via a factory function)
+		// and seed an "eth0" parent device carrying the host address.
+		dataplane := mocknetlink.New()
+		_, err := dataplane.NewMockNetlink()
+		Expect(err).NotTo(HaveOccurred())
+		eth0 := dataplane.AddIface(2, "eth0", true, true)
+		Expect(dataplane.AddrAdd(eth0, &netlink.Addr{IPNet: &net.IPNet{IP: net.IPv4(172, 0, 0, 2)}})).To(Succeed())
+		dataplane.ResetDeltas()
+
+		dataplaneV6 := mocknetlink.New()
+		_, err = dataplaneV6.NewMockNetlink()
+		Expect(err).NotTo(HaveOccurred())
+		eth0V6 := dataplaneV6.AddIface(2, "eth0", true, true)
+		Expect(dataplaneV6.AddrAdd(eth0V6, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("fc00:10:96::2")}})).To(Succeed())
+		dataplaneV6.ResetDeltas()
 
 		noencapMgr = newNoEncapManagerWithSims(
 			rt,
@@ -54,10 +72,7 @@ var _ = Describe("NoEncap Manager", func() {
 				DeviceRouteProtocol:  dataplanedefs.DefaultRouteProto,
 			},
 			opRecorder,
-			&mockTunnelDataplane{
-				links:     []netlink.Link{&mockLink{attrs: la}},
-				ipVersion: 4,
-			},
+			dataplane,
 		)
 		noencapMgrV6 = newNoEncapManagerWithSims(
 			rt,
@@ -68,10 +83,7 @@ var _ = Describe("NoEncap Manager", func() {
 				DeviceRouteProtocol:  dataplanedefs.DefaultRouteProto,
 			},
 			opRecorder,
-			&mockTunnelDataplane{
-				links:     []netlink.Link{&mockLink{attrs: la}},
-				ipVersion: 6,
-			},
+			dataplaneV6,
 		)
 	})
 

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -110,9 +110,6 @@ var _ = Describe("VXLANManager", func() {
 
 		opRecorder := logutils.NewSummarizer("test")
 
-		// Mark the mock netlink connections as open (the managers are handed
-		// the handles directly rather than connecting via a factory function)
-		// and seed an "eth0" parent device carrying the host address.
 		dataplane := mocknetlink.New()
 		_, err := dataplane.NewMockNetlink()
 		Expect(err).NotTo(HaveOccurred())

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/projectcalico/calico/felix/dataplane/linux/dataplanedefs"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/netlinkshim/mocknetlink"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/routetable"
 	"github.com/projectcalico/calico/felix/rules"
@@ -107,9 +108,26 @@ var _ = Describe("VXLANManager", func() {
 
 		fdb = &mockVXLANFDB{}
 
-		la := netlink.NewLinkAttrs()
-		la.Name = "eth0"
 		opRecorder := logutils.NewSummarizer("test")
+
+		// Mark the mock netlink connections as open (the managers are handed
+		// the handles directly rather than connecting via a factory function)
+		// and seed an "eth0" parent device carrying the host address.
+		dataplane := mocknetlink.New()
+		_, err := dataplane.NewMockNetlink()
+		Expect(err).NotTo(HaveOccurred())
+		dataplane.ImmediateLinkUp = true
+		eth0 := dataplane.AddIface(2, "eth0", true, true)
+		Expect(dataplane.AddrAdd(eth0, &netlink.Addr{IPNet: &net.IPNet{IP: net.IPv4(172, 0, 0, 2)}})).To(Succeed())
+		dataplane.ResetDeltas()
+
+		dataplaneV6 := mocknetlink.New()
+		_, err = dataplaneV6.NewMockNetlink()
+		Expect(err).NotTo(HaveOccurred())
+		dataplaneV6.ImmediateLinkUp = true
+		eth0V6 := dataplaneV6.AddIface(2, "eth0", true, true)
+		Expect(dataplaneV6.AddrAdd(eth0V6, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("fc00:10:96::2")}})).To(Succeed())
+		dataplaneV6.ResetDeltas()
 
 		dpConfig := Config{
 			MaxIPSetSize:       5,
@@ -129,11 +147,7 @@ var _ = Describe("VXLANManager", func() {
 			4444,
 			dpConfig,
 			opRecorder,
-			&mockTunnelDataplane{
-				links:          []netlink.Link{&mockLink{attrs: la}},
-				tunnelLinkName: dataplanedefs.VXLANIfaceNameV4,
-				ipVersion:      4,
-			},
+			dataplane,
 		)
 
 		dpConfigV6 := Config{
@@ -154,11 +168,7 @@ var _ = Describe("VXLANManager", func() {
 			6666,
 			dpConfigV6,
 			opRecorder,
-			&mockTunnelDataplane{
-				links:          []netlink.Link{&mockLink{attrs: la}},
-				tunnelLinkName: dataplanedefs.VXLANIfaceNameV6,
-				ipVersion:      6,
-			},
+			dataplaneV6,
 		)
 	})
 

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -114,7 +114,7 @@ func init() {
 	}
 
 	// All good, proceed with the sketchy cast...
-	var lnf = (*myLinkNotFoundError)((unsafe.Pointer)(&ErrLinkNotFound))
+	lnf := (*myLinkNotFoundError)((unsafe.Pointer)(&ErrLinkNotFound))
 	lnf.error = ErrNotFound
 }
 

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -307,6 +307,8 @@ type MockNetlinkDataplane struct {
 	WireguardOpen               bool
 	NumLinkAddCalls             int
 	NumLinkDeleteCalls          int
+	NumLinkSetMTUCalls          int
+	NumLinkSetUpCalls           int
 	ImmediateLinkUp             bool
 	NumRuleListCalls            int
 	NumRuleAddCalls             int
@@ -357,6 +359,8 @@ func (d *MockNetlinkDataplane) ResetDeltas() {
 	d.UpdatedRouteKeys = set.New[string]()
 	d.NumLinkAddCalls = 0
 	d.NumLinkDeleteCalls = 0
+	d.NumLinkSetMTUCalls = 0
+	d.NumLinkSetUpCalls = 0
 	d.NumNewNetlinkCalls = 0
 	d.NumNewWireguardCalls = 0
 	d.NumRuleListCalls = 0
@@ -495,7 +499,7 @@ func (d *MockNetlinkDataplane) LinkList() ([]netlink.Link, error) {
 	}
 	var links []netlink.Link
 	for _, link := range d.NameToLink {
-		links = append(links, link.copy())
+		links = append(links, link.typedCopy())
 	}
 	return links, nil
 }
@@ -517,7 +521,7 @@ func (d *MockNetlinkDataplane) LinkByName(name string) (netlink.Link, error) {
 	}
 	log.Debugf("Looking for interface: %s", name)
 	if link, ok := d.NameToLink[name]; ok {
-		return link.copy(), nil
+		return link.typedCopy(), nil
 	}
 	return nil, ErrLinkNotFound
 }
@@ -544,8 +548,9 @@ func (d *MockNetlinkDataplane) LinkAdd(link netlink.Link) error {
 		attrs.Index = 100 + d.NumLinkAddCalls
 	}
 	d.NameToLink[link.Attrs().Name] = &MockLink{
-		LinkAttrs: attrs,
-		LinkType:  link.Type(),
+		LinkAttrs:    attrs,
+		LinkType:     link.Type(),
+		ConcreteLink: link,
 	}
 	d.AddedLinks.Add(link.Attrs().Name)
 	return nil
@@ -577,6 +582,8 @@ func (d *MockNetlinkDataplane) LinkSetMTU(link netlink.Link, mtu int) error {
 	defer d.mutex.Unlock()
 	defer ginkgo.GinkgoRecover()
 
+	d.NumLinkSetMTUCalls++
+
 	Expect(d.NetlinkOpen).To(BeTrue())
 	if d.shouldFail(FailNextLinkSetMTU) {
 		return ErrSimulated
@@ -593,6 +600,8 @@ func (d *MockNetlinkDataplane) LinkSetUp(link netlink.Link) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	defer ginkgo.GinkgoRecover()
+
+	d.NumLinkSetUpCalls++
 
 	Expect(d.NetlinkOpen).To(BeTrue())
 	if d.shouldFail(FailNextLinkSetUp) {
@@ -1173,6 +1182,12 @@ type MockLink struct {
 	Addrs     []netlink.Addr
 	LinkType  string
 
+	// ConcreteLink holds the concrete netlink.Link (e.g. *netlink.Vxlan) that
+	// was passed to LinkAdd, if the link was created through the netlink API.
+	// LinkByName/LinkList return a copy of it so that callers that type-assert
+	// the result (as they would with the real netlink library) keep working.
+	ConcreteLink netlink.Link
+
 	WireguardPrivateKey   wgtypes.Key
 	WireguardPublicKey    wgtypes.Key
 	WireguardListenPort   int
@@ -1202,9 +1217,10 @@ func (l *MockLink) copy() *MockLink {
 	}
 
 	return &MockLink{
-		LinkAttrs: l.LinkAttrs, // Shallow copy, but we don't use the nested pointers AFAICT.
-		Addrs:     addrsCopy,
-		LinkType:  l.LinkType,
+		LinkAttrs:    l.LinkAttrs, // Shallow copy, but we don't use the nested pointers AFAICT.
+		Addrs:        addrsCopy,
+		LinkType:     l.LinkType,
+		ConcreteLink: l.ConcreteLink,
 
 		WireguardPrivateKey:   l.WireguardPrivateKey,
 		WireguardPublicKey:    l.WireguardPublicKey,
@@ -1212,4 +1228,19 @@ func (l *MockLink) copy() *MockLink {
 		WireguardFirewallMark: l.WireguardFirewallMark,
 		WireguardPeers:        wgPeersCopy,
 	}
+}
+
+// typedCopy returns the link as the netlink API would: if the link was created
+// via LinkAdd, a copy of the original concrete type (e.g. *netlink.Vxlan) with
+// up-to-date attributes; otherwise, a copy of the MockLink itself.
+func (l *MockLink) typedCopy() netlink.Link {
+	if l.ConcreteLink == nil {
+		return l.copy()
+	}
+	v := reflect.ValueOf(l.ConcreteLink).Elem()
+	cp := reflect.New(v.Type())
+	cp.Elem().Set(v)
+	link := cp.Interface().(netlink.Link)
+	*link.Attrs() = l.LinkAttrs
+	return link
 }


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Replacing `mockTunnelDataplane` used in ipip, vxlan, and no-encap manager's UT with existing mocked netlink in netlinkshim package.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
