### PR TITLE
[v3.31] calicoctl cluster diags: collect calico-bpf dumps as JSON (no maglev)

### DIFF
--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -443,6 +443,14 @@ func collectKubernetesResource(dir string) {
 		CmdStr:   "kubectl get baselineadminnetworkpolicies.policy.networking.k8s.io -Ao wide",
 		FilePath: fmt.Sprintf("%s/baselineadminnetworkpolicies.txt", dir),
 	}, common.Cmd{
+		Info:     "Collect multus network-attachment-definitions (yaml)",
+		CmdStr:   "kubectl get network-attachment-definitions.k8s.cni.cncf.io -Ao yaml",
+		FilePath: fmt.Sprintf("%s/network-attachment-definitions.yaml", dir),
+	}, common.Cmd{
+		Info:     "Collect multus network-attachment-definitions (text)",
+		CmdStr:   "kubectl get network-attachment-definitions.k8s.cni.cncf.io -Ao wide",
+		FilePath: fmt.Sprintf("%s/network-attachment-definitions.txt", dir),
+	}, common.Cmd{
 		Info:     "Collect k8s validatingwebhookconfigurations (text)",
 		CmdStr:   "kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -o wide",
 		FilePath: fmt.Sprintf("%s/validatingwebhookconfigurations.txt", dir),

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -309,7 +309,12 @@ func collectCalicoResource(dir string) {
 
 	// Phase 1: Discover Calico resources via CRD listing. This finds resources registered as
 	// CustomResourceDefinitions (both crd.projectcalico.org/v1 and projectcalico.org/v3 CRD modes).
-	buf, err := common.Exec([]string{"kubectl", "get", "customresourcedefinition", "-o", "go-template", "--template", "{{range .items}}{{.metadata.name}} {{end}}"})
+	// The template outputs "name=version" pairs where name is the CRD metadata.name (<plural>.<group>)
+	// and version is the storage version. We use these to construct fully qualified resource identifiers
+	// (<plural>.<version>.<group>) to avoid ambiguity when multiple API groups define the same resource
+	// name (e.g., apiservers.operator.tigera.io vs apiservers.config.openshift.io).
+	buf, err := common.Exec([]string{"kubectl", "get", "customresourcedefinition", "-o", "go-template", "--template",
+		"{{range .items}}{{.metadata.name}}={{range .spec.versions}}{{if .storage}}{{.name}}{{end}}{{end}} {{end}}"})
 	if err != nil {
 		fmt.Printf("Couldn't list CRDs: %s\n", err)
 		if buf != nil {
@@ -317,19 +322,33 @@ func collectCalicoResource(dir string) {
 		}
 	} else {
 		crds := strings.Fields(buf.String())
-		for _, resource := range crds {
-			if !strings.Contains(resource, "projectcalico") && !strings.Contains(resource, "tigera") {
+		for _, entry := range crds {
+			parts := strings.SplitN(entry, "=", 2)
+			crdName := parts[0]
+			if !strings.Contains(crdName, "projectcalico") && !strings.Contains(crdName, "tigera") {
 				continue
 			}
-			collected.Add(resource)
+			collected.Add(crdName)
+
+			// Build the fully qualified resource: <plural>.<version>.<group>.
+			resource := crdName
+			if len(parts) == 2 && parts[1] != "" {
+				dotIdx := strings.Index(crdName, ".")
+				if dotIdx > 0 {
+					plural := crdName[:dotIdx]
+					group := crdName[dotIdx+1:]
+					resource = fmt.Sprintf("%s.%s.%s", plural, parts[1], group)
+				}
+			}
+
 			commands = append(commands, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
-				FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.yaml", dir, crdName),
 			}, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
-				FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.txt", dir, crdName),
 			})
 		}
 	}
@@ -337,7 +356,8 @@ func collectCalicoResource(dir string) {
 	// Phase 2: Discover v3 resources via the projectcalico.org API group. When the Calico API
 	// server is running, v3 resources are served via API aggregation rather than CRDs, so they
 	// won't appear in the CRD listing above. This catches them regardless of serving mode.
-	buf, err = common.Exec([]string{"kubectl", "api-resources", "--api-group=projectcalico.org", "-o", "name"})
+	// Use --no-headers with default output to get APIVERSION and NAME columns for fully qualified lookups.
+	buf, err = common.Exec([]string{"kubectl", "api-resources", "--api-group=projectcalico.org", "--no-headers"})
 	if err != nil {
 		log.WithError(err).Warn("Couldn't list api-resources for projectcalico.org group, skipping v3 API resource discovery")
 		fmt.Printf("Couldn't list api-resources for projectcalico.org group, skipping v3 API resource discovery: %s\n", err)
@@ -345,20 +365,47 @@ func collectCalicoResource(dir string) {
 			fmt.Printf("\tcmd output:\n\t\t%s", buf.String())
 		}
 	} else {
-		apiResources := strings.Fields(buf.String())
-		for _, resource := range apiResources {
-			if collected.Contains(resource) {
+		for _, line := range strings.Split(buf.String(), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 3 {
 				continue
 			}
-			collected.Add(resource)
+			// api-resources output columns: NAME SHORTNAMES APIVERSION NAMESPACED KIND
+			// (SHORTNAMES may be empty, but fields are whitespace-separated so columns shift)
+			// The APIVERSION column contains <group>/<version> and KIND is always last.
+			// Find the APIVERSION field which contains a '/'.
+			var plural, apiVersion string
+			plural = fields[0]
+			for _, f := range fields[1:] {
+				if strings.Contains(f, "/") {
+					apiVersion = f
+					break
+				}
+			}
+
+			crdName := plural + ".projectcalico.org"
+			if collected.Contains(crdName) {
+				continue
+			}
+			collected.Add(crdName)
+
+			// Build fully qualified resource: <plural>.<version>.<group>.
+			resource := crdName
+			if apiVersion != "" {
+				parts := strings.SplitN(apiVersion, "/", 2)
+				if len(parts) == 2 {
+					resource = fmt.Sprintf("%s.%s.%s", plural, parts[1], parts[0])
+				}
+			}
+
 			commands = append(commands, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
-				FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.yaml", dir, crdName),
 			}, common.Cmd{
 				Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
 				CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
-				FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
+				FilePath: fmt.Sprintf("%s/%v.txt", dir, crdName),
 			})
 		}
 	}

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -303,32 +303,64 @@ func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient
 
 func collectCalicoResource(dir string) {
 	log.Info("Auditing calico resource definitions")
+
+	collected := set.New[string]()
+	commands := []common.Cmd{}
+
+	// Phase 1: Discover Calico resources via CRD listing. This finds resources registered as
+	// CustomResourceDefinitions (both crd.projectcalico.org/v1 and projectcalico.org/v3 CRD modes).
 	buf, err := common.Exec([]string{"kubectl", "get", "customresourcedefinition", "-o", "go-template", "--template", "{{range .items}}{{.metadata.name}} {{end}}"})
 	if err != nil {
 		fmt.Printf("Couldn't list CRDs: %s\n", err)
 		if buf != nil {
 			fmt.Printf("\tcmd output:\n\t\t%s", buf.String())
 		}
-		return
+	} else {
+		crds := strings.Fields(buf.String())
+		for _, resource := range crds {
+			if !strings.Contains(resource, "projectcalico") && !strings.Contains(resource, "tigera") {
+				continue
+			}
+			collected.Add(resource)
+			commands = append(commands, common.Cmd{
+				Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
+				CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
+				FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
+			}, common.Cmd{
+				Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
+				CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
+				FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
+			})
+		}
 	}
 
-	rawStr := buf.String()
-	crds := strings.Fields(rawStr)
-	commands := []common.Cmd{}
-	for _, resource := range crds {
-		if !strings.Contains(resource, "projectcalico") && !strings.Contains(resource, "tigera") {
-			continue
+	// Phase 2: Discover v3 resources via the projectcalico.org API group. When the Calico API
+	// server is running, v3 resources are served via API aggregation rather than CRDs, so they
+	// won't appear in the CRD listing above. This catches them regardless of serving mode.
+	buf, err = common.Exec([]string{"kubectl", "api-resources", "--api-group=projectcalico.org", "-o", "name"})
+	if err != nil {
+		log.WithError(err).Warn("Couldn't list api-resources for projectcalico.org group, skipping v3 API resource discovery")
+		fmt.Printf("Couldn't list api-resources for projectcalico.org group, skipping v3 API resource discovery: %s\n", err)
+		if buf != nil {
+			fmt.Printf("\tcmd output:\n\t\t%s", buf.String())
 		}
-
-		commands = append(commands, common.Cmd{
-			Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
-			CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
-			FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
-		}, common.Cmd{
-			Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
-			CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
-			FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
-		})
+	} else {
+		apiResources := strings.Fields(buf.String())
+		for _, resource := range apiResources {
+			if collected.Contains(resource) {
+				continue
+			}
+			collected.Add(resource)
+			commands = append(commands, common.Cmd{
+				Info:     fmt.Sprintf("Collect Calico %v (yaml)", resource),
+				CmdStr:   fmt.Sprintf("kubectl get %v -Ao yaml", resource),
+				FilePath: fmt.Sprintf("%s/%v.yaml", dir, resource),
+			}, common.Cmd{
+				Info:     fmt.Sprintf("Collect Calico %v (wide text)", resource),
+				CmdStr:   fmt.Sprintf("kubectl get %v -Ao wide", resource),
+				FilePath: fmt.Sprintf("%s/%v.txt", dir, resource),
+			})
+		}
 	}
 
 	common.ExecAllCmdsWriteToFile(commands)

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -35,6 +35,8 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
@@ -165,14 +167,17 @@ func collectDiags(opts *diagOpts) error {
 	dir := fmt.Sprintf("%s/%s", tempDir, directoryName)
 
 	// Create Kubernetes client from config or env vars.
-	kubeClient, _, _, err := clientmgr.GetClients(opts.Config)
+	kubeClient, calicoClient, _, err := clientmgr.GetClients(opts.Config)
 	if err != nil {
 		fmt.Printf("ERROR creating clients: %v\n", err)
 		return err
 	}
+	// Skip the per-node BPF dumps if the BPF dataplane isn't enabled —
+	// they are slow and on iptables/nftables clusters produce no useful data.
+	bpfEnabled := isBPFEnabled(calicoClient)
 	if kubeClient != nil {
 		collectTLSSecrets(kubeClient, dir+"/tls")
-		collectSelectedNodeLogs(kubeClient, dir+"/nodes", dir+"/links", opts)
+		collectSelectedNodeLogs(kubeClient, dir+"/nodes", dir+"/links", opts, bpfEnabled)
 	}
 	collectGlobalClusterInformation(dir + "/cluster")
 	collectUnsupportedAnnotations(tempDir, directoryName)
@@ -181,7 +186,29 @@ func collectDiags(opts *diagOpts) error {
 	return nil
 }
 
-func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts) {
+// isBPFEnabled reports whether the BPF dataplane is turned on in the cluster's
+// default FelixConfiguration. If the field is unset, BPF defaults to off and
+// we skip the BPF section. If we can't tell at all (no client, lookup error),
+// fall back to assuming it is on — better to collect noisy-but-empty BPF
+// diags than to silently drop them on a real BPF cluster we couldn't query.
+func isBPFEnabled(calicoClient clientv3.Interface) bool {
+	if calicoClient == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	fc, err := calicoClient.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
+	if err != nil {
+		log.WithError(err).Debug("Could not read default FelixConfiguration; assuming BPF is enabled")
+		return true
+	}
+	if fc.Spec.BPFEnabled == nil {
+		return false
+	}
+	return *fc.Spec.BPFEnabled
+}
+
+func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir string, opts *diagOpts, bpfEnabled bool) {
 	// If --focus-nodes is specified, put those node names at the start of the node list.
 	nodeList := strings.Split(opts.FocusNodes, ",")
 
@@ -225,7 +252,7 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			// Continue because deployments or other namespaces might work.
 		} else {
 			for _, ds := range dsl.Items {
-				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, ns.Name, ds.Spec.Selector)
+				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, bpfEnabled, ns.Name, ds.Spec.Selector)
 			}
 		}
 
@@ -236,7 +263,7 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			// Continue because other namespaces might work.
 		} else {
 			for _, d := range dl.Items {
-				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, ns.Name, d.Spec.Selector)
+				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, bpfEnabled, ns.Name, d.Spec.Selector)
 			}
 		}
 
@@ -247,13 +274,13 @@ func collectSelectedNodeLogs(kubeClient kubernetes.Interface, dir, linkDir strin
 			// Continue because other namespaces might work.
 		} else {
 			for _, s := range sl.Items {
-				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, ns.Name, s.Spec.Selector)
+				collectDiagsForSelectedPods(dir, linkDir, opts, kubeClient, nodeList, bpfEnabled, ns.Name, s.Spec.Selector)
 			}
 		}
 	}
 }
 
