### PR TITLE
Wire up built-in tier deletion protection (#12824)

### DIFF
--- a/api/admission/protect-builtin-tiers.yaml
+++ b/api/admission/protect-builtin-tiers.yaml
@@ -15,8 +15,8 @@ spec:
         resources: ["tiers"]
         operations: ["DELETE"]
   validations:
-    - expression: "!(object.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
-      messageExpression: "'The built-in tier ' + object.metadata.name + ' cannot be deleted'"
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/manifests/calico-v3-crds.yaml
+++ b/manifests/calico-v3-crds.yaml
@@ -7678,6 +7678,37 @@ spec:
           - stagednetworkpolicies
           - stagedglobalnetworkpolicies
 ---
+# Source: calico/templates/admission-policies.yaml
+---
+# ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
+# (default, kube-admin, kube-baseline). These tiers are required for correct
+# operation and should never be deleted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        resources: ["tiers"]
+        operations: ["DELETE"]
+  validations:
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
+---
+# Source: calico/templates/admission-policies.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  policyName: protect-builtin-tiers.projectcalico.org
+  validationActions:
+    - Deny
+---
 # Source: calico/templates/calico-webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
Backport of #12824 to `release-v3.32`.

The tier-protection ValidatingAdmissionPolicy added in #12026 was left at `api/config/admission/`, which neither the calico Helm chart nor the operator read - they only pick up `api/admission/`. So on v3.32 the policy never gets installed, and the operator's tier-protection test fails on release-v1.43 because it asserts a policy that v3.32 doesn't ship. Move the policy into `api/admission/` so the chart picks it up via the `charts/calico/admission` symlink, fix the CEL expressions to read `oldObject` (`object` is null on DELETE), and regenerate manifests.

Note this turns tier-deletion protection on in OSS v3.32, and it won't reach the operator until a new v3.32.x tag plus a pin bump.

Drops the `e2e/config/gcp-bpf.yaml` change from #12824 - that file doesn't exist on this branch.

```release-note
Prevent deletion of built-in tiers in CRD mode.
```
