### PR TITLE
ci(felix): raise Ubuntu 25.10 FV job timeouts to 75 minutes

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1220,14 +1220,14 @@ blocks:
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
         - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
           execution_time_limit:
-            minutes: 60
+            minutes: 75
           env_vars:
             - name: FELIX_TEST_GROUP
               value: "bpf-25.10-nft-no-fv-with-ut"
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
-              value: "60"
+              value: "75"
             - name: FELIX_FV_NETKIT
               value: "Enabled"
           commands:
@@ -1236,10 +1236,10 @@ blocks:
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
         - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
           execution_time_limit:
-            minutes: 60
+            minutes: 75
           env_vars:
             - name: JOB_TIMEOUT_MINUTES
-              value: "60"
+              value: "75"
             - name: FELIX_TEST_GROUP
               value: "bpf-25.10-nft-with-ut-jitharden"
             - name: FELIX_FV_BPFATTACHTYPE

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3998,14 +3998,14 @@ blocks:
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
         - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
           execution_time_limit:
-            minutes: 60
+            minutes: 75
           env_vars:
             - name: FELIX_TEST_GROUP
               value: "bpf-25.10-nft-no-fv-with-ut"
             - name: FELIX_FV_BPFATTACHTYPE
               value: "tc"
             - name: JOB_TIMEOUT_MINUTES
-              value: "60"
+              value: "75"
             - name: FELIX_FV_NETKIT
               value: "Enabled"
           commands:
@@ -4014,10 +4014,10 @@ blocks:
             - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
         - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
           execution_time_limit:
-            minutes: 60
+            minutes: 75
           env_vars:
             - name: JOB_TIMEOUT_MINUTES
-              value: "60"
+              value: "75"
             - name: FELIX_TEST_GROUP
               value: "bpf-25.10-nft-with-ut-jitharden"
             - name: FELIX_FV_BPFATTACHTYPE

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -261,14 +261,14 @@
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
       - name: "Felix: BPF tests on Ubuntu 25.10 with netkit (nftables)"
         execution_time_limit:
-          minutes: 60
+          minutes: 75
         env_vars:
           - name: FELIX_TEST_GROUP
             value: "bpf-25.10-nft-no-fv-with-ut"
           - name: FELIX_FV_BPFATTACHTYPE
             value: "tc"
           - name: JOB_TIMEOUT_MINUTES
-            value: "60"
+            value: "75"
           - name: FELIX_FV_NETKIT
             value: "Enabled"
         commands:
@@ -277,10 +277,10 @@
           - .semaphore/vms/run-tests-on-vms ${VM_PREFIX}
       - name: "Felix: BPF tests on Ubuntu 25.10 with jitharden=2 (nftables)"
         execution_time_limit:
-          minutes: 60
+          minutes: 75
         env_vars:
           - name: JOB_TIMEOUT_MINUTES
-            value: "60"
+            value: "75"
           - name: FELIX_TEST_GROUP
             value: "bpf-25.10-nft-with-ut-jitharden"
           - name: FELIX_FV_BPFATTACHTYPE


### PR DESCRIPTION
Both Ubuntu 25.10 Felix FV jobs (netkit and jitharden=2) run the BPF UT suite on their test VMs, and the `ut` batch has started tripping the `run-tests-on-vms` watchdog, which kills batches at `(JOB_TIMEOUT_MINUTES - 5) * 60` = 3300s. The UT suite itself passes (2778 tests in roughly 29 minutes once it starts); the remaining budget goes to VM provisioning and the `make ut-bpf-no-prereqs` build, and the total now sits right at the line. Two recent master runs failed this way with "Batch ut timed out after 3300s" and zero test failures, one on each of the two jobs.

This raises `execution_time_limit` and `JOB_TIMEOUT_MINUTES` from 60 to 75 minutes for both jobs, lifting the batch budget from 55 to 70 minutes. Template change in `.semaphore/semaphore.yml.d/blocks/20-felix.yml` plus the regenerated YAMLs. Infrastructure-only change, no test to add.

The same timeout is also being applied to the enterprise fork, where the jitharden job fails the same way.

**Release note:**
```release-note
None
```
