### PR TITLE
cherry-pick-candidate: fix PR lookup so it works for fork PRs

### DIFF
--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -44,15 +44,37 @@ module.exports = async ({ github, context, core }) => {
   }
 
   // 1. Find the open master PR for this head SHA.
-  const associated = await github.paginate(
-    github.rest.repos.listPullRequestsAssociatedWithCommit,
-    { owner, repo, commit_sha: headSha },
-  );
-  const pr = associated.find(p =>
-    p.state === 'open' && p.head.sha === headSha && p.base.ref === 'master',
-  );
-  if (!pr) {
-    core.warning(`no open master PR found with head SHA ${headSha}, skipping`);
+  // search/issues is fork-friendly: the /repos/.../commits/{sha}/pulls
+  // endpoint (which listPullRequestsAssociatedWithCommit wraps) returns
+  // nothing for fork PRs because the head commit lives on the fork's
+  // repo, not the base repo's commit DAG. The search index can lag a
+  // few seconds for very fresh commits, so we retry once after 5s.
+  let prNumber = null;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const { data: search } = await github.rest.search.issuesAndPullRequests({
+      q: `repo:${owner}/${repo} is:pr sha:${headSha}`,
+    });
+    const hit = search.items.find(i => i.state === 'open');
+    if (hit) {
+      prNumber = hit.number;
+      break;
+    }
+    if (attempt === 1) {
+      core.info(`Search index empty for ${headSha}, retrying in 5s`);
+      await new Promise(r => setTimeout(r, 5000));
+    }
+  }
+  if (!prNumber) {
+    core.warning(`no open PR found with head SHA ${headSha}, skipping`);
+    return;
+  }
+  // Confirm base.ref and head.sha via the PR API; search returns
+  // issue-shaped results that don't carry those fields.
+  const { data: pr } = await github.rest.pulls.get({
+    owner, repo, pull_number: prNumber,
+  });
+  if (pr.base.ref !== 'master' || pr.head.sha !== headSha || pr.state !== 'open') {
+    core.info(`PR #${pr.number} no longer matches expected state (base=${pr.base.ref}, head_sha=${pr.head.sha}, state=${pr.state}), skipping`);
     return;
   }
 


### PR DESCRIPTION
## What

The PR lookup in `cherry_pick_candidate.js` used `listPullRequestsAssociatedWithCommit`, which calls `GET /repos/{owner}/{repo}/commits/{sha}/pulls`. That endpoint **only walks the base repo's main commit DAG**, so it returns empty for fork PRs (the head commit lives on the fork repo, not the base; even after GitHub fetches it into `refs/pull/N/head`, the endpoint doesn't see it).

This broke the workflow for the dominant case in this OSS repo: a fork PR opened by a contributor hits the "no open master PR found" skip path instead of being classified by the agent. Confirmed in production on a draft test PR from `skoryk-oleksandr/calico`: https://github.com/projectcalico/calico/actions/runs/27636229884 — Stage 2 ran, looked up the PR by head SHA, got nothing, warned and skipped.

Same-repo PRs (push to base, open PR same-repo) worked because their head SHA is in the base repo's main commit graph by definition. The calico-oss-test staging tests only exercised that path, which is why the gap was not caught before merge of #12926.

## Fix

Switch to `search.issuesAndPullRequests` with `repo:O/N is:pr sha:S` — works for both fork and same-repo PRs. After the match, confirm `base.ref` and `head.sha` via a `pulls.get` so we never act on a stale or wrong-base hit (search returns issue-shaped objects that lack those fields). Adds one retry after 5s to absorb search-index lag on very fresh commits.

Diff: +31 / -9 in `cherry_pick_candidate.js` only. No YAML changes, no permission changes (search and pulls.get are covered by the existing token).

## Verification

Verified end-to-end in `tigera/calico-oss-test` after the same patch landed there as #220:

- Same-repo PR (regression): `tigera/calico-oss-test#221` — bug-fix shape, labelled.
- Same-repo PR (regression): `tigera/calico-oss-test#222` — feature shape, not labelled.
- **Fork PR (new path)**: `tigera/calico-oss-test#223` from `skoryk-oleksandr/calico-oss-test-fork` — bug-fix shape, **labelled** (previously the broken path).

Log from the fork-PR run:
```
Label authority: bot (last actor: none, present=false)
agent decision: backport (confidence=high)
Adding cherry-pick-candidate to PR #223
```

## Release note

```release-note
None
```