### PR TITLE
ci: cut GCS egress for go-build image and master build cache

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -53,8 +53,7 @@ global_job_config:
           # use GCS. (For PRs, SEMAPHORE_GIT_BRANCH is the base branch, so PRs
           # targeting master restore master's Semaphore cache.) Note: `cache
           # restore` exits 0 even on a miss, so we test for the restored file.
-          use_sem_cache=false
-          [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]] && use_sem_cache=true
+          if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then use_sem_cache=true; else use_sem_cache=false; fi
           rm -f /tmp/working-copy.tar.zstd
           if ${use_sem_cache}; then
             cache restore "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
@@ -347,12 +346,11 @@ blocks:
             - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
             - |-
               if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
-                # master uses Semaphore's free cache. Only refresh it on real
-                # branch builds, never on PRs: on a PR SEMAPHORE_GIT_BRANCH is the
-                # base branch (master), so storing here would thrash the shared
-                # master cache for concurrent PRs and master builds. PRs only
-                # restore (in the prologue) the copy populated by master builds.
-                # Semaphore cache keys are not overwritten, so delete-then-store.
+                # master uses Semaphore's free cache (other branches use GCS). This
+                # block's `when` already restricts it to branch builds; the
+                # SEMAPHORE_GIT_PR_NUMBER guard is belt-and-suspenders so a PR can
+                # never store (it would thrash the shared master cache that PRs only
+                # restore). Cache keys are not overwritten, so delete-then-store.
                 if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
                   cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
                   cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -49,12 +49,30 @@ global_job_config:
         if [[ -n "${SEMAPHORE_GIT_BRANCH}" && -z "$SKIP_CACHE_RESTORE" ]]; then
           echo "Looking for cached working copy for branch ${SEMAPHORE_GIT_BRANCH}"
           gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          if gcloud storage cp "$gcs_branch_cache_dir/working-copy.tar.zstd" /tmp/working-copy.tar.zstd; then
+          # On master, use Semaphore's free built-in cache; other branches still
+          # use GCS. (For PRs, SEMAPHORE_GIT_BRANCH is the base branch, so PRs
+          # targeting master restore master's Semaphore cache.) Note: `cache
+          # restore` exits 0 even on a miss, so we test for the restored file.
+          use_sem_cache=false
+          [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]] && use_sem_cache=true
+          rm -f /tmp/working-copy.tar.zstd
+          if ${use_sem_cache}; then
+            cache restore "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+          else
+            gcloud storage cp "$gcs_branch_cache_dir/working-copy.tar.zstd" /tmp/working-copy.tar.zstd || true
+          fi
+          if [[ -f /tmp/working-copy.tar.zstd ]]; then
             echo "Restoring cache for branch ${SEMAPHORE_GIT_BRANCH}"
             tar --use-compress-program=zstd -xf /tmp/working-copy.tar.zstd & tar_pid=$!
             downloaded_build_cache=false
             if [[ -n "$BUILD_CACHE_GROUP" && -n "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
-              if gcloud storage cp "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd" /tmp/build-cache.tar.zstd; then
+              rm -f /tmp/build-cache.tar.zstd
+              if ${use_sem_cache}; then
+                cache restore "build-cache-${SEMAPHORE_GIT_BRANCH}-${BUILD_CACHE_GROUP}" || true
+              else
+                gcloud storage cp "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd" /tmp/build-cache.tar.zstd || true
+              fi
+              if [[ -f /tmp/build-cache.tar.zstd ]]; then
                 echo "Found build cache for group ${BUILD_CACHE_GROUP}"
                 downloaded_build_cache=true
               fi
@@ -94,26 +112,6 @@ global_job_config:
           mkdir -p artifacts
         fi
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      # Best-effort: load calico/go-build from the GCS cache populated by the
-      # "Pull: go-build image" prerequisite job. Falls back to a Docker Hub pull
-      # on cache miss. Skipped on non-x86_64 / cross-compile agents since the
-      # cache is amd64-only.
-      - |-
-        if [[ $(uname -m) == "x86_64" && -z "$ARCH" ]]; then
-          GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
-          image="calico/go-build:${GO_BUILD_VER}"
-          if ! docker image inspect "$image" >/dev/null 2>&1; then
-            cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
-            if gcloud storage cp "$cache_path" /tmp/go-build.tar.zst 2>/dev/null; then
-              echo "Loading ${image} from GCS cache"
-              zstd -d --rm -o /tmp/go-build.tar /tmp/go-build.tar.zst
-              docker load -i /tmp/go-build.tar
-              rm -f /tmp/go-build.tar
-            else
-              echo "No GCS cache for ${image}, docker will pull from Docker Hub if needed"
-            fi
-          fi
-        fi
   epilogue:
     commands:
       - cd $HOME
@@ -121,8 +119,16 @@ global_job_config:
         if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && -n "$BUILD_CACHE_GROUP" && "$STORE_BUILD_CACHE" = "true" ]]; then
           echo "On branch, storing build cache group ${BUILD_CACHE_GROUP}"
           tar --use-compress-program="zstd -3" -cf /tmp/build-cache.tar.zstd go ${CALICO_DIR_NAME}/.go-pkg-cache
