### PR TITLE
Bump bundled Envoy (1.38.2) and Istio Prometheus (v0.311.3) for CVE fixes (v3.32)

### DIFF
--- a/istio/patches/0002-Update-deps-for-CVE-fixes.patch
+++ b/istio/patches/0002-Update-deps-for-CVE-fixes.patch
@@ -6,11 +6,15 @@ Subject: [PATCH] Update deps for CVE fixes
 Regenerated against istio 1.29.4. The earlier (1.29.2-era) version of this
 patch is now almost entirely redundant: 1.29.4 already ships the otel,
 envoy go-control-plane, k8s.io, genproto, etc. bumps it carried, generally
-at equal-or-higher versions. Only two gaps remain, plus the x/net family is
+at equal-or-higher versions. The remaining gaps, plus the x/net family
 advanced to match the calico module:
 
-  github.com/moby/spdystream v0.5.0 -> v0.5.1   GO-2026-4958 / CVE-2026-35469
-                                                (SPDY frame parser memory DoS)
+  github.com/moby/spdystream     v0.5.0  -> v0.5.1    GO-2026-4958 / CVE-2026-35469
+                                                      (SPDY frame parser memory DoS)
+  github.com/prometheus/prometheus v0.310.0 -> v0.311.3  CVE-2026-42154 / GHSA-8rm2-7qqf-34qm
+                                                      (remote-read snappy heap-alloc DoS) and
+                                                      CVE-2026-42151 / GHSA-wg65-39gg-5wfj
+                                                      (Azure AD OAuth secret stored in plaintext)
   golang.org/x/net   v0.55.0 -> v0.56.0         CVE-2026-33814 (HTTP/2
   golang.org/x/crypto v0.51.0 -> v0.53.0         SETTINGS loop; already >=
   golang.org/x/sys   v0.45.0 -> v0.46.0          0.53.0 in 1.29.4, bumped to
@@ -19,13 +23,26 @@ advanced to match the calico module:
   golang.org/x/sync  v0.20.0 -> v0.21.0
 
 Regenerated via `go get github.com/moby/spdystream@v0.5.1
-golang.org/x/net@v0.56.0 && go mod tidy` against the pinned tag; the only
-churn is those modules. The module's `go` directive is unchanged at 1.25.7.
+golang.org/x/net@v0.56.0 github.com/prometheus/prometheus@v0.311.3 &&
+go mod tidy` against the pinned tag. The prometheus bump additionally
+advances its transitive deps (cloud.google.com/go/auth, gax-go/v2,
+google.golang.org/api, enterprise-certificate-proxy, client_golang/exp)
+in go.sum; none become new explicit requires. The module's `go` directive
+is unchanged at 1.25.7.
 ---
 diff --git a/go.mod b/go.mod
-index 2f624b1..7c75d76 100644
+index 2f624b1..076b2ef 100644
 --- a/go.mod
 +++ b/go.mod
+@@ -57,7 +57,7 @@ require (
+ 	github.com/prometheus/client_model v0.6.2
+ 	github.com/prometheus/common v0.68.1
+ 	github.com/prometheus/procfs v0.20.1
+-	github.com/prometheus/prometheus v0.310.0
++	github.com/prometheus/prometheus v0.311.3
+ 	github.com/quic-go/quic-go v0.59.1
+ 	github.com/ryanuber/go-glob v1.0.0
+ 	github.com/spf13/cobra v1.10.2
 @@ -80,10 +80,10 @@ require (
  	go.opentelemetry.io/proto/otlp v1.10.0
  	go.uber.org/atomic v1.11.0
@@ -65,9 +82,34 @@ index 2f624b1..7c75d76 100644
  	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/go.sum b/go.sum
-index 580e7a2..8f64068 100644
+index 580e7a2..26723cb 100644
 --- a/go.sum
 +++ b/go.sum
+@@ -1,7 +1,7 @@
+ cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+ cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+-cloud.google.com/go/auth v0.18.1 h1:IwTEx92GFUo2pJ6Qea0EU3zYvKnTAeRCODxfA/G5UWs=
+-cloud.google.com/go/auth v0.18.1/go.mod h1:GfTYoS9G3CWpRA3Va9doKN9mjPGRS+v41jmZAhBzbrA=
++cloud.google.com/go/auth v0.18.2 h1:+Nbt5Ev0xEqxlNjd6c+yYUeosQ5TtEUaNcN/3FozlaM=
++cloud.google.com/go/auth v0.18.2/go.mod h1:xD+oY7gcahcu7G2SG2DsBerfFxgPAJz17zz2joOFF3M=
+ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
+ cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
+ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+@@ -247,10 +247,10 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
+ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+-github.com/googleapis/enterprise-certificate-proxy v0.3.11 h1:vAe81Msw+8tKUxi2Dqh/NZMz7475yUvmRIkXr4oN2ao=
+-github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
+-github.com/googleapis/gax-go/v2 v2.16.0 h1:iHbQmKLLZrexmb0OSsNGTeSTS0HO4YvFOG8g5E4Zd0Y=
+-github.com/googleapis/gax-go/v2 v2.16.0/go.mod h1:o1vfQjjNZn4+dPnRdl/4ZD7S9414Y4xA+a/6Icj6l14=
++github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA6RlzjJaT4hi3kII+zYw8wmLb8=
++github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
++github.com/googleapis/gax-go/v2 v2.18.0 h1:jxP5Uuo3bxm3M6gGtV94P4lliVetoCB4Wk2x8QA86LI=
++github.com/googleapis/gax-go/v2 v2.18.0/go.mod h1:uSzZN4a356eRG985CzJ3WfbFSpqkLTjsnhWGJR6EwrE=
+ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+ github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 @@ -333,8 +333,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
  github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
  github.com/moby/buildkit v0.30.0 h1:OsK8T3BaYH52UNStpKd7gytDtHWWt2Fawak/lAPWatU=
@@ -79,6 +121,28 @@ index 580e7a2..8f64068 100644
  github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
  github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
  github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+@@ -381,8 +381,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
+ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+ github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
+ github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
+-github.com/prometheus/client_golang/exp v0.0.0-20260108101519-fb0838f53562 h1:vwqZvuobg82U0gcG2eVrFH27806bUbNr32SvfRbvdsg=
+-github.com/prometheus/client_golang/exp v0.0.0-20260108101519-fb0838f53562/go.mod h1:PmAYDB13uBFBG9qE1qxZZgZWhg7Rg6SfKM5DMK7hjyI=
++github.com/prometheus/client_golang/exp v0.0.0-20260325093428-d8591d0db856 h1:1Y6bmpZb8peQCy1IpctnAhIFuyhrdtMaDnETChhSNns=
++github.com/prometheus/client_golang/exp v0.0.0-20260325093428-d8591d0db856/go.mod h1:Vf0QcmVhGqpjLxZOaWrFSep86vchQtJmbztFaMM4f6Q=
+ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+ github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+ github.com/prometheus/common v0.68.1 h1:omjRRl4QP4komogpXuhfeOiisQg7xdy8VM1UY+pStaY=
+@@ -391,8 +391,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
+ github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
+ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
+ github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+-github.com/prometheus/prometheus v0.310.0 h1:iS0Uul/dHjy8ifBnqo3YEOhRxlTOWantRoDWwmIowwA=
+-github.com/prometheus/prometheus v0.310.0/go.mod h1:rs6XoWKvgAStqxHxb2Twh1BR6rp7qw7fmUgW+gaXjbw=
++github.com/prometheus/prometheus v0.311.3 h1:3IrVxQv6v5i/ZCGi6OrYeBhtCwaPTn6Z3DYruXoYm3M=
++github.com/prometheus/prometheus v0.311.3/go.mod h1:gjsCxTKtHO1Q8T9333u1s+lUR1OjPyM7ruuGH8RvVyo=
+ github.com/prometheus/sigv4 v0.4.1 h1:EIc3j+8NBea9u1iV6O5ZAN8uvPq2xOIUPcqCTivHuXs=
+ github.com/prometheus/sigv4 v0.4.1/go.mod h1:eu+ZbRvsc5TPiHwqh77OWuCnWK73IdkETYY46P4dXOU=
+ github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 @@ -514,8 +514,8 @@ go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
  golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
  golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -131,3 +195,14 @@ index 580e7a2..8f64068 100644
  golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
  golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+@@ -567,8 +567,8 @@ gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0
+ gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
+ gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+ gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
+-google.golang.org/api v0.265.0 h1:FZvfUdI8nfmuNrE34aOWFPmLC+qRBEiNm3JdivTvAAU=
+-google.golang.org/api v0.265.0/go.mod h1:uAvfEl3SLUj/7n6k+lJutcswVojHPp2Sp08jWCu8hLY=
++google.golang.org/api v0.272.0 h1:eLUQZGnAS3OHn31URRf9sAmRk3w2JjMx37d2k8AjJmA=
++google.golang.org/api v0.272.0/go.mod h1:wKjowi5LNJc5qarNvDCvNQBn3rVK8nSy6jg2SwRwzIA=
+ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:Kjn0N0tCrDgiAFW+lGO4JZ3ck44CehvJQMAwj9QF0G8=
+ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=

--- a/third_party/envoy-proxy/Makefile
+++ b/third_party/envoy-proxy/Makefile
@@ -8,7 +8,7 @@ BUILD_IMAGES ?= $(ENVOY_PROXY_IMAGE)
 # For updating this version please see
 # https://github.com/tigera/operator/blob/master/docs/common_tasks.md#updating-the-bundled-version-of-envoy-gateway
 # See https://gateway.envoyproxy.io/news/releases/matrix/ for version compatibility.
-ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.38.0-ef1b67e315
+ENVOYBINARY_IMAGE ?= quay.io/tigera/envoybinary:v1.38.2-74b6da5880
 
 EXCLUDEARCH ?= ppc64le s390x
 


### PR DESCRIPTION
## Description

Remediates CVEs in third-party components bundled into release-v3.32 images. Both are dependency/version bumps in the relevant build inputs (bug-fix / security type).

**1. Envoy 1.38.0 → 1.38.2 (`calico/envoy-proxy`)** — `third_party/envoy-proxy/Makefile`
Bumps `ENVOYBINARY_IMAGE` to the multi-arch `v1.38.2-74b6da5880` build, fixing:
- **CVE-2026-47774** (GHSA-22m2-hvr2-xqc8) — HTTP/2 HPACK cookie-bomb that lets an unauthenticated client exhaust Envoy worker memory (OOM/DoS). Fixed in Envoy 1.38.1; 1.38.2 is the latest 1.38.x patch and also carries CVE-2026-27135 (nghttp2) and oauth2 fixes.

Stays within the 1.38.x line that Envoy Gateway v1.8.0 expects, so no `ENVOY_GATEWAY_VERSION` change is needed.

**2. Prometheus v0.310.0 → v0.311.3 in Istio (`calico/istio-pilot`, `calico/istio-proxyv2`)** — `istio/patches/0002-Update-deps-for-CVE-fixes.patch`
Extends the existing Istio CVE-fix patch to bump `github.com/prometheus/prometheus`, fixing:
- **CVE-2026-42154** (GHSA-8rm2-7qqf-34qm) — remote-read snappy heap-allocation DoS
- **CVE-2026-42151** (GHSA-wg65-39gg-5wfj) — Azure AD OAuth client secret stored in plaintext

## Testing

- **istio**: regenerated the patch against a clean istio 1.29.4 extract via `go get github.com/prometheus/prometheus@v0.311.3 && go mod tidy`; `go mod verify` passes and both `pilot-discovery` and `pilot-agent` build with the production build tags.
- **envoy-proxy**: verified `quay.io/tigera/envoybinary:v1.38.2-74b6da5880` resolves as a multi-arch manifest list (linux/amd64 + linux/arm64), so `FROM ${ENVOYBINARY_IMAGE}` builds for both arches.

## Not addressed here (upstream-gated)

- `istio-proxyv2` is also flagged for CVE-2026-47774 in its **Envoy** binary, but that Envoy is Istio's custom build pulled prebuilt from upstream `istio/proxyv2`; no released Istio (1.29.5/1.30.2) yet bundles a fixed Envoy. Tracked separately for an `ISTIO_VERSION` bump.

**Release note:**
```release-note
Bump bundled Envoy to 1.38.2 (CVE-2026-47774) and Prometheus to v0.311.3 in the Istio components (CVE-2026-42154, CVE-2026-42151) to address CVEs.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
