### PR TITLE
Import third-party-cni-plugins image in Windows FV local-build flow

### DIFF
--- a/process/testing/winfv-felix/import-images.sh
+++ b/process/testing/winfv-felix/import-images.sh
@@ -50,14 +50,24 @@ SSH_OPTS="-i ${SSH_KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChe
 function import_linux_images() {
   # Re-tag the GCS-cached images to the tag the operator renders. The operator
   # collapses cni/typha/kube-controllers/csi/apiserver/flexvol onto calico/calico,
-  # so calico/calico + calico/node + calico/operator cover the whole Linux side.
+  # so calico/calico + calico/node + calico/operator cover most of the Linux side.
   docker tag calico/calico:latest-amd64 "calico/calico:${DEV_IMAGE_TAG}"
   docker tag calico/node:latest-amd64 "calico/node:${DEV_IMAGE_TAG}"
+
+  # third-party-cni-plugins is a separate init-container image (it is not
+  # collapsed onto calico/calico) that the operator stages into /opt/cni/bin via
+  # the calico-node cni-plugins init container. It is not in the GCS image cache,
+  # so build it from the commit under test and re-tag to the operator-rendered
+  # tag. Without this the cni-plugins init container ImagePullBackOffs and the
+  # install never completes.
+  make -C "${CALICO_HOME}/third_party/cni-plugins" image
+  docker tag calico/third-party-cni-plugins:latest-amd64 "calico/third-party-cni-plugins:${DEV_IMAGE_TAG}"
 
   local tar="/tmp/winfv-linux-images.tar"
   docker save -o "${tar}" \
     "calico/calico:${DEV_IMAGE_TAG}" \
     "calico/node:${DEV_IMAGE_TAG}" \
+    "calico/third-party-cni-plugins:${DEV_IMAGE_TAG}" \
     "calico/operator:${DEV_IMAGE_TAG}"
 
   scp ${SSH_OPTS} "${tar}" "aso@${LINUX_EIP}:/tmp/winfv-linux-images.tar"


### PR DESCRIPTION
The operator now renders the upstream CNI plugins as a separate cni-plugins init container on the calico-node DaemonSet (using the third-party-cni-plugins image) instead of collapsing them onto calico/calico. The win-fv local-build flow only imported calico/calico, calico/node, and calico/operator onto the Linux node, so the new init container hit ImagePullBackOff, calico-node never became Ready, and install-calico.sh timed out before any Felix Windows FV spec ran.

Build the third-party-cni-plugins image from the commit under test and ctr-import it onto the Linux node alongside the others, mirroring the existing in-job Windows image builds and matching how the kind flow was wired up for the same operator change.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
