### PR TITLE
Make proxy-neighbor listener goroutine the sole owner of its socket

### DIFF
--- a/felix/dataplane/linux/proxy_neigh_mgr.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr.go
@@ -501,41 +501,20 @@ func (m *proxyNeighManager) reconcileListeners(desiredByIface map[string]set.Set
 	return err
 }
 
-// publishDesiredIPs atomically swaps each listener's desired IP set and sends a
-// gratuitous ARP (IPv4) / unsolicited NA (IPv6) for every IP that is newly
-// appearing on that interface.
+// publishDesiredIPs hands each listener its latest desired IP set and wakes its
+// goroutine to reconcile. The listener goroutine owns the raw socket and
+// performs every write itself — gratuitous ARP (IPv4) / unsolicited NA +
+// solicited-node group join (IPv6) for newly desired IPs, and group leave for
+// IPs that dropped out — so this method does no socket I/O.
 func (m *proxyNeighManager) publishDesiredIPs(desiredByIface map[string]set.Set[string]) {
 	for ifaceName, desired := range desiredByIface {
 		l, ok := m.listeners[ifaceName]
 		if !ok {
 			continue
 		}
-		// Atomically swap in the new desired set; the previous pointer tells
-		// us which IPs are new and which are gone.
-		old := l.desired.Swap(&desired)
-		for ip := range desired.All() {
-			if old == nil || !(*old).Contains(ip) {
-				addr, err := netip.ParseAddr(ip)
-				if err != nil {
-					logrus.WithError(err).WithField("ip", ip).Debug("Failed to parse IP for GARP")
-					continue
-				}
-				if m.ipVersion == 6 {
-					l.joinNDPGroup(ip)
-					l.sendUNA(addr)
-				} else {
-					l.sendGARP(addr)
-				}
-			}
-		}
-		// Drop multicast subscriptions for IPs we no longer answer for.
-		if old != nil && m.ipVersion == 6 {
-			for ip := range (*old).All() {
-				if !desired.Contains(ip) {
-					l.leaveNDPGroup(ip)
-				}
-			}
-		}
+		l.desired.Store(&desired)
+		l.signalReconcile()
+		l.wake()
 	}
 }
 
