### PR TITLE
[v3.32] Fix CI flakes from Windows build downloads and built-in tier protection

### DIFF
--- a/calicoctl/calicoctl/commands/datastore/migrate/import.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/import.go
@@ -43,6 +43,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	calicoErrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
@@ -247,6 +248,25 @@ func checkCalicoResourcesNotExist(args map[string]any, c client.Interface) error
 
 						// Make sure that the network policy is a K8s network policy
 						if !strings.HasPrefix(metaObj.GetObjectMeta().GetName(), converter.KubernetesNetworkPolicyEtcdPrefix) {
+							return fmt.Errorf("found existing Calico %s resource", results.SingleKind)
+						}
+					}
+				case "tiers":
+					// The protected built-in tiers (default, kube-admin, kube-baseline) are
+					// created automatically and can't be deleted, so they'll be present in any
+					// KDD target and shouldn't block an import.
+					objs, err := meta.ExtractList(resource)
+					if err != nil {
+						return fmt.Errorf("error extracting tiers for inspection: %w", err)
+					}
+
+					for _, obj := range objs {
+						metaObj, ok := obj.(v1.ObjectMetaAccessor)
+						if !ok {
+							return fmt.Errorf("unable to convert Calico tier for inspection")
+						}
+
+						if !names.TierIsProtected(metaObj.GetObjectMeta().GetName()) {
 							return fmt.Errorf("found existing Calico %s resource", results.SingleKind)
 						}
 					}

--- a/libcalico-go/lib/backend/k8s/client.go
+++ b/libcalico-go/lib/backend/k8s/client.go
@@ -46,6 +46,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 	"github.com/projectcalico/calico/libcalico-go/lib/winutils"
 )
