### PR TITLE
[release-v3.31] Bump golang.org/x dependencies for CVE fixes (envoy-ratelimit)

### DIFF
--- a/third_party/envoy-ratelimit/patches/0001-CVE-dependency-fixes.patch
+++ b/third_party/envoy-ratelimit/patches/0001-CVE-dependency-fixes.patch
@@ -1,21 +1,27 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tigera <noreply@tigera.io>
-Date: Thu, 22 May 2026 12:00:00 -0700
-Subject: [PATCH] Update dependencies for CVE fixes (refreshed for ff287602, x/net v0.54.0)
+Date: Tue, 10 Jun 2026 09:00:00 -0700
+Subject: [PATCH] Update dependencies for CVE fixes (refreshed for ff287602, x/net v0.55.0)
 
 Refreshed against envoy-ratelimit pin ff287602 ("build: pin
 golang:1.26.2 to multi-arch index digest", 2026-05-07) — the ref
 pinned by the Envoy Gateway v1.8.0 helm chart.
 
 Upstream ff287602 already carries the prior refresh's go-control-plane,
-otel, grpc, protobuf, and client_model bumps. Only `golang.org/x/net`
-still needs advancing from v0.52.0 to v0.54.0 to clear GO-2026-4918
-(CVE-2026-33814, HTTP/2 infinite loop on bad SETTINGS_MAX_FRAME_SIZE).
-The x/sys + x/text ripples below come straight from `go mod tidy`.
+otel, grpc, protobuf, and client_model bumps, so the only changes
+carried here advance the golang.org/x modules past the versions the
+pinned ref ships. This keeps the bundled ratelimit image in lockstep
+with the envoy-gateway image, whose patch lands on the same x/ versions.
 
 Carried bump:
-  golang.org/x/net   v0.52.0 -> v0.54.0
-plus transitive ripple (x/sys v0.42.0 -> v0.44.0, x/text v0.35.0 -> v0.37.0).
+  golang.org/x/net   v0.52.0 -> v0.55.0  (GO-2026-4918 / CVE-2026-33814,
+                                          HTTP/2 SETTINGS infinite loop)
+plus the transitive ripple from `go mod tidy`:
+  golang.org/x/sys   v0.42.0 -> v0.46.0
+  golang.org/x/text  v0.35.0 -> v0.38.0
+
+Verified `patch -p1 --dry-run` clean against the upstream ff287602
+checkout.
 
 ---
  go.mod |  6 +++---
@@ -23,7 +29,7 @@ plus transitive ripple (x/sys v0.42.0 -> v0.44.0, x/text v0.35.0 -> v0.37.0).
  2 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/go.mod b/go.mod
-index 4a05be8..0c5ebd7 100644
+index 4a05be8..5f0d423 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -35,7 +35,7 @@ require (
@@ -31,7 +37,7 @@ index 4a05be8..0c5ebd7 100644
  	go.opentelemetry.io/otel/sdk v1.43.0
  	go.opentelemetry.io/otel/trace v1.43.0
 -	golang.org/x/net v0.52.0
-+	golang.org/x/net v0.54.0
++	golang.org/x/net v0.55.0
  	google.golang.org/grpc v1.80.0
  	google.golang.org/protobuf v1.36.11
  	gopkg.in/yaml.v2 v2.4.0
@@ -41,13 +47,13 @@ index 4a05be8..0c5ebd7 100644
  	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 -	golang.org/x/sys v0.42.0 // indirect
 -	golang.org/x/text v0.35.0 // indirect
-+	golang.org/x/sys v0.44.0 // indirect
-+	golang.org/x/text v0.37.0 // indirect
++	golang.org/x/sys v0.46.0 // indirect
++	golang.org/x/text v0.38.0 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
  	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
 diff --git a/go.sum b/go.sum
-index 55358ed..592b811 100644
+index 55358ed..119cf3f 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -201,8 +201,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
@@ -56,8 +62,8 @@ index 55358ed..592b811 100644
  golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 -golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 -golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
-+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
++golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
++golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -67,15 +73,15 @@ index 55358ed..592b811 100644
  golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 -golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
++golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
++golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 -golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
-+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
-+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
++golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
++golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=


### PR DESCRIPTION
## Description

Refreshes the bundled `envoy-ratelimit` dependency patch (`third_party/envoy-ratelimit/patches/0001-CVE-dependency-fixes.patch`) to advance the `golang.org/x` modules, bringing it in lockstep with the recent `envoy-gateway` patch refresh (#12933 follow-up).

| Module | Before | After | Reason |
|---|---|---|---|
| `golang.org/x/net` | v0.52.0 | **v0.55.0** | GO-2026-4918 / CVE-2026-33814 — HTTP/2 SETTINGS infinite loop |
| `golang.org/x/sys` *(indirect)* | v0.42.0 | **v0.46.0** | `go mod tidy` ripple |
| `golang.org/x/text` *(indirect)* | v0.35.0 | **v0.38.0** | `go mod tidy` ripple |

These now match the versions the `envoy-gateway` image patch lands on, keeping the two bundled third-party images consistent.

The patch was regenerated (not hand-edited) by resetting the cloned source to the pinned upstream ref `ff287602`, running `go get` for the three modules + `go mod tidy`, and capturing the resulting `go.mod`/`go.sum` diff. The only churn is those three modules.

## How was this validated?

Against a pristine `ff287602` checkout:
- `patch -p1 --dry-run` and real apply — clean
- `go mod verify` — all modules verified
- `go build ./src/service_cmd` (the exact Makefile build target) — succeeds

## Release Note

```release-note
NONE
```