### PR TITLE
[v3.32] Set CNI installMode to CalicoOnly for Windows FV

### DIFF
--- a/process/testing/aso/EE/templates/custom-resources.yaml
+++ b/process/testing/aso/EE/templates/custom-resources.yaml
@@ -17,6 +17,9 @@ spec:
 
   cni:
     type: Calico
+    # Skip the cni-plugins init container; the Windows FV doesn't need the
+    # upstream plugins and this avoids building/importing their image.
+    installMode: CalicoOnly
   calicoNetwork:
     bgp: Disabled
     linuxDataplane: {{$.Env.ASO_LINUX_DATAPLANE}}

--- a/process/testing/aso/OSS/templates/custom-resources.yaml
+++ b/process/testing/aso/OSS/templates/custom-resources.yaml
@@ -8,6 +8,9 @@ spec:
   variant: Calico
   cni:
     type: Calico
+    # Skip the cni-plugins init container; the Windows FV doesn't need the
+    # upstream plugins and this avoids building/importing their image.
+    installMode: CalicoOnly
   calicoNetwork:
     bgp: Disabled
     linuxDataplane: {{$.Env.ASO_LINUX_DATAPLANE}}


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.32**: projectcalico/calico#13014

The operator now renders the upstream CNI plugins as a separate cni-plugins init container on the calico-node DaemonSet. The Windows FV local-build flow only imports calico/calico, calico/node, and calico/operator onto the Linux node, so the new init container hits ImagePullBackOff, calico-node never goes Ready, and the install times out before any Felix Windows FV spec runs.

The Windows FV doesn't need the upstream plugins on the Linux node, so set `installMode: CalicoOnly` on the Installation to skip the init container altogether. This avoids having to build and import the third-party-cni-plugins image.

Alternative to #13013, which fixes the same breakage by building and importing the image instead.

```release-note
None
```

