### PR TITLE
[v3.31] fix(felix): exclude LB-only IPPools from BPF in-pool route flag

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -17,9 +17,11 @@ package calc
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"time"
 
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/dispatcher"
@@ -624,12 +626,12 @@ func (c *L3RouteResolver) OnPoolUpdate(update api.Update) (_ bool) {
 	if update.Value != nil {
 		newPool = c.getPoolInfo(update)
 	}
-	if newPool != nil && newPool.PoolType != proto.IPPoolType_NONE {
+	if newPool != nil {
 		logrus.WithFields(logrus.Fields{
 			"oldType": oldPool.PoolType,
 			"newType": newPool.PoolType,
 			"newPool": *newPool,
-		}).Info("Pool is active")
+		}).Info("Pool update")
 		c.allPools[poolKey] = *newPool
 		c.trie.UpdatePool(newPool.CIDR, newPool.PoolType, newPool.NATOutgoing, newPool.CrossSubnet)
 	} else if oldPoolExists {
@@ -661,6 +663,9 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 	if pool == nil {
 		return proto.IPPoolType_NONE
 	}
+	if isLoadBalancerOnlyPool(pool) {
+		return proto.IPPoolType_NONE
+	}
 	if pool.VXLANMode != encap.Undefined {
 		return proto.IPPoolType_VXLAN
 	}
@@ -668,6 +673,17 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 		return proto.IPPoolType_IPIP
 	}
 	return proto.IPPoolType_NO_ENCAP
+}
+
+// isLoadBalancerOnlyPool returns true if the pool's AllowedUses contains only
+// "LoadBalancer". Such pools should not contribute to route pool type because
+// their CIDRs do not represent workload/tunnel addresses and traffic destined
+// to them should still be masqueraded (not exempted from SNAT via the
+// FlagInIPAMPool BPF route flag or the network-ip-pools ipset).
+//
+// NOTE: keep in sync with isLoadBalancerOnly in felix/dataplane/linux/masq_mgr.go.
+func isLoadBalancerOnlyPool(pool *model.IPPool) bool {
+	return len(pool.AllowedUses) == 1 && slices.Contains(pool.AllowedUses, apiv3.IPPoolAllowedUseLoadBalancer)
 }
 
 // routesFromBlock returns a list of routes which should exist based on the provided

--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"time"
 
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/dispatcher"
@@ -683,7 +683,7 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 //
 // NOTE: keep in sync with isLoadBalancerOnly in felix/dataplane/linux/masq_mgr.go.
 func isLoadBalancerOnlyPool(pool *model.IPPool) bool {
-	return len(pool.AllowedUses) == 1 && slices.Contains(pool.AllowedUses, apiv3.IPPoolAllowedUseLoadBalancer)
+	return len(pool.AllowedUses) == 1 && slices.Contains(pool.AllowedUses, v3.IPPoolAllowedUseLoadBalancer)
 }
 
 // routesFromBlock returns a list of routes which should exist based on the provided

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -144,160 +144,15 @@ var _ = Describe("L3RouteResolver", func() {
 		})
 	})
 