-          gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          gcloud storage cp /tmp/build-cache.tar.zstd "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd"
+          if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
+            # master uses Semaphore's free cache; delete-then-store guarantees a
+            # refresh each master build regardless of `cache store` overwrite semantics.
+            key="build-cache-${SEMAPHORE_GIT_BRANCH}-${BUILD_CACHE_GROUP}"
+            cache delete "$key" || true
+            cache store "$key" /tmp/build-cache.tar.zstd
+          else
+            gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
+            gcloud storage cp /tmp/build-cache.tar.zstd "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd"
+          fi
         fi
       - cd "$CALICO_DIR"
       - .semaphore/publish-artifacts
@@ -339,8 +345,22 @@ blocks:
           commands:
             - cd ..
             - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
-            - gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-            - gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+            - |-
+              if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
+                # master uses Semaphore's free cache. Only refresh it on real
+                # branch builds, never on PRs: on a PR SEMAPHORE_GIT_BRANCH is the
+                # base branch (master), so storing here would thrash the shared
+                # master cache for concurrent PRs and master builds. PRs only
+                # restore (in the prologue) the copy populated by master builds.
+                # Semaphore cache keys are not overwritten, so delete-then-store.
+                if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
+                  cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+                  cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
+                fi
+              else
+                gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
+                gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+              fi
   - name: "Build: nftables RPMs"
     # Producer for the patched nftables + libnftnl RPMs that calico/node and the
     # istio CNI install image consume. The image tag is content-addressed (sha
@@ -385,34 +405,6 @@ blocks:
                 - s390x
           commands:
             - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
-  - name: "Pull: go-build image"
-    # Populate the GCS cache of calico/go-build so that every downstream job can
-    # docker-load it from GCS (faster, and avoids Docker Hub rate limits) rather
-    # than pulling cold from Docker Hub. The cache is keyed by GO_BUILD_VER so
-    # the tarball survives across workflows — the common case is a no-op
-    # `gcloud storage ls` on a cache hit.
-    run:
-      when: "true"
-    dependencies: []
-    task:
-      env_vars:
-        - name: SKIP_CACHE_RESTORE
-          value: "true"
-      jobs:
-        - name: "Cache calico/go-build to GCS"
-          commands:
-            - GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
-            - cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
-            - |-
-              if gcloud storage ls "$cache_path" >/dev/null 2>&1; then
-                echo "Cache hit for calico/go-build:${GO_BUILD_VER}"
-              else
-                echo "Cache miss for calico/go-build:${GO_BUILD_VER}, pulling and uploading"
-                docker pull "calico/go-build:${GO_BUILD_VER}"
-                docker save "calico/go-build:${GO_BUILD_VER}" -o /tmp/go-build.tar
-                zstd -3 --rm /tmp/go-build.tar
-                gcloud storage cp /tmp/go-build.tar.zst "$cache_path"
-              fi
   - name: "Build: calico image"
     # Build and cache the calico image so that downstream CI blocks can load it
     # from GCS instead of rebuilding per component. This block is the sole
@@ -560,7 +552,6 @@ blocks:
       - Check protobufs
       - Manifests and API docs
       - Store working copy
-      - "Pull: go-build image"
     task:
       jobs:
         - name: Pre-flight checks

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -375,14 +375,11 @@ blocks:
             - |-
               if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
                 # master uses Semaphore's free cache (other branches use GCS). This
-                # block's `when` already restricts it to branch builds; the
-                # SEMAPHORE_GIT_PR_NUMBER guard is belt-and-suspenders so a PR can
-                # never store (it would thrash the shared master cache that PRs only
-                # restore). Cache keys are not overwritten, so delete-then-store.
-                if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
-                  cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
-                  cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
-                fi
+                # block only runs on branch builds (its `when: "branch =~ '.*'"`),
+                # so PRs never store here — they only restore, in the prologue.
+                # Cache keys are not overwritten, so delete-then-store to refresh.
+                cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+                cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
               else
                 gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
                 gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -111,6 +111,34 @@ global_job_config:
           mkdir -p artifacts
         fi
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Ensure calico/go-build is present, cheaply. Pull from Docker Hub first
+      # (free egress) and only fall back to the GCS cache — populated by the
+      # "Pull: go-build image" prerequisite job — if the pull fails. This keeps
+      # GCS egress near zero in the common case while keeping GCS as a robustness
+      # fallback for the occasional Docker Hub pull failure (which we still see
+      # even with an authenticated session). Skipped on non-x86_64 / cross-compile
+      # agents since the cache is amd64-only.
+      - |-
+        if [[ $(uname -m) == "x86_64" && -z "$ARCH" ]]; then
+          GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
+          image="calico/go-build:${GO_BUILD_VER}"
+          if ! docker image inspect "$image" >/dev/null 2>&1; then
+            if docker pull "$image"; then
+              echo "Pulled ${image} from Docker Hub"
+            else
+              echo "Docker Hub pull failed for ${image}, falling back to GCS cache"
+              cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
+              if gcloud storage cp "$cache_path" /tmp/go-build.tar.zst 2>/dev/null; then
+                echo "Loading ${image} from GCS cache"
+                zstd -d --rm -o /tmp/go-build.tar /tmp/go-build.tar.zst
+                docker load -i /tmp/go-build.tar
+                rm -f /tmp/go-build.tar
+              else
+                echo "No GCS fallback for ${image}; later docker use will retry the pull"
+              fi
+            fi
+          fi
+        fi
   epilogue:
     commands:
       - cd $HOME
