### PR TITLE
felix CI: pass workflow_id to fv-tests-guru

### DIFF
--- a/felix/.semaphore/analyze-test-failures
+++ b/felix/.semaphore/analyze-test-failures
@@ -305,11 +305,13 @@ printf '{
   "max_parallel": 4,
   "max_timeout": "6m",
   "job_url": %s,
+  "workflow_id": %s,
   "git_branch": %s,
   "git_repo_url": %s,
   "pr_title": %s,
   "batches": [%s]
 }' "$(json_escape "$CALICO_REPO")" "$UT_MODE" "$(json_escape "$job_url")" \
+  "$(json_escape "${SEMAPHORE_WORKFLOW_ID:-}")" \
   "$(json_escape "${SEMAPHORE_GIT_WORKING_BRANCH:-$SEMAPHORE_GIT_BRANCH}")" "$(json_escape "$SEMAPHORE_GIT_URL")" \
   "$(json_escape "${SEMAPHORE_GIT_PR_NAME:-}")" "$batches_json" \
   | timeout 660 fv-tests-guru-sem-integration || true


### PR DESCRIPTION
The `analyze-test-failures` wrapper never set `workflow_id` in the JSON config piped to fv-tests-guru, so `analysis_metrics` rows always had an empty `source_workflow` (used to attribute total diagnostic cost to one CI workflow). Populate it from `SEMAPHORE_WORKFLOW_ID`.

The fv-guru binary also backfills run context (branch/repo/job/workflow) from the Semaphore env (tigera/fv-tests-guru#32), so this makes the JSON self-describing rather than relying on that fallback.

## Release Note
```release-note
None
```