### PR TITLE
fix(e2e): use valid CNI_PLUGIN values for the EKS WireGuard jobs

### DIFF
--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -637,7 +637,7 @@ blocks:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: CNI_PLUGIN
-              value: aws
+              value: AmazonVPC
 
         - name: kdd (Calico CNI)
           execution_time_limit:
@@ -646,7 +646,7 @@ blocks:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: CNI_PLUGIN
-              value: calico
+              value: Calico
             # Skipping these upstream k8s tests since they are failing because of limitations of Calico CNI on EKS:
             # - [IT] "Proxy version v1 A set of valid responses are returned for both pod and service Proxy"
             # - [IT] "Proxy version v1 should proxy through a service and a pod"


### PR DESCRIPTION
## Problem

The **"Focused WireGuard E2E (EKS)"** jobs in `iptables.yml` set `CNI_PLUGIN` to lowercase/invalid values:
- `kdd (AWS CNI)` → `CNI_PLUGIN: aws`
- `kdd (Calico CNI)` → `CNI_PLUGIN: calico`

banzai-core passes `CNI_PLUGIN` straight through, and its aws-eks `check-prereqs` only accepts `Calico`, `AmazonVPC`, or empty — so both jobs **fail at the prereq check, before provisioning anything** (deterministic, every run):

```
[ERROR] Expected CNI_PLUGIN to be one of [Calico AmazonVPC] or empty but got calico
task: Failed to run task "aws-eks:check-prereqs" → "provisioner:check-prereqs" → "check:one-of-options"
[ERROR] Cannot provision cluster - failed banzai-core checks for aws-eks
```

## Fix

Use the accepted values (also the capitalized form the AKS and patch-verification blocks already use — verified these two are the only wrong `CNI_PLUGIN` values across all pipelines):
- `kdd (AWS CNI)`: `aws` → **`AmazonVPC`**
- `kdd (Calico CNI)`: `calico` → **`Calico`**

This also drives the correct behaviour: `CNI_PLUGIN: Calico` triggers the AWS-VPC-CNI removal in the aws-eks provisioner; `AmazonVPC` keeps it.

## Validation status (draft)

Root cause confirmed from full artifact provision logs (the check-prereqs error above). `yaml.safe_load` parses clean. Not yet validated by a green EKS WireGuard run. (`Check semaphore files` CI red is the same pre-existing `master` drift noted on #13039 — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)