### PR TITLE
felix/fv: consolidate policy-existence helpers into shared policy package

### DIFF
--- a/felix/fv/bpf_counters_test.go
+++ b/felix/fv/bpf_counters_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf/counters"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -98,7 +99,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test counters", [
 		pol.Spec.Egress = []api.Rule{{Action: api.Allow}}
 		pol = createPolicy(pol)
 
-		bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], w[1].InterfaceName, "ingress", "drop-workload0-to-workload1")
+		polutil.WaitForGlobalNetworkPolicyBPF(tc.Felixes[0], w[1].InterfaceName, "ingress", "drop-workload0-to-workload1")
 
 		By("generating packets and checking the counter")
 		numberOfpackets := 10
@@ -123,19 +124,19 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test counters", [
 		pol = createPolicy(pol)
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-test", "deny", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-test", "deny", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-test", "deny", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-test", "deny", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-test", "deny", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-test", "deny", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-test", "deny", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-test", "deny", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		for range 10 {
@@ -155,19 +156,19 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test counters", [
 
 		pol = updatePolicy(pol)
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-test", "allow", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-test", "allow", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-test", "allow", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-test", "allow", true)
 		}, "2s", "200ms").Should(BeTrue())
 
 		for range 10 {
@@ -190,19 +191,19 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test counters", [
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-test", "allow", true)
 		}, "2s", "200ms").ShouldNot(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-test", "allow", true)
 		}, "2s", "200ms").ShouldNot(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-test", "allow", true)
 		}, "2s", "200ms").ShouldNot(BeTrue())
 
 		Eventually(func() bool {
-			return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-test", "allow", true)
+			return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-test", "allow", true)
 		}, "2s", "200ms").ShouldNot(BeTrue())
 
 		Eventually(func() int {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -53,10 +53,10 @@ import (
 	. "github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/tcpdump"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
-	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/apis/internalapi"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -611,16 +611,16 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 				pol = createPolicy(pol)
 				Eventually(func() bool {
-					return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-1", "allow", true)
+					return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "ingress", "policy-1", "allow", true)
 				}, "5s", "200ms").Should(BeTrue())
 				Eventually(func() bool {
-					return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-1", "allow", true)
+					return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0].InterfaceName, "egress", "policy-1", "allow", true)
 				}, "5s", "200ms").Should(BeTrue())
 				Eventually(func() bool {
-					return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-1", "allow", true)
+					return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "ingress", "policy-1", "allow", true)
 				}, "5s", "200ms").Should(BeTrue())
 				Eventually(func() bool {
-					return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-1", "allow", true)
+					return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[1].InterfaceName, "egress", "policy-1", "allow", true)
 				}, "5s", "200ms").Should(BeTrue())
 			})
 
@@ -1716,7 +1716,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							pol = createPolicy(pol)
 						})
 
-						bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "egress", "host-0-1")
+						polutil.WaitForGlobalNetworkPolicyBPF(tc.Felixes[0], "eth0", "egress", "host-0-1")
 					})
 
 					// With a HostEndpoint Deny policy (applyOnForward:false) on
@@ -1767,8 +1767,8 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							denyPol.Spec.Egress = []api.Rule{{Action: "Deny"}}
 							_ = createPolicy(denyPol)
 
-							bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "ingress", "ci-1988-hep-deny")
-							bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], "eth0", "egress", "ci-1988-hep-deny")
+							polutil.WaitForGlobalNetworkPolicyBPF(tc.Felixes[0], "eth0", "ingress", "ci-1988-hep-deny")
+							polutil.WaitForGlobalNetworkPolicyBPF(tc.Felixes[0], "eth0", "egress", "ci-1988-hep-deny")
 
 							// externalClient sits outside the cluster — not a felix node and not
 							// in any IP pool — so NAT-outgoing applies regardless of