-func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient kubernetes.Interface, nodeList []string, ns string, selector *v1.LabelSelector) {
+func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient kubernetes.Interface, nodeList []string, bpfEnabled bool, ns string, selector *v1.LabelSelector) {
 	labelMap, err := v1.LabelSelectorAsMap(selector)
 	if err != nil {
 		fmt.Printf("ERROR forming pod selector: %v\n", err)
@@ -268,10 +295,10 @@ func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient
 		return
 	}
 
-	// Map the pod names against their node names.
-	podNamesByNode := map[string][]string{}
+	// Map the pods against their node names.
+	podsByNode := map[string][]apiv1.Pod{}
 	for _, p := range pl.Items {
-		podNamesByNode[p.Spec.NodeName] = append(podNamesByNode[p.Spec.NodeName], p.Name)
+		podsByNode[p.Spec.NodeName] = append(podsByNode[p.Spec.NodeName], p)
 	}
 
 	nextNodeIndex := 0
@@ -285,13 +312,13 @@ func collectDiagsForSelectedPods(dir, linkDir string, opts *diagOpts, kubeClient
 		nodeName := nodeList[nextNodeIndex]
 		nextNodeIndex++
 
-		for _, podName := range podNamesByNode[nodeName] {
-			fmt.Printf("Collecting detailed diags for pod %v in namespace %v on node %v...\n", podName, ns, nodeName)
-			if strings.HasPrefix(podName, "calico-node-") {
+		for _, pod := range podsByNode[nodeName] {
+			fmt.Printf("Collecting detailed diags for pod %v in namespace %v on node %v...\n", pod.Name, ns, nodeName)
+			if strings.HasPrefix(pod.Name, "calico-node-") {
 				nodeDir := dir + "/" + nodeName
-				collectCalicoNodeDiags(nodeDir, nodeName, ns, podName)
+				collectCalicoNodeDiags(nodeDir, nodeName, ns, pod.Name, bpfEnabled)
 			}
-			cmds = append(cmds, diagsCmdsForPod(dir, linkDir, opts, nodeName, ns, podName)...)
+			cmds = append(cmds, diagsCmdsForPod(dir, linkDir, opts, nodeName, ns, &pod)...)
 			logsWanted--
 			if logsWanted <= 0 {
 				break
@@ -674,30 +701,52 @@ func collectGlobalClusterInformation(dir string) {
 	collectThirdPartyResource(dir + "/third-party")
 }
 
-// func diagsCmdsForPod(pod, namespace, dir /*node_name*/, sinceFlag string) {
-func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace, podName string) []common.Cmd {
+func diagsCmdsForPod(dir, linkDir string, opts *diagOpts, nodeName, namespace string, pod *apiv1.Pod) []common.Cmd {
 	nodeDir := dir + "/" + nodeName
 	namespaceDir := nodeDir + "/" + namespace
 	cmds := []common.Cmd{
 		{
-			Info:     fmt.Sprintf("Collect logs for pod %s", podName),
-			CmdStr:   fmt.Sprintf("kubectl logs --since=%s -n %s %s --all-containers", opts.Since, namespace, podName),
-			FilePath: fmt.Sprintf("%s/%s.log", namespaceDir, podName),
-			SymLink:  fmt.Sprintf("%s/%s/%s.log", linkDir, namespace, podName),
+			Info:     fmt.Sprintf("Collect logs for pod %s", pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl logs --since=%s -n %s %s --all-containers", opts.Since, namespace, pod.Name),
+			FilePath: fmt.Sprintf("%s/%s.log", namespaceDir, pod.Name),
+			SymLink:  fmt.Sprintf("%s/%s/%s.log", linkDir, namespace, pod.Name),
 		},
 		{
-			Info:     fmt.Sprintf("Collect describe for pod %s", podName),
-			CmdStr:   fmt.Sprintf("kubectl -n %s describe pods %s", namespace, podName),
-			FilePath: fmt.Sprintf("%s/%s.txt", namespaceDir, podName),
-			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, podName),
+			Info:     fmt.Sprintf("Collect describe for pod %s", pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl -n %s describe pods %s", namespace, pod.Name),
+			FilePath: fmt.Sprintf("%s/%s.txt", namespaceDir, pod.Name),
+			SymLink:  fmt.Sprintf("%s/%s/%s.txt", linkDir, namespace, pod.Name),
 		},
+	}
+	// If any container has restarted, also grab the previous incarnation's
+	// logs — those are usually the ones that explain the restart.
+	if hasPreviousLogs(pod) {
+		cmds = append(cmds, common.Cmd{
+			Info:     fmt.Sprintf("Collect previous logs for pod %s", pod.Name),
+			CmdStr:   fmt.Sprintf("kubectl logs --previous --since=%s -n %s %s --all-containers", opts.Since, namespace, pod.Name),
+			FilePath: fmt.Sprintf("%s/%s.previous.log", namespaceDir, pod.Name),
+			SymLink:  fmt.Sprintf("%s/%s/%s.previous.log", linkDir, namespace, pod.Name),
+		})
 	}
 	return cmds
 }
 
-func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName string) {
+// hasPreviousLogs reports whether any container in the pod has a prior
+// incarnation worth fetching logs from.
+func hasPreviousLogs(pod *apiv1.Pod) bool {
+	statuses := append([]apiv1.ContainerStatus{}, pod.Status.ContainerStatuses...)
+	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	for _, cs := range statuses {
+		if cs.RestartCount > 0 || cs.LastTerminationState.Terminated != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName string, bpfEnabled bool) {
 	fmt.Printf("Collecting dataplane diags for calico-node: %s\n", podName)
-	common.ExecAllCmdsWriteToFile([]common.Cmd{
+	cmds := []common.Cmd{
 		// ip diagnostics
 		{
 			Info:     fmt.Sprintf("Collect iptables (legacy) for node %s", nodeName),
@@ -754,79 +803,87 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- conntrack -LSC", namespace, podName),
 			FilePath: fmt.Sprintf("%s/conntrack-list.txt", curNodeDir),
 		},
-		// eBPF diagnostics
-		{
-			Info:     fmt.Sprintf("Collect eBPF conntrack for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf conntrack dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-conntrack.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF ipsets for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf ipsets dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-ipsets.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF nat for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf nat dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-nat.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF routes for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico-node -bpf routes dump", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-routes.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-prog.txt", curNodeDir),
-		},
-		{
-			Info:     fmt.Sprintf("Collect eBPF map for node %s", nodeName),
-			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map list", namespace, podName),
-			FilePath: fmt.Sprintf("%s/bpf-maps.txt", curNodeDir),
-		},
 		{
 			Info:     fmt.Sprintf("Collect tc qdisc for node %s", nodeName),
 			CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- tc qdisc show", namespace, podName),
 			FilePath: fmt.Sprintf("%s/tc-qdisc.txt", curNodeDir),
 		},
-	})
+	}
+	if bpfEnabled {
+		// eBPF diagnostics. The calico-bpf tool is reached via the combined
+		// calico binary's `component node bpf` subcommand.
+		cmds = append(cmds,
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF conntrack for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf conntrack dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-conntrack.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF ipsets for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf ipsets dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-ipsets.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF nat for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf nat dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-nat.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF routes for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf routes dump", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-routes.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-prog.txt", curNodeDir),
+			},
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF map for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map list", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-maps.txt", curNodeDir),
+			},
+		)
+	}
+	common.ExecAllCmdsWriteToFile(cmds)
 
-	output, err := common.ExecCmd(fmt.Sprintf(
-		"kubectl exec -n %s -t %s -c calico-node -- bpftool map list",
-		namespace,
-		podName,
-	))
-	if err != nil {
-		fmt.Printf("Could not retrieve eBPF maps: %s\n", err)
-	} else {
-		bpfMaps := strings.Split(strings.TrimSpace(output.String()), "\n")
-		log.Debugf("eBPF maps: %s\n", bpfMaps)
+	if bpfEnabled {
+		output, err := common.ExecCmd(fmt.Sprintf(
+			"kubectl exec -n %s -t %s -c calico-node -- bpftool map list",
+			namespace,
+			podName,
+		))
+		if err != nil {
+			fmt.Printf("Could not retrieve eBPF maps: %s\n", err)
+		} else {
+			bpfMaps := strings.Split(strings.TrimSpace(output.String()), "\n")
+			log.Debugf("eBPF maps: %s\n", bpfMaps)
 
-		// Output looks like this:
-		//
-		// 35: lru_hash  name cali_v4_srmsg  flags 0x0
-		//	key 16B  value 8B  max_entries 510000  memlock 12242944B
-		//	pids calico-node(28576)
+			// Output looks like this:
+			//
+			// 35: lru_hash  name cali_v4_srmsg  flags 0x0
+			//	key 16B  value 8B  max_entries 510000  memlock 12242944B
+			//	pids calico-node(28576)
 
-		bpfInfoLineRe := regexp.MustCompile(`^(\d+):.*name (cali\w+)`)
-		var bpfDumpCmds []common.Cmd
-		for _, line := range bpfMaps {
-			if m := bpfInfoLineRe.FindStringSubmatch(line); m != nil {
-				id := m[1]
-				name := m[2]
-				bpfDumpCmds = append(bpfDumpCmds, common.Cmd{
-					Info:     fmt.Sprintf("Collect eBPF map %s:%s for node %s", id, name, nodeName),
-					CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map dump id %s", namespace, podName, id),
-					FilePath: fmt.Sprintf("%s/bpf-maps/%s-id_%s.txt", curNodeDir, name, id),
-				})
+			bpfInfoLineRe := regexp.MustCompile(`^(\d+):.*name (cali\w+)`)
+			var bpfDumpCmds []common.Cmd
+			for _, line := range bpfMaps {
+				if m := bpfInfoLineRe.FindStringSubmatch(line); m != nil {
+					id := m[1]
+					name := m[2]
+					bpfDumpCmds = append(bpfDumpCmds, common.Cmd{
+						Info:     fmt.Sprintf("Collect eBPF map %s:%s for node %s", id, name, nodeName),
+						CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool map dump id %s", namespace, podName, id),
+						FilePath: fmt.Sprintf("%s/bpf-maps/%s-id_%s.txt", curNodeDir, name, id),
+					})
+				}
 			}
+			common.ExecAllCmdsWriteToFile(bpfDumpCmds)
 		}
-		common.ExecAllCmdsWriteToFile(bpfDumpCmds)
 	}
 
 	// Collect all of the CNI logs
-	output, err = common.ExecCmd(fmt.Sprintf(
+	output, err := common.ExecCmd(fmt.Sprintf(
 		"kubectl exec -n %s -t %s -c calico-node -- ls /var/log/calico/cni",
 		namespace,
 		podName,

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -842,6 +842,11 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 				FilePath: fmt.Sprintf("%s/bpf-conntrack-stats.json", curNodeDir),
 			},
 			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF nat affinity for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf nat aff --json", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-nat-aff.json", curNodeDir),
+			},
+			common.Cmd{
 				Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
 				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),
 				FilePath: fmt.Sprintf("%s/bpf-prog.txt", curNodeDir),

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -744,6 +744,19 @@ func hasPreviousLogs(pod *apiv1.Pod) bool {
 	return false
 }
 
+// bpfDumpCmd builds a diagnostic command that dumps the named calico-bpf map
+// (conntrack, ipsets, nat, routes, ...) in JSON format. The calico-bpf tool
+// gained machine-parseable output via the --json flag, and the diags bundle
+// always collects these dumps as JSON so downstream tooling can parse them
+// directly; the output file therefore carries a .json extension.
+func bpfDumpCmd(curNodeDir, nodeName, namespace, podName, dump string) common.Cmd {
+	return common.Cmd{
+		Info:     fmt.Sprintf("Collect eBPF %s for node %s", dump, nodeName),
+		CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf %s dump --json", namespace, podName, dump),
+		FilePath: fmt.Sprintf("%s/bpf-%s.json", curNodeDir, dump),
+	}
+}
+
 func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName string, bpfEnabled bool) {
 	fmt.Printf("Collecting dataplane diags for calico-node: %s\n", podName)
 	cmds := []common.Cmd{
@@ -811,28 +824,15 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 	}
 	if bpfEnabled {
 		// eBPF diagnostics. The calico-bpf tool is reached via the combined
-		// calico binary's `component node bpf` subcommand.
+		// calico binary's `component node bpf` subcommand. The map dumps are
+		// collected in JSON format (the tool's --json flag) so the bundle
+		// carries machine-parseable output; the bpftool listings below have no
+		// equivalent calico-bpf JSON path here and stay as plain text.
 		cmds = append(cmds,
-			common.Cmd{
-				Info:     fmt.Sprintf("Collect eBPF conntrack for node %s", nodeName),
-				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf conntrack dump", namespace, podName),
-				FilePath: fmt.Sprintf("%s/bpf-conntrack.txt", curNodeDir),
-			},
-			common.Cmd{
-				Info:     fmt.Sprintf("Collect eBPF ipsets for node %s", nodeName),
-				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf ipsets dump", namespace, podName),
-				FilePath: fmt.Sprintf("%s/bpf-ipsets.txt", curNodeDir),
-			},
-			common.Cmd{
-				Info:     fmt.Sprintf("Collect eBPF nat for node %s", nodeName),
-				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf nat dump", namespace, podName),
-				FilePath: fmt.Sprintf("%s/bpf-nat.txt", curNodeDir),
-			},
-			common.Cmd{
-				Info:     fmt.Sprintf("Collect eBPF routes for node %s", nodeName),
-				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf routes dump", namespace, podName),
-				FilePath: fmt.Sprintf("%s/bpf-routes.txt", curNodeDir),
-			},
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "conntrack"),
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "ipsets"),
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "nat"),
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "routes"),
 			common.Cmd{
 				Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
 				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -744,16 +744,28 @@ func hasPreviousLogs(pod *apiv1.Pod) bool {
 	return false
 }
 
-// bpfDumpCmd builds a diagnostic command that dumps the named calico-bpf map
-// (conntrack, ipsets, nat, routes, ...) in JSON format. The calico-bpf tool
-// gained machine-parseable output via the --json flag, and the diags bundle
-// always collects these dumps as JSON so downstream tooling can parse them
-// directly; the output file therefore carries a .json extension.
-func bpfDumpCmd(curNodeDir, nodeName, namespace, podName, dump string) common.Cmd {
+// bpfJSONCmd builds a diagnostic command that dumps calico-bpf state as JSON,
+// writing <file>.json.
+//
+// Current calico-node runs the combined `calico` binary and exposes the bpf
+// tool as `calico component node bpf <sub>`, with machine-parseable `--json`
+// output. Both that invocation path and the --json flag landed together; older
+// (pre-combined-binary) calico-node has neither — it only understands the
+// legacy `calico-node -bpf <sub>` form, with text output. calicoctl is
+// frequently run against an older cluster, so the command falls back to that
+// legacy text form (writing <file>.txt) when the modern invocation fails,
+// degrading gracefully rather than capturing an "unknown command" error.
+//
+// sub is the bpf subcommand, e.g. "nat dump" or "conntrack stats"; file is the
+// output basename without extension, e.g. "bpf-nat".
+func bpfJSONCmd(curNodeDir, nodeName, namespace, podName, info, sub, file string) common.Cmd {
+	kexec := fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node --", namespace, podName)
 	return common.Cmd{
-		Info:     fmt.Sprintf("Collect eBPF %s for node %s", dump, nodeName),
-		CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf %s dump --json", namespace, podName, dump),
-		FilePath: fmt.Sprintf("%s/bpf-%s.json", curNodeDir, dump),
+		Info:             fmt.Sprintf("Collect eBPF %s for node %s", info, nodeName),
+		CmdStr:           fmt.Sprintf("%s calico component node bpf %s --json", kexec, sub),
+		FilePath:         fmt.Sprintf("%s/%s.json", curNodeDir, file),
+		FallbackCmdStr:   fmt.Sprintf("%s calico-node -bpf %s", kexec, sub),
+		FallbackFilePath: fmt.Sprintf("%s/%s.txt", curNodeDir, file),
 	}
 }
 
@@ -824,28 +836,21 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 	}
 	if bpfEnabled {
 		// eBPF diagnostics. The calico-bpf tool is reached via the combined
-		// calico binary's `component node bpf` subcommand. The map dumps are
+		// calico binary's `component node bpf` subcommand. The dumps are
 		// collected in JSON format (the tool's --json flag) so the bundle
-		// carries machine-parseable output; the bpftool listings below have no
+		// carries machine-parseable output, falling back to plain text against
+		// older calico-node versions. The bpftool listings below have no
 		// equivalent calico-bpf JSON path here and stay as plain text.
 		cmds = append(cmds,
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "conntrack"),
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "ipsets"),
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "nat"),
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "routes"),
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "counters"),
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "arp"),
-			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "ifstate"),
-			common.Cmd{
-				Info:     fmt.Sprintf("Collect eBPF conntrack stats for node %s", nodeName),
-				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf conntrack stats --json", namespace, podName),
-				FilePath: fmt.Sprintf("%s/bpf-conntrack-stats.json", curNodeDir),
-			},
-			common.Cmd{
-				Info:     fmt.Sprintf("Collect eBPF nat affinity for node %s", nodeName),
-				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf nat aff --json", namespace, podName),
-				FilePath: fmt.Sprintf("%s/bpf-nat-aff.json", curNodeDir),
-			},
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "conntrack", "conntrack dump", "bpf-conntrack"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "ipsets", "ipsets dump", "bpf-ipsets"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "nat", "nat dump", "bpf-nat"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "routes", "routes dump", "bpf-routes"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "counters", "counters dump", "bpf-counters"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "arp", "arp dump", "bpf-arp"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "ifstate", "ifstate dump", "bpf-ifstate"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "conntrack stats", "conntrack stats", "bpf-conntrack-stats"),
+			bpfJSONCmd(curNodeDir, nodeName, namespace, podName, "nat affinity", "nat aff", "bpf-nat-aff"),
 			common.Cmd{
 				Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
 				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),

--- a/calicoctl/calicoctl/commands/cluster/diags.go
+++ b/calicoctl/calicoctl/commands/cluster/diags.go
@@ -833,6 +833,14 @@ func collectCalicoNodeDiags(curNodeDir string, nodeName, namespace, podName stri
 			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "ipsets"),
 			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "nat"),
 			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "routes"),
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "counters"),
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "arp"),
+			bpfDumpCmd(curNodeDir, nodeName, namespace, podName, "ifstate"),
+			common.Cmd{
+				Info:     fmt.Sprintf("Collect eBPF conntrack stats for node %s", nodeName),
+				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- calico component node bpf conntrack stats --json", namespace, podName),
+				FilePath: fmt.Sprintf("%s/bpf-conntrack-stats.json", curNodeDir),
+			},
 			common.Cmd{
 				Info:     fmt.Sprintf("Collect eBPF prog for node %s", nodeName),
 				CmdStr:   fmt.Sprintf("kubectl exec -n %s -t %s -c calico-node -- bpftool prog list", namespace, podName),

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
 
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
@@ -152,4 +154,42 @@ func TestDiags(t *testing.T) {
 			FocusNodes:           "infra1,control2",
 			AllowVersionMismatch: false,
 		})
