### PR TITLE
DO NOT MERGE: intentional Felix FV failure to test fv-tests-guru CI pipeline

### DIFF
--- a/felix/fv/iptables_force_programming_test.go
+++ b/felix/fv/iptables_force_programming_test.go
@@ -62,6 +62,12 @@ var _ = infrastructure.DatastoreDescribe("iptables force-programming tests", []a
 	})
 
 	It("should program an AssumeNeededOnEveryNode policy even with no users", func() {
+		// INTENTIONAL FAILURE — DO NOT MERGE. This draft PR exists only to drive a
+		// single, controlled Felix FV failure through the fv-tests-guru CI analysis
+		// and triage pipeline (verifying DB recording + PR triage). Revert this line.
+		Expect("fv-guru-pipeline").To(Equal("intentionally-failed"),
+			"intentional failure to exercise the fv-tests-guru CI analysis pipeline")
+
 		pol := api.NewGlobalNetworkPolicy()
 		pol.Name = "policy-1"
 		pol.Spec.Ingress = []api.Rule{


### PR DESCRIPTION
**DO NOT MERGE — draft / test PR.**

This intentionally fails a single Felix FV test (`iptables force-programming`,
iptables-mode only, so it fails in just the one iptables FV job) to drive one
controlled failure through the `fv-tests-guru` CI analysis + triage pipeline and
verify it end-to-end (DB recording to the new cluster, PR triage comment). The
failing line is clearly marked and will be reverted.

### Release Note
```release-note
None
```