-	Describe("tunnel IP within IPAM block", func() {
-		var l3RR *L3RouteResolver
-		var eventBuf rtEventsMock
-
-		BeforeEach(func() {
-			eventBuf = make(rtEventsMock, 100)
-			l3RR = NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
-			l3RR.OnAlive = func() {}
-		})
-
-		drainEvents := func() []*proto.RouteUpdate {
-			var routes []*proto.RouteUpdate
-			for {
-				select {
-				case ev := <-eventBuf:
-					if rt, ok := ev.(*proto.RouteUpdate); ok {
-						routes = append(routes, rt)
-					}
-				default:
-					return routes
-				}
-			}
-		}
-
-		findRoute := func(routes []*proto.RouteUpdate, dst string) *proto.RouteUpdate {
-			for _, rt := range routes {
-				if rt.Dst == dst {
-					return rt
-				}
-			}
-			return nil
-		}
-
-		// Set up a remote host with a VXLAN tunnel IP that falls within an IPAM block.
-		// The tunnel IP 10.0.1.0 is the first address of the /29 block 10.0.1.0/29.
-		// In production (KIND clusters), this causes the tunnel route to get REMOTE_WORKLOAD
-		// OR'd in alongside REMOTE_TUNNEL, which triggers spurious /32 route programming.
-		It("should not add REMOTE_WORKLOAD to a tunnel IP just because it falls within a block", func() {
-			// Add the IP pool.
-			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
-			pool := model.IPPool{
-				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
-				VXLANMode: encap.Always,
-			}
-			l3RR.OnPoolUpdate(api.Update{
-				KVPair: model.KVPair{
-					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(pool.CIDR)},
-					Value: &pool,
-				},
-			})
-			drainEvents()
-
-			// Add the IPAM block (10.0.1.0/29) with affinity to remote-host.
-			remoteAffinity := "host:remote-host"
-			blockCIDR := net.MustParseCIDR("10.0.1.0/29")
-			l3RR.OnBlockUpdate(api.Update{
-				KVPair: model.KVPair{
-					Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
-					Value: &model.AllocationBlock{
-						CIDR:        blockCIDR,
-						Affinity:    &remoteAffinity,
-						Allocations: make([]*int, 8),
-						Unallocated: []int{0, 1, 2, 3, 4, 5, 6, 7},
-					},
-				},
-			})
-			drainEvents()
-
-			// Add the remote host IP and VXLAN tunnel address via OnNodeUpdate +
-			// a direct tunnel address update. The tunnel IP 10.0.1.0 falls within
-			// the block 10.0.1.0/29.
-			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
-				V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
-				VXLANAddr: ip.FromString("10.0.1.0"),
-			})
-			l3RR.flush()
-
-			routes := drainEvents()
-
-			// Find the tunnel route for 10.0.1.0/32.
-			tunnelRoute := findRoute(routes, "10.0.1.0/32")
-			Expect(tunnelRoute).NotTo(BeNil(), "expected a route for the tunnel IP 10.0.1.0/32")
-
-			// The tunnel route should only have REMOTE_TUNNEL, not REMOTE_WORKLOAD.
-			// If REMOTE_WORKLOAD is present, the route manager will incorrectly program
-			// an extra /32 directly-connected route on the tunnel device.
-			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_TUNNEL).NotTo(BeZero(),
-				"tunnel route should have REMOTE_TUNNEL type")
-			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).To(BeZero(),
-				"tunnel route should NOT have REMOTE_WORKLOAD just because it falls within a block")
-		})
-
-		It("should add REMOTE_WORKLOAD to a tunnel IP in a /32 block", func() {
-			// A dedicated tunnel pool with blockSize=32 creates /32 blocks for each
-			// tunnel IP. In this case the block IS the tunnel IP, and the route manager
-			// needs REMOTE_WORKLOAD to program the directly-connected /32 route.
-			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
-			pool := model.IPPool{
-				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
-				VXLANMode: encap.Always,
-			}
-			l3RR.OnPoolUpdate(api.Update{
-				KVPair: model.KVPair{
-					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(pool.CIDR)},
-					Value: &pool,
-				},
-			})
-			drainEvents()
-
-			// Add a /32 IPAM block at the same CIDR as the tunnel IP.
-			remoteAffinity := "host:remote-host"
-			blockCIDR := net.MustParseCIDR("10.0.1.0/32")
-			l3RR.OnBlockUpdate(api.Update{
-				KVPair: model.KVPair{
-					Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
-					Value: &model.AllocationBlock{
-						CIDR:        blockCIDR,
-						Affinity:    &remoteAffinity,
-						Allocations: make([]*int, 1),
-						Unallocated: []int{0},
-					},
-				},
-			})
-			drainEvents()
-
-			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
-				V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
-				VXLANAddr: ip.FromString("10.0.1.0"),
-			})
-			l3RR.flush()
-
-			routes := drainEvents()
-
-			tunnelRoute := findRoute(routes, "10.0.1.0/32")
-			Expect(tunnelRoute).NotTo(BeNil(), "expected a route for the tunnel IP 10.0.1.0/32")
-
-			// With a /32 block, the tunnel route should have BOTH types so the route
-			// manager programs a directly-connected route.
-			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_TUNNEL).NotTo(BeZero(),
-				"tunnel route should have REMOTE_TUNNEL type")
-			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).NotTo(BeZero(),
-				"tunnel route in /32 block should have REMOTE_WORKLOAD")
-		})
-	})
-
 	It("should not set IpPoolType but still propagate NatOutgoing for LoadBalancer-only pools", func() {
 		eventBuf := make(rtEventsMock, 100)
-		l3RR := NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+		l3RR := NewL3RouteResolver("local-host", eventBuf, false, "CalicoIPAM")
 		l3RR.OnAlive = func() {}
 
 		lbPoolCIDR, _ := ip.CIDRFromString("10.96.0.0/16")
 		l3RR.OnPoolUpdate(api.Update{
 			KVPair: model.KVPair{
-				Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(net.IPNet{IPNet: lbPoolCIDR.ToIPNet()})},
+				Key: model.IPPoolKey{CIDR: net.IPNet{IPNet: lbPoolCIDR.ToIPNet()}},
 				Value: &model.IPPool{
 					CIDR:        net.IPNet{IPNet: lbPoolCIDR.ToIPNet()},
 					Masquerade:  true,
@@ -310,7 +165,7 @@ var _ = Describe("L3RouteResolver", func() {
 		blockCIDR := net.MustParseCIDR("10.96.1.0/26")
 		l3RR.OnBlockUpdate(api.Update{
 			KVPair: model.KVPair{
-				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+				Key: model.BlockKey{CIDR: blockCIDR},
 				Value: &model.AllocationBlock{
 					CIDR:        blockCIDR,
 					Affinity:    &remoteAffinity,
@@ -342,13 +197,13 @@ var _ = Describe("L3RouteResolver", func() {
 
 	It("should set IpPoolType for pools with Workload and LoadBalancer uses", func() {
 		eventBuf := make(rtEventsMock, 100)
-		l3RR := NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+		l3RR := NewL3RouteResolver("local-host", eventBuf, false, "CalicoIPAM")
 		l3RR.OnAlive = func() {}
 
 		mixedPoolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
 		l3RR.OnPoolUpdate(api.Update{
 			KVPair: model.KVPair{
-				Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()})},
+				Key: model.IPPoolKey{CIDR: net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()}},
 				Value: &model.IPPool{
 					CIDR:        net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()},
 					VXLANMode:   encap.Always,
@@ -362,7 +217,7 @@ var _ = Describe("L3RouteResolver", func() {
 		blockCIDR := net.MustParseCIDR("10.0.1.0/26")
 		l3RR.OnBlockUpdate(api.Update{
 			KVPair: model.KVPair{
-				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+				Key: model.BlockKey{CIDR: blockCIDR},
 				Value: &model.AllocationBlock{
 					CIDR:        blockCIDR,
 					Affinity:    &remoteAffinity,

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -17,6 +17,7 @@ package calc
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/proto"
@@ -142,6 +143,257 @@ var _ = Describe("L3RouteResolver", func() {
 			Expect(rt.SameSubnet).NotTo(BeTrue())
 		})
 	})
+
+	Describe("tunnel IP within IPAM block", func() {
+		var l3RR *L3RouteResolver
+		var eventBuf rtEventsMock
+
+		BeforeEach(func() {
+			eventBuf = make(rtEventsMock, 100)
+			l3RR = NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+			l3RR.OnAlive = func() {}
+		})
+
+		drainEvents := func() []*proto.RouteUpdate {
+			var routes []*proto.RouteUpdate
+			for {
+				select {
+				case ev := <-eventBuf:
+					if rt, ok := ev.(*proto.RouteUpdate); ok {
+						routes = append(routes, rt)
+					}
+				default:
+					return routes
+				}
+			}
+		}
+
+		findRoute := func(routes []*proto.RouteUpdate, dst string) *proto.RouteUpdate {
+			for _, rt := range routes {
+				if rt.Dst == dst {
+					return rt
+				}
+			}
+			return nil
+		}
+
+		// Set up a remote host with a VXLAN tunnel IP that falls within an IPAM block.
+		// The tunnel IP 10.0.1.0 is the first address of the /29 block 10.0.1.0/29.
+		// In production (KIND clusters), this causes the tunnel route to get REMOTE_WORKLOAD
+		// OR'd in alongside REMOTE_TUNNEL, which triggers spurious /32 route programming.
+		It("should not add REMOTE_WORKLOAD to a tunnel IP just because it falls within a block", func() {
+			// Add the IP pool.
+			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+			pool := model.IPPool{
+				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
+				VXLANMode: encap.Always,
+			}
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(pool.CIDR)},
+					Value: &pool,
+				},
+			})
+			drainEvents()
+
+			// Add the IPAM block (10.0.1.0/29) with affinity to remote-host.
+			remoteAffinity := "host:remote-host"
+			blockCIDR := net.MustParseCIDR("10.0.1.0/29")
+			l3RR.OnBlockUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+					Value: &model.AllocationBlock{
+						CIDR:        blockCIDR,
+						Affinity:    &remoteAffinity,
+						Allocations: make([]*int, 8),
+						Unallocated: []int{0, 1, 2, 3, 4, 5, 6, 7},
+					},
+				},
+			})
+			drainEvents()
+
+			// Add the remote host IP and VXLAN tunnel address via OnNodeUpdate +
+			// a direct tunnel address update. The tunnel IP 10.0.1.0 falls within
+			// the block 10.0.1.0/29.
+			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+				V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
+				VXLANAddr: ip.FromString("10.0.1.0"),
+			})
+			l3RR.flush()
+
+			routes := drainEvents()
+
+			// Find the tunnel route for 10.0.1.0/32.
+			tunnelRoute := findRoute(routes, "10.0.1.0/32")
+			Expect(tunnelRoute).NotTo(BeNil(), "expected a route for the tunnel IP 10.0.1.0/32")
+
+			// The tunnel route should only have REMOTE_TUNNEL, not REMOTE_WORKLOAD.
+			// If REMOTE_WORKLOAD is present, the route manager will incorrectly program
+			// an extra /32 directly-connected route on the tunnel device.
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_TUNNEL).NotTo(BeZero(),
+				"tunnel route should have REMOTE_TUNNEL type")
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).To(BeZero(),
+				"tunnel route should NOT have REMOTE_WORKLOAD just because it falls within a block")
+		})
+
+		It("should add REMOTE_WORKLOAD to a tunnel IP in a /32 block", func() {
+			// A dedicated tunnel pool with blockSize=32 creates /32 blocks for each
+			// tunnel IP. In this case the block IS the tunnel IP, and the route manager
+			// needs REMOTE_WORKLOAD to program the directly-connected /32 route.
+			poolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+			pool := model.IPPool{
+				CIDR:      net.IPNet{IPNet: poolCIDR.ToIPNet()},
+				VXLANMode: encap.Always,
+			}
+			l3RR.OnPoolUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key:   model.IPPoolKey{CIDR: model.PrefixFromIPNet(pool.CIDR)},
+					Value: &pool,
+				},
+			})
+			drainEvents()
+
+			// Add a /32 IPAM block at the same CIDR as the tunnel IP.
+			remoteAffinity := "host:remote-host"
+			blockCIDR := net.MustParseCIDR("10.0.1.0/32")
+			l3RR.OnBlockUpdate(api.Update{
+				KVPair: model.KVPair{
+					Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+					Value: &model.AllocationBlock{
+						CIDR:        blockCIDR,
+						Affinity:    &remoteAffinity,
+						Allocations: make([]*int, 1),
+						Unallocated: []int{0},
+					},
+				},
+			})
+			drainEvents()
+
+			l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+				V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
+				VXLANAddr: ip.FromString("10.0.1.0"),
+			})
+			l3RR.flush()
+
+			routes := drainEvents()
+
+			tunnelRoute := findRoute(routes, "10.0.1.0/32")
+			Expect(tunnelRoute).NotTo(BeNil(), "expected a route for the tunnel IP 10.0.1.0/32")
+
+			// With a /32 block, the tunnel route should have BOTH types so the route
+			// manager programs a directly-connected route.
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_TUNNEL).NotTo(BeZero(),
+				"tunnel route should have REMOTE_TUNNEL type")
+			Expect(tunnelRoute.Types&proto.RouteType_REMOTE_WORKLOAD).NotTo(BeZero(),
+				"tunnel route in /32 block should have REMOTE_WORKLOAD")
+		})
+	})
+
+	It("should not set IpPoolType but still propagate NatOutgoing for LoadBalancer-only pools", func() {
+		eventBuf := make(rtEventsMock, 100)
+		l3RR := NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+		l3RR.OnAlive = func() {}
+
+		lbPoolCIDR, _ := ip.CIDRFromString("10.96.0.0/16")
+		l3RR.OnPoolUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(net.IPNet{IPNet: lbPoolCIDR.ToIPNet()})},
+				Value: &model.IPPool{
+					CIDR:        net.IPNet{IPNet: lbPoolCIDR.ToIPNet()},
+					Masquerade:  true,
+					AllowedUses: []v3.IPPoolAllowedUse{v3.IPPoolAllowedUseLoadBalancer},
+				},
+			},
+		})
+
+		remoteAffinity := "virtual:loadbalancer"
+		blockCIDR := net.MustParseCIDR("10.96.1.0/26")
+		l3RR.OnBlockUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+				Value: &model.AllocationBlock{
+					CIDR:        blockCIDR,
+					Affinity:    &remoteAffinity,
+					Allocations: make([]*int, 64),
+					Unallocated: []int{0},
+				},
+			},
+		})
+
+		l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{V4Addr: ip.FromString("192.168.0.2").(ip.V4Addr)})
+		l3RR.flush()
+
+		var routes []*proto.RouteUpdate
+		for len(eventBuf) > 0 {
+			if rt, ok := (<-eventBuf).(*proto.RouteUpdate); ok {
+				routes = append(routes, rt)
+			}
+		}
+		var blockRoute *proto.RouteUpdate
+		for _, rt := range routes {
+			if rt.Dst == "10.96.1.0/26" {
+				blockRoute = rt
+			}
+		}
+		Expect(blockRoute).NotTo(BeNil(), "expected a route for 10.96.1.0/26")
+		Expect(blockRoute.IpPoolType).To(Equal(proto.IPPoolType_NONE))
+		Expect(blockRoute.NatOutgoing).To(BeTrue())
+	})
+
+	It("should set IpPoolType for pools with Workload and LoadBalancer uses", func() {
+		eventBuf := make(rtEventsMock, 100)
+		l3RR := NewL3RouteResolver("local-host", eventBuf, "CalicoIPAM")
+		l3RR.OnAlive = func() {}
+
+		mixedPoolCIDR, _ := ip.CIDRFromString("10.0.0.0/16")
+		l3RR.OnPoolUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.IPPoolKey{CIDR: model.PrefixFromIPNet(net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()})},
+				Value: &model.IPPool{
+					CIDR:        net.IPNet{IPNet: mixedPoolCIDR.ToIPNet()},
+					VXLANMode:   encap.Always,
+					Masquerade:  true,
+					AllowedUses: []v3.IPPoolAllowedUse{v3.IPPoolAllowedUseWorkload, v3.IPPoolAllowedUseLoadBalancer},
+				},
+			},
+		})
+
+		remoteAffinity := "host:remote-host"
+		blockCIDR := net.MustParseCIDR("10.0.1.0/26")
+		l3RR.OnBlockUpdate(api.Update{
+			KVPair: model.KVPair{
+				Key: model.BlockKey{CIDR: model.PrefixFromIPNet(blockCIDR)},
+				Value: &model.AllocationBlock{
+					CIDR:        blockCIDR,
+					Affinity:    &remoteAffinity,
+					Allocations: make([]*int, 64),
+					Unallocated: []int{0},
+				},
+			},
+		})
+
+		l3RR.onNodeUpdate("remote-host", &l3rrNodeInfo{
+			V4Addr:    ip.FromString("192.168.0.2").(ip.V4Addr),
+			VXLANAddr: ip.FromString("10.0.1.1"),
+		})
+		l3RR.flush()
+
+		var routes []*proto.RouteUpdate
+		for len(eventBuf) > 0 {
+			if rt, ok := (<-eventBuf).(*proto.RouteUpdate); ok {
+				routes = append(routes, rt)
+			}
+		}
+		var blockRoute *proto.RouteUpdate
+		for _, rt := range routes {
+			if rt.Dst == "10.0.1.0/26" {
+				blockRoute = rt
+			}
+		}
+		Expect(blockRoute).NotTo(BeNil(), "expected a route for 10.0.1.0/26")
+		Expect(blockRoute.IpPoolType).To(Equal(proto.IPPoolType_VXLAN))
+	})
+
 	Describe("l3rrNodeInfo UTs", func() {
 		It("should not return empty IP addresses in AddressesAsCIDRs()", func() {
 			var (


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#12861

## Description

IPPools with `allowedUses: [LoadBalancer]` caused `poolTypeForPool()` to return `NO_ENCAP`, which set `FlagInIPAMPool` on BPF routes and exempted traffic to LB VIPs from SNAT masquerading. This broke cross-cluster connectivity when a shared LB pool was used across clusters.

### Changes

1. **Return `IPPoolType_NONE` for LB-only pools** in `poolTypeForPool()` via a new `isLoadBalancerOnlyPool()` helper, preventing `FlagInIPAMPool` from being set on BPF routes.

2. **Remove the stale `PoolType != NONE` guard** from the pool update path. This was previously dead code (a non-nil pool never resolved to `NONE`). With the new LB-only check it must be removed to keep LB-only pools in the trie so `NATOutgoing` and `CrossSubnet` continue to propagate correctly.

3. **Unit tests** covering:
   - LB-only pool → `IpPoolType == NONE` and `NatOutgoing` still propagated
   - Mixed-use pool (Workload + LoadBalancer) → `IpPoolType == VXLAN` (not excluded)

### Context

Complements PR #12769 which fixed the iptables/ipset path (`network-ip-pools` ipset). This PR fixes the BPF dataplane path (route map `FlagInIPAMPool` flag).

Fixes: https://github.com/projectcalico/calico/issues/12767

