### PR TITLE
Document IPAM IP cooldown in the design docs

### DIFF
--- a/design/ipam/DESIGN.md
+++ b/design/ipam/DESIGN.md
@@ -25,7 +25,7 @@ IPAM state is stored as four CRDs, plus `IPReservation` for carve-outs:
 | `IPAMBlock` | Contiguous slice of a pool (default /26 IPv4, /122 IPv6). Holds the ordinal bitmap, per-allocation attributes, and per-ordinal sequence numbers. |
 | `BlockAffinity` | Per-host (or per-virtual-owner) claim on a block. State machine: `pending` -> `confirmed` -> `pendingDeletion`. |
 | `IPAMHandle` | Secondary index keyed by handle ID, so `ReleaseByHandle` doesn't scan blocks. Also enforces per-handle allocation caps (KubeVirt VM persistence). |
-| `IPAMConfig` / `IPAMConfiguration` | Singleton. Holds `StrictAffinity`, `MaxBlocksPerHost`, `AutoAllocateBlocks`, `KubeVirtVMAddressPersistence`. The v1 name is `IPAMConfig`; the v3 name is `IPAMConfiguration`. |
+| `IPAMConfig` / `IPAMConfiguration` | Singleton. Holds `StrictAffinity`, `MaxBlocksPerHost`, `AutoAllocateBlocks`, `KubeVirtVMAddressPersistence`, `IPCooldownSeconds`. The v1 name is `IPAMConfig`; the v3 name is `IPAMConfiguration`. |
 | `IPReservation` | Carve-outs from the pool (tunnel addresses, externally-managed IPs). Filtered at block-skip and ordinal-skip granularity. |
 
 The IPAM CRDs exist on both `crd.projectcalico.org/v1` and `projectcalico.org/v3`. The two groups are not symmetric - they differ in field shape, naming (`IPAMConfig` vs

--- a/design/ipam/ipam-core-library.md
+++ b/design/ipam/ipam-core-library.md
@@ -93,6 +93,30 @@ Block release is parallelised per block via a semaphore sized at `GOMAXPROCS`.
   (relevant to https://github.com/projectcalico/calico/issues/12638).
 - Older blocks may not have per-ordinal sequence numbers. New code must tolerate the absent case (default + heal-forward), not crash.
 
+## IP release and cooldown
+
+Releasing an IP and freeing it for reuse are two distinct steps, separated by a configurable cooldown. This sits on top of the `Unallocated` FIFO queue: the queue cycles freed
+ordinals so the longest-idle IP is reused first, and the cooldown adds a wall-clock floor on how soon any released IP can come back.
+
+- **Release marks the IP, it does not free it.** `release` / `releaseByHandle` ([`ipam_block.go`](../../libcalico-go/lib/ipam/ipam_block.go)) clear the handle association and stamp
+  the allocation's `ReleasedAt` with the current time. The ordinal stays in `Allocations` - the IP is no longer tied to a workload, but it is not yet available for reallocation. An
+  IP in this state is "in cooldown".
+- **`garbageCollect` deallocates IPs whose cooldown has elapsed.** It moves an ordinal to `Unallocated`, clears its sequence number, and prunes the now-unreferenced attribute, but
+  only once `ReleasedAt` is older than `IPCooldownSeconds`. With `IPCooldownSeconds=0` the IP is deallocated on the next GC pass. This is the only place ordinals move to
+  `Unallocated`.
+- **GC runs implicitly on every read by the IPAM client.** `blockFromBackend` calls `garbageCollect` whenever a block is loaded. On write paths (`AutoAssign`, `release`,
+  `releaseByHandle`, `SetOwnerAttributes`) the reclamation folds into the same CAS write, so a new allocation can reuse IPs that finished cooling down in one transaction. On
+  read-only paths the GC'd view is computed and then discarded - the caller sees cooled-down IPs as not-yet-reusable, but nothing is persisted.
+- **Blocks with no write activity need a backstop.** Because read-only GC doesn't persist, a block that sees no further allocation or release never gets rewritten, so its
+  cooled-down IPs would never be deallocated. The kube-controllers GC closes that gap; see [ipam-gc](./ipam-gc.md#cold-ip-garbage-collection).
+
+**Review notes**
+
+- Release and deallocation are distinct states. Code that counts "allocated" IPs has to decide whether cooldown counts as allocated, released, or its own state - don't silently fold
+  it into one. `calicoctl ipam check` treats it as its own state.
+- A release call against an IP already in cooldown is not an error - it's already released. Don't return an error for the idempotent case.
+- The cooldown floor is on top of the `Unallocated` FIFO, not a replacement for it. Both exist; don't remove the queue cycling thinking the timestamp covers it.
+
 ## Handle IDs
 
 A handle ID is an opaque string from the library's point of view, but its **format is a convention every IPAM caller has to follow** because `calicoctl datastore migrate` parses
@@ -141,6 +165,7 @@ Fields:
 | `MaxBlocksPerHost` | Per-host cap on the number of affine blocks. 0 means default (20). Once a host hits the cap, `allowNewClaim` is forced false; existing blocks still fill. |
 | `AutoAllocateBlocks` | When false, `AutoAssign` will never claim a new block - only allocate from blocks the host already owns. |
 | `KubeVirtVMAddressPersistence` | Default for whether KubeVirt VM addresses survive VM restart / migration. Auto-detection is on by default. |
+| `IPCooldownSeconds` | Minimum age of a released IP before it can be reused. Release stamps the IP's `ReleasedAt`; `garbageCollect` only deallocates it once this many seconds have passed. 0 deallocates on the next GC pass. Capped at 1200. See [IP release and cooldown](#ip-release-and-cooldown). |
 
 **Review notes**
 

--- a/design/ipam/ipam-datastore.md
+++ b/design/ipam/ipam-datastore.md
@@ -25,6 +25,9 @@ An `IPAMBlock` is a contiguous slice of a pool, default /26 for IPv4 and /122 fo
 - **`SequenceNumber` is paired with per-ordinal `SequenceNumberForAllocation`.** Together they detect ABA on release; see [Sequence numbers](#sequence-numbers).
 - **`Affinity` is `host:<name>` or `virtual:<name>`.** `nil` means unaffine. `virtual:` is used by the LoadBalancer controller; `host:` is the standard pod/tunnel case.
 - **`Deleted` is a soft-delete marker.** Readers must filter; see [Soft vs hard delete](#soft-vs-hard-delete).
+- **`AllocationAttribute.ReleasedAt` records an IP in cooldown.** A released IP is detached from its workload (handle cleared) but not yet returned to `Unallocated`: its attribute
+  carries a `ReleasedAt` timestamp and the ordinal stays in `Allocations`. It becomes reusable only once it is deallocated, after `IPCooldownSeconds` have elapsed. The
+  released-vs-deallocated split is the cooldown mechanism; the semantics live in [ipam-core-library](./ipam-core-library.md#ip-release-and-cooldown).
 
 **Review notes**
 
@@ -32,6 +35,8 @@ An `IPAMBlock` is a contiguous slice of a pool, default /26 for IPv4 and /122 fo
 - The `Unallocated` queue cycling is load-bearing for IP-reuse delay. Code that punches the bitmap directly breaks reuse rate-limiting.
 - Don't mutate the in-memory `*model.AllocationBlock` before persisting. Persist via `updateBlock`, then update auxiliary state. See
   https://github.com/projectcalico/calico/pull/12697.
+- Both the v1 and v3 backends must round-trip `ReleasedAt`. If a conversion drops it, a released IP reloads with no timestamp, never deallocates, and leaks permanently on the
+  default v1 datastore. The cooldown default of 0 hides this in CI, so a round-trip test through the KDD v1 backend is required.
 
 ## BlockAffinity
 

--- a/design/ipam/ipam-gc.md
+++ b/design/ipam/ipam-gc.md
@@ -116,8 +116,8 @@ if !c.handleTracker.isConfirmedLeak(a.handle) {
 If even one IP on a handle is still valid, the entire handle is skipped this sync. Otherwise the per-block `IPAMHandle` counters (`Block[blockCIDR]int`) would desync from the
 actual block bitmap and the controller would lose track of the live IPs.
 
-Periodic sweep: every full sync rebuilds `confirmedLeaks` via `checkAllocations`, calls `garbageCollectKnownLeaks`, then `releaseUnusedBlocks` and `releaseNodes` (`syncIPAM`,
-`ipam.go:1174`). Unreleased items roll over to the next sync.
+Periodic sweep: every full sync rebuilds `confirmedLeaks` via `checkAllocations`, calls `garbageCollectKnownLeaks`, then [cold-IP GC](#cold-ip-garbage-collection),
+`releaseUnusedBlocks`, and `releaseNodes` (`syncIPAM`). Unreleased items roll over to the next sync.
 
 The GC calls `ReleaseIPs` rather than [`ReleaseByHandle`](./ipam-core-library.md) because it operates at the per-allocation level (`ReleaseOptions`), preserving sequence-number
 protection for each ordinal.
@@ -131,6 +131,30 @@ protection for each ordinal.
   https://github.com/projectcalico/calico/pull/12713 must hold this line.
 - `ReleaseIPs` plumbs sequence numbers through `ReleaseOptions`. Any new release path here must do the same.
 - The crash at `ipam.go:1281` (`log.Fatalf("BUG: unable to find allocation for release options")`) is reachable if released options can't be mapped back to tracked allocations.
+
+## Cold IP garbage collection
+
+A released IP sits in cooldown - its attribute stamped with `ReleasedAt`, its ordinal still in `Allocations` - until it is deallocated. Deallocation happens in `garbageCollect`,
+which the core library runs on every block read but only persists on write paths (see [IP release and cooldown](./ipam-core-library.md#ip-release-and-cooldown)). A block that sees
+no further allocation or release activity is never rewritten, so its cooled-down IPs would never be deallocated. `garbageCollectColdIPs` is the backstop that deallocates them.
+
+Invariants:
+
+- **The backstop is required, not just an optimization.** Without it, the last cooled-down IPs in an otherwise-idle block keep the block non-empty forever. That blocks empty-block
+  release and node cleanup indefinitely, not just for the cooldown window. Read-time GC alone does not cover the idle-block case.
+- **It must stay cheap.** It runs on every sync trigger - each batched pod/node delete, syncer update, and the periodic tick - and shares the sync loop with leak GC, which is
+  latency-sensitive in some clusters. The cost scales with the number of blocks actually in cooldown, not the total number of blocks.
+
+The controller keeps a `coldBlocks` map - block CIDR to the earliest `ReleasedAt` among that block's cooldown IPs - built up incrementally from streamed block updates in
+`onBlockUpdated`. The backstop visits only those blocks, and only once that earliest timestamp plus `IPCooldownSeconds` has passed. When nothing is in cooldown it does no work. The
+global IPAM config (for `IPCooldownSeconds`) is cached and refreshed on the periodic sync rather than read from the datastore on every trigger.
+
+**Review notes**
+
+- Don't reintroduce a walk over all blocks here. Visiting every block on every trigger is the regression this is built to avoid; the loop is shared with leak GC.
+- `coldBlocks` is in-memory state derived from the block stream, like every other map in this controller. It must satisfy `assertConsistentState` (every CIDR present in `allBlocks`)
+  and be cleaned up on block deletion. A new mutation needs the consistency check, or it joins the memory-leak class of bug.
+- The backstop is a failsafe, not the primary path. The common case is read-time GC folding deallocation into a write; don't move primary reclamation here.
 
 ## Empty block release
 


### PR DESCRIPTION
The IP cooldown feature landed without design-doc coverage. This fills that in across the IPAM design docs:

- `ipam-datastore.md` - the `ReleasedAt` block state (released vs deallocated, ordinal stays in `Allocations`).
- `ipam-core-library.md` - a new "IP release and cooldown" section covering the release/cooldown/deallocate flow and read-time GC, plus `IPCooldownSeconds` in the config table.
- `ipam-gc.md` - a new "Cold IP garbage collection" section for the kube-controllers backstop, and the `syncIPAM` step list now includes it.
- `DESIGN.md` - `IPCooldownSeconds` added to the config field list.

The cold-IP GC section describes the backstop as it stands with the candidate-block filtering and config caching from #13075 and #13076, so this should merge after those two.

```release-note
None
```