@@ -403,6 +431,36 @@ blocks:
                 - s390x
           commands:
             - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
+  - name: "Pull: go-build image"
+    # Populate the GCS cache of calico/go-build so it can serve as a fallback when
+    # a Docker Hub pull fails (which we still see occasionally even with an
+    # authenticated session). Jobs pull from Docker Hub first and only fall back to
+    # this GCS copy on failure (see the global prologue), so this is just an
+    # insurance upload — uploads are free and the common case is a no-op
+    # `gcloud storage ls` cache hit, keyed by GO_BUILD_VER so the tarball survives
+    # across workflows.
+    run:
+      when: "true"
+    dependencies: []
+    task:
+      env_vars:
+        - name: SKIP_CACHE_RESTORE
+          value: "true"
+      jobs:
+        - name: "Cache calico/go-build to GCS"
+          commands:
+            - GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
+            - cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
+            - |-
+              if gcloud storage ls "$cache_path" >/dev/null 2>&1; then
+                echo "Cache hit for calico/go-build:${GO_BUILD_VER}"
+              else
+                echo "Cache miss for calico/go-build:${GO_BUILD_VER}, pulling and uploading"
+                docker pull "calico/go-build:${GO_BUILD_VER}"
+                docker save "calico/go-build:${GO_BUILD_VER}" -o /tmp/go-build.tar
+                zstd -3 --rm /tmp/go-build.tar
+                gcloud storage cp /tmp/go-build.tar.zst "$cache_path"
+              fi
   - name: "Build: calico image"
     # Build and cache the calico image so that downstream CI blocks can load it
     # from GCS instead of rebuilding per component. This block is the sole
@@ -550,6 +608,7 @@ blocks:
       - Check protobufs
       - Manifests and API docs
       - Store working copy
+      - "Pull: go-build image"
     task:
       jobs:
         - name: Pre-flight checks

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -53,8 +53,7 @@ global_job_config:
           # use GCS. (For PRs, SEMAPHORE_GIT_BRANCH is the base branch, so PRs
           # targeting master restore master's Semaphore cache.) Note: `cache
           # restore` exits 0 even on a miss, so we test for the restored file.
-          use_sem_cache=false
-          [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]] && use_sem_cache=true
+          if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then use_sem_cache=true; else use_sem_cache=false; fi
           rm -f /tmp/working-copy.tar.zstd
           if ${use_sem_cache}; then
             cache restore "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
@@ -347,12 +346,11 @@ blocks:
             - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
             - |-
               if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
-                # master uses Semaphore's free cache. Only refresh it on real
-                # branch builds, never on PRs: on a PR SEMAPHORE_GIT_BRANCH is the
-                # base branch (master), so storing here would thrash the shared
-                # master cache for concurrent PRs and master builds. PRs only
-                # restore (in the prologue) the copy populated by master builds.
-                # Semaphore cache keys are not overwritten, so delete-then-store.
+                # master uses Semaphore's free cache (other branches use GCS). This
+                # block's `when` already restricts it to branch builds; the
+                # SEMAPHORE_GIT_PR_NUMBER guard is belt-and-suspenders so a PR can
+                # never store (it would thrash the shared master cache that PRs only
+                # restore). Cache keys are not overwritten, so delete-then-store.
                 if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
                   cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
                   cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,12 +49,30 @@ global_job_config:
         if [[ -n "${SEMAPHORE_GIT_BRANCH}" && -z "$SKIP_CACHE_RESTORE" ]]; then
           echo "Looking for cached working copy for branch ${SEMAPHORE_GIT_BRANCH}"
           gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          if gcloud storage cp "$gcs_branch_cache_dir/working-copy.tar.zstd" /tmp/working-copy.tar.zstd; then
