### PR TITLE
fix(e2e): pin a T2A-capable zone for the bpf ARM64 gcp-kubeadm job

### DIFF
--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -54,6 +54,10 @@ blocks:
           env_vars:
             - name: PROVISIONER
               value: gcp-kubeadm
+            - name: GOOGLE_REGION
+              value: us-central1 # Needed for arm machines
+            - name: GOOGLE_ZONE
+              value: us-central1-a # Needed for arm machines
             - name: GOOGLE_MACHINE_TYPE
               value: t2a-standard-2
             - name: K8S_VERSION


### PR DESCRIPTION
## Problem

The bpf.yml **"Kubeadm - ARM64"** job uses `GOOGLE_MACHINE_TYPE=t2a-standard-2` but doesn't pin `GOOGLE_REGION`/`GOOGLE_ZONE`. `global_prologue.sh` then selects a **random** region (`us-central1` or `us-west1`) and a **random zone** within it, with no awareness of machine-type availability:

```sh
GOOGLE_REGIONS=("us-central1" "us-west1")
GOOGLE_REGION=${GOOGLE_REGION:-${GOOGLE_REGIONS[RANDOM%…]}}
GOOGLE_ZONE=${GOOGLE_ZONE:-$(gcloud compute zones list --filter=region~$GOOGLE_REGION … random pick)}
```

`t2a-standard-2` is offered **only** in `us-central1-{a,b,f}`, `europe-west4-*`, `asia-southeast1-*` (verified via `gcloud compute machine-types list`) — **never in us-west1**, and **not** in `us-central1-c`/`-d`. So the random pick frequently lands where T2A doesn't exist and provisioning fails (deterministically, by draw — not a cloud flake):

```
Error 400: Invalid value for field 'resource.machineType': … Machine type with name
't2a-standard-2' does not exist in zone 'us-central1-c'.
…task: Failed to run task "gcp-kubeadm:provision" → "terraform:apply": exit status 1
```

## Fix

Pin `GOOGLE_REGION=us-central1` / `GOOGLE_ZONE=us-central1-a` for this job — exactly what **`nftables.yml` already does** for its identical ARM64 `t2a-standard-2` job (comment and all). bpf.yml was simply the outlier missing the pin. (`global_prologue` only randomizes when these are unset, so pinning them is sufficient.)

## Follow-up (not in this PR)

The root cause is that `global_prologue.sh`'s random region/zone selection is **machine-type-blind**, so every ARM job must remember to pin a T2A zone. A more robust fix would constrain the random zone list to zones that actually offer the requested `GOOGLE_MACHINE_TYPE` (e.g. filter via `gcloud compute machine-types list`). Left out here to keep the fix minimal and consistent with existing practice.

## Validation status (draft)

Root cause confirmed from the full artifact provision log + `gcloud` T2A availability; the pinned zone is a verified T2A zone and matches nftables.yml's working config. Not yet validated by a green ARM64 run. (`Check semaphore files` CI red is the same pre-existing `master` drift noted on #13039 — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)