### PR TITLE
docs(skill): default ci-repro VM boot disk to 100GB

### DIFF
--- a/.claude/skills/ci-reproduce-on-gcp-vm/SKILL.md
+++ b/.claude/skills/ci-reproduce-on-gcp-vm/SKILL.md
@@ -39,11 +39,11 @@ gcloud --quiet compute instances create "${vm_name}" \
   --image-family=${image_family} \
   --image-project=ubuntu-os-cloud \
   --machine-type=n4-highcpu-4 \
-  --boot-disk-size=20G \
+  --boot-disk-size=100GB \
   --boot-disk-type=hyperdisk-balanced
 ```
 
-The machine type and disk size above match CI defaults (see `felix/.semaphore/fv-prologue`).
+The machine type matches CI defaults (see `felix/.semaphore/fv-prologue`). The disk is deliberately larger than CI's 20GB default (`.semaphore/vms/run-tests-on-vms`): CI VMs receive prebuilt images and binaries from the Semaphore runner, but a repro VM runs `make fv` prereqs locally (go-build image, felix/calico image builds, Go build cache), which overflows a small disk with `no space left on device` partway through the build. The cost difference is negligible for a VM that lives a few hours.
 
 ## Step 3: Wait for SSH and Install Dependencies
 


### PR DESCRIPTION
The ci-reproduce-on-gcp-vm skill creates its VM with a 20G boot disk and says that matches CI defaults. That size works in CI because Semaphore pushes prebuilt images and binaries to the test VMs, but a repro VM runs the `make fv` prereq builds itself, and the go-build image plus the felix and calico image builds plus the Go build cache overflow 20G with `no space left on device` before the first test runs. Hit this in practice while reproducing a Felix FV flake on ubuntu-2510; had to live-resize the disk and rerun.

Default to 100GB instead (and use the GB suffix the CI scripts use). A repro VM lives a few hours, so the price difference between the two sizes is noise.

**Release note:**
```release-note
None
```
