### PR TITLE
felix: deflake proxy neigh manager re-announce test via injectable ticker

### DIFF
--- a/felix/dataplane/linux/proxy_neigh_mgr.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr.go
@@ -84,6 +84,22 @@ type (
 	ndpConnFactory   func(ifaceName string) (ndpConn, net.HardwareAddr, error)
 )
 
+// tickerShim is the minimal slice of *time.Ticker the periodic re-announce loop
+// uses, abstracted so unit tests can drive ticks by hand rather than waiting on
+// a real wall-clock interval (which flakes under load).
+type tickerShim interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+// newTickerFunc constructs a tickerShim for the given interval.
+type newTickerFunc func(time.Duration) tickerShim
+
+// realTicker adapts *time.Ticker to tickerShim.
+type realTicker struct{ *time.Ticker }
+
+func (t realTicker) Chan() <-chan time.Time { return t.C }
+
 // proxyNeighManager automatically responds to ARP (IPv4) and NDP (IPv6) requests for
 // pod and LoadBalancer IPs that fall within the same L2 subnet as a host interface.
 // It listens on raw sockets and responds directly in userspace.
@@ -124,6 +140,11 @@ type proxyNeighManager struct {
 
 	arpFactory arpClientFactory
 	ndpFactory ndpConnFactory
+
+	// newTicker constructs the ticker that drives periodic re-announcement.
+	// Real time in production; overridden by unit tests to fire ticks
+	// deterministically.
+	newTicker newTickerFunc
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -234,6 +255,7 @@ func newProxyNeighManagerWithShims(
 		nlHandle:         nl,
 		arpFactory:       af,
 		ndpFactory:       nf,
+		newTicker:        func(d time.Duration) tickerShim { return realTicker{time.NewTicker(d)} },
 		ctx:              ctx,
 		cancel:           cancel,
 	}
@@ -524,6 +546,7 @@ func (m *proxyNeighManager) startListener(ifaceName string) error {
 		ifaceName:        ifaceName,
 		readTimeout:      m.readTimeout,
 		announceInterval: m.announceInterval,
+		newTicker:        m.newTicker,
 		reconcile:        make(chan struct{}, 1),
 		announced:        set.New[string](),
 		done:             make(chan struct{}),
@@ -590,6 +613,9 @@ type ifaceListener struct {
 	// Zero or negative disables periodic re-announcement (only the initial
 	// announce on add fires).
 	announceInterval time.Duration
+
+	// newTicker constructs the re-announce ticker; injectable so tests drive it.
+	newTicker newTickerFunc
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -822,9 +848,9 @@ func (l *ifaceListener) runListener(proto string, setDeadline func(time.Time) er
 	// forwarding tables stay warm even when the desired set is unchanged.
 	var refreshC <-chan time.Time
 	if l.announceInterval > 0 {
-		ticker := time.NewTicker(l.announceInterval)
+		ticker := l.newTicker(l.announceInterval)
 		defer ticker.Stop()
-		refreshC = ticker.C
+		refreshC = ticker.Chan()
 	}
 
 	logCtx := logrus.WithFields(logrus.Fields{"iface": l.ifaceName, "proto": proto})

--- a/felix/dataplane/linux/proxy_neigh_mgr_test.go
+++ b/felix/dataplane/linux/proxy_neigh_mgr_test.go
@@ -41,12 +41,30 @@ const (
 	// than waiting the production readDeadlineInterval.
 	testReadTimeout = 10 * time.Millisecond
 
-	// testAnnounceInterval is a short periodic re-announce interval used by the
-	// re-announcement tests: comfortably larger than testReadTimeout so the loop
-	// gets several read iterations per interval, but small enough that a couple of
-	// refreshes land well within an Eventually timeout.
+	// testAnnounceInterval merely enables periodic re-announcement (any value > 0
+	// does). The re-announcement tests inject a mockTicker and fire ticks by
+	// hand, so the actual duration is never waited on — keeping the tests
+	// deterministic rather than racing a real wall-clock interval.
 	testAnnounceInterval = 40 * time.Millisecond
 )
+
+// mockTicker is a tickerShim whose ticks the test fires by hand via tick(), so
+// the periodic re-announce loop runs deterministically instead of racing a real
+// wall-clock interval.
+type mockTicker struct {
+	c chan time.Time
+}
+
+func newMockTicker() *mockTicker {
+	return &mockTicker{c: make(chan time.Time, 1)}
+}
+
+func (t *mockTicker) Chan() <-chan time.Time { return t.c }
+func (t *mockTicker) Stop()                  {}
+
+// tick fires a single re-announce tick. Tests gate successive ticks behind an
+// Eventually on the resulting writes, so the buffered channel never blocks.
+func (t *mockTicker) tick() { t.c <- time.Time{} }
 
 func newMockNetlinkForProxyNeigh() *mocknetlink.MockNetlinkDataplane {
 	dp := mocknetlink.New()
@@ -1045,6 +1063,8 @@ var _ = Describe("Proxy neighbor manager - periodic re-announcement", func() {
 			return nil, nil, fmt.Errorf("no mock for %s", ifaceName)
 		}
 		mgr := newProxyNeighManagerWithShims(config, 4, nl, af, nil, testReadTimeout, testAnnounceInterval)
+		ticker := newMockTicker()
+		mgr.newTicker = func(time.Duration) tickerShim { return ticker }
 		defer mgr.Stop()
 		sendNoEncapPool(mgr, "default-test-pool", "10.0.0.0/8")
 		setIfaceAddr(nl, "eth0", "10.0.0.1/24")
@@ -1052,12 +1072,14 @@ var _ = Describe("Proxy neighbor manager - periodic re-announcement", func() {
 		mgr.OnUpdate(proxyNeighWepUpdate("k8s", "default/pod1", "eth0", "10.0.0.50/32"))
 		Expect(mgr.CompleteDeferredWork()).To(Succeed())
 
-		// The initial announce fires once; the periodic refresh then keeps
-		// sending more GARPs for the same IP without any reconcile.
+		// The initial announce fires once on add.
 		Eventually(func() int { return len(arpClients["eth0"].getWrites()) }).Should(Equal(1))
-		Eventually(func() int {
-			return len(arpClients["eth0"].getWrites())
-		}, "100ms").Should(BeNumerically(">=", 2))
+		// Each fired tick drives one more refresh round (one owned IP), with no
+		// reconcile in between.
+		ticker.tick()
+		Eventually(func() int { return len(arpClients["eth0"].getWrites()) }).Should(Equal(2))
+		ticker.tick()
+		Eventually(func() int { return len(arpClients["eth0"].getWrites()) }).Should(Equal(3))
 
 		// Every refresh is a well-formed GARP for the owned IP.
 		for _, w := range arpClients["eth0"].getWrites() {
@@ -1082,6 +1104,8 @@ var _ = Describe("Proxy neighbor manager - periodic re-announcement", func() {
 			return nil, nil, fmt.Errorf("no mock for %s", ifaceName)
 		}
 		mgr := newProxyNeighManagerWithShims(config, 6, nl, nil, nf, testReadTimeout, testAnnounceInterval)
+		ticker := newMockTicker()
+		mgr.newTicker = func(time.Duration) tickerShim { return ticker }
 		defer mgr.Stop()
 		sendNoEncapPool(mgr, "default-test-pool-v6", "fd00::/8")
 		setIfaceAddr(nl, "eth0", "fd00::1/64")
@@ -1089,10 +1113,11 @@ var _ = Describe("Proxy neighbor manager - periodic re-announcement", func() {
 		mgr.OnUpdate(wepUpdateV6("k8s", "default/pod1", "eth0", "fd00::50/128"))
 		Expect(mgr.CompleteDeferredWork()).To(Succeed())
 
-		// Periodic refresh keeps sending unsolicited NAs for the owned IP.
-		Eventually(func() int {
-			return len(ndpConns["eth0"].getWrites())
-		}, "100ms").Should(BeNumerically(">=", 2))
+		// The initial announce fires once on add; each fired tick drives one more
+		// unsolicited NA for the owned IP.
+		Eventually(func() int { return len(ndpConns["eth0"].getWrites()) }).Should(Equal(1))
+		ticker.tick()
+		Eventually(func() int { return len(ndpConns["eth0"].getWrites()) }).Should(Equal(2))
 
 		// The solicited-node group is joined exactly once on add — the refresh
 		// must not re-join it every interval.


### PR DESCRIPTION
## Description

The two `periodic re-announcement` specs in `felix/dataplane/linux/proxy_neigh_mgr_test.go` drove a real `40ms` `time.NewTicker` and asserted how many re-announce writes landed inside a `100ms` wall-clock `Eventually` window. Under CI load that races — goroutine scheduling slips and the expected ticks may not fire in time — so the tests flake.

This change makes the re-announce ticker injectable:

- Adds a small `tickerShim` interface (`Chan() <-chan time.Time`, `Stop()`), a `newTickerFunc` factory type, and a `realTicker` adapter over `*time.Ticker`.
- `proxyNeighManager` and `ifaceListener` gain a `newTicker` field; the constructor defaults it to the real `time.NewTicker`, `startListener` threads it to the listener, and `runListener` builds its refresh channel through it. **Production behaviour is unchanged.**
- The tests inject a `mockTicker`, fire ticks by hand, and assert the exact write count after each tick — removing all dependence on real elapsed time.

## Testing

- `make ut GINKGO_FOCUS="Proxy"` passes.
- Ran `make ut GINKGO_FOCUS="periodic re-announcement"` 5× — 994/994 specs SUCCESS every run, 0 failures.

## Release Note

```release-note
None
```