### PR TITLE
Felix CI: recover BPF UT result when the test VM wedges after tests finish

### DIFF
--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -195,20 +195,26 @@ for batch in "${batches[@]}"; do
       fi
     fi
 
+    # The SSH-based teardown steps below are wrapped in 'timeout': if the VM
+    # wedged (e.g. a kernel BPF/vmap teardown deadlock that leaves it
+    # SSH-unreachable), these would otherwise hang until the watchdog kills the
+    # whole batch.  Bounding them lets a batch whose tests already finished
+    # proceed straight to the (control-plane) VM delete.  gcloud delete does not
+    # need SSH, so it reclaims a wedged VM regardless.
     collect_log_file="$artifacts_dir/collect-artifacts-$batch_formatted.log"
-    if "${ssh_cmd[@]}" COMPONENT="${COMPONENT}" "${CALICO_DIR_NAME}/.semaphore/collect-artifacts" >& "$collect_log_file"; then
+    if timeout 180 "${ssh_cmd[@]}" COMPONENT="${COMPONENT}" "${CALICO_DIR_NAME}/.semaphore/collect-artifacts" >& "$collect_log_file"; then
       echo "$prefix Remote artifact collection SUCCEEDED"
     else
-      echo "$prefix Remote artifact collection FAILED"
+      echo "$prefix Remote artifact collection FAILED (rc=$?)"
     fi
-    if scp "${SSH_OPTIONS[@]}" -r -C "ubuntu@${vm_ip}:${CALICO_DIR_NAME}/artifacts" "${repo_dir}/artifacts/${batch}" >> "$collect_log_file" 2>&1; then
+    if timeout 180 scp "${SSH_OPTIONS[@]}" -r -C "ubuntu@${vm_ip}:${CALICO_DIR_NAME}/artifacts" "${repo_dir}/artifacts/${batch}" >> "$collect_log_file" 2>&1; then
       echo "$prefix Artifact retrieval SUCCEEDED"
     else
-      echo "$prefix Artifact retrieval FAILED"
+      echo "$prefix Artifact retrieval FAILED (rc=$?)"
     fi
 
     echo "$prefix Deleting test VM $vm_name"
-    if gcloud --quiet beta compute instances delete "$vm_name" --zone="${zone}" --no-graceful-shutdown; then
+    if timeout 300 gcloud --quiet beta compute instances delete "$vm_name" --zone="${zone}" --no-graceful-shutdown; then
       echo "$prefix Deletion of test VM $vm_name SUCCEEDED"
     else
       echo "$prefix Deletion of test VM $vm_name FAILED, will retry at end of job. "

--- a/felix/.semaphore/batches.sh
+++ b/felix/.semaphore/batches.sh
@@ -10,6 +10,88 @@ else
   export batches=($(seq 1 ${num_fv_batches}))
 fi
 
