### PR TITLE
Fix HNS endpoint not found errors (Calico windows fix)

### DIFF
--- a/node/windows-packaging/CalicoWindows/node/node-service.ps1
+++ b/node/windows-packaging/CalicoWindows/node/node-service.ps1
@@ -70,49 +70,6 @@ if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_
 {
     Write-Host "Calico $env:CALICO_NETWORKING_BACKEND networking enabled."
 
-    # Check if the node has been rebooted.  If so, the HNS networks will be in unknown state so we need to
-    # clean them up and recreate them.
-    $prevLastBootTime = Get-StoredLastBootTime
-    if ($prevLastBootTime -NE $lastBootTime)
-    {
-        if ((Get-HNSNetwork | ? Type -NE nat))
-        {
-            Write-Host "First time Calico has run since boot up, cleaning out any old network state."
-            Get-HNSNetwork | ? Type -NE nat | Remove-HNSNetwork
-            do
-            {
-                Write-Host "Waiting for network deletion to complete."
-                Start-Sleep 1
-            } while ((Get-HNSNetwork | ? Type -NE nat))
-        }
-
-        # After deletion of all hns networks, wait for an interface to have an IP that is not a 169.254.0.0/16 (or 127.0.0.0/8) address,
-        # before creation of External network.
-        $isValidIP = $false
-        $IPRegEx1='(^127\.0\.0\.)'
-        $IPRegEx2='(^169\.254\.)'
-        while(!($isValidIP) -AND ($timeout -gt 0))
-        {
-            $IPAddress = (Get-NetIPAddress -AddressFamily IPv4).IPAddress
-            Write-Host "`nTimeout Remaining: $timeout sec"
-            Write-Host "List of IP Address before initialising Calico: $IPAddress"
-            Foreach ($ip in $IPAddress)
-            {
-                if (($ip -NotMatch $IPRegEx1) -AND ($ip -NotMatch $IPRegEx2))
-                {
-                    $isValidIP = $true
-                    Write-Host "`nFound valid IP: $ip"
-                    break
-                }
-            }
-            if (!($isValidIP))
-            {
-                Start-Sleep -s 5
-                $timeout = $timeout - 5
-            }
-        }
-    }
-
     # Create a bridge to trigger a vSwitch creation. Do this only once
     Write-Host "`nStart creating vSwitch. Note: Connection may get lost for RDP, please reconnect...`n"
     while (!(Get-HnsNetwork | ? Name -EQ "External"))

--- a/node/windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1
+++ b/node/windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1
@@ -42,7 +42,7 @@ function Remove-CalicoService($ServiceName)
     }
 }
 
-# Only clean up CNI dirs if using Calico CNI
+# Only clean up CNI artifacts if using Calico CNI
 if ("$env:CNI_PLUGIN_TYPE" -eq "Calico") {
     if ("$env:CNI_NET_DIR" -eq $null)
     {
@@ -82,54 +82,55 @@ if ("$env:CNI_PLUGIN_TYPE" -eq "Calico") {
                     rm $cniBinPath
             }
     }
-}
 
-# Clean up HNS networks if node has rebooted. Must occur before CNI re-install.
-$lastBootTime = Get-LastBootTime
-$timeout = $env:STARTUP_VALID_IP_TIMEOUT
-if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_BACKEND -EQ "vxlan")
-{
-    Write-Host "Calico $env:CALICO_NETWORKING_BACKEND networking enabled."
-
-    # Check if the node has been rebooted.  If so, the HNS networks will be in unknown state so we need to
-    # clean them up and recreate them.
-    $prevLastBootTime = Get-StoredLastBootTime
-    if ($prevLastBootTime -NE $lastBootTime)
+    # Clean up HNS networks if node has rebooted. Must occur before CNI re-install.
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_BACKEND -EQ "vxlan")
     {
-        if ((Get-HNSNetwork | ? Type -NE nat))
-        {
-            Write-Host "First time Calico has run since boot up, cleaning out any old network state."
-            Get-HNSNetwork | ? Type -NE nat | Remove-HNSNetwork
-            do
-            {
-                Write-Host "Waiting for network deletion to complete."
-                Start-Sleep 1
-            } while ((Get-HNSNetwork | ? Type -NE nat))
-        }
+        Write-Host "Calico $env:CALICO_NETWORKING_BACKEND networking enabled."
 
-        # After deletion of all hns networks, wait for an interface to have an IP that is not a 169.254.0.0/16 (or 127.0.0.0/8) address,
-        # before creation of External network.
-        $isValidIP = $false
-        $IPRegEx1='(^127\.0\.0\.)'
-        $IPRegEx2='(^169\.254\.)'
-        while(!($isValidIP) -AND ($timeout -gt 0))
+        # Check if the node has been rebooted.  If so, the HNS networks will be in unknown state so we need to
+        # clean them up and recreate them.
+        $lastBootTime = Get-LastBootTime
+        $prevLastBootTime = Get-StoredLastBootTime
+        Write-Output "calico-install: StoredLastBootTime $prevLastBootTime, CurrentLastBootTime $lastBootTime"
+        if ($prevLastBootTime -NE $lastBootTime)
         {
-            $IPAddress = (Get-NetIPAddress -AddressFamily IPv4).IPAddress
-            Write-Host "`nTimeout Remaining: $timeout sec"
-            Write-Host "List of IP Address before initialising Calico: $IPAddress"
-            Foreach ($ip in $IPAddress)
+            if ((Get-HNSNetwork | ? Type -NE nat))
             {
-                if (($ip -NotMatch $IPRegEx1) -AND ($ip -NotMatch $IPRegEx2))
+                Write-Host "First time Calico has run since boot up, cleaning out any old network state."
+                Get-HNSNetwork | ? Type -NE nat | Remove-HNSNetwork
+                do
                 {
-                    $isValidIP = $true
-                    Write-Host "`nFound valid IP: $ip"
-                    break
-                }
+                    Write-Host "Waiting for network deletion to complete."
+                    Start-Sleep 1
+                } while ((Get-HNSNetwork | ? Type -NE nat))
             }
-            if (!($isValidIP))
+
+            # After deletion of all hns networks, wait for an interface to have an IP that is not a 169.254.0.0/16 (or 127.0.0.0/8) address,
+            # before creation of External network.
+            $isValidIP = $false
+            $timeout = $env:STARTUP_VALID_IP_TIMEOUT
+            $IPRegEx1='(^127\.0\.0\.)'
+            $IPRegEx2='(^169\.254\.)'
+            while(!($isValidIP) -AND ($timeout -gt 0))
             {
-                Start-Sleep -s 5
-                $timeout = $timeout - 5
+                $IPAddress = (Get-NetIPAddress -AddressFamily IPv4).IPAddress
+                Write-Host "`nTimeout Remaining: $timeout sec"
+                Write-Host "List of IP Address before initialising Calico: $IPAddress"
+                Foreach ($ip in $IPAddress)
+                {
+                    if (($ip -NotMatch $IPRegEx1) -AND ($ip -NotMatch $IPRegEx2))
+                    {
+                        $isValidIP = $true
+                        Write-Host "`nFound valid IP: $ip"
+                        break
+                    }
+                }
+                if (!($isValidIP))
+                {
+                    Start-Sleep -s 5
+                    $timeout = $timeout - 5
+                }
             }
         }
     }

