### PR TITLE
[v3.31] fix(deps): bump dependencies to resolve Dependabot security advisories

### DIFF
--- a/node/calico_test/requirements.txt
+++ b/node/calico_test/requirements.txt
@@ -22,8 +22,8 @@ oauthlib==3.1.0
 packaging==20.9
 pathlib2==2.3.7.post1
 pluggy==0.13.1
-pyasn1-modules==0.3.0
-pyasn1==0.5.1
+pyasn1-modules==0.4.2
+pyasn1==0.6.3
 pyparsing==2.4.7
 pytest==4.6.11
 python-dateutil==2.8.2

--- a/node/calico_test/requirements.txt
+++ b/node/calico_test/requirements.txt
@@ -22,8 +22,8 @@ oauthlib==3.1.0
 packaging==20.9
 pathlib2==2.3.7.post1
 pluggy==0.13.1
-pyasn1-modules==0.4.2
-pyasn1==0.6.3
+pyasn1-modules==0.3.0
+pyasn1==0.5.1
 pyparsing==2.4.7
 pytest==4.6.11
 python-dateutil==2.8.2

--- a/whisker/package.json
+++ b/whisker/package.json
@@ -37,7 +37,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
         "react-json-view-lite": "^1.2.0",
-        "react-router-dom": "6.30.3",
+        "react-router-dom": "6.30.4",
         "react-table": "^7.7.0",
         "react-window": "^1.8.6",
         "uuid": "^11.1.0"
@@ -75,8 +75,13 @@
     },
     "resolutions": {
         "@eslint/plugin-kit": "^0.3.4",
+        "@tootallnate/once": "^2.0.1",
         "brace-expansion": "^2.0.2",
-        "js-yaml": "^4.1.1"
+        "flatted": "^3.4.2",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^2.3.2",
+        "ws": "^8.20.1",
+        "yaml": "^1.10.3"
     },
     "packageManager": "yarn@1.22.19"
 }

--- a/whisker/package.json
+++ b/whisker/package.json
@@ -79,7 +79,6 @@
         "brace-expansion": "^2.0.2",
         "flatted": "^3.4.2",
         "js-yaml": "^4.1.1",
-        "picomatch": "^2.3.2",
         "ws": "^8.20.1",
         "yaml": "^1.10.3"
     },

--- a/whisker/yarn.lock
+++ b/whisker/yarn.lock
@@ -3987,10 +3987,15 @@ picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^2.3.2, picomatch@^4.0.3:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+
+picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.7:
   version "4.0.7"

--- a/whisker/yarn.lock
+++ b/whisker/yarn.lock
@@ -1288,10 +1288,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@remix-run/router@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
-  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
+"@remix-run/router@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
+  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
 "@rsbuild/core@^1.1.10":
   version "1.1.10"
@@ -1587,6 +1587,11 @@
   version "14.5.2"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
   integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
+
+"@tootallnate/once@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
 
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"
@@ -2783,7 +2788,7 @@ flat-cache@^4.0.0:
     flatted "^3.2.9"
     keyv "^4.5.4"
 
-flatted@^3.2.9:
+flatted@^3.2.9, flatted@^3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
@@ -3982,15 +3987,10 @@ picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^2.3.2, picomatch@^4.0.3:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
-
-picomatch@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
-  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.7:
   version "4.0.7"
@@ -4154,20 +4154,20 @@ react-remove-scroll@^2.5.7:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.2"
 
-react-router-dom@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.3.tgz#42ae6dc4c7158bfb0b935f162b9621b29dddf740"
-  integrity sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==
+react-router-dom@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.4.tgz#f7167bf3da6c7d9132130ea985dd06def25e84d5"
+  integrity sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==
   dependencies:
-    "@remix-run/router" "1.23.2"
-    react-router "6.30.3"
+    "@remix-run/router" "1.23.3"
+    react-router "6.30.4"
 
-react-router@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
-  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+react-router@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
 
 react-select@5.8.x:
   version "5.8.3"
@@ -4797,10 +4797,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^8.18.0:
-  version "8.20.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
-  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+ws@^8.18.0, ws@^8.20.1:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^5.0.0:
   version "5.0.0"
@@ -4822,7 +4822,7 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^1.10.0:
+yaml@^1.10.0, yaml@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
   integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: #12961

Backport of #12961, manually conflict-resolved because `release-v3.31` carries a much older dependency tree than master. On this branch the backport is **whisker (npm) only** — the Python advisories from the master PR are not backportable here (see below).

### `whisker` (npm)
| Package | From | To | Advisory | Scope |
|---|---|---|---|---|
| react-router / react-router-dom | 6.30.3 | 6.30.4 | open redirect via protocol-relative URL (medium) | runtime |
| ws | 8.20.0 | 8.21.0 | uninitialized memory disclosure (medium) | dev |

`react-router-dom 6.30.4` also pulls `@remix-run/router` 1.23.2 → 1.23.3. `react-json-view-lite` is kept at v3.31's `^1.2.0` (the master PR's bump to `2.5.0` is an unrelated feature change and is not backported).

`yarn resolutions` were added for `ws`, `flatted`, `yaml`, and `@tootallnate/once` to guard against regression; on v3.31 `flatted` (3.4.2) and `yaml` (1.10.3) were already at patched versions, so those entries are no-ops here. The `picomatch` resolution from the master PR was **deliberately omitted** — v3.31 has a legitimate `picomatch@^4.0.3` consumer (its Jest 29 glob tooling), and a global `picomatch: ^2.3.2` resolution would force that v4 consumer down to v2, breaking its dependency contract. Without the resolution the v2 chain still resolves to the patched 2.3.2 and v4 stays at 4.0.4. `whisker/yarn.lock` regenerated via `yarn install`.

### `node/calico_test/requirements.txt` (pip) — not changed on this branch
The Python security bumps from #12961 (`pyasn1`, `urllib3`, `pytest`) are **not backportable to v3.31**: the k8st test container (`node/calico_test/Dockerfile`) runs **Python 3.7**, and the patched releases require Python ≥3.8 — `pyasn1-modules 0.4.x` / `pyasn1 0.6.x`, `urllib3 2.7.0`, and `pytest 9.0.3` are all unavailable for that interpreter (`pip install` fails to build the test image). Note this manifest is **test-only** — it is consumed solely to build the k8st system-test container and is **not part of any shipped Calico image**. These advisories would need a base-image Python upgrade and are out of scope here.

### Testing
- whisker `yarn build` (type-check enabled) — clean
- whisker `yarn test` — 182 passed, 3 skipped (49 suites)

**Release note:**
```release-note
TBD
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
