### PR TITLE
Ship corresponding source for the patched nftables RPMs

### DIFF
--- a/hack/rpms/nftables/Dockerfile
+++ b/hack/rpms/nftables/Dockerfile
@@ -54,4 +54,14 @@ RUN rpmbuild -ba /root/rpmbuild/SPECS/libnftnl.spec && \
     cp /root/rpmbuild/RPMS/$(rpm --eval '%{_arch}')/libnftnl-${LIBNFTNL_VER}-*.rpm /rpms/ && \
     cp /root/rpmbuild/RPMS/$(rpm --eval '%{_arch}')/nftables-${NFTABLES_VER}-*.rpm /rpms/
 
+# Stash the corresponding source (the pinned, checksum-verified upstream
+# tarballs plus our patches) under /src. nftables and libnftnl are both GPL-2.0,
+# so consuming images COPY --from=nft-rpms /src into their /included-source to
+# ship the complete corresponding source alongside the binaries.
+RUN mkdir -p /src && \
+    cp /root/rpmbuild/SOURCES/libnftnl-${LIBNFTNL_VER}.tar.xz \
+       /root/rpmbuild/SOURCES/nftables-${NFTABLES_VER}.tar.xz \
+       /root/rpmbuild/SOURCES/*.patch \
+       /src/
+
 RUN dnf clean all

--- a/hack/rpms/nftables/README.md
+++ b/hack/rpms/nftables/README.md
@@ -3,8 +3,8 @@
 This directory builds the `calico/nftables-rpms` image consumed by the calico/node and istio install-cni image builds. It rebuilds two upstream packages as RPMs:
 
 - **nftables** (GPL-2.0-only), pinned at 1.1.1 (see [#11750](https://github.com/projectcalico/calico/issues/11750)), with a single patch backported from upstream commit [be737a1](https://git.netfilter.org/nftables/commit/?id=be737a1986bfee0ddea4bee7863dca0123a2bcbc) ("src: netlink: fix crash when ops doesn't support udata"). See `patches/`.
-- **libnftnl** (LGPL-2.1-or-later), rebuilt unmodified.
+- **libnftnl** (LGPL-2.1-or-later), rebuilt from unpatched upstream source.
 
 ## Source availability
 
-The binaries in the `calico/nftables-rpms` image (and the images that install RPMs from it) are built entirely from the pinned upstream release tarballs (versions and SHAs in `/metadata.mk`) plus the spec files and patches in this directory, which together are the complete corresponding source for the modified nftables. The upstream license text ships alongside the binaries via the RPMs' `%license` tag.
+The binaries in the `calico/nftables-rpms` image (and the images that install RPMs from it) are built entirely from the pinned upstream release tarballs (versions and SHAs in `/metadata.mk`) plus the spec files and patches in this directory, which together are the complete corresponding source for both packages. The upstream license text ships alongside the binaries via the RPMs' `%license` tag.

--- a/hack/rpms/nftables/README.md
+++ b/hack/rpms/nftables/README.md
@@ -1,0 +1,10 @@
+# nftables / libnftnl RPMs
+
+This directory builds the `calico/nftables-rpms` image consumed by the calico/node and istio install-cni image builds. It rebuilds two upstream packages as RPMs:
+
+- **nftables** (GPL-2.0-only), pinned at 1.1.1 (see [#11750](https://github.com/projectcalico/calico/issues/11750)), with a single patch backported from upstream commit [be737a1](https://git.netfilter.org/nftables/commit/?id=be737a1986bfee0ddea4bee7863dca0123a2bcbc) ("src: netlink: fix crash when ops doesn't support udata"). See `patches/`.
+- **libnftnl** (LGPL-2.1-or-later), rebuilt unmodified.
+
+## Source availability
+
+The binaries in the `calico/nftables-rpms` image (and the images that install RPMs from it) are built entirely from the pinned upstream release tarballs (versions and SHAs in `/metadata.mk`) plus the spec files and patches in this directory, which together are the complete corresponding source for the modified nftables. The upstream license text ships alongside the binaries via the RPMs' `%license` tag.

--- a/hack/rpms/nftables/README.md
+++ b/hack/rpms/nftables/README.md
@@ -3,8 +3,8 @@
 This directory builds the `calico/nftables-rpms` image consumed by the calico/node and istio install-cni image builds. It rebuilds two upstream packages as RPMs:
 
 - **nftables** (GPL-2.0-only), pinned at 1.1.1 (see [#11750](https://github.com/projectcalico/calico/issues/11750)), with a single patch backported from upstream commit [be737a1](https://git.netfilter.org/nftables/commit/?id=be737a1986bfee0ddea4bee7863dca0123a2bcbc) ("src: netlink: fix crash when ops doesn't support udata"). See `patches/`.
-- **libnftnl** (LGPL-2.1-or-later), rebuilt from unpatched upstream source.
+- **libnftnl** (GPL-2.0-or-later), rebuilt from unpatched upstream source.
 
 ## Source availability
 
-The binaries in the `calico/nftables-rpms` image (and the images that install RPMs from it) are built entirely from the pinned upstream release tarballs (versions and SHAs in `/metadata.mk`) plus the spec files and patches in this directory, which together are the complete corresponding source for both packages. The upstream license text ships alongside the binaries via the RPMs' `%license` tag.
+Both packages are built entirely from the pinned upstream release tarballs (versions and SHAs in `/metadata.mk`) plus the spec files and patches in this directory, which together are the complete corresponding source. The producer image stashes the upstream tarballs and our patches under `/src`; calico/node and the istio install-cni image copy that into `/included-source`, so the corresponding source for the GPL-2.0 binaries ships in the image alongside them (next to the BIRD and Felix GPL source). The upstream license text also ships via the RPMs' `%license` tag.

--- a/hack/rpms/nftables/libnftnl.spec
+++ b/hack/rpms/nftables/libnftnl.spec
@@ -7,7 +7,7 @@ Name:           libnftnl
 Version:        1.2.8
 Release:        1.tigera%{?dist}
 Summary:        Library for low-level interaction with nftables Netlink's API
-License:        LGPL-2.1-or-later
+License:        GPL-2.0-or-later
 URL:            https://netfilter.org/projects/libnftnl/
 Source0:        https://netfilter.org/projects/libnftnl/files/libnftnl-%{version}.tar.xz
 

--- a/istio/Dockerfile-install-cni
+++ b/istio/Dockerfile-install-cni
@@ -124,6 +124,10 @@ COPY bin/install-cni-${TARGETARCH} /usr/bin/install-cni
 COPY bin/istio-cni-${TARGETARCH} /opt/cni/bin/istio-cni
 COPY istio/LICENSE /LICENSE
 
+# Corresponding source for the patched, GPL-2.0 nftables + libnftnl whose .so
+# and nft binary we ship above (upstream tarballs plus our patches).
+COPY --from=nft-rpms /src/ /included-source/
+
 FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -146,6 +146,9 @@ COPY --from=bird /birdcl6 /bin/birdcl6
 # Copy in the filesystem - this contains licenses, etc...
 COPY filesystem/etc/ /etc
 COPY filesystem/included-source/ /included-source
+# Corresponding source for the patched, GPL-2.0 nftables + libnftnl we install
+# above, shipped alongside the BIRD and Felix GPL source already in this dir.
+COPY --from=nft-rpms /src/ /included-source/
 COPY filesystem/sbin/ /usr/sbin/
 COPY filesystem/usr/ /usr
 


### PR DESCRIPTION
We build patched nftables (GPL-2.0-only) and libnftnl (GPL-2.0-or-later) RPMs in `hack/rpms/nftables/` and ship the binaries in calico/node and the istio install-cni image. The corresponding source wasn't in either image. This adds it: the producer stashes the pinned upstream tarballs plus our patches under `/src`, and both consumers copy that into `/included-source` alongside the BIRD and Felix GPL source already there.

Also corrects the libnftnl spec license tag - it's GPL-2.0-or-later upstream (COPYING and every `src/` header), not LGPL-2.1-or-later. The LGPL tag looks copied from libmnl, its build dependency.

```release-note
None
```