### PR TITLE
nftables: skip dataplane reload after a no-op Apply

### DIFF
--- a/felix/nftables/bench_test.go
+++ b/felix/nftables/bench_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/prometheus/procfs"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/environment"
+	"github.com/projectcalico/calico/felix/generictables"
+	"github.com/projectcalico/calico/felix/ipsets"
+	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/nftables"
+	"github.com/projectcalico/calico/felix/rules"
+)
+
+// These benchmarks isolate the nftables programming path - render plus the nft
+// transaction to the kernel - so we can measure the cost of a change without
+// standing up a cluster.  They program a real "calico" table in the host's
+// network namespace, so they must run as root (CAP_NET_ADMIN), same as the
+// routetable benchmarks.
+//
+// The scale knobs (IP sets, members per set, policy chains, rules per chain)
+// map onto the dimensions the higher-level k8sfv scale runs drive from real
+// policy, so a finding here is reproducible there.  Service-heavy workloads
+// show up as many small IP sets with many referencing rules, which is what the
+// larger specs below approximate.
+
+type scaleSpec struct {
+	name string
+
+	numIPSets     int
+	membersPerSet int
+	numPolicies   int
+	rulesPerChain int
+}
+
+// scaleSpecs is a deliberately modest first sweep.  The dimensions can be
+// turned up towards the k8sfv headline scales (10k+ policies, 250k members)
+// once we trust the numbers; start small so the suite stays runnable.
+var scaleSpecs = []scaleSpec{
+	{name: "100sets_100chains", numIPSets: 100, membersPerSet: 20, numPolicies: 100, rulesPerChain: 10},
+	{name: "500sets_500chains", numIPSets: 500, membersPerSet: 50, numPolicies: 500, rulesPerChain: 10},
+	{name: "2000sets_2000chains", numIPSets: 2000, membersPerSet: 100, numPolicies: 2000, rulesPerChain: 10},
+}
+
+// BenchmarkResync measures the cost of a full resync against an already-correct
+// dataplane: read the current state back, diff it against the desired state,
+// and reconcile.  This is the periodic-refresh cost and the analogue of
+// BenchmarkResync in felix/routetable.
+func BenchmarkResync(b *testing.B) {
+	for _, s := range scaleSpecs {
+		b.Run(s.name, func(b *testing.B) {
+			table, ipv := newRealTable(b)
+			buildState(table, ipv, s)
+			table.ApplyUpdates(nil)
+			table.Apply()
+
+			b.ReportAllocs()
+			reportScale(b, s)
+			cpu := startCPUTimer()
+			b.ResetTimer()
+
+			for range b.N {
+				table.InvalidateDataplaneCache("bench")
+				table.QueueResync()
+				table.ApplyUpdates(nil)
+				table.Apply()
+			}
+
+			b.StopTimer()
+			cpu.report(b)
+		})
+	}
+}
+
+// BenchmarkDeltaUpdate measures the incremental write cost: each iteration
+// churns a single IP set's membership and reprograms.  This is the steady-state
+// case - a pod coming or going - rather than a full resync.
+func BenchmarkDeltaUpdate(b *testing.B) {
+	for _, s := range scaleSpecs {
+		b.Run(s.name, func(b *testing.B) {
+			table, ipv := newRealTable(b)
+			buildState(table, ipv, s)
+			table.ApplyUpdates(nil)
+			table.Apply()
+
+			b.ReportAllocs()
+			reportScale(b, s)
+			cpu := startCPUTimer()
+			b.ResetTimer()
+
+			// Toggle one member of set 0 in and out so each iteration is a real
+			// add or remove rather than a no-op.
+			churn := intToIP(172<<24 | 16<<16)
+			for i := range b.N {
+				if i%2 == 0 {
+					table.AddMembers("s000000", []string{churn})
+				} else {
+					table.RemoveMembers("s000000", []string{churn})
+				}
+				table.ApplyUpdates(nil)
+				table.Apply()
+			}
+
+			b.StopTimer()
+			cpu.report(b)
+		})
+	}
+}
+
+// newRealTable builds an NftablesTable wired to the real kernel via knftables.
+// It skips (rather than fails) when not run as root so a plain "go test" on a
+// dev box doesn't error - the benchmark is only meaningful with kernel access.
+func newRealTable(b *testing.B) (*nftables.NftablesTable, *ipsets.IPVersionConfig) {
+	if os.Getuid() != 0 {
+		b.Skip("Must run as root: programs the real nftables dataplane.")
+	}
+	logutils.ConfigureEarlyLogging()
+	logrus.SetLevel(logrus.WarnLevel)
+
+	// Start clean and tidy up after ourselves - we program a real table in the
+	// host's network namespace.
+	deleteCalicoTable()
+	b.Cleanup(deleteCalicoTable)
+
+	table := nftables.NewTable(
+		"calico",
+		4,
+		rules.RuleHashPrefix,
+		environment.NewFeatureDetector(nil),
+		nftables.TableOptions{
+			OpRecorder: logutils.NewSummarizer("bench"),
+		},
+		true,
+	)
+	ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, ipsets.IPSetNamePrefix, nil, nil)
+	return table, ipv
+}
+
+func deleteCalicoTable() {
+	// May not exist yet on the first call; ignore the error.
+	_ = exec.Command("nft", "delete", "table", "ip", "calico").Run()
+}
+
+// buildState queues the desired state onto the table: numIPSets hash:ip sets,
+// and numPolicies chains each holding rulesPerChain rules that match on a source
+// IP set and TCP destination port.  Each chain is jumped to from filter-FORWARD
+// so it is referenced and therefore programmed.
+func buildState(table *nftables.NftablesTable, ipv *ipsets.IPVersionConfig, s scaleSpec) {
+	ipCounter := uint32(10 << 24)
+	setNames := make([]string, s.numIPSets)
+	for i := range s.numIPSets {
+		setID := fmt.Sprintf("s%06d", i)
+		setNames[i] = ipv.NameForMainIPSet(setID)
+		members := make([]string, s.membersPerSet)
+		for j := range s.membersPerSet {
+			members[j] = intToIP(ipCounter)
+			ipCounter++
+		}
+		table.AddOrReplaceIPSet(
+			ipsets.IPSetMetadata{
+				SetID:   setID,
+				Type:    ipsets.IPSetTypeHashIP,
+				MaxSize: 1 << 20,
+			},
+			members,
+		)
+	}
+
+	jumps := make([]generictables.Rule, s.numPolicies)
+	for p := range s.numPolicies {
+		chainName := fmt.Sprintf("cali-pi-%06d", p)
+		policyRules := make([]generictables.Rule, s.rulesPerChain)
+		for r := range s.rulesPerChain {
+			setName := setNames[(p*s.rulesPerChain+r)%s.numIPSets]
+			policyRules[r] = generictables.Rule{
+				Match: nftables.Match().
+					Protocol("tcp").
+					SourceIPSet(setName).
+					DestPorts(uint16(1000 + r)),
+				Action: nftables.ReturnAction{},
+			}
+		}
+		table.UpdateChain(&generictables.Chain{Name: chainName, Rules: policyRules})
+		jumps[p] = generictables.Rule{
+			Match:  nftables.Match(),
+			Action: nftables.JumpAction{Target: chainName},
+		}
+	}
+	table.InsertOrAppendRules("filter-FORWARD", jumps)
+}
+
+func intToIP(v uint32) string {
+	return fmt.Sprintf("%d.%d.%d.%d", byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+func reportScale(b *testing.B, s scaleSpec) {
+	b.ReportMetric(float64(s.numIPSets), "ipsets")
+	b.ReportMetric(float64(s.numIPSets*s.membersPerSet), "members")
+	b.ReportMetric(float64(s.numPolicies), "chains")
+	b.ReportMetric(float64(s.numPolicies*s.rulesPerChain), "rules")
+}
+
+// cpuTimer captures process CPU time across a benchmark loop so we can report
+// per-op CPU alongside wall-clock - the two diverge once the nft path blocks on
+// the kernel.
+type cpuTimer struct {
+	proc  procfs.Proc
+	start float64
+}
+
+func startCPUTimer() cpuTimer {
+	proc, _ := procfs.NewProc(os.Getpid())
+	stat, _ := proc.Stat()
+	return cpuTimer{proc: proc, start: stat.CPUTime()}
+}
+
+func (c cpuTimer) report(b *testing.B) {
+	runtime.GC()
+	stat, _ := c.proc.Stat()
+	b.ReportMetric((stat.CPUTime()-c.start)/float64(b.N)*1e9, "ncpu/op")
+}

--- a/felix/nftables/bench_test.go
+++ b/felix/nftables/bench_test.go
@@ -135,6 +135,51 @@ func BenchmarkDeltaUpdate(b *testing.B) {
 	}
 }
 
+// BenchmarkChainUpdate measures the incremental cost of changing a single policy
+// chain's rules and reprogramming, in steady state (no forced resync).  This is
+// the path the flush-and-rewrite change targets: today a chain write invalidates
+// the cache and the next Apply() does a full O(total) reload to recover rule
+// handles; rewriting the chain wholesale removes the need for handles, so no
+// reload is required.
+func BenchmarkChainUpdate(b *testing.B) {
+	for _, s := range scaleSpecs {
+		b.Run(s.name, func(b *testing.B) {
+			table, ipv := newRealTable(b)
+			buildState(table, ipv, s)
+			table.ApplyUpdates(nil)
+			table.Apply()
+			// Settle the cache before timing (see BenchmarkDeltaUpdate).
+			table.Apply()
+
+			b.ReportAllocs()
+			reportScale(b, s)
+			cpu := startCPUTimer()
+			b.ResetTimer()
+
+			// Toggle one rule's destination port on a single chain so each
+			// iteration is a real change to that chain and nothing else.
+			chainName := "cali-pi-000000"
+			setName := ipv.NameForMainIPSet("s000000")
+			for i := range b.N {
+				port := uint16(2000 + i%2)
+				table.UpdateChain(&generictables.Chain{
+					Name: chainName,
+					Rules: []generictables.Rule{
+						{
+							Match:  nftables.Match().Protocol("tcp").SourceIPSet(setName).DestPorts(port),
+							Action: nftables.ReturnAction{},
+						},
+					},
+				})
+				table.Apply()
+			}
+
+			b.StopTimer()
+			cpu.report(b)
+		})
+	}
+}
+
 // benchTableName is a dedicated, benchmark-only table. We deliberately avoid
 // "calico" so a run can never touch a real Calico dataplane on this host.
 const benchTableName = "calico-bench"

--- a/felix/nftables/bench_test.go
+++ b/felix/nftables/bench_test.go
@@ -135,38 +135,51 @@ func BenchmarkDeltaUpdate(b *testing.B) {
 	}
 }
 