+          # On master, use Semaphore's free built-in cache; other branches still
+          # use GCS. (For PRs, SEMAPHORE_GIT_BRANCH is the base branch, so PRs
+          # targeting master restore master's Semaphore cache.) Note: `cache
+          # restore` exits 0 even on a miss, so we test for the restored file.
+          use_sem_cache=false
+          [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]] && use_sem_cache=true
+          rm -f /tmp/working-copy.tar.zstd
+          if ${use_sem_cache}; then
+            cache restore "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+          else
+            gcloud storage cp "$gcs_branch_cache_dir/working-copy.tar.zstd" /tmp/working-copy.tar.zstd || true
+          fi
+          if [[ -f /tmp/working-copy.tar.zstd ]]; then
             echo "Restoring cache for branch ${SEMAPHORE_GIT_BRANCH}"
             tar --use-compress-program=zstd -xf /tmp/working-copy.tar.zstd & tar_pid=$!
             downloaded_build_cache=false
             if [[ -n "$BUILD_CACHE_GROUP" && -n "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
-              if gcloud storage cp "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd" /tmp/build-cache.tar.zstd; then
+              rm -f /tmp/build-cache.tar.zstd
+              if ${use_sem_cache}; then
+                cache restore "build-cache-${SEMAPHORE_GIT_BRANCH}-${BUILD_CACHE_GROUP}" || true
+              else
+                gcloud storage cp "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd" /tmp/build-cache.tar.zstd || true
+              fi
+              if [[ -f /tmp/build-cache.tar.zstd ]]; then
                 echo "Found build cache for group ${BUILD_CACHE_GROUP}"
                 downloaded_build_cache=true
               fi
@@ -94,26 +112,6 @@ global_job_config:
           mkdir -p artifacts
         fi
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      # Best-effort: load calico/go-build from the GCS cache populated by the
-      # "Pull: go-build image" prerequisite job. Falls back to a Docker Hub pull
-      # on cache miss. Skipped on non-x86_64 / cross-compile agents since the
-      # cache is amd64-only.
-      - |-
-        if [[ $(uname -m) == "x86_64" && -z "$ARCH" ]]; then
-          GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
-          image="calico/go-build:${GO_BUILD_VER}"
-          if ! docker image inspect "$image" >/dev/null 2>&1; then
-            cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
-            if gcloud storage cp "$cache_path" /tmp/go-build.tar.zst 2>/dev/null; then
-              echo "Loading ${image} from GCS cache"
-              zstd -d --rm -o /tmp/go-build.tar /tmp/go-build.tar.zst
-              docker load -i /tmp/go-build.tar
-              rm -f /tmp/go-build.tar
-            else
-              echo "No GCS cache for ${image}, docker will pull from Docker Hub if needed"
-            fi
-          fi
-        fi
   epilogue:
     commands:
       - cd $HOME
@@ -121,8 +119,16 @@ global_job_config:
         if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && -n "$BUILD_CACHE_GROUP" && "$STORE_BUILD_CACHE" = "true" ]]; then
           echo "On branch, storing build cache group ${BUILD_CACHE_GROUP}"
           tar --use-compress-program="zstd -3" -cf /tmp/build-cache.tar.zstd go ${CALICO_DIR_NAME}/.go-pkg-cache
-          gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          gcloud storage cp /tmp/build-cache.tar.zstd "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd"
+          if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
+            # master uses Semaphore's free cache; delete-then-store guarantees a
+            # refresh each master build regardless of `cache store` overwrite semantics.
+            key="build-cache-${SEMAPHORE_GIT_BRANCH}-${BUILD_CACHE_GROUP}"
+            cache delete "$key" || true
+            cache store "$key" /tmp/build-cache.tar.zstd
+          else
+            gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
+            gcloud storage cp /tmp/build-cache.tar.zstd "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd"
+          fi
         fi
       - cd "$CALICO_DIR"
       - .semaphore/publish-artifacts
@@ -339,8 +345,22 @@ blocks:
           commands:
             - cd ..
             - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
-            - gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-            - gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+            - |-
+              if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
+                # master uses Semaphore's free cache. Only refresh it on real
+                # branch builds, never on PRs: on a PR SEMAPHORE_GIT_BRANCH is the
+                # base branch (master), so storing here would thrash the shared
+                # master cache for concurrent PRs and master builds. PRs only
+                # restore (in the prologue) the copy populated by master builds.
+                # Semaphore cache keys are not overwritten, so delete-then-store.
+                if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
+                  cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+                  cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
+                fi
+              else
+                gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
+                gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+              fi
   - name: "Build: nftables RPMs"
     # Producer for the patched nftables + libnftnl RPMs that calico/node and the
     # istio CNI install image consume. The image tag is content-addressed (sha
@@ -654,34 +674,6 @@ blocks:
                 - s390x
           commands:
             - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