@@ -6639,130 +6639,6 @@ func checkServiceRoute(felix *infrastructure.Felix, ip string) bool {
 	rtRE := regexp.MustCompile(ip + " .* dev bpfin.cali")
 
 	return slices.ContainsFunc(lines, rtRE.MatchString)
-}
-
-func checkIfPolicyOrRuleProgrammed(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool, polType string, ipFamily proto.IPVersion) bool {
-	startStr := ""
-	endStr := ""
-	if polType != "" {
-		startStr = fmt.Sprintf("Start of %s %s", polType, polName)
-		endStr = fmt.Sprintf("End of %s %s", polType, polName)
-	}
-	actionStr := fmt.Sprintf("Start of rule %s action:\"%s\"", polName, action)
-	var policyDbg bpf.PolicyDebugInfo
-	out, err := felix.ExecOutput("cat", bpf.PolicyDebugJSONFileName(iface, hook, ipFamily))
-	if err != nil {
-		return false
-	}
-	dec := json.NewDecoder(strings.NewReader(string(out)))
-	err = dec.Decode(&policyDbg)
-	if err != nil {
-		return false
-	}
-
-	hookStr := "tc ingress"
-	if isWorkload {
-		if hook == "ingress" {
-			hookStr = "tc egress"
-		}
-	} else {
-		if hook == "egress" {
-			hookStr = "tc egress"
-		}
-	}
-	if policyDbg.IfaceName != iface || policyDbg.Hook != hookStr || policyDbg.Error != "" {
-		return false
-	}
-
-	startOfPolicy := false
-	endOfPolicy := false
-	actionMatch := false
-
-	for _, insn := range policyDbg.PolicyInfo {
-		for _, comment := range insn.Comments {
-			if strings.Contains(comment, startStr) {
-				startOfPolicy = true
-			}
-			if strings.Contains(comment, actionStr) && startOfPolicy && !endOfPolicy {
-				actionMatch = true
-			}
-			if startOfPolicy && actionMatch && strings.Contains(comment, endStr) {
-				endOfPolicy = true
-			}
-		}
-	}
-
-	return (startOfPolicy && endOfPolicy && actionMatch)
-}
-
-func bpfCheckIfRuleProgrammed(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
-	return checkIfPolicyOrRuleProgrammed(felix, iface, hook, polName, action, isWorkload, "", proto.IPVersion_IPV4)
-}
-
-func bpfCheckIfNetworkPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polNS, polName, action string, isWorkload bool) bool {
-	namespacedName := fmt.Sprintf("%s/%s", polNS, polName)
-	return checkIfPolicyOrRuleProgrammed(felix, iface, hook, namespacedName, action, isWorkload, "NetworkPolicy", proto.IPVersion_IPV4)
-}
-
-func bpfCheckIfGlobalNetworkPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
-	return checkIfPolicyOrRuleProgrammed(felix, iface, hook, polName, action, isWorkload, "GlobalNetworkPolicy", proto.IPVersion_IPV4)
-}
-
-func bpfCheckIfGlobalNetworkPolicyProgrammedV6(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
-	return checkIfPolicyOrRuleProgrammed(felix, iface, hook, polName, action, isWorkload, "GlobalNetworkPolicy", proto.IPVersion_IPV6)
-}
-
-func bpfDumpPolicy(felix *infrastructure.Felix, iface, hook string) string {
-	var (
-		out string
-		err error
-	)
-
-	if felix.TopologyOptions.EnableIPv6 {
-		out, err = felix.ExecOutput("calico-bpf", "-6", "policy", "dump", iface, hook)
-	} else {
-		out, err = felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook)
-	}
-	Expect(err).NotTo(HaveOccurred())
-	return out
-}
-
-func bpfDumpPolicyAsm(felix *infrastructure.Felix, iface, hook string) string {
-	var (
-		out string
-		err error
-	)
-
-	if felix.TopologyOptions.EnableIPv6 {
-		out, err = felix.ExecOutput("calico-bpf", "-6", "policy", "dump", iface, hook, "--asm")
-	} else {
-		out, err = felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook, "--asm")
-	}
-	Expect(err).NotTo(HaveOccurred())
-	return out
-}
-
-// bpfWaitForGlobalNetworkPolicy waits for the given global network policy to appear in BPF policy.
-func bpfWaitForGlobalNetworkPolicy(felix *infrastructure.Felix, iface, hook, policyName string) string {
-	search := fmt.Sprintf("Policy: GlobalNetworkPolicy %s", policyName)
-	return bpfWaitForPolicy(felix, iface, hook, search)
-}
-
-// bpfWaitForNetworkPolicy waits for the given network policy in the given namespace to appear in BPF policy.
-func bpfWaitForNetworkPolicy(felix *infrastructure.Felix, iface, hook, ns, policyName string) string {
-	search := fmt.Sprintf("Policy: NetworkPolicy %s/%s", ns, policyName)
-	return bpfWaitForPolicy(felix, iface, hook, search)
-}
-
-// bpfWaitForNetworkPolicy waits for the given search string to appear in BPF policy.
-func bpfWaitForPolicy(felix *infrastructure.Felix, iface, hook, search string) string {
-	out := ""
-	EventuallyWithOffset(2, func() string {
-		out = bpfDumpPolicy(felix, iface, hook)
-		return out
-	}, "5s", "200ms").Should(ContainSubstring(search))
-
-	return out
 }
 
 func bpfDumpRoutes(felix *infrastructure.Felix) string {

--- a/felix/fv/cluster_network_policy_test.go
+++ b/felix/fv/cluster_network_policy_test.go
@@ -17,7 +17,6 @@ package fv_test
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,6 +32,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/flowlogs"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -109,40 +109,7 @@ var _ = infrastructure.DatastoreDescribe(
 
 		// policyProgrammed checks whether a policy name appears in Felix[1]'s w[1] dataplane.
 		policyProgrammed := func(policyName string) func() bool {
-			return func() bool {
-				if BPFMode() {
-					out := bpfDumpPolicy(tc.Felixes[1], w[1].InterfaceName, "ingress")
-					out += bpfDumpPolicy(tc.Felixes[1], w[1].InterfaceName, "egress")
-					return strings.Contains(out, policyName)
-				}
-				if NFTMode() {
-					out, err := tc.Felixes[1].ExecOutput("nft", "list", "ruleset")
-					Expect(err).NotTo(HaveOccurred())
-					return strings.Contains(out, policyName)
-				}
-				out, err := tc.Felixes[1].ExecOutput("iptables-save", "-t", "filter")
-				Expect(err).NotTo(HaveOccurred())
-				return strings.Contains(out, policyName)
-			}
-		}
-
-		// policyProgrammedOn checks whether a policy name appears on a specific Felix/interface.
-		policyProgrammedOn := func(felix *infrastructure.Felix, ifaceName, policyName string) func() bool {
-			return func() bool {
-				if BPFMode() {
-					out := bpfDumpPolicy(felix, ifaceName, "ingress")
-					out += bpfDumpPolicy(felix, ifaceName, "egress")
-					return strings.Contains(out, policyName)
-				}
-				if NFTMode() {
-					out, err := felix.ExecOutput("nft", "list", "ruleset")
-					Expect(err).NotTo(HaveOccurred())
-					return strings.Contains(out, policyName)
-				}
-				out, err := felix.ExecOutput("iptables-save", "-t", "filter")
-				Expect(err).NotTo(HaveOccurred())
-				return strings.Contains(out, policyName)
-			}
+			return polutil.ProgrammedOn(tc.Felixes[1], w[1].InterfaceName, policyName)
 		}
 
 		// --- KCNP helpers ---
@@ -521,11 +488,11 @@ var _ = infrastructure.DatastoreDescribe(
 				// KCNP: allow ingress in baseline tier so the pass from default tier is accepted.
 				createAllowTCPIngressKCNP("baseline-allow", clusternetpol.BaselineTier, 100)
 
-				Eventually(policyProgrammedOn(tc.Felixes[0], w[0].InterfaceName, "w0-allow-all"), "15s", "200ms").Should(BeTrue())
+				Eventually(polutil.ProgrammedOn(tc.Felixes[0], w[0].InterfaceName, "w0-allow-all"), "15s", "200ms").Should(BeTrue())
 				Eventually(policyProgrammed("pass-ingress"), "15s", "200ms").Should(BeTrue())
-				Eventually(policyProgrammedOn(tc.Felixes[1], w[1].InterfaceName, "allow-w1"), "15s", "200ms").Should(BeTrue())
-				Eventually(policyProgrammedOn(tc.Felixes[1], w[2].InterfaceName, "pass-w2"), "15s", "200ms").Should(BeTrue())
-				Eventually(policyProgrammedOn(tc.Felixes[1], w[2].InterfaceName, "baseline-allow"), "15s", "200ms").Should(BeTrue())
+				Eventually(polutil.ProgrammedOn(tc.Felixes[1], w[1].InterfaceName, "allow-w1"), "15s", "200ms").Should(BeTrue())
+				Eventually(polutil.ProgrammedOn(tc.Felixes[1], w[2].InterfaceName, "pass-w2"), "15s", "200ms").Should(BeTrue())
+				Eventually(polutil.ProgrammedOn(tc.Felixes[1], w[2].InterfaceName, "baseline-allow"), "15s", "200ms").Should(BeTrue())
 
 				cc = &connectivity.Checker{}
 				cc.ExpectSome(w[0], w[1]) // pass from admin, NP allow in default

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -350,11 +351,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 
 			for _, felix := range tc.Felixes {
 				Eventually(func() bool {
-					return bpfCheckIfGlobalNetworkPolicyProgrammed(felix, "bond0", "egress", "allow-egress", "allow", false)
+					return polutil.GlobalNetworkPolicyProgrammedBPF(felix, "bond0", "egress", "allow-egress", "allow", false)
 				}, "5s", "200ms").Should(BeTrue())
 
 				Eventually(func() bool {
-					return bpfCheckIfGlobalNetworkPolicyProgrammedV6(felix, "bond0", "egress", "allow-egress", "allow", false)
+					return polutil.GlobalNetworkPolicyProgrammedBPFV6(felix, "bond0", "egress", "allow-egress", "allow", false)
 				}, "5s", "200ms").Should(BeTrue())
 
 			}

--- a/felix/fv/flow_logs_goldmane_staged_test.go
+++ b/felix/fv/flow_logs_goldmane_staged_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/flowlogs"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -352,8 +353,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 
 			Eventually(checkNat, "10s", "1s").Should(BeTrue(), "Expected NAT to be programmed")
 
-			bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default.ep1-1-allow-all")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_2.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForGlobalNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default.ep1-1-allow-all")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_2.InterfaceName, "ingress", "default", "tier1.np1-1")
 
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
@@ -362,7 +363,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -816,10 +817,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
 				for _, c := range []felixIface{
@@ -827,7 +828,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -864,10 +865,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
 				for _, c := range []felixIface{
@@ -875,7 +876,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -909,10 +910,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
 				for _, c := range []felixIface{
@@ -920,7 +921,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -954,10 +955,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
@@ -966,7 +967,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -1485,10 +1486,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
@@ -1497,7 +1498,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -1606,10 +1607,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
@@ -1618,7 +1619,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}
@@ -1678,10 +1679,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 				return nil
 			}, "5s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
-			bpfWaitForNetworkPolicy(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "ingress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "egress", "default", "tier1.np1-1")
+			polutil.WaitForNetworkPolicyBPF(tc.Felixes[1], ep2_1.InterfaceName, "ingress", "default", "tier1.np1-1")
 			// When policies are programmed, make sure no staged policy is programmed. Staged policies must be skipped.
 			Consistently(func() error {
 				for _, c := range []felixIface{
@@ -1689,7 +1690,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 					{tc.Felixes[1], ep2_1.InterfaceName},
 				} {
 					for _, hook := range []string{"ingress", "egress"} {
-						if strings.Contains(bpfDumpPolicy(c.f, c.iface, hook), "staged") {
+						if strings.Contains(polutil.DumpBPF(c.f, c.iface, hook), "staged") {
 							return fmt.Errorf("found staged policy in BPF dump for %s on %s %s", c.f.Hostname, c.iface, hook)
 						}
 					}

--- a/felix/fv/flow_logs_goldmane_test.go
+++ b/felix/fv/flow_logs_goldmane_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/flowlogs"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -254,23 +255,23 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log tests", [
 				"Expected iptables rules to appear on the correct felix instances")
 		} else {
 			Eventually(func() bool {
-				return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[1], "eth0", "egress", "gnp-1", "allow", false)
+				return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[1], "eth0", "egress", "gnp-1", "allow", false)
 			}, "5s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[1], "eth0", "ingress", "gnp-1", "allow", false)
+				return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[1], "eth0", "ingress", "gnp-1", "allow", false)
 			}, "5s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfNetworkPolicyProgrammed(tc.Felixes[1], wlHost2[1].InterfaceName, "ingress", "default", "default.np-1", "deny", true)
+				return polutil.NetworkPolicyProgrammedBPF(tc.Felixes[1], wlHost2[1].InterfaceName, "ingress", "default", "default.np-1", "deny", true)
 			}, "5s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfRuleProgrammed(tc.Felixes[0], wlHost1[0].InterfaceName, "ingress", "default", "allow", true)
+				return polutil.RuleProgrammedBPF(tc.Felixes[0], wlHost1[0].InterfaceName, "ingress", "default", "allow", true)
 			}, "15s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfRuleProgrammed(tc.Felixes[0], wlHost1[0].InterfaceName, "egress", "default", "allow", true)
+				return polutil.RuleProgrammedBPF(tc.Felixes[0], wlHost1[0].InterfaceName, "egress", "default", "allow", true)
 			}, "15s", "200ms").Should(BeTrue())
 		}
 
