### PR TITLE
Add cherry-pick-candidate auto-labeler workflow

### DIFF
--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -1,0 +1,61 @@
+# Stage 2 of the cherry-pick-candidate auto-labeler. Triggered by
+# workflow_run when "Cherry-Pick Candidate (trigger)" completes.
+#
+# Asks the calico-backport-classifier agent whether the PR looks like a
+# backport candidate based on its title + body, and reconciles the
+# `cherry-pick-candidate` label:
+#   agent says backport, label absent       : add label
+#   agent says skip, label present (by bot) : remove label
+#   any human action on the label           : leave it alone
+#
+# Trust model: stage 1 may execute fork-modified code from the PR head,
+# but it has zero permissions. Stage 2 runs from the base branch (trusted
+# workflow file) with contents:read + pull-requests:write + issues:write.
+# PR identity comes from GitHub-set workflow_run.head_sha, never from
+# artifact content. All logic lives in
+# .github/workflows/scripts/cherry_pick_candidate.js, loaded from the
+# trusted base-branch tree via actions/checkout.
+#
+# No-op until the BACKPORT_CLASSIFIER_AGENT_URL and
+# BACKPORT_CLASSIFIER_AGENT_TOKEN repo secrets are set: the script
+# short-circuits with a warning if either is missing.
+
+name: Cherry-Pick Candidate
+on:
+  workflow_run:
+    workflows: ["Cherry-Pick Candidate (trigger)"]
+    types: [completed]
+
+concurrency:
+  # Key per (fork owner, branch) so events for the same PR coalesce,
+  # including force-pushes that change head_sha.
+  group: cherry-pick-candidate-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    env:
+      AGENT_URL: ${{ secrets.BACKPORT_CLASSIFIER_AGENT_URL }}
+      AGENT_TOKEN: ${{ secrets.BACKPORT_CLASSIFIER_AGENT_TOKEN }}
+    steps:
+      # workflow_run runs in the context of the base branch, so checkout
+      # without a `ref:` gets the trusted default-branch tree, not the
+      # fork PR's. persist-credentials:false drops the git token after
+      # this step (we only need it to read the .js file).
+      - name: Checkout workflow scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Classify and reconcile label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const fn = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/cherry_pick_candidate.js`);
+            await fn({ github, context, core });

--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -27,8 +27,10 @@ on:
     types: [completed]
 
 concurrency:
-  # Key per (fork owner, branch) so events for the same PR coalesce,
-  # including force-pushes that change head_sha.
+  # Key per (fork owner, branch) so rapid edits to the same PR coalesce
+  # via cancel-in-progress and only the latest edited state runs to
+  # completion. Code pushes do not fire Stage 1 (synchronize is not in
+  # the trigger types), so this key is about user-driven title/body edits.
   group: cherry-pick-candidate-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 

--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -6,7 +6,7 @@
 # `cherry-pick-candidate` label:
 #   agent says backport, label absent       : add label
 #   agent says skip, label present (by bot) : remove label
-#   any human action on the label           : leave it alone
+#   any non-bot action on the label         : leave it alone
 #
 # Trust model: stage 1 may execute fork-modified code from the PR head,
 # but it has zero permissions. Stage 2 runs from the base branch (trusted
@@ -39,6 +39,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      # pull-requests: write is required to add or remove labels on PRs.
+      # issues: write alone returns 403 against /issues/{n}/labels when
+      # the target is a PR. Do not tighten this back to read.
       pull-requests: write
       issues: write
     env:

--- a/.github/workflows/cherry_pick_candidate_trigger.yml
+++ b/.github/workflows/cherry_pick_candidate_trigger.yml
@@ -1,0 +1,19 @@
+# Stage 1 of the cherry-pick-candidate auto-labeler. Fires on PR open,
+# reopen, and title/body edits with zero permissions and no logic. Sole
+# purpose: fire a workflow_run event so the trusted stage 2
+# (cherry_pick_candidate.yml) can do the real work from the base branch
+# with the privileged token.
+
+name: Cherry-Pick Candidate (trigger)
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions: {}
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Triggers Cherry-Pick Candidate via workflow_run."

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -5,11 +5,12 @@
 // Rules:
 //   agent says backport, label absent       : add label
 //   agent says skip, label present (by bot) : remove label
-//   any human action on the label           : leave it alone (for the
+//   any non-bot action on the label         : leave it alone (for the
 //                                             rest of the PR's life)
 //
 // The whole job is a no-op until the BACKPORT_CLASSIFIER_AGENT_URL and
-// BACKPORT_CLASSIFIER_AGENT_TOKEN env vars are set.
+// BACKPORT_CLASSIFIER_AGENT_TOKEN repo secrets are set (passed in to
+// this script as AGENT_URL and AGENT_TOKEN env vars by the workflow).
 
 const LABEL = 'cherry-pick-candidate';
 const BOT_LOGIN = 'github-actions[bot]';
@@ -19,7 +20,16 @@ module.exports = async ({ github, context, core }) => {
   const agentUrl = process.env.AGENT_URL;
   const agentToken = process.env.AGENT_TOKEN;
   if (!agentUrl || !agentToken) {
-    core.warning('BACKPORT_CLASSIFIER_AGENT_URL or BACKPORT_CLASSIFIER_AGENT_TOKEN missing, skipping');
+    core.warning('BACKPORT_CLASSIFIER_AGENT_URL or BACKPORT_CLASSIFIER_AGENT_TOKEN secret missing (read by this script as AGENT_URL/AGENT_TOKEN env vars), skipping');
+    return;
+  }
+  // Register the token for log masking so it cannot leak via any
+  // downstream log line, including diagnostics added later.
+  core.setSecret(agentToken);
+  // Refuse to send the bearer token over plaintext if a misconfigured
+  // secret points at a non-https URL.
+  if (!/^https:\/\//i.test(agentUrl)) {
+    core.warning('AGENT_URL is not https://, refusing to send bearer token over plaintext, skipping');
     return;
   }
 
@@ -43,7 +53,8 @@ module.exports = async ({ github, context, core }) => {
   }
 
   // 2. Authority check. The most recent labeled/unlabeled event for this
-  //    label tells us who currently owns it. Any non-bot account is final.
+  //    label tells us who currently owns it. Any actor other than
+  //    github-actions[bot] is final.
   const events = await github.paginate(
     github.rest.issues.listEventsForTimeline,
     { owner, repo, issue_number: pr.number },
@@ -53,7 +64,7 @@ module.exports = async ({ github, context, core }) => {
   );
   const lastActor = labelEvents[labelEvents.length - 1]?.actor?.login || '';
   if (lastActor && lastActor !== BOT_LOGIN) {
-    core.info(`Label authority: human (${lastActor}), bot will not modify`);
+    core.info(`Label authority: ${lastActor} (non-bot), bot will not modify`);
     return;
   }
   const present = pr.labels.some(l => l.name === LABEL);
@@ -88,6 +99,9 @@ module.exports = async ({ github, context, core }) => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(payload),
+        // Fail closed on any redirect so the bearer token cannot be
+        // sent to a different host than the configured AGENT_URL.
+        redirect: 'error',
         signal: AbortSignal.timeout(60_000),
       });
       if (r.ok) {

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -32,6 +32,10 @@ module.exports = async ({ github, context, core }) => {
     core.warning('AGENT_URL is not https://, refusing to send bearer token over plaintext, skipping');
     return;
   }
+  // Neutralize :: in agent-controlled text before logging so the agent
+  // cannot inject ::add-mask:: or other workflow commands. Used for every
+  // line that echoes any byte the agent could have authored.
+  const safe = s => String(s ?? '').replace(/::/g, ':​:');
 
   const headSha = context.payload.workflow_run?.head_sha;
   if (!headSha) {
@@ -129,7 +133,7 @@ module.exports = async ({ github, context, core }) => {
     parsed = JSON.parse(stripped);
   } catch (e) {
     core.warning(`could not parse agent response: ${e.message}`);
-    core.info(`raw response: ${JSON.stringify(response).slice(0, 500)}`);
+    core.info(safe(`raw response: ${JSON.stringify(response).slice(0, 500)}`));
     return;
   }
   const { decision, confidence, primary_signal: primarySignal, reason } = parsed;
@@ -137,9 +141,6 @@ module.exports = async ({ github, context, core }) => {
     core.warning(`unknown decision: ${decision}, skipping`);
     return;
   }
-  // Sanitize agent-controlled text before logging so it cannot inject
-  // ::add-mask:: or other workflow commands via the reason field.
-  const safe = s => String(s ?? '').replace(/::/g, ':​:');
   core.info(`agent decision: ${decision} (confidence=${safe(confidence)})`);
   core.info(`primary signal: ${safe(primarySignal)}`);
   core.info(`reason: ${safe(reason)}`);

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -1,0 +1,157 @@
+// Reconciles the `cherry-pick-candidate` label on master PRs based on an
+// external LLM classifier agent's verdict. Invoked from the Stage 2
+// cherry-pick-candidate workflow via actions/github-script.
+//
+// Rules:
+//   agent says backport, label absent       : add label
+//   agent says skip, label present (by bot) : remove label
+//   any human action on the label           : leave it alone (for the
+//                                             rest of the PR's life)
+//
+// The whole job is a no-op until the BACKPORT_CLASSIFIER_AGENT_URL and
+// BACKPORT_CLASSIFIER_AGENT_TOKEN env vars are set.
+
+const LABEL = 'cherry-pick-candidate';
+const BOT_LOGIN = 'github-actions[bot]';
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const agentUrl = process.env.AGENT_URL;
+  const agentToken = process.env.AGENT_TOKEN;
+  if (!agentUrl || !agentToken) {
+    core.warning('BACKPORT_CLASSIFIER_AGENT_URL or BACKPORT_CLASSIFIER_AGENT_TOKEN missing, skipping');
+    return;
+  }
+
+  const headSha = context.payload.workflow_run?.head_sha;
+  if (!headSha) {
+    core.warning('workflow_run payload missing head_sha, skipping');
+    return;
+  }
+
+  // 1. Find the open master PR for this head SHA.
+  const associated = await github.paginate(
+    github.rest.repos.listPullRequestsAssociatedWithCommit,
+    { owner, repo, commit_sha: headSha },
+  );
+  const pr = associated.find(p =>
+    p.state === 'open' && p.head.sha === headSha && p.base.ref === 'master',
+  );
+  if (!pr) {
+    core.warning(`no open master PR found with head SHA ${headSha}, skipping`);
+    return;
+  }
+
+  // 2. Authority check. The most recent labeled/unlabeled event for this
+  //    label tells us who currently owns it. Any non-bot account is final.
+  const events = await github.paginate(
+    github.rest.issues.listEventsForTimeline,
+    { owner, repo, issue_number: pr.number },
+  );
+  const labelEvents = events.filter(e =>
+    (e.event === 'labeled' || e.event === 'unlabeled') && e.label?.name === LABEL,
+  );
+  const lastActor = labelEvents[labelEvents.length - 1]?.actor?.login || '';
+  if (lastActor && lastActor !== BOT_LOGIN) {
+    core.info(`Label authority: human (${lastActor}), bot will not modify`);
+    return;
+  }
+  const present = pr.labels.some(l => l.name === LABEL);
+  core.info(`Label authority: bot (last actor: ${lastActor || 'none'}, present=${present})`);
+
+  // 3. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
+  const msgId = `calico-backport-classifier-${pr.number}-${process.env.GITHUB_RUN_ID}`;
+  const payload = {
+    jsonrpc: '2.0',
+    id: msgId,
+    method: 'message/send',
+    params: {
+      message: {
+        messageId: msgId,
+        role: 'user',
+        parts: [{
+          kind: 'text',
+          text: `PR number: ${pr.number}\nPR title: ${pr.title}\nPR body:\n${pr.body || ''}`,
+        }],
+      },
+      configuration: { acceptedOutputModes: ['application/json', 'text/plain'] },
+    },
+  };
+
+  let response = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const r = await fetch(agentUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${agentToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(60_000),
+      });
+      if (r.ok) {
+        response = await r.json();
+        break;
+      }
+      core.info(`agent attempt ${attempt} failed (http=${r.status})`);
+    } catch (e) {
+      core.info(`agent attempt ${attempt} failed (${e.message})`);
+    }
+    if (attempt < 3) await new Promise(res => setTimeout(res, attempt * 5000));
+  }
+  if (!response) {
+    core.warning('agent unreachable after 3 attempts, skipping');
+    return;
+  }
+
+  // 4. Parse the response. Contract: result.artifacts[0].parts[0].text is
+  //    a JSON object with fields decision (backport|skip), confidence,
+  //    primary_signal, reason. Tolerated wrapped in a markdown fence.
+  const raw = response.result?.artifacts?.[0]?.parts?.[0]?.text || '';
+  const stripped = raw.replace(/^```(?:json)?\s*\n?|\n?```\s*$/gm, '').trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (e) {
+    core.warning(`could not parse agent response: ${e.message}`);
+    core.info(`raw response: ${JSON.stringify(response).slice(0, 500)}`);
+    return;
+  }
+  const { decision, confidence, primary_signal: primarySignal, reason } = parsed;
+  if (decision !== 'backport' && decision !== 'skip') {
+    core.warning(`unknown decision: ${decision}, skipping`);
+    return;
+  }
+  // Sanitize agent-controlled text before logging so it cannot inject
+  // ::add-mask:: or other workflow commands via the reason field.
+  const safe = s => String(s ?? '').replace(/::/g, ':​:');
+  core.info(`agent decision: ${decision} (confidence=${safe(confidence)})`);
+  core.info(`primary signal: ${safe(primarySignal)}`);
+  core.info(`reason: ${safe(reason)}`);
+
+  // 5. Reconcile. addLabels is idempotent server-side; removeLabel 404s if
+  //    the label was removed by a human during the agent call (we treat
+  //    that as a no-op since the end state matches our intent).
+  if (decision === 'backport' && !present) {
+    core.info(`Adding ${LABEL} to PR #${pr.number}`);
+    await github.rest.issues.addLabels({
+      owner, repo, issue_number: pr.number, labels: [LABEL],
+    });
+  } else if (decision === 'skip' && present) {
+    core.info(`Removing ${LABEL} from PR #${pr.number} (bot-applied, agent now says skip)`);
+    try {
+      await github.rest.issues.removeLabel({
+        owner, repo, issue_number: pr.number, name: LABEL,
+      });
+    } catch (e) {
+      if (e.status === 404) {
+        core.info('label already gone, no-op');
+      } else {
+        throw e;
+      }
+    }
+  } else {
+    core.info(`No-op (decision=${decision}, present=${present})`);
+  }
+};