-  - name: "Pull: go-build image"
-    # Populate the GCS cache of calico/go-build so that every downstream job can
-    # docker-load it from GCS (faster, and avoids Docker Hub rate limits) rather
-    # than pulling cold from Docker Hub. The cache is keyed by GO_BUILD_VER so
-    # the tarball survives across workflows — the common case is a no-op
-    # `gcloud storage ls` on a cache hit.
-    run:
-      when: "true"
-    dependencies: []
-    task:
-      env_vars:
-        - name: SKIP_CACHE_RESTORE
-          value: "true"
-      jobs:
-        - name: "Cache calico/go-build to GCS"
-          commands:
-            - GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
-            - cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
-            - |-
-              if gcloud storage ls "$cache_path" >/dev/null 2>&1; then
-                echo "Cache hit for calico/go-build:${GO_BUILD_VER}"
-              else
-                echo "Cache miss for calico/go-build:${GO_BUILD_VER}, pulling and uploading"
-                docker pull "calico/go-build:${GO_BUILD_VER}"
-                docker save "calico/go-build:${GO_BUILD_VER}" -o /tmp/go-build.tar
-                zstd -3 --rm /tmp/go-build.tar
-                gcloud storage cp /tmp/go-build.tar.zst "$cache_path"
-              fi
   - name: "Build: calico image"
     # Build and cache the calico image so that downstream CI blocks can load it
     # from GCS instead of rebuilding per component. This block is the sole
@@ -970,8 +962,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -1501,7 +1495,6 @@ blocks:
       - Check protobufs
       - Manifests and API docs
       - Store working copy
-      - "Pull: go-build image"
     task:
       jobs:
         - name: Pre-flight checks
@@ -2078,8 +2071,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -2869,8 +2864,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -5520,8 +5517,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -6025,7 +6024,9 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/testutils/json/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -375,14 +375,11 @@ blocks:
             - |-
               if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
                 # master uses Semaphore's free cache (other branches use GCS). This
-                # block's `when` already restricts it to branch builds; the
-                # SEMAPHORE_GIT_PR_NUMBER guard is belt-and-suspenders so a PR can
-                # never store (it would thrash the shared master cache that PRs only
-                # restore). Cache keys are not overwritten, so delete-then-store.
-                if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
-                  cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
-                  cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
-                fi
+                # block only runs on branch builds (its `when: "branch =~ '.*'"`),
+                # so PRs never store here — they only restore, in the prologue.
+                # Cache keys are not overwritten, so delete-then-store to refresh.
+                cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+                cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
               else
                 gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
                 gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -111,6 +111,34 @@ global_job_config:
           mkdir -p artifacts
         fi
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Ensure calico/go-build is present, cheaply. Pull from Docker Hub first
+      # (free egress) and only fall back to the GCS cache — populated by the
+      # "Pull: go-build image" prerequisite job — if the pull fails. This keeps
+      # GCS egress near zero in the common case while keeping GCS as a robustness
+      # fallback for the occasional Docker Hub pull failure (which we still see
+      # even with an authenticated session). Skipped on non-x86_64 / cross-compile
+      # agents since the cache is amd64-only.
+      - |-
+        if [[ $(uname -m) == "x86_64" && -z "$ARCH" ]]; then
+          GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
+          image="calico/go-build:${GO_BUILD_VER}"
+          if ! docker image inspect "$image" >/dev/null 2>&1; then
+            if docker pull "$image"; then
+              echo "Pulled ${image} from Docker Hub"
+            else
+              echo "Docker Hub pull failed for ${image}, falling back to GCS cache"
+              cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
+              if gcloud storage cp "$cache_path" /tmp/go-build.tar.zst 2>/dev/null; then
+                echo "Loading ${image} from GCS cache"
+                zstd -d --rm -o /tmp/go-build.tar /tmp/go-build.tar.zst
+                docker load -i /tmp/go-build.tar
+                rm -f /tmp/go-build.tar
+              else
+                echo "No GCS fallback for ${image}; later docker use will retry the pull"
+              fi
+            fi
+          fi
+        fi
   epilogue:
     commands:
       - cd $HOME
@@ -672,6 +700,36 @@ blocks:
                 - s390x
           commands:
             - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
+  - name: "Pull: go-build image"
+    # Populate the GCS cache of calico/go-build so it can serve as a fallback when
+    # a Docker Hub pull fails (which we still see occasionally even with an
+    # authenticated session). Jobs pull from Docker Hub first and only fall back to
+    # this GCS copy on failure (see the global prologue), so this is just an
+    # insurance upload — uploads are free and the common case is a no-op
+    # `gcloud storage ls` cache hit, keyed by GO_BUILD_VER so the tarball survives
+    # across workflows.
+    run:
+      when: "true"
+    dependencies: []
+    task:
+      env_vars:
+        - name: SKIP_CACHE_RESTORE
+          value: "true"
+      jobs:
+        - name: "Cache calico/go-build to GCS"
+          commands:
+            - GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
+            - cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
+            - |-
+              if gcloud storage ls "$cache_path" >/dev/null 2>&1; then
+                echo "Cache hit for calico/go-build:${GO_BUILD_VER}"
+              else
+                echo "Cache miss for calico/go-build:${GO_BUILD_VER}, pulling and uploading"
+                docker pull "calico/go-build:${GO_BUILD_VER}"
+                docker save "calico/go-build:${GO_BUILD_VER}" -o /tmp/go-build.tar
+                zstd -3 --rm /tmp/go-build.tar
+                gcloud storage cp /tmp/go-build.tar.zst "$cache_path"
+              fi
   - name: "Build: calico image"
     # Build and cache the calico image so that downstream CI blocks can load it
     # from GCS instead of rebuilding per component. This block is the sole