@@ -545,6 +524,8 @@ func (m *proxyNeighManager) startListener(ifaceName string) error {
 	l := &ifaceListener{
 		ifaceName:   ifaceName,
 		readTimeout: m.readTimeout,
+		reconcile:   make(chan struct{}, 1),
+		announced:   set.New[string](),
 		done:        make(chan struct{}),
 	}
 
@@ -576,11 +557,27 @@ func (m *proxyNeighManager) startListener(ifaceName string) error {
 }
 
 // ifaceListener manages a raw socket listener for a single host interface.
+//
+// The listener goroutine is the sole owner of the raw socket: it performs all
+// reads, replies, announcements (GARP / unsolicited NA), multicast group
+// join/leave, and the final close. The manager never touches the socket — it
+// hands off a new desired set via the atomic desired pointer and wakes the
+// goroutine through the reconcile channel.
 type ifaceListener struct {
 	ifaceName string
 	// desired is the set of IPs this listener answers ARP/NDP for. Built fresh
-	// and swapped atomically; never mutated after publishing.
-	desired     atomic.Pointer[set.Set[string]]
+	// and swapped atomically by the manager; read by both the goroutine's
+	// reply path and applyDesiredState. Never mutated after publishing.
+	desired atomic.Pointer[set.Set[string]]
+	// reconcile wakes the goroutine to apply a freshly published desired set.
+	// Buffered (size 1) and coalescing: a single pending signal suffices since
+	// applyDesiredState always reads the latest desired set.
+	reconcile chan struct{}
+	// announced tracks the IPs the goroutine has already announced/joined for,
+	// so it can compute the delta against a new desired set. Goroutine-local:
+	// only ever touched by the listener goroutine, so it needs no
+	// synchronization.
+	announced   set.Set[string]
 	arpCli      arpClient // IPv4 only
 	ndpCli      ndpConn   // IPv6 only
 	hwAddr      net.HardwareAddr
@@ -591,24 +588,117 @@ type ifaceListener struct {
 	failed      atomic.Bool
 }
 
-// stop cancels the listener goroutine, closes its raw socket, and waits for the
-// goroutine to exit.
+// stop cancels the listener goroutine and waits for it to exit. The goroutine
+// owns the raw socket, so it leaves any joined NDP multicast groups and closes
+// the socket on its way out (see closeSocket). wake() interrupts the in-flight
+// read so the goroutine observes the cancellation immediately rather than
+// waiting out its read deadline.
 func (l *ifaceListener) stop() {
 	l.cancel()
-	if l.arpCli != nil {
-		err := l.arpCli.Close()
+	l.wake()
+	<-l.done
+	logrus.WithField("iface", l.ifaceName).Info("Stopped proxy neighbor listener")
+}
+
+// signalReconcile queues a request for the listener goroutine to apply the
+// latest desired set. Non-blocking: the buffered channel coalesces signals,
+// which is safe because applyDesiredState always reads the freshest desired
+// set. Pair with wake() to interrupt the goroutine's in-flight read so it acts
+// on the signal promptly.
+func (l *ifaceListener) signalReconcile() {
+	select {
+	case l.reconcile <- struct{}{}:
+	default:
+	}
+}
+
+// wake forces a blocked Read on the listener's socket to return immediately by
+// moving its read deadline into the past. It is the one place a goroutine other
+// than the listener's touches the socket; setting a read deadline concurrently
+// with a Read is the standard, safe way to interrupt it. This cuts the
+// up-to-readTimeout latency between the manager publishing a new desired set
+// (or cancelling) and the goroutine acting on it.
+//
+// Best-effort: if wake lands in the narrow window after the goroutine has
+// re-armed its own read deadline but before it next blocks in Read, the wake is
+// clobbered and the goroutine falls back to its next readTimeout tick. Nothing
+// is lost — the reconcile signal is buffered and the context cancellation
+// sticks — only delayed, i.e. it degrades to the no-wake behavior.
+func (l *ifaceListener) wake() {
+	var setReadDeadline func(time.Time) error
+	switch {
+	case l.arpCli != nil:
+		setReadDeadline = l.arpCli.SetReadDeadline
+	case l.ndpCli != nil:
+		setReadDeadline = l.ndpCli.SetReadDeadline
+	default:
+		return
+	}
+	if err := setReadDeadline(time.Now()); err != nil {
+		logrus.WithError(err).WithField("iface", l.ifaceName).Debug("Failed to wake listener read")
+	}
+}
+
+// applyDesiredState reconciles the IPs this listener announces for against the
+// latest desired set published by the manager. For newly desired IPs it sends
+// a gratuitous ARP (IPv4) or an unsolicited NA plus a solicited-node group join
+// (IPv6); for IPs that dropped out it leaves the group (IPv6). It runs only on
+// the listener goroutine, so every socket write funnels through here.
+func (l *ifaceListener) applyDesiredState() {
+	var desired set.Set[string] = set.New[string]()
+	if d := l.desired.Load(); d != nil {
+		desired = *d
+	}
+
+	// Newly desired IPs: announce ourselves as their owner.
+	for ip := range desired.All() {
+		if l.announced.Contains(ip) {
+			continue
+		}
+		addr, err := netip.ParseAddr(ip)
 		if err != nil {
-			logrus.WithError(err).WithField("iface", l.ifaceName).Warn("Failed to close ARP client")
+			logrus.WithError(err).WithField("ip", ip).Debug("Failed to parse IP for announce")
+			continue
+		}
+		if l.ndpCli != nil {
+			l.joinNDPGroup(ip)
+			l.sendUNA(addr)
+		} else {
+			l.sendGARP(addr)
 		}
 	}
+
+	// IPs that dropped out of the desired set: release the multicast
+	// subscription (IPv6 only; there is nothing to undo for IPv4).
+	for ip := range l.announced.All() {
+		if desired.Contains(ip) {
+			continue
+		}
+		if l.ndpCli != nil {
+			l.leaveNDPGroup(ip)
+		}
+	}
+
+	l.announced = desired
+}
+
+// closeSocket leaves any joined NDP multicast groups and closes the raw socket.
+// It runs on the listener goroutine (deferred from runListener) so the socket
+// stays single-owner; stop() only cancels the context and waits.
+func (l *ifaceListener) closeSocket() {
 	if l.ndpCli != nil {
-		err := l.ndpCli.Close()
-		if err != nil {
+		for ip := range l.announced.All() {
+			l.leaveNDPGroup(ip)
+		}
+		if err := l.ndpCli.Close(); err != nil {
 			logrus.WithError(err).WithField("iface", l.ifaceName).Warn("Failed to close NDP client")
 		}
 	}
-	<-l.done
-	logrus.WithField("iface", l.ifaceName).Info("Stopped proxy neighbor listener")
+	if l.arpCli != nil {
+		if err := l.arpCli.Close(); err != nil {
+			logrus.WithError(err).WithField("iface", l.ifaceName).Warn("Failed to close ARP client")
+		}
+	}
 }
 
 // runARPListener listens for ARP requests on a raw socket and replies for
@@ -703,12 +793,22 @@ func (l *ifaceListener) runNDPListener() {
 // and reply.
 func (l *ifaceListener) runListener(proto string, setDeadline func(time.Time) error, readAndRespond func() error) {
 	defer close(l.done)
+	defer l.closeSocket()
 
 	logCtx := logrus.WithFields(logrus.Fields{"iface": l.ifaceName, "proto": proto})
 	for {
 		if l.ctx.Err() != nil {
 			logCtx.Debug("Listener stopping: context cancelled")
 			return
+		}
+
+		// Apply any desired-set change the manager published. All socket
+		// writes (GARP / NA / multicast join+leave) happen here, on this
+		// goroutine, keeping the listener the sole owner of the raw socket.
+		select {
+		case <-l.reconcile:
+			l.applyDesiredState()
+		default:
 		}
 
 		if err := setDeadline(time.Now().Add(l.readTimeout)); err != nil {

--- a/felix/dataplane/linux/proxy_neigh_mgr.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr.go
@@ -77,8 +77,10 @@ type ndpConn interface {
 	Close() error
 }
 
-type arpClientFactory func(ifaceName string) (arpClient, net.HardwareAddr, error)
-type ndpConnFactory func(ifaceName string) (ndpConn, net.HardwareAddr, error)
+type (
+	arpClientFactory func(ifaceName string) (arpClient, net.HardwareAddr, error)
+	ndpConnFactory   func(ifaceName string) (ndpConn, net.HardwareAddr, error)
+)
 
 // proxyNeighManager automatically responds to ARP (IPv4) and NDP (IPv6) requests for
 // pod and LoadBalancer IPs that fall within the same L2 subnet as a host interface.
@@ -503,9 +505,7 @@ func (m *proxyNeighManager) reconcileListeners(desiredByIface map[string]set.Set
 
 // publishDesiredIPs hands each listener its latest desired IP set and wakes its
 // goroutine to reconcile. The listener goroutine owns the raw socket and
-// performs every write itself — gratuitous ARP (IPv4) / unsolicited NA +
-// solicited-node group join (IPv6) for newly desired IPs, and group leave for
-// IPs that dropped out — so this method does no socket I/O.
+// performs every write itself.
 func (m *proxyNeighManager) publishDesiredIPs(desiredByIface map[string]set.Set[string]) {
 	for ifaceName, desired := range desiredByIface {
 		l, ok := m.listeners[ifaceName]
@@ -559,25 +559,29 @@ func (m *proxyNeighManager) startListener(ifaceName string) error {
 // ifaceListener manages a raw socket listener for a single host interface.
 //
 // The listener goroutine is the sole owner of the raw socket: it performs all
-// reads, replies, announcements (GARP / unsolicited NA), multicast group
+// reads, replies, announcements, multicast group
 // join/leave, and the final close. The manager never touches the socket — it
 // hands off a new desired set via the atomic desired pointer and wakes the
 // goroutine through the reconcile channel.
 type ifaceListener struct {
 	ifaceName string
+
 	// desired is the set of IPs this listener answers ARP/NDP for. Built fresh
 	// and swapped atomically by the manager; read by both the goroutine's
 	// reply path and applyDesiredState. Never mutated after publishing.
 	desired atomic.Pointer[set.Set[string]]
-	// reconcile wakes the goroutine to apply a freshly published desired set.
-	// Buffered (size 1) and coalescing: a single pending signal suffices since
-	// applyDesiredState always reads the latest desired set.
+
+	// reconcile signals the goroutine to apply the latest desired set. Only one
+	// signal is buffered; extra ones are dropped, which is fine because
+	// applyDesiredState always reads the newest set.
 	reconcile chan struct{}
+
 	// announced tracks the IPs the goroutine has already announced/joined for,
 	// so it can compute the delta against a new desired set. Goroutine-local:
 	// only ever touched by the listener goroutine, so it needs no
 	// synchronization.
-	announced   set.Set[string]
+	announced set.Set[string]
+
 	arpCli      arpClient // IPv4 only
 	ndpCli      ndpConn   // IPv6 only
 	hwAddr      net.HardwareAddr
@@ -601,10 +605,7 @@ func (l *ifaceListener) stop() {
 }
 
 // signalReconcile queues a request for the listener goroutine to apply the
-// latest desired set. Non-blocking: the buffered channel coalesces signals,
-// which is safe because applyDesiredState always reads the freshest desired
-// set. Pair with wake() to interrupt the goroutine's in-flight read so it acts
-// on the signal promptly.
+// latest desired set.
 func (l *ifaceListener) signalReconcile() {
 	select {
 	case l.reconcile <- struct{}{}:
@@ -668,8 +669,7 @@ func (l *ifaceListener) applyDesiredState() {
 		}
 	}
 
-	// IPs that dropped out of the desired set: release the multicast
-	// subscription (IPv6 only; there is nothing to undo for IPv4).
+	// Release the multicast subscription for IPs that dropped out of the desired set.
 	for ip := range l.announced.All() {
 		if desired.Contains(ip) {
 			continue

--- a/felix/dataplane/linux/proxy_neigh_mgr_test.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr_test.go
@@ -89,7 +89,11 @@ type mockARPClient struct {
 	writes       []arpWrite
 	hwAddr       net.HardwareAddr
 	readDeadline time.Time
-	closed       bool
+	// deadlineChanged is closed (and replaced) whenever SetReadDeadline is
+	// called, so a blocked Read re-evaluates against the new deadline — as a
+	// real socket does when SetReadDeadline is called concurrently with Read.
+	deadlineChanged chan struct{}
+	closed          bool
 }
 
 type arpWrite struct {
@@ -99,23 +103,31 @@ type arpWrite struct {
 
 func newMockARPClient(hwAddr net.HardwareAddr) *mockARPClient {
 	return &mockARPClient{
-		reads:   make(chan *arp.Packet, 10),
-		readErr: make(chan error, 1),
-		hwAddr:  hwAddr,
+		reads:           make(chan *arp.Packet, 10),
+		readErr:         make(chan error, 1),
+		hwAddr:          hwAddr,
+		deadlineChanged: make(chan struct{}),
 	}
 }
 
 func (c *mockARPClient) Read() (*arp.Packet, *ethernet.Frame, error) {
-	select {
-	case err := <-c.readErr:
-		return nil, nil, err
-	case pkt, ok := <-c.reads:
-		if !ok {
-			return nil, nil, fmt.Errorf("closed")
+	for {
+		c.mu.Lock()
+		deadline, changed := c.readDeadline, c.deadlineChanged
+		c.mu.Unlock()
+		select {
+		case err := <-c.readErr:
+			return nil, nil, err
+		case pkt, ok := <-c.reads:
+			if !ok {
+				return nil, nil, fmt.Errorf("closed")
+			}
+			return pkt, nil, nil
+		case <-deadlineCh(deadline):
+			return nil, nil, readTimeoutError{}
+		case <-changed:
+			// Deadline was updated (e.g. a wake); re-evaluate it.
 		}
-		return pkt, nil, nil
-	case <-deadlineCh(c.readDeadline):
-		return nil, nil, readTimeoutError{}
 	}
 }
 
@@ -135,7 +147,12 @@ func (c *mockARPClient) WriteTo(p *arp.Packet, addr net.HardwareAddr) error {
 }
 
 func (c *mockARPClient) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.readDeadline = t
+	// Wake any in-flight Read so it re-evaluates against the new deadline.
+	close(c.deadlineChanged)
+	c.deadlineChanged = make(chan struct{})
 	return nil
 }
 
@@ -168,7 +185,11 @@ type mockNDPConn struct {
 	joinedGroups []netip.Addr
 	leftGroups   []netip.Addr
 	readDeadline time.Time
-	closed       bool
+	// deadlineChanged is closed (and replaced) whenever SetReadDeadline is
+	// called, so a blocked ReadFrom re-evaluates against the new deadline — as
+	// a real socket does when SetReadDeadline races a read.
+	deadlineChanged chan struct{}
+	closed          bool
 }
 
 type ndpWrite struct {
@@ -185,19 +206,27 @@ type ndpRead struct {
 
 func newMockNDPConn() *mockNDPConn {
 	return &mockNDPConn{
-		reads: make(chan ndpRead, 10),
+		reads:           make(chan ndpRead, 10),
+		deadlineChanged: make(chan struct{}),
 	}
 }
 
 func (c *mockNDPConn) ReadFrom() (ndp.Message, *ipv6.ControlMessage, netip.Addr, error) {
-	select {
-	case r, ok := <-c.reads:
-		if !ok {
-			return nil, nil, netip.Addr{}, fmt.Errorf("closed")
+	for {
+		c.mu.Lock()
+		deadline, changed := c.readDeadline, c.deadlineChanged
+		c.mu.Unlock()
+		select {
+		case r, ok := <-c.reads:
+			if !ok {
+				return nil, nil, netip.Addr{}, fmt.Errorf("closed")
+			}
+			return r.msg, nil, r.src, nil
+		case <-deadlineCh(deadline):
+			return nil, nil, netip.Addr{}, readTimeoutError{}
+		case <-changed:
+			// Deadline was updated (e.g. a wake); re-evaluate it.
 		}
-		return r.msg, nil, r.src, nil
-	case <-deadlineCh(c.readDeadline):
-		return nil, nil, netip.Addr{}, readTimeoutError{}
 	}
 }
 
@@ -239,7 +268,12 @@ func (c *mockNDPConn) getLeftGroups() []netip.Addr {
 }
 
 func (c *mockNDPConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.readDeadline = t
+	// Wake any in-flight ReadFrom so it re-evaluates against the new deadline.
+	close(c.deadlineChanged)
+	c.deadlineChanged = make(chan struct{})
 	return nil
 }
 
@@ -529,7 +563,10 @@ var _ = Describe("Proxy neighbor manager (IPv4)", func() {
 			mgr.OnUpdate(proxyNeighWepUpdate("k8s", "default/pod1", "eth0", "10.0.0.50/32"))
 			Expect(mgr.CompleteDeferredWork()).To(Succeed())
 
-			// Reset writes and trigger another reconciliation.
+			// Wait for the initial GARP (the announce is asynchronous on the
+			// listener goroutine), then reset writes and trigger another
+			// reconciliation.
+			Eventually(func() int { return len(arpClients["eth0"].getWrites()) }).Should(Equal(1))
 			arpClients["eth0"].resetWrites()
 			mgr.dirty = true
 			Expect(mgr.CompleteDeferredWork()).To(Succeed())
@@ -608,6 +645,11 @@ var _ = Describe("Proxy neighbor manager (IPv4)", func() {
 
 		It("answers ARP on each interface using that interface's own MAC", func() {
 			requesterHW := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x99}
+			// Wait for the initial GARP on each interface (announce is
+			// asynchronous on the listener goroutine), then reset so we observe
+			// only the replies.
+			Eventually(func() int { return len(arpClients["eth0"].getWrites()) }).Should(Equal(1))
+			Eventually(func() int { return len(arpClients["eth1"].getWrites()) }).Should(Equal(1))
 			arpClients["eth0"].resetWrites()
 			arpClients["eth1"].resetWrites()
 
@@ -638,6 +680,9 @@ var _ = Describe("Proxy neighbor manager (IPv4)", func() {
 			Expect(mgr.CompleteDeferredWork()).To(Succeed())
 			Expect(getDesiredIPs(mgr, "eth0").Contains(ownedIP)).To(BeTrue())
 			// Drop the gratuitous ARP sent on enable so we only observe replies.
+			// Wait for it first, since the announce is asynchronous on the
+			// listener goroutine.
+			Eventually(func() int { return len(arpClients["eth0"].getWrites()) }).Should(Equal(1))
 			arpClients["eth0"].resetWrites()
 		})
 
@@ -770,22 +815,35 @@ var _ = Describe("Proxy NDP manager (IPv6)", func() {
 		It("joins the desired IP's solicited-node multicast group", func() {
 			// Without joining this group the kernel never delivers Neighbor
 			// Solicitations for the proxied IP to the listener, so it could
-			// never answer them.
+			// never answer them. The join is asynchronous on the listener
+			// goroutine.
 			want, err := ndp.SolicitedNodeMulticast(netip.MustParseAddr("fd00::50"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ndpConns["eth0"].getJoinedGroups()).To(ContainElement(want))
+			Eventually(func() []netip.Addr {
+				return ndpConns["eth0"].getJoinedGroups()
+			}).Should(ContainElement(want))
 		})
 
 		It("leaves the solicited-node multicast group when the IP is no longer desired", func() {
+			// Wait for the initial join so there is actually a subscription to
+			// leave: the announce is asynchronous and coalescing, so if we moved
+			// the pod before the join landed the listener would simply never
+			// join (nor leave) fd00::50's group.
+			group, err := ndp.SolicitedNodeMulticast(netip.MustParseAddr("fd00::50"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() []netip.Addr {
+				return ndpConns["eth0"].getJoinedGroups()
+			}).Should(ContainElement(group))
+
 			// Move the pod to a different host-subnet IP: fd00::50 drops out of
 			// the desired set, so its group should be left.
 			mgr.OnUpdate(wepUpdateV6("k8s", "default/pod1", "eth0", "fd00::51/128"))
 			Expect(mgr.CompleteDeferredWork()).To(Succeed())
 			Expect(getDesiredIPs(mgr, "eth0").Contains("fd00::50")).To(BeFalse())
 
-			left, err := ndp.SolicitedNodeMulticast(netip.MustParseAddr("fd00::50"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ndpConns["eth0"].getLeftGroups()).To(ContainElement(left))
+			Eventually(func() []netip.Addr {
+				return ndpConns["eth0"].getLeftGroups()
+			}).Should(ContainElement(group))
 		})
 	})
 
@@ -799,6 +857,9 @@ var _ = Describe("Proxy NDP manager (IPv6)", func() {
 			Expect(mgr.CompleteDeferredWork()).To(Succeed())
 			Expect(getDesiredIPs(mgr, "eth0").Contains(ownedIP)).To(BeTrue())
 			// Drop the unsolicited NA sent on enable so we only observe replies.
+			// Wait for it first, since the announce is asynchronous on the
+			// listener goroutine.
+			Eventually(func() int { return len(ndpConns["eth0"].getWrites()) }).Should(Equal(1))
 			ndpConns["eth0"].resetWrites()
 		})
 

--- a/felix/dataplane/linux/proxy_neigh_mgr_test.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr_test.go
@@ -93,7 +93,6 @@ type mockARPClient struct {
 	// called, so a blocked Read re-evaluates against the new deadline — as a
 	// real socket does when SetReadDeadline is called concurrently with Read.
 	deadlineChanged chan struct{}
-	closed          bool
 }
 
 type arpWrite struct {
@@ -157,7 +156,6 @@ func (c *mockARPClient) SetReadDeadline(t time.Time) error {
 }
 
 func (c *mockARPClient) Close() error {
-	c.closed = true
 	close(c.reads)
 	return nil
 }
@@ -189,7 +187,6 @@ type mockNDPConn struct {
 	// called, so a blocked ReadFrom re-evaluates against the new deadline — as
 	// a real socket does when SetReadDeadline races a read.
 	deadlineChanged chan struct{}
-	closed          bool
 }
 
 type ndpWrite struct {
@@ -278,7 +275,6 @@ func (c *mockNDPConn) SetReadDeadline(t time.Time) error {
 }
 
 func (c *mockNDPConn) Close() error {
-	c.closed = true
 	close(c.reads)
 	return nil
 }
@@ -723,7 +719,6 @@ var _ = Describe("Proxy neighbor manager (IPv4)", func() {
 })
 
 var _ = Describe("Proxy neighbor manager - LoadBalancer IPs", func() {
-
 	It("is claimed by exactly one node, which answers and GARPs for it", func() {
 		const vip = "10.0.0.100"
 		answering := 0


### PR DESCRIPTION
## Description

Refactor the proxy neighbor manager (`felix/dataplane/linux/proxy_neigh_mgr.go`, added in #12451) so that each interface's raw ARP/NDP socket is touched by exactly one goroutine.

Previously the socket writes — gratuitous ARP / unsolicited NA, solicited-node multicast join/leave — and the socket close ran on the manager/dataplane goroutine (`publishDesiredIPs`, `stop()`), while the listener goroutine did the reads and replies. That left the raw socket accessed concurrently from two goroutines, relying on the mdlayher `arp`/`ndp` conns tolerating concurrent write/join/leave/close during a blocked read.

Now all socket I/O funnels through the listener goroutine:

- The manager only publishes the desired IP set (atomic pointer) and wakes the goroutine — it never touches the socket.
- `applyDesiredState` (on the goroutine) computes the delta against a goroutine-local `announced` set and performs the GARP/NA and multicast join/leave.
- `closeSocket` (deferred on the goroutine) leaves multicast groups and closes the socket; `stop()` just cancels and waits.
- `wake()` moves the read deadline into the past to interrupt the in-flight read, so a published change (or cancellation) is acted on promptly rather than after the read timeout.

The reply path still reads the desired set synchronously, so answering ARP/NDP is unaffected; only the announcements become asynchronous.

## Tests

- Unit tests updated to wait (`Eventually`) for the now-asynchronous announcements, and the leave-group test waits for the join first (coalescing means an un-joined IP is never left).
- The mock `arp`/`ndp` conns now model a real socket: `SetReadDeadline` is concurrency-safe and interrupts an in-flight read.
- `make ut` (focused) passes 990/990 specs; a focused `go test -race` run is clean.

## Release Note


🤖 Generated with [Claude Code](https://claude.com/claude-code)