+# Determine pass/fail for a batch purely from its *streamed* log.  Used as a
+# fallback when the VM stops responding before it can write test.rc -- e.g. a
+# kernel BPF/vmap teardown deadlock that wedges the VM *after* the tests
+# finished.  In that case test.rc never lands and ssh hangs, but the test
+# framework's end-of-run summary line was already streamed to the runner host
+# before the VM locked up, so we can still recover the verdict from it.
+#
+# Echoes "pass", "fail", or nothing (run not finished / no summary line yet).
+# Anchored to each framework's end-of-run summary so a mid-run "PASS"/"SUCCESS"
+# can never be mistaken for completion.
+batch_log_verdict() {
+  local batch="$1" log_file="$2"
+  [ -f "$log_file" ] || return 0
+  # Strip ANSI colour codes (ginkgo colourises its summary line).
+  local tail_clean
+  tail_clean="$(tail -n 300 "$log_file" 2>/dev/null | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g')"
+  if [ "$batch" = "ut" ]; then
+    # gotestsum's final line:
+    #   "DONE <n> tests[, <s> skipped][, <f> failures] in <d>s"
+    local done_line
+    done_line="$(grep -E '^DONE [0-9]+ tests' <<<"$tail_clean" | tail -n 1)"
+    [ -z "$done_line" ] && return 0
+    if grep -qE ', [0-9]+ (failures|errors)' <<<"$done_line"; then
+      echo fail
+    else
+      echo pass
+    fi
+  else
+    # ginkgo's final summary line: "SUCCESS! -- ..." or "FAIL! -- ...".
+    if grep -qE '^FAIL!' <<<"$tail_clean"; then
+      echo fail
+    elif grep -qE '^SUCCESS!' <<<"$tail_clean"; then
+      echo pass
+    fi
+  fi
+  # Always succeed: callers do `verdict="$(batch_log_verdict ...)"` under
+  # `set -e`, so a non-zero return (e.g. the no-match grep above) would abort
+  # the batch.  The verdict is conveyed via stdout; "" means "not finished".
+  return 0
+}
+
+# Capture the VM serial console (works via the GCP control plane even when ssh
+# is dead) into an artifact next to the batch log, for diagnosing a wedged VM.
+capture_serial_console() {
+  local vm_name="$1" log_file="$2" batch="$3"
+  local serial; serial="$(dirname "$log_file")/vm-serial-${batch}-wedged.log"
+  echo "RUNNER: Capturing serial console for wedged VM '$vm_name' to $(basename "$serial")" >> "$log_file"
+  timeout 120 gcloud compute instances get-serial-port-output "$vm_name" \
+      --zone="${ZONE}" --port=1 > "$serial" 2>&1 \
+      || echo "RUNNER: serial console capture failed/timed out" >> "$log_file"
+}
+
+# Write a synthetic JUnit report for a batch whose real report could not be
+# retrieved because the VM wedged after the tests completed.  Mirrors the
+# watchdog's synthetic report so the batch still appears in Semaphore test
+# results (clearly labelled) instead of silently vanishing.
+write_synthetic_report() {
+  local batch="$1" log_file="$2" verdict="$3"
+  local report_type batch_formatted
+  if [ "$batch" = "ut" ]; then report_type="ut"; else report_type="fv"; fi
+  if [[ "$batch" =~ ^[0-9]+$ ]]; then
+    batch_formatted="$(printf '%03d' "$batch")"
+  else
+    batch_formatted="$batch"
+  fi
+  local report_dir; report_dir="$(dirname "$log_file")/$batch/report"
+  mkdir -p "$report_dir"
+  local failures=0 body=""
+  if [ "$verdict" = fail ]; then
+    failures=1
+    body="<failure message=\"Batch ${batch} reported failure in its streamed log; the VM wedged before its real report could be retrieved.\"></failure>"
+  fi
+  cat > "$report_dir/felix_${report_type}_wedged_${batch_formatted}.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="batch-${batch}" tests="1" failures="${failures}" errors="0" time="0">
+    <testcase name="batch ${batch} completion (VM wedged post-test)" classname="ci.wedge-recovery" time="0">${body}</testcase>
+  </testsuite>
+</testsuites>
+EOF
+}
+
 run_batch() {
   local remote_exec="$1"
   local batch="$2"
@@ -90,27 +172,60 @@ run_batch() {
     # "kill the process group", i.e. while loop and its children.
     trap 'stopped=true; kill -TERM -$tail_pid || true; wait $tail_pid || true' EXIT
 
-    num_fails=0
+    # Poll the VM for the batch's exit code.  wait-for-test-completion is
+    # single-shot (returns "running" / a number / "66"); we own the cadence and
+    # the timeout here.  Each poll is bounded by 'timeout' so a wedged VM -- one
+    # where even a trivial ssh never returns -- cannot block this loop.  That is
+    # the case that matters: when a batch wedges the VM *after* its tests
+    # finished (kernel BPF/vmap teardown deadlock), test.rc never lands and ssh
+    # hangs, but the framework's end-of-run summary was already streamed to us,
+    # so we recover the verdict from the log rather than waiting for the
+    # 55-minute watchdog.
+    unresponsive=0
     while true; do
-      rc=$(VM_NAME="$vm_name" ${remote_exec} "$CALICO_DIR_NAME/felix/.semaphore/wait-for-test-completion" || echo "ssh error $?")
-      # Verify that we got a number; if not, probably an ssh error or similar.
-      if grep -q '^[0-9]\+$' <<< "$rc"; then
-        if [ "$rc" -eq 66 ]; then
-          echo "RUNNER: WARNING: Batch '$batch' on VM '$vm_name' stopped without outputting its RC file (possible VM crash/reboot?)." >> "$log_file"
-          echo "RUNNER: Fetching serial console output for debugging:" >> "$log_file"
-          gcloud compute instances get-serial-port-output "$vm_name" --zone=${ZONE} --port=1 >> "$log_file"
-        fi
-        echo "RUNNER: Batch '$batch' on VM '$vm_name' completed with rc=$rc" >> "$log_file"
-        exit "$rc"
-      else
-        echo "RUNNER: Failed to read batch RC got '$rc', continuing to monitor log..." >> "$log_file"
+      status="$(timeout 30 env VM_NAME="$vm_name" ${remote_exec} \
+                  "$CALICO_DIR_NAME/felix/.semaphore/wait-for-test-completion" 2>/dev/null)" \
+        || status=""
+
+      if [ "$status" = "running" ]; then
+        unresponsive=0
         sleep 10
-        num_fails=$((num_fails + 1))
-        if [ "$num_fails" -ge 10 ]; then
-          echo "RUNNER: Too many failures reading batch RC, aborting batch '$batch' on VM '$vm_name'" >> "$log_file"
-          exit 1
-        fi
+        continue
       fi
+
+      if [ "$status" = "66" ]; then
+        echo "RUNNER: WARNING: Batch '$batch' on VM '$vm_name' stopped without outputting its RC file (possible VM crash/reboot?)." >> "$log_file"
+        capture_serial_console "$vm_name" "$log_file" "$batch"
+        echo "RUNNER: Batch '$batch' on VM '$vm_name' completed with rc=66" >> "$log_file"
+        exit 66
+      fi
+
+      if [[ "$status" =~ ^[0-9]+$ ]]; then
+        echo "RUNNER: Batch '$batch' on VM '$vm_name' completed with rc=$status" >> "$log_file"
+        exit "$status"
+      fi
+
+      # Empty/non-numeric: the ssh poll failed or timed out -- the VM is not
+      # responding.  Before treating that as an infra failure, check whether the
+      # streamed log already shows the batch finished (the post-test wedge case).
+      verdict="$(batch_log_verdict "$batch" "$log_file")"
+      if [ -n "$verdict" ]; then
+        capture_serial_console "$vm_name" "$log_file" "$batch"
+        write_synthetic_report "$batch" "$log_file" "$verdict"
+        local rc=1
+        [ "$verdict" = "pass" ] && rc=0
+        echo "RUNNER: VM '$vm_name' is unresponsive, but the streamed log shows batch '$batch' finished ($verdict). The VM most likely wedged during post-test teardown (kernel BPF/vmap deadlock -- see vm-serial-${batch}-wedged.log). Recording rc=$rc from the streamed log." >> "$log_file"
+        exit "$rc"
+      fi
+
+      unresponsive=$((unresponsive + 1))
+      echo "RUNNER: Batch '$batch' on VM '$vm_name': ssh poll failed and no end-of-run marker in the log yet (attempt $unresponsive); continuing to monitor..." >> "$log_file"
+      if [ "$unresponsive" -ge 10 ]; then
+        echo "RUNNER: VM '$vm_name' has been unresponsive too long with no completion marker; aborting batch '$batch'." >> "$log_file"
+        capture_serial_console "$vm_name" "$log_file" "$batch"
+        exit 1
+      fi
+      sleep 15
     done
   )
 }

