### PR TITLE
Grant tigera-operator RBAC to manage ValidatingAdmissionPolicy

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -438,6 +438,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
 {{- if eq (lower .Values.installation.kubernetesProvider) "openshift" }}
   # When running in OpenShift, we need to update networking config.
   - apiGroups:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -438,6 +438,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
   # When running in OpenShift, we need to update networking config.
   - apiGroups:
       - config.openshift.io

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -478,6 +478,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
   # When running in OpenShift, we need to update networking config.
   - apiGroups:
       - config.openshift.io

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -476,6 +476,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
   # Add the appropriate pod security policy permissions
   - apiGroups:
       - policy


### PR DESCRIPTION
Operator #4878 added management of the protect-builtin-tiers ValidatingAdmissionPolicy — registering it as a tracked API kind and reconciling it via EnsureValidating / updateValidatingAdmissionPolicies — but did not grant the operator ClusterRole permission on the resource.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
