### PR TITLE
fix(e2e): untaint control-plane nodes before the e2e run (OpenShift)

### DIFF
--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -81,6 +81,16 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     auth_mount=(-v "${BZ_LOCAL_DIR}/bin/aws-iam-authenticator:/usr/local/bin/aws-iam-authenticator:ro")
   fi
 
+  # Some provisioners (notably OpenShift) taint control-plane nodes
+  # NoSchedule. The k8s e2e framework waits for *all* nodes to be schedulable
+  # (--allowed-not-ready-nodes 0) and otherwise hangs until the 30m
+  # SynchronizedBeforeSuite timeout, so untaint them first — matching what the
+  # legacy `bz tests` runner did. Harmless (`|| true`) on clusters with no such
+  # taint. Run on the host (API is reachable here; install used it).
+  for _taint in node-role.kubernetes.io/master- node-role.kubernetes.io/control-plane-; do
+    KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" ./hack/test/kind/kubectl taint nodes --all "${_taint}" 2>/dev/null || true
+  done
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -88,7 +88,7 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # legacy `bz tests` runner did. Harmless (`|| true`) on clusters with no such
   # taint. Run on the host (API is reachable here; install used it).
   for _taint in node-role.kubernetes.io/master- node-role.kubernetes.io/control-plane-; do
-    KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" ./hack/test/kind/kubectl taint nodes --all "${_taint}" 2>/dev/null || true
+    KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" ./hack/test/kind/kubectl taint nodes --all "${_taint}" || true
   done
 
   # Capture the exit code so the JUnit copy below runs even when tests fail


### PR DESCRIPTION
## Problem

The monorepo-native e2e runner (`.semaphore/end-to-end/scripts/phases/run_tests.sh`, scheduled CI on `master`) runs the k8s e2e binary, whose `SynchronizedBeforeSuite` waits for **all** nodes to be schedulable (`--allowed-not-ready-nodes 0`). **OpenShift taints its control-plane nodes `NoSchedule` by design**, so the wait never completes — it sits at `3 out of 6 nodes are ready … need 3 more` for the full 30m and times out, and **no tests run**.

The cluster is healthy at this point (the install phase logs show all 6 nodes `Ready` and every `calico-node` pod `1/1 Running`) — the only problem is the master taint.

## Fix

The legacy `bz tests` runner untainted control-plane nodes before running (with a comment noting "k8s-e2e will hang if all nodes are not schedulable, and some provisioners taint the master that way"). The monorepo runner dropped that step; this restores it — on the host, where the API is reachable (install already drives `kubectl` from the host). `|| true` keeps it a no-op on clusters without the taint.

## Scope

~25% setup-failure rate on **aws-openshift** `master_hashrel` e2e (iptables/vpp/patch-verification), ongoing. Release branches (v3.30/31/32) use the legacy `bz tests` path and are unaffected — but they inherit this runner when cut, so **v3.33 would regress** without this.

## Relationship to #13039

Same root pattern as #13039 (the monorepo runner dropping setup steps the legacy `bz tests` runner did): #13039 restores the EKS auth binary; this restores the OpenShift untaint. Both touch `run_tests.sh` near `make kubectl` but in distinct spots; kept as separate PRs for independent review.

## Validation status (why draft)

Root cause is established from logs (node-wait stuck at 3/6 = the 3 tainted control-plane nodes; cluster otherwise healthy). Not yet validated by a green aws-openshift run. `bash -n` passes. (Note: the `Check semaphore files` CI job fails on a pre-existing `master` drift in generated `.semaphore` YAML — unrelated to this change; same as noted on #13039.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)