### PR TITLE
ci: spread CI test VMs across zones by capacity

### DIFF
--- a/.semaphore/cleanup.yml
+++ b/.semaphore/cleanup.yml
@@ -17,7 +17,8 @@ blocks:
           - checkout
           - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
           - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-          - export ZONE=europe-west3-c
+          # clean-up-vms is zone-agnostic (it discovers each VM's zone), so no
+          # ZONE is needed here.
           - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-
           - echo VM_PREFIX=${VM_PREFIX}
       jobs:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1598,7 +1598,9 @@ blocks:
           - gcloud config set project unique-caldron-775
           - cd node
           - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-          - export ZONE=europe-west3-c
+          # Spread the test VMs across the zones of this region (by available
+          # capacity); see .semaphore/vms/run-tests-on-vms.
+          - export REGION=europe-west3
           - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-kind-
           - echo VM_PREFIX=${VM_PREFIX}
           - export COMPONENT=node

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -970,8 +970,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -2078,8 +2080,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -2869,8 +2873,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -5520,8 +5526,10 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/chanutil/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',
         '/lib/std/uniquestr/*.go',
@@ -5711,7 +5719,9 @@ blocks:
           - gcloud config set project unique-caldron-775
           - cd node
           - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-          - export ZONE=europe-west3-c
+          # Spread the test VMs across the zones of this region (by available
+          # capacity); see .semaphore/vms/run-tests-on-vms.
+          - export REGION=europe-west3
           - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-kind-
           - echo VM_PREFIX=${VM_PREFIX}
           - export COMPONENT=node
@@ -6025,7 +6035,9 @@ blocks:
         '/lib/httpmachinery/pkg/header/*.go',
         '/lib/httpmachinery/pkg/server/*.go',
         '/lib/httpmachinery/pkg/server/adaptors/gorilla/*.go',
+        '/lib/logrusr/*.go',
         '/lib/std/cryptoutils/*.go',
+        '/lib/std/log/*.go',
         '/lib/std/testutils/json/*.go',
         '/lib/std/time/*.go',
         '/lib/std/uniquelabels/*.go',

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -91,7 +91,9 @@
         - gcloud config set project unique-caldron-775
         - cd node
         - export SHORT_WORKFLOW_ID=$(echo ${SEMAPHORE_WORKFLOW_ID} | sha256sum | cut -c -8)
-        - export ZONE=europe-west3-c
+        # Spread the test VMs across the zones of this region (by available
+        # capacity); see .semaphore/vms/run-tests-on-vms.
+        - export REGION=europe-west3
         - export VM_PREFIX=sem-${SEMAPHORE_PROJECT_NAME}-${SHORT_WORKFLOW_ID}-kind-
         - echo VM_PREFIX=${VM_PREFIX}
         - export COMPONENT=node

--- a/.semaphore/vms/clean-up-vms
+++ b/.semaphore/vms/clean-up-vms
@@ -44,7 +44,11 @@ while true; do
   cat instance-list
   while IFS=, read -r name zone; do
     [ -n "$name" ] || continue
-    gcloud --quiet beta compute instances delete "$name" --zone="$zone" --no-graceful-shutdown
+    # Best-effort: don't let one failed delete (instance vanished between list
+    # and delete, or a transient API error) abort the whole sweep under 'set -e'
+    # and leak the rest.  Anything still present is retried on the next pass.
+    gcloud --quiet beta compute instances delete "$name" --zone="$zone" --no-graceful-shutdown \
+      || echo "WARNING: failed to delete $name in $zone; will retry."
   done < instance-list
   sleep 1
 done

--- a/.semaphore/vms/clean-up-vms
+++ b/.semaphore/vms/clean-up-vms
@@ -28,17 +28,23 @@ gcp_secret_key=${GCP_SECRET_KEY:-$HOME/secrets/secret.google-service-account-key
 gcloud config set project $project
 gcloud auth activate-service-account --key-file=$gcp_secret_key
 
+# The test VMs are spread across the zones of a region (see run-tests-on-vms),
+# so we list project-wide by name prefix and delete each instance in whichever
+# zone it ended up in.  This is zone-agnostic, so it also reclaims any leaked
+# VMs regardless of where they landed.
 while true; do
   gcloud --quiet compute instances list \
         "--filter=name~'${vm_prefix}.*'" \
-        --zones=${ZONE} \
-        --format='table[no-heading](name)' > instance-list
-  instances="$(cat instance-list)"
-  if [ "${instances}" = "" ]; then
+        --format='csv[no-heading](name,zone.basename())' > instance-list
+  if [ ! -s instance-list ]; then
     echo "All instances deleted"
     break
   fi
-  echo "Instances to delete: $instances"
-  gcloud --quiet beta compute instances delete ${instances} --zone=${ZONE} --no-graceful-shutdown
+  echo "Instances to delete:"
+  cat instance-list
+  while IFS=, read -r name zone; do
+    [ -n "$name" ] || continue
+    gcloud --quiet beta compute instances delete "$name" --zone="$zone" --no-graceful-shutdown
+  done < instance-list
   sleep 1
 done

--- a/.semaphore/vms/clean-up-vms
+++ b/.semaphore/vms/clean-up-vms
@@ -42,13 +42,23 @@ while true; do
   fi
   echo "Instances to delete:"
   cat instance-list
+
+  # Group the instances by zone so we can delete each zone's VMs in a single
+  # 'gcloud delete' call.  A single delete with multiple names tears them down
+  # in parallel, which is much faster than one call per VM -- but gcloud
+  # requires every name in a call to share a --zone, hence the per-zone grouping.
+  declare -A zone_names=()
   while IFS=, read -r name zone; do
     [ -n "$name" ] || continue
-    # Best-effort: don't let one failed delete (instance vanished between list
+    zone_names["$zone"]+=" $name"
+  done < instance-list
+
+  for zone in "${!zone_names[@]}"; do
+    # Best-effort: don't let one failed delete (an instance vanished between list
     # and delete, or a transient API error) abort the whole sweep under 'set -e'
     # and leak the rest.  Anything still present is retried on the next pass.
-    gcloud --quiet beta compute instances delete "$name" --zone="$zone" --no-graceful-shutdown \
-      || echo "WARNING: failed to delete $name in $zone; will retry."
-  done < instance-list
+    gcloud --quiet beta compute instances delete ${zone_names[$zone]} --zone="$zone" --no-graceful-shutdown \
+      || echo "WARNING: failed to delete one or more instances in $zone; will retry."
+  done
   sleep 1
 done

--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -186,8 +186,14 @@ for batch in "${batches[@]}"; do
   vm_name="$vm_name_prefix$batch"
   # Each VM may be in a different zone; look up the one it landed in.  Every
   # downstream command in this iteration (vm-ip, on-test-vm, configure-test-vm,
-  # the delete, and the watchdog's serial/snapshot capture) uses $zone.
+  # the delete, and the watchdog's serial/snapshot capture) uses $zone.  We also
+  # export ZONE: run_batch (sourced from batches.sh) shells out to
+  # 'gcloud get-serial-port-output --zone="${ZONE}"' to grab the serial console
+  # when a VM wedges, and it reads ZONE from the environment.  The backgrounded
+  # per-batch subshell below captures this value at fork time, so each batch
+  # sees its own VM's zone.
   zone="${vm_zone[$vm_name]}"
+  export ZONE="$zone"
   vm_ip="$(env VM_NAME="$vm_name" ZONE="$zone" "$my_dir/vm-ip")"
   batch_formatted="$(format_batch_for_log "$batch")"
   log_file="$artifacts_dir/test-$batch_formatted.log"

--- a/.semaphore/vms/run-tests-on-vms
+++ b/.semaphore/vms/run-tests-on-vms
@@ -22,7 +22,11 @@ my_dir="$(dirname $0)"
 repo_dir="$my_dir/../.."
 vm_name_prefix=$1
 artifacts_dir="$repo_dir/artifacts"
-zone=${ZONE:-europe-west3-c}
+# We bulk-create the VMs across all the zones in a region (based on available
+# capacity) rather than pinning a single zone, so a single zone running out of
+# capacity no longer blocks the job.  REGION selects the region; the zone each
+# VM actually lands in is discovered after creation (see below).
+region=${REGION:-europe-west3}
 : "${VM_MACHINE_TYPE:=n4-standard-4}"
 : "${IMAGE_FAMILY:=ubuntu-minimal-2404-lts-amd64}"
 : "${MAX_RUN_DURATION:=4h}"
@@ -74,12 +78,17 @@ else
 fi
 
 # Do a bulk create; this is faster and it saves API quota.
-echo "Creating test VMs in bulk..."
+#
+# We pass --region (not --zone) with --target-distribution-shape=any so that
+# GCP spreads the VMs across the zones of the region according to available
+# capacity.  This avoids a single zone filling up and failing the whole job.
+echo "Creating test VMs in bulk across region ${region}..."
 gcloud --quiet compute instances bulk create \
        --service-account="semaphore-v2-gcr@unique-caldron-775.iam.gserviceaccount.com" \
        --scopes="https://www.googleapis.com/auth/cloud-platform" \
        --predefined-names="$names" \
-       --zone=${zone} \
+       --region=${region} \
+       --target-distribution-shape=any \
        --machine-type=${VM_MACHINE_TYPE} \
        --image-family=${IMAGE_FAMILY} \
        --image-project=ubuntu-os-cloud \
@@ -90,6 +99,31 @@ gcloud --quiet compute instances bulk create \
        --labels="${labels}" \
        --metadata-from-file startup-script="$my_dir/vm-bootstrap.sh" \
        --metadata block-project-ssh-keys=TRUE,ssh-keys="ubuntu:$(ssh-keygen -y -f $HOME/.ssh/id_rsa)",enable-guest-attributes=TRUE
+
+# Since the VMs are spread across the region's zones, we can no longer assume a
+# single zone for the downstream describe/ssh/delete commands.  Build a
+# name->zone map by listing the instances we just created, filtered by our
+# workflow-unique name prefix.  bulk create is synchronous, so the instances
+# already exist by the time it returns.
+echo "Discovering which zone each VM landed in..."
+declare -A vm_zone
+while IFS=, read -r name vm_z; do
+  [ -n "$name" ] || continue
+  vm_zone["$name"]="$vm_z"
+  echo "  $name -> $vm_z"
+done < <(gcloud --quiet compute instances list \
+              --filter="name~'^${vm_name_prefix}'" \
+              --format='csv[no-heading](name,zone.basename())')
+
+# Fail fast if any expected VM is missing from the map; the rest of the script
+# relies on knowing every VM's zone.
+for batch in "${batches[@]}"; do
+  vm_name="$vm_name_prefix$batch"
+  if [ -z "${vm_zone[$vm_name]:-}" ]; then
+    echo "ERROR: could not determine the zone of VM $vm_name after bulk create." 1>&2
+    exit 1
+  fi
+done
 
 ###### Configure VMs, run tests and shut them down ######
 
@@ -150,6 +184,10 @@ format_batch_for_log() {
 
 for batch in "${batches[@]}"; do
   vm_name="$vm_name_prefix$batch"
+  # Each VM may be in a different zone; look up the one it landed in.  Every
+  # downstream command in this iteration (vm-ip, on-test-vm, configure-test-vm,
+  # the delete, and the watchdog's serial/snapshot capture) uses $zone.
+  zone="${vm_zone[$vm_name]}"
   vm_ip="$(env VM_NAME="$vm_name" ZONE="$zone" "$my_dir/vm-ip")"
   batch_formatted="$(format_batch_for_log "$batch")"
   log_file="$artifacts_dir/test-$batch_formatted.log"
@@ -171,7 +209,7 @@ for batch in "${batches[@]}"; do
 
     conf_log_file="$artifacts_dir/configure-vm-$batch_formatted.log"
     echo "$prefix Configuring test VM $vm_name. Redirecting log to $conf_log_file."
-    if "${my_dir}/configure-test-vm" "$vm_name" >& "$conf_log_file"; then
+    if env ZONE="$zone" "${my_dir}/configure-test-vm" "$vm_name" >& "$conf_log_file"; then
       echo "$prefix Configuration of VM $vm_name SUCCEEDED."
     else
       echo "$prefix Configuration of VM $vm_name FAILED.  Log file will be uploaded as artifact $conf_log_file. "

--- a/felix/.semaphore/fv-prologue
+++ b/felix/.semaphore/fv-prologue
@@ -6,7 +6,9 @@ gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS
 gcloud config set project unique-caldron-775
 
 export COMPONENT=felix
-export ZONE=europe-west3-c
+# Spread the test VMs across the zones of this region (by available capacity)
+# rather than pinning a single zone; see .semaphore/vms/run-tests-on-vms.
+export REGION=europe-west3
 
 # 4 vCPUs seems to be the minimum for stable tests.  8 vCPUs doesn't seem to
 # help performance very much.


### PR DESCRIPTION
CI test VMs were bulk-created in a single hard-coded GCP zone (`europe-west3-c`), and the downstream describe/ssh/delete logic assumed that one zone. When the zone ran out of capacity, the whole job failed.

This change spreads the VMs across the zones of a region by available capacity:

- **`run-tests-on-vms`** — bulk create now uses `--region` + `--target-distribution-shape=any` instead of `--zone`, so GCP places the VMs in whichever zones have capacity. After creation it discovers each VM's actual zone (`gcloud compute instances list` filtered by the workflow-unique name prefix, formatted as `name,zone.basename()`) and threads the per-VM zone through every downstream command. `configure-test-vm` is now passed `ZONE` explicitly rather than relying on inherited env.
- **`clean-up-vms`** — no longer restricts to one zone; lists project-wide by name prefix and deletes each instance in whichever zone it landed in. Also reclaims leaked VMs regardless of zone.
- **Entry points** — `felix/.semaphore/fv-prologue` and the node block now export `REGION=europe-west3` instead of `ZONE`; the scheduled cleanup pipeline no longer needs `ZONE`.