### PR TITLE
[v3.32] Fix RouteTable resync not repairing externally modified routes; related routetable fixes

### DIFF
--- a/felix/routetable/conntrack_owner_tracker.go
+++ b/felix/routetable/conntrack_owner_tracker.go
@@ -131,6 +131,13 @@ func (c *ConntrackCleanupManager) UpdateCIDROwner(cidr ip.CIDR, ifaceIdx int, ro
 // a call to UpdateCIDROwner for the same CIDR before the cleanup is triggered
 // will undo the removal.
 func (c *ConntrackCleanupManager) RemoveCIDROwner(cidr ip.CIDR) {
+	// Mirror the check in UpdateCIDROwner: we only track single-address
+	// CIDRs.  Without this check, removing (say) a /26 block route would
+	// incorrectly delete the entry for a workload that happens to own the
+	// block's network address.
+	if !cidr.IsSingleAddress() {
+		return
+	}
 	c.addrOwners.Desired().Delete(cidr.Addr())
 }
 

--- a/felix/routetable/conntrack_owner_tracker_test.go
+++ b/felix/routetable/conntrack_owner_tracker_test.go
@@ -165,6 +165,29 @@ func TestConntrackCleanupManager_DeletedRoute(t *testing.T) {
 	expectWaitForPendingDeletionToDelay(h.ccm, h.conntrack, cidr1)
 }
 
+func TestConntrackCleanupManager_BlockRouteRemovalLeavesWorkloadIP(t *testing.T) {
+	h := setupConntrackTrackerTest(t)
+
+	// Workload owns an IP that is also an IPAM block's network address.
+	workloadAddr := ip.MustParseCIDROrIP("10.0.0.0/32")
+	h.ccm.UpdateCIDROwner(workloadAddr, 10, RouteClassLocalWorkload)
+	h.ccm.StartConntrackCleanupAndReset()
+
+	// The IPAM block route is removed.  Since we only track single-address
+	// CIDRs, this must not disturb the workload's entry, which is keyed on
+	// the same address.
+	h.ccm.RemoveCIDROwner(ip.MustParseCIDROrIP("10.0.0.0/26"))
+
+	// A dataplane flap of the workload's route should not trigger conntrack
+	// cleanup: the route isn't moving anywhere.
+	h.ccm.OnDataplaneRouteDeleted(workloadAddr, 10)
+	h.ccm.StartConntrackCleanupAndReset()
+	Consistently(h.conntrack.NumPendingRemovals, "10ms").Should(Equal(0))
+	expectWaitForPendingDeletionToReturnImmediately(h.ccm, workloadAddr)
+
+	expectInSyncAtEnd(h.ccm)
+}
+
 func TestConntrackCleanupManager_DeletedStaleRoute(t *testing.T) {
 	h := setupConntrackTrackerTest(t)
 

--- a/felix/routetable/export_test.go
+++ b/felix/routetable/export_test.go
@@ -24,3 +24,9 @@ func (r *RouteTable) IfacesToARPLen() int {
 func (r *RouteTable) IfacesToARPAdd(ifaceName string) {
 	r.ifacesToARP.Add(ifaceName)
 }
+
+// GraceInfoCount returns the number of interface grace-period records
+// currently being tracked.
+func (r *RouteTable) GraceInfoCount() int {
+	return len(r.ifaceIndexToGraceInfo)
+}

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -773,13 +773,14 @@ func (r *RouteTable) recalculateDesiredKernelRoute(routeKey RouteKey) {
 	kernRoute := kernelRoute{
 		Type:     bestTarget.RouteType(),
 		Scope:    bestTarget.RouteScope(),
-		GW:       bestTarget.GW,
 		Src:      src,
-		Ifindex:  bestIfaceIdx,
 		OnLink:   bestTarget.Flags()&unix.RTNH_F_ONLINK != 0,
 		Protocol: proto,
 	}
 	if len(bestTarget.MultiPath) > 0 {
+		// Note: GW/Ifindex deliberately left unset; the kernel reports
+		// multi-path routes with no top-level OIF (and InterfaceNone maps to
+		// ifindex 1 for IPv6, which would never round-trip).
 		for _, nh := range bestTarget.MultiPath {
 			ifIndex, ok := r.ifaceIndexForName(nh.IfaceName)
 			if !ok {
@@ -934,11 +935,11 @@ func (r *RouteTable) attemptApply(attempt int) (err error) {
 }
 
 func (r *RouteTable) maybeCleanUpGracePeriods() {
-	if time.Since(r.lastGracePeriodCleanup) < r.routeCleanupGracePeriod {
+	if r.time.Since(r.lastGracePeriodCleanup) < r.routeCleanupGracePeriod {
 		return
 	}
 	for k, v := range r.ifaceIndexToGraceInfo {
-		if time.Since(v.FirstSeen) < r.routeCleanupGracePeriod {
+		if r.time.Since(v.FirstSeen) < r.routeCleanupGracePeriod {
 			continue
 		}
 		if _, ok := r.ifaceIndexToName[k]; ok {
@@ -948,6 +949,7 @@ func (r *RouteTable) maybeCleanUpGracePeriods() {
 
 		r.livenessCallback()
 	}
+	r.lastGracePeriodCleanup = r.time.Now()
 }
 
 func (r *RouteTable) maybeResyncWithDataplane() error {
@@ -1008,7 +1010,7 @@ func (r *RouteTable) doFullResync(nl netlinkshim.Interface) error {
 			}
 
 			routeKey, kernRoute := r.netlinkRouteToKernelRoute(&scratchRoute)
-			if oldRoute, ok := r.kernelRoutes.Dataplane().Get(routeKey); !ok || oldRoute.Equals(kernRoute) {
+			if oldRoute, ok := r.kernelRoutes.Dataplane().Get(routeKey); !ok || !oldRoute.Equals(kernRoute) {
 				r.kernelRoutes.Dataplane().Set(routeKey, kernRoute)
 			}
 			seenKeys.Add(routeKey)
@@ -1118,7 +1120,7 @@ func (r *RouteTable) resyncIface(nl netlinkshim.Interface, ifaceName string) err
 			}
 
 			routeKey, kernRoute := r.netlinkRouteToKernelRoute(&scratchRoute)
-			if oldRoute, ok := r.kernelRoutes.Dataplane().Get(routeKey); !ok || oldRoute.Equals(kernRoute) {
+			if oldRoute, ok := r.kernelRoutes.Dataplane().Get(routeKey); !ok || !oldRoute.Equals(kernRoute) {
 				r.kernelRoutes.Dataplane().Set(routeKey, kernRoute)
 			}
 			seenRoutes.Add(routeKey)

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -2821,6 +2821,189 @@ var _ = Describe("Tests to verify ip version is policed", func() {
 	})
 })
 
+var _ = Describe("RouteTable resync repair of externally modified routes", func() {
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
+	var rt *RouteTable
+
+	BeforeEach(func() {
+		dataplane = mocknetlink.New()
+		t = mocktime.New()
+		rt = New(
+			&defaultOwnershipPolicy,
+			4,
+			10*time.Second,
+			nil,
+			FelixRouteProtocol,
+			true,
+			0,
+			logutils.NewSummarizer("test"),
+			dataplane,
+			WithTimeShim(t),
+			WithConntrackShim(dataplane),
+			WithNetlinkHandleShim(dataplane.NewMockNetlink),
+		)
+	})
+
+	// programAndModifyRoute programs a route, then modifies it in the mock
+	// dataplane behind the RouteTable's back, keeping the same key
+	// (CIDR/TOS/priority) but changing the route's attributes.  It returns
+	// the mock dataplane key and the original (desired) route.
+	programAndModifyRoute := func() (key string, want netlink.Route) {
+		dataplane.AddIface(2, "cali1", true, true)
+		rt.RouteUpdate(RouteClassLocalWorkload, "cali1", Target{
+			RouteKey: RouteKey{CIDR: ip.MustParseCIDROrIP("10.0.0.1/32")},
+			Type:     TargetTypeLinkLocalUnicast,
+		})
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+
+		key = routeKeyStr(254, "10.0.0.1/32", 0)
+		var ok bool
+		want, ok = dataplane.RouteKeyToRoute[key]
+		Expect(ok).To(BeTrue(), "route was not programmed")
+
+		modified := want
+		modified.Src = net.ParseIP("1.2.3.4")
+		dataplane.RouteKeyToRoute[key] = modified
+		return
+	}
+
+	It("should repair an externally modified route on full resync", func() {
+		key, want := programAndModifyRoute()
+		rt.QueueResync()
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(dataplane.RouteKeyToRoute[key]).To(Equal(want),
+			"full resync should have repaired the externally modified route")
+	})
+
+	It("should repair an externally modified route on interface resync", func() {
+		key, want := programAndModifyRoute()
+		rt.QueueResyncIface("cali1")
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(dataplane.RouteKeyToRoute[key]).To(Equal(want),
+			"interface resync should have repaired the externally modified route")
+	})
+})
+
+var _ = Describe("RouteTable IPv6 multi-path routes", func() {
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
+	var rt *RouteTable
+
+	deviceRouteProtocol := netlink.RouteProtocol(10)
+	ownershipPol := defaultOwnershipPolicy
+	ownershipPol.AllRouteProtocols = []netlink.RouteProtocol{deviceRouteProtocol}
+	ownershipPol.ExclusiveRouteProtocols = []netlink.RouteProtocol{deviceRouteProtocol}
+
+	BeforeEach(func() {
+		dataplane = mocknetlink.New()
+		t = mocktime.New()
+		rt = New(
+			&ownershipPol,
+			6,
+			10*time.Second,
+			nil,
+			deviceRouteProtocol,
+			true,
+			0,
+			logutils.NewSummarizer("test"),
+			dataplane,
+			WithTimeShim(t),
+			WithConntrackShim(dataplane),
+			WithNetlinkHandleShim(dataplane.NewMockNetlink),
+		)
+	})
+
+	It("should not reprogram an unchanged multi-path route on resync", func() {
+		dataplane.AddIface(10, "cali10", true, true)
+		dataplane.AddIface(11, "cali11", true, true)
+		rt.SetRoutes(RouteClassVXLANTunnel, InterfaceNone, []Target{{
+			Type:     TargetTypeVXLAN,
+			RouteKey: RouteKey{CIDR: ip.MustParseCIDROrIP("fd00:10::/64")},
+			MultiPath: []NextHop{
+				{IfaceName: "cali10", Gw: ip.FromString("fe80::10")},
+				{IfaceName: "cali11", Gw: ip.FromString("fe80::11")},
+			},
+		}})
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		key := routeKeyStr(254, "fd00:10::/64", 1024)
+		Expect(dataplane.RouteKeyToRoute).To(HaveKey(key))
+
+		// A resync should read back exactly what we programmed and so
+		// shouldn't touch the route.  (IPv6 is the interesting case here:
+		// InterfaceNone maps to ifindex 1 on IPv6 but the kernel reports
+		// multi-path routes with no top-level OIF.)
+		dataplane.UpdatedRouteKeys.Clear()
+		rt.QueueResync()
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(dataplane.UpdatedRouteKeys.Contains(key)).To(BeFalse(),
+			"resync should not reprogram an unchanged multi-path route")
+	})
+})
+
+var _ = Describe("RouteTable grace-period bookkeeping", func() {
+	var dataplane *mocknetlink.MockNetlinkDataplane
+	var t *mocktime.MockTime
+	var rt *RouteTable
+
+	const gracePeriod = 100 * time.Second
+
+	BeforeEach(func() {
+		dataplane = mocknetlink.New()
+		t = mocktime.New()
+		t.SetAutoIncrement(0)
+		rt = New(
+			&defaultOwnershipPolicy,
+			4,
+			10*time.Second,
+			nil,
+			FelixRouteProtocol,
+			true,
+			0,
+			logutils.NewSummarizer("test"),
+			dataplane,
+			WithTimeShim(t),
+			WithConntrackShim(dataplane),
+			WithNetlinkHandleShim(dataplane.NewMockNetlink),
+			WithRouteCleanupGracePeriod(gracePeriod),
+		)
+	})
+
+	It("should clean up records for deleted ifaces, at most once per grace period", func() {
+		// Tell the RouteTable about an interface.  The first Apply()'s full
+		// resync won't find it in the (empty) mock dataplane, so it will be
+		// marked not-present, leaving just its grace-period record behind.
+		rt.OnIfaceStateChanged("cali1", 2, ifacemonitor.StateUp)
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(rt.GraceInfoCount()).To(Equal(1),
+			"grace-period record should be retained within the grace period")
+
+		// Second interface seen 60s later, then deleted.
+		t.IncrementTime(60 * time.Second)
+		rt.OnIfaceStateChanged("cali2", 3, ifacemonitor.StateUp)
+		rt.OnIfaceStateChanged("cali2", 3, ifacemonitor.StateNotPresent)
+		Expect(rt.GraceInfoCount()).To(Equal(2))
+
+		// 120s after start: the cleanup scan runs (it last ran at t0);
+		// cali1's record has aged out, cali2's hasn't.
+		t.IncrementTime(60 * time.Second)
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(rt.GraceInfoCount()).To(Equal(1))
+
+		// 180s: cali2's record is now stale too, but the cleanup scan is
+		// throttled (it last ran 60s ago), so the record survives.
+		t.IncrementTime(60 * time.Second)
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(rt.GraceInfoCount()).To(Equal(1),
+			"cleanup scan should be throttled to once per grace period")
+
+		// 240s: throttle has expired; the stale record gets cleaned up.
+		t.IncrementTime(60 * time.Second)
+		Expect(rt.Apply()).NotTo(HaveOccurred())
+		Expect(rt.GraceInfoCount()).To(Equal(0))
+	})
+})
+
 func mustParseCIDR(cidr string) *net.IPNet {
 	_, c, err := net.ParseCIDR(cidr)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#12943

Fixes four bugs found in a review of `felix/routetable`:

1. **Resync never repaired an externally *modified* route.** The cache-update condition in `doFullResync`/`resyncIface` was accidentally inverted in f4e3e80345 ("Add Equals to kernRoute", `oldRoute != kernRoute` became `oldRoute.Equals(kernRoute)` without the negation). As a result, when another process modified one of our routes in place (same CIDR/TOS/priority key, different gateway/src/scope/MTU), resync didn't update the DeltaTracker's dataplane view, no pending update was generated, and Felix never repaired the route. External additions/deletions were unaffected, which is why existing tests didn't catch it.

2. **Grace-period record cleanup throttle never engaged.** `lastGracePeriodCleanup` was never written, so the cleanup scan ran on every `Apply()` instead of once per grace period. Also switched to the time shim so the logic is exercisable under mock time.

3. **Multi-path routes didn't round-trip on IPv6.** The desired `kernelRoute` had `Ifindex` set to the InterfaceNone sentinel index (1 on IPv6), but kernel read-back reports multi-path routes with no top-level OIF (0), so every resync would reprogram unchanged IPv6 multi-path routes. Latent today since multi-path is only used for IPv4 EGW routes (and was further masked by bug 1).

4. **`ConntrackCleanupManager.RemoveCIDROwner` was missing the single-address guard** that `UpdateCIDROwner` has. Removing a block route (e.g. an IPAM block's /26 blackhole) deleted the tracking entry for a workload that owns the block's network address, risking a spurious conntrack cleanup (broken long-lived connections) for a live workload.

Each fix comes with a regression test that fails without it (for bug 3, with bug 1's fix applied, since bug 1 masked it).

**Release note:**
```release-note
Fixed a bug where Felix's periodic route resync did not detect (and repair) Calico-owned routes that had been modified in place by another process. Fixed unnecessary reprogramming of unchanged IPv6 multi-path routes on resync, and a corner case where removing an IPAM block route could trigger a spurious conntrack cleanup for a workload owning the block's network address.
```

<details>
<summary><b>Cherry-Pick PR details</b></summary>

- **Original PR ID**: 12943
- **Original Commit SHA**: cd27e0af84
</details>