### PR TITLE
Fix e2e kind diags collection when images come from the build cache

### DIFF
--- a/.semaphore/collect-kind-diags
+++ b/.semaphore/collect-kind-diags
@@ -50,41 +50,28 @@ if ! "$kubectl_bin" --kubeconfig="$kubeconfig" cluster-info >/dev/null 2>&1; the
   exit 0
 fi
 
-# Extract the calico binary from an image in the local Docker daemon. The
-# combined `calico` binary dispatches `ctl` to the calicoctl subcommand.
+# Extract the calico binary from the locally-built image to run cluster diags.
+# The combined `calico` binary dispatches `ctl` to the calicoctl subcommand.
 #
-# Try the daemon-local source tag first. When images come from the GCS cache,
-# load-cached-images `docker load`s calico/calico:latest-<arch> but kind-up
-# skips the retag, so the localhost:5000/...:test-build tag the cluster pulls
-# from never lands in the daemon - only the latest-<arch> tag does.
+# Use the daemon-local calico/calico:latest-<arch> tag, which is present in both
+# paths: load-cached-images `docker load`s it on a cache hit, and the build
+# produces it on a miss. The localhost:5000/...:test-build tag the cluster pulls
+# from is only ever `docker tag`d from latest-<arch> for the push, so it isn't
+# reliably left in the daemon - extracting from it was silently skipping diags.
 arch="${ARCH:-amd64}"
+calico_image="${CALICO_IMAGE:-calico/calico:latest-${arch}}"
 calico_bin="$(mktemp -d)/calico"
-
-extract_calico_bin() {
-  local image="$1" cid
-  cid="$(docker create "$image" 2>/dev/null)" || return 1
-  [ -n "$cid" ] || return 1
-  docker cp "$cid:/usr/bin/calico" "$calico_bin"
-  local rc=$?
-  docker rm -f "$cid" >/dev/null 2>&1 || true
-  return $rc
-}
-
-extracted=false
-for image in \
-  ${CALICO_IMAGE:+"$CALICO_IMAGE"} \
-  "calico/calico:latest-${arch}" \
-  "localhost:5000/calico/calico:test-build"; do
-  if extract_calico_bin "$image"; then
-    echo "collect-kind-diags: extracted calico binary from $image"
-    extracted=true
-    break
-  fi
-done
-if [ "$extracted" != true ]; then
-  echo "collect-kind-diags: no local calico image to extract a binary from, skipping"
+cid="$(docker create "$calico_image" 2>/dev/null)"
+if [ -z "$cid" ]; then
+  echo "collect-kind-diags: no local $calico_image to extract a binary from, skipping"
   exit 0
 fi
+if ! docker cp "$cid:/usr/bin/calico" "$calico_bin"; then
+  docker rm -f "$cid" >/dev/null 2>&1 || true
+  echo "collect-kind-diags: could not extract calico binary, skipping"
+  exit 0
+fi
+docker rm -f "$cid" >/dev/null 2>&1 || true
 chmod +x "$calico_bin"
 
 mkdir -p "$artifacts_dir"

--- a/.semaphore/collect-kind-diags
+++ b/.semaphore/collect-kind-diags
@@ -50,22 +50,41 @@ if ! "$kubectl_bin" --kubeconfig="$kubeconfig" cluster-info >/dev/null 2>&1; the
   exit 0
 fi
 
-# Extract the calico binary from the image that's already loaded for the
-# e2e run. The combined `calico` binary dispatches `ctl` to the calicoctl
-# subcommand.
-calico_image="${CALICO_IMAGE:-localhost:5000/calico/calico:test-build}"
+# Extract the calico binary from an image in the local Docker daemon. The
+# combined `calico` binary dispatches `ctl` to the calicoctl subcommand.
+#
+# Try the daemon-local source tag first. When images come from the GCS cache,
+# load-cached-images `docker load`s calico/calico:latest-<arch> but kind-up
+# skips the retag, so the localhost:5000/...:test-build tag the cluster pulls
+# from never lands in the daemon - only the latest-<arch> tag does.
+arch="${ARCH:-amd64}"
 calico_bin="$(mktemp -d)/calico"
-cid="$(docker create "$calico_image" 2>/dev/null)"
-if [ -z "$cid" ]; then
-  echo "collect-kind-diags: could not create container from $calico_image, skipping"
-  exit 0
-fi
-if ! docker cp "$cid:/usr/bin/calico" "$calico_bin"; then
+
+extract_calico_bin() {
+  local image="$1" cid
+  cid="$(docker create "$image" 2>/dev/null)" || return 1
+  [ -n "$cid" ] || return 1
+  docker cp "$cid:/usr/bin/calico" "$calico_bin"
+  local rc=$?
   docker rm -f "$cid" >/dev/null 2>&1 || true
-  echo "collect-kind-diags: could not extract calico binary, skipping"
+  return $rc
+}
+
+extracted=false
+for image in \
+  ${CALICO_IMAGE:+"$CALICO_IMAGE"} \
+  "calico/calico:latest-${arch}" \
+  "localhost:5000/calico/calico:test-build"; do
+  if extract_calico_bin "$image"; then
+    echo "collect-kind-diags: extracted calico binary from $image"
+    extracted=true
+    break
+  fi
+done
+if [ "$extracted" != true ]; then
+  echo "collect-kind-diags: no local calico image to extract a binary from, skipping"
   exit 0
 fi
-docker rm -f "$cid" >/dev/null 2>&1 || true
 chmod +x "$calico_bin"
 
 mkdir -p "$artifacts_dir"


### PR DESCRIPTION
When an e2e (KinD) job fails, the epilogue runs collect-kind-diags to package pod logs, events and Calico resources into an artifact. On every recent failing run it has silently skipped instead: "could not create container from localhost:5000/calico/calico:test-build". That's why these failures have no apiserver/operator pod logs to diagnose from.

The script extracts the calico binary from a local image, but only tried the registry-qualified test-build tag. That tag isn't in the Docker daemon when the job restores images from the build cache: load-cached-images `docker load`s calico/calico:latest-<arch>, and kind-up skips the retag to localhost:5000, so docker create found nothing. This tries the daemon-local latest-<arch> tag first (present in both the cached-restore and build-from-source paths), falls back to the registry tag, and honours a CALICO_IMAGE override.

```release-note
None
```
