### PR TITLE
Only garbage collect IPAM blocks with elapsed cooldown IPs

### DIFF
--- a/kube-controllers/pkg/controllers/node/fake_client.go
+++ b/kube-controllers/pkg/controllers/node/fake_client.go
@@ -16,6 +16,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -291,9 +292,20 @@ type fakeIPAMClient struct {
 	upgradeErrors    []error // returned in order on successive calls
 	garbageCollected bool
 
+	// garbageCollectedBlocks records the CIDR of every block passed to
+	// GarbageCollectColdIPs, so tests can assert which blocks the GC visited.
+	garbageCollectedBlocks []string
+
 	// releaseHostAffinityErrors maps host names to errors that ReleaseHostAffinities
 	// should return, simulating per-node "block not empty" failures during cleanup.
 	releaseHostAffinityErrors map[string]error
+}
+
+// gcBlocks returns the CIDRs of the blocks GarbageCollectColdIPs was called with.
+func (f *fakeIPAMClient) gcBlocks() []string {
+	f.Lock()
+	defer f.Unlock()
+	return slices.Clone(f.garbageCollectedBlocks)
 }
 
 func (f *fakeIPAMClient) affinityReleased(aff string) bool {
@@ -455,6 +467,7 @@ func (f *fakeIPAMClient) GarbageCollectColdIPs(ctx context.Context, config *ipam
 	f.Lock()
 	defer f.Unlock()
 	f.garbageCollected = true
+	f.garbageCollectedBlocks = append(f.garbageCollectedBlocks, kvp.Key.(model.BlockKey).CIDR.String())
 	return nil
 }
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -1368,10 +1368,13 @@ func (c *IPAMController) garbageCollectColdIPs() error {
 	for cidr, earliestReleasedAt := range c.coldBlocks {
 		if earliestReleasedAt.Add(cooldown).After(now) {
 			// The oldest cooldown IP in this block hasn't finished cooling down yet.
+			log.WithField("block", cidr).Debug("Block has IPs in cooldown but none are ready to deallocate yet")
 			continue
 		}
 		kvp, ok := c.allBlocks[cidr]
 		if !ok {
+			// coldBlocks should always be a subset of allBlocks; see assertConsistentState.
+			log.WithField("block", cidr).Warn("Block tracked as having cooldown IPs is missing from the block cache")
 			continue
 		}
 		if err := c.client.IPAM().GarbageCollectColdIPs(ctx, ipamConfig, &kvp); err != nil {

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -638,17 +638,22 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 func (c *IPAMController) onBlockDeleted(key model.BlockKey) {
 	blockCIDR := key.CIDR.String()
 	log.WithField("block", blockCIDR).Info("Received block delete")
+	c.forgetBlock(blockCIDR)
+}
 
-	// Remove allocations that were contributed by this block.
-	allocations := c.allocationsByBlock[blockCIDR]
-	for _, alloc := range allocations {
+// forgetBlock removes all cached state for a block. Every path that stops tracking a
+// block - a block delete from the datastore, or an affinity release of an empty block
+// in releaseUnusedBlocks - must funnel through here so the cache maps can't drift out
+// of sync.
+func (c *IPAMController) forgetBlock(blockCIDR string) {
+	// Release any allocations the block contributed.
+	for _, alloc := range c.allocationsByBlock[blockCIDR] {
 		c.releaseAllocation(alloc)
 	}
 	delete(c.allocationsByBlock, blockCIDR)
 
-	// Remove from raw block storage.
+	// Drop the block from its node, removing the node entry if it has no blocks left.
 	if n := c.nodesByBlock[blockCIDR]; n != "" {
-		// The block was assigned to a node, make sure to update internal cache.
 		delete(c.blocksByNode[n], blockCIDR)
 		if len(c.blocksByNode[n]) == 0 {
 			delete(c.blocksByNode, n)
@@ -817,20 +822,11 @@ func (c *IPAMController) releaseUnusedBlocks() error {
 			continue
 		}
 
-		// Update internal state. We released affinity on an empty block, and so
-		// it will have been deleted. It's important that we update blocksByNode here
-		// in case there are other empty blocks allocated to the node so that we don't
+		// Update internal state. We released affinity on an empty block, and so it will
+		// have been deleted. Forgetting the block updates blocksByNode, which matters in
+		// case there are other empty blocks affine to the node, so that we don't
 		// accidentally release all of the node's blocks.
-		delete(c.emptyBlocks, blockCIDR)
-		delete(c.blocksByNode[node], blockCIDR)
-		if len(c.blocksByNode[node]) == 0 {
-			delete(c.blocksByNode, node)
-		}
-		delete(c.nodesByBlock, blockCIDR)
-		delete(c.allBlocks, blockCIDR)
-
-		c.blockReleaseTracker.onBlockDeleted(blockCIDR)
-		c.poolManager.onBlockDeleted(blockCIDR)
+		c.forgetBlock(blockCIDR)
 	}
 	return nil
 }

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -179,6 +179,7 @@ func NewIPAMController(cfg config.NodeControllerConfig, c client.Interface, cs k
 		nodesByBlock:                make(map[string]string),
 		blocksByNode:                make(map[string]map[string]bool),
 		emptyBlocks:                 make(map[string]string),
+		coldBlocks:                  make(map[string]metav1.Time),
 		poolManager:                 newPoolManager(),
 		datastoreReady:              true,
 		consolidationWindow:         1 * time.Second,
@@ -242,6 +243,12 @@ type IPAMController struct {
 	blockReleaseTracker *blockReleaseTracker
 
 	emptyBlocks map[string]string
+
+	// coldBlocks tracks blocks that have at least one IP in cooldown, mapping the
+	// block CIDR to the earliest ReleasedAt among its cooldown IPs. The cold-IP GC
+	// backstop only needs to visit these blocks, and only once their cooldown has
+	// elapsed, rather than walking every block on every sync.
+	coldBlocks map[string]metav1.Time
 
 	// poolManager associates IPPools with their blocks.
 	poolManager *poolManager
@@ -544,6 +551,7 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 	// Update allocations contributed from this block.
 	numAllocationsInBlock := 0
 	currentAllocations := map[string]bool{}
+	var earliestReleasedAt *metav1.Time
 	for ord, idx := range b.Allocations {
 		if idx == nil {
 			// Not allocated.
@@ -551,6 +559,12 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 		}
 		numAllocationsInBlock++
 		attr := b.Attributes[*idx]
+
+		// Track the oldest cooldown IP in the block so the GC backstop knows when
+		// this block becomes a candidate for deallocation.
+		if attr.ReleasedAt != nil && (earliestReleasedAt == nil || attr.ReleasedAt.Before(earliestReleasedAt)) {
+			earliestReleasedAt = attr.ReleasedAt
+		}
 
 		// If there is no handle, then skip this IP. We need the handle
 		// in order to release the IP below.
@@ -607,6 +621,14 @@ func (c *IPAMController) onBlockUpdated(kvp model.KVPair) {
 		}
 	}
 
+	// Track whether this block has IPs in cooldown so the GC backstop can skip
+	// blocks that don't.
+	if earliestReleasedAt != nil {
+		c.coldBlocks[blockCIDR] = *earliestReleasedAt
+	} else {
+		delete(c.coldBlocks, blockCIDR)
+	}
+
 	c.poolManager.onBlockUpdated(blockCIDR)
 
 	// Finally, update the raw storage.
@@ -635,6 +657,7 @@ func (c *IPAMController) onBlockDeleted(key model.BlockKey) {
 	delete(c.allBlocks, blockCIDR)
 	delete(c.nodesByBlock, blockCIDR)
 	delete(c.emptyBlocks, blockCIDR)
+	delete(c.coldBlocks, blockCIDR)
 
 	c.blockReleaseTracker.onBlockDeleted(blockCIDR)
 	c.poolManager.onBlockDeleted(blockCIDR)
@@ -1321,10 +1344,13 @@ func (c *IPAMController) garbageCollectKnownLeaks() error {
 	return nil
 }
 
-// garbageCollectColdIPs runs GC on every known IPAM block, writing back any block
-// that was modified (i.e. had IPs whose ReleasedAt grace period had elapsed).
+// garbageCollectColdIPs deallocates IPs whose cooldown has elapsed, writing back any
+// block that was modified. It is a backstop for blocks that see no further allocation
+// activity, since read-time GC only persists on write paths. Only blocks with IPs in
+// cooldown are visited, and only once their oldest cooldown IP has finished cooling
+// down, so the common case where nothing is cooling down does no work.
 func (c *IPAMController) garbageCollectColdIPs() error {
-	if len(c.allBlocks) == 0 {
+	if len(c.coldBlocks) == 0 {
 		return nil
 	}
 	defer logIfSlow(time.Now(), "Block GC complete")
@@ -1336,7 +1362,18 @@ func (c *IPAMController) garbageCollectColdIPs() error {
 	if err != nil {
 		return err
 	}
-	for _, kvp := range c.allBlocks {
+
+	cooldown := time.Duration(ipamConfig.IPCooldownSeconds) * time.Second
+	now := time.Now()
+	for cidr, earliestReleasedAt := range c.coldBlocks {
+		if earliestReleasedAt.Add(cooldown).After(now) {
+			// The oldest cooldown IP in this block hasn't finished cooling down yet.
+			continue
+		}
+		kvp, ok := c.allBlocks[cidr]
+		if !ok {
+			continue
+		}
 		if err := c.client.IPAM().GarbageCollectColdIPs(ctx, ipamConfig, &kvp); err != nil {
 			return err
 		}

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -16,6 +16,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"time"
 
@@ -76,6 +77,10 @@ func assertConsistentState(c *IPAMController) {
 	for cidr := range c.allocationsByBlock {
 		_, ok := c.allBlocks[cidr]
 		Expect(ok).To(BeTrue(), fmt.Sprintf("Block %s not present in allBlocks, but is present in allocationsByBlock", cidr))
+	}
+	for cidr := range c.coldBlocks {
+		_, ok := c.allBlocks[cidr]
+		Expect(ok).To(BeTrue(), fmt.Sprintf("Block %s not present in allBlocks, but is present in coldBlocks", cidr))
 	}
 
 	// Make sure blocksByNode and nodesByBlock are consistent.
@@ -720,6 +725,108 @@ var _ = Describe("IPAM controller UTs", func() {
 			defer done()
 			return c.allocationsByBlock[blockCIDR]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
+	})
+
+	Describe("cold IP garbage collection", func() {
+		var fakeIPAM *fakeIPAMClient
+
+		cidrOf := func(kvp model.KVPair) string {
+			return kvp.Key.(model.BlockKey).CIDR.String()
+		}
+
+		// coldBlock builds a block affine to cnode containing a single IP whose
+		// ReleasedAt is set to releasedAt, i.e. an IP in cooldown.
+		coldBlock := func(cidrStr string, releasedAt metav1.Time) model.KVPair {
+			cidr := net.MustParseCIDR(cidrStr)
+			aff := "host:cnode"
+			idx := 0
+			b := model.AllocationBlock{
+				CIDR:        cidr,
+				Affinity:    &aff,
+				Allocations: []*int{&idx, nil, nil, nil},
+				Unallocated: []int{1, 2, 3},
+				Attributes:  []model.AllocationAttribute{{ReleasedAt: &releasedAt}},
+			}
+			return model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}, Value: &b}
+		}
+
+		// liveBlock builds a block affine to cnode with a single normal allocation
+		// and no IPs in cooldown.
+		liveBlock := func(cidrStr string) model.KVPair {
+			cidr := net.MustParseCIDR(cidrStr)
+			aff := "host:cnode"
+			idx := 0
+			handle := "live-handle"
+			b := model.AllocationBlock{
+				CIDR:        cidr,
+				Affinity:    &aff,
+				Allocations: []*int{&idx, nil, nil, nil},
+				Unallocated: []int{1, 2, 3},
+				Attributes: []model.AllocationAttribute{{
+					HandleID:         &handle,
+					ActiveOwnerAttrs: map[string]string{ipam.AttributeNode: "cnode"},
+				}},
+			}
+			return model.KVPair{Key: model.BlockKey{CIDR: model.PrefixFromIPNet(cidr)}, Value: &b}
+		}
+
+		BeforeEach(func() {
+			fakeIPAM = cli.IPAM().(*fakeIPAMClient)
+			fakeIPAM.config.IPCooldownSeconds = 3600
+			c.Start(stopChan)
+		})
+
+		It("only garbage collects blocks whose cooldown has elapsed", func() {
+			expired := coldBlock("10.0.0.0/30", metav1.NewTime(time.Now().Add(-2*time.Hour)))
+			cooling := coldBlock("10.0.1.0/30", metav1.NewTime(time.Now()))
+			live := liveBlock("10.0.2.0/30")
+
+			for _, kvp := range []model.KVPair{expired, cooling, live} {
+				c.onUpdate(bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew})
+			}
+
+			// Both cooldown blocks are tracked; the live block is not.
+			Eventually(func() map[string]metav1.Time {
+				done := c.pause()
+				defer done()
+				return maps.Clone(c.coldBlocks)
+			}, 1*time.Second, 100*time.Millisecond).Should(And(
+				HaveKey(cidrOf(expired)),
+				HaveKey(cidrOf(cooling)),
+				Not(HaveKey(cidrOf(live))),
+			))
+
+			// Only the block past its cooldown is visited.
+			done := c.pause()
+			Expect(c.garbageCollectColdIPs()).To(Succeed())
+			done()
+			Expect(fakeIPAM.gcBlocks()).To(ConsistOf(cidrOf(expired)))
+		})
+
+		It("stops tracking a block once its cooldown IPs are deallocated", func() {
+			block := coldBlock("10.0.0.0/30", metav1.NewTime(time.Now().Add(-2*time.Hour)))
+			c.onUpdate(bapi.Update{KVPair: block, UpdateType: bapi.UpdateTypeKVNew})
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				_, ok := c.coldBlocks[cidrOf(block)]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			// The IP is deallocated, so the block no longer carries a ReleasedAt.
+			b := block.Value.(*model.AllocationBlock)
+			b.Allocations[0] = nil
+			b.Unallocated = []int{0, 1, 2, 3}
+			b.Attributes = []model.AllocationAttribute{}
+			c.onUpdate(bapi.Update{KVPair: block, UpdateType: bapi.UpdateTypeKVUpdated})
+
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				_, ok := c.coldBlocks[cidrOf(block)]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeFalse())
+		})
 	})
 
 	It("should refresh the sequence number of an already-tracked allocation on block update", func() {


### PR DESCRIPTION
Follow-up to #12638. The cold-IP GC backstop in kube-controllers walked every IPAM block on every sync trigger - each batched pod-delete, node-delete, syncer update, plus the periodic tick. That's a lot of work on a loop that's critical for IPAM GC in some scenarios, and we've been bitten before by doing too much in it.

This tracks which blocks have IPs in cooldown as block updates stream in, so the backstop only visits those blocks, and only once their oldest cooldown IP has actually finished cooling down. When nothing is cooling down, it does no work.

The design doc for the cold-IP GC backstop is missing entirely (the cooldown feature merged without one), so I'm handling that in a separate follow-up rather than partially documenting it here.

```release-note
None
```