@@ -683,19 +684,19 @@ var _ = infrastructure.DatastoreDescribe("goldmane flow log ipv6 tests", []apico
 				"Expected iptables rules to appear on the correct felix instances")
 		} else {
 			Eventually(func() bool {
-				return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0][0].InterfaceName, "egress", "gnp-1", "allow", true)
+				return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0][0].InterfaceName, "egress", "gnp-1", "allow", true)
 			}, "15s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0][0].InterfaceName, "ingress", "gnp-1", "allow", true)
+				return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0][0].InterfaceName, "ingress", "gnp-1", "allow", true)
 			}, "5s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0][1].InterfaceName, "egress", "gnp-2", "deny", true)
+				return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0][1].InterfaceName, "egress", "gnp-2", "deny", true)
 			}, "5s", "200ms").Should(BeTrue())
 
 			Eventually(func() bool {
-				return bpfCheckIfGlobalNetworkPolicyProgrammed(tc.Felixes[0], w[0][1].InterfaceName, "ingress", "gnp-2", "deny", true)
+				return polutil.GlobalNetworkPolicyProgrammedBPF(tc.Felixes[0], w[0][1].InterfaceName, "ingress", "gnp-2", "deny", true)
 			}, "5s", "200ms").Should(BeTrue())
 		}
 
