### PR TITLE
eBPF: split cali_qos into rate and connlimit maps to fix lost-update on packet-rate state

### DIFF
--- a/felix/bpf-gpl/qos.h
+++ b/felix/bpf-gpl/qos.h
@@ -16,6 +16,16 @@ struct calico_qos_key {
 	__u16 family;  // 4=IPv4, 6=IPv6
 };
 
+/* Packet-rate state lives in cali_qos; connection-limit state lives in
+ * cali_qos_conn. They share the same key shape (ifindex, direction,
+ * family) but have disjoint values and disjoint writers. Splitting
+ * them avoids a lost-update race: the userspace ConnLimitScanner
+ * periodically writes current_count under BPF_F_LOCK, and if
+ * packet-rate state shared the same value the locked write would
+ * clobber the dataplane's running token-bucket state (the lock covers
+ * only the write, not the earlier unlocked read). See
+ * felix/bpf/conntrack/connlimit_scanner.go for the userspace side.
+ */
 struct calico_qos_val {
 	struct bpf_spin_lock lock;
 	// packet rate config
@@ -25,7 +35,10 @@ struct calico_qos_val {
 	__s16 packet_rate_tokens;
 	__s16 padding[3]; // alignment
 	__u64 packet_rate_last_update;
-	// connection limit
+};
+
+struct calico_qos_conn_val {
+	struct bpf_spin_lock lock;
 	__u32 max_connections; // 0 = no limit, >0 = limit
 	__u32 current_count;   // maintained by BPF (increment on SYN) and scanner (recount)
 };
@@ -36,6 +49,11 @@ struct calico_qos_val {
 CALI_MAP(cali_qos, 2,
 		BPF_MAP_TYPE_HASH,
 		struct calico_qos_key, struct calico_qos_val,
+		4*IFACE_STATE_MAP_SIZE, BPF_F_NO_PREALLOC)
+
+CALI_MAP_V1(cali_qos_conn,
+		BPF_MAP_TYPE_HASH,
+		struct calico_qos_key, struct calico_qos_conn_val,
 		4*IFACE_STATE_MAP_SIZE, BPF_F_NO_PREALLOC)
 
 static CALI_BPF_INLINE int qos_enforce_packet_rate(struct cali_tc_ctx *ctx)
@@ -163,8 +181,8 @@ static CALI_BPF_INLINE bool qos_dscp_set(struct cali_tc_ctx *ctx, __s8 dscp)
 }
 
 /* qos_connlimit_check_and_increment atomically checks the connection limit for
- * the current interface and direction using the cali_qos map. If below the
- * limit, increments the counter and returns 0 (allow). If at or above the
+ * the current interface and direction using the cali_qos_conn map. If below
+ * the limit, increments the counter and returns 0 (allow). If at or above the
  * limit, returns -1 (reject). Returns 0 if no limit is configured for this
  * interface+direction (no map entry or max_connections <= 0).
  *
@@ -192,7 +210,7 @@ static CALI_BPF_INLINE int qos_connlimit_check_and_increment(struct cali_tc_ctx 
 #endif
 	};
 
-	struct calico_qos_val *qos = cali_qos_lookup_elem(&key);
+	struct calico_qos_conn_val *qos = cali_qos_conn_lookup_elem(&key);
 	if (!qos || qos->max_connections <= 0) {
 		return 0;
 	}
@@ -235,7 +253,7 @@ static CALI_BPF_INLINE void qos_connlimit_decrement(__u32 ifindex, __u16 directi
 		.family = family,
 	};
 
-	struct calico_qos_val *qos = cali_qos_lookup_elem(&key);
+	struct calico_qos_conn_val *qos = cali_qos_conn_lookup_elem(&key);
 	if (!qos || qos->max_connections <= 0) {
 		return;
 	}

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -70,6 +70,7 @@ type CommonMaps struct {
 	ProfilingMap       maps.Map
 	CTLBProgramsMaps   []maps.Map
 	QoSMap             maps.MapWithUpdateWithFlags
+	QoSConnMap         maps.MapWithUpdateWithFlags
 }
 
 type Maps struct {
@@ -103,6 +104,7 @@ func getCommonMaps() *CommonMaps {
 		ProfilingMap:     profiling.Map(),
 		CTLBProgramsMaps: nat.ProgramsMaps(),
 		QoSMap:           qos.Map().(maps.MapWithUpdateWithFlags),
+		QoSConnMap:       qos.ConnMap().(maps.MapWithUpdateWithFlags),
 	}
 	jumpMaps := jump.Maps()
 	for _, jm := range jumpMaps {
@@ -207,6 +209,7 @@ func (c *CommonMaps) slice() []maps.Map {
 		c.XDPJumpMap,
 		c.ProfilingMap,
 		c.QoSMap,
+		c.QoSConnMap,
 	}
 	mapslice = append(mapslice, c.ProgramsMaps...)
 	mapslice = append(mapslice, c.NetkitProgramsMaps...)

--- a/felix/bpf/conntrack/connlimit_scanner.go
+++ b/felix/bpf/conntrack/connlimit_scanner.go
@@ -43,7 +43,7 @@ type connlimitKey struct {
 
 // ConnLimitScanner is an EntryScannerSynced that periodically recounts active
 // TCP connections per interface+direction using the BPF CT map and writes the
-// true count to the cali_qos BPF map. This corrects any drift from LRU
+// true count to the cali_qos_conn BPF map. This corrects any drift from LRU
 // eviction or connection close without explicit decrement.
 //
 // The BPF dataplane increments the count on new TCP SYN. This scanner
@@ -77,8 +77,8 @@ type ConnLimitScanner struct {
 	podInfo    map[string]ConnLimitPodInfo
 	counts     map[connlimitKey]uint32
 	// family is the IP family this scanner runs over (4 or 6). Used as
-	// the family dimension when writing back to the cali_qos map so v4
-	// and v6 each update their own counter, avoiding the dual-stack
+	// the family dimension when writing back to the cali_qos_conn map so
+	// v4 and v6 each update their own counter, avoiding the dual-stack
 	// overwrite that would otherwise happen with a shared map entry.
 	family      uint16
 	iterCount   int
@@ -87,8 +87,8 @@ type ConnLimitScanner struct {
 
 // NewConnLimitScanner creates a new ConnLimitScanner. family must be either
 // qos.IPFamilyV4 (4) or qos.IPFamilyV6 (6) — it identifies which family's
-// CT map this scanner is walking and which family's QoS map entry it
-// writes back to.
+// CT map this scanner is walking and which family's cali_qos_conn entry
+// it writes back to.
 func NewConnLimitScanner(
 	qosMap connLimitQoSMap,
 	getPodInfo ConnLimitPodInfoProvider,
@@ -257,7 +257,7 @@ func (s *ConnLimitScanner) prepareUpdate(ifindex uint32, direction uint16, count
 	qosValBytes, err := s.qosMap.Get(qosKey.AsBytes())
 	if err != nil {
 		if !maps.IsNotExists(err) {
-			log.WithField("ifindex", ifindex).WithField("direction", direction).WithError(err).Debug("ConnLimitScanner: error reading QoS map entry.")
+			log.WithField("ifindex", ifindex).WithField("direction", direction).WithError(err).Debug("ConnLimitScanner: error reading cali_qos_conn entry.")
 		}
 		return nil, nil, false
 	}

--- a/felix/bpf/conntrack/connlimit_scanner.go
+++ b/felix/bpf/conntrack/connlimit_scanner.go
@@ -58,10 +58,14 @@ type connlimitKey struct {
 // network partition), so a ~30s recovery window is adequate.
 const connLimitScannerRunEveryN = 3
 
-// connLimitQoSMap is the subset of the QoS BPF map API that the scanner needs.
-// Narrowed from maps.MapWithUpdateWithFlags so tests can supply a small fake
-// without taking a dependency on the full Map interface (avoids an import
-// cycle with felix/bpf/mock, which itself depends on conntrack).
+// connLimitQoSMap is the subset of the cali_qos_conn BPF map API that the
+// scanner needs. Narrowed from maps.MapWithUpdateWithFlags so tests can
+// supply a small fake without taking a dependency on the full Map interface
+// (avoids an import cycle with felix/bpf/mock, which itself depends on
+// conntrack). The scanner only touches the connection-limit map — packet-
+// rate state lives in a separate cali_qos map that the scanner never
+// reads or writes; this is what prevents the lost-update race that
+// motivated the split (see qos.h).
 type connLimitQoSMap interface {
 	Get(k []byte) ([]byte, error)
 	BatchUpdate(ks, vs [][]byte, flags uint64) (int, error)
@@ -243,10 +247,11 @@ func (s *ConnLimitScanner) IterationEnd() {
 	}
 }
 
-// prepareUpdate reads the existing QoS map entry and returns the key bytes
-// and a new value with current_count replaced by `count` (preserving the
-// packet-rate fields and max_connections). Returns changed=false when the
-// existing count already matches `count`, or when the read fails.
+// prepareUpdate reads the existing cali_qos_conn entry and returns the key
+// bytes and a new value with current_count replaced by `count` (preserving
+// max_connections). Returns changed=false when the existing count already
+// matches `count`, or when the read fails. Packet-rate state lives in a
+// separate map (cali_qos) that the scanner never touches.
 func (s *ConnLimitScanner) prepareUpdate(ifindex uint32, direction uint16, count uint32) (keyBytes, valBytes []byte, changed bool) {
 	qosKey := qos.NewKey(ifindex, direction, s.family)
 	qosValBytes, err := s.qosMap.Get(qosKey.AsBytes())
@@ -256,15 +261,11 @@ func (s *ConnLimitScanner) prepareUpdate(ifindex uint32, direction uint16, count
 		}
 		return nil, nil, false
 	}
-	existing := qos.ValueFromBytes(qosValBytes)
+	existing := qos.ConnValueFromBytes(qosValBytes)
 	if existing.CurrentCount() == count {
 		return nil, nil, false
 	}
-	newVal := qos.NewValue(
-		existing.PacketRate(), existing.PacketBurst(),
-		existing.PacketRateTokens(), existing.PacketRateLastUpdate(),
-		existing.MaxConnections(), count,
-	)
+	newVal := qos.NewConnValue(existing.MaxConnections(), count)
 	return qosKey.AsBytes(), newVal.AsBytes(), true
 }
 

--- a/felix/bpf/conntrack/connlimit_scanner_test.go
+++ b/felix/bpf/conntrack/connlimit_scanner_test.go
@@ -66,10 +66,14 @@ func (f *fakeQoSMap) BatchUpdate(ks, vs [][]byte, flags uint64) (int, error) {
 	return len(ks), nil
 }
 
+// seed populates the connlimit map with (maxConn, current) for the given
+// (ifindex, direction) pair. The scanner only touches the connlimit map;
+// packet-rate state lives in a sibling map (cali_qos) the scanner never
+// reads or writes.
 func (f *fakeQoSMap) seed(t *testing.T, ifindex uint32, direction uint16, maxConn, current uint32) {
 	t.Helper()
 	k := qos.NewKey(ifindex, direction, qos.IPFamilyV4).AsBytes()
-	v := qos.NewValue(100, 50, 25, 12345, maxConn, current).AsBytes()
+	v := qos.NewConnValue(maxConn, current).AsBytes()
 	f.contents[string(k)] = v[:]
 }
 
@@ -79,7 +83,7 @@ func (f *fakeQoSMap) currentCount(t *testing.T, ifindex uint32, direction uint16
 	if err != nil {
 		t.Fatalf("fake Get for (%d,%d) failed: %v", ifindex, direction, err)
 	}
-	return qos.ValueFromBytes(bytes).CurrentCount()
+	return qos.ConnValueFromBytes(bytes).CurrentCount()
 }
 
 // TestConnLimitScannerCheckNoPodsIsNoOp verifies that the scanner's Check
@@ -570,15 +574,16 @@ func TestConnLimitScannerBatchesActiveCountUpdates(t *testing.T) {
 		t.Errorf("expected batch flags=BPF_F_LOCK (0x%x), got 0x%x", unix.BPF_F_LOCK, m.lastBatchFlags)
 	}
 
-	// Packet-rate fields and max_connections must survive the recount.
+	// max_connections must survive the recount. Packet-rate state lives
+	// in a separate map that the scanner never touches — see
+	// TestConnLimitScannerDoesNotTouchPacketRateMap for that property.
 	bytes, err := m.Get(qos.NewKey(ifA, 1, qos.IPFamilyV4).AsBytes())
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
-	v := qos.ValueFromBytes(bytes)
-	if v.PacketRate() != 100 || v.PacketBurst() != 50 || v.MaxConnections() != 5 {
-		t.Errorf("packet-rate / max_connections fields not preserved: rate=%d burst=%d max=%d",
-			v.PacketRate(), v.PacketBurst(), v.MaxConnections())
+	v := qos.ConnValueFromBytes(bytes)
+	if v.MaxConnections() != 5 {
+		t.Errorf("max_connections not preserved: got %d, want 5", v.MaxConnections())
 	}
 }
 

--- a/felix/bpf/conntrack/connlimit_scanner_test.go
+++ b/felix/bpf/conntrack/connlimit_scanner_test.go
@@ -575,8 +575,9 @@ func TestConnLimitScannerBatchesActiveCountUpdates(t *testing.T) {
 	}
 
 	// max_connections must survive the recount. Packet-rate state lives
-	// in a separate map that the scanner never touches — see
-	// TestConnLimitScannerDoesNotTouchPacketRateMap for that property.
+	// in a separate map (cali_qos) the scanner has no handle to; the
+	// connLimitQoSMap interface structurally precludes the scanner from
+	// touching it.
 	bytes, err := m.Get(qos.NewKey(ifA, 1, qos.IPFamilyV4).AsBytes())
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)

--- a/felix/bpf/qos/map.go
+++ b/felix/bpf/qos/map.go
@@ -24,12 +24,25 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/maps"
 )
 
+// Packet-rate (cali_qos) and connection-limit (cali_qos_conn) live in two
+// separate BPF maps sharing the same key shape. They were split because the
+// userspace ConnLimitScanner has to write current_count back to the map,
+// and a shared value forced a read-modify-write that would clobber the
+// BPF dataplane's running token-bucket state (BPF_F_LOCK only covers the
+// write — locks don't span syscall boundaries). With two maps, each
+// writer owns its own field group exclusively.
+
 func init() {
 	SetMapSize(MapParams.MaxEntries)
+	SetConnMapSize(ConnMapParams.MaxEntries)
 }
 
 func SetMapSize(size int) {
 	maps.SetSize(MapParams.VersionedName(), size)
+}
+
+func SetConnMapSize(size int) {
+	maps.SetSize(ConnMapParams.VersionedName(), size)
 }
 
 const (
@@ -38,7 +51,11 @@ const (
 	// version number to keep BPF-side debug output legible.
 	IPFamilyV4 uint16 = 4
 	IPFamilyV6 uint16 = 6
-	ValueSize         = 4 + 2 + 2 + 2 + 3*2 + 8 + 4 + 4
+	// ValueSize: lock(4) + packetRate(2) + packetBurst(2) +
+	// packetRateTokens(2) + padding(6) + packetRateLastUpdate(8) = 24
+	ValueSize = 4 + 2 + 2 + 2 + 3*2 + 8
+	// ConnValueSize: lock(4) + maxConnections(4) + currentCount(4) = 12
+	ConnValueSize = 4 + 4 + 4
 	// 4 entries per interface: 2 directions × 2 IP families.
 	MaxEntries = 4 * ifstate.MaxEntries
 )
@@ -54,8 +71,23 @@ var MapParams = maps.MapParameters{
 	UpdatedByBPF: true,
 }
 
+var ConnMapParams = maps.MapParameters{
+	Type:         "hash",
+	KeySize:      KeySize,
+	ValueSize:    ConnValueSize,
+	MaxEntries:   MaxEntries,
+	Name:         "cali_qos_conn",
+	Flags:        unix.BPF_F_NO_PREALLOC,
+	Version:      1,
+	UpdatedByBPF: true,
+}
+
 func Map() maps.Map {
 	return maps.NewPinnedMap(MapParams)
+}
+
+func ConnMap() maps.Map {
+	return maps.NewPinnedMap(ConnMapParams)
 }
 
 type Key [KeySize]byte
@@ -103,8 +135,6 @@ func NewValue(
 	packetBurst,
 	packetRateTokens int16,
 	packetRateLastUpdate uint64,
-	maxConnections,
-	currentCount uint32,
 ) Value {
 	var v Value
 
@@ -114,8 +144,6 @@ func NewValue(
 	binary.LittleEndian.PutUint16(v[8:10], uint16(packetRateTokens))
 	// skip padding (v[10:16])
 	binary.LittleEndian.PutUint64(v[16:24], uint64(packetRateLastUpdate))
-	binary.LittleEndian.PutUint32(v[24:28], uint32(maxConnections))
-	binary.LittleEndian.PutUint32(v[28:32], uint32(currentCount))
 
 	return v
 }
@@ -140,23 +168,48 @@ func (v Value) PacketRateLastUpdate() uint64 {
 	return binary.LittleEndian.Uint64(v[16:24])
 }
 
-func (v Value) MaxConnections() uint32 {
-	return uint32(binary.LittleEndian.Uint32(v[24:28]))
-}
-
-func (v Value) CurrentCount() uint32 {
-	return uint32(binary.LittleEndian.Uint32(v[28:32]))
-}
-
 func (v Value) String() string {
 	return fmt.Sprintf(
-		"{PacketRate: %d, PacketBurst: %d, PacketRateTokens: %d, PacketRateLastUpdate: %d, MaxConnections: %d, CurrentCount: %d}",
-		v.PacketRate(), v.PacketBurst(), v.PacketRateTokens(), v.PacketRateLastUpdate(),
-		v.MaxConnections(), v.CurrentCount())
+		"{PacketRate: %d, PacketBurst: %d, PacketRateTokens: %d, PacketRateLastUpdate: %d}",
+		v.PacketRate(), v.PacketBurst(), v.PacketRateTokens(), v.PacketRateLastUpdate())
 }
 
 func ValueFromBytes(b []byte) Value {
 	var v Value
+	copy(v[:], b)
+	return v
+}
+
+type ConnValue [ConnValueSize]byte
+
+func NewConnValue(maxConnections, currentCount uint32) ConnValue {
+	var v ConnValue
+
+	// skip lock (v[0:4])
+	binary.LittleEndian.PutUint32(v[4:8], maxConnections)
+	binary.LittleEndian.PutUint32(v[8:12], currentCount)
+
+	return v
+}
+
+func (v ConnValue) AsBytes() []byte {
+	return v[:]
+}
+
+func (v ConnValue) MaxConnections() uint32 {
+	return binary.LittleEndian.Uint32(v[4:8])
+}
+
+func (v ConnValue) CurrentCount() uint32 {
+	return binary.LittleEndian.Uint32(v[8:12])
+}
+
+func (v ConnValue) String() string {
+	return fmt.Sprintf("{MaxConnections: %d, CurrentCount: %d}", v.MaxConnections(), v.CurrentCount())
+}
+
+func ConnValueFromBytes(b []byte) ConnValue {
+	var v ConnValue
 	copy(v[:], b)
 	return v
 }
@@ -172,6 +225,23 @@ func MapMemIter(m MapMem) func(k, v []byte) {
 		copy(key[:ks], k[:ks])
 
 		var val Value
+		copy(val[:vs], v[:vs])
+
+		m[key] = val
+	}
+}
+
+type ConnMapMem map[Key]ConnValue
+
+func ConnMapMemIter(m ConnMapMem) func(k, v []byte) {
+	ks := len(Key{})
+	vs := len(ConnValue{})
+
+	return func(k, v []byte) {
+		var key Key
+		copy(key[:ks], k[:ks])
+
+		var val ConnValue
 		copy(val[:vs], v[:vs])
 
 		m[key] = val

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -623,7 +623,7 @@ var (
 	policyJumpMap                                                                                                                                            []maps.Map
 	ringBufMap, ringBufDropsMap                                                                                                                              maps.Map
 	profilingMap, ipfragsMapTmp                                                                                                                              maps.Map
-	qosMap                                                                                                                                                   maps.Map
+	qosMap, qosConnMap                                                                                                                                       maps.Map
 	ctlbProgsMap                                                                                                                                             []maps.Map
 	progMap                                                                                                                                                  []maps.Map
 	allMaps                                                                                                                                                  []maps.Map
@@ -662,6 +662,7 @@ func initMapsOnce() {
 		ctlbProgsMap = nat.ProgramsMaps()
 		progMap = hook.NewProgramsMaps()
 		qosMap = qos.Map()
+		qosConnMap = qos.ConnMap()
 		maglevMap = nat.MaglevMap()
 		maglevMapV6 = nat.MaglevMapV6()
 		allowSourcesMap = allowsources.Map()
@@ -673,7 +674,7 @@ func initMapsOnce() {
 		allMaps = []maps.Map{natMap, natBEMap, natMapV6, natBEMapV6, ctMap, ctMapV6, ctCleanupMap, ctCleanupMapV6, rtMap, rtMapV6, ipsMap, ipsMapV6,
 			stateMap, testStateMap, affinityMap, affinityMapV6, arpMap, arpMapV6, fsafeMap, fsafeMapV6,
 			countersMap, ipfragsMap, ipfragsMapTmp, ipfragsFwdMap, ifstateMap, profilingMap,
-			policyJumpMap[0], policyJumpMap[1], policyJumpMapXDP, ctlbProgsMap[0], ctlbProgsMap[1], ctlbProgsMap[2], qosMap, maglevMap, maglevMapV6,
+			policyJumpMap[0], policyJumpMap[1], policyJumpMapXDP, ctlbProgsMap[0], ctlbProgsMap[1], ctlbProgsMap[2], qosMap, qosConnMap, maglevMap, maglevMapV6,
 			allowSourcesMap, allowSourcesMapV6, ringBufMap, ringBufDropsMap}
 		for _, m := range allMaps {
 			err := m.EnsureExists()
@@ -2230,6 +2231,7 @@ func resetBPFMaps() {
 	resetMap(natMap)
 	resetMap(natBEMap)
 	resetMap(qosMap)
+	resetMap(qosConnMap)
 	resetMap(maglevMap)
 }
 

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -63,7 +63,7 @@ func TestQoSPacketRate(t *testing.T) {
 	defer resetQoSMap(qosMap)
 	key1 := qos.NewKey(uint32(ifIndex), 1, qos.IPFamilyV4)
 	key2 := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV4)
-	value := qos.NewValue(1, 1, -1, 0, 0, 0)
+	value := qos.NewValue(1, 1, -1, 0)
 
 	err = qosMap.Update(
 		key1.AsBytes(),
@@ -404,20 +404,19 @@ func TestQoSConnLimitEgressRecycleNotDoubleCounted(t *testing.T) {
 		Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
 	}
 
-	// seedQoSCount populates the egress QoS map entry for ifIndex with
-	// max=maxConnections and the given current_count.
+	// seedQoSCount populates the egress connlimit map entry for ifIndex
+	// with max=maxConnections and the given current_count.
 	seedQoSCount := func(current uint32) {
 		key := qos.NewKey(uint32(ifIndex), 0 /* egress */, qos.IPFamilyV4)