+}
+
+func TestDiagsCmdsForPod_Previous(t *testing.T) {
+	RegisterTestingT(t)
+
+	opts := &diagOpts{Since: "0s"}
+
+	// A pod with no restarts gets only the current-log and describe commands.
+	steady := &apiv1.Pod{}
+	steady.Name = "calico-typha-0"
+	steady.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 0}}
+	cmds := diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", steady)
+	Expect(cmdStrs(cmds)).NotTo(ContainElement(ContainSubstring("--previous")))
+
+	// A pod whose container has restarted picks up an extra previous-log
+	// command alongside the usual current-log + describe.
+	restarted := &apiv1.Pod{}
+	restarted.Name = "calico-apiserver-0"
+	restarted.Status.ContainerStatuses = []apiv1.ContainerStatus{{RestartCount: 2}}
+	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-apiserver", restarted)
+	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+
+	// An init container that previously terminated also flips the flag.
+	initTerminated := &apiv1.Pod{}
+	initTerminated.Name = "calico-node-xyz"
+	initTerminated.Status.InitContainerStatuses = []apiv1.ContainerStatus{{
+		LastTerminationState: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+	}}
+	cmds = diagsCmdsForPod("/dir", "/links", opts, "nodeA", "calico-system", initTerminated)
+	Expect(cmdStrs(cmds)).To(ContainElement(ContainSubstring("kubectl logs --previous")))
+}
+
+func cmdStrs(cmds []common.Cmd) []string {
+	out := make([]string, len(cmds))
+	for i, c := range cmds {
+		out[i] = c.CmdStr
+	}
+	return out
 }

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -32,6 +32,20 @@ func init() {
 	logutils.ConfigureFormatter("test")
 }
 