@@ -1011,7 +1012,7 @@ var _ = infrastructure.DatastoreDescribe("flow log with deleted service pod test
 
 			Eventually(checkNat, "10s", "1s").Should(BeTrue(), "Expected NAT to be programmed")
 
-			bpfWaitForGlobalNetworkPolicy(tc.Felixes[0], ep1_1.InterfaceName, "egress", "ep1-1-allow-test-service")
+			polutil.WaitForGlobalNetworkPolicyBPF(tc.Felixes[0], ep1_1.InterfaceName, "egress", "ep1-1-allow-test-service")
 		}
 
 		if !bpfEnabled {
@@ -1227,8 +1228,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log networkse
 			Eventually(getRuleFuncTable(tc.Felixes[0], "API0|gnp/allow-all", "filter"), "10s", "1s").ShouldNot(HaveOccurred())
 			Eventually(getRuleFuncTable(tc.Felixes[0], "APE0|gnp/allow-all", "filter"), "10s", "1s").ShouldNot(HaveOccurred())
 		} else {
-			bpfWaitForPolicy(tc.Felixes[0], swl1.InterfaceName, "ingress", "allow-all")
-			bpfWaitForPolicy(tc.Felixes[0], swl1.InterfaceName, "egress", "allow-all")
+			polutil.WaitForBPF(tc.Felixes[0], swl1.InterfaceName, "ingress", "allow-all")
+			polutil.WaitForBPF(tc.Felixes[0], swl1.InterfaceName, "egress", "allow-all")
 		}
 
 		// NetworkSets