@@ -1493,6 +1551,7 @@ blocks:
       - Check protobufs
       - Manifests and API docs
       - Store working copy
+      - "Pull: go-build image"
     task:
       jobs:
         - name: Pre-flight checks

--- a/.semaphore/semaphore.yml.d/02-global_job_config.yml
+++ b/.semaphore/semaphore.yml.d/02-global_job_config.yml
@@ -37,8 +37,7 @@ global_job_config:
           # use GCS. (For PRs, SEMAPHORE_GIT_BRANCH is the base branch, so PRs
           # targeting master restore master's Semaphore cache.) Note: `cache
           # restore` exits 0 even on a miss, so we test for the restored file.
-          use_sem_cache=false
-          [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]] && use_sem_cache=true
+          if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then use_sem_cache=true; else use_sem_cache=false; fi
           rm -f /tmp/working-copy.tar.zstd
           if ${use_sem_cache}; then
             cache restore "working-copy-${SEMAPHORE_GIT_BRANCH}" || true

--- a/.semaphore/semaphore.yml.d/02-global_job_config.yml
+++ b/.semaphore/semaphore.yml.d/02-global_job_config.yml
@@ -33,12 +33,30 @@ global_job_config:
         if [[ -n "${SEMAPHORE_GIT_BRANCH}" && -z "$SKIP_CACHE_RESTORE" ]]; then
           echo "Looking for cached working copy for branch ${SEMAPHORE_GIT_BRANCH}"
           gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          if gcloud storage cp "$gcs_branch_cache_dir/working-copy.tar.zstd" /tmp/working-copy.tar.zstd; then
