### PR TITLE
Grant tigera-operator RBAC to manage ValidatingAdmissionPolicy

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -442,6 +442,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
 {{- if eq (lower .Values.installation.kubernetesProvider) "openshift" }}
   # When running in OpenShift, we need to update networking config.
   - apiGroups:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -442,6 +442,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
   # When running in OpenShift, we need to update networking config.
   - apiGroups:
       - config.openshift.io

--- a/manifests/tigera-operator-ocp-upgrade.yaml
+++ b/manifests/tigera-operator-ocp-upgrade.yaml
@@ -482,6 +482,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
   # When running in OpenShift, we need to update networking config.
   - apiGroups:
       - config.openshift.io

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -480,6 +480,20 @@ rules:
       - get
       - list
       - watch
+  # The operator manages ValidatingAdmissionPolicy resources protecting built-in
+  # Calico tiers (e.g. protect-builtin-tiers) when serving v3 CRDs (k8s 1.30+).
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
   # Add the appropriate pod security policy permissions
   - apiGroups:
       - policy


### PR DESCRIPTION
Operator PR tigera/operator#4878 (eeb4d808d) added management of the protect-builtin-tiers ValidatingAdmissionPolicy — registering it as a tracked API kind and reconciling it via EnsureValidating / updateValidatingAdmissionPolicies — but did not grant the operator ClusterRole permission on the resource. On clusters serving v3 CRDs the operator's cache watch on ValidatingAdmissionPolicy is then forbidden, which stalls the controller-runtime cache so the Installation reconcile never creates the `calico-system` namespace and every tigerastatus times out.

This grants `validatingadmissionpolicies` / `validatingadmissionpolicybindings` (create/update/delete/get/list/watch) to the operator ClusterRole, alongside the existing MutatingAdmissionPolicy grant, and regenerates the manifests.

This is the ValidatingAdmissionPolicy twin of the MutatingAdmissionPolicy grant added in #12565 (the calico-side companion to operator MAP management). Operator #4878 extended management to VAP.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
