### PR TITLE
Wire kube-controllers into make generate and regenerate migration CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ generate:
 	$(MAKE) -C libcalico-go gen-files
 	$(MAKE) -C felix gen-files
 	$(MAKE) -C goldmane gen-files
+	$(MAKE) -C kube-controllers gen-files
 	$(MAKE) get-operator-crds
 	$(MAKE) gen-manifests
 	$(MAKE) fix-changed

--- a/kube-controllers/pkg/controllers/migration/api.go
+++ b/kube-controllers/pkg/controllers/migration/api.go
@@ -95,7 +95,8 @@ type DatastoreMigration struct {
 	// Spec defines the desired migration behavior.
 	Spec DatastoreMigrationSpec `json:"spec"`
 	// Status reports the observed state of the migration.
-	Status DatastoreMigrationStatus `json:"status"`
+	// +optional
+	Status DatastoreMigrationStatus `json:"status,omitempty"`
 }
 
 // DatastoreMigrationList contains a list of DatastoreMigration resources.

--- a/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
+++ b/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: datastoremigrations.migration.projectcalico.org
 spec:
   group: migration.projectcalico.org
@@ -68,8 +68,10 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec defines the desired migration behavior.
             properties:
               type:
+                description: Type specifies the migration to perform (e.g., APIServerToCRDs).
                 enum:
                 - APIServerToCRDs
                 type: string
@@ -77,13 +79,16 @@ spec:
             - type
             type: object
           status:
+            description: Status reports the observed state of the migration.
             properties:
               completedAt:
+                description: CompletedAt is the timestamp when the migration transitioned
+                  to Complete.
                 format: date-time
                 type: string
-              message:
-                type: string
               conditions:
+                description: Conditions report conflicts and errors encountered during
+                  migration.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -139,48 +144,85 @@ spec:
                   - type
                   type: object
                 type: array
+              message:
+                description: |-
+                  Message is a human-readable status message describing what the controller
+                  is currently doing or waiting on.
+                type: string
               phase:
+                description: Phase is the current phase of the migration state machine.
                 type: string
               progress:
+                description: Progress tracks per-type and aggregate migration counters.
                 properties:
                   completedTypes:
+                    description: CompletedTypes is the number of resource types that
+                      have been fully processed.
                     type: integer
                   conflicts:
+                    description: Conflicts is the number of resources that existed
+                      in v3 with different content.
                     type: integer
                   currentType:
+                    description: CurrentType is the resource kind currently being
+                      migrated, or empty if done.
                     type: string
                   migrated:
+                    description: Migrated is the number of resources successfully
+                      copied to v3.
                     type: integer
                   skipped:
+                    description: Skipped is the number of resources that already existed
+                      in v3 with matching content.
                     type: integer
                   total:
+                    description: Total is the total number of resources processed
+                      across all types.
                     type: integer
                   totalTypes:
+                    description: TotalTypes is the number of resource types to migrate.
                     type: integer
-                  typeProgress:
-                    type: string
                   typeDetails:
+                    description: TypeDetails contains per-resource-type migration
+                      results.
                     items:
-                      description: TypeMigrationProgress tracks the result for a single
-                        resource type.
+                      description: TypeMigrationProgress tracks the migration result
+                        for a single resource kind.
                       properties:
                         conflicts:
+                          description: Conflicts is the number of resources of this
+                            kind that existed in v3 with different content.
                           type: integer
                         kind:
+                          description: Kind is the Calico resource kind (e.g., "NetworkPolicy",
+                            "GlobalNetworkPolicy").
                           type: string
                         migrated:
+                          description: Migrated is the number of resources of this
+                            kind successfully copied to v3.
                           type: integer
                         skipped:
+                          description: Skipped is the number of resources of this
+                            kind that already existed in v3 with matching content.
                           type: integer
                       required:
                       - kind
                       type: object
                     type: array
+                  typeProgress:
+                    description: TypeProgress is a human-readable summary like "5
+                      / 21" for printer columns.
+                    type: string
                 type: object
               startedAt:
+                description: StartedAt is the timestamp when the migration transitioned
+                  to Migrating.
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
+        - status
         type: object
     served: true
     storage: true

--- a/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
+++ b/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
@@ -222,7 +222,6 @@ spec:
             type: object
         required:
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/kube-controllers/pkg/controllers/migration/groupversion_info.go
+++ b/kube-controllers/pkg/controllers/migration/groupversion_info.go
@@ -16,6 +16,7 @@
 //
 // +kubebuilder:object:generate=true
 // +groupName=migration.projectcalico.org
+// +versionName=v1beta1
 package migration
 
 import (


### PR DESCRIPTION
The root `make generate` target runs `gen-files` for most components but never included kube-controllers, so the DatastoreMigration CRD silently drifted from its kubebuilder markers (stale field descriptions, missing `required`, old controller-gen version). This adds kube-controllers to the target and regenerates the CRD.

It also adds a `+versionName=v1beta1` marker to the migration package. controller-gen derives the version name from the package name (`migration`), and the old `gen.go` used a `sed` fixup to rewrite it - that fixup was lost when `gen.go` was replaced by the Makefile target. The marker lets controller-gen emit the correct served version (`v1beta1`, which the controller's informer expects) directly, so generation is now idempotent.

```release-note
None
```