+          # On master, use Semaphore's free built-in cache; other branches still
+          # use GCS. (For PRs, SEMAPHORE_GIT_BRANCH is the base branch, so PRs
+          # targeting master restore master's Semaphore cache.) Note: `cache
+          # restore` exits 0 even on a miss, so we test for the restored file.
+          use_sem_cache=false
+          [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]] && use_sem_cache=true
+          rm -f /tmp/working-copy.tar.zstd
+          if ${use_sem_cache}; then
+            cache restore "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+          else
+            gcloud storage cp "$gcs_branch_cache_dir/working-copy.tar.zstd" /tmp/working-copy.tar.zstd || true
+          fi
+          if [[ -f /tmp/working-copy.tar.zstd ]]; then
             echo "Restoring cache for branch ${SEMAPHORE_GIT_BRANCH}"
             tar --use-compress-program=zstd -xf /tmp/working-copy.tar.zstd & tar_pid=$!
             downloaded_build_cache=false
             if [[ -n "$BUILD_CACHE_GROUP" && -n "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
-              if gcloud storage cp "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd" /tmp/build-cache.tar.zstd; then
+              rm -f /tmp/build-cache.tar.zstd
+              if ${use_sem_cache}; then
+                cache restore "build-cache-${SEMAPHORE_GIT_BRANCH}-${BUILD_CACHE_GROUP}" || true
+              else
+                gcloud storage cp "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd" /tmp/build-cache.tar.zstd || true
+              fi
+              if [[ -f /tmp/build-cache.tar.zstd ]]; then
                 echo "Found build cache for group ${BUILD_CACHE_GROUP}"
                 downloaded_build_cache=true
               fi
@@ -78,26 +96,6 @@ global_job_config:
           mkdir -p artifacts
         fi
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      # Best-effort: load calico/go-build from the GCS cache populated by the
-      # "Pull: go-build image" prerequisite job. Falls back to a Docker Hub pull
-      # on cache miss. Skipped on non-x86_64 / cross-compile agents since the
-      # cache is amd64-only.
-      - |-
-        if [[ $(uname -m) == "x86_64" && -z "$ARCH" ]]; then
-          GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
-          image="calico/go-build:${GO_BUILD_VER}"
-          if ! docker image inspect "$image" >/dev/null 2>&1; then
-            cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
-            if gcloud storage cp "$cache_path" /tmp/go-build.tar.zst 2>/dev/null; then
-              echo "Loading ${image} from GCS cache"
-              zstd -d --rm -o /tmp/go-build.tar /tmp/go-build.tar.zst
-              docker load -i /tmp/go-build.tar
-              rm -f /tmp/go-build.tar
-            else
-              echo "No GCS cache for ${image}, docker will pull from Docker Hub if needed"
-            fi
-          fi
-        fi
   epilogue:
     commands:
       - cd $HOME
@@ -105,8 +103,16 @@ global_job_config:
         if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" && -n "$BUILD_CACHE_GROUP" && "$STORE_BUILD_CACHE" = "true" ]]; then
           echo "On branch, storing build cache group ${BUILD_CACHE_GROUP}"
           tar --use-compress-program="zstd -3" -cf /tmp/build-cache.tar.zstd go ${CALICO_DIR_NAME}/.go-pkg-cache
-          gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          gcloud storage cp /tmp/build-cache.tar.zstd "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd"
+          if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
+            # master uses Semaphore's free cache; delete-then-store guarantees a
+            # refresh each master build regardless of `cache store` overwrite semantics.
+            key="build-cache-${SEMAPHORE_GIT_BRANCH}-${BUILD_CACHE_GROUP}"
+            cache delete "$key" || true
+            cache store "$key" /tmp/build-cache.tar.zstd
+          else
+            gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
+            gcloud storage cp /tmp/build-cache.tar.zstd "$gcs_branch_cache_dir/build-cache-${BUILD_CACHE_GROUP}.tar.zstd"
+          fi
         fi
       - cd "$CALICO_DIR"
       - .semaphore/publish-artifacts

--- a/.semaphore/semaphore.yml.d/02-global_job_config.yml
+++ b/.semaphore/semaphore.yml.d/02-global_job_config.yml
@@ -95,6 +95,34 @@ global_job_config:
           mkdir -p artifacts
         fi
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Ensure calico/go-build is present, cheaply. Pull from Docker Hub first
+      # (free egress) and only fall back to the GCS cache — populated by the
+      # "Pull: go-build image" prerequisite job — if the pull fails. This keeps
+      # GCS egress near zero in the common case while keeping GCS as a robustness
+      # fallback for the occasional Docker Hub pull failure (which we still see
+      # even with an authenticated session). Skipped on non-x86_64 / cross-compile
+      # agents since the cache is amd64-only.
+      - |-
+        if [[ $(uname -m) == "x86_64" && -z "$ARCH" ]]; then
+          GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
+          image="calico/go-build:${GO_BUILD_VER}"
+          if ! docker image inspect "$image" >/dev/null 2>&1; then
+            if docker pull "$image"; then
+              echo "Pulled ${image} from Docker Hub"
+            else
+              echo "Docker Hub pull failed for ${image}, falling back to GCS cache"
+              cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
+              if gcloud storage cp "$cache_path" /tmp/go-build.tar.zst 2>/dev/null; then
+                echo "Loading ${image} from GCS cache"
+                zstd -d --rm -o /tmp/go-build.tar /tmp/go-build.tar.zst
+                docker load -i /tmp/go-build.tar
+                rm -f /tmp/go-build.tar
+              else
+                echo "No GCS fallback for ${image}; later docker use will retry the pull"
+              fi
+            fi
+          fi
+        fi
   epilogue:
     commands:
       - cd $HOME

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -126,12 +126,11 @@
           - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
           - |-
             if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
-              # master uses Semaphore's free cache. Only refresh it on real
-              # branch builds, never on PRs: on a PR SEMAPHORE_GIT_BRANCH is the
-              # base branch (master), so storing here would thrash the shared
-              # master cache for concurrent PRs and master builds. PRs only
-              # restore (in the prologue) the copy populated by master builds.
-              # Semaphore cache keys are not overwritten, so delete-then-store.
+              # master uses Semaphore's free cache (other branches use GCS). This
+              # block's `when` already restricts it to branch builds; the
+              # SEMAPHORE_GIT_PR_NUMBER guard is belt-and-suspenders so a PR can
+              # never store (it would thrash the shared master cache that PRs only
+              # restore). Cache keys are not overwritten, so delete-then-store.
               if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
                 cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
                 cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -185,6 +185,36 @@
         commands:
           - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
 
+- name: "Pull: go-build image"
+  # Populate the GCS cache of calico/go-build so it can serve as a fallback when
+  # a Docker Hub pull fails (which we still see occasionally even with an
+  # authenticated session). Jobs pull from Docker Hub first and only fall back to
+  # this GCS copy on failure (see the global prologue), so this is just an
+  # insurance upload — uploads are free and the common case is a no-op
+  # `gcloud storage ls` cache hit, keyed by GO_BUILD_VER so the tarball survives
+  # across workflows.
+  run:
+    when: "true"
+  dependencies: []
+  task:
+    env_vars:
+      - name: SKIP_CACHE_RESTORE
+        value: "true"
+    jobs:
+      - name: "Cache calico/go-build to GCS"
+        commands:
+          - GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
+          - cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
+          - |-
+            if gcloud storage ls "$cache_path" >/dev/null 2>&1; then
+              echo "Cache hit for calico/go-build:${GO_BUILD_VER}"
+            else
+              echo "Cache miss for calico/go-build:${GO_BUILD_VER}, pulling and uploading"
+              docker pull "calico/go-build:${GO_BUILD_VER}"
+              docker save "calico/go-build:${GO_BUILD_VER}" -o /tmp/go-build.tar
+              zstd -3 --rm /tmp/go-build.tar
+              gcloud storage cp /tmp/go-build.tar.zst "$cache_path"
+            fi
 - name: "Build: calico image"
   # Build and cache the calico image so that downstream CI blocks can load it
   # from GCS instead of rebuilding per component. This block is the sole
@@ -332,6 +362,7 @@
     - Check protobufs
     - Manifests and API docs
     - Store working copy
+    - "Pull: go-build image"
   task:
     jobs:
       - name: Pre-flight checks

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -124,8 +124,22 @@
         commands:
           - cd ..
           - tar --use-compress-program="zstd -3" -cf /tmp/working-copy.tar.zstd $CALICO_DIR_NAME
-          - gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
-          - gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+          - |-
+            if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
+              # master uses Semaphore's free cache. Only refresh it on real
+              # branch builds, never on PRs: on a PR SEMAPHORE_GIT_BRANCH is the
+              # base branch (master), so storing here would thrash the shared
+              # master cache for concurrent PRs and master builds. PRs only
+              # restore (in the prologue) the copy populated by master builds.
+              # Semaphore cache keys are not overwritten, so delete-then-store.
+              if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
+                cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+                cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
+              fi
+            else
+              gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
+              gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"
+            fi
 
 - name: "Build: nftables RPMs"
   # Producer for the patched nftables + libnftnl RPMs that calico/node and the
@@ -172,34 +186,6 @@
         commands:
           - .semaphore/scripts/build-nft-rpms.sh "${ARCH}"
 
-- name: "Pull: go-build image"
-  # Populate the GCS cache of calico/go-build so that every downstream job can
-  # docker-load it from GCS (faster, and avoids Docker Hub rate limits) rather
-  # than pulling cold from Docker Hub. The cache is keyed by GO_BUILD_VER so
-  # the tarball survives across workflows — the common case is a no-op
-  # `gcloud storage ls` on a cache hit.
-  run:
-    when: "true"
-  dependencies: []
-  task:
-    env_vars:
-      - name: SKIP_CACHE_RESTORE
-        value: "true"
-    jobs:
-      - name: "Cache calico/go-build to GCS"
-        commands:
-          - GO_BUILD_VER=$(make --no-print-directory -f metadata.mk -f - <<<'print:; @echo $(GO_BUILD_VER)' print)
-          - cache_path="gs://${GCS_BUILD_CACHE_BUCKET}/images/calico-go-build-${GO_BUILD_VER}.tar.zst"
-          - |-
-            if gcloud storage ls "$cache_path" >/dev/null 2>&1; then
-              echo "Cache hit for calico/go-build:${GO_BUILD_VER}"
-            else
-              echo "Cache miss for calico/go-build:${GO_BUILD_VER}, pulling and uploading"
-              docker pull "calico/go-build:${GO_BUILD_VER}"
-              docker save "calico/go-build:${GO_BUILD_VER}" -o /tmp/go-build.tar
-              zstd -3 --rm /tmp/go-build.tar
-              gcloud storage cp /tmp/go-build.tar.zst "$cache_path"
-            fi
 - name: "Build: calico image"
   # Build and cache the calico image so that downstream CI blocks can load it
   # from GCS instead of rebuilding per component. This block is the sole
@@ -347,7 +333,6 @@
     - Check protobufs
     - Manifests and API docs
     - Store working copy
-    - "Pull: go-build image"
   task:
     jobs:
       - name: Pre-flight checks

--- a/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
+++ b/.semaphore/semaphore.yml.d/blocks/10-prerequisites.yml
@@ -127,14 +127,11 @@
           - |-
             if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" ]]; then
               # master uses Semaphore's free cache (other branches use GCS). This
-              # block's `when` already restricts it to branch builds; the
-              # SEMAPHORE_GIT_PR_NUMBER guard is belt-and-suspenders so a PR can
-              # never store (it would thrash the shared master cache that PRs only
-              # restore). Cache keys are not overwritten, so delete-then-store.
-              if [[ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]]; then
-                cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
-                cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
-              fi
+              # block only runs on branch builds (its `when: "branch =~ '.*'"`),
+              # so PRs never store here — they only restore, in the prologue.
+              # Cache keys are not overwritten, so delete-then-store to refresh.
+              cache delete "working-copy-${SEMAPHORE_GIT_BRANCH}" || true
+              cache store "working-copy-${SEMAPHORE_GIT_BRANCH}" /tmp/working-copy.tar.zstd
             else
               gcs_branch_cache_dir="${GCS_CACHE_DIR}/${SEMAPHORE_GIT_BRANCH}"
               gcloud storage cp /tmp/working-copy.tar.zstd "$gcs_branch_cache_dir/working-copy.tar.zstd"


### PR DESCRIPTION
Storing the build cache to GCS bucket
(`calico-transient-build-artifacts-europe-west3`) is driving high egress costs,
because Semaphore agents download them on nearly every job. This trims the two
biggest contributors with no change to other branches.

- **Move master's branch-keyed caches to Semaphore's free built-in `cache`
  command.** The ~1.8 GB Go build cache (`build-cache-<group>`) and the
  working-copy tarball now use `cache store`/`cache restore` on master. Other
  branches keep using GCS for now. 
- **Use the cached `calico/go-build` image in GCS as fallback only.** Try a (free!)
  pull from dockerhub first and only fall back to GCS on failure.