--- a/felix/fv/policy/bpf.go
+++ b/felix/fv/policy/bpf.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/proto"
+)
+
+// DumpBPF returns the human-readable BPF policy program dump for the given
+// interface and hook ("ingress"/"egress"). It asserts that the dump command
+// succeeds; use it inside an Eventually when the program may not yet be
+// attached.
+func DumpBPF(felix *infrastructure.Felix, iface, hook string) string {
+	var (
+		out string
+		err error
+	)
+
+	if felix.TopologyOptions.EnableIPv6 {
+		out, err = felix.ExecOutput("calico-bpf", "-6", "policy", "dump", iface, hook)
+	} else {
+		out, err = felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook)
+	}
+	Expect(err).NotTo(HaveOccurred())
+	return out
+}
+
+// DumpBPFAsm is like DumpBPF but includes the generated assembly.
+func DumpBPFAsm(felix *infrastructure.Felix, iface, hook string) string {
+	var (
+		out string
+		err error
+	)
+
+	if felix.TopologyOptions.EnableIPv6 {
+		out, err = felix.ExecOutput("calico-bpf", "-6", "policy", "dump", iface, hook, "--asm")
+	} else {
+		out, err = felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook, "--asm")
+	}
+	Expect(err).NotTo(HaveOccurred())
+	return out
+}
+
+// WaitForGlobalNetworkPolicyBPF waits for the given GlobalNetworkPolicy to
+// appear in the BPF policy dump for the given interface and hook.
+func WaitForGlobalNetworkPolicyBPF(felix *infrastructure.Felix, iface, hook, policyName string) string {
+	search := fmt.Sprintf("Policy: GlobalNetworkPolicy %s", policyName)
+	return WaitForBPF(felix, iface, hook, search)
+}
+
+// WaitForNetworkPolicyBPF waits for the given NetworkPolicy in the given
+// namespace to appear in the BPF policy dump for the given interface and hook.
+func WaitForNetworkPolicyBPF(felix *infrastructure.Felix, iface, hook, ns, policyName string) string {
+	search := fmt.Sprintf("Policy: NetworkPolicy %s/%s", ns, policyName)
+	return WaitForBPF(felix, iface, hook, search)
+}
+
+// WaitForBPF waits for the given search string to appear in the BPF policy
+// dump for the given interface and hook, returning the matching dump.
+func WaitForBPF(felix *infrastructure.Felix, iface, hook, search string) string {
+	out := ""
+	EventuallyWithOffset(2, func() string {
+		out = DumpBPF(felix, iface, hook)
+		return out
+	}, "5s", "200ms").Should(ContainSubstring(search))
+
+	return out
+}
+
+// RuleProgrammedBPF reports whether a rule with the given action is programmed
+// for polName in the BPF policy debug info for the given interface and hook.
+func RuleProgrammedBPF(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
+	return checkProgrammedBPF(felix, iface, hook, polName, action, isWorkload, "", proto.IPVersion_IPV4)
+}
+
+// NetworkPolicyProgrammedBPF reports whether the given NetworkPolicy (in
+// namespace polNS) with the given action is programmed in the BPF policy debug
+// info for the given interface and hook.
+func NetworkPolicyProgrammedBPF(felix *infrastructure.Felix, iface, hook, polNS, polName, action string, isWorkload bool) bool {
+	namespacedName := fmt.Sprintf("%s/%s", polNS, polName)
+	return checkProgrammedBPF(felix, iface, hook, namespacedName, action, isWorkload, "NetworkPolicy", proto.IPVersion_IPV4)
+}
+
+// GlobalNetworkPolicyProgrammedBPF reports whether the given
+// GlobalNetworkPolicy with the given action is programmed in the BPF policy
+// debug info for the given interface and hook (IPv4).
+func GlobalNetworkPolicyProgrammedBPF(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
+	return checkProgrammedBPF(felix, iface, hook, polName, action, isWorkload, "GlobalNetworkPolicy", proto.IPVersion_IPV4)
+}
+
+// GlobalNetworkPolicyProgrammedBPFV6 is the IPv6 equivalent of
+// GlobalNetworkPolicyProgrammedBPF.
+func GlobalNetworkPolicyProgrammedBPFV6(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool) bool {
+	return checkProgrammedBPF(felix, iface, hook, polName, action, isWorkload, "GlobalNetworkPolicy", proto.IPVersion_IPV6)
+}
+
+// checkProgrammedBPF inspects the per-interface BPF policy debug JSON and
+// reports whether the named policy (and, when action is set, a rule with that
+// action) is present between the policy's start/end markers.
+func checkProgrammedBPF(felix *infrastructure.Felix, iface, hook, polName, action string, isWorkload bool, polType string, ipFamily proto.IPVersion) bool {
+	startStr := ""
+	endStr := ""
+	if polType != "" {
+		startStr = fmt.Sprintf("Start of %s %s", polType, polName)
+		endStr = fmt.Sprintf("End of %s %s", polType, polName)
+	}
+	actionStr := fmt.Sprintf("Start of rule %s action:\"%s\"", polName, action)
+	var policyDbg bpf.PolicyDebugInfo
+	out, err := felix.ExecOutput("cat", bpf.PolicyDebugJSONFileName(iface, hook, ipFamily))
+	if err != nil {
+		return false
+	}
+	dec := json.NewDecoder(strings.NewReader(string(out)))
+	err = dec.Decode(&policyDbg)
+	if err != nil {
+		return false
+	}
+
+	hookStr := "tc ingress"
+	if isWorkload {
+		if hook == "ingress" {
+			hookStr = "tc egress"
+		}
+	} else {
+		if hook == "egress" {
+			hookStr = "tc egress"
+		}
+	}
+	if policyDbg.IfaceName != iface || policyDbg.Hook != hookStr || policyDbg.Error != "" {
+		return false
+	}
+
+	startOfPolicy := false
+	endOfPolicy := false
+	actionMatch := false
+
+	for _, insn := range policyDbg.PolicyInfo {
+		for _, comment := range insn.Comments {
+			if strings.Contains(comment, startStr) {
+				startOfPolicy = true
+			}
+			if strings.Contains(comment, actionStr) && startOfPolicy && !endOfPolicy {
+				actionMatch = true
+			}
+			if startOfPolicy && actionMatch && strings.Contains(comment, endStr) {
+				endOfPolicy = true
+			}
+		}
+	}
+
+	return startOfPolicy && endOfPolicy && actionMatch
+}

