### PR TITLE
fix(release): build Windows images after Linux so nft-rpms context resolves (v3.32)

### DIFF
--- a/hack/rpms/nftables/image.mk
+++ b/hack/rpms/nftables/image.mk
@@ -11,11 +11,12 @@
 
 NFT_RPMS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-# Content-addressed tag. Hashes the spec files, patches, and the four
-# nftables/libnftnl version pins from metadata.mk. First 12 hex chars so the
-# tag stays human-scannable.
+# Content-addressed tag. Hashes the producer Dockerfile (whose base image
+# determines the dist tag and glibc requirements of the resulting RPMs), the
+# spec files, patches, and the four nftables/libnftnl version pins from
+# metadata.mk. First 12 hex chars so the tag stays human-scannable.
 NFT_RPMS_TAG := $(shell ( \
-		cat $(NFT_RPMS_DIR)libnftnl.spec $(NFT_RPMS_DIR)nftables.spec $(NFT_RPMS_DIR)patches/*.patch && \
+		cat $(NFT_RPMS_DIR)Dockerfile $(NFT_RPMS_DIR)libnftnl.spec $(NFT_RPMS_DIR)nftables.spec $(NFT_RPMS_DIR)patches/*.patch && \
 		echo $(NFTABLES_VER) $(NFTABLES_SHA256) $(LIBNFTNL_VER) $(LIBNFTNL_SHA256) \
 	) | sha256sum | cut -c1-12)
 

--- a/release/pkg/manager/calico/manager.go
+++ b/release/pkg/manager/calico/manager.go
@@ -1271,15 +1271,23 @@ func (r *CalicoManager) buildContainerImages() error {
 			return fmt.Errorf("failed to build %s: %s", dir, err)
 		}
 		logrus.Info(out)
-		if slices.Contains(windowsReleaseDirs, dir) {
-			out, err := r.makeInDirectoryWithOutput(filepath.Join(r.repoRoot, dir), "image-windows", env...)
-			if err != nil {
-				logrus.Error(out)
-				return fmt.Errorf("failed to build %s windows images: %s", dir, err)
-			}
-			logrus.Info(out)
+	}
 
+	// Build Windows images only after every Linux image is built. image-windows
+	// runs setup-windows-builder, which does `docker buildx create --use` and
+	// switches the global default buildx builder to the docker-container
+	// "calico-windows-builder". That builder cannot resolve the nft-rpms
+	// `--build-context docker-image://calico/nftables-rpms:<sha>-<arch>`
+	// reference, which only exists in the local docker daemon (node and istio
+	// rely on this). Running the Windows builds in a separate trailing loop
+	// keeps the builder switch from poisoning those Linux builds.
+	for _, dir := range windowsReleaseDirs {
+		out, err := r.makeInDirectoryWithOutput(filepath.Join(r.repoRoot, dir), "image-windows", env...)
+		if err != nil {
+			logrus.Error(out)
+			return fmt.Errorf("failed to build %s windows images: %s", dir, err)
 		}
+		logrus.Info(out)
 	}
 	return nil
 }
@@ -1369,10 +1377,10 @@ func (r *CalicoManager) publishContainerImages() error {
 	// We allow for a certain number of retries when publishing each directory, since
 	// network flakes can occasionally result in images failing to push.
 	maxRetries := 1
-	for _, dir := range imageReleaseDirs {
+	publish := func(dir, target string) error {
 		attempt := 0
 		for {
-			out, err := r.makeInDirectoryWithOutput(filepath.Join(r.repoRoot, dir), "release-publish", env...)
+			out, err := r.makeInDirectoryWithOutput(filepath.Join(r.repoRoot, dir), target, env...)
 			if err != nil {
 				if attempt < maxRetries {
 					logrus.WithField("attempt", attempt).WithError(err).Warn("Publish failed, retrying")
@@ -1380,31 +1388,25 @@ func (r *CalicoManager) publishContainerImages() error {
 					continue
 				}
 				logrus.Error(out)
-				return fmt.Errorf("failed to publish %s: %s", dir, err)
+				return fmt.Errorf("failed to publish %s (%s): %s", dir, target, err)
 			}
 
-			// Success - move on to the next directory.
+			// Success.
 			logrus.Info(out)
-			break
+			return nil
 		}
-		if slices.Contains(windowsReleaseDirs, dir) {
-			attempt := 0
-			for {
-				out, err := r.makeInDirectoryWithOutput(filepath.Join(r.repoRoot, dir), "release-windows", env...)
-				if err != nil {
-					if attempt < maxRetries {
-						logrus.WithField("attempt", attempt).WithError(err).Warn("Publish failed, retrying")
-						attempt++
-						continue
-					}
-					logrus.Error(out)
-					return fmt.Errorf("failed to publish %s windows images: %s", dir, err)
-				}
-
-				// Success - move on to the next directory.
-				logrus.Info(out)
-				break
-			}
+	}
+	for _, dir := range imageReleaseDirs {
+		if err := publish(dir, "release-publish"); err != nil {
+			return err
+		}
+	}
+	// Publish Windows images in a separate trailing loop, mirroring the build
+	// step: release-windows runs setup-windows-builder, which switches the
+	// global default buildx builder, so keep it out of the Linux publish loop.
+	for _, dir := range windowsReleaseDirs {
+		if err := publish(dir, "release-windows"); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
## What / why

`make hashrelease` on `release-v3.32` started failing on 2026-06-17 with:

```
docker.io/calico/nftables-rpms:225fa0e89ff5-amd64: not found
make[3]: *** [Makefile:110: .istio-cni.created-amd64] Error 1
```

### Root cause

The release tool ran the Windows `image-windows`/`release-windows` targets
**interleaved inside** the Linux loop in `buildContainerImages` /
`publishContainerImages`. `image-windows` runs `setup-windows-builder`, which
does `docker buildx create --use` and switches the **global default buildx
builder** to the docker-container `calico-windows-builder` (and never resets
it). Because `cni-plugin` (a Windows dir) builds *before* `istio`/`node` in the
loop, that switch poisoned the builder for the later Linux builds.

`node` and `istio` install-cni consume the patched nftables RPMs via
`--build-context nft-rpms=docker-image://calico/nftables-rpms:<sha>-<arch>`,
which is `--load`ed into the **local docker daemon** by design (see
`node/Makefile` / `istio/Makefile` comments). The docker-container builder
cannot read local-daemon-only images — it resolves `docker-image://` from a
**registry** — so the build only worked while that content-addressed tag
happened to be present on Docker Hub.

The trigger: #13005 (Jun 17) flipped `libnftnl.spec`'s license line
`LGPL-2.1-or-later → GPL-2.0-or-later`, a hash input to the content-addressed
tag, bumping it `af87a3eebfaf → 225fa0e89ff5`. The new tag was never pushed to
the registry, so the poisoned builder got a 404.

This is a structural drift, not a regression in #13005: `release-v3.31` and
`master` already build Windows images in a separate trailing loop (master
#12225). `release-v3.32` inherited the interleaved loop from #11285 and never
got #12225, so it's the only branch affected.

### Changes

1. **`release/.../manager.go`** — build/publish Windows images in a separate
   trailing loop after all Linux images, so the builder switch never poisons
   the nft-rpms-consuming Linux builds. Matches master and `release-v3.31`.
   Removes the dependency on the tag being pre-pushed to the registry.
2. **`hack/rpms/nftables/image.mk`** — include the producer `Dockerfile` in the
   content-addressed tag hash (it was omitted on v3.32, present on v3.31 and
   master). Prevents a stale producer image from being reused after a
   Dockerfile-only change (e.g. the `/src` corresponding-source stage). After
   this, `image.mk` is identical to master/v3.31.

### Testing

- `go build` / `go vet` / `go test ./release/pkg/manager/calico/` pass.
- `make -C hack/rpms/nftables print-tag` computes cleanly with the Dockerfile
  included.

**Release note:**
```release-note
None
```
