### PR TITLE
flannel-migration: flush leftover Flannel iptables chains on node cleanup

### DIFF
--- a/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
@@ -85,6 +85,27 @@ func (m *networkMigrator) Initialise() error {
 	return nil
 }
 
+// flannelIPTablesCleanup removes the iptables chains that Flannel programs:
+// FLANNEL-POSTRTG in the nat table and FLANNEL-FWD in the filter table.
+// Deleting the Flannel daemonset and tunnel devices does not remove these
+// rules, so they survive the migration. In particular the masquerade rule in
+// FLANNEL-POSTRTG SNATs cross-node pod-to-pod traffic to the node's tunnel IP,
+// which silently breaks Calico NetworkPolicy after migration: the source
+// address no longer matches pod-selector based rules and the traffic is dropped
+// by the default-deny. Flush the chains on the node so Calico (cali-nat-outgoing)
+// is the only owner of pod masquerading. Both the legacy and nft iptables
+// backends are cleaned since either may hold the rules; missing binaries are
+// skipped, and every command is idempotent.
+const flannelIPTablesCleanup = `for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do ` +
+	`command -v "$ipt" >/dev/null 2>&1 || continue; ` +
+	`"$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null; ` +
+	`"$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null; ` +
+	`"$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null; ` +
+	`"$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null; ` +
+	`"$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null; ` +
+	`"$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null; ` +
+	`done; `
+
 // Remove Flannel network device/routes on node.
 // Write a dummy calico cni config file in front of Flannel/Canal CNI config.
 // This will prevent Flannel CNI from running and make sure new pod created will not get networked
@@ -105,6 +126,11 @@ func (m *networkMigrator) removeFlannelNetworkAndInstallDummyCalicoCNI(node *v1.
 		cmd = fmt.Sprintf("{ ip link show cni0; ip link show flannel.%d; } || exit 0 && { echo '%s' > /host/%s/%s ; ip link delete cni0 type bridge; ip link delete flannel.%d; } && exit 0 || exit 1",
 			m.config.FlannelVNI, dummyCNI, m.config.CniConfigDir, m.calicoCNIConfigName, m.config.FlannelVNI)
 	}
+
+	// Removing the daemonset and the tunnel/bridge devices above does not delete
+	// the iptables chains Flannel installed, so flush them as part of the same
+	// node cleanup. See flannelIPTablesCleanup for why this is required.
+	cmd = flannelIPTablesCleanup + cmd
 
 	// Run a remove-flannel pod with specified nodeName, this will bypass kube-scheduler.
 	// https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodename


### PR DESCRIPTION
### Description

When the flannel-migration controller migrates a node to Calico it:

- removes the Flannel daemonset, and
- deletes the Flannel network devices on the node (`flannel.<vni>`, and `cni0` for non-Canal flannel) via the per-node `remove-flannel` pod in `removeFlannelNetworkAndInstallDummyCalicoCNI`.

It does **not** remove the iptables chains Flannel installs: `FLANNEL-POSTRTG` (nat) and `FLANNEL-FWD` (filter). These are programmed by `flanneld` at runtime and are **not** cleaned up when the daemonset/devices are removed, so they persist after an otherwise successful migration.

### Why it matters

`FLANNEL-POSTRTG` contains:

```
ip saddr <podCIDR> ip daddr != 224.0.0.0/4  masquerade
```

with `RETURN` exceptions only for the node-**local** subnet. After migration this rule keeps masquerading **cross-node** pod-to-pod traffic to the source node's VXLAN tunnel IP (`<block>.0`).

This is invisible until a `NetworkPolicy` is applied. Once it is, the SNAT'd source address no longer matches pod-selector / same-namespace rules, so Felix's default-deny drops the traffic. Symptom: after a clean migration, **cross-node** connections to any pod covered by a NetworkPolicy silently time out, while **same-node** traffic keeps working (Flannel's own RETURN rules exempt the node-local subnet). Calico's own `cali-nat-outgoing` correctly does *not* masquerade pod-to-pod, so it's purely the leftover Flannel chain.

### Reproduction

1. Migrate a flannel cluster to Calico with this controller.
2. `nft list chain ip nat POSTROUTING` on any node still shows `jump FLANNEL-POSTRTG` (non-zero counters).
3. Apply a NetworkPolicy selecting some pods.
4. Cross-node traffic to those pods times out; a listener sees the source as the sender node's `<block>.0` tunnel IP instead of the client pod IP.

### Fix

Flush `FLANNEL-POSTRTG` and `FLANNEL-FWD` as part of the existing per-node `remove-flannel` step, so Calico becomes the sole owner of pod masquerading. The cleanup:

- runs in the same privileged `calico/node` pod that already deletes the devices;
- cleans both the legacy and nft iptables backends (either may hold the rules), skipping missing binaries;
- is fully idempotent (safe if the chains are already gone).

### Testing

- Manually verified on a live migrated cluster that `FLANNEL-POSTRTG` persists post-migration, SNATs cross-node pod traffic to the tunnel IP, and breaks NetworkPolicy; removing the chains restores cross-node policy traffic with no other changes.
- `gofmt`-clean. I was not able to run the flannel-migration FV suite locally; happy to iterate.

### Release Note

```release-note
flannel-migration: remove leftover Flannel iptables chains (FLANNEL-POSTRTG/FLANNEL-FWD) during node migration so they no longer masquerade cross-node pod traffic and break NetworkPolicy after migrating to Calico.
```
