### PR TITLE
[v3.31] felix: preserve API server service NAT backend across transient endpoint loss

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -423,6 +423,49 @@ func (s *Syncer) applySvc(skey svcKey, sinfo Service, eps []k8sp.Endpoint) error
 	return nil
 }
 
+// isKubernetesAPIServerService reports whether sname is the default Kubernetes
+// API server service (default/kubernetes).
+func isKubernetesAPIServerService(sname k8sp.ServicePortName) bool {
+	return sname.Namespace == "default" && sname.Name == "kubernetes"
+}
+
+// countReadyEndpoints returns the number of ready endpoints in eps.
+func countReadyEndpoints(eps []k8sp.Endpoint) int {
+	n := 0
+	for _, ep := range eps {
+		if ep.IsReady() {
+			n++
+		}
+	}
+	return n
+}
+
+// apiServerFallbackEps returns the API server service's last-known-good
+// endpoints, marked ready.
+func (s *Syncer) apiServerFallbackEps(sname k8sp.ServicePortName) []k8sp.Endpoint {
+	prev := s.prevEpsMap[sname]
+	if len(prev) == 0 {
+		return nil
+	}
+
+	src := make([]k8sp.Endpoint, 0, len(prev))
+	for _, ep := range prev {
+		if ep.IsReady() {
+			src = append(src, ep)
+		}
+	}
+	if len(src) == 0 {
+		src = prev
+	}
+
+	out := make([]k8sp.Endpoint, 0, len(src))
+	for _, ep := range src {
+		out = append(out, NewEndpointInfo(ep.IP(), ep.Port(),
+			EndpointInfoOptIsReady(true), EndpointInfoOptIsServing(true)))
+	}
+	return out
+}
+
 func (s *Syncer) addActiveEps(id uint32, svc Service, eps []k8sp.Endpoint) {
 	svcKey := servicePortToIPPortProto(svc)
 
@@ -611,6 +654,17 @@ func (s *Syncer) apply(state DPSyncerState) error {
 			eps = FilterEpsByTrafficDistribution(state.EpsMap[sname], nodeName, nodeZone)
 		} else {
 			log.Debugf("Topology Aware Routing applied for service %s, mode %s.", sname, topologyMode)
+		}
+
+		// In bpfNetworkBootstrap mode Felix reaches the API server through this service's
+		// NAT; dropping its backends would sever and deadlock its own recovery, so keep the last-known-good.
+		if isKubernetesAPIServerService(sname) && countReadyEndpoints(eps) == 0 {
+			if fallback := s.apiServerFallbackEps(sname); len(fallback) > 0 {
+				log.WithField("service", sname).Warn(
+					"Kubernetes API server service has no ready endpoints; retaining " +
+						"last-known-good backends to avoid severing Felix's connection to the API server.")
+				eps = fallback
+			}
 		}
 
 		err := s.applySvc(skey, svc, eps)

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -1360,6 +1360,104 @@ var _ = Describe("BPF Syncer", func() {
 	})
 })
 
