### PR TITLE
node k8st: emit JUnit report for Go-side tests

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -124,6 +124,13 @@ K8ST_TO_RUN?=tests/
 ST_OPTIONS?=
 
 K8ST_REPORT_FILENAME ?= k8s-tests.xml
+# JUnit report for the Go-side k8st suite. The Go test binary runs inside the
+# alpine-based calico/test container, which has no go toolchain or junit tool,
+# so it writes its `go test -v` output to K8ST_GO_REPORT_LOG and a second
+# go-build step converts that into the K8ST_GO_REPORT_FILENAME JUnit XML that CI
+# collects from report/*.xml (the pytest suite already emits its own XML).
+K8ST_GO_REPORT_LOG ?= k8s-go-tests.log
+K8ST_GO_REPORT_FILENAME ?= k8s-go-tests.xml
 
 # Filesystem of the node container that is checked in to this repository.
 NODE_CONTAINER_FILES=$(shell find ./filesystem -type f -not -path './filesystem/usr/lib/calico/bpf/*')
@@ -377,6 +384,8 @@ bin/k8st.test:
 
 .PHONY: kind-k8st-run-test
 kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG) bin/k8st.test
+	mkdir -p report
+	rm -f report/$(K8ST_GO_REPORT_LOG) report/$(K8ST_GO_REPORT_FILENAME) report/.go-rc report/.py-rc
 	docker run -t --rm \
 	    -v $(CURDIR):/code \
 	    -v /var/run/docker.sock:/var/run/docker.sock \
@@ -391,11 +400,20 @@ kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG) bin/k8st.test
 	${TEST_CONTAINER_NAME} \
 	    sh -c 'echo "container started.." && \
 	     cd /code/tests/k8st && \
-	     go_rc=0; py_rc=0; \
-	     /code/bin/k8st.test -test.v -test.run "$(K8ST_GO_TO_RUN)" || go_rc=$$?; \
+	     py_rc=0; \
+	     { /code/bin/k8st.test -test.v -test.run "$(K8ST_GO_TO_RUN)"; echo $$? > /code/report/.go-rc; } 2>&1 | tee /code/report/$(K8ST_GO_REPORT_LOG); \
 	     pytest $(K8ST_TO_RUN) -v --junit-xml="/code/report/$(K8ST_REPORT_FILENAME)" || py_rc=$$?; \
-	     echo "Go suite rc=$$go_rc, Python suite rc=$$py_rc"; \
-	     [ $$go_rc -eq 0 ] && [ $$py_rc -eq 0 ]'
+	     echo "$$py_rc" > /code/report/.py-rc; \
+	     echo "Go suite rc=$$(cat /code/report/.go-rc), Python suite rc=$$py_rc"'
+	# The Go tests are plain `go test` (not Ginkgo), so the binary emits no
+	# JUnit of its own. Convert its captured output into a JUnit report so CI
+	# collects it alongside the pytest report. go-junit-report lives in the
+	# go-build image, not the alpine calico/test image, so this runs separately.
+	$(DOCKER_GO_BUILD) sh -c 'go-junit-report -package-name k8st-go < report/$(K8ST_GO_REPORT_LOG) > report/$(K8ST_GO_REPORT_FILENAME)' || true
+	# Now that both reports exist, propagate the real pass/fail of the suites.
+	@go_rc=$$(cat report/.go-rc 2>/dev/null || echo 1); py_rc=$$(cat report/.py-rc 2>/dev/null || echo 1); \
+	  echo "Go suite rc=$$go_rc, Python suite rc=$$py_rc"; \
+	  [ "$$go_rc" -eq 0 ] && [ "$$py_rc" -eq 0 ]
 
 ###############################################################################
 # CI/CD

--- a/node/tests/k8st/tests/cluster_routes_test.go
+++ b/node/tests/k8st/tests/cluster_routes_test.go
@@ -82,7 +82,7 @@ func TestClusterRouteOwnership(t *testing.T) {
 		},
 	}
 	g.Expect(cli.Create(ctx, pool)).To(Succeed(), "creating IPPool")
-	t.Cleanup(func() { deletePool(cli, pool.Name) })
+	t.Cleanup(func() { deletePool(t, cli, pool.Name) })
 
 	nsName := "cluster-routes"
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}