+// benchTableName is a dedicated, benchmark-only table. We deliberately avoid
+// "calico" so a run can never touch a real Calico dataplane on this host.
+const benchTableName = "calico-bench"
+
 // newRealTable builds an NftablesTable wired to the real kernel via knftables.
-// It skips (rather than fails) when not run as root so a plain "go test" on a
-// dev box doesn't error - the benchmark is only meaningful with kernel access.
+// It skips (rather than fails) when its prerequisites aren't met (not root, or
+// no nft binary) so a plain "go test" on a dev box doesn't error - the benchmark
+// is only meaningful with kernel access.
 func newRealTable(b *testing.B) (*nftables.NftablesTable, *ipsets.IPVersionConfig) {
 	if os.Getuid() != 0 {
 		b.Skip("Must run as root: programs the real nftables dataplane.")
+	}
+	if _, err := exec.LookPath("nft"); err != nil {
+		b.Skip("nft binary not found; skipping nftables dataplane benchmark.")
 	}
 	logutils.ConfigureEarlyLogging()
 	logrus.SetLevel(logrus.WarnLevel)
 
 	// Start clean and tidy up after ourselves - we program a real table in the
 	// host's network namespace.
-	deleteCalicoTable()
-	b.Cleanup(deleteCalicoTable)
+	deleteBenchTable()
+	b.Cleanup(deleteBenchTable)
 
+	// required=false so we return nil (and skip) rather than panic if the
+	// knftables client can't be created, e.g. the kernel lacks nftables support.
 	table := nftables.NewTable(
-		"calico",
+		benchTableName,
 		4,
 		rules.RuleHashPrefix,
 		environment.NewFeatureDetector(nil),
 		nftables.TableOptions{
 			OpRecorder: logutils.NewSummarizer("bench"),
 		},
-		true,
+		false,
 	)
+	if table == nil {
+		b.Skip("nftables not available on this host; skipping benchmark.")
+	}
 	ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, ipsets.IPSetNamePrefix, nil, nil)
 	return table, ipv
 }
 
