### PR TITLE
[release-v3.32] Backport e2e pipeline fixes (#13053, #13054, #13055)

### DIFF
--- a/.semaphore/end-to-end/pipelines/bpf.yml
+++ b/.semaphore/end-to-end/pipelines/bpf.yml
@@ -54,6 +54,10 @@ blocks:
           env_vars:
             - name: PROVISIONER
               value: gcp-kubeadm
+            - name: GOOGLE_REGION
+              value: us-central1 # Needed for arm machines
+            - name: GOOGLE_ZONE
+              value: us-central1-a # Needed for arm machines
             - name: GOOGLE_MACHINE_TYPE
               value: t2a-standard-2
             - name: K8S_VERSION

--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -630,7 +630,7 @@ blocks:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: CNI_PLUGIN
-              value: aws
+              value: AmazonVPC
 
         - name: kdd (Calico CNI)
           execution_time_limit:
@@ -639,7 +639,7 @@ blocks:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           env_vars:
             - name: CNI_PLUGIN
-              value: calico
+              value: Calico
             # Skipping these upstream k8s tests since they are failing because of limitations of Calico CNI on EKS:
             # - [IT] "Proxy version v1 A set of valid responses are returned for both pod and service Proxy"
             # - [IT] "Proxy version v1 should proxy through a service and a pod"

--- a/.semaphore/end-to-end/pipelines/iptables.yml
+++ b/.semaphore/end-to-end/pipelines/iptables.yml
@@ -684,10 +684,10 @@ blocks:
             - env_var: CLUSTER_IMAGE
               values:
                 [
-                  "ubuntu-2404-lts",
+                  "ubuntu-2404-lts-amd64",
                   "ubuntu-2204-lts",
                   "rhel-10",
-                  "centos-stream-8",
+                  "centos-stream-9",
                   "rhel-9",
                   "rocky-linux-8",
                 ]


### PR DESCRIPTION
Backports three approved+merged e2e pipeline config fixes to `release-v3.32`.
Each is a deterministic config error present **identically** on this branch
(verified line-for-line), so the affected jobs fail whenever they run.

| master PR | Fix |
|-----------|-----|
| #13053 | `iptables.yml` Distro-support matrix: invalid GCP image families `ubuntu-2404-lts`→`ubuntu-2404-lts-amd64`, `centos-stream-8`→`centos-stream-9` (centos-stream-8 is EOL/removed by Google). |
| #13054 | `bpf.yml` "Kubeadm - ARM64": pin `GOOGLE_REGION/ZONE=us-central1[-a]` so the `t2a-standard-2` ARM machine lands in a T2A-capable zone (matches nftables.yml). |
| #13055 | `iptables.yml` "Focused WireGuard E2E (EKS)": CNI_PLUGIN `aws`→`AmazonVPC`, `calico`→`Calico` (banzai-core's CNI_PLUGIN enum is case-sensitive). |

Cherry-picked cleanly (no conflicts) from the merged commits. The fixed values
(GCE image families, `us-central1` zone, `AmazonVPC`/`Calico`) are all
branch-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)