### PR TITLE
ci-notify: fix CI_NOTIFY_MAP parsing that mangled all but the last entry

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -145,10 +145,14 @@ jobs:
           LOGIN=$(jq -r .login pr.json)
           # CI_NOTIFY_MAP is "login:slackid, login:slackid, ...".
           # Logins are [A-Za-z0-9-] and Slack IDs are [A-Z0-9], so ':'
-          # is an unambiguous delimiter.
+          # is an unambiguous delimiter. Split entries on ',' (one per line),
+          # then strip whitespace *inside awk per record* — a global
+          # `tr -d '[:space:]'` would also delete the newlines and re-join
+          # every entry into one line, concatenating an ID with the next
+          # entry's login (e.g. "Uxxxxnextlogin").
           SLACK_ID=$(printf '%s' "$CI_NOTIFY_MAP" \
-            | tr ',' '\n' | tr -d '[:space:]' \
-            | awk -F: -v u="$LOGIN" '$1==u {print $2; exit}')
+            | tr ',' '\n' \
+            | awk -F: -v u="$LOGIN" '{gsub(/[[:space:]]/, "")} $1==u {print $2; exit}')
           if [[ -z "$SLACK_ID" ]]; then
             echo "::notice::author '$LOGIN' not in CI_NOTIFY_MAP — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

Fixes the bug that actually stopped CI-finished Slack DMs from arriving (surfaced by the improved error logging in projectcalico/calico#12946).

The opt-in lookup in `ci-notify.yml` parsed `CI_NOTIFY_MAP` like this:

```
printf '%s' "$CI_NOTIFY_MAP" | tr ',' '\n' | tr -d '[:space:]' | awk -F: ...
```

`tr ',' '\n'` puts each `login:slackid` entry on its own line — then `tr -d '[:space:]'` **deletes those newlines too**, re-joining everything into one line. For `CI_NOTIFY_MAP="a:U1,b:U2"`, awk then reads field 2 as `U1b` (the first user's ID concatenated with the next user's login) and never matches `b` at all.

Consequence: notifications only worked while the map had a **single** entry. Adding a second opted-in user silently corrupted the first user's Slack member ID, and Slack rejected the malformed ID (`channel_not_found` before #12946, `user_not_found` after). This is the real reason DMs stopped — the member IDs in the map are correct.

Fix: drop the global `tr -d` and strip whitespace **per record inside awk** (`gsub` on `$0`, which re-splits the fields), so the comma-split survives. Verified locally against both `a:U1,b:U2` and the documented spaced form `a:U1, b:U2` — each login now resolves to its own ID.

Verified with `actionlint` (includes shellcheck on the `run:` block).

## Release Note

```release-note
TBD
```