### PR TITLE
Make developer Makefiles work on SELinux-enforcing hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ check-ocp-no-crds:
 	@CRD_FILES_IN_OCP_DIR=$$(grep "^kind: CustomResourceDefinition" manifests/ocp/* -l || true); if [ ! -z "$$CRD_FILES_IN_OCP_DIR" ]; then echo "ERROR: manifests/ocp should not have any CustomResourceDefinitions, these files should be removed:"; echo "$$CRD_FILES_IN_OCP_DIR"; exit 1; fi
 
 yaml-lint:
-	@docker run --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest .
+	@$(DOCKER_RUN_CMD) --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest .
 
 protobuf:
 	$(MAKE) -C app-policy protobuf
@@ -449,7 +449,7 @@ endif
 	@echo "This file is auto-generated based on commit records reported" >> AUTHORS.md
 	@echo "by git for the projectcalico/calico repository. It is ordered alphabetically." >> AUTHORS.md
 	@echo "" >> AUTHORS.md
-	@docker run -ti --rm --net=host \
+	@$(DOCKER_RUN_CMD) -ti --rm --net=host \
 		-v $(REPO_ROOT):/code \
 		-w /code \
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \

--- a/api/Makefile
+++ b/api/Makefile
@@ -67,8 +67,12 @@ gen-files .generate_files: lint-cache-dir clean-generated
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) $(CALICO_CONTROLLER_GEN) crd:allowDangerousTypes=true,crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false paths=./pkg/apis/... output:crd:dir=config/crd/'
 	# Remove the first yaml separator line.
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'find ./config/crd -name "*.yaml" | xargs sed -i 1d'
-	# Run prettier to fix indentation
-	docker run --rm --user $(id -u):$(id -g) -v $(CURDIR)/config/crd/:/work/config/crd/ tmknom/prettier --write --parser=yaml /work
+	# Run prettier to fix indentation.
+	# Use the bare flag rather than $(DOCKER_RUN_CMD): this Makefile is also
+	# used in the exported standalone projectcalico/api repo, whose metadata.mk
+	# may not define DOCKER_RUN_CMD. An undefined DOCKER_SELINUX_ARGS expands to
+	# nothing (harmless); an undefined DOCKER_RUN_CMD would break the recipe.
+	docker run $(DOCKER_SELINUX_ARGS) --rm --user $(id -u):$(id -g) -v $(CURDIR)/config/crd/:/work/config/crd/ tmknom/prettier --write --parser=yaml /work
 	# Remove the profiles CRD. Profiles are backed by Namespaces in Kubernetes and the CRD is not needed.
 	rm -f config/crd/*.orig config/crd/projectcalico.org_profiles.yaml
 

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -69,7 +69,7 @@ hack-lib:
 ## Run a local kubernetes server with API in a container.
 run-kubernetes-server: run-k8s-controller-manager
 	# Create a Node in the API for the tests to use.
-	docker run \
+	$(DOCKER_RUN_CMD) \
 		--net=host \
 		--rm \
 		-v  $(CURDIR):/manifests \
@@ -80,7 +80,7 @@ run-kubernetes-server: run-k8s-controller-manager
 
 	# Create Namespaces required by namespaced Calico `NetworkPolicy`
 	# tests from the manifests namespaces.yaml.
-	docker run \
+	$(DOCKER_RUN_CMD) \
 		--net=host \
 		--rm \
 		-v  $(CURDIR):/manifests \

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -135,7 +135,7 @@ st: bin/calicoctl-linux-$(ARCH) version-helper
 # to keep them separate.
 run-kubernetes-control-plane: stop-kubernetes-control-plane
 	# Run a Kubernetes apiserver using Docker.
-	docker run --net=host --detach \
+	$(DOCKER_RUN_CMD) --net=host --detach \
 		--name st-apiserver-${KUBE_APISERVER_PORT} \
 		-v $(CURDIR):/code \
 		-v $(CURDIR)/../:/go/src/github.com/projectcalico/calico \
@@ -163,7 +163,7 @@ run-kubernetes-control-plane: stop-kubernetes-control-plane
 	while ! docker exec st-apiserver-${KUBE_APISERVER_PORT} kubectl --server=https://127.0.0.1:${KUBE_APISERVER_PORT} get nodes; do echo "Waiting for apiserver to come up..."; sleep 2; done
 
 	# And run the controller manager.
-	docker run --detach --net=host \
+	$(DOCKER_RUN_CMD) --detach --net=host \
 	  --name st-controller-manager-${KUBE_APISERVER_PORT} \
 	  -v $(CERTS_PATH):/home/user/certs \
 	  $(CALICO_BUILD) kube-controller-manager \

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -123,8 +123,8 @@ $(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
 	cp flannel-cni-plugin/dist/flannel-$(ARCH) $(BIN)/flannel
 
 $(WINDOWS_BIN)/flannel.exe: $(FLANNEL_CNI_PLUGIN_CLONED)
-	docker run \
-		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
+	$(DOCKER_RUN_CMD) \
+		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \
 			ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_windows'

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -496,7 +496,7 @@ bin/k8sfv.test: $(K8SFV_GO_FILES)
 run-prometheus: stop-prometheus $(K8SFV_PROMETHEUS_DATA_DIR)
 	FELIX_IP=`$(GET_CONTAINER_IP) k8sfv-felix` && \
 	sed "s/__FELIX_IP__/$${FELIX_IP}/" < $(K8SFV_DIR)/prometheus/prometheus.yml.in > $(K8SFV_DIR)/prometheus/prometheus.yml
-	docker run --detach --name k8sfv-prometheus \
+	$(DOCKER_RUN_CMD) --detach --name k8sfv-prometheus \
 	-v $(CURDIR)/$(K8SFV_DIR)/prometheus/prometheus.yml:/etc/prometheus.yml \
 	-v $(K8SFV_PROMETHEUS_DATA_DIR):/prometheus \
 	prom/prometheus \
@@ -508,7 +508,7 @@ stop-prometheus:
 	sleep 2
 
 run-grafana: stop-grafana run-prometheus
-	docker run --detach --name k8sfv-grafana -p 3000:3000 \
+	$(DOCKER_RUN_CMD) --detach --name k8sfv-grafana -p 3000:3000 \
 	-v $(CURDIR)/$(K8SFV_DIR)/grafana:/etc/grafana \
 	-v $(CURDIR)/$(K8SFV_DIR)/grafana-dashboards:/etc/grafana-dashboards \
 	grafana/grafana:$(GRAFANA_VERSION) --config /etc/grafana/grafana.ini

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -710,7 +710,7 @@ endif
 ifdef LOCAL_PYTHON
 PYTHON3_CMD       = python3
 else
-PYTHON3_CMD       = docker run --rm -e QUAY_API_TOKEN -v $(REPO_ROOT):$(REPO_ROOT) -w $(REPO_ROOT) python:3.13 python3.13
+PYTHON3_CMD       = $(DOCKER_RUN_CMD) --rm -e QUAY_API_TOKEN -v $(REPO_ROOT):$(REPO_ROOT) -w $(REPO_ROOT) python:3.13 python3.13
 endif
 
 GIT_CMD           = git
@@ -1533,7 +1533,7 @@ run-k8s-apiserver: run-etcd
 	@if docker inspect $(APISERVER_NAME) >/dev/null 2>&1; then \
 		echo "$(APISERVER_NAME) already running"; \
 	else \
-		docker run --detach --net=host \
+		$(DOCKER_RUN_CMD) --detach --net=host \
 			--name $(APISERVER_NAME) \
 			-v $(REPO_ROOT):/go/src/github.com/projectcalico/calico \
 			-v $(CERTS_PATH):/home/user/certs \
@@ -1585,7 +1585,7 @@ run-k8s-controller-manager: run-k8s-apiserver
 	@if docker inspect $(CONTROLLER_MANAGER_NAME) >/dev/null 2>&1; then \
 		echo "$(CONTROLLER_MANAGER_NAME) already running"; \
 	else \
-		docker run --detach --net=host \
+		$(DOCKER_RUN_CMD) --detach --net=host \
 			--name $(CONTROLLER_MANAGER_NAME) \
 			-v $(CERTS_PATH):/home/user/certs \
 			$(CALICO_BUILD) kube-controller-manager \

--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -57,7 +57,7 @@ gen-crds:
 	# Add K8S ClusterNetworkPolicy CRD
 	curl -sSfL --retry 3 $(NETPOL_CNP_CRD_URL)/$(NETPOL_CNP_CRD) -o ./config/crd/$(NETPOL_CNP_CRD)
 	# Run prettier to fix indentation
-	docker run --rm --user $(id -u):$(id -g) -v $(CURDIR)/config/crd/:/work/config/crd/ tmknom/prettier --write --parser=yaml /work
+	$(DOCKER_RUN_CMD) --rm --user $(id -u):$(id -g) -v $(CURDIR)/config/crd/:/work/config/crd/ tmknom/prettier --write --parser=yaml /work
 
 ./lib/apis/internalapi/zz_generated.deepcopy.go: $(APIS_SRCS)
 	$(DOCKER_GO_BUILD) sh -c 'deepcopy-gen \
@@ -162,7 +162,7 @@ cluster-create: kind-cluster-create
 run-etcd-tls: stop-etcd-tls
 	# TODO: We shouldn't need to enable the v2 API, but some of our test code
 	# still relies on it.
-	docker run --detach \
+	$(DOCKER_RUN_CMD) --detach \
 		-v $(CURDIR)/test/etcd-ut-certs:/root/etcd-certificates/ \
 		--net=host \
 		--entrypoint=/usr/local/bin/etcd \
@@ -184,7 +184,7 @@ stop-etcd-tls:
 	-docker rm -f calico-etcd-tls
 
 run-coredns: stop-coredns
-	docker run \
+	$(DOCKER_RUN_CMD) \
 		--detach \
 		--name coredns \
 		--rm \

--- a/metadata.mk
+++ b/metadata.mk
@@ -56,7 +56,7 @@ endif
 # $(DOCKER_RUN_CMD) in place of a bare `docker run`. It carries the flags that
 # every container run needs regardless of purpose (currently just SELinux
 # handling); keeping it separate from EXTRA_DOCKER_ARGS, which is scoped to the
-# go-build containers (ssh-agent, module cache, CPU caps, ...).
+# build containers (ssh-agent, module cache, CPU caps, ...).
 DOCKER_RUN_CMD := docker run $(DOCKER_SELINUX_ARGS)
 
 # The version of BIRD to use for calico/node builds and confd tests.

--- a/metadata.mk
+++ b/metadata.mk
@@ -40,6 +40,25 @@ GIT_REPO_SLUG ?= $(ORGANIZATION)/$(GIT_REPO)
 # Configure git to access repositories using SSH.
 GIT_USE_SSH = true
 
+# On hosts with SELinux enabled (e.g. Fedora) and Docker's SELinux support
+# turned on, confined containers are denied access to bind mounts unless the
+# files are relabelled (":z"). Relabelling the whole repo is slow and mutates
+# host file labels, so instead run our build/test containers with SELinux
+# label confinement disabled. The flag is harmless when Docker's SELinux
+# support is off, and is omitted entirely on hosts without SELinux.
+ifneq ($(wildcard /sys/fs/selinux),)
+DOCKER_SELINUX_ARGS := --security-opt label=disable
+EXTRA_DOCKER_ARGS += $(DOCKER_SELINUX_ARGS)
+endif
+
+# Ad-hoc containers that bind-mount host files but don't go through the
+# $(DOCKER_RUN)/$(EXTRA_DOCKER_ARGS) build-container wrappers should invoke
+# $(DOCKER_RUN_CMD) in place of a bare `docker run`. It carries the flags that
+# every container run needs regardless of purpose (currently just SELinux
+# handling); keeping it separate from EXTRA_DOCKER_ARGS, which is scoped to the
+# go-build containers (ssh-agent, module cache, CPU caps, ...).
+DOCKER_RUN_CMD := docker run $(DOCKER_SELINUX_ARGS)
+
 # The version of BIRD to use for calico/node builds and confd tests.
 BIRD_VERSION=v0.3.3-211-g9111ec3c
 

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -9,7 +9,7 @@ export BUILDKIT_PROGRESS=plain
 build-test-container:
 	docker build -t networking-calico-test .
 
-RUN_TEST_CONTAINER = docker run -i --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT --rm networking-calico-test
+RUN_TEST_CONTAINER = $(DOCKER_RUN_CMD) -i --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT --rm networking-calico-test
 
 tox: build-test-container
 	$(RUN_TEST_CONTAINER) tox -e py38

--- a/whisker/Makefile
+++ b/whisker/Makefile
@@ -17,7 +17,7 @@ BUILD_IMAGE_NAME=node:22.15
 ###############################################################################
 include ../lib.Makefile
 
-DOCKER_RUN_RM:=docker run --rm \
+DOCKER_RUN_RM:=$(DOCKER_RUN_CMD) --rm \
 	--env CYPRESS_CACHE_FOLDER=/code/.cache/Cypress \
 	--env NPM_TOKEN=${NPM_TOKEN} \
 	--user $(shell id -u):$(shell id -g) \


### PR DESCRIPTION
## Description

On Fedora (and other SELinux-enforcing hosts) with Docker's SELinux support enabled, unprivileged containers are denied access to bind-mounted repo files. Ad-hoc `docker run` invocations that mount host paths therefore fail with `permission denied` — for example the local kube-apiserver helper (`run-k8s-apiserver`) crashes on its mounted certs, and `make ut` hangs forever waiting for the apiserver to come up.

Relabelling the repo (`:z`) is slow and mutates host file labels, so instead this disables SELinux label confinement for our build/test containers:

- Define `DOCKER_SELINUX_ARGS` (`--security-opt label=disable`), gated on `/sys/fs/selinux` existing, and append it to `EXTRA_DOCKER_ARGS` so the `DOCKER_RUN`/`DOCKER_RUN_PRIV_NET`/`DOCKER_GO_BUILD` wrapper family is covered automatically.
- Add a `DOCKER_RUN_CMD` shared command for the ad-hoc `docker run` sites that bind-mount host files but don't go through those wrappers, and convert them to use it.

It is a no-op on non-SELinux hosts (the flag expands to nothing) and changes nothing in CI.

## Release Note

Not required; developer visible only