### PR TITLE
Do not default loadbalancer config when not part of ENABLED_CONTROLLERS

### DIFF
--- a/kube-controllers/pkg/config/config_fv_test.go
+++ b/kube-controllers/pkg/config/config_fv_test.go
@@ -191,12 +191,12 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 			Expect(out.Status.RunningConfig.Controllers.Policy).To(BeNil())
 			Expect(out.Status.RunningConfig.Controllers.WorkloadEndpoint).To(BeNil())
 			Expect(out.Status.RunningConfig.Controllers.ServiceAccount).To(BeNil())
+			Expect(out.Status.RunningConfig.Controllers.LoadBalancer).To(BeNil())
 
 			// These fields are defaulted
 			Expect(out.Status.RunningConfig.HealthChecks).To(Equal(v3.Enabled))
 			Expect(out.Status.RunningConfig.LogSeverityScreen).To(Equal("Info"))
 			Expect(out.Status.RunningConfig.EtcdV3CompactionPeriod).To(Equal(&metav1.Duration{Duration: time.Minute * 10}))
-			Expect(out.Status.RunningConfig.Controllers.LoadBalancer.AssignIPs).To(Equal(v3.AllServices))
 		})
 	})
 
@@ -244,6 +244,19 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 			kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kcc.Status.EnvironmentVars).To(Equal(map[string]string{"ENABLED_CONTROLLERS": "node"}))
+		})
+
+		It("should not default loadbalancer config if not part of ENABLED_CONTROLLERS", func() {
+			// Wait until controller is up and has set status
+			var kcc *v3.KubeControllersConfiguration
+			Eventually(func() map[string]string {
+				var err error
+				kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return kcc.Status.EnvironmentVars
+			}, time.Second*10, time.Millisecond*500).Should(Equal(map[string]string{"ENABLED_CONTROLLERS": "node"}))
+
+			Expect(kcc.Status.RunningConfig.Controllers.LoadBalancer).To(BeNil())
 		})
 	})
 })

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -398,14 +398,6 @@ func mergeLoadBalancer(status *v3.KubeControllersConfigurationStatus, rCfg *RunC
 			rCfg.Controllers.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
 			status.RunningConfig.Controllers.LoadBalancer.AssignIPs = apiCfg.Controllers.LoadBalancer.AssignIPs
 		}
-	} else {
-		// We can enable the LoadBalancer controller as it won't be assigning any IPs if IPPool for LoadBalancer is not set
-		rCfg.Controllers.LoadBalancer = &LoadBalancerControllerConfig{
-			AssignIPs: v3.AllServices,
-		}
-		status.RunningConfig.Controllers.LoadBalancer = &v3.LoadBalancerControllerConfig{
-			AssignIPs: v3.AllServices,
-		}
 	}
 }
 
@@ -638,8 +630,12 @@ func mergeEnabledControllers(envVars map[string]string, status *v3.KubeControlle
 				rc.ServiceAccount = &GenericControllerConfig{}
 				sc.ServiceAccount = &v3.ServiceAccountControllerConfig{}
 			case "loadbalancer":
-				rc.LoadBalancer = &LoadBalancerControllerConfig{}
-				sc.LoadBalancer = &v3.LoadBalancerControllerConfig{}
+				rc.LoadBalancer = &LoadBalancerControllerConfig{
+					AssignIPs: v3.AllServices,
+				}
+				sc.LoadBalancer = &v3.LoadBalancerControllerConfig{
+					AssignIPs: v3.AllServices,
+				}
 			case "flannelmigration":
 				log.WithField(EnvEnabledControllers, v).Fatal("cannot run flannelmigration with other controllers")
 			default:

--- a/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
+++ b/kube-controllers/pkg/controllers/loadbalancer/loadbalancer_controller.go
@@ -463,7 +463,18 @@ func (c *loadBalancerController) syncService(svcKey serviceKey) {
 			}
 		} else {
 			// We can skip service sync if there are no ippools defined that can be used for Service LoadBalancer
-			log.Debugf("No ippools with allowedUse LoadBalancer found. Skipping IP assignment for Service %s/%s", svcKey.namespace, svcKey.name)
+			svc, err := c.serviceLister.Services(svcKey.namespace).Get(svcKey.name)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			if err != nil {
+				log.WithError(err).Errorf("Error getting service %s/%s", svcKey.namespace, svcKey.name)
+				return
+			}
+			if IsCalicoManagedLoadBalancer(svc, c.cfg.AssignIPs) {
+				// Only warn the user if the service is managed by Calico and should have IP assigned
+				log.Debugf("No ippools with allowedUse LoadBalancer found. Skipping IP assignment for Service %s/%s", svcKey.namespace, svcKey.name)
+			}
 		}
 		return
 	}


### PR DESCRIPTION
- Updates LoadBalancer controller to not run when not explicitly configured as part of ENABLED_CONTROLLERS
- Updates logging to warn only about service managed by calico when no ippool is present

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
Updates LoadBalancer controller to not run when not explicitly configured as part of ENABLED_CONTROLLERS
```

Cherry-pick of https://github.com/projectcalico/calico/pull/11728
Fixes https://github.com/projectcalico/calico/issues/12897