+func TestBpfDumpCmd_CollectsJSON(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Every calico-bpf dump in the diags bundle must request JSON output and
+	// land in a .json file so downstream tooling can parse it directly.
+	for _, dump := range []string{"conntrack", "ipsets", "nat", "routes"} {
+		cmd := bpfDumpCmd("/node-dir", "nodeA", "calico-system", "calico-node-xyz", dump)
+		Expect(cmd.CmdStr).To(ContainSubstring(fmt.Sprintf("calico component node bpf %s dump", dump)))
+		Expect(cmd.CmdStr).To(HaveSuffix("--json"),
+			"bpf %s dump must be collected in JSON format", dump)
+		Expect(cmd.FilePath).To(Equal(fmt.Sprintf("/node-dir/bpf-%s.json", dump)))
+	}
+}
+
 func TestDiags(t *testing.T) {
 	RegisterTestingT(t)
 	test := func(invocation string, expectedErr error, expectedOutput string, expectedOpts *diagOpts) {

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -32,18 +32,25 @@ func init() {
 	logutils.ConfigureFormatter("test")
 }
 
-func TestBpfDumpCmd_CollectsJSON(t *testing.T) {
+func TestBpfJSONCmd_CollectsJSONWithTextFallback(t *testing.T) {
 	RegisterTestingT(t)
 
-	// Every calico-bpf dump in the diags bundle must request JSON output and
-	// land in a .json file so downstream tooling can parse it directly.
-	for _, dump := range []string{"conntrack", "ipsets", "nat", "routes", "counters", "arp", "ifstate"} {
-		cmd := bpfDumpCmd("/node-dir", "nodeA", "calico-system", "calico-node-xyz", dump)
-		Expect(cmd.CmdStr).To(ContainSubstring(fmt.Sprintf("calico component node bpf %s dump", dump)))
-		Expect(cmd.CmdStr).To(HaveSuffix("--json"),
-			"bpf %s dump must be collected in JSON format", dump)
-		Expect(cmd.FilePath).To(Equal(fmt.Sprintf("/node-dir/bpf-%s.json", dump)))
-	}
+	// Each calico-bpf dump must request JSON via the combined-binary path and
+	// land in a .json file, with a fallback to the legacy `calico-node -bpf`
+	// text form (.txt file) for older calico-node versions that have neither
+	// the `calico component node bpf` path nor --json.
+	cmd := bpfJSONCmd("/node-dir", "nodeA", "calico-system", "calico-node-xyz", "nat affinity", "nat aff", "bpf-nat-aff")
+
+	Expect(cmd.CmdStr).To(ContainSubstring("calico component node bpf nat aff"))
+	Expect(cmd.CmdStr).To(HaveSuffix("--json"))
+	Expect(cmd.FilePath).To(Equal("/node-dir/bpf-nat-aff.json"))
+
+	Expect(cmd.FallbackCmdStr).To(ContainSubstring("calico-node -bpf nat aff"))
+	Expect(cmd.FallbackCmdStr).NotTo(ContainSubstring("calico component node bpf"),
+		"fallback must use the legacy calico-node -bpf invocation")
+	Expect(cmd.FallbackCmdStr).NotTo(ContainSubstring("--json"),
+		"legacy fallback predates --json")
+	Expect(cmd.FallbackFilePath).To(Equal("/node-dir/bpf-nat-aff.txt"))
 }
 
 func TestDiags(t *testing.T) {

--- a/calicoctl/calicoctl/commands/cluster/diags_test.go
+++ b/calicoctl/calicoctl/commands/cluster/diags_test.go
@@ -37,7 +37,7 @@ func TestBpfDumpCmd_CollectsJSON(t *testing.T) {
 
 	// Every calico-bpf dump in the diags bundle must request JSON output and
 	// land in a .json file so downstream tooling can parse it directly.
-	for _, dump := range []string{"conntrack", "ipsets", "nat", "routes"} {
+	for _, dump := range []string{"conntrack", "ipsets", "nat", "routes", "counters", "arp", "ifstate"} {
 		cmd := bpfDumpCmd("/node-dir", "nodeA", "calico-system", "calico-node-xyz", dump)
 		Expect(cmd.CmdStr).To(ContainSubstring(fmt.Sprintf("calico component node bpf %s dump", dump)))
 		Expect(cmd.CmdStr).To(HaveSuffix("--json"),

--- a/calicoctl/calicoctl/commands/common/cmd.go
+++ b/calicoctl/calicoctl/commands/common/cmd.go
@@ -129,6 +129,10 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 
 	parts := strings.Fields(c.CmdStr)
 	logCtx.Debugf("cmd tokens: [%+v]", parts)
+	if len(parts) == 0 {
+		fmt.Printf("%s No command to execute\n", logPrefix)
+		return
+	}
 
 	logCtx.Debugf("Executing command: %+v ... ", c.CmdStr)
 	content, err := exec.Command(parts[0], parts[1:]...).CombinedOutput()
@@ -141,11 +145,15 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 	if err != nil && c.FallbackCmdStr != "" {
 		logCtx.Debugf("Command failed, trying fallback: %s", c.FallbackCmdStr)
 		fParts := strings.Fields(c.FallbackCmdStr)
-		fContent, fErr := exec.Command(fParts[0], fParts[1:]...).CombinedOutput()
-		if fErr == nil {
-			content, err = fContent, nil
-			if c.FallbackFilePath != "" {
-				filePath = c.FallbackFilePath
+		if len(fParts) == 0 {
+			logCtx.Warn("Empty fallback command, skipping")
+		} else {
+			fContent, fErr := exec.Command(fParts[0], fParts[1:]...).CombinedOutput()
+			if fErr == nil {
+				content, err = fContent, nil
+				if c.FallbackFilePath != "" {
+					filePath = c.FallbackFilePath
+				}
 			}
 		}
 	}

--- a/calicoctl/calicoctl/commands/common/cmd.go
+++ b/calicoctl/calicoctl/commands/common/cmd.go
@@ -100,6 +100,14 @@ type Cmd struct {
 	CmdStr   string
 	FilePath string
 	SymLink  string
+
+	// FallbackCmdStr, if set, is run when CmdStr exits non-zero — for example
+	// when collecting from an older component that doesn't understand a newer
+	// flag or subcommand. Its output is written to FallbackFilePath (or to
+	// FilePath if FallbackFilePath is empty). This keeps diags useful across
+	// version skew: e.g. try a JSON dump, fall back to the plain-text dump.
+	FallbackCmdStr   string
+	FallbackFilePath string
 }
 
 // ExecCmdWriteToFile executes the provided command c and outputs the result to a
@@ -124,21 +132,39 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 
 	logCtx.Debugf("Executing command: %+v ... ", c.CmdStr)
 	content, err := exec.Command(parts[0], parts[1:]...).CombinedOutput()
+
+	// Determine where the output should land. If the primary command failed and
+	// a fallback is configured, run the fallback instead (e.g. an older
+	// calico-node that doesn't support --json: retry without it and keep the
+	// plain-text output). The fallback output replaces the primary output.
+	filePath := c.FilePath
+	if err != nil && c.FallbackCmdStr != "" {
+		logCtx.Debugf("Command failed, trying fallback: %s", c.FallbackCmdStr)
+		fParts := strings.Fields(c.FallbackCmdStr)
+		fContent, fErr := exec.Command(fParts[0], fParts[1:]...).CombinedOutput()
+		if fErr == nil {
+			content, err = fContent, nil
+			if c.FallbackFilePath != "" {
+				filePath = c.FallbackFilePath
+			}
+		}
+	}
+
 	if err != nil {
 		fmt.Printf("%s Failed to run command: %s\nError: %s\n", logPrefix, c.CmdStr, string(content))
 	}
 
 	// This is for the commands we want to run but don't want to save the output
 	// or for commands that don't produce any output to stdout
-	if c.FilePath == "" {
+	if filePath == "" {
 		logCtx.Debugln("Command executed successfully, skipping writing output (no filepath specified)")
 		return
 	}
 
-	if err := os.WriteFile(c.FilePath, content, 0644); err != nil {
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
 		logCtx.Errorf("Error writing diags to file: %s\n", err)
 	}
-	logCtx.Debugf("Command executed successfully and outputted to %s", c.FilePath)
+	logCtx.Debugf("Command executed successfully and outputted to %s", filePath)
 
 	if c.SymLink != "" {
 		dir = filepath.Dir(c.SymLink)
@@ -146,7 +172,7 @@ func ExecCmdWriteToFile(logPrefix string, c Cmd) {
 			fmt.Printf("%s Error creating directory for %v: %v\n", logPrefix, c.SymLink, err)
 			return
 		}
-		relativeTarget, err := filepath.Rel(dir, c.FilePath)
+		relativeTarget, err := filepath.Rel(dir, filePath)
 		if err != nil {
 			fmt.Printf("%s Error computing relative path for %v: %v\n", logPrefix, c.SymLink, err)
 			return

--- a/calicoctl/calicoctl/commands/common/cmd_test.go
+++ b/calicoctl/calicoctl/commands/common/cmd_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
+)
+
+// TestExecCmdWriteToFile_Fallback verifies that when the primary command exits
+// non-zero and a fallback is configured, the fallback output is collected into
+// the fallback file and the primary file is not written. This is what keeps
+// diags useful against an older component (e.g. --json unsupported -> retry
+// without it and keep the plain-text output).
+func TestExecCmdWriteToFile_Fallback(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	txtPath := filepath.Join(dir, "out.txt")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:           "false", // exits non-zero
+		FilePath:         jsonPath,
+		FallbackCmdStr:   "echo fellback", // succeeds
+		FallbackFilePath: txtPath,
+	})
+
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Fatalf("expected primary file %s not to be written, stat err=%v", jsonPath, err)
+	}
+	got, err := os.ReadFile(txtPath)
+	if err != nil {
+		t.Fatalf("reading fallback file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "fellback" {
+		t.Fatalf("unexpected fallback content: %q", got)
+	}
+}
+
+// TestExecCmdWriteToFile_PrimarySucceeds verifies the fallback is not used when
+// the primary command succeeds.
+func TestExecCmdWriteToFile_PrimarySucceeds(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	txtPath := filepath.Join(dir, "out.txt")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:           "echo primary",
+		FilePath:         jsonPath,
+		FallbackCmdStr:   "echo fellback",
+		FallbackFilePath: txtPath,
+	})
+
+	got, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("reading primary file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "primary" {
+		t.Fatalf("unexpected primary content: %q", got)
+	}
+	if _, err := os.Stat(txtPath); !os.IsNotExist(err) {
+		t.Fatalf("fallback file should not exist when primary succeeds")
+	}
+}

--- a/calicoctl/calicoctl/commands/common/cmd_test.go
+++ b/calicoctl/calicoctl/commands/common/cmd_test.go
@@ -52,6 +52,41 @@ func TestExecCmdWriteToFile_Fallback(t *testing.T) {
 	}
 }
 
+// TestExecCmdWriteToFile_EmptyCmd verifies that an empty/whitespace command
+// string is handled gracefully rather than panicking on parts[0].
+func TestExecCmdWriteToFile_EmptyCmd(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:   "   ", // whitespace only -> no tokens
+		FilePath: jsonPath,
+	})
+
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no output file for an empty command, stat err=%v", err)
+	}
+}
+
+// TestExecCmdWriteToFile_EmptyFallback verifies that an empty fallback command
+// is skipped (not executed) and does not panic when the primary fails.
+func TestExecCmdWriteToFile_EmptyFallback(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	txtPath := filepath.Join(dir, "out.txt")
+
+	common.ExecCmdWriteToFile("[test]", common.Cmd{
+		CmdStr:           "false", // exits non-zero
+		FilePath:         jsonPath,
+		FallbackCmdStr:   "   ", // whitespace only -> no tokens
+		FallbackFilePath: txtPath,
+	})
+
+	if _, err := os.Stat(txtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no fallback file for an empty fallback command, stat err=%v", err)
+	}
+}
+
 // TestExecCmdWriteToFile_PrimarySucceeds verifies the fallback is not used when
 // the primary command succeeds.
 func TestExecCmdWriteToFile_PrimarySucceeds(t *testing.T) {

--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -94,16 +94,34 @@ var natDelCmd = &cobra.Command{
 	Short: "deletes an entry from the NAT tables",
 }
 
-func dumpAff(cmd *cobra.Command) (err error) {
+func dumpAff(cmd *cobra.Command) error {
+	if ipv6 != nil && *ipv6 {
+		affMap, err := nat.LoadAffinityMapV6(nat.AffinityMapV6())
+		if err != nil {
+			return err
+		}
+		return writeAff(cmd, makeAffinityJSON(affMap))
+	}
+
 	affMap, err := nat.LoadAffinityMap(nat.AffinityMap())
 	if err != nil {
 		return err
 	}
+	return writeAff(cmd, makeAffinityJSON(affMap))
+}
 
-	for k, v := range affMap {
-		cmd.Printf("%-40s %s\n", k, v)
+func writeAff(cmd *cobra.Command, entries []affinityEntryJSON) error {
+	if *jsonOutput {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
 	}
 
+	for _, e := range entries {
+		cmd.Printf("client %s svc proto %d %s -> %s ts %s\n",
+			e.ClientIP, e.Proto, net.JoinHostPort(e.Addr, fmt.Sprint(e.Port)),
+			net.JoinHostPort(e.Backend.Addr, fmt.Sprint(e.Backend.Port)), e.Timestamp)
+	}
 	cmd.Printf("\n")
 
 	return nil
@@ -365,6 +383,51 @@ type natServiceGroupJSON struct {
 	ID        uint32            `json:"id"`
 	Frontends []natFrontendJSON `json:"frontends"`
 	Backends  []natBackendJSON  `json:"backends"`
+}
+
+// affinityEntryJSON is one client -> backend affinity entry, keyed by the
+// client IP and the frontend service it is sticky to.
+type affinityEntryJSON struct {
+	ClientIP  string         `json:"client_ip"`
+	Proto     uint8          `json:"proto"`
+	Addr      string         `json:"addr"`
+	Port      uint16         `json:"port"`
+	Backend   natBackendJSON `json:"backend"`
+	Timestamp string         `json:"timestamp"`
+}
+
+// affinityKey is the constraint for an affinity map key: comparable and
+// exposing the affinity key accessors.
+type affinityKey interface {
+	comparable
+	nat.AffinityKeyInterface
+}
+
+func makeAffinityJSON[K affinityKey, V nat.AffinityValueInterface](m map[K]V) []affinityEntryJSON {
+	entries := make([]affinityEntryJSON, 0, len(m))
+	for k, v := range m {
+		fe := k.FrontendAffinityKey()
+		be := v.Backend()
+		entries = append(entries, affinityEntryJSON{
+			ClientIP:  k.ClientIP().String(),
+			Proto:     fe.Proto(),
+			Addr:      fe.Addr().String(),
+			Port:      fe.Port(),
+			Backend:   natBackendJSON{Addr: be.Addr().String(), Port: be.Port()},
+			Timestamp: v.Timestamp().String(),
+		})
+	}
+	// Sort by (service addr, port, client) for deterministic output.
+	slices.SortFunc(entries, func(a, b affinityEntryJSON) int {
+		if c := cmp.Compare(a.Addr, b.Addr); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Port, b.Port); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ClientIP, b.ClientIP)
+	})
+	return entries
 }
 
 func dumpNATJSON[FK nat.FrontendKeyComparable, BV nat.BackendValueInterface](

--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -417,12 +417,18 @@ func makeAffinityJSON[K affinityKey, V nat.AffinityValueInterface](m map[K]V) []
 			Timestamp: v.Timestamp().String(),
 		})
 	}
-	// Sort by (service addr, port, client) for deterministic output.
+	// Sort by (service addr, port, proto, client) for deterministic output.
+	// Proto is part of the sort key because a service can be sticky on the same
+	// addr+port for more than one protocol; without it those entries would
+	// compare equal and order non-deterministically.
 	slices.SortFunc(entries, func(a, b affinityEntryJSON) int {
 		if c := cmp.Compare(a.Addr, b.Addr); c != 0 {
 			return c
 		}
 		if c := cmp.Compare(a.Port, b.Port); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Proto, b.Proto); c != 0 {
 			return c
 		}
 		return cmp.Compare(a.ClientIP, b.ClientIP)

--- a/felix/cmd/calico-bpf/commands/nat_test.go
+++ b/felix/cmd/calico-bpf/commands/nat_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -37,6 +38,31 @@ func TestNATDump(t *testing.T) {
 	}
 
 	dumpNice(func(format string, i ...any) { fmt.Printf(format, i...) }, nat, back, false)
+}
+
+// TestAffinityDumpJSON checks that makeAffinityJSON exposes the client, the
+// frontend service tuple, and the chosen backend as structured fields.
+func TestAffinityDumpJSON(t *testing.T) {
+	m := nat2.AffinityMapMem{
+		nat2.NewAffinityKey(net.IPv4(10, 0, 0, 1), nat2.NewNATKey(net.IPv4(1, 1, 1, 1), 80, 6)): nat2.NewAffinityValue(
+			0, nat2.NewNATBackendValue(net.IPv4(5, 5, 5, 5), 8080)),
+	}
+
+	entries := makeAffinityJSON(m)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %+v", len(entries), entries)
+	}
+	e := entries[0]
+	if e.ClientIP != "10.0.0.1" || e.Addr != "1.1.1.1" || e.Port != 80 || e.Proto != 6 {
+		t.Fatalf("unexpected affinity key fields: %+v", e)
+	}
+	if e.Backend.Addr != "5.5.5.5" || e.Backend.Port != 8080 {
+		t.Fatalf("unexpected backend: %+v", e.Backend)
+	}
+	if _, err := json.Marshal(entries); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
 }
 
 // TestDumpNiceGrouping verifies that dumpNiceGrouped groups frontends sharing the

--- a/felix/cmd/calico-bpf/commands/nat_test.go
+++ b/felix/cmd/calico-bpf/commands/nat_test.go
@@ -65,6 +65,38 @@ func TestAffinityDumpJSON(t *testing.T) {
 	}
 }
 
+// TestAffinityDumpJSONProtoOrdering verifies that affinity entries sharing the
+// same service addr+port and client IP but differing in protocol are ordered
+// deterministically (by protocol). Without proto in the sort key these entries
+// compare equal and slices.SortFunc leaves their order unspecified.
+func TestAffinityDumpJSONProtoOrdering(t *testing.T) {
+	client := net.IPv4(10, 0, 0, 1)
+	svc := net.IPv4(1, 1, 1, 1)
+	m := nat2.AffinityMapMem{
+		// Same client, same addr+port; only the protocol differs (TCP=6, UDP=17).
+		nat2.NewAffinityKey(client, nat2.NewNATKey(svc, 53, 17)): nat2.NewAffinityValue(
+			0, nat2.NewNATBackendValue(net.IPv4(6, 6, 6, 6), 5353)),
+		nat2.NewAffinityKey(client, nat2.NewNATKey(svc, 53, 6)): nat2.NewAffinityValue(
+			0, nat2.NewNATBackendValue(net.IPv4(5, 5, 5, 5), 5353)),
+	}
+
+	// Map iteration order is randomised, so a single deterministic ordering
+	// across repeated calls is what we assert.
+	first := makeAffinityJSON(m)
+	if len(first) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(first), first)
+	}
+	if first[0].Proto != 6 || first[1].Proto != 17 {
+		t.Fatalf("entries not ordered by proto: %+v", first)
+	}
+	for i := 0; i < 20; i++ {
+		got := makeAffinityJSON(m)
+		if got[0].Proto != first[0].Proto || got[1].Proto != first[1].Proto {
+			t.Fatalf("non-deterministic ordering across calls: %+v vs %+v", first, got)
+		}
+	}
+}
+
 // TestDumpNiceGrouping verifies that dumpNiceGrouped groups frontends sharing the
 // same service ID so the backend list is printed just once per service.
 func TestDumpNiceGrouping(t *testing.T) {


### PR DESCRIPTION
## Cherry-pick history
Brings the `calicoctl cluster diags` calico-bpf JSON-collection work (#12923)
and its follow-up review fixes (#12980) to **v3.31**.

v3.31 had diverged substantially from the branch #12923 was authored against,
so #12923 does not apply on its own — it depends on a chain of earlier diags
commits and on a `collectCalicoNodeDiags` refactor. The full chain picked here,
in order:

- projectcalico/calico#11601 — collect unsupported annotation usage
- projectcalico/calico#11816 — collect Multus network-attachment-definitions
- projectcalico/calico#11983 — collect v3 API resources
- projectcalico/calico#12152 — use fully qualified resource names
- projectcalico/calico#12804 — `collectCalicoNodeDiags` refactor + `isBPFEnabled` gating (the `.semaphore/collect-kind-diags` CI script from that PR is **not** included — it does not exist on v3.31 and is unrelated to the feature)
- projectcalico/calico#12923 — collect calico-bpf dumps as JSON (+ legacy text fallback for older nodes)
- projectcalico/calico#12980 — review fixes (deterministic affinity ordering; empty-command panic guard)

## Maglev omitted
The `nat maglev` parts of #12923 are **dropped**: the Maglev consistent-hash
backend maps (`nat.MaglevMap`, `LoadMaglevMap`, `MaglevBackendKeyInterface`, …)
are part of a large eBPF dataplane feature that does not exist on v3.31.
Specifically dropped vs upstream:

- felix `calico-bpf`: the `nat maglev` dump subcommand and its JSON builder. The `nat aff` JSON output (which #12980 polishes) is kept.
- calicoctl diags: the `bpf-nat-maglev.json` collection entry. The `nat aff` collection is kept.

The non-maglev felix/calicoctl commits were adapted accordingly and their
commit messages note the omission.

## Testing
- `calicoctl` diags/common packages build and unit tests pass (`go test ./calicoctl/calicoctl/commands/cluster/ ./calicoctl/calicoctl/commands/common/`).
- felix `calico-bpf/commands` package compiles (`go build`); its cgo test binary requires the prebuilt libbpf static lib (CI/Docker), same as upstream. The affinity unit tests are unchanged from upstream.

**Release note:**
```release-note
calicoctl cluster diags now collects additional cluster state (v3 API resources, Multus network-attachment-definitions, unsupported-annotation usage) and collects eBPF map dumps as machine-parseable JSON, falling back to legacy text output against older calico-node versions.
```