--- a/felix/.semaphore/wait-for-test-completion
+++ b/felix/.semaphore/wait-for-test-completion
@@ -1,38 +1,45 @@
 #!/bin/bash
+# Single-shot status check for a detached test batch (see batches.sh:run_batch).
+# Prints exactly one token on stdout and exits:
+#   <number>  the batch finished; this is its exit code (read from test.rc)
+#   running   the batch process is still alive
+#   66        the batch process is gone but left no test.rc (crash/reboot)
+#
+# This script must NOT block or loop: the caller polls it repeatedly and owns
+# the overall timeout.  A loop here is exactly what used to wedge the whole job
+# when the VM locked up *after* the tests completed -- the loop would spin on
+# the VM forever, the caller's ssh would never return, and the batch would only
+# end at the 55-minute watchdog.  Returning promptly lets the caller fall back
+# to the streamed-log verdict when the VM stops responding.
 
-while true; do
-  if [ -f test.rc ]; then
-    # Test finished, output its return code and exit.
-    cat test.rc
-    break
-  fi
+if [ -f test.rc ]; then
+  cat test.rc
+  exit 0
+fi
 
-  # Avoid tight loop.
-  sleep 1
-
-  # Check if the process is still running.
-  if [ ! -f test.pid ]; then
-    echo "ERROR: test.pid not found" >&2
-    echo "66"
-    break
-  fi
-  pid=$(cat test.pid)
-  if ! [[ "$pid" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: test.pid contains non-numeric value: '$pid'" >&2
-    echo "66"
-    break
-  fi
-  if [ -e "/proc/$pid" ]; then
-    # It is, so keep waiting.
-    continue
-  fi
-  # Make sure we didn't race with it finishing...
-  sleep 1
-  if [ -f test.rc ]; then
-    continue
-  fi
-
-  # Not still running and no return code file, something went wrong.
+if [ ! -f test.pid ]; then
+  echo "ERROR: test.pid not found" >&2
   echo "66"
-  break
-done
+  exit 0
+fi
+pid=$(cat test.pid)
+if ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: test.pid contains non-numeric value: '$pid'" >&2
+  echo "66"
+  exit 0
+fi
+if [ -e "/proc/$pid" ]; then
+  echo "running"
+  exit 0
+fi
+
+# Process gone: re-check test.rc in case we raced with it being written.
+sleep 1
+if [ -f test.rc ]; then
+  cat test.rc
+  exit 0
+fi
+
+# Not still running and no return code file: something went wrong.
+echo "66"
+exit 0


### PR DESCRIPTION
Felix BPF unit tests intermittently wedge their test VM via a kernel deadlock (`bpf_prog_free_deferred` vs `drain_vmap_area_work` on `vmap_purge_lock`, observed on `6.17.0-1018-gcp`) during post-test teardown — *after* the tests have already passed. The VM goes SSH-unreachable, the in-VM wrapper never writes `test.rc`, so `run_batch`'s completion poll blocked until the 55-minute watchdog killed the batch and reported a timeout, even though the tests passed.

This decouples the batch verdict from `test.rc`:

- `wait-for-test-completion` is now single-shot (`running` / `<rc>` / `66`); the runner owns the poll cadence and bounds each ssh with `timeout`, so a wedged VM (where even a trivial ssh never returns) can no longer block the monitor loop.
- When the poll is unresponsive, the verdict is recovered from the framework's end-of-run summary line already streamed to the runner host before the VM locked up (gotestsum `DONE N tests…` for `ut`, ginkgo `SUCCESS!/FAIL!` for `fv`), anchored so a mid-run `PASS` can't be mistaken for completion. The serial console is captured and a synthetic JUnit written so the wedge stays visible in test results.
- The SSH teardown steps (`collect-artifacts`, `scp`) and the VM delete are `timeout`-wrapped; `gcloud delete` reclaims a wedged VM via the control plane.

Only a clean end-of-run sentinel counts as a pass; a genuinely hung VM with no completion marker still fails (now in minutes instead of 55), so real failures are never masked.

The underlying kernel deadlock is unfixed upstream through Linux 7.0 / 7.1-rc7; this keeps a passing UT run from being reported as a CI timeout when it recurs.

**Release note:**
```release-note
TBD
```