+// In BPF bootstrap mode Felix reaches the API server through the
+// default/kubernetes ClusterIP service's NAT entry. If a transient loss of that
+// service's endpoints cleared the NAT backend, Felix would sever its own
+// connection to the API server and could never learn the restored endpoints —
+// an unrecoverable deadlock that only a calico-node restart fixes. The syncer
+// must therefore retain the last-known-good backend for that service.
+var _ = Describe("BPF Syncer API server NAT preservation", func() {
+	var (
+		svcs  *mockNATMap
+		eps   *mockNATBackendMap
+		mgEps *mockMaglevMap
+		aff   *mockAffinityMap
+		rt    *proxy.RTCache
+		s     *proxy.Syncer
+	)
+
+	nodeIPs := []net.IP{net.IPv4(192, 168, 0, 1)}
+
+	apiSvcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "kubernetes"},
+	}
+	apiClusterIP := net.IPv4(10, 49, 0, 1)
+	apiPort := 443
+	apiServerIP := net.IPv4(10, 0, 1, 20)
+
+	regularSvcKey := k8sp.ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "regular"},
+	}
+	regClusterIP := net.IPv4(10, 49, 0, 2)
+	regPort := 80
+
+	tcp := proxy.ProtoV1ToIntPanic(v1.ProtocolTCP)
+	apiFrontKey := nat.NewNATKey(apiClusterIP, uint16(apiPort), tcp)
+	regFrontKey := nat.NewNATKey(regClusterIP, uint16(regPort), tcp)
+	apiBackend := nat.NewNATBackendValue(apiServerIP, 6443)
+
+	// state builds a sync state with the regular service backed by a ready
+	// endpoint. The API server service is backed by a ready endpoint when
+	// apiServerHasEP is true, otherwise it has none (the outage we reproduce).
+	state := func(apiServerHasEP bool) proxy.DPSyncerState {
+		st := proxy.DPSyncerState{
+			SvcMap: k8sp.ServicePortMap{
+				apiSvcKey:     svc(apiClusterIP.String(), apiPort).build(),
+				regularSvcKey: svc(regClusterIP.String(), regPort).build(),
+			},
+			EpsMap: k8sp.EndpointsMap{
+				regularSvcKey: {ep("10.2.0.1", 8080).build()},
+			},
+		}
+		if apiServerHasEP {
+			st.EpsMap[apiSvcKey] = []k8sp.Endpoint{ep(apiServerIP.String(), 6443).build()}
+		}
+		return st
+	}
+
+	// expectAPIServerBackend asserts the API server NAT frontend has exactly one
+	// backend pointing at the API server.
+	expectAPIServerBackend := func() {
+		front, ok := svcs.m[apiFrontKey]
+		ExpectWithOffset(1, ok).To(BeTrue(), "API server NAT frontend missing")
+		ExpectWithOffset(1, front.Count()).To(Equal(uint32(1)), "API server NAT frontend must have its backend")
+		ExpectWithOffset(1, eps.m[nat.NewNATBackendKey(front.ID(), 0)]).To(Equal(apiBackend), "API server backend incorrect")
+	}
+
+	BeforeEach(func() {
+		svcs = newMockNATMap()
+		eps = newMockNATBackendMap()
+		mgEps = newMockMaglevMap()
+		aff = newMockAffinityMap()
+		rt = proxy.NewRTCache()
+		s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, mgEps, aff, rt, nil, maglevLUTSize)
+	})
+
+	It("retains the API server backend across a transient loss of endpoints", func() {
+		By("programming the API server backend from real endpoints")
+		Expect(s.Apply(state(true))).NotTo(HaveOccurred())
+		expectAPIServerBackend()
+
+		By("losing all API server endpoints: the backend must be preserved")
+		Expect(s.Apply(state(false))).NotTo(HaveOccurred())
+		expectAPIServerBackend()
+
+		By("a regular service losing its endpoints still drops to zero (scoping)")
+		scoping := state(false)
+		scoping.EpsMap[regularSvcKey] = nil
+		Expect(s.Apply(scoping)).NotTo(HaveOccurred())
+		regFront, ok := svcs.m[regFrontKey]
+		Expect(ok).To(BeTrue())
+		Expect(regFront.Count()).To(Equal(uint32(0)),
+			"only the API server service is protected; regular services are not")
+		expectAPIServerBackend() // API server backend stays preserved here too.
+
+		By("API server endpoints returning: the NAT converges on the live backend")
+		Expect(s.Apply(state(true))).NotTo(HaveOccurred())
+		expectAPIServerBackend()
+	})
+})
+
 type mockNATMap struct {
 	mock.DummyMap
 	sync.Mutex


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v3.31**: projectcalico/calico#13060

## Description

In the BPF dataplane with `bpfNetworkBootstrap` enabled, Felix reaches the API server **through** the `default/kubernetes` ClusterIP service's NAT entry (its `KUBERNETES_SERVICE_HOST` is the ClusterIP, and the `ebpf-bootstrap` init container seeds the frontend/backend from `KUBERNETES_SERVICE_IPS_PORTS` / `KUBERNETES_APISERVER_ENDPOINTS` before Felix starts).

This creates a self-dependency the generic kube-proxy model doesn't have. When the `kubernetes` service transiently loses all of its ready endpoints — e.g. a single control-plane apiserver restarting (service/process restart, cert rotation, upgrade, node reboot, OOM) removes the sole master endpoint — the syncer wrote `count=0` and deleted the backend. With no backend, new connections to the k8s api server cannot start, so **Felix severs its own connection to the API server** and can no longer learn the restored endpoints. The NAT stays empty until calico-node is restarted (which re-seeds it from the init container).

This only manifests in bootstrap mode, because that is the only configuration where Felix routes itself through the ClusterIP. It also requires the outage to last long enough that Felix's existing watch socket is torn down and a new connect (which goes through the CTLB `connect4` hook) is needed.

## Fix

Retain the last-known-good backend for the API server service whenever an update would leave it with zero ready endpoints, sourced from `prevEpsMap` (rebuilt from the BPF maps on restart by `startupBuildPrev`). The API server's backend is the control-plane node IP, which is stable across such an outage, so the retained backend is correct; a later update with real ready endpoints overwrites it. This is the same defensive shape as #12192 — don't let a transient, incomplete view erase a pre-existing NAT entry that traffic (here, Felix's own) depends on.

The protection is scoped to `default/kubernetes` only. Other services must still drop to zero backends so clients get a connection refusal rather than NAT to a dead backend.

## Testing

### Unit test

New unit test in `felix/bpf/proxy/syncer_test.go`: programs the API server backend, empties its endpoints and asserts the backend is preserved, asserts a regular service emptied in the same apply still drops to zero (scoping), and asserts convergence when real endpoints return. Verified the test fails without the fix (the API server backend is deleted) and passes with it.

`go test ./felix/bpf/proxy/...`, `go vet`, `gofmt` clean.

### Validated on a live cluster

Reproduced and verified on a single-control-plane kubeadm cluster running the eBPF dataplane with `bpfNetworkBootstrap: Enabled` (calico-node confirmed to reach the API server through the ClusterIP — `KUBERNETES_SERVICE_HOST` is the service VIP).

Repro: move the `kube-apiserver` static-pod manifest out of `/etc/kubernetes/manifests/`, wait ~40s, move it back. The API server's own endpoint reconciler removes the sole control-plane endpoint on the way down, so the `kubernetes` EndpointSlice transiently empties.

| | Stock build (no fix) | Fixed build (this PR) |
|---|---|---|
| `kubernetes` VIP NAT after bounce (`calico component node bpf nat dump`) | drops to `count 0`, backend deleted | stays `count 1`, backend preserved |
| Connect to the VIP from calico-node | `dial tcp <vip>:443: connect: operation not permitted` (EPERM — CTLB `connect4` hard-deny), on every node, persistent | no errors |
| Recovery | required a manual `kubectl rollout restart daemonset/calico-node` | self-recovered, no restart, calico-node pods stayed up with 0 restarts |

In both cases the API server itself was healthy and its `kubernetes` endpoint repopulated after the bounce — confirming the failure was the dataplane retaining an empty NAT, not the API server, and that the fix lets Felix ride out the outage and re-converge on its own.

**Release note:**
```release-note
eBPF dataplane: fix loss of connectivity to the Kubernetes API server service after the API server is unavailable for a period, when using bpfNetworkBootstrap. Felix no longer clears the API server service's NAT backend when its endpoints transiently empty, so connectivity recovers without a calico-node restart.
```

