### PR TITLE
goldmane: add source and destination IP sets to flows

### DIFF
--- a/felix/collector/flowlog/aggregator_test.go
+++ b/felix/collector/flowlog/aggregator_test.go
@@ -810,4 +810,37 @@ var _ = Describe("Flow log aggregator tests", func() {
 			Expect(flowLog.BytesOut).Should(Equal(33))
 		})
 	})
+
+	Context("Flow log aggregator source/destination IP collection", func() {
+		It("preserves distinct source and destination IPs even when the aggregated tuple is zeroed", func() {
+			// FlowPrefixName (the default aggregation level) zeroes the FlowMeta tuple so that
+			// connections from many source IPs collapse into a single flow log. The IP sets must
+			// still be collected from the underlying connection tuples and surfaced on the FlowLog.
+			ca := NewAggregator()
+
+			// First connection: src 10.0.0.1 -> dst 20.0.0.1 (tuple1).
+			Expect(ca.FeedUpdate(&muNoConn1Rule1AllowUpdateWithEndpointMeta)).NotTo(HaveOccurred())
+
+			// Second connection: same endpoints/key, but a different source IP and port.
+			muCopy := muNoConn1Rule1AllowUpdateWithEndpointMeta
+			tupleCopy := tuple1
+			tupleCopy.L4Src = 44123
+			tupleCopy.Src = utils.IpStrTo16Byte("10.0.0.3")
+			muCopy.Tuple = tupleCopy
+			Expect(ca.FeedUpdate(&muCopy)).NotTo(HaveOccurred())
+
+			messages := ca.GetAndCalibrate()
+			// Both updates aggregate into a single flow log at FlowPrefixName level.
+			Expect(len(messages)).Should(Equal(1))
+			flowLog := messages[0]
+
+			// The aggregated tuple is zeroed (IPs are not part of the aggregation key)...
+			Expect(flowLog.Tuple.Src).Should(Equal(EmptyIP))
+			Expect(flowLog.Tuple.Dst).Should(Equal(EmptyIP))
+
+			// ...but the distinct source / destination IPs are preserved as bounded, sorted sets.
+			Expect(flowLog.SourceIPs).Should(Equal([]string{"10.0.0.1", "10.0.0.3"}))
+			Expect(flowLog.DestIPs).Should(Equal([]string{"20.0.0.1"}))
+		})
+	})
 })

--- a/felix/collector/flowlog/aggregator_test.go
+++ b/felix/collector/flowlog/aggregator_test.go
@@ -842,5 +842,35 @@ var _ = Describe("Flow log aggregator tests", func() {
 			Expect(flowLog.SourceIPs).Should(Equal([]string{"10.0.0.1", "10.0.0.3"}))
 			Expect(flowLog.DestIPs).Should(Equal([]string{"20.0.0.1"}))
 		})
+
+		It("collects and renders IPv6 source and destination IPs", func() {
+			// IPs are stored as a 16-byte array (net.IP.To16 covers both families) and rendered with
+			// net.IP.String, so IPv6 connections must surface as canonical IPv6 strings.
+			ca := NewAggregator()
+
+			// First connection: IPv6 src 2001:db8::1 -> dst 2001:db8:1::1.
+			muV6 := muNoConn1Rule1AllowUpdateWithEndpointMeta
+			tupleV6 := tuple1
+			tupleV6.Src = utils.IpStrTo16Byte("2001:db8::1")
+			tupleV6.Dst = utils.IpStrTo16Byte("2001:db8:1::1")
+			muV6.Tuple = tupleV6
+			Expect(ca.FeedUpdate(&muV6)).NotTo(HaveOccurred())
+
+			// Second connection: same key, a different IPv6 source IP and port.
+			muV6Copy := muNoConn1Rule1AllowUpdateWithEndpointMeta
+			tupleV6Copy := tupleV6
+			tupleV6Copy.L4Src = 44123
+			tupleV6Copy.Src = utils.IpStrTo16Byte("2001:db8::3")
+			muV6Copy.Tuple = tupleV6Copy
+			Expect(ca.FeedUpdate(&muV6Copy)).NotTo(HaveOccurred())
+
+			messages := ca.GetAndCalibrate()
+			Expect(len(messages)).Should(Equal(1))
+			flowLog := messages[0]
+
+			// The distinct IPv6 addresses are preserved and rendered in canonical form.
+			Expect(flowLog.SourceIPs).Should(Equal([]string{"2001:db8::1", "2001:db8::3"}))
+			Expect(flowLog.DestIPs).Should(Equal([]string{"2001:db8:1::1"}))
+		})
 	})
 })