--- a/felix/fv/policy/policy.go
+++ b/felix/fv/policy/policy.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package policy provides shared helpers for Felix FV tests that need to
+// assert whether a policy is (or is not) programmed in the dataplane. The
+// helpers are dataplane-mode aware (BPF, nftables, iptables) so individual
+// tests do not have to re-implement the same mode-switching logic.
+package policy
+
+import (
+	"strings"
+
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+)
+
+// ProgrammedOn returns a function, suitable for use with Eventually, that
+// reports whether the named policy is programmed on the given workload
+// interface of the given Felix instance.
+//
+// In BPF mode it inspects the per-interface BPF policy dump for both the
+// ingress and egress hooks. The per-interface dump must be used (rather than
+// the "all" pseudo-interface) because the debug JSON is keyed by real
+// interface name and the command silently produces no output when the file is
+// missing; dump errors are tolerated and simply reported as "not programmed
+// yet" so the caller's Eventually can retry.
+//
+// In iptables/nftables mode the policy chain names embed the policy name, so a
+// ruleset grep is sufficient.
+func ProgrammedOn(felix *infrastructure.Felix, ifaceName, policyName string) func() bool {
+	return func() bool {
+		if infrastructure.BPFMode() {
+			for _, hook := range []string{"ingress", "egress"} {
+				out, err := bpfDump(felix, ifaceName, hook)
+				if err != nil {
+					continue
+				}
+				if strings.Contains(out, policyName) {
+					return true
+				}
+			}
+			return false
+		}
+
+		var cmd []string
+		if infrastructure.NFTMode() {
+			cmd = []string{"nft", "list", "ruleset"}
+		} else {
+			cmd = []string{"iptables-save", "-t", "filter"}
+		}
+		out, err := felix.ExecOutput(cmd...)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(out, policyName)
+	}
+}
+
+// bpfDump is an error-tolerant variant of DumpBPF used by ProgrammedOn.
+func bpfDump(felix *infrastructure.Felix, iface, hook string) (string, error) {
+	if felix.TopologyOptions.EnableIPv6 {
+		return felix.ExecOutput("calico-bpf", "-6", "policy", "dump", iface, hook)
+	}
+	return felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook)
+}