@@ -535,6 +536,16 @@ func (c *KubeClient) Clean() error {
 					return nil // Problems are reported through kindsWithProblems set.
 				} else {
 					for _, r := range rs.KVPairs {
+						// The protected built-in tiers cannot be deleted - a
+						// ValidatingAdmissionPolicy blocks it. Skip them, otherwise every Clean()
+						// burns its full retry budget failing to delete them and logs spurious
+						// errors. Don't skip the deletable static tiers (anp/banp), or they leak
+						// into later specs.
+						if k == apiv3.KindTier {
+							if rk, ok := r.Key.(model.ResourceKey); ok && names.TierIsProtected(rk.Name) {
+								continue
+							}
+						}
 						delEG.Go(func() error {
 							if _, err := c.DeleteKVP(ctx, r); err != nil {
 								log.WithError(err).WithField("Key", r.Key).Warning("Failed to delete entry from KDD")

--- a/libcalico-go/lib/clientv3/tier_e2e_test.go
+++ b/libcalico-go/lib/clientv3/tier_e2e_test.go
@@ -38,6 +38,20 @@ func init() {
 	format.MaxLength = 0
 }
 
+// filterProtectedTiers returns only the tiers that are not protected built-in
+// tiers. Tests that snapshot all tiers must filter these out, since whether
+// they are present depends on which other specs in the suite have run (they
+// always exist, can't be deleted, and are recreated by EnsureInitialized).
+func filterProtectedTiers(tiers []apiv3.Tier) []apiv3.Tier {
+	var out []apiv3.Tier
+	for _, tier := range tiers {
+		if !names.TierIsProtected(tier.Name) {
+			out = append(out, tier)
+		}
+	}
+	return out
+}
+
 var _ = testutils.E2eDatastoreDescribe("Tier tests", testutils.DatastoreAll, func(config apiconfig.CalicoAPIConfig) {
 	ctx := context.Background()
 	defaultOrder := apiv3.DefaultTierOrder
@@ -512,10 +526,15 @@ var _ = testutils.E2eDatastoreDescribe("Tier tests", testutils.DatastoreAll, fun
 			Expect(err).NotTo(HaveOccurred())
 			Expect(be.Clean()).NotTo(HaveOccurred())
 
-			By("Listing Tiers with the latest resource version and checking for two results with name1/spec2 and name2/spec2")
+			// be.Clean() cannot remove the built-in tiers (default, kube-admin,
+			// kube-baseline) - they are protected by a ValidatingAdmissionPolicy and
+			// recreated by EnsureInitialized. Whether they exist here depends on which
+			// other specs in the suite have already run, so filter them out rather than
+			// asserting an empty list.
+			By("Listing Tiers and checking there are no non-built-in tiers")
 			outList, outError := c.Tiers().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
-			Expect(outList.Items).To(HaveLen(0))
+			Expect(filterProtectedTiers(outList.Items)).To(HaveLen(0))
 			rev0 := outList.ResourceVersion
 
 			By("Configuring a Tier name1/spec1 and storing the response")
@@ -622,7 +641,7 @@ var _ = testutils.E2eDatastoreDescribe("Tier tests", testutils.DatastoreAll, fun
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.Tiers().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			testWatcher3 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+			testWatcher3 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w, names.ProtectedTierNames...)
 			defer testWatcher3.Stop()
 			testWatcher3.ExpectEvents(apiv3.KindTier, []watch.Event{
 				{
@@ -645,7 +664,7 @@ var _ = testutils.E2eDatastoreDescribe("Tier tests", testutils.DatastoreAll, fun
 			By("Starting a watcher not specifying a rev - expect the current snapshot")
 			w, err = c.Tiers().Watch(ctx, options.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			testWatcher4 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w)
+			testWatcher4 := testutils.NewTestResourceWatch(config.Spec.DatastoreType, w, names.ProtectedTierNames...)
 			defer testWatcher4.Stop()
 			testWatcher4.ExpectEventsAnyOrder(apiv3.KindTier, []watch.Event{
 				{

--- a/libcalico-go/lib/names/policy.go
+++ b/libcalico-go/lib/names/policy.go
@@ -14,7 +14,10 @@
 
 package names
 
-import "reflect"
+import (
+	"reflect"
+	"slices"
+)
 
 const (
 	DefaultTierName      = "default"
@@ -24,6 +27,22 @@ const (
 	// OpenStackNetworkPolicyNamePrefix is the prefix for OpenStack security groups.
 	OpenStackNetworkPolicyNamePrefix = "ossg."
 )
+
+// ProtectedTierNames are the built-in tiers that always exist and cannot be
+// deleted: a ValidatingAdmissionPolicy blocks their deletion and
+// EnsureInitialized recreates them. This is narrower than TierIsStatic, which
+// also covers the adminnetworkpolicy/baselineadminnetworkpolicy tiers - those
+// are static but deletable, so cleanup paths must not skip them.
+var ProtectedTierNames = []string{
+	DefaultTierName,
+	KubeAdminTierName,
+	KubeBaselineTierName,
+}
+
+// TierIsProtected returns true for the built-in tiers that cannot be deleted.
+func TierIsProtected(name string) bool {
+	return slices.Contains(ProtectedTierNames, name)
+}
 
 // TierOrDefault returns the tier name, or the default if blank.
 func TierOrDefault(tier string) string {

--- a/libcalico-go/lib/testutils/resources.go
+++ b/libcalico-go/lib/testutils/resources.go
@@ -113,15 +113,23 @@ func (m *resourceMatcher) NegatedFailureMessage(actual any) (message string) {
 	return
 }
 
-// TestResourceWatch is a test helper used to validate a set of events are received
-// from a watcher.  The caller creates a watch.Interface from the resource-specific
-// client and passes that to TestResourceWatch to create a TestResourceWatchInterface.
-func NewTestResourceWatch(datastoreType apiconfig.DatastoreType, w watch.Interface) TestResourceWatchInterface {
+// NewTestResourceWatch is a test helper used to validate a set of events are
+// received from a watcher. The caller creates a watch.Interface from the
+// resource-specific client and passes that in to get a TestResourceWatchInterface.
+// Any names passed in ignoredNames are filtered out of the received events, which
+// is useful for watches that return a snapshot of resources the caller does not
+// control - for example the built-in tiers, which always exist and cannot be deleted.
+func NewTestResourceWatch(datastoreType apiconfig.DatastoreType, w watch.Interface, ignoredNames ...string) TestResourceWatchInterface {
+	ignored := map[string]bool{}
+	for _, n := range ignoredNames {
+		ignored[n] = true
+	}
 	tw := &testResourceWatcher{
 		datastoreType: datastoreType,
 		watch:         w,
 		events:        []watch.Event{},
 		watchClosedCh: make(chan struct{}),
+		ignoredNames:  ignored,
 	}
 	go tw.run()
 	return tw
@@ -154,6 +162,10 @@ type testResourceWatcher struct {
 	watchClosedCh chan struct{}
 	closing       bool
 	lock          sync.Mutex
+
+	// ignoredNames are resource names whose events are dropped before they reach
+	// the events list, so they don't count towards the expected event set.
+	ignoredNames map[string]bool
 }
 
 // run is the main loop that consumes and stores the watch events.
@@ -161,6 +173,9 @@ func (t *testResourceWatcher) run() {
 	for {
 		select {
 		case event := <-t.watch.ResultChan():
+			if t.ignored(event) {
+				continue
+			}
 			t.lock.Lock()
 			t.events = append(t.events, event)
 			t.lock.Unlock()
@@ -169,6 +184,22 @@ func (t *testResourceWatcher) run() {
 			return
 		}
 	}
+}
+
+// ignored reports whether the event is for a resource the caller asked to skip.
+func (t *testResourceWatcher) ignored(e watch.Event) bool {
+	if len(t.ignoredNames) == 0 {
+		return false
+	}
+	obj := e.Object
+	if obj == nil {
+		obj = e.Previous
+	}
+	accessor, ok := obj.(v1.ObjectMetaAccessor)
+	if !ok {
+		return false
+	}
+	return t.ignoredNames[accessor.GetObjectMeta().GetName()]
 }
 
 // Stop closes down the Watcher and the main watch loop.

--- a/libcalico-go/lib/validator/v3/validator_test.go
+++ b/libcalico-go/lib/validator/v3/validator_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
@@ -3890,7 +3891,14 @@ var _ = testutils.E2eDatastoreDescribe("e2e validation tests", testutils.Datasto
 		// Try to create the Tier.
 		_, err = client.Tiers().Create(context.Background(), &tierSpec, options.SetOptions{})
 		if errStr == "" {
-			Expect(err).NotTo(HaveOccurred())
+			// The built-in tiers (default, kube-admin, kube-baseline) can't be deleted,
+			// so Clean() leaves them in place between tests. A create that collides with
+			// one returns AlreadyExists, which still means validation admitted the spec.
+			if names.TierIsProtected(tierSpec.Name) && err != nil {
+				Expect(err).To(BeAssignableToTypeOf(cerrors.ErrorResourceAlreadyExists{}))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
 		} else {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(errStr), "Expected error message to contain substring")

--- a/node/Makefile
+++ b/node/Makefile
@@ -318,7 +318,7 @@ $(BIRD_SOURCE): .bird-source.created
 .bird-source.created:
 	rm -rf filesystem/included-source/bird*
 	mkdir -p filesystem/included-source/
-	curl -sSf -L --retry 5 -o $(BIRD_SOURCE) https://github.com/projectcalico/bird/tarball/$(BIRD_VERSION)
+	curl -sSf -L --retry 5 --retry-all-errors --http1.1 -o $(BIRD_SOURCE) https://github.com/projectcalico/bird/tarball/$(BIRD_VERSION)
 	touch $@
 
 # include GPL felix code in the image.
@@ -493,14 +493,14 @@ $(WINDOWS_ARCHIVE_ROOT)/confd/templates/%: windows-packaging/templates/%
         chmod +w $@
 
 $(WINDOWS_ARCHIVE_ROOT)/libs/hns/hns.psm1:
-	curl -sSf -L --retry 5 -o $@ $(MICROSOFT_SDN_GITHUB_RAW_URL)/Kubernetes/windows/hns.psm1
+	curl -sSf -L --retry 5 --retry-all-errors --http1.1 -o $@ $(MICROSOFT_SDN_GITHUB_RAW_URL)/Kubernetes/windows/hns.psm1
 
 $(WINDOWS_ARCHIVE_ROOT)/libs/hns/License.txt:
-	curl -sSf -L --retry 5 -o $@  $(MICROSOFT_SDN_GITHUB_RAW_URL)/License.txt
+	curl -sSf -L --retry 5 --retry-all-errors --http1.1 -o $@  $(MICROSOFT_SDN_GITHUB_RAW_URL)/License.txt
 
 ## Download NSSM.
 windows-packaging/nssm.zip:
-	curl -sSf -L --retry 5 -o $@ $(WINDOWS_NSSM_URL)
+	curl -sSf -L --retry 5 --retry-all-errors --http1.1 -o $@ $(WINDOWS_NSSM_URL)
 
 windows-packaging/nssm.exe: windows-packaging/nssm.zip
 	cd windows-packaging && \


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#12884

A handful of CI flakes that showed up on https://github.com/projectcalico/calico/pull/12794, all pre-existing and unrelated to that PR's changes. The last two are fallout from #12824 landing on master.

**Windows archive build.** `make build-windows-archive` intermittently fails downloading `nssm.zip` (and friends) with `curl: (92) HTTP/2 stream 0 was not closed cleanly`. These downloads already had `--retry 5`, but plain `--retry` doesn't cover a mid-transfer HTTP/2 stream reset. Force HTTP/1.1 and add `--retry-all-errors`.

**libcalico-go tier watch test.** The "Tier watch functionality" test calls `Clean()` then asserts the datastore is empty. Since #12026 added a ValidatingAdmissionPolicy protecting the built-in tiers (default, kube-admin, kube-baseline), `Clean()` can't delete them, so they persist once any earlier spec creates them via `EnsureInitialized`. Ginkgo randomizes top-level container order, so whether they're present depends on the seed, which is the flake. The test now filters built-in tiers out of its list and snapshot-watch assertions, and `Clean()` skips them rather than burning its full retry budget failing to delete them.

**libcalico-go tier validation tests.** Same root cause. The validation tests create the built-in tiers and expect success. Now that they can't be deleted (#12824), `Clean()` leaves them around between tests, so the create comes back as `AlreadyExists`. That still means validation admitted the spec, so the test tolerates it for the built-in tiers.

**calicoctl datastore migrate import.** Same root cause. The import precondition refuses to run when the target datastore already has Calico resources, and the built-in tiers now count even though they're created automatically and can't be deleted. In practice the apiserver is usually installed after the migration so a real import target won't have them yet, but the check shouldn't treat them as user data regardless. Import now skips the built-in tiers, the same way it already skips Kubernetes-backed network policies.

```release-note
None
```

