### PR TITLE
cherry-pick-candidate: send labels and changed file paths to classifier

### DIFF
--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -106,11 +106,18 @@ module.exports = async ({ github, context, core }) => {
   const filesResp = await github.rest.pulls.listFiles({
     owner, repo, pull_number: pr.number, per_page: 100,
   });
-  const changedFiles = filesResp.data.map(f => f.filename);
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
-  const filesText = changedFiles.length === 0
+  // Each entry is "- [status] path" where status is added / removed /
+  // modified / renamed / copied. Status disambiguates new API surface
+  // (`[added] api/**/*types.go`) from API bug fixes (`[modified]` only).
+  const filesText = filesResp.data.length === 0
     ? '(none)'
-    : changedFiles.map(p => `- ${p}`).join('\n');
+    : filesResp.data.map(f => {
+        const base = `- [${f.status}] ${f.filename}`;
+        return f.status === 'renamed' && f.previous_filename
+          ? `${base} (was ${f.previous_filename})`
+          : base;
+      }).join('\n');
 
   // 4. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
   const msgId = `calico-backport-classifier-${pr.number}-${process.env.GITHUB_RUN_ID}`;

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -96,7 +96,23 @@ module.exports = async ({ github, context, core }) => {
   const present = pr.labels.some(l => l.name === LABEL);
   core.info(`Label authority: bot (last actor: ${lastActor || 'none'}, present=${present})`);
 
-  // 3. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
+  // 3. Gather extra context for the classifier: existing labels and
+  //    changed file paths. Both are stronger signals than parsing the
+  //    body alone (labels are deliberate human classifications, paths
+  //    reveal whether the change touches production code or only CI /
+  //    tests / docs). Filter out the bot's own label so the agent's
+  //    verdict is not influenced by a prior classification round.
+  const labels = (pr.labels || []).map(l => l.name).filter(n => n !== LABEL);
+  const filesResp = await github.rest.pulls.listFiles({
+    owner, repo, pull_number: pr.number, per_page: 100,
+  });
+  const changedFiles = filesResp.data.map(f => f.filename);
+  const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
+  const filesText = changedFiles.length === 0
+    ? '(none)'
+    : changedFiles.map(p => `- ${p}`).join('\n');
+
+  // 4. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
   const msgId = `calico-backport-classifier-${pr.number}-${process.env.GITHUB_RUN_ID}`;
   const payload = {
     jsonrpc: '2.0',
@@ -108,7 +124,7 @@ module.exports = async ({ github, context, core }) => {
         role: 'user',
         parts: [{
           kind: 'text',
-          text: `PR number: ${pr.number}\nPR title: ${pr.title}\nPR body:\n${pr.body || ''}`,
+          text: `PR number: ${pr.number}\nPR title: ${pr.title}\nPR body:\n${pr.body || ''}\n\nLabels: ${labelsText}\nChanged files:\n${filesText}`,
         }],
       },
       configuration: { acceptedOutputModes: ['application/json', 'text/plain'] },

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -103,7 +103,11 @@ module.exports = async ({ github, context, core }) => {
   //    tests / docs). Filter out the bot's own label so the agent's
   //    verdict is not influenced by a prior classification round.
   const labels = (pr.labels || []).map(l => l.name).filter(n => n !== LABEL);
-  const filesResp = await github.rest.pulls.listFiles({
+  // Paginate so big PRs (the monorepo regularly has changes touching
+  // 100+ files) don't get silently truncated to the first page, which
+  // would bias the classifier or let a fork-PR pad with unrelated
+  // paths past the page boundary.
+  const files = await github.paginate(github.rest.pulls.listFiles, {
     owner, repo, pull_number: pr.number, per_page: 100,
   });
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
@@ -112,14 +116,13 @@ module.exports = async ({ github, context, core }) => {
   // and deleted. Status + size lets the classifier separate new API
   // surface (`[added +N]` on api types) from small API fixes
   // (`[modified +2/-1]`), and small defensive tweaks from substantial
-  // rewrites.
-  const filesText = filesResp.data.length === 0
+  // rewrites. previous_filename shows on any status that carries it
+  // (typically renamed, sometimes copied).
+  const filesText = files.length === 0
     ? '(none)'
-    : filesResp.data.map(f => {
+    : files.map(f => {
         const base = `- [${f.status} +${f.additions}/-${f.deletions}] ${f.filename}`;
-        return f.status === 'renamed' && f.previous_filename
-          ? `${base} (was ${f.previous_filename})`
-          : base;
+        return f.previous_filename ? `${base} (was ${f.previous_filename})` : base;
       }).join('\n');
 
   // 4. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -96,28 +96,11 @@ module.exports = async ({ github, context, core }) => {
   const present = pr.labels.some(l => l.name === LABEL);
   core.info(`Label authority: bot (last actor: ${lastActor || 'none'}, present=${present})`);
 
-  // 3. Gather extra context for the classifier: existing labels and
-  //    changed file paths. Both are stronger signals than parsing the
-  //    body alone (labels are deliberate human classifications, paths
-  //    reveal whether the change touches production code or only CI /
-  //    tests / docs). Filter out the bot's own label so the agent's
-  //    verdict is not influenced by a prior classification round.
   const labels = (pr.labels || []).map(l => l.name).filter(n => n !== LABEL);
-  // Paginate so big PRs (the monorepo regularly has changes touching
-  // 100+ files) don't get silently truncated to the first page, which
-  // would bias the classifier or let a fork-PR pad with unrelated
-  // paths past the page boundary.
   const files = await github.paginate(github.rest.pulls.listFiles, {
     owner, repo, pull_number: pr.number, per_page: 100,
   });
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
-  // Each entry is "- [status +A/-D] path" where status is added /
-  // removed / modified / renamed / copied and +A/-D are lines added
-  // and deleted. Status + size lets the classifier separate new API
-  // surface (`[added +N]` on api types) from small API fixes
-  // (`[modified +2/-1]`), and small defensive tweaks from substantial
-  // rewrites. previous_filename shows on any status that carries it
-  // (typically renamed, sometimes copied).
   const filesText = files.length === 0
     ? '(none)'
     : files.map(f => {

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -107,13 +107,16 @@ module.exports = async ({ github, context, core }) => {
     owner, repo, pull_number: pr.number, per_page: 100,
   });
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
-  // Each entry is "- [status] path" where status is added / removed /
-  // modified / renamed / copied. Status disambiguates new API surface
-  // (`[added] api/**/*types.go`) from API bug fixes (`[modified]` only).
+  // Each entry is "- [status +A/-D] path" where status is added /
+  // removed / modified / renamed / copied and +A/-D are lines added
+  // and deleted. Status + size lets the classifier separate new API
+  // surface (`[added +N]` on api types) from small API fixes
+  // (`[modified +2/-1]`), and small defensive tweaks from substantial
+  // rewrites.
   const filesText = filesResp.data.length === 0
     ? '(none)'
     : filesResp.data.map(f => {
-        const base = `- [${f.status}] ${f.filename}`;
+        const base = `- [${f.status} +${f.additions}/-${f.deletions}] ${f.filename}`;
         return f.status === 'renamed' && f.previous_filename
           ? `${base} (was ${f.previous_filename})`
           : base;


### PR DESCRIPTION
## What

The backport classifier prompt was recently extended to recognise PR labels (`kind/bug`, `kind/feature`, `skip-bot-cherry-pick`, `release-note-not-required`, etc.) and changed file paths (production code vs tests / CI / docs) as primary signals. The workflow was still only sending PR title + body, so the prompt had nothing to act on. This PR wires the missing context through.

Two new fields are appended to the agent payload (`Labels:` and `Changed files:`). No YAML changes, no permission changes, no schema change on the agent side.

## Why

Earlier feedback flagged false-positive classifications for PRs that used bug-fix wording in the body but were really test or CI infrastructure changes (e.g. Windows FV setup, RPM image promotion). Title + body alone was not enough to distinguish those from real production bug fixes. Labels and file paths solve this:

- A PR with `release-note-not-required` and only `.semaphore/` paths is clearly CI infra.
- A PR with `kind/feature` and `api/` type changes is clearly a feature, not a bug fix.
- A PR with `skip-bot-cherry-pick` already has a maintainer veto and should be a hard skip.

## Implementation

`+18 / -2` in `cherry_pick_candidate.js` only.

- Labels come from the `pr` object already in scope. The bot's own `cherry-pick-candidate` label is filtered out so the agent's verdict is not influenced by a prior classification round.
- Changed files come from a single `pulls.listFiles` call with `per_page: 100`. That cap is enough to identify what kind of change this is in essentially every real PR; the first 100 paths are representative and any rule like "all paths under X" is still correct on the truncated view in practice.

The new payload looks like:

```
PR number: <n>
PR title: <title>
PR body:
<body>

Labels: kind/bug, release-note-required, docs-not-required
Changed files:
- felix/foo.go
- libcalico-go/lib/ipam/bar.go
```

The agent prompt already knows how to use these fields; no agent-side change is needed.


## Release note

```release-note
None
```