--- a/felix/fv/route_sync_disabled_test.go
+++ b/felix/fv/route_sync_disabled_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -99,7 +100,7 @@ var _ = infrastructure.DatastoreDescribe(
 			}
 
 			By("Verifying the default-allow policy is programmed in the dataplane")
-			Eventually(policyProgrammedOn(tc.Felixes[0], probeWl.InterfaceName, "default-allow"), "30s", "500ms").
+			Eventually(polutil.ProgrammedOn(tc.Felixes[0], probeWl.InterfaceName, "default-allow"), "30s", "500ms").
 				Should(BeTrue(), "Felix should program the default-allow policy even when RouteSyncDisabled is true")
 		})
 
@@ -197,40 +198,3 @@ var _ = infrastructure.DatastoreDescribe(
 		})
 	},
 )
-
-// policyProgrammedOn returns a function that reports whether the given policy
-// is programmed on the given workload interface. In BPF mode it inspects the
-// per-interface BPF policy dump for the canonical
-// "Policy: GlobalNetworkPolicy <name>" marker — the tool's "all" pseudo-iface
-// cannot be used because the debug JSON is keyed by real interface name and
-// the command silently produces no output when the file is missing. In
-// iptables/nftables mode, policy chain names embed the policy name, so a
-// ruleset grep is sufficient.
-func policyProgrammedOn(felix *infrastructure.Felix, ifaceName, policyName string) func() bool {
-	return func() bool {
-		if BPFMode() {
-			marker := "Policy: GlobalNetworkPolicy " + policyName
-			for _, hook := range []string{"ingress", "egress"} {
-				out, err := felix.ExecOutput("calico-bpf", "policy", "dump", ifaceName, hook)
-				if err != nil {
-					continue
-				}
-				if strings.Contains(out, marker) {
-					return true
-				}
-			}
-			return false
-		}
-		var cmd []string
-		if NFTMode() {
-			cmd = []string{"nft", "list", "ruleset"}
-		} else {
-			cmd = []string{"iptables-save", "-t", "filter"}
-		}
-		out, err := felix.ExecOutput(cmd...)
-		if err != nil {
-			return false
-		}
-		return strings.Contains(out, policyName)
-	}
-}