--- a/node/windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1
+++ b/node/windows-packaging/CalicoWindows/uninstall-calico-hpc.ps1
@@ -23,6 +23,10 @@ Param(
 
 $ErrorActionPreference = 'SilentlyContinue'
 
+. "$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/config.ps1"
+ipmo "$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/libs/calico/calico.psm1" -Force
+ipmo "$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/libs/hns/hns.psm1" -Force -DisableNameChecking
+
 function Remove-CalicoService($ServiceName)
 {
     $svc = Get-Service | where Name -EQ "$ServiceName"
@@ -77,6 +81,57 @@ if ("$env:CNI_PLUGIN_TYPE" -eq "Calico") {
                 Write-Host "Removing Calico CNI binaries at $cniBinPath ..."
                     rm $cniBinPath
             }
+    }
+}
+
+# Clean up HNS networks if node has rebooted. Must occur before CNI re-install.
+$lastBootTime = Get-LastBootTime
+$timeout = $env:STARTUP_VALID_IP_TIMEOUT
+if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_BACKEND -EQ "vxlan")
+{
+    Write-Host "Calico $env:CALICO_NETWORKING_BACKEND networking enabled."
+
+    # Check if the node has been rebooted.  If so, the HNS networks will be in unknown state so we need to
+    # clean them up and recreate them.
+    $prevLastBootTime = Get-StoredLastBootTime
+    if ($prevLastBootTime -NE $lastBootTime)
+    {
+        if ((Get-HNSNetwork | ? Type -NE nat))
+        {
+            Write-Host "First time Calico has run since boot up, cleaning out any old network state."
+            Get-HNSNetwork | ? Type -NE nat | Remove-HNSNetwork
+            do
+            {
+                Write-Host "Waiting for network deletion to complete."
+                Start-Sleep 1
+            } while ((Get-HNSNetwork | ? Type -NE nat))
+        }
+
+        # After deletion of all hns networks, wait for an interface to have an IP that is not a 169.254.0.0/16 (or 127.0.0.0/8) address,
+        # before creation of External network.
+        $isValidIP = $false
+        $IPRegEx1='(^127\.0\.0\.)'
+        $IPRegEx2='(^169\.254\.)'
+        while(!($isValidIP) -AND ($timeout -gt 0))
+        {
+            $IPAddress = (Get-NetIPAddress -AddressFamily IPv4).IPAddress
+            Write-Host "`nTimeout Remaining: $timeout sec"
+            Write-Host "List of IP Address before initialising Calico: $IPAddress"
+            Foreach ($ip in $IPAddress)
+            {
+                if (($ip -NotMatch $IPRegEx1) -AND ($ip -NotMatch $IPRegEx2))
+                {
+                    $isValidIP = $true
+                    Write-Host "`nFound valid IP: $ip"
+                    break
+                }
+            }
+            if (!($isValidIP))
+            {
+                Start-Sleep -s 5
+                $timeout = $timeout - 5
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Describe your changes, including the type of change (bug fix, feature, etc.), -->
Fix HNS endpoint not found failures on boot up by placing remove-hnsnetwork call before calico's cni conf publishing.

Windows pods initiate CNI add call after kubelet indicates the cni plugin is initialized. This introduces a race condition between the creation of calico hns network (in the go layer) and the hns network removal call in node-service.ps1.  If calico's create hns call wins, the hns endpoint could not be found error is thrown. All pods with this error would require a restart to become healthy again. This PR is to prevent HNS endpoint failures. 

Caveat: For reboot cases, the calico's cni config may already exist. So kubelet may indicate cni is already initialized before removal of the cni config file in uninstall-calico-hpc.ps1 is run. Clients may need to remove the cni config on bootup to eliminate the race for node reboots.

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