-func deleteCalicoTable() {
+func deleteBenchTable() {
 	// May not exist yet on the first call; ignore the error.
-	_ = exec.Command("nft", "delete", "table", "ip", "calico").Run()
+	_ = exec.Command("nft", "delete", "table", "ip", benchTableName).Run()
 }
 
 // buildState queues the desired state onto the table: numIPSets hash:ip sets,

--- a/felix/nftables/bench_test.go
+++ b/felix/nftables/bench_test.go
@@ -102,6 +102,11 @@ func BenchmarkDeltaUpdate(b *testing.B) {
 			buildState(table, ipv, s)
 			table.ApplyUpdates(nil)
 			table.Apply()
+			// The first Apply() programs the whole table, which invalidates the
+			// dataplane cache. Apply once more so the cache is settled before we
+			// start timing - we want the steady-state delta cost, not the one-off
+			// reload that follows the initial program.
+			table.Apply()
 
 			b.ReportAllocs()
 			reportScale(b, s)

--- a/felix/nftables/bench_test.go
+++ b/felix/nftables/bench_test.go
@@ -40,9 +40,12 @@ import (
 //
 // The scale knobs (IP sets, members per set, policy chains, rules per chain)
 // map onto the dimensions the higher-level k8sfv scale runs drive from real
-// policy, so a finding here is reproducible there.  Service-heavy workloads
-// show up as many small IP sets with many referencing rules, which is what the
-// larger specs below approximate.
+// policy, so a finding here is reproducible there.  Felix's IP sets come from
+// policy selectors (label selectors over pods/namespaces, network sets, named
+// ports), not from Kubernetes services - those are kube-proxy's job and live in
+// its own table.  So the large specs below model policies that select across
+// many endpoints, which is where Felix's IP set and rule load actually comes
+// from.
 
 type scaleSpec struct {
 	name string

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -1171,7 +1171,8 @@ func (t *NftablesTable) applyUpdates() error {
 		tx.Delete(&knftables.Table{})
 	}
 
-	if tx.NumOperations() == 0 {
+	wroteToDataplane := tx.NumOperations() > 0
+	if !wroteToDataplane {
 		t.logCxt.Debug("Update ended up being no-op, skipping call to nftables.")
 	} else {
 		// Run the transaction.
@@ -1219,11 +1220,16 @@ func (t *NftablesTable) applyUpdates() error {
 	// in-memory for each of the objects we've just written. nftables requires an object's handle in order to
 	// perform update or delete operations.
 	//
+	// Only do this if we actually wrote to the dataplane. A no-op apply leaves our in-memory handles valid, so
+	// invalidating here would force a full, pointless resync on the next apply. This matters at scale: a sync that
+	// only touches IP set members (programmed via the separate IPSets path) leaves this apply a no-op, and we don't
+	// want it to trigger an O(total rules) re-read of the whole table.
+	//
 	// Skip invalidation for disabled tables that have finished cleanup (no chains left in the dataplane).
 	// These tables only exist to remove leftover nftables state when switching to iptables mode. Once cleanup
 	// is confirmed, there's no need to reload state on every apply cycle — doing so would fork nft processes
 	// on every iteration for no useful work.
-	if !t.disabled || len(t.chainToDataplaneHashes) != 0 {
+	if wroteToDataplane && (!t.disabled || len(t.chainToDataplaneHashes) != 0) {
 		t.InvalidateDataplaneCache("post-write")
 	}
 	return nil

--- a/felix/nftables/table_test.go
+++ b/felix/nftables/table_test.go
@@ -160,6 +160,24 @@ var _ = Describe("Table with an empty dataplane", func() {
 		}).To(Panic())
 	})
 
+	It("should not reload the dataplane on a no-op Apply()", func() {
+		// Drive to a settled, in-sync state. The first Apply() writes the base
+		// chains; the second reloads once to recover their handles and is then
+		// a no-op.
+		table.Apply()
+		table.Apply()
+		listCalls := f.ListCallCount
+		Expect(listCalls).To(BeNumerically(">", 0))
+
+		// Further no-op Applies must not re-read the dataplane. A full re-read is
+		// O(total rules), so a sync that changed nothing - or only touched IP set
+		// members, which are programmed via the separate IPSets path - must not
+		// trigger one.
+		table.Apply()
+		table.Apply()
+		Expect(f.ListCallCount).To(Equal(listCalls))
+	})
+
 	Describe("after inserting a rule", func() {
 		BeforeEach(func() {
 			table.InsertOrAppendRules("filter-FORWARD", []generictables.Rule{


### PR DESCRIPTION
Stacked on #12979 (nftables programming micro-benchmark) - the actual change here is the last commit ("skip dataplane reload after a no-op Apply"); the first two commits are that PR and will drop out of this diff once it merges.

---

`NftablesTable.Apply()` invalidated its in-memory dataplane cache after every call, including when the apply wrote nothing. That forced the next `Apply()` to do a full re-read of the table (`nft list` + a JSON parse of every chain, rule, set and map), which is O(total rules).

In steady state that's expensive. A sync that only changes IP set members programs them via the separate IPSets path, leaving the table's own `applyUpdates` a no-op - but it still triggered the reload. So every pod or policy churn on a large node paid a full ruleset re-read on the following sync.

The reload only exists to recover nftables object handles for the objects we just wrote. On a no-op there's nothing to recover, so we can skip it: only invalidate the cache when we actually ran a transaction.

Measured with the micro-benchmark from #12979 (nftables programming micro-benchmark), single IP set member churn at 2000 sets / 2000 chains: steady-state apply drops from ~2.9s and 6.1M allocations to ~17ms and ~2k allocations.

A smaller O(total) cost remains on the no-op path - `applyUpdates` unconditionally deep-copies `chainToFullRules` - worth a separate follow-up.

```release-note
Improved nftables dataplane performance by skipping a full table re-read on dataplane syncs that don't modify nftables rules (for example, IP set member churn).
```
