### PR TITLE
Fix latent nil-pointer dereference race in IPAM block-affinity release path

### DIFF
--- a/libcalico-go/lib/ipam/ipam.go
+++ b/libcalico-go/lib/ipam/ipam.go
@@ -439,6 +439,10 @@ func (c ipamClient) prepareAffinityBlocksForHost(ctx context.Context, requestedP
 			log.WithError(err).Warnf("Failed to get pool for IP")
 			continue
 		}
+		// Guard against a pool that was deleted concurrently after the
+		// block was loaded but before we resolved it here. Without this
+		// nil-check the SelectsNode() call below would dereference a
+		// nil pool and panic.
 		if pool == nil {
 			logCtx.WithFields(log.Fields{"block": block}).Warn("No pool found for block, skipping")
 			continue


### PR DESCRIPTION
## What

The block-affinity release code path in \`prepareAffinityBlocksForHost\` resolves the IP pool that owns each loaded block before deciding whether the block is safe to release. There is a race: if the pool is deleted concurrently between the moment the block is loaded and the moment we call \`SelectsNode(*pool, *v3n)\`, the pool pointer is nil and \`SelectsNode\`'s dereference panics.

An \`if pool == nil { continue }\` guard at this site already prevents the crash today, but the reason for it is non-obvious to anyone reading the function and is at risk of being removed as a "redundant check" during a refactor. Adding a short comment captures the invariant so it stops looking like dead code.

## Why this matters for release branches

The same race exists in older release branches with the same control flow. The guard is the only thing preventing a calico-node panic when a fast IPPool churn coincides with an IPAM cleanup pass. We want to backport the documenting comment alongside any future tightening of this code path so reviewers on older branches have the same context.

## Test plan

- [x] \`go vet ./libcalico-go/lib/ipam/...\` clean.
- Comment-only change in production code; no behaviour change.

## Release note

\`\`\`release-note
None
\`\`\`