### PR TITLE
fix(e2e): open the private-cluster SOCKS tunnel for the e2e run

### DIFF
--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -100,9 +100,14 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
   # --net=host the container reaches the host's proxy port. No-op (TUNNEL_CMD
   # empty) for public clusters. `|| true` keeps the read safe under `set -e`.
   TUNNEL_CMD="$(grep -E '^MASTER_TUNNEL_COMMAND:' "$(dirname "${BZ_LOCAL_DIR}")/Taskvars.yml" 2>/dev/null | sed -E 's/^MASTER_TUNNEL_COMMAND:[[:space:]]*//' || true)"
+  # Only teardown a tunnel this script started; a pre-existing one is someone
+  # else's to manage. The command is a foreground `ssh -qN` (no -f), so the
+  # backgrounded job is the ssh process itself and $! is the PID to kill.
+  TUNNEL_PID=""
   if [[ -n "${TUNNEL_CMD}" ]] && ! pgrep -fx "${TUNNEL_CMD}" >/dev/null 2>&1; then
     echo "[INFO] opening SOCKS tunnel for private-cluster API access"
     ${TUNNEL_CMD} &
+    TUNNEL_PID=$!
   fi
 
   # Capture the exit code so the JUnit copy below runs even when tests fail
@@ -131,8 +136,8 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
         E2E_JUNIT_REPORT=junit.xml" \
     |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
 
-  # Close the SOCKS tunnel if we opened one (no-op otherwise).
-  [[ -n "${TUNNEL_CMD}" ]] && pkill -fx "${TUNNEL_CMD}" >/dev/null 2>&1 || true
+  # Close the SOCKS tunnel only if we opened it (no-op otherwise).
+  [[ -n "${TUNNEL_PID}" ]] && kill "${TUNNEL_PID}" >/dev/null 2>&1 || true
 
   # Copy JUnit XML to REPORT_DIR so the epilogue publishes it.
   mkdir -p "${REPORT_DIR}"

--- a/.semaphore/end-to-end/scripts/phases/run_tests.sh
+++ b/.semaphore/end-to-end/scripts/phases/run_tests.sh
@@ -91,6 +91,20 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
     KUBECONFIG="${BZ_LOCAL_DIR}/kubeconfig" ./hack/test/kind/kubectl taint nodes --all "${_taint}" || true
   done
 
+  # Private clusters (e.g. private AKS) have no public API endpoint; the API is
+  # reachable only through a SOCKS proxy over an SSH tunnel to an in-VNet host.
+  # banzai-core persists that tunnel command (incl. its SSH key) to Taskvars.yml
+  # and the kubeconfig points at the proxy (proxy-url: socks5://localhost:<port>).
+  # The legacy `bz tests` runner opened the tunnel around the test; this runner
+  # bypasses `bz tests`, so open it here for the run and close it after. With
+  # --net=host the container reaches the host's proxy port. No-op (TUNNEL_CMD
+  # empty) for public clusters. `|| true` keeps the read safe under `set -e`.
+  TUNNEL_CMD="$(grep -E '^MASTER_TUNNEL_COMMAND:' "$(dirname "${BZ_LOCAL_DIR}")/Taskvars.yml" 2>/dev/null | sed -E 's/^MASTER_TUNNEL_COMMAND:[[:space:]]*//' || true)"
+  if [[ -n "${TUNNEL_CMD}" ]] && ! pgrep -fx "${TUNNEL_CMD}" >/dev/null 2>&1; then
+    echo "[INFO] opening SOCKS tunnel for private-cluster API access"
+    ${TUNNEL_CMD} &
+  fi
+
   # Capture the exit code so the JUnit copy below runs even when tests fail
   # (set -e would otherwise bail out before the cp).
   e2e_rc=0
@@ -116,6 +130,9 @@ if [[ -n "${E2E_BINARY:-}" ]]; then
         E2E_OUTPUT_DIR=report \
         E2E_JUNIT_REPORT=junit.xml" \
     |& tee "${BZ_LOGS_DIR}/${TEST_TYPE}-tests.log" || e2e_rc=$?
+
+  # Close the SOCKS tunnel if we opened one (no-op otherwise).
+  [[ -n "${TUNNEL_CMD}" ]] && pkill -fx "${TUNNEL_CMD}" >/dev/null 2>&1 || true
 
   # Copy JUnit XML to REPORT_DIR so the epilogue publishes it.
   mkdir -p "${REPORT_DIR}"


### PR DESCRIPTION
## Problem

Private clusters (e.g. **private AKS**, `CLUSTER_MODE=private`) expose no public API endpoint — the API is reachable only through a SOCKS proxy over an SSH tunnel to an in-VNet host (the documented "connect via a host in the cluster's VNet" pattern). The provisioner persists that tunnel command (with its SSH key) to `Taskvars.yml` as `MASTER_TUNNEL_COMMAND` and points the kubeconfig at the proxy (`proxy-url: socks5://localhost:<port>`).

The legacy `bz tests` runner opened that tunnel around the test run. The monorepo-native `run_tests.sh` bypasses `bz tests`, so **during the e2e step no tunnel is up**: `SynchronizedBeforeSuite` can't reach the private API and fails with `proxyconnect … connection refused`, and no tests run.

## Fix

Open the tunnel for the run and close it after — mirroring banzai-core's own idiom (it reads `MASTER_TUNNEL_COMMAND` from `Taskvars.yml` and backgrounds the ssh). With `--net=host` the container reaches the host's proxy port; the kubeconfig's `proxy-url` does the routing.

- **No-op for public clusters** (`MASTER_TUNNEL_COMMAND` absent → empty).
- Read is `|| true`-guarded so it's safe under the `set -eo pipefail` body script (verified: private/public/missing-Taskvars all extract correctly and don't abort).
- Explicit start/`pkill` rather than a `trap` (the script is *sourced* into `body_*.sh`), matching banzai-core's explicit `ssh:tunnel:end`.

## Scope

~10 setup-failures on **azr-aks** `master_hashrel` e2e (the private-cluster job), ongoing. Public AKS and other platforms are unaffected; release branches use the legacy `bz tests` path (so they're fine until they inherit this runner — i.e. **v3.33** when cut).

## Relationship to #13039 / #13051

Same root pattern (the monorepo runner dropping a setup step the legacy `bz tests` runner did): #13039 = the EKS auth binary; #13051 = the OpenShift control-plane untaint; this = the private-cluster tunnel. Distinct spots in `run_tests.sh`; kept as separate PRs for independent review.

## Validation status (why draft)

Root cause and the read/extraction are verified from logs + a simulated `set -e` test; the SSH key and `MASTER_TUNNEL_COMMAND` are confirmed present in `Taskvars.yml` at `$(dirname "${BZ_LOCAL_DIR}")`. Not yet validated by a green private-AKS run. `bash -n` passes. (`Check semaphore files` CI red is the same pre-existing `master` drift noted on #13039 — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)