### PR TITLE
Remove flaky k8st assertion

### DIFF
--- a/node/tests/k8st/tests/node_status_test.go
+++ b/node/tests/k8st/tests/node_status_test.go
@@ -50,7 +50,7 @@ func TestNodeMeshStatus(t *testing.T) {
 	// NodeInfo returns the control-plane node first, then the workers. The test
 	// scopes its status to the first worker (nodes[1]) and asserts on the peers
 	// formed with the other three mesh members (indices 0, 2 and 3).
-	nodes, ips, ip6s := utils.NodeInfo(t)
+	nodes, ips, _ := utils.NodeInfo(t)
 	g.Expect(len(nodes)).To(BeNumerically(">=", 4),
 		"node status test needs a four-node mesh (control-plane + three workers)")
 	testNode := nodes[1]
@@ -101,46 +101,4 @@ func TestNodeMeshStatus(t *testing.T) {
 	g.Expect(st.BGP.NumberEstablishedV6).To(Equal(3), "numberEstablishedV6")
 	g.Expect(st.BGP.NumberNotEstablishedV4).To(Equal(0), "numberNotEstablishedV4")
 	g.Expect(st.BGP.NumberNotEstablishedV6).To(Equal(0), "numberNotEstablishedV6")
-
-	// Peers and routes for each of the three other mesh members. (The Python
-	// original computed these subdict matches but never asserted on the result
-	// — a latent no-op; this port turns them into real assertions.)
-	for _, i := range []int{0, 2, 3} {
-		g.Expect(hasMeshPeer(st.BGP.PeersV4, ips[i])).To(BeTrue(),
-			"expected established NodeMesh IPv4 peer %s in %v", ips[i], st.BGP.PeersV4)
-		g.Expect(hasMeshPeer(st.BGP.PeersV6, ip6s[i])).To(BeTrue(),
-			"expected established NodeMesh IPv6 peer %s in %v", ip6s[i], st.BGP.PeersV6)
-
-		g.Expect(hasMeshRoute(st.Routes.RoutesV4, ips[i])).To(BeTrue(),
-			"expected NodeMesh-learned IPv4 route via %s in %v", ips[i], st.Routes.RoutesV4)
-		g.Expect(hasMeshRoute(st.Routes.RoutesV6, ip6s[i])).To(BeTrue(),
-			"expected NodeMesh-learned IPv6 route via %s in %v", ip6s[i], st.Routes.RoutesV6)
-	}
-}
-
-// hasMeshPeer reports whether peers contains an established node-to-node-mesh
-// session with the given peer IP.
-func hasMeshPeer(peers []v3.CalicoNodePeer, peerIP string) bool {
-	for _, p := range peers {
-		if p.PeerIP == peerIP &&
-			p.State == v3.BGPSessionStateEstablished &&
-			p.Type == v3.BGPPeerTypeNodeMesh {
-			return true
-		}
-	}
-	return false
-}
-
-// hasMeshRoute reports whether routes contains a FIB route over eth0 with the
-// given gateway that was learned from the node-to-node mesh.
-func hasMeshRoute(routes []v3.CalicoNodeRoute, gateway string) bool {
-	for _, r := range routes {
-		if r.Gateway == gateway &&
-			r.Interface == "eth0" &&
-			r.Type == v3.RouteTypeFIB &&
-			r.LearnedFrom.SourceType == v3.RouteSourceTypeNodeMesh {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

Removing an assertion that was added in the previous PR: https://github.com/projectcalico/calico/pull/12981

This assertion was not part of original python test. 

Claude diagnosis about flake:

```
What was wrong

TestNodeMeshStatus required a NodeMesh-learned route via every one of the three mesh peers (nodes[0,2,3]). The failure output shows the bug clearly: BGP reported the full mesh (3 peers established), but only 2 of the 3 peers had a route — peer 2001:20::3 was established yet had no advertised route.
 
That's not a Calico bug, it's a faulty test assumption. A node only advertises a NodeMesh route for an IPAM block
it owns. A mesh member with no pod IPs allocated — the tainted control-plane (nodes[0]), or any worker that happens to have no pods scheduled — owns no block and contributes no route. So which peers have routes 
is non-deterministic, while the peer count is deterministic.

The Python original never actually caught this because its assert_dictlist_has_subdict returned a bool that was never asserted (a latent no-op, as the port's own comment notes). The Go port promoted it to a hard per-peer assertion, surfacing the flake.
```

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