--- a/node/tests/k8st/tests/proxy_neigh_test.go
+++ b/node/tests/k8st/tests/proxy_neigh_test.go
@@ -133,7 +133,7 @@ func runFamily(t *testing.T, family corev1.IPFamily) {
 		},
 	}
 	g.Expect(cli.Create(ctx, workloadPool)).To(Succeed(), "creating workload IPPool")
-	t.Cleanup(func() { deletePool(cli, workloadPool.Name) })
+	t.Cleanup(func() { deletePool(t, cli, workloadPool.Name) })
 
 	lbPool := &v3.IPPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "proxy-neigh-lb-" + suffix},
@@ -146,7 +146,7 @@ func runFamily(t *testing.T, family corev1.IPFamily) {
 		},
 	}
 	g.Expect(cli.Create(ctx, lbPool)).To(Succeed(), "creating LoadBalancer IPPool")
-	t.Cleanup(func() { deletePool(cli, lbPool.Name) })
+	t.Cleanup(func() { deletePool(t, cli, lbPool.Name) })
 
 	// Turn on the feature under test, restoring the original value afterwards.
 	restore := setLocalSubnetL2Reachability(ctx, g, cli, v3.LocalSubnetL2ReachabilityPodsAndLoadBalancers)
@@ -257,12 +257,13 @@ func newClient(g *WithT) ctrlclient.Client {
 
 // deletePool best-effort removes an IPPool; runs during cleanup so it logs
 // rather than fails.
-func deletePool(cli ctrlclient.Client, name string) {
+func deletePool(t testing.TB, cli ctrlclient.Client, name string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	pool := &v3.IPPool{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	if err := cli.Delete(ctx, pool); err != nil && !apierrors.IsNotFound(err) {
-		fmt.Printf("WARNING: failed to delete IPPool %s: %v\n", name, err)
+		// Log via t (not stdout) so the test2json stream stays pure JSON.
+		t.Logf("WARNING: failed to delete IPPool %s: %v", name, err)
 	}
 }
 

--- a/node/tests/k8st/tests/proxy_neigh_test.go
+++ b/node/tests/k8st/tests/proxy_neigh_test.go
@@ -262,7 +262,6 @@ func deletePool(t testing.TB, cli ctrlclient.Client, name string) {
 	defer cancel()
 	pool := &v3.IPPool{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	if err := cli.Delete(ctx, pool); err != nil && !apierrors.IsNotFound(err) {
-		// Log via t (not stdout) so the test2json stream stays pure JSON.
 		t.Logf("WARNING: failed to delete IPPool %s: %v", name, err)
 	}
 }


### PR DESCRIPTION
## Description

The Go k8st tests (`node/tests/k8st/tests/*_test.go`) ran but produced no JUnit XML, so they never showed up in Semaphore's test reports. CI collects `node/report/*.xml`, and only the **pytest** suite was emitting a report (`--junit-xml`). The Go binary was run as `k8st.test -test.v` with its output discarded, and plain `go test` (not Ginkgo) emits no JUnit of its own.

### Fix

- In `node/Makefile`'s `kind-k8st-run-test`, tee the Go binary's `-test.v` output to `report/k8s-go-tests.log` (capturing its exit code through the pipe), then add a second step running `go-junit-report` in the `calico/go-build` image to convert that into `report/k8s-go-tests.xml`. The alpine-based `calico/test` container that runs the tests has no Go toolchain or JUnit tool, so the conversion is a separate go-build step. The existing `collect-artifacts` / `publish-reports` plumbing already picks up `node/report/*.xml`.
- The report is generated **even when tests fail** — the conversion runs unconditionally and real pass/fail is propagated at the end from captured rc files — which is exactly when the report matters most.
- `go-junit-report` on plain text is used rather than the test2json/`gotestsum` path because the suite has no `t.Parallel()` (only sequential `t.Run` subtests), so text parsing is reliable, keeps the VM log human-readable, and tolerates interleaved stderr lines.
- Route a stray `fmt.Printf` in `proxy_neigh_test.go`'s `deletePool` through `t.Logf` so cleanup diagnostics are attributed to the test (and updated its callers; `deletePool` is shared with `cluster_routes_test.go`).

### Testing

- Go test binary compiles; `go vet` clean; `gofmt` clean.
- Verified `go-junit-report` produces valid JUnit (nested subtests + failure messages) from `-test.v` output.
- Verified the rc-capture-through-pipe construct in busybox `sh` (the test container's shell).
- `make -n` dry-run confirms the recipe expands correctly.

**Release note:**
```release-note
None
```