### PR TITLE
Auto-publish nftables-rpms image on master/release

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -194,8 +194,13 @@ promotions:
     pipeline_file: push-images/e2e-test.yml
   - name: Push istio images
     pipeline_file: push-images/istio.yml
+  # Auto-fires (unlike the component pushes above) because this is a build-time
+  # prerequisite node/istio pull before building, not a release artifact. No-op
+  # when the tag is already published.
   - name: Push nftables RPM images
     pipeline_file: push-images/nft-rpms.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"
 blocks:
   - name: Check images availability
     run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -194,8 +194,13 @@ promotions:
     pipeline_file: push-images/e2e-test.yml
   - name: Push istio images
     pipeline_file: push-images/istio.yml
+  # Auto-fires (unlike the component pushes above) because this is a build-time
+  # prerequisite node/istio pull before building, not a release artifact. No-op
+  # when the tag is already published.
   - name: Push nftables RPM images
     pipeline_file: push-images/nft-rpms.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"
 blocks:
   - name: Check images availability
     run:

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -66,5 +66,10 @@ promotions:
     pipeline_file: push-images/e2e-test.yml
   - name: Push istio images
     pipeline_file: push-images/istio.yml
+  # Auto-fires (unlike the component pushes above) because this is a build-time
+  # prerequisite node/istio pull before building, not a release artifact. No-op
+  # when the tag is already published.
   - name: Push nftables RPM images
     pipeline_file: push-images/nft-rpms.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"


### PR DESCRIPTION
The "Push nftables RPM images" promotion was a manual button, so when the content-addressed tag changes (a spec/patch/version/Dockerfile bump in `hack/rpms/nftables/`) the new image doesn't land on Docker Hub until someone manually promotes it. But that image is a build-time prerequisite: `node` and the istio CNI install image pull it via `COPY --from=nft-rpms`, and the enterprise build pulls it too. So a tag bump breaks those builds until the push is clicked.

This makes the nft-rpms push auto-fire on master/release, like the openstack packaging push. It's a build prerequisite rather than a release artifact, so it shouldn't follow the manual, hashrelease-driven pattern of the component image pushes. `push-nft-rpms.sh` already no-ops when the tag is published, so this is cheap on every merge.

**Release note:**
```release-note
NONE
```
