### PR TITLE
calicoctl diags / calico-bpf: address review nits in BPF JSON dumps

### DIFF
--- a/calicoctl/calicoctl/commands/common/cmd.go
+++ b/calicoctl/calicoctl/commands/common/cmd.go
@@ -129,6 +129,10 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 
 	parts := strings.Fields(c.CmdStr)
 	logCtx.Debugf("cmd tokens: [%+v]", parts)
+	if len(parts) == 0 {
+		fmt.Printf("%s No command to execute\n", logPrefix)
+		return
+	}
 
 	logCtx.Debugf("Executing command: %+v ... ", c.CmdStr)
 	content, err := exec.Command(parts[0], parts[1:]...).CombinedOutput()
@@ -141,11 +145,15 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 	if err != nil && c.FallbackCmdStr != "" {
 		logCtx.Debugf("Command failed, trying fallback: %s", c.FallbackCmdStr)
 		fParts := strings.Fields(c.FallbackCmdStr)
-		fContent, fErr := exec.Command(fParts[0], fParts[1:]...).CombinedOutput()
-		if fErr == nil {
-			content, err = fContent, nil
-			if c.FallbackFilePath != "" {
-				filePath = c.FallbackFilePath
+		if len(fParts) == 0 {
+			logCtx.Warn("Empty fallback command, skipping")
+		} else {
+			fContent, fErr := exec.Command(fParts[0], fParts[1:]...).CombinedOutput()
+			if fErr == nil {
+				content, err = fContent, nil
+				if c.FallbackFilePath != "" {
+					filePath = c.FallbackFilePath
+				}
 			}
 		}
 	}

--- a/calicoctl/calicoctl/commands/common/cmd_test.go
+++ b/calicoctl/calicoctl/commands/common/cmd_test.go
@@ -52,6 +52,41 @@ func TestExecCmdWriteToFile_Fallback(t *testing.T) {
 	}
 }
 
+// TestExecCmdWriteToFile_EmptyCmd verifies that an empty/whitespace command
+// string is handled gracefully rather than panicking on parts[0].
+func TestExecCmdWriteToFile_EmptyCmd(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:   "   ", // whitespace only -> no tokens
+		FilePath: jsonPath,
+	})
+
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file for an empty command, stat err=%v", err)
+	}
+}
+
+// TestExecCmdWriteToFile_EmptyFallback verifies that an empty fallback command
+// is skipped (not executed) and does not panic when the primary fails.
+func TestExecCmdWriteToFile_EmptyFallback(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	txtPath := filepath.Join(dir, "out.txt")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:           "false", // exits non-zero
+		FilePath:         jsonPath,
+		FallbackCmdStr:   "   ", // whitespace only -> no tokens
+		FallbackFilePath: txtPath,
+	})
+
+	if _, err := os.Stat(txtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no fallback file for an empty fallback command, stat err=%v", err)
+	}
+}
+
 // TestExecCmdWriteToFile_PrimarySucceeds verifies the fallback is not used when
 // the primary command succeeds.
 func TestExecCmdWriteToFile_PrimarySucceeds(t *testing.T) {

--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -495,12 +495,18 @@ func makeAffinityJSON[K affinityKey, V nat.AffinityValueInterface](m map[K]V) []
 			Timestamp: v.Timestamp().String(),
 		})
 	}
-	// Sort by (service addr, port, client) for deterministic output.
+	// Sort by (service addr, port, proto, client) for deterministic output.
+	// Proto is part of the sort key because a service can be sticky on the same
+	// addr+port for more than one protocol; without it those entries would
+	// compare equal and order non-deterministically.
 	slices.SortFunc(entries, func(a, b affinityEntryJSON) int {
 		if c := cmp.Compare(a.Addr, b.Addr); c != 0 {
 			return c
 		}
 		if c := cmp.Compare(a.Port, b.Port); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Proto, b.Proto); c != 0 {
 			return c
 		}
 		return cmp.Compare(a.ClientIP, b.ClientIP)

--- a/felix/cmd/calico-bpf/commands/nat_test.go
+++ b/felix/cmd/calico-bpf/commands/nat_test.go
@@ -92,6 +92,38 @@ func TestAffinityDumpJSON(t *testing.T) {
 	}
 }
 
+// TestAffinityDumpJSONProtoOrdering verifies that affinity entries sharing the
+// same service addr+port and client IP but differing in protocol are ordered
+// deterministically (by protocol). Without proto in the sort key these entries
+// compare equal and slices.SortFunc leaves their order unspecified.
+func TestAffinityDumpJSONProtoOrdering(t *testing.T) {
+	client := net.IPv4(10, 0, 0, 1)
+	svc := net.IPv4(1, 1, 1, 1)
+	m := nat2.AffinityMapMem{
+		// Same client, same addr+port; only the protocol differs (TCP=6, UDP=17).
+		nat2.NewAffinityKey(client, nat2.NewNATKey(svc, 53, 17)): nat2.NewAffinityValue(
+			0, nat2.NewNATBackendValue(net.IPv4(6, 6, 6, 6), 5353)),
+		nat2.NewAffinityKey(client, nat2.NewNATKey(svc, 53, 6)): nat2.NewAffinityValue(
+			0, nat2.NewNATBackendValue(net.IPv4(5, 5, 5, 5), 5353)),
+	}
+
+	// Map iteration order is randomised, so a single deterministic ordering
+	// across repeated calls is what we assert.
+	first := makeAffinityJSON(m)
+	if len(first) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(first), first)
+	}
+	if first[0].Proto != 6 || first[1].Proto != 17 {
+		t.Fatalf("entries not ordered by proto: %+v", first)
+	}
+	for i := 0; i < 20; i++ {
+		got := makeAffinityJSON(m)
+		if got[0].Proto != first[0].Proto || got[1].Proto != first[1].Proto {
+			t.Fatalf("non-deterministic ordering across calls: %+v vs %+v", first, got)
+		}
+	}
+}
+
 // TestDumpNiceGrouping verifies that dumpNiceGrouped groups frontends sharing the
 // same service ID so the backend list is printed just once per service.
 func TestDumpNiceGrouping(t *testing.T) {


### PR DESCRIPTION
Follow-ups to #12923, addressing review comments raised on the cherry-pick.

## felix (calico-bpf)
- `makeAffinityJSON` sorted entries on `(addr, port, client)` only, omitting the protocol. A service that is sticky on the same addr+port for more than one protocol (e.g. DNS on TCP **and** UDP 53) produces affinity entries that compared equal, so their relative order in the JSON dump was non-deterministic. Proto is now part of the sort key.

## calicoctl (diags)
- `ExecCmdWriteToFile` indexed `parts[0]` without checking that `strings.Fields` returned any tokens, so an empty/whitespace `CmdStr` (or `FallbackCmdStr`) would panic. Both are now guarded, matching the `len(parts)==0` check `ExecCmd` already has.

## Testing
- New unit test asserts deterministic affinity ordering across protocols (and across repeated calls, since map iteration is randomised).
- New unit tests cover the empty-command and empty-fallback-command guards.

**Release note:**
```release-note
None
```