-		// Packet-rate fields zero; max=maxConnections; current=current.
-		v := qos.NewValue(0, 0, 0, 0, maxConnections, current)
-		Expect(qosMap.Update(key.AsBytes(), v.AsBytes())).NotTo(HaveOccurred())
+		v := qos.NewConnValue(maxConnections, current)
+		Expect(qosConnMap.Update(key.AsBytes(), v.AsBytes())).NotTo(HaveOccurred())
 	}
 
 	readQoSCount := func() uint32 {
 		key := qos.NewKey(uint32(ifIndex), 0, qos.IPFamilyV4)
-		b, err := qosMap.Get(key.AsBytes())
+		b, err := qosConnMap.Get(key.AsBytes())
 		Expect(err).NotTo(HaveOccurred())
-		return qos.ValueFromBytes(b).CurrentCount()
+		return qos.ConnValueFromBytes(b).CurrentCount()
 	}
 
 	// SYN packet from srcIP:srcPort → dstIP:dstPort.
@@ -427,9 +426,9 @@ func TestQoSConnLimitEgressRecycleNotDoubleCounted(t *testing.T) {
 	t.Run("recycle of properly-closed entry: counter stays at 1", func(t *testing.T) {
 		RegisterTestingT(t)
 		resetCTMap(ctMap)
-		resetQoSMap(qosMap)
+		resetQoSMap(qosConnMap)
 		defer resetCTMap(ctMap)
-		defer resetQoSMap(qosMap)
+		defer resetQoSMap(qosConnMap)
 
 		// Close-time decrement already fired on the old entry, leaving
 		// CONNLIMIT_DEC set and the QoS counter at 0.
@@ -455,9 +454,9 @@ func TestQoSConnLimitEgressRecycleNotDoubleCounted(t *testing.T) {
 	t.Run("recycle of never-decremented entry: counter stays at 1, not 2", func(t *testing.T) {
 		RegisterTestingT(t)
 		resetCTMap(ctMap)
-		resetQoSMap(qosMap)
+		resetQoSMap(qosConnMap)
 		defer resetCTMap(ctMap)
-		defer resetQoSMap(qosMap)
+		defer resetQoSMap(qosConnMap)
 
 		// Old entry was counted at SYN time (CONNLIMIT_EGRESS set) but
 		// never decremented (CONNLIMIT_DEC NOT set). QoS counter is at
@@ -541,20 +540,20 @@ func TestQoSConnLimitIngressRetransmissionOfRejectedStillOverLimit(t *testing.T)
 		legA, legB)
 	Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
 
-	// Pre-populate the ingress QoS map entry with the counter AT the
-	// limit. The retransmission's second-chance check should re-run and
-	// fail (current_count >= max_connections), keeping the rejection.
-	defer resetQoSMap(qosMap)
-	resetQoSMap(qosMap)
+	// Pre-populate the ingress connlimit map entry with the counter AT
+	// the limit. The retransmission's second-chance check should re-run
+	// and fail (current_count >= max_connections), keeping the rejection.
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
 	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
-	Expect(qosMap.Update(qosKey.AsBytes(),
-		qos.NewValue(0, 0, 0, 0, maxConnections, maxConnections).AsBytes())).
+	Expect(qosConnMap.Update(qosKey.AsBytes(),
+		qos.NewConnValue(maxConnections, maxConnections).AsBytes())).
 		NotTo(HaveOccurred())
 
 	readQoSCount := func() uint32 {
-		b, err := qosMap.Get(qosKey.AsBytes())
+		b, err := qosConnMap.Get(qosKey.AsBytes())
 		Expect(err).NotTo(HaveOccurred())
-		return qos.ValueFromBytes(b).CurrentCount()
+		return qos.ConnValueFromBytes(b).CurrentCount()
 	}
 
 	// Retransmitted SYN matching the same 5-tuple as the rejected entry.
@@ -640,17 +639,17 @@ func TestQoSConnLimitIngressRetransmissionOfRejectedSecondChance(t *testing.T) {
 	// QoS counter is one below the limit — slot has freed since the
 	// original rejection. The retransmission's second-chance check
 	// should re-run and succeed.
-	defer resetQoSMap(qosMap)
-	resetQoSMap(qosMap)
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
 	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
-	Expect(qosMap.Update(qosKey.AsBytes(),
-		qos.NewValue(0, 0, 0, 0, maxConnections, maxConnections-1).AsBytes())).
+	Expect(qosConnMap.Update(qosKey.AsBytes(),
+		qos.NewConnValue(maxConnections, maxConnections-1).AsBytes())).
 		NotTo(HaveOccurred())
 
 	readQoSCount := func() uint32 {
-		b, err := qosMap.Get(qosKey.AsBytes())
+		b, err := qosConnMap.Get(qosKey.AsBytes())
 		Expect(err).NotTo(HaveOccurred())
-		return qos.ValueFromBytes(b).CurrentCount()
+		return qos.ConnValueFromBytes(b).CurrentCount()
 	}
 
 	_, _, _, _, pktBytes, err := testPacketTCPV4WithPayload(dstIP, srcPort, dstPort, true /* syn */, nil)
@@ -726,18 +725,18 @@ func TestQoSConnLimitIngressRetransmissionOfAccepted(t *testing.T) {
 		legA, legB)
 	Expect(ctMap.Update(k.AsBytes(), v.AsBytes()[:])).NotTo(HaveOccurred())
 
-	// QoS map: max=3, current=1 (this entry was already counted).
-	defer resetQoSMap(qosMap)
-	resetQoSMap(qosMap)
+	// Connlimit map: max=3, current=1 (this entry was already counted).
+	defer resetQoSMap(qosConnMap)
+	resetQoSMap(qosConnMap)
 	qosKey := qos.NewKey(uint32(ifIndex), 1 /* ingress */, qos.IPFamilyV4)
-	Expect(qosMap.Update(qosKey.AsBytes(),
-		qos.NewValue(0, 0, 0, 0, maxConnections, 1).AsBytes())).
+	Expect(qosConnMap.Update(qosKey.AsBytes(),
+		qos.NewConnValue(maxConnections, 1).AsBytes())).
 		NotTo(HaveOccurred())
 
 	readQoSCount := func() uint32 {
-		b, err := qosMap.Get(qosKey.AsBytes())
+		b, err := qosConnMap.Get(qosKey.AsBytes())
 		Expect(err).NotTo(HaveOccurred())
-		return qos.ValueFromBytes(b).CurrentCount()
+		return qos.ConnValueFromBytes(b).CurrentCount()
 	}
 
 	// Retransmitted SYN matching the accepted entry's 5-tuple.

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2998,15 +2998,18 @@ func (m *bpfEndpointManager) applyPolicy(ifaceName string) error {
 }
 
 // writeQoSRateEntry updates the cali_qos packet-rate map entry for one
-// (ifindex, direction, family) triple. If hasRate is false the entry is
-// deleted. On config change (rate or burst differs from the existing
-// entry) the token-bucket state is reset to "uninitialised" so the BPF
-// dataplane re-fills from burst on the next packet; otherwise the
-// existing dynamic state is preserved.
+// (ifindex, direction, family) triple.
 //
-// This RMW only touches the packet-rate map. The connlimit map has its
-// own write path (writeQoSConnEntry) — the two maps are independent and
-// no value is shared between them.
+//   - If hasRate is false: the entry is deleted.
+//   - If the entry exists and (packetRate, packetBurst) match: no write.
+//     The BPF dataplane owns packet_rate_tokens and
+//     packet_rate_last_update; rewriting them from a userspace snapshot
+//     would race with packet-rate updates and re-introduce the same
+//     class of lost-update bug the cali_qos / cali_qos_conn split was
+//     introduced to fix.
+//   - Otherwise (fresh entry, or config changed): write the new config
+//     with the token-bucket state reset to the sentinel so the BPF
+//     dataplane re-initialises from burst on the next packet.
 func (m *bpfEndpointManager) writeQoSRateEntry(qosKey qos.Key, hasRate bool, packetRate, packetBurst int16) error {
 	if !hasRate {
 		if err := m.QoSMap.Delete(qosKey.AsBytes()); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -3014,19 +3017,18 @@ func (m *bpfEndpointManager) writeQoSRateEntry(qosKey qos.Key, hasRate bool, pac
 		}
 		return nil
 	}
-	existingBytes, err := m.QoSMap.Get(qosKey.AsBytes())
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+	existingBytes, getErr := m.QoSMap.Get(qosKey.AsBytes())
+	if getErr != nil && !errors.Is(getErr, os.ErrNotExist) {
+		return getErr
 	}
-	existing := qos.ValueFromBytes(existingBytes)
-	qosTokens := existing.PacketRateTokens()
-	qosLastUpdate := existing.PacketRateLastUpdate()
-	// Reset state if config changed.
-	if existing.PacketRate() != packetRate || existing.PacketBurst() != packetBurst {
-		qosTokens = int16(-1)
-		qosLastUpdate = uint64(0)
+	if getErr == nil {
+		existing := qos.ValueFromBytes(existingBytes)
+		if existing.PacketRate() == packetRate && existing.PacketBurst() == packetBurst {
+			// Config unchanged — leave the dataplane's running state alone.
+			return nil
+		}
 	}
-	val := qos.NewValue(packetRate, packetBurst, qosTokens, qosLastUpdate)
+	val := qos.NewValue(packetRate, packetBurst, int16(-1), 0)
 	if err := m.QoSMap.UpdateWithFlags(qosKey.AsBytes(), val.AsBytes(), unix.BPF_F_LOCK); err != nil {
 		return fmt.Errorf("failed to update cali_qos map: %w", err)
 	}
@@ -3034,13 +3036,17 @@ func (m *bpfEndpointManager) writeQoSRateEntry(qosKey qos.Key, hasRate bool, pac
 }
 
 // writeQoSConnEntry updates the cali_qos_conn connlimit map entry for one
-// (ifindex, direction, family) triple. If hasLimit is false the entry is
-// deleted. The current_count is read-preserved from the existing entry —
-// the BPF dataplane writes it on SYN/FIN/RST and the scanner overwrites
-// it on recount, so preserving it across a config change is the right
-// default (a freshly-configured limit on an interface that already had
-// state will keep its count; if no entry existed, current_count starts
-// at zero).
+// (ifindex, direction, family) triple.
+//
+//   - If hasLimit is false: the entry is deleted.
+//   - If the entry exists and max_connections matches: no write. The
+//     BPF dataplane (SYN / FIN/RST / cleanup) and the Go scanner both
+//     write current_count concurrently; rewriting it from a userspace
+//     snapshot would race with both.
+//   - Otherwise (fresh entry, or config changed): write the new
+//     max_connections, preserving current_count from the snapshot when
+//     present. The race here is bounded to the rare config-change event
+//     and the Go scanner reconciles drift within ~30s.
 func (m *bpfEndpointManager) writeQoSConnEntry(qosKey qos.Key, hasLimit bool, maxConnections uint32) error {
 	if !hasLimit {
 		if err := m.QoSConnMap.Delete(qosKey.AsBytes()); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -3048,12 +3054,20 @@ func (m *bpfEndpointManager) writeQoSConnEntry(qosKey qos.Key, hasLimit bool, ma
 		}
 		return nil
 	}
-	existingBytes, err := m.QoSConnMap.Get(qosKey.AsBytes())
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+	existingBytes, getErr := m.QoSConnMap.Get(qosKey.AsBytes())
+	if getErr != nil && !errors.Is(getErr, os.ErrNotExist) {
+		return getErr
 	}
-	existing := qos.ConnValueFromBytes(existingBytes)
-	val := qos.NewConnValue(maxConnections, existing.CurrentCount())
+	var currentCount uint32
+	if getErr == nil {
+		existing := qos.ConnValueFromBytes(existingBytes)
+		if existing.MaxConnections() == maxConnections {
+			// Config unchanged — leave current_count to the dataplane and the scanner.
+			return nil
+		}
+		currentCount = existing.CurrentCount()
+	}
+	val := qos.NewConnValue(maxConnections, currentCount)
 	if err := m.QoSConnMap.UpdateWithFlags(qosKey.AsBytes(), val.AsBytes(), unix.BPF_F_LOCK); err != nil {
 		return fmt.Errorf("failed to update cali_qos_conn map: %w", err)
 	}
@@ -4413,12 +4427,12 @@ func (m *bpfEndpointManager) ensureNoProgram(ap attachPoint) error {
 		qosIngressKey := qos.NewKey(uint32(ap.IfaceIndex()), 1, family) // ingress=1
 		if qosErr := m.deleteQoSEntry(qosIngressKey); qosErr != nil {
 			err = qosErr
-			logrus.WithField("family", family).WithError(err).Warn("QoS map may leak.")
+			logrus.WithField("family", family).WithError(err).Warn("QoS maps may leak.")
 		}
 		qosEgressKey := qos.NewKey(uint32(ap.IfaceIndex()), 0, family) // egress=0
 		if qosErr := m.deleteQoSEntry(qosEgressKey); qosErr != nil {
 			err = qosErr
-			logrus.WithField("family", family).WithError(err).Warn("QoS map may leak.")
+			logrus.WithField("family", family).WithError(err).Warn("QoS maps may leak.")
 		}
 	}
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -419,7 +419,8 @@ type bpfEndpointManager struct {
 	updateRateLimitedLog    *logutilslc.RateLimitedLogger
 	istioDSCP               uint8
 
-	QoSMap maps.MapWithUpdateWithFlags
+	QoSMap     maps.MapWithUpdateWithFlags
+	QoSConnMap maps.MapWithUpdateWithFlags
 
 	// connLimitPodInfo maps each connection-limited pod's IP (as a 4- or
 	// 16-byte string) to the info the CT scanner needs (ifindex + which
@@ -615,6 +616,7 @@ func NewBPFEndpointManager(
 		bpfAttachType:      config.BPFAttachType,
 
 		QoSMap:                 bpfmaps.CommonMaps.QoSMap,
+		QoSConnMap:             bpfmaps.CommonMaps.QoSConnMap,
 		connLimitPodInfo:       map[string]bpfconntrack.ConnLimitPodInfo{},
 		connLimitWLToIPs:       map[types.WorkloadEndpointID][]string{},
 		maglevLUTSize:          config.BPFMaglevLUTSize,
@@ -2769,7 +2771,6 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 	}
 
 	var (
-		err                   error
 		ingressErr, egressErr error
 		err4, err6            error
 		ingressAP4, egressAP4 *tc.AttachPoint
@@ -2822,142 +2823,71 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 			ap.SkipEgressRedirect = true
 		}
 
-		// Handle ingress QoS (packet rate + connection limit) in a single map entry
+		// Handle ingress QoS. Packet-rate and connection-limit live in
+		// separate maps (cali_qos and cali_qos_conn) so the two field
+		// groups never share a value — see qos.h for the rationale.
 		hasIngressPR := wep.QosControls.IngressPacketRate > 0
 		hasIngressCL := wep.QosControls.IngressMaxConnections > 0
-		if hasIngressPR || hasIngressCL {
-			if hasIngressPR {
-				ap.IngressPacketRateConfigured = true
+		if hasIngressPR {
+			ap.IngressPacketRateConfigured = true
+		}
+		if hasIngressCL {
+			ap.IngressConnLimitConfigured = true
+		}
+
+		// One entry per IP family — v4 and v6 traffic count against
+		// independent counters, matching iptables/nftables.
+		for _, family := range m.qosFamilies() {
+			qosKey := qos.NewKey(uint32(ifindex), 1, family) // ingress=1
+			if err := m.writeQoSRateEntry(qosKey, hasIngressPR,
+				int16(wep.QosControls.IngressPacketRate),
+				int16(wep.QosControls.IngressPacketBurst)); err != nil {
+				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error updating ingress packet-rate entry.")
+				return state, err
 			}
-			if hasIngressCL {
-				ap.IngressConnLimitConfigured = true
-			}
-
-			// One entry per IP family — v4 and v6 traffic count against
-			// independent counters, matching iptables/nftables.
-			for _, family := range m.qosFamilies() {
-				qosKey := qos.NewKey(uint32(ifindex), 1, family) // ingress=1
-				qosValBytes, err := m.QoSMap.Get(qosKey.AsBytes())
-				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error retrieving ingress entry from QoS map.")
-					return state, err
-				}
-				existing := qos.ValueFromBytes(qosValBytes)
-
-				// Packet rate fields
-				var qosPacketRate, qosPacketBurst, qosTokens int16
-				var qosLastUpdate uint64
-				if hasIngressPR {
-					qosPacketRate = existing.PacketRate()
-					qosPacketBurst = existing.PacketBurst()
-					qosTokens = existing.PacketRateTokens()
-					qosLastUpdate = existing.PacketRateLastUpdate()
-					// Reset state if config changed. Safe to cast to int16 since the maximum value is 10000
-					if existing.PacketRate() != int16(wep.QosControls.IngressPacketRate) || existing.PacketBurst() != int16(wep.QosControls.IngressPacketBurst) {
-						qosPacketRate = int16(wep.QosControls.IngressPacketRate)
-						qosPacketBurst = int16(wep.QosControls.IngressPacketBurst)
-						qosTokens = int16(-1)
-						qosLastUpdate = uint64(0)
-					}
-				}
-
-				// Connection limit fields
-				var maxConnections, currentCount uint32
-				if hasIngressCL {
-					maxConnections = uint32(wep.QosControls.IngressMaxConnections)
-					currentCount = existing.CurrentCount() // preserve per-family current count
-				}
-
-				qosVal := qos.NewValue(qosPacketRate, qosPacketBurst, qosTokens, qosLastUpdate, maxConnections, currentCount)
-				if err := m.QoSMap.UpdateWithFlags(qosKey.AsBytes(), qosVal.AsBytes(), unix.BPF_F_LOCK); err != nil {
-					logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error updating ingress entry in QoS map.")
-					return state, fmt.Errorf("failed to update QoS map. err=%w", err)
-				}
-			}
-		} else {
-			for _, family := range m.qosFamilies() {
-				qosKey := qos.NewKey(uint32(ifindex), 1, family) // ingress=1
-				err = m.QoSMap.Delete(qosKey.AsBytes())
-				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error removing ingress entry from QoS map.")
-					return state, err
-				}
+			if err := m.writeQoSConnEntry(qosKey, hasIngressCL,
+				uint32(wep.QosControls.IngressMaxConnections)); err != nil {
+				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error updating ingress connlimit entry.")
+				return state, err
 			}
 		}
 
-		// Handle egress QoS (packet rate + connection limit) in a single map entry
+		// Handle egress QoS. Same shape as ingress, two separate maps.
 		hasEgressPR := wep.QosControls.EgressPacketRate > 0
 		hasEgressCL := wep.QosControls.EgressMaxConnections > 0
-		if hasEgressPR || hasEgressCL {
-			if hasEgressPR {
-				ap.EgressPacketRateConfigured = true
+		if hasEgressPR {
+			ap.EgressPacketRateConfigured = true
+		}
+		if hasEgressCL {
+			ap.EgressConnLimitConfigured = true
+		}
+
+		for _, family := range m.qosFamilies() {
+			qosKey := qos.NewKey(uint32(ifindex), 0, family) // egress=0
+			if err := m.writeQoSRateEntry(qosKey, hasEgressPR,
+				int16(wep.QosControls.EgressPacketRate),
+				int16(wep.QosControls.EgressPacketBurst)); err != nil {
+				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error updating egress packet-rate entry.")
+				return state, err
 			}
-			if hasEgressCL {
-				ap.EgressConnLimitConfigured = true
-			}
-
-			for _, family := range m.qosFamilies() {
-				qosKey := qos.NewKey(uint32(ifindex), 0, family) // egress=0
-				qosValBytes, err := m.QoSMap.Get(qosKey.AsBytes())
-				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error retrieving egress entry from QoS map.")
-					return state, err
-				}
-				existing := qos.ValueFromBytes(qosValBytes)
-
-				// Packet rate fields
-				var qosPacketRate, qosPacketBurst, qosTokens int16
-				var qosLastUpdate uint64
-				if hasEgressPR {
-					qosPacketRate = existing.PacketRate()
-					qosPacketBurst = existing.PacketBurst()
-					qosTokens = existing.PacketRateTokens()
-					qosLastUpdate = existing.PacketRateLastUpdate()
-					// Reset state if config changed
-					if existing.PacketRate() != int16(wep.QosControls.EgressPacketRate) || existing.PacketBurst() != int16(wep.QosControls.EgressPacketBurst) {
-						qosPacketRate = int16(wep.QosControls.EgressPacketRate)
-						qosPacketBurst = int16(wep.QosControls.EgressPacketBurst)
-						qosTokens = int16(-1)
-						qosLastUpdate = uint64(0)
-					}
-				}
-
-				// Connection limit fields
-				var maxConnections, currentCount uint32
-				if hasEgressCL {
-					maxConnections = uint32(wep.QosControls.EgressMaxConnections)
-					currentCount = existing.CurrentCount() // preserve per-family current count
-				}
-
-				qosVal := qos.NewValue(qosPacketRate, qosPacketBurst, qosTokens, qosLastUpdate, maxConnections, currentCount)
-				if err := m.QoSMap.UpdateWithFlags(qosKey.AsBytes(), qosVal.AsBytes(), unix.BPF_F_LOCK); err != nil {
-					logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error updating egress entry in QoS map.")
-					return state, fmt.Errorf("failed to update QoS map. err=%w", err)
-				}
-			}
-		} else {
-			for _, family := range m.qosFamilies() {
-				qosKey := qos.NewKey(uint32(ifindex), 0, family) // egress=0
-				err = m.QoSMap.Delete(qosKey.AsBytes())
-				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error removing egress entry from QoS map.")
-					return state, err
-				}
+			if err := m.writeQoSConnEntry(qosKey, hasEgressCL,
+				uint32(wep.QosControls.EgressMaxConnections)); err != nil {
+				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error updating egress connlimit entry.")
+				return state, err
 			}
 		}
 	} else {
-		// Either the workload endpoint or QoSControls were removed, clean up both ingress and egress state from map
+		// Either the workload endpoint or QoSControls were removed, clean up
+		// both ingress and egress state from both maps.
 		for _, family := range m.qosFamilies() {
 			qosIngressKey := qos.NewKey(uint32(ifindex), 1, family) // ingress=1
-			err = m.QoSMap.Delete(qosIngressKey.AsBytes())
-			if err != nil && !errors.Is(err, os.ErrNotExist) {
-				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error removing ingress entry from QoS map.")
+			if err := m.deleteQoSEntry(qosIngressKey); err != nil {
+				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error removing ingress QoS entries.")
 				return state, err
 			}
 			qosEgressKey := qos.NewKey(uint32(ifindex), 0, family) // egress=0
-			err = m.QoSMap.Delete(qosEgressKey.AsBytes())
-			if err != nil && !errors.Is(err, os.ErrNotExist) {
-				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error removing egress entry from QoS map.")
+			if err := m.deleteQoSEntry(qosEgressKey); err != nil {
+				logrus.WithField("ifindex", ifindex).WithField("family", family).WithError(err).Debug("Error removing egress QoS entries.")
 				return state, err
 			}
 		}
@@ -3065,6 +2995,81 @@ func (m *bpfEndpointManager) applyPolicy(ifaceName string) error {
 	m.ifacesLock.Unlock()
 
 	return err
+}
+
+// writeQoSRateEntry updates the cali_qos packet-rate map entry for one
+// (ifindex, direction, family) triple. If hasRate is false the entry is
+// deleted. On config change (rate or burst differs from the existing
+// entry) the token-bucket state is reset to "uninitialised" so the BPF
+// dataplane re-fills from burst on the next packet; otherwise the
+// existing dynamic state is preserved.
+//
+// This RMW only touches the packet-rate map. The connlimit map has its
+// own write path (writeQoSConnEntry) — the two maps are independent and
+// no value is shared between them.
+func (m *bpfEndpointManager) writeQoSRateEntry(qosKey qos.Key, hasRate bool, packetRate, packetBurst int16) error {
+	if !hasRate {
+		if err := m.QoSMap.Delete(qosKey.AsBytes()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	existingBytes, err := m.QoSMap.Get(qosKey.AsBytes())
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	existing := qos.ValueFromBytes(existingBytes)
+	qosTokens := existing.PacketRateTokens()
+	qosLastUpdate := existing.PacketRateLastUpdate()
+	// Reset state if config changed.
+	if existing.PacketRate() != packetRate || existing.PacketBurst() != packetBurst {
+		qosTokens = int16(-1)
+		qosLastUpdate = uint64(0)
+	}
+	val := qos.NewValue(packetRate, packetBurst, qosTokens, qosLastUpdate)
+	if err := m.QoSMap.UpdateWithFlags(qosKey.AsBytes(), val.AsBytes(), unix.BPF_F_LOCK); err != nil {
+		return fmt.Errorf("failed to update cali_qos map: %w", err)
+	}
+	return nil
+}
+
+// writeQoSConnEntry updates the cali_qos_conn connlimit map entry for one
+// (ifindex, direction, family) triple. If hasLimit is false the entry is
+// deleted. The current_count is read-preserved from the existing entry —
+// the BPF dataplane writes it on SYN/FIN/RST and the scanner overwrites
+// it on recount, so preserving it across a config change is the right
+// default (a freshly-configured limit on an interface that already had
+// state will keep its count; if no entry existed, current_count starts
+// at zero).
+func (m *bpfEndpointManager) writeQoSConnEntry(qosKey qos.Key, hasLimit bool, maxConnections uint32) error {
+	if !hasLimit {
+		if err := m.QoSConnMap.Delete(qosKey.AsBytes()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	existingBytes, err := m.QoSConnMap.Get(qosKey.AsBytes())
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	existing := qos.ConnValueFromBytes(existingBytes)
+	val := qos.NewConnValue(maxConnections, existing.CurrentCount())
+	if err := m.QoSConnMap.UpdateWithFlags(qosKey.AsBytes(), val.AsBytes(), unix.BPF_F_LOCK); err != nil {
+		return fmt.Errorf("failed to update cali_qos_conn map: %w", err)
+	}
+	return nil
+}
+
+// deleteQoSEntry deletes the entry for one (ifindex, direction, family)
+// from both the packet-rate and the connlimit map.
+func (m *bpfEndpointManager) deleteQoSEntry(qosKey qos.Key) error {
+	if err := m.QoSMap.Delete(qosKey.AsBytes()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := m.QoSConnMap.Delete(qosKey.AsBytes()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func mergeAttachPoints(ap4, ap6 attachPoint) attachPoint {
@@ -4402,17 +4407,16 @@ func (m *bpfEndpointManager) ensureNoProgram(ap attachPoint) error {
 		m.removePolicyDebugInfo(ap.IfaceName(), 6, ap.HookName())
 	}
 
-	// Clean up QoS map: one entry per (direction, family) combination.
+	// Clean up QoS maps: one entry per (direction, family) combination in
+	// each of cali_qos (packet-rate) and cali_qos_conn (connlimit).
 	for _, family := range m.qosFamilies() {
 		qosIngressKey := qos.NewKey(uint32(ap.IfaceIndex()), 1, family) // ingress=1
-		qosErr := m.QoSMap.Delete(qosIngressKey.AsBytes())
-		if qosErr != nil && !errors.Is(qosErr, os.ErrNotExist) {
+		if qosErr := m.deleteQoSEntry(qosIngressKey); qosErr != nil {
 			err = qosErr
 			logrus.WithField("family", family).WithError(err).Warn("QoS map may leak.")
 		}
 		qosEgressKey := qos.NewKey(uint32(ap.IfaceIndex()), 0, family) // egress=0
-		qosErr = m.QoSMap.Delete(qosEgressKey.AsBytes())
-		if qosErr != nil && !errors.Is(qosErr, os.ErrNotExist) {
+		if qosErr := m.deleteQoSEntry(qosEgressKey); qosErr != nil {
 			err = qosErr
 			logrus.WithField("family", family).WithError(err).Warn("QoS map may leak.")
 		}

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -405,6 +405,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		jumpMapEgr           *mock.Map
 		xdpJumpMap           *mock.Map
 		qosMap               *mock.Map
+		qosConnMap           *mock.Map
 	)
 
 	BeforeEach(func() {
@@ -436,6 +437,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		commonMaps.IfStateMap = ifStateMap
 		qosMap = mock.NewMockMap(qos.MapParams)
 		commonMaps.QoSMap = qosMap
+		qosConnMap = mock.NewMockMap(qos.ConnMapParams)
+		commonMaps.QoSConnMap = qosConnMap
 		cparams := counters.MapParameters
 		cparams.ValueSize *= bpfmaps.NumPossibleCPUs()
 		countersMap = mock.NewMockMap(cparams)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1131,11 +1131,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			}
 			if conntrackScannerV4 != nil {
 				conntrackScannerV4.AddUnlocked(bpfconntrack.NewConnLimitScanner(
-					bpfMaps.CommonMaps.QoSMap, connLimitProvider, qos.IPFamilyV4))
+					bpfMaps.CommonMaps.QoSConnMap, connLimitProvider, qos.IPFamilyV4))
 			}
 			if conntrackScannerV6 != nil {
 				conntrackScannerV6.AddUnlocked(bpfconntrack.NewConnLimitScanner(
-					bpfMaps.CommonMaps.QoSMap, connLimitProvider, qos.IPFamilyV6))
+					bpfMaps.CommonMaps.QoSConnMap, connLimitProvider, qos.IPFamilyV6))
 			}
 		}
 

--- a/felix/design/bpf-observability.md
+++ b/felix/design/bpf-observability.md
@@ -215,33 +215,77 @@ which is acceptable on the fast path.
 ### Scope of BPF involvement
 
 Calico's QoS controls cover bandwidth, packet rate, connection count
-and DSCP. Not all of those live in BPF:
+and DSCP. The BPF dataplane handles three of the four:
 
 - **Bandwidth** is handled by tc qdiscs on the workload veth and by
   the upstream CNI bandwidth plugin. BPF is not involved.
-- **Connection count** (`IngressMaxConnections` / `EgressMaxConnections`
-  on a workload endpoint) is enforced via `*tables` rules — look for
-  `LimitNumConnections` in `felix/rules/endpoints.go`. BPF is not
-  involved.
 - **Packet rate** is enforced by BPF (per-workload token bucket).
+- **Connection count** (`IngressMaxConnections` / `EgressMaxConnections`
+  on a workload endpoint) is enforced by BPF in BPF mode and by
+  `*tables` rules (`LimitNumConnections` in `felix/rules/endpoints.go`)
+  in iptables/nftables mode.
 - **DSCP** marking is applied by BPF on egress to external
   destinations and HEPs.
 
-The BPF-specific implementation lives under `felix/bpf/qos/` (Go) and
-`felix/bpf-gpl/qos.h` (C).
+The BPF-specific implementation lives under `felix/bpf/qos/` (Go),
+`felix/bpf/conntrack/connlimit_scanner.go` (the userspace recount
+loop), and `felix/bpf-gpl/qos.h` (C).
+
+### Two maps: `cali_qos` (packet rate) and `cali_qos_conn` (connlimit)
+
+Packet-rate and connection-limit state live in two separate BPF maps
+that share the same key shape but have disjoint values. Splitting
+them is what allows the userspace `ConnLimitScanner` to write
+`current_count` back without clobbering the BPF dataplane's running
+token-bucket state — see PR #13009 for the lost-update bug the split
+fixes.
+
+Shared key (`felix/bpf/qos/map.go`):
+
+```c
+struct calico_qos_key {
+    __u32 ifindex;
+    __u16 ingress; // 0=egress, 1=ingress
+    __u16 family;  // 4=IPv4, 6=IPv6
+};
+```
+
+The family dimension means v4 and v6 traffic on the same (ifindex,
+direction) count against independent entries, matching iptables and
+nftables semantics where connlimit and rate-limit rules live in
+family-specific chains.
+
+`cali_qos` value holds packet-rate state only:
+
+```c
+struct calico_qos_val {
+    struct bpf_spin_lock lock;
+    __s16 packet_rate, packet_burst;       // config
+    __s16 packet_rate_tokens, padding[3];  // dynamic state
+    __u64 packet_rate_last_update;         // dynamic state
+};
+```
+
+`cali_qos_conn` value holds connlimit state only:
+
+```c
+struct calico_qos_conn_val {
+    struct bpf_spin_lock lock;
+    __u32 max_connections;  // config
+    __u32 current_count;    // dynamic state
+};
+```
+
+Both maps use a `BPF_F_NO_PREALLOC` hash with a BPF spinlock at
+value offset 0. They are created with BTF type info via the shared
+`common_map_stub.o` so the kernel can validate `BPF_F_LOCK` writes.
 
 ### Packet rate
 
-Packet rate is enforced per-interface, per-direction. The BPF map
-`cali_qos` (`felix/bpf/qos/map.go`, key `(ifindex, ingress)`)
-holds the TBF state per attach point. The value struct carries the
-configured `packet_rate` (tokens/second) and `packet_burst` (bucket
-size), plus mutable token count and the last-update timestamp,
-protected by a BPF spinlock.
-
+Packet rate is enforced per-interface, per-direction, per-family.
 `qos_enforce_packet_rate` in `qos.h`:
 
-- No entry in the map → no rate limit → accept.
+- No entry in `cali_qos` → no rate limit → accept.
 - Under the spinlock: advance the token count based on elapsed time,
   cap at burst, decrement by one per accepted packet.
 - No tokens → drop with `TC_ACT_SHOT`.
@@ -250,6 +294,42 @@ The per-direction `INGRESS_PACKET_RATE_CONFIGURED` /
 `EGRESS_PACKET_RATE_CONFIGURED` flags (set on the AttachPoint and
 propagated to BPF globals) let the program skip the map lookup
 entirely when the feature isn't configured for that attach point.
+
+### Connection count
+
+Connection count is enforced at TCP-SYN admission time and decremented
+on connection close.
+
+- **SYN admission**: at `to-wep` for ingress and at egress
+  CT-create time for outgoing connections,
+  `qos_connlimit_check_and_increment` (in `qos.h`) looks up the
+  `cali_qos_conn` entry for this (ifindex, direction, family).
+  No entry or `max_connections <= 0` → no limit. Otherwise:
+  spin-lock; if `current_count >= max_connections` → return -1
+  (reject with TCP RST); else increment and return 0 (allow).
+- **CT-entry stamping**: a successful admission stamps
+  `CALI_CT_FLAG_CONNLIMIT_INGRESS` (or `_EGRESS`) on the CT entry.
+  Rejection at the ingress check stamps `CONNLIMIT_INGRESS_REJECTED`
+  instead. These flags drive the close-time decrement decision.
+- **Decrement on close (fast path)**: `qos_connlimit_decrement_for_ct`
+  (in `conntrack.h`) is invoked from `calico_ct_lookup` when a TCP
+  close is observed. It decrements the per-(direction, family)
+  counter for an entry that was counted at SYN time — gated on
+  `(INGRESS && !INGRESS_REJECTED)` or `EGRESS`, idempotent via
+  `CONNLIMIT_DEC`.
+- **Decrement on cleanup**: when the BPF conntrack cleanup scanner
+  removes an expired CT entry, the same helper fires so silent
+  purges (LRU eviction, idle TCPEstablished) don't leak slots.
+- **Decrement (safety net)**: a userspace `ConnLimitScanner`
+  (`felix/bpf/conntrack/connlimit_scanner.go`) recounts established
+  TCP CT entries every ~30s and overwrites `current_count` in
+  `cali_qos_conn` via `BPF_F_LOCK` batch updates. It corrects any
+  residual drift the fast/cleanup paths missed and skips entries
+  with `CONNLIMIT_DEC` already set so it doesn't double-count.
+
+The per-direction `INGRESS_CONN_LIMIT_CONFIGURED` /
+`EGRESS_CONN_LIMIT_CONFIGURED` flags gate the BPF connlimit code
+path entirely when no limit is configured for that attach point.
 
 ### DSCP
 
@@ -275,26 +355,36 @@ global, `ISTIO_DSCP`; see Istio ambient mode integration for the integration.
 
 ### Review notes for this section
 
-- A new BPF-enforced QoS field needs a slot in the `cali_qos` value
-  struct. That struct contains a `bpf_spin_lock` at offset 0, which
-  must stay at offset 0; its presence also means the map is a
-  `BPF_MAP_TYPE_HASH` (not LRU/percpu/etc.). Do not relax those
-  without a plan for concurrent access.
+- A new BPF-enforced QoS field needs a slot in either `cali_qos` or
+  `cali_qos_conn`, depending on which writer owns it. Both structs
+  contain a `bpf_spin_lock` at offset 0, which must stay at offset 0;
+  its presence also means the map is a `BPF_MAP_TYPE_HASH` (not
+  LRU/percpu/etc.). Do not relax those without a plan for concurrent
+  access. **Do not add a field that needs to be written by both the
+  BPF dataplane and userspace to the same value** — userspace cannot
+  RMW under the lock (locks don't span syscall boundaries), and the
+  cali_qos / cali_qos_conn split exists precisely to avoid that
+  class of lost-update.
 - Any change to packet-rate accounting must preserve the spinlock
   discipline: all reads and writes of `packet_rate_tokens` /
   `packet_rate_last_update` happen under the lock, and the drop
   decision is part of the atomic section. Dropping outside the lock
   allows overshoot.
+- Any change to connlimit decrement paths must preserve the
+  `CONNLIMIT_DEC` idempotence flag — both the fast path (FIN/RST in
+  `calico_ct_lookup`) and the cleanup path (BPF conntrack cleanup
+  scanner) set it before decrementing, and the Go scanner skips
+  entries that carry it. Without that, drift accumulates upward.
+- ep_mgr writes to `cali_qos` / `cali_qos_conn` must skip the
+  UpdateWithFlags when the configured fields match the existing
+  entry. The dataplane owns the dynamic fields between configuration
+  changes; rewriting them from a userspace snapshot races with
+  per-packet updates. See `writeQoSRateEntry` and `writeQoSConnEntry`.
 - A change that extends DSCP marking to new paths (a new tunnel
   type, a new forwarded-packet case) must set `CALI_ST_SET_DSCP`
   based on the CT flag, _not_ on the globals alone — globals are a
   per-attach-point configuration, not a per-flow decision. The CT
   flag is what records the per-flow policy decision.
-- If a feature is added that looks like it belongs in the QoS chain
-  but only needs per-packet iptables-visible behaviour (e.g. a
-  simple drop rule), prefer placing it in the `*tables` rule
-  generators — `felix/rules/endpoints.go` already handles the
-  connection-count and similar per-WEP knobs.
 
 
 

--- a/felix/fv/qos_controls_test.go
+++ b/felix/fv/qos_controls_test.go
@@ -291,41 +291,53 @@ var _ = infrastructure.DatastoreDescribe(
 				}
 
 				qosMapName := qos.MapParams.VersionedName()
+				qosConnMapName := qos.ConnMapParams.VersionedName()
 
-				getBPFQoSValue := func(felixId, wlId int, hook string) *qos.Value {
-					var ingress uint32
+				ingressFromHook := func(hook string) uint16 {
 					switch hook {
 					case "ingress":
-						ingress = 1
+						return 1
 					case "egress":
-						ingress = 0
+						return 0
 					default:
 						Expect(true).To(BeFalse(), "hook must be either 'ingress' or 'egress', '%s' is invalid", hook)
 					}
+					return 0
+				}
 
-					key := qos.NewKey(uint32(w[wlId].InterfaceIndex()), uint16(ingress), qos.IPFamilyV4)
+				dumpQoSEntry := func(felixId int, mapName string, key qos.Key) string {
 					keyStr := bytesToHexString(key.AsBytes())
-
-					args := []string{"bash", "-c", fmt.Sprintf(`bpftool map dump name %s -j | jq '.[].elements[] | select(.key | join(" ") == "%s") | .value | join(" ")'`, qosMapName, keyStr)}
-
+					args := []string{"bash", "-c", fmt.Sprintf(`bpftool map dump name %s -j | jq '.[].elements[] | select(.key | join(" ") == "%s") | .value | join(" ")'`, mapName, keyStr)}
 					out, _ := tc.Felixes[felixId].ExecOutput(args...)
 					logrus.Infof("%s output:\n%v", strings.Join(args, " "), out)
-					valueStr := strings.Trim(strings.TrimSuffix(out, "\n"), "\"")
+					return strings.Trim(strings.TrimSuffix(out, "\n"), "\"")
+				}
+
+				getBPFQoSRateValue := func(felixId, wlId int, hook string) *qos.Value {
+					key := qos.NewKey(uint32(w[wlId].InterfaceIndex()), ingressFromHook(hook), qos.IPFamilyV4)
+					valueStr := dumpQoSEntry(felixId, qosMapName, key)
 					if valueStr == "" {
 						return nil
 					}
-					valueBytes := hexStringToBytes(valueStr)
+					value := qos.ValueFromBytes(hexStringToBytes(valueStr))
+					logrus.Infof("rate value: %s", value.String())
+					return &value
+				}
 
-					value := qos.ValueFromBytes(valueBytes)
-
-					logrus.Infof("value: %s", value.String())
-
+				getBPFQoSConnValue := func(felixId, wlId int, hook string) *qos.ConnValue {
+					key := qos.NewKey(uint32(w[wlId].InterfaceIndex()), ingressFromHook(hook), qos.IPFamilyV4)
+					valueStr := dumpQoSEntry(felixId, qosConnMapName, key)
+					if valueStr == "" {
+						return nil
+					}
+					value := qos.ConnValueFromBytes(hexStringToBytes(valueStr))
+					logrus.Infof("conn value: %s", value.String())
 					return &value
 				}
 
 				getBPFPacketRateAndBurst := func(felixId, wlId int, hook string) func() string {
 					return func() string {
-						value := getBPFQoSValue(felixId, wlId, hook)
+						value := getBPFQoSRateValue(felixId, wlId, hook)
 						if value == nil {
 							return "0 0"
 						}
@@ -335,7 +347,7 @@ var _ = infrastructure.DatastoreDescribe(
 
 				getBPFMaxConnections := func(felixId, wlId int, hook string) func() uint32 {
 					return func() uint32 {
-						value := getBPFQoSValue(felixId, wlId, hook)
+						value := getBPFQoSConnValue(felixId, wlId, hook)
 						if value == nil {
 							return 0
 						}
@@ -345,7 +357,7 @@ var _ = infrastructure.DatastoreDescribe(
 
 				getBPFCurrentCount := func(felixId, wlId int, hook string) func() uint32 {
 					return func() uint32 {
-						value := getBPFQoSValue(felixId, wlId, hook)
+						value := getBPFQoSConnValue(felixId, wlId, hook)
 						if value == nil {
 							return 0
 						}


### PR DESCRIPTION
The userspace ConnLimitScanner did an unlocked Get → modify → BPF_F_LOCK write of the whole cali_qos value to update current_count. Between the read and the write the BPF dataplane updates packet_rate_tokens and packet_rate_last_update on every packet under its own lock; the scanner's locked write then atomically overwrites those fields with the stale snapshot. BPF_F_LOCK covered only the write — locks don't span syscall boundaries — so this was a classic lost update.

Damage: packets sent during the scanner's IterationEnd window were effectively free from the packet-rate limit. The token bucket regressed to its t=Get values; the next packet computed tokens_inc = (now - stale_last_update) * rate, refilled to burst, and discarded the intervening drainage. Recurred every scan interval (~30s) on endpoints with both packet-rate AND connlimit configured. The same RMW shape existed at two bpf_ep_mgr config-change sites, with lower exposure (per config change, not per scan) but the same bug.

Fix: split cali_qos along the field-group seam into two maps that share the same key but have disjoint values. cali_qos keeps packet-rate state; new cali_qos_conn holds (lock, max_connections, current_count). No BPF helper touches both groups; no Go writer needs both atomically. The scanner reads/writes only cali_qos_conn — packet-rate state is structurally inaccessible. bpf_ep_mgr splits each direction into two independent locked writes, eliminating the cross-feature preservation that the RMW was paying the lost-update tax for.

BPF helpers retargeted: qos_connlimit_check_and_increment and qos_connlimit_decrement now look up cali_qos_conn; qos_enforce_packet_rate keeps using cali_qos. No hot-path lookup cost change — no BPF program reads both maps on the same packet.

cali_qos_conn ships as v1 via CALI_MAP_V1 so the unversioned C symbol matches Go's versionedStr (which strips the suffix for ver<=1). CALI_MAP(name, 1, ...) would produce cali_qos_conn1 in C but cali_qos_conn in Go, breaking the pin-path-based libbpf binding and causing fresh-map creation instead of reuse — the kind of mismatch that only shows up as silent lookup misses against a seeded map.

Tests: scanner UT seeds via NewConnValue; the now-irrelevant packet-rate preservation assertion is replaced with a MaxConnections check. qos_test.go connlimit sites switch to qosConnMap + NewConnValue. FV helper getBPFQoSValue splits into rate/conn variants. bpf_ep_mgr_test.go gains a mock cali_qos_conn map.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
