### PR TITLE
felix/fv: give dumpBPFMap's map-existence wait room for slow BPF starts

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -6126,10 +6126,15 @@ func dumpCTMapsAny(family int, felix *infrastructure.Felix) map[conntrack.KeyInt
 
 func dumpBPFMap(felix *infrastructure.Felix, m maps.Map, iter func(k, v []byte)) {
 	// Wait for the map to exist before trying to access it.  Otherwise, we
-	// might fail a test that was retrying this dump anyway.
+	// might fail a test that was retrying this dump anyway.  This must be
+	// generous: it is a hard assertion, so when a caller polls a dump from
+	// inside its own Eventually, a timeout here fails the test outright and
+	// defeats the caller's retry loop.  Under bpf_jit_harden=2 and a loaded
+	// CI VM, Felix can take over 10s to create and pin its full map set
+	// after a restart into BPF mode.
 	Eventually(func() bool {
 		return felix.FileExists(m.Path())
-	}, "10s", "300ms").Should(BeTrue(), fmt.Sprintf("dumpBPFMap: map %s didn't show up inside container", m.Path()))
+	}, "30s", "300ms").Should(BeTrue(), fmt.Sprintf("dumpBPFMap: map %s didn't show up inside container", m.Path()))
 	cmd, err := maps.DumpMapCmd(m)
 	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map dump command: "+m.Path())
 	log.WithField("cmd", cmd).Debug("dumpBPFMap")


### PR DESCRIPTION
Several "with BPF disabled to begin with ... should keep a connection up when BPF is enabled" specs have been flaking on the Ubuntu 25.10 jitharden and 24.04 BPF jobs. The failure looks like a connectivity problem from the test name, but the artifact log tells a different story: the spec dies at dumpBPFMap's map-existence wait, 10.0s after `STEP: Enabling BPF`, while the Felix log shows it still busily creating and pinning maps 14ms before the timeout fires. Under `bpf_jit_harden=2` on a loaded CI VM, Felix needs more than 10s to restart into BPF mode and pin its full map set.

The structural problem is that the wait is a hard assertion nested inside callers' own retry loops. `ensureBPFProgramsAttached` polls `dumpIfStateMap` from an `Eventually(..., "1m", "1s")` precisely so slow starts retry, but the inner 10s assertion fails the whole spec before that outer patience can matter. The comment on the wait says its purpose is to avoid failing "a test that was retrying this dump anyway"; at 10s it defeats itself.

This raises the wait to 30s (Felix finished pinning at roughly 12s in the failing run) and documents why it must stay generous.

No new test: this is a timing fix in test infrastructure. It does not reproduce on an idle VM with the same kernel and jitharden setting (48 consecutive clean runs of the affected specs, including 28 replays of the exact failing CI batch); the failure needs CI-level load, and the diagnosis above is from the failing run's own artifact log.

**Release note:**
```release-note
None
```