--- a/felix/collector/flowlog/types.go
+++ b/felix/collector/flowlog/types.go
@@ -588,14 +588,20 @@ func (f *FlowStatsByProcess) collectIPs() (srcIPs, dstIPs []string) {
 	srcSeen := make(map[[16]byte]struct{})
 	dstSeen := make(map[[16]byte]struct{})
 	for t := range stats.flowsRefs {
-		if t.Src != EmptyIP {
-			if _, seen := srcSeen[t.Src]; !seen && len(srcSeen) < MaxIPsPerFlowLog {
+		srcFull := len(srcSeen) >= MaxIPsPerFlowLog
+		dstFull := len(dstSeen) >= MaxIPsPerFlowLog
+		if srcFull && dstFull {
+			// Both sets are at capacity; nothing more to collect.
+			break
+		}
+		if !srcFull && t.Src != EmptyIP {
+			if _, seen := srcSeen[t.Src]; !seen {
 				srcSeen[t.Src] = struct{}{}
 				srcIPs = append(srcIPs, net.IP(t.Src[:]).String())
 			}
 		}
-		if t.Dst != EmptyIP {
-			if _, seen := dstSeen[t.Dst]; !seen && len(dstSeen) < MaxIPsPerFlowLog {
+		if !dstFull && t.Dst != EmptyIP {
+			if _, seen := dstSeen[t.Dst]; !seen {
 				dstSeen[t.Dst] = struct{}{}
 				dstIPs = append(dstIPs, net.IP(t.Dst[:]).String())
 			}

--- a/felix/collector/flowlog/types.go
+++ b/felix/collector/flowlog/types.go
@@ -16,7 +16,9 @@ package flowlog
 
 import (
 	"fmt"
+	"net"
 	"reflect"
+	"sort"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -34,6 +36,12 @@ import (
 
 const (
 	unsetIntField = -1
+
+	// MaxIPsPerFlowLog bounds the number of distinct source / destination IP addresses retained per
+	// flow log. Aggregated flows (e.g. at FlowPrefixName level) can span many connections, so the IP
+	// sets are capped to keep memory and downstream wire size bounded. Once the cap is reached,
+	// additional distinct addresses are dropped.
+	MaxIPsPerFlowLog = 100
 )
 
 type empty struct{}
@@ -151,6 +159,11 @@ func (f *FlowSpec) ContainsActiveRefs(mu *metric.Update) bool {
 func (f *FlowSpec) ToFlowLogs(fm FlowMeta, startTime, endTime time.Time, includeLabels bool, includePolicies bool) []*FlowLog {
 	stats := f.toFlowProcessReportedStats()
 
+	// Collect the bounded source / destination IP sets once. The connection tuples retain their
+	// real IPs even when fm.Tuple has been zeroed for aggregation, so these are populated regardless
+	// of aggregation level.
+	srcIPs, dstIPs := f.collectIPs()
+
 	flogs := make([]*FlowLog, 0, len(stats))
 	for _, stat := range stats {
 		fl := &FlowLog{
@@ -158,6 +171,8 @@ func (f *FlowSpec) ToFlowLogs(fm FlowMeta, startTime, endTime time.Time, include
 			StartTime:                startTime,
 			EndTime:                  endTime,
 			FlowProcessReportedStats: stat,
+			SourceIPs:                srcIPs,
+			DestIPs:                  dstIPs,
 		}
 
 		if includeLabels {
@@ -560,6 +575,37 @@ func (f *FlowStatsByProcess) toFlowProcessReportedStats() []FlowProcessReportedS
 	return reportedStats
 }
 
+// collectIPs returns the bounded sets of distinct source and destination IP addresses observed
+// across all connections tracked for this flow. The connection tuples retain their real IPs even
+// when the FlowMeta tuple has been zeroed for aggregation, so we read them from flowsRefs here.
+// Each set is deduplicated, sorted for deterministic output, and truncated to MaxIPsPerFlowLog.
+func (f *FlowStatsByProcess) collectIPs() (srcIPs, dstIPs []string) {
+	stats, ok := f.statsByProcessName[FieldNotIncluded]
+	if !ok {
+		return nil, nil
+	}
+
+	srcSeen := make(map[[16]byte]struct{})
+	dstSeen := make(map[[16]byte]struct{})
+	for t := range stats.flowsRefs {
+		if t.Src != EmptyIP {
+			if _, seen := srcSeen[t.Src]; !seen && len(srcSeen) < MaxIPsPerFlowLog {
+				srcSeen[t.Src] = struct{}{}
+				srcIPs = append(srcIPs, net.IP(t.Src[:]).String())
+			}
+		}
+		if t.Dst != EmptyIP {
+			if _, seen := dstSeen[t.Dst]; !seen && len(dstSeen) < MaxIPsPerFlowLog {
+				dstSeen[t.Dst] = struct{}{}
+				dstIPs = append(dstIPs, net.IP(t.Dst[:]).String())
+			}
+		}
+	}
+	sort.Strings(srcIPs)
+	sort.Strings(dstIPs)
+	return srcIPs, dstIPs
+}
+
 // FlowProcessReportedStats contains FlowReportedStats along with process information.
 type FlowProcessReportedStats struct {
 	FlowReportedStats
@@ -574,4 +620,12 @@ type FlowLog struct {
 	FlowProcessReportedStats
 
 	FlowEnforcedPolicySet, FlowPendingPolicySet FlowPolicySet
+
+	// SourceIPs and DestIPs are the bounded sets of distinct source / destination IP addresses
+	// observed for the connections aggregated into this flow log. The IPs are preserved here even
+	// when the aggregation level (e.g. FlowPrefixName) zeroes the per-flow Tuple, so that
+	// downstream consumers such as Goldmane can still report them. The sets are capped at
+	// MaxIPsPerFlowLog entries and are best-effort rather than exhaustive.
+	SourceIPs []string
+	DestIPs   []string
 }

--- a/felix/collector/goldmane/client.go
+++ b/felix/collector/goldmane/client.go
@@ -148,6 +148,11 @@ func ConvertFlowlogToGoldmane(fl *flowlog.FlowLog) *types.Flow {
 		StartTime: fl.StartTime.Unix(),
 		EndTime:   fl.StartTime.Unix(),
 
+		// SourceIPs and DestIPs carry the bounded sets of IP addresses accumulated by the flow log
+		// aggregator. These are populated even when the aggregation level zeroes the per-flow tuple.
+		SourceIps: fl.SourceIPs,
+		DestIps:   fl.DestIPs,
+
 		PacketsIn:               int64(fl.PacketsIn),
 		PacketsOut:              int64(fl.PacketsOut),
 		BytesIn:                 int64(fl.BytesIn),
@@ -176,6 +181,8 @@ func ConvertGoldmaneToFlowlog(gl *proto.Flow) flowlog.FlowLog {
 
 	fl.SrcLabels = ensureFlowLogLabels(gl.SourceLabels)
 	fl.DstLabels = ensureFlowLogLabels(gl.DestLabels)
+	fl.SourceIPs = gl.SourceIps
+	fl.DestIPs = gl.DestIps
 	fl.FlowEnforcedPolicySet = toFlowPolicySet(gl.Key.Policies.EnforcedPolicies)
 	fl.FlowPendingPolicySet = toFlowPolicySet(gl.Key.Policies.PendingPolicies)
 

--- a/felix/collector/goldmane/client_test.go
+++ b/felix/collector/goldmane/client_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldmane
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/projectcalico/calico/felix/collector/flowlog"
+	"github.com/projectcalico/calico/felix/collector/types/endpoint"
+	"github.com/projectcalico/calico/felix/collector/types/tuple"
+	"github.com/projectcalico/calico/goldmane/pkg/types"
+	"github.com/projectcalico/calico/lib/std/uniquelabels"
+)
+
+func newConvertibleFlowLog() *flowlog.FlowLog {
+	return &flowlog.FlowLog{
+		StartTime: time.Unix(1234567890, 0),
+		EndTime:   time.Unix(1234567890, 0),
+		FlowMeta: flowlog.FlowMeta{
+			// The aggregated tuple has zeroed IPs (FlowPrefixName aggregation); the IP sets are
+			// carried separately on SourceIPs / DestIPs.
+			Tuple: tuple.Tuple{Proto: 6, L4Dst: 80},
+			SrcMeta: endpoint.Metadata{
+				AggregatedName: "web-frontend",
+				Namespace:      "production",
+				Type:           endpoint.Wep,
+			},
+			DstMeta: endpoint.Metadata{
+				AggregatedName: "api-backend",
+				Namespace:      "production",
+				Type:           endpoint.Wep,
+			},
+			Action:   flowlog.ActionAllow,
+			Reporter: flowlog.ReporterSrc,
+		},
+		FlowLabels: flowlog.FlowLabels{
+			SrcLabels: uniquelabels.Empty,
+			DstLabels: uniquelabels.Empty,
+		},
+		SourceIPs: []string{"10.0.0.1", "10.0.0.3"},
+		DestIPs:   []string{"20.0.0.1"},
+	}
+}
+
+// TestConvertFlowlogToGoldmane_IPs verifies that the source / destination IP sets on the flow log
+// are carried onto the Goldmane Flow (and not into the FlowKey).
+func TestConvertFlowlogToGoldmane_IPs(t *testing.T) {
+	fl := newConvertibleFlowLog()
+
+	gf := ConvertFlowlogToGoldmane(fl)
+
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.3"}, gf.SourceIps)
+	assert.Equal(t, []string{"20.0.0.1"}, gf.DestIps)
+}
+
+// TestConvertGoldmaneToFlowlog_IPs verifies the reverse direction: the IP sets on the proto Flow
+// are restored onto the flow log.
+func TestConvertGoldmaneToFlowlog_IPs(t *testing.T) {
+	fl := newConvertibleFlowLog()
+	protoFlow := types.FlowToProto(ConvertFlowlogToGoldmane(fl))
+
+	out := ConvertGoldmaneToFlowlog(protoFlow)
+
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.3"}, out.SourceIPs)
+	assert.Equal(t, []string{"20.0.0.1"}, out.DestIPs)
+}
+
+// TestConvertFlowlogToGoldmane_NoIPs verifies that a flow log without IP sets converts cleanly
+// (backward compatibility with flows that carry no IP information).
+func TestConvertFlowlogToGoldmane_NoIPs(t *testing.T) {
+	fl := newConvertibleFlowLog()
+	fl.SourceIPs = nil
+	fl.DestIPs = nil
+
+	gf := ConvertFlowlogToGoldmane(fl)
+
+	assert.Empty(t, gf.SourceIps)
+	assert.Empty(t, gf.DestIps)
+}

--- a/goldmane/DESIGN.md
+++ b/goldmane/DESIGN.md
@@ -85,8 +85,36 @@ Felix (per-node) --gRPC--> FlowCollector --> Goldmane main loop --> BucketRing
   upstream endpoint over HTTPS with mTLS. Tracks progress in a
   `ConfigMap` (`flow-emitter-state` in `calico-system`).
 
+### Source and destination IP sets
+
+Flows are aggregated by `FlowKey`, which deliberately excludes IP addresses:
+a single key aggregates traffic across many connections, nodes, and time
+intervals. Putting individual IPs in the key would explode key cardinality
+(e.g. a large Deployment talking to another would create O(n) or O(n²) flows
+instead of one). Instead, the distinct source and destination IPs observed for
+a flow are carried as **bounded sets on the `Flow` message** (`source_ips`,
+`dest_ips`), not on the `FlowKey`.
+
+- Felix collects the IP sets from the underlying connection tuples before the
+  aggregation level zeroes the per-flow tuple, and sends them on each
+  `FlowUpdate`.
+- Goldmane merges these sets as flows with the same key are combined across
+  nodes and time windows (`storage.Window` / `DiachronicFlow`), deduplicating
+  and **truncating to `storage.MaxIPsPerFlow` (100) entries** to cap memory and
+  wire size. Once the cap is reached the sets are best-effort, not exhaustive.
+- The sets are surfaced to consumers via the `Flows` API and the Whisker
+  backend (`source_ips` / `dest_ips` JSON fields).
+
+Source/destination *ports* are intentionally not included: they are typically
+ephemeral and high-volume, which would inflate the sets without adding much
+value. This can be revisited if a compelling use case arises.
+
 ### Review notes
 
+- The IP sets must never move into the `FlowKey` — doing so reintroduces the
+  cardinality explosion described above. Keep them on `Flow` / `Window`.
+- The truncation cap (`MaxIPsPerFlow`) bounds memory; changing it affects the
+  per-flow footprint at scale. Benchmark before raising it.
 - A change to any of the five concepts above — bucket layout,
   rollover cadence, emit semantics, sink reload protocol — is a
   protocol-level change. Callers (Felix's flow reporter, Whisker,

--- a/goldmane/pkg/storage/diachronic_flow.go
+++ b/goldmane/pkg/storage/diachronic_flow.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"slices"
 	"sort"
 	"strings"
 	"unique"
@@ -38,12 +39,22 @@ type DiachronicFlow struct {
 	Windows []Window
 }
 
+// MaxIPsPerFlow bounds the number of distinct source / destination IP addresses retained per
+// flow window. A single FlowKey aggregates traffic from many connections (and across nodes and
+// time), so the IP sets are capped to keep memory and wire size bounded. Once the cap is reached,
+// additional distinct addresses are dropped, making the sets best-effort rather than exhaustive.
+const MaxIPsPerFlow = 100
+
 type Window struct {
 	start int64
 	end   int64
 
-	SourceLabels            unique.Handle[string]
-	DestLabels              unique.Handle[string]
+	SourceLabels unique.Handle[string]
+	DestLabels   unique.Handle[string]
+	// SourceIPs and DestIPs are the bounded sets of distinct source / destination IP addresses
+	// observed for the connections aggregated into this window. They are capped at MaxIPsPerFlow.
+	SourceIPs               []string
+	DestIPs                 []string
 	PacketsIn               int64
 	PacketsOut              int64
 	BytesIn                 int64
@@ -148,6 +159,8 @@ func (d *DiachronicFlow) addToWindow(flow *types.Flow, index int) {
 	d.Windows[index].NumConnectionsLive += flow.NumConnectionsLive
 	d.Windows[index].SourceLabels = intersection(d.Windows[index].SourceLabels, flow.SourceLabels)
 	d.Windows[index].DestLabels = intersection(d.Windows[index].DestLabels, flow.DestLabels)
+	d.Windows[index].SourceIPs = mergeBoundedIPs(d.Windows[index].SourceIPs, flow.SourceIps, MaxIPsPerFlow)
+	d.Windows[index].DestIPs = mergeBoundedIPs(d.Windows[index].DestIPs, flow.DestIps, MaxIPsPerFlow)
 }
 
 func (d *DiachronicFlow) insertWindow(flow *types.Flow, index int, start, end int64) {
@@ -163,6 +176,8 @@ func (d *DiachronicFlow) insertWindow(flow *types.Flow, index int, start, end in
 		NumConnectionsLive:      flow.NumConnectionsLive,
 		SourceLabels:            flow.SourceLabels,
 		DestLabels:              flow.DestLabels,
+		SourceIPs:               mergeBoundedIPs(nil, flow.SourceIps, MaxIPsPerFlow),
+		DestIPs:                 mergeBoundedIPs(nil, flow.DestIps, MaxIPsPerFlow),
 	}
 	d.Windows = append(d.Windows[:index], append([]Window{w}, d.Windows[index:]...)...)
 
@@ -188,6 +203,8 @@ func (d *DiachronicFlow) appendWindow(flow *types.Flow, start, end int64) {
 		NumConnectionsLive:      flow.NumConnectionsLive,
 		SourceLabels:            flow.SourceLabels,
 		DestLabels:              flow.DestLabels,
+		SourceIPs:               mergeBoundedIPs(nil, flow.SourceIps, MaxIPsPerFlow),
+		DestIPs:                 mergeBoundedIPs(nil, flow.DestIps, MaxIPsPerFlow),
 	}
 	d.Windows = append(d.Windows, w)
 
@@ -266,6 +283,10 @@ func (d *DiachronicFlow) AggregateWindows(windows []*Window) *types.Flow {
 		} else {
 			f.DestLabels = w.DestLabels
 		}
+
+		// Merge the bounded IP sets across windows, deduplicating and truncating to the cap.
+		f.SourceIps = mergeBoundedIPs(f.SourceIps, w.SourceIPs, MaxIPsPerFlow)
+		f.DestIps = mergeBoundedIPs(f.DestIps, w.DestIPs, MaxIPsPerFlow)
 
 		// Update the flow's start and end times.
 		if f.StartTime == 0 || w.start < f.StartTime {
@@ -353,4 +374,40 @@ func sortedCSVIntersection(a, b string) string {
 		}
 	}
 	return buf.String()
+}
+
+// mergeBoundedIPs returns the union of the existing IP set and the incoming IPs, deduplicated and
+// truncated to at most maxIPs entries. The result is sorted for deterministic output. The existing
+// slice is assumed to already be within the cap; once the cap is reached, additional distinct
+// addresses are dropped, so the returned set is best-effort rather than exhaustive.
+func mergeBoundedIPs(existing, incoming []string, maxIPs int) []string {
+	if len(incoming) == 0 {
+		return existing
+	}
+
+	seen := make(map[string]struct{}, len(existing)+len(incoming))
+	merged := make([]string, 0, len(existing)+len(incoming))
+	add := func(ips []string) {
+		for _, ip := range ips {
+			if ip == "" {
+				continue
+			}
+			if maxIPs > 0 && len(merged) >= maxIPs {
+				return
+			}
+			if _, ok := seen[ip]; ok {
+				continue
+			}
+			seen[ip] = struct{}{}
+			merged = append(merged, ip)
+		}
+	}
+	add(existing)
+	add(incoming)
+
+	if len(merged) == 0 {
+		return existing
+	}
+	slices.Sort(merged)
+	return merged
 }

--- a/goldmane/pkg/storage/diachronic_flow_test.go
+++ b/goldmane/pkg/storage/diachronic_flow_test.go
@@ -15,6 +15,7 @@
 package storage_test
 
 import (
+	"net"
 	"testing"
 	"unique"
 
@@ -103,4 +104,79 @@ func TestDiachronicFlow(t *testing.T) {
 	df.Rollover(401)
 	af = df.Aggregate(0, 400)
 	require.Nil(t, af)
+}
+
+// TestDiachronicFlow_IPSets verifies that source / destination IP sets are unioned and
+// deduplicated as flows are added to a window and aggregated across windows.
+func TestDiachronicFlow_IPSets(t *testing.T) {
+	defer setupTest(t)()
+
+	k := types.NewFlowKey(
+		&types.FlowKeySource{},
+		&types.FlowKeyDestination{},
+		&types.FlowKeyMeta{},
+		&proto.PolicyTrace{},
+	)
+	df := storage.NewDiachronicFlow(k, 0)
+
+	// Two flows in the same window, with overlapping source IPs and distinct dest IPs.
+	df.AddFlow(&types.Flow{
+		Key:          k,
+		SourceLabels: unique.Make(""),
+		DestLabels:   unique.Make(""),
+		SourceIps:    []string{"10.0.0.1", "10.0.0.2"},
+		DestIps:      []string{"192.168.0.1"},
+	}, 0, 1)
+	df.AddFlow(&types.Flow{
+		Key:          k,
+		SourceLabels: unique.Make(""),
+		DestLabels:   unique.Make(""),
+		SourceIps:    []string{"10.0.0.2", "10.0.0.3"},
+		DestIps:      []string{"192.168.0.2"},
+	}, 0, 1)
+
+	af := df.Aggregate(0, 1)
+	require.Equal(t, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, af.SourceIps, "source IPs should be unioned and deduplicated")
+	require.Equal(t, []string{"192.168.0.1", "192.168.0.2"}, af.DestIps, "dest IPs should be unioned")
+
+	// A flow in a different window contributes additional IPs that must merge on aggregation.
+	df.AddFlow(&types.Flow{
+		Key:          k,
+		SourceLabels: unique.Make(""),
+		DestLabels:   unique.Make(""),
+		SourceIps:    []string{"10.0.0.4"},
+		DestIps:      []string{"192.168.0.1"},
+	}, 1, 2)
+
+	af = df.Aggregate(0, 2)
+	require.Equal(t, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"}, af.SourceIps)
+	require.Equal(t, []string{"192.168.0.1", "192.168.0.2"}, af.DestIps)
+}
+
+// TestDiachronicFlow_IPSetCap verifies the per-flow IP set is capped at MaxIPsPerFlow.
+func TestDiachronicFlow_IPSetCap(t *testing.T) {
+	defer setupTest(t)()
+
+	k := types.NewFlowKey(
+		&types.FlowKeySource{},
+		&types.FlowKeyDestination{},
+		&types.FlowKeyMeta{},
+		&proto.PolicyTrace{},
+	)
+	df := storage.NewDiachronicFlow(k, 0)
+
+	// Add far more distinct source IPs than the cap allows.
+	manyIPs := make([]string, storage.MaxIPsPerFlow*2)
+	for i := range manyIPs {
+		manyIPs[i] = net.IP{10, byte(i >> 16), byte(i >> 8), byte(i)}.String()
+	}
+	df.AddFlow(&types.Flow{
+		Key:          k,
+		SourceLabels: unique.Make(""),
+		DestLabels:   unique.Make(""),
+		SourceIps:    manyIPs,
+	}, 0, 1)
+
+	af := df.Aggregate(0, 1)
+	require.Len(t, af.SourceIps, storage.MaxIPsPerFlow, "source IP set should be truncated to the cap")
 }

--- a/goldmane/pkg/types/flow.go
+++ b/goldmane/pkg/types/flow.go
@@ -141,11 +141,17 @@ func (k *FlowKey) DestServicePort() int64 {
 
 // This struct should be an exact copy of the proto.Flow structure, but without the private fields.
 type Flow struct {
-	Key                     *FlowKey
-	StartTime               int64
-	EndTime                 int64
-	SourceLabels            unique.Handle[string]
-	DestLabels              unique.Handle[string]
+	Key          *FlowKey
+	StartTime    int64
+	EndTime      int64
+	SourceLabels unique.Handle[string]
+	DestLabels   unique.Handle[string]
+	// SourceIps and DestIps hold the bounded, best-effort sets of source and destination IP
+	// addresses observed for the connections aggregated into this Flow. They are not part of the
+	// FlowKey: a single key aggregates many connections (and across nodes/time), so the IPs are
+	// stored as sets on the Flow to avoid exploding key cardinality. See goldmane/DESIGN.md.
+	SourceIps               []string
+	DestIps                 []string
 	PacketsIn               int64
 	PacketsOut              int64
 	BytesIn                 int64
@@ -201,6 +207,8 @@ func ProtoToFlow(p *proto.Flow) *Flow {
 		EndTime:                 p.EndTime,
 		SourceLabels:            toHandles(p.SourceLabels),
 		DestLabels:              toHandles(p.DestLabels),
+		SourceIps:               p.SourceIps,
+		DestIps:                 p.DestIps,
 		PacketsIn:               p.PacketsIn,
 		PacketsOut:              p.PacketsOut,
 		BytesIn:                 p.BytesIn,
@@ -276,6 +284,8 @@ func FlowIntoProto(f *Flow, pf *proto.Flow) {
 	pf.EndTime = f.EndTime
 	pf.SourceLabels = fromHandles(f.SourceLabels)
 	pf.DestLabels = fromHandles(f.DestLabels)
+	pf.SourceIps = f.SourceIps
+	pf.DestIps = f.DestIps
 	pf.PacketsIn = f.PacketsIn
 	pf.PacketsOut = f.PacketsOut
 	pf.BytesIn = f.BytesIn
@@ -325,6 +335,8 @@ func FlowToProto(f *Flow) *proto.Flow {
 		EndTime:                 f.EndTime,
 		SourceLabels:            fromHandles(f.SourceLabels),
 		DestLabels:              fromHandles(f.DestLabels),
+		SourceIps:               f.SourceIps,
+		DestIps:                 f.DestIps,
 		PacketsIn:               f.PacketsIn,
 		PacketsOut:              f.PacketsOut,
 		BytesIn:                 f.BytesIn,

--- a/goldmane/pkg/types/flow_test.go
+++ b/goldmane/pkg/types/flow_test.go
@@ -70,6 +70,8 @@ func TestTranslation(t *testing.T) {
 				EndTime:                 1234567891,
 				SourceLabels:            []string{"source-label-1", "source-label-2"},
 				DestLabels:              []string{"dest-label-1", "dest-label-2"},
+				SourceIps:               []string{"10.0.0.1", "10.0.0.2"},
+				DestIps:                 []string{"192.168.0.1", "192.168.0.2"},
 				PacketsIn:               123,
 				PacketsOut:              456,
 				BytesIn:                 789,

--- a/goldmane/proto/api.pb.go
+++ b/goldmane/proto/api.pb.go
@@ -7,12 +7,11 @@
 package proto
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1794,8 +1793,17 @@ type Flow struct {
 	// NumConnectionsLive tracks the total number of still active connections recorded for this Flow. It counts each
 	// connection that matches the FlowKey that was active at this Flow's EndTime.
 	NumConnectionsLive int64 `protobuf:"varint,12,opt,name=num_connections_live,json=numConnectionsLive,proto3" json:"num_connections_live,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// SourceIps contains the set of distinct source IP addresses observed for the connections aggregated
+	// into this Flow. Because a single FlowKey aggregates traffic across many individual connections (and
+	// across nodes and time), this is a set rather than a single value. The list is bounded: at most a
+	// configurable maximum number of addresses are retained per Flow to cap memory and wire size. When the
+	// limit is exceeded, addresses are dropped (the set is best-effort, not exhaustive).
+	SourceIps []string `protobuf:"bytes,13,rep,name=source_ips,json=sourceIps,proto3" json:"source_ips,omitempty"`
+	// DestIps contains the set of distinct destination IP addresses observed for the connections aggregated
+	// into this Flow. As with source_ips, this is a bounded, best-effort set rather than a single value.
+	DestIps       []string `protobuf:"bytes,14,rep,name=dest_ips,json=destIps,proto3" json:"dest_ips,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Flow) Reset() {
@@ -1910,6 +1918,20 @@ func (x *Flow) GetNumConnectionsLive() int64 {
 		return x.NumConnectionsLive
 	}
 	return 0
+}
+
+func (x *Flow) GetSourceIps() []string {
+	if x != nil {
+		return x.SourceIps
+	}
+	return nil
+}
+
+func (x *Flow) GetDestIps() []string {
+	if x != nil {
+		return x.DestIps
+	}
+	return nil
 }
 
 type PolicyTrace struct {
@@ -2418,7 +2440,7 @@ const file_api_proto_rawDesc = "" +
 	"\x05proto\x18\f \x01(\tR\x05proto\x12.\n" +
 	"\breporter\x18\r \x01(\x0e2\x12.goldmane.ReporterR\breporter\x12(\n" +
 	"\x06action\x18\x0e \x01(\x0e2\x10.goldmane.ActionR\x06action\x121\n" +
-	"\bpolicies\x18\x0f \x01(\v2\x15.goldmane.PolicyTraceR\bpolicies\"\xc9\x03\n" +
+	"\bpolicies\x18\x0f \x01(\v2\x15.goldmane.PolicyTraceR\bpolicies\"\x83\x04\n" +
 	"\x04Flow\x12#\n" +
 	"\x03Key\x18\x01 \x01(\v2\x11.goldmane.FlowKeyR\x03Key\x12\x1d\n" +
 	"\n" +
@@ -2436,7 +2458,10 @@ const file_api_proto_rawDesc = "" +
 	"\x17num_connections_started\x18\n" +
 	" \x01(\x03R\x15numConnectionsStarted\x12:\n" +
 	"\x19num_connections_completed\x18\v \x01(\x03R\x17numConnectionsCompleted\x120\n" +
-	"\x14num_connections_live\x18\f \x01(\x03R\x12numConnectionsLive\"\x8f\x01\n" +
+	"\x14num_connections_live\x18\f \x01(\x03R\x12numConnectionsLive\x12\x1d\n" +
+	"\n" +
+	"source_ips\x18\r \x03(\tR\tsourceIps\x12\x19\n" +
+	"\bdest_ips\x18\x0e \x03(\tR\adestIps\"\x8f\x01\n" +
 	"\vPolicyTrace\x12@\n" +
 	"\x11enforced_policies\x18\x01 \x03(\v2\x13.goldmane.PolicyHitR\x10enforcedPolicies\x12>\n" +
 	"\x10pending_policies\x18\x02 \x03(\v2\x13.goldmane.PolicyHitR\x0fpendingPolicies\"\x96\x02\n" +

--- a/goldmane/proto/api.proto
+++ b/goldmane/proto/api.proto
@@ -428,6 +428,17 @@ message Flow {
   // NumConnectionsLive tracks the total number of still active connections recorded for this Flow. It counts each
   // connection that matches the FlowKey that was active at this Flow's EndTime.
   int64 num_connections_live = 12;
+
+  // SourceIps contains the set of distinct source IP addresses observed for the connections aggregated
+  // into this Flow. Because a single FlowKey aggregates traffic across many individual connections (and
+  // across nodes and time), this is a set rather than a single value. The list is bounded: at most a
+  // configurable maximum number of addresses are retained per Flow to cap memory and wire size. When the
+  // limit is exceeded, addresses are dropped (the set is best-effort, not exhaustive).
+  repeated string source_ips = 13;
+
+  // DestIps contains the set of distinct destination IP addresses observed for the connections aggregated
+  // into this Flow. As with source_ips, this is a bounded, best-effort set rather than a single value.
+  repeated string dest_ips = 14;
 }
 
 message PolicyTrace {

--- a/whisker-backend/pkg/apis/v1/flows.go
+++ b/whisker-backend/pkg/apis/v1/flows.go
@@ -257,9 +257,11 @@ type FlowResponse struct {
 	SourceName      string      `json:"source_name"`
 	SourceNamespace string      `json:"source_namespace"`
 	SourceLabels    string      `json:"source_labels"`
+	SourceIPs       []string    `json:"source_ips,omitempty"`
 	DestName        string      `json:"dest_name"`
 	DestNamespace   string      `json:"dest_namespace"`
 	DestLabels      string      `json:"dest_labels"`
+	DestIPs         []string    `json:"dest_ips,omitempty"`
 	Protocol        string      `json:"protocol"`
 	DestPort        int64       `json:"dest_port"`
 	Reporter        Reporter    `json:"reporter"`

--- a/whisker-backend/pkg/handlers/v1/flows_test.go
+++ b/whisker-backend/pkg/handlers/v1/flows_test.go
@@ -47,6 +47,8 @@ func TestListFlows(t *testing.T) {
 		[]*proto.FlowResult{
 			{
 				Flow: &proto.Flow{
+					SourceIps: []string{"10.0.0.1", "10.0.0.2"},
+					DestIps:   []string{"192.168.0.1"},
 					Key: &proto.FlowKey{
 						SourceNamespace: "default",
 						SourceName:      "test-pod",
@@ -100,6 +102,8 @@ func TestListFlows(t *testing.T) {
 					EndTime:         zerotime,
 					SourceNamespace: "default",
 					SourceName:      "test-pod",
+					SourceIPs:       []string{"10.0.0.1", "10.0.0.2"},
+					DestIPs:         []string{"192.168.0.1"},
 					Policies: whiskerv1.PolicyTrace{
 						Enforced: []*whiskerv1.PolicyHit{
 							{

--- a/whisker-backend/pkg/handlers/v1/protoconvert.go
+++ b/whisker-backend/pkg/handlers/v1/protoconvert.go
@@ -149,10 +149,12 @@ func protoToFlow(flow *proto.Flow) whiskerv1.FlowResponse {
 		SourceName:      protoToName(flow.Key.SourceName),
 		SourceNamespace: flow.Key.SourceNamespace,
 		SourceLabels:    strings.Join(flow.SourceLabels, " | "),
+		SourceIPs:       flow.SourceIps,
 
 		DestName:      protoToName(flow.Key.DestName),
 		DestNamespace: flow.Key.DestNamespace,
 		DestLabels:    strings.Join(flow.DestLabels, " | "),
+		DestIPs:       flow.DestIps,
 
 		Protocol:   flow.Key.Proto,
 		DestPort:   flow.Key.DestPort,


### PR DESCRIPTION
## Summary

Adds the distinct **source and destination IP addresses** of a flow to the Goldmane API, surfacing them through to the Whisker backend. This implements #10601 and supersedes the now-stale #10714, addressing the maintainer review feedback on that PR.

Goldmane aggregates flows by `FlowKey`, which deliberately excludes IP addresses, so today there is no way to see the IPs that contributed to a flow. Putting IPs in the `FlowKey` would explode key cardinality (a large Deployment talking to another would create O(n) / O(n²) flows instead of one). Following the guidance from #10714's review, the IPs are carried as **bounded sets on the `Flow` message** (`source_ips`, `dest_ips`) rather than on the `FlowKey`.

## Changes

- **proto**: add `repeated string source_ips` / `dest_ips` to `Flow` (fields 13/14). Not on `FlowKey`, and no ports.
- **felix**: collect the source/dest IP sets from the underlying connection tuples *before* the aggregation level (`FlowPrefixName`) zeroes the per-flow tuple, and send them to Goldmane. Without this the IPs are already gone by the time the flow log is built.
- **goldmane**: merge the IP sets as flows with the same key are combined across nodes and time windows (`storage.Window` / `DiachronicFlow`), deduplicating and truncating to a bounded cap (`MaxIPsPerFlow = 100`) to keep memory and wire size bounded.
- **whisker-backend**: expose `source_ips` / `dest_ips` in the flows API response.
- **docs**: document the design and review notes in `goldmane/DESIGN.md`.

## Why no source ports?

Per maintainer feedback on #10714, source/destination ports are intentionally **not** included — they are typically ephemeral and high-volume, which would inflate the sets without much value. This can be revisited if a compelling use case arises.

## Differences from #10714

- IPs live on `Flow` as bounded sets, **not** on `FlowKey` (no cardinality explosion).
- **Both** source and destination IPs, symmetric, as `repeated` fields.
- Source ports removed.
- The set merge/dedup/truncation is actually **wired into the storage aggregation engine** (the prior PR added a `MergeFlows` helper that was never called).
- Felix now actually **collects** the IPs before aggregation zeroes the tuple, so the feature works at the default aggregation level.

## Testing

- `goldmane/pkg/types`: extended the bidirectional proto translation test to cover the IP arrays.
- `goldmane/pkg/storage`: new tests for union/dedup across windows and truncation to the cap.
- `felix/collector/flowlog`: new aggregator test proving the IPs are preserved on the flow log even though the aggregated tuple is zeroed.
- `whisker-backend`: extended the list-flows handler test to assert the IP arrays round-trip into the JSON response.

**Release note:**
```release-note
Goldmane flows now include the set of source and destination IP addresses, viewable via the Whisker flows API.
```

Closes #10601