--- a/felix/fv/tiered_policy_test.go
+++ b/felix/fv/tiered_policy_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/flowlogs"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -362,8 +363,8 @@ var _ = infrastructure.DatastoreDescribe("connectivity tests and flow logs with 
 			}
 
 			// BPF
-			out0 := bpfDumpPolicy(tc.Felixes[1], ep2_4.InterfaceName, "ingress")
-			out1 := bpfDumpPolicy(tc.Felixes[1], ep2_4.InterfaceName, "egress")
+			out0 := polutil.DumpBPF(tc.Felixes[1], ep2_4.InterfaceName, "ingress")
+			out1 := polutil.DumpBPF(tc.Felixes[1], ep2_4.InterfaceName, "egress")
 			return strings.Contains(out0, "End Tier: tier1  (action: deny)") &&
 				strings.Contains(out1, "End Tier: tier1  (action: deny)")
 		}

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	polutil "github.com/projectcalico/calico/felix/fv/policy"
 	"github.com/projectcalico/calico/felix/fv/tcpdump"
 	"github.com/projectcalico/calico/felix/fv/utils"
 	"github.com/projectcalico/calico/felix/fv/workload"
@@ -849,7 +850,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 						By("Waiting for the policy to apply")
 						if BPFMode() {
 							for _, felix := range topologyContainers.Felixes {
-								bpfWaitForGlobalNetworkPolicy(felix, "eth0", "egress", "deny-wg-port")
+								polutil.WaitForGlobalNetworkPolicyBPF(felix, "eth0", "egress", "deny-wg-port")
 							}
 						}
 


### PR DESCRIPTION
## Description

Felix FV tests check whether a policy is programmed in the dataplane in several different ways:

- Two near-identical copies of a dataplane-mode-aware `policyProgrammedOn`/`policyProgrammed` helper, in `cluster_network_policy_test.go` and `route_sync_disabled_test.go`.
- A family of BPF policy dump/wait/check helpers (`bpfDumpPolicy`, `bpfWaitFor*`, `bpfCheckIf*Programmed`) defined in `bpf_test.go` and used across many test files.

This PR introduces a shared `felix/fv/policy` package and routes all callers through it:

- `ProgrammedOn(felix, iface, name)` — dataplane-mode-aware (BPF / nftables / iptables) existence probe, replacing the duplicated local helpers.
- `DumpBPF` / `DumpBPFAsm` / `WaitForBPF` / `WaitForGlobalNetworkPolicyBPF` / `WaitForNetworkPolicyBPF` and the `*ProgrammedBPF` check family, moved out of `bpf_test.go`.

The package is imported under the `polutil` alias because many test files already use a local `policy` variable.

This is a test-infrastructure-only change — no production code is touched.

### Notes for reviewers

- The de-duplication target is the two copies of `policyProgrammedOn`. The BPF helper family was already a single set of package-level functions (not duplicated); moving it into the new package is a relocation for a better home and importability, which is why the diff spans several files.
- Minor behavioural note: the consolidated `ProgrammedOn` tolerates a failing BPF dump and retries via `Eventually` (returns false), whereas the old `cluster_network_policy` variant asserted on the dump error. The `EventuallyWithOffset(2, …)` semantics in `WaitForBPF` are preserved verbatim.

### Testing

`go vet ./felix/fv/ ./felix/fv/policy/...` and `gofmt` clean. The FV suite itself requires built images / privileged Docker and was not executed; the change is mechanical and type-checks.

**Release note:**
```release-note
None
```