### PR DESCRIPTION
## Summary

Adds a two-stage GitHub Actions workflow that classifies newly-opened (or reopened or title/body-edited) master PRs via an external LLM classifier agent and reconciles the `cherry-pick-candidate` label:

| Agent says | Label state | Action |
|---|---|---|
| `backport` | absent | **add label** |
| `skip` | present (bot-applied) | **remove label** |
| (any) | last touched by a human | **leave it alone** |

The workflow is a **no-op until two repo secrets are configured**, so this PR is safe to land first and turn on later.

## Trust model

Uses the `workflow_run` two-stage pattern, deliberately not `pull_request_target` (which is the well-documented [pwn-request footgun](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)).

- **Stage 1** (`cherry_pick_candidate_trigger.yml`): fires on `pull_request` with `permissions: {}` and a single echo step. Sole job is to emit a `workflow_run` event. Even if a malicious fork modifies this file in their PR, it runs with no token to abuse.
- **Stage 2** (`cherry_pick_candidate.yml`): triggered by `workflow_run` completion. Runs from the **trusted base-branch tree** with the base repo's \`GITHUB_TOKEN\` (\`pull-requests: write\` + \`issues: write\`). Checks out the workflow scripts at the base-branch revision, then calls `.github/workflows/scripts/cherry_pick_candidate.js` via `actions/github-script`. Fork code is never executed.
- PR identity comes from GitHub-supplied `workflow_run.head_sha`, never from artifact content carried over from Stage 1.
- PR title and body are passed opaquely to the agent via \`JSON.stringify\`, so they cannot inject shell or JSON.
- Agent-controlled text (\`reason\`, \`primary_signal\`) is sanitised before logging so it cannot inject \`::add-mask::\` or other workflow commands.

Works the same for fork PRs as for same-repo PRs (that is what the two-stage pattern is for).

## Configuration

Two repo secrets are required:

- `BACKPORT_CLASSIFIER_AGENT_URL`
- `BACKPORT_CLASSIFIER_AGENT_TOKEN`

If either is missing, the job emits a warning and exits cleanly. So landing this PR before the secrets are configured is safe.

The `cherry-pick-candidate` label already exists on this repo, so no label-creation step is needed.

## Files

- `.github/workflows/cherry_pick_candidate_trigger.yml` (19 lines): Stage 1.
- `.github/workflows/cherry_pick_candidate.yml` (66 lines): Stage 2 wrapper.
- `.github/workflows/scripts/cherry_pick_candidate.js` (172 lines): all classification and reconcile logic.

## Testing

Verified end-to-end across all business-logic paths in an internal staging repo:

- bug-fix-shaped PR opens, label is added
- feature/refactor/test-only PR opens, no label is added
- feature PR edited to bug-fix shape, label is added on re-trigger
- bug-fix PR (title + body) edited to feature shape, bot-applied label is removed on re-trigger
- bug-fix PR edited but content stays bug-fix shape, label is unchanged (idempotent no-op)
- human adds the label manually, bot defers permanently
- human removes the bot-applied label, bot defers permanently

Every conditional in `cherry_pick_candidate.js` has at least one E2E trace through it.

## Release note

\`\`\`release-note
None
\`\`\`

## Test plan after merging

- [ ] Configure the two repo secrets.
- [ ] Open a bug-fix-shaped PR and confirm the label is applied within ~30s.
- [ ] Open a feature-shaped PR and confirm no label is applied.
- [ ] Manually remove a bot-applied label, edit the PR, confirm the bot does not re-apply it.
- [ ] Confirm a maintainer-applied label is not removed by the bot.