### PR TITLE
fix(e2e): provide aws-iam-authenticator to the e2e runner container for EKS

### DIFF
--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -73,6 +73,19 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # the container, and we prepend that to PATH inside the bash -c below.
   make kubectl
 
+  # EKS kubeconfigs authenticate via an `aws-iam-authenticator` exec credential
+  # plugin (a bare command name -> PATH lookup inside the runner). The stock
+  # golang image used for the hashrelease path doesn't include it, so client-go
+  # fails with "executable aws-iam-authenticator not found" in
+  # SynchronizedBeforeSuite and no tests run. The aws-eks provisioner already
+  # installs the binary on the host (under ${BZ_LOCAL_DIR}/bin); bind-mount it
+  # onto the container PATH when present. The -x guard makes this a no-op for
+  # non-EKS runs, where the host binary doesn't exist.
+  auth_mount=()
+  if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
+    auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
+  fi
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
@@ -83,6 +96,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     -e KUBECONFIG=/kubeconfig \
     -e PRODUCT=${PRODUCT:-calico} \
     ${K8S_E2E_DOCKER_EXTRA_FLAGS:-} \
+    "${auth_mount[@]}" \
     -v "$(pwd)":/go/src/github.com/projectcalico/calico:rw \
     -v "$(pwd)"/.go-pkg-cache:/go-cache:rw \
     -v "${BZ_LOCAL_DIR}/kubeconfig:/kubeconfig:ro" \

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -73,14 +73,9 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # the container, and we prepend that to PATH inside the bash -c below.
   make kubectl
 
-  # EKS kubeconfigs authenticate via an `aws-iam-authenticator` exec credential
-  # plugin (a bare command name -> PATH lookup inside the runner). The stock
-  # golang image used for the hashrelease path doesn't include it, so client-go
-  # fails with "executable aws-iam-authenticator not found" in
-  # SynchronizedBeforeSuite and no tests run. The aws-eks provisioner already
-  # installs the binary on the host (under ${BZ_LOCAL_DIR}/bin); bind-mount it
-  # onto the container PATH when present. The -x guard makes this a no-op for
-  # non-EKS runs, where the host binary doesn't exist.
+  # EKS kubeconfigs exec aws-iam-authenticator (PATH lookup), which the stock
+  # golang image lacks, so client-go fails before any tests run. The aws-eks
+  # provisioner installs it on the host; bind-mount it when present (no-op otherwise).
   auth_mount=()
   if [[ -x "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator" ]]; then
     auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")


### PR DESCRIPTION
## Problem

The monorepo-native e2e runner (`.semaphore/end-to-end/scripts/phases/run_tests.sh`, used by scheduled CI — currently on `master`) runs the e2e binary in a stock `golang:<ver>-bookworm` container (the hashrelease path). EKS kubeconfigs authenticate via an `aws-iam-authenticator` **exec credential plugin** — a bare command name resolved on `PATH` inside the runner. That image doesn't include the binary, and the `docker run` never provided it, so on **aws-eks** client-go fails in `SynchronizedBeforeSuite`:

```
Get "https://<id>.gr7.us-west-2.eks.amazonaws.com/api/v1/nodes...":
  getting credentials: exec: executable aws-iam-authenticator not found
```

No tests run (the job records 0 testcases).

## Scope

- Observed as an intermittent **~19% setup-failure rate on aws-eks `master_hashrel`** e2e (26/134 runs over 90 days), starting mid-May 2026 — right after this runner took over the scheduled-CI path.
- **Release branches (v3.30/v3.31/v3.32) are unaffected**: they still use the `bz tests` → `k8s-e2e:stable` path, whose image bundles `aws-iam-authenticator`.
- ⚠️ This runner flows into each release branch when cut from master, so **v3.33 will inherit the bug** unless this lands on master first (or is backported after cut).

## Fix

The aws-eks provisioner already installs `aws-iam-authenticator` on the host under `${BZ_LOCAL_DIR}/bin`. Bind-mount it onto the container `PATH` when present — guarded by `-x` so it's a no-op for non-EKS runs (where the host binary doesn't exist). This mirrors how `kubectl` and the kubeconfig are already provided to the runner, and reuses the existing host install (no new download or version pin).

## Validation status (why draft)

Root cause is established from job logs + diags (bare-name kubeconfig exec; stock golang runner image; no authenticator provided) and the fix is a minimal, guarded mount. It has **not** yet been validated by a green aws-eks e2e run — the failing image is GC'd and the live `stable` happens to currently bundle the binary, so a clean repro wasn't reproducible on demand. Marking draft pending a scheduled aws-eks run on this branch (or a maintainer's confirmation). `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)