### PR TITLE
e2e: skip default-tier update/delete RBAC tests on release-v3.32

### DIFF
--- a/e2e/pkg/tests/policy/tiered_rbac.go
+++ b/e2e/pkg/tests/policy/tiered_rbac.go
@@ -371,6 +371,8 @@ var _ = describe.CalicoDescribe(
 			}
 
 			It("should not allow updating the default tier", func() {
+				Skip("requires built-in tier order CEL validation (#12250/#12441), not backported to release-v3.32")
+
 				tier := v3.NewTier()
 				tier.Name = "default"
 				Expect(adminCli.Get(ctx, ctrlclient.ObjectKeyFromObject(tier), tier)).To(
@@ -386,6 +388,8 @@ var _ = describe.CalicoDescribe(
 			})
 
 			It("should not allow deleting the default tier", func() {
+				Skip("requires operator-managed protect-builtin-tiers VAP (operator #4878), not in operator v1.42 / release-v3.32")
+
 				tier := v3.NewTier()
 				tier.Name = "default"
 				Expect(adminCli.Get(ctx, ctrlclient.ObjectKeyFromObject(tier), tier)).To(


### PR DESCRIPTION
## What

Skip the two default-tier RBAC e2e tests on `release-v3.32`:

- `Tiered RBAC default tier should not allow updating the default tier`
- `Tiered RBAC default tier should not allow deleting the default tier`

Each is annotated with a `Skip(...)` carrying a one-line reason and the prerequisite PR numbers.

## Why

These two tests have been present on `release-v3.32` since it branched from master — they were added by #11895 (`a18274194f5`, 2026-03-02), before the v3.32 branch point (`5df0f788d34`, 2026-03-20). The product-side hardening that makes them pass landed on master *after* the branch point and was not backported into the v3.32 patch stream:

| Test | Depends on | Status on v3.32 |
|---|---|---|
| update default tier | CRD-level CEL order-immutability rules — #12250 (`projectcalico.org/v3` Tier CRD, 2026-03-31) + #12441 (`crd.projectcalico.org/v1` Tier CRD, 2026-04-11) | Not present. v3.32 still enforces built-in tier order via the libcalico-go Go validator, just not on the aggregated API server path this test exercises. |
| delete default tier | `protect-builtin-tiers` ValidatingAdmissionPolicy, bootstrapped/reconciled by tigera/operator — operator #4878 ("Manage ValidatingAdmissionPolicies in admission imports", 2026-06-02) | Not present. Operator release-v1.42 (shipped with Calico v3.32) does not manage the VAP, so nothing rejects the delete at admission time. |

Backporting these is out of scope for a patch stream: the update fix is a validation-model migration (Go → CEL) plus new rules, and the delete fix requires a new operator reconcile capability, an operator patch release, and a Calico operator-version bump.

We use `Skip()` rather than deleting the blocks so they stay visible in CI output and are trivially re-enabled if the prerequisites are ever backported.

## Testing

- `go vet ./e2e/pkg/tests/policy/...` passes.
- Change is limited to two `Skip()` calls; no production code touched.

**Release note:**
```release-note
NONE
```
