### PR TITLE
[release-v3.32] calicoctl cluster diags: collect calico-bpf dumps as JSON

### DIFF
--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -695,6 +695,29 @@ func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace, p
 	return cmds
 }
 
+// bpfJSONCmd builds a diagnostic command that dumps calico-bpf state as JSON,
+// writing <file>.json. calico-bpf gained machine-parseable output via the
+// --json flag, and the diags bundle prefers JSON so downstream tooling can
+// parse it directly.
+//
+// calicoctl is frequently run against an older cluster whose calico-node
+// predates --json (or a newer subcommand like `nat maglev`), in which case the
+// command exits non-zero. To degrade gracefully it falls back to the plain-text
+// form (--json dropped) and writes <file>.txt instead of capturing an error.
+//
+// sub is the bpf subcommand, e.g. "nat dump" or "conntrack stats"; file is the
+// output basename without extension, e.g. "bpf-nat".
+func bpfJSONCmd(curNodeDir, nodeName, namespace, podName, info, sub, file string) common.Cmd {
+	base := fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf %s", namespace, podName, sub)
+	return common.Cmd{
+		Info:             fmt.Sprintf("Collect eBPF %s for node %s", info, nodeName),
+		CmdStr:           base + " --json",
+		FilePath:         fmt.Sprintf("%s/%s.json", curNodeDir, file),
+		FallbackCmdStr:   base,
+		FallbackFilePath: fmt.Sprintf("%s/%s.txt", curNodeDir, file),
+	}
+}
+
 func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName string) {
 	fmt.Printf("Collecting dataplane diags for calico-node: %s\n", podName)
 	common.ExecAllCmdsWriteToFile([]common.Cmd{
@@ -754,27 +777,18 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- conntrack -LSC", namespace, podName),
 			FilePath: fmt.Sprintf("%s/conntrack-list.txt", curNodeDir),
 		},
-		// eBPF diagnostics
-		{
-			Info:     fmt.Sprintf("Collect eBPF conntrack for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf conntrack dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-conntrack.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF ipsets for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf ipsets dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-ipsets.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF nat for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf nat dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-nat.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF routes for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf routes dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-routes.txt", curNodeDir),
-		},
+		// eBPF diagnostics. Collected as JSON via calico-bpf's --json flag,
+		// falling back to plain text for older calico-node that predates it.
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "conntrack", "conntrack dump", "bpf-conntrack"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "ipsets", "ipsets dump", "bpf-ipsets"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "nat", "nat dump", "bpf-nat"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "routes", "routes dump", "bpf-routes"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "counters", "counters dump", "bpf-counters"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "arp", "arp dump", "bpf-arp"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "ifstate", "ifstate dump", "bpf-ifstate"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "conntrack stats", "conntrack stats", "bpf-conntrack-stats"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "nat affinity", "nat aff", "bpf-nat-aff"),
+		bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "nat maglev table", "nat maglev", "bpf-nat-maglev"),
 		{
 			Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
 			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -30,6 +30,24 @@ func init() {
 	logutils.ConfigureFormatter("test")
 }
 
+func TestBpfJSONCmd_CollectsJSONWithTextFallback(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Each calico-bpf dump must request JSON output and land in a .json file,
+	// with a plain-text fallback (--json dropped, .txt file) for older
+	// calico-node versions that don't support --json or the subcommand.
+	cmd := bpfJSONCmd("/node-dir", "nodeA", "calico-system", "calico-node-xyz", "nat maglev table", "nat maglev", "bpf-nat-maglev")
+
+	Expect(cmd.CmdStr).To(ContainSubstring("calico-node -bpf nat maglev"))
+	Expect(cmd.CmdStr).To(HaveSuffix("--json"))
+	Expect(cmd.FilePath).To(Equal("/node-dir/bpf-nat-maglev.json"))
+
+	Expect(cmd.FallbackCmdStr).To(ContainSubstring("calico-node -bpf nat maglev"))
+	Expect(cmd.FallbackCmdStr).NotTo(ContainSubstring("--json"),
+		"fallback command must not pass --json")
+	Expect(cmd.FallbackFilePath).To(Equal("/node-dir/bpf-nat-maglev.txt"))
+}
+
 func TestDiags(t *testing.T) {
 	RegisterTestingT(t)
 	test := func(invocation string, expectedErr error, expectedOutput string, expectedOpts *diagOpts) {

--- a/calicoctl/calicoctl/commands/common/cmd.go
+++ b/calicoctl/calicoctl/commands/common/cmd.go
@@ -100,6 +100,14 @@ type Cmd struct {
 	CmdStr   string
 	FilePath string
 	SymLink  string
+
+	// FallbackCmdStr, if set, is run when CmdStr exits non-zero — for example
+	// when collecting from an older component that doesn't understand a newer
+	// flag or subcommand. Its output is written to FallbackFilePath (or to
+	// FilePath if FallbackFilePath is empty). This keeps diags useful across
+	// version skew: e.g. try a JSON dump, fall back to the plain-text dump.
+	FallbackCmdStr   string
+	FallbackFilePath string
 }
 
 // ExecCmdWriteToFile executes the provided command c and outputs the result to a
@@ -124,21 +132,39 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 
 	logCtx.Debugf("Executing command: %+v ... ", c.CmdStr)
 	content, err := exec.Command(parts[0], parts[1:]...).CombinedOutput()
+
+	// Determine where the output should land. If the primary command failed and
+	// a fallback is configured, run the fallback instead (e.g. an older
+	// calico-node that doesn't support --json: retry without it and keep the
+	// plain-text output). The fallback output replaces the primary output.
+	filePath := c.FilePath
+	if err != nil && c.FallbackCmdStr != "" {
+		logCtx.Debugf("Command failed, trying fallback: %s", c.FallbackCmdStr)
+		fParts := strings.Fields(c.FallbackCmdStr)
+		fContent, fErr := exec.Command(fParts[0], fParts[1:]...).CombinedOutput()
+		if fErr == nil {
+			content, err = fContent, nil
+			if c.FallbackFilePath != "" {
+				filePath = c.FallbackFilePath
+			}
+		}
+	}
+
 	if err != nil {
 		fmt.Printf("%s Failed to run command: %s\nError: %s\n", logPrefix, c.CmdStr, string(content))
 	}
 
 	// This is for the commands we want to run but don't want to save the output
 	// or for commands that don't produce any output to stdout
-	if c.FilePath == "" {
+	if filePath == "" {
 		logCtx.Debugln("Command executed successfully, skipping writing output (no filepath specified)")
 		return
 	}
 
-	if err := os.WriteFile(c.FilePath, content, 0644); err != nil {
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
 		logCtx.Errorf("Error writing diags to file: %s\n", err)
 	}
-	logCtx.Debugf("Command executed successfully and outputted to %s", c.FilePath)
+	logCtx.Debugf("Command executed successfully and outputted to %s", filePath)
 
 	if c.SymLink != "" {
 		dir = filepath.Dir(c.SymLink)
@@ -146,7 +172,7 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 			fmt.Printf("%s Error creating directory for %v: %v\n", logPrefix, c.SymLink, err)
 			return
 		}
-		relativeTarget, err := filepath.Rel(dir, c.FilePath)
+		relativeTarget, err := filepath.Rel(dir, filePath)
 		if err != nil {
 			fmt.Printf("%s Error computing relative path for %v: %v\n", logPrefix, c.SymLink, err)
 			return

--- a/calicoctl/calicoctl/commands/common/cmd_test.go
+++ b/calicoctl/calicoctl/commands/common/cmd_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
+)
+
+// TestExecCmdWriteToFile_Fallback verifies that when the primary command exits
+// non-zero and a fallback is configured, the fallback output is collected into
+// the fallback file and the primary file is not written. This is what keeps
+// diags useful against an older component (e.g. --json unsupported -> retry
+// without it and keep the plain-text output).
+func TestExecCmdWriteToFile_Fallback(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	txtPath := filepath.Join(dir, "out.txt")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:           "false", // exits non-zero
+		FilePath:         jsonPath,
+		FallbackCmdStr:   "echo fellback", // succeeds
+		FallbackFilePath: txtPath,
+	})
+
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Fatalf("expected primary file %s not to be written, stat err=%v", jsonPath, err)
+	}
+	got, err := os.ReadFile(txtPath)
+	if err != nil {
+		t.Fatalf("reading fallback file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "fellback" {
+		t.Fatalf("unexpected fallback content: %q", got)
+	}
+}
+
+// TestExecCmdWriteToFile_PrimarySucceeds verifies the fallback is not used when
+// the primary command succeeds.
+func TestExecCmdWriteToFile_PrimarySucceeds(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	txtPath := filepath.Join(dir, "out.txt")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:           "echo primary",
+		FilePath:         jsonPath,
+		FallbackCmdStr:   "echo fellback",
+		FallbackFilePath: txtPath,
+	})
+
+	got, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("reading primary file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "primary" {
+		t.Fatalf("unexpected primary content: %q", got)
+	}
+	if _, err := os.Stat(txtPath); !os.IsNotExist(err) {
+		t.Fatalf("fallback file should not exist when primary succeeds")
+	}
+}

--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -38,6 +38,7 @@ func init() {
 		"group frontends that share the same service ID and print their backends once per group")
 	natCmd.AddCommand(natDumpCmd)
 	natCmd.AddCommand(natAffDumpCmd)
+	natCmd.AddCommand(natMaglevDumpCmd)
 
 	natSetCmd.AddCommand(newNatSetFrontend())
 	natSetCmd.AddCommand(newNatSetBackend())
@@ -84,6 +85,16 @@ var natAffDumpCmd = &cobra.Command{
 	},
 }
 
+var natMaglevDumpCmd = &cobra.Command{
+	Use:   "maglev",
+	Short: "dumps the maglev consistent-hash backend table",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := dumpMaglev(cmd); err != nil {
+			log.WithError(err).Error("Failed to dump maglev map")
+		}
+	},
+}
+
 var natSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "sets an entry in the NAT tables",
@@ -94,17 +105,66 @@ var natDelCmd = &cobra.Command{
 	Short: "deletes an entry from the NAT tables",
 }
 
-func dumpAff(cmd *cobra.Command) (err error) {
+func dumpAff(cmd *cobra.Command) error {
+	if ipv6 != nil && *ipv6 {
+		affMap, err := nat.LoadAffinityMapV6(nat.AffinityMapV6())
+		if err != nil {
+			return err
+		}
+		return writeAff(cmd, makeAffinityJSON(affMap))
+	}
+
 	affMap, err := nat.LoadAffinityMap(nat.AffinityMap())
 	if err != nil {
 		return err
 	}
+	return writeAff(cmd, makeAffinityJSON(affMap))
+}
 
-	for k, v := range affMap {
-		cmd.Printf("%-40s %s\n", k, v)
+func writeAff(cmd *cobra.Command, entries []affinityEntryJSON) error {
+	if *jsonOutput {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
 	}
 
+	for _, e := range entries {
+		cmd.Printf("client %s svc proto %d %s -> %s ts %s\n",
+			e.ClientIP, e.Proto, net.JoinHostPort(e.Addr, fmt.Sprint(e.Port)),
+			net.JoinHostPort(e.Backend.Addr, fmt.Sprint(e.Backend.Port)), e.Timestamp)
+	}
 	cmd.Printf("\n")
+
+	return nil
+}
+
+func dumpMaglev(cmd *cobra.Command) error {
+	if ipv6 != nil && *ipv6 {
+		mglvMap, err := nat.LoadMaglevMapV6(nat.MaglevMapV6())
+		if err != nil {
+			return err
+		}
+		return writeMaglev(cmd, makeMaglevJSON(mglvMap))
+	}
+
+	mglvMap, err := nat.LoadMaglevMap(nat.MaglevMap())
+	if err != nil {
+		return err
+	}
+	return writeMaglev(cmd, makeMaglevJSON(mglvMap))
+}
+
+func writeMaglev(cmd *cobra.Command, entries []maglevEntryJSON) error {
+	if *jsonOutput {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+
+	for _, e := range entries {
+		cmd.Printf("svc %d ordinal %d -> %s\n",
+			e.SvcID, e.Ordinal, net.JoinHostPort(e.Addr, fmt.Sprint(e.Port)))
+	}
 
 	return nil
 }
@@ -365,6 +425,87 @@ type natServiceGroupJSON struct {
 	ID        uint32            `json:"id"`
 	Frontends []natFrontendJSON `json:"frontends"`
 	Backends  []natBackendJSON  `json:"backends"`
+}
+
+// maglevEntryJSON is one (service, ordinal) -> backend slot of the maglev
+// consistent-hash table.
+type maglevEntryJSON struct {
+	SvcID   uint32 `json:"svc_id"`
+	Ordinal uint32 `json:"ordinal"`
+	Addr    string `json:"addr"`
+	Port    uint16 `json:"port"`
+}
+
+// maglevKey is the constraint for a maglev map key: comparable (so it can be a
+// Go map key) and exposing the maglev key accessors.
+type maglevKey interface {
+	comparable
+	nat.MaglevBackendKeyInterface
+}
+
+func makeMaglevJSON[K maglevKey, V nat.BackendValueInterface](m map[K]V) []maglevEntryJSON {
+	entries := make([]maglevEntryJSON, 0, len(m))
+	for k, v := range m {
+		entries = append(entries, maglevEntryJSON{
+			SvcID:   k.SvcID(),
+			Ordinal: k.Ordinal(),
+			Addr:    v.Addr().String(),
+			Port:    v.Port(),
+		})
+	}
+	// Sort by (service, ordinal) for deterministic output.
+	slices.SortFunc(entries, func(a, b maglevEntryJSON) int {
+		if a.SvcID != b.SvcID {
+			return cmp.Compare(a.SvcID, b.SvcID)
+		}
+		return cmp.Compare(a.Ordinal, b.Ordinal)
+	})
+	return entries
+}
+
+// affinityEntryJSON is one client -> backend affinity entry, keyed by the
+// client IP and the frontend service it is sticky to.
+type affinityEntryJSON struct {
+	ClientIP  string         `json:"client_ip"`
+	Proto     uint8          `json:"proto"`
+	Addr      string         `json:"addr"`
+	Port      uint16         `json:"port"`
+	Backend   natBackendJSON `json:"backend"`
+	Timestamp string         `json:"timestamp"`
+}
+
+// affinityKey is the constraint for an affinity map key: comparable and
+// exposing the affinity key accessors.
+type affinityKey interface {
+	comparable
+	nat.AffinityKeyInterface
+}
+
+func makeAffinityJSON[K affinityKey, V nat.AffinityValueInterface](m map[K]V) []affinityEntryJSON {
+	entries := make([]affinityEntryJSON, 0, len(m))
+	for k, v := range m {
+		fe := k.FrontendAffinityKey()
+		be := v.Backend()
+		entries = append(entries, affinityEntryJSON{
+			ClientIP:  k.ClientIP().String(),
+			Proto:     fe.Proto(),
+			Addr:      fe.Addr().String(),
+			Port:      fe.Port(),
+			Backend:   natBackendJSON{Addr: be.Addr().String(), Port: be.Port()},
+			Timestamp: v.Timestamp().String(),
+		})
+	}
+	// Sort by (service addr, port, client) for deterministic output.
+	slices.SortFunc(entries, func(a, b affinityEntryJSON) int {
+		if c := cmp.Compare(a.Addr, b.Addr); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Port, b.Port); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ClientIP, b.ClientIP)
+	})
+	return entries
 }
 
 func dumpNATJSON[FK nat.FrontendKeyComparable, BV nat.BackendValueInterface](

--- a/felix/cmd/calico-bpf/commands/nat_test.go
+++ b/felix/cmd/calico-bpf/commands/nat_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -37,6 +38,58 @@ func TestNATDump(t *testing.T) {
 	}
 
 	dumpNice(func(format string, i ...any) { fmt.Printf(format, i...) }, nat, back, false)
+}
+
+// TestMaglevDumpJSON checks that makeMaglevJSON flattens the maglev map into
+// (svc, ordinal) -> backend entries, sorted deterministically, and that the
+// result marshals to JSON.
+func TestMaglevDumpJSON(t *testing.T) {
+	m := nat2.MaglevMapMem{
+		nat2.NewMaglevBackendKey(35, 1): nat2.NewNATBackendValue(net.IPv4(6, 6, 6, 6), 8080),
+		nat2.NewMaglevBackendKey(35, 0): nat2.NewNATBackendValue(net.IPv4(5, 5, 5, 5), 8080),
+		nat2.NewMaglevBackendKey(12, 0): nat2.NewNATBackendValue(net.IPv4(7, 7, 7, 7), 90),
+	}
+
+	entries := makeMaglevJSON(m)
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(entries), entries)
+	}
+	// Sorted by (svc, ordinal): (12,0), (35,0), (35,1).
+	if entries[0].SvcID != 12 || entries[1].SvcID != 35 || entries[1].Ordinal != 0 || entries[2].Ordinal != 1 {
+		t.Fatalf("entries not sorted by (svc, ordinal): %+v", entries)
+	}
+	if entries[1].Addr != "5.5.5.5" || entries[1].Port != 8080 {
+		t.Fatalf("unexpected backend for (35,0): %+v", entries[1])
+	}
+	if _, err := json.Marshal(entries); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}
+
+// TestAffinityDumpJSON checks that makeAffinityJSON exposes the client, the
+// frontend service tuple, and the chosen backend as structured fields.
+func TestAffinityDumpJSON(t *testing.T) {
+	m := nat2.AffinityMapMem{
+		nat2.NewAffinityKey(net.IPv4(10, 0, 0, 1), nat2.NewNATKey(net.IPv4(1, 1, 1, 1), 80, 6)): nat2.NewAffinityValue(
+			0, nat2.NewNATBackendValue(net.IPv4(5, 5, 5, 5), 8080)),
+	}
+
+	entries := makeAffinityJSON(m)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %+v", len(entries), entries)
+	}
+	e := entries[0]
+	if e.ClientIP != "10.0.0.1" || e.Addr != "1.1.1.1" || e.Port != 80 || e.Proto != 6 {
+		t.Fatalf("unexpected affinity key fields: %+v", e)
+	}
+	if e.Backend.Addr != "5.5.5.5" || e.Backend.Port != 8080 {
+		t.Fatalf("unexpected backend: %+v", e.Backend)
+	}
+	if _, err := json.Marshal(entries); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
 }
 
 // TestDumpNiceGrouping verifies that dumpNiceGrouped groups frontends sharing the


### PR DESCRIPTION
Cherry-pick of #12923 to `release-v3.32`.

Collects the eBPF dataplane state in `calicoctl cluster diags` as JSON, and
adds the `nat maglev` dump + `nat aff --json` to calico-bpf.

Adapted for v3.32: this release reaches the bpf tool via the legacy
`calico-node -bpf <sub>` invocation (the combined `calico component node bpf`
binary and the `--json` flag landed together on master; v3.32 already has
`--json`, so only the invocation form differs). v3.32's calico-bpf already
supported `--json` for the existing dumps — this cherry adds the missing
`nat maglev` command and `nat aff --json`, then switches the diags collection
to JSON with a plain-text fallback for older nodes.

## What's collected (now JSON, `.json`)
conntrack, ipsets, nat, routes, counters, arp, ifstate, conntrack stats,
nat affinity, nat maglev. `bpftool` prog/map listings stay text.

## Cross-version safety
Each dump tries `calico-node -bpf <sub> --json` and falls back to
`calico-node -bpf <sub>` (plain text, `.txt`) when the deployed calico-node is
too old to understand `--json` or the subcommand.

## Testing
- Unit tests: JSON builders (`makeMaglevJSON`/`makeAffinityJSON`), the
  `bpfJSONCmd` helper, and the `common.Cmd` fallback path.
- The calico-bpf maglev/affinity JSON output was verified end-to-end on a BPF
  cluster as part of #12923 (identical code).

**Release note:**
```release-note
calicoctl cluster diags now collects the eBPF dataplane state (conntrack, ipsets, nat, routes, counters, arp, ifstate, conntrack stats, nat affinity and maglev tables) in JSON format. A new `calico-bpf nat maglev` command dumps the maglev table, and `calico-bpf nat aff` gains JSON output.
```
