### PR TITLE
Add fv-guru-db secret to Felix CI blocks for MONGODB_URI

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -997,6 +997,7 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
+        - name: fv-guru-db
       jobs:
         - name: "Felix: Build and cache FV prerequisites"
           priority:
@@ -1064,6 +1065,7 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
+        - name: fv-guru-db
       jobs:
         - name: "Felix: UT"
           execution_time_limit:
@@ -1165,6 +1167,7 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
+        - name: fv-guru-db
       jobs:
         - name: "Felix: iptables tests on Ubuntu 22.04"
           execution_time_limit:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3326,6 +3326,7 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
+        - name: fv-guru-db
       jobs:
         - name: "Felix: Build and cache FV prerequisites"
           priority:
@@ -3508,6 +3509,7 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
+        - name: fv-guru-db
       jobs:
         - name: "Felix: UT"
           execution_time_limit:
@@ -3943,6 +3945,7 @@ blocks:
         - name: google-service-account-for-gce
         - name: gemini-api-key
         - name: fv-tests-guru-github-token
+        - name: fv-guru-db
       jobs:
         - name: "Felix: iptables tests on Ubuntu 22.04"
           execution_time_limit:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -38,6 +38,7 @@
       - name: google-service-account-for-gce
       - name: gemini-api-key
       - name: fv-tests-guru-github-token
+      - name: fv-guru-db
     jobs:
       - name: "Felix: Build and cache FV prerequisites"
         priority:
@@ -105,6 +106,7 @@
       - name: google-service-account-for-gce
       - name: gemini-api-key
       - name: fv-tests-guru-github-token
+      - name: fv-guru-db
     jobs:
       - name: "Felix: UT"
         execution_time_limit:
@@ -206,6 +208,7 @@
       - name: google-service-account-for-gce
       - name: gemini-api-key
       - name: fv-tests-guru-github-token
+      - name: fv-guru-db
     jobs:
       - name: "Felix: iptables tests on Ubuntu 22.04"
         execution_time_limit:


### PR DESCRIPTION
The `fv-tests-guru-sem-integration` tool invoked from `analyze-test-failures` now needs a MongoDB connection. This exposes `MONGODB_URI` to the Felix Build, UT, and FV blocks via the `fv-guru-db` Semaphore secret, alongside the existing `gemini-api-key` and `fv-tests-guru-github-token` secrets.

Edited the `.semaphore/semaphore.yml.d/blocks/20-felix.yml` template and regenerated `.semaphore/semaphore.yml` and `.semaphore/semaphore-scheduled-builds.yml`.

**Release note:**
```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)