### PR TITLE
fix(e2e): correct invalid GCP image families in iptables Distro-support matrix

### DIFF
--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -691,10 +691,10 @@ blocks:
             - env_var: CLUSTER_IMAGE
               values:
                 [
-                  "ubuntu-2404-lts",
+                  "ubuntu-2404-lts-amd64",
                   "ubuntu-2204-lts",
                   "rhel-10",
-                  "centos-stream-8",
+                  "centos-stream-9",
                   "rhel-9",
                   "rocky-linux-8",
                 ]


### PR DESCRIPTION
## Problem

The gcp-kubeadm **"Distro support"** matrix in `iptables.yml` lists two `CLUSTER_IMAGE` values that are **not valid GCP image families**, so `terraform apply` fails at provision with `Could not find image or family ...` — **every retry, deterministically, on all release streams** (master/v3.30/31/32). `CLUSTER_IMAGE` is passed straight to terraform as the image family (`provisioners/gcp-kubeadm/Taskfile.yml`), so these never reach install/tests.

Confirmed from full provision logs (artifact store): e.g.
```
Error: Error resolving image name 'ubuntu-2404-lts': Could not find image or family ubuntu-2404-lts
…task: Failed to run task "gcp-kubeadm:provision" → "terraform:apply": exit status 1
```

## Fix

- `ubuntu-2404-lts` → **`ubuntu-2404-lts-amd64`** — the correct family; `patch-verification.yml` already uses this exact form, so this is just a typo here.
- `centos-stream-8` → **`centos-stream-9`** — CentOS Stream 8 reached **EOL (May 2024)** and its family was removed from `centos-cloud`.

The other four values (`ubuntu-2204-lts`, `rhel-10`, `rhel-9`, `rocky-linux-8`) are valid and unchanged.

## Note for reviewers

The `ubuntu-2404-lts-amd64` change is unambiguous. The `centos-stream-8` → `centos-stream-9` change is a **judgment call** — I kept CentOS-Stream coverage on the live version rather than dropping it; if you'd rather **drop** CentOS Stream entirely from this matrix, say so and I'll remove the entry instead.

## Validation status (draft)

Root cause confirmed from full artifact provision logs; not yet validated by a green Distro-support run. (`Check semaphore files` CI red is the same pre-existing `master` drift noted on #13039 — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)