### PR TITLE
networking-calico: stop module-level eventlet.monkey_patch in unit tests

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1869,7 +1869,7 @@ blocks:
       jobs:
         - name: "OpenStack: Unit and FV tests (tox) on Caracal"
           commands:
-            - ../.semaphore/run-and-monitor tox.log make tox-caracal
+            - ../.semaphore/run-and-monitor tox.log make tox-caracal tox-fv-caracal
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
             # Env vars needed for saving performance results.

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1869,7 +1869,12 @@ blocks:
       jobs:
         - name: "OpenStack: Unit and FV tests (tox) on Caracal"
           commands:
-            - ../.semaphore/run-and-monitor tox.log make tox-caracal tox-fv-caracal
+            # Run sequentially via `bash -c '... && ...'` rather than as
+            # multiple targets on a single make invocation: a make invoked
+            # with MAKEFLAGS=-j would otherwise schedule the two targets in
+            # parallel and have two concurrent tox runs contend over the
+            # shared .tox/ working tree.
+            - ../.semaphore/run-and-monitor tox.log bash -c 'make tox-caracal && make tox-fv-caracal'
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
             # Env vars needed for saving performance results.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6214,7 +6214,12 @@ blocks:
       jobs:
         - name: "OpenStack: Unit and FV tests (tox) on Caracal"
           commands:
-            - ../.semaphore/run-and-monitor tox.log make tox-caracal tox-fv-caracal
+            # Run sequentially via `bash -c '... && ...'` rather than as
+            # multiple targets on a single make invocation: a make invoked
+            # with MAKEFLAGS=-j would otherwise schedule the two targets in
+            # parallel and have two concurrent tox runs contend over the
+            # shared .tox/ working tree.
+            - ../.semaphore/run-and-monitor tox.log bash -c 'make tox-caracal && make tox-fv-caracal'
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
             # Env vars needed for saving performance results.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6214,7 +6214,7 @@ blocks:
       jobs:
         - name: "OpenStack: Unit and FV tests (tox) on Caracal"
           commands:
-            - ../.semaphore/run-and-monitor tox.log make tox-caracal
+            - ../.semaphore/run-and-monitor tox.log make tox-caracal tox-fv-caracal
         - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
           commands:
             # Env vars needed for saving performance results.

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -16,7 +16,7 @@
     jobs:
       - name: "OpenStack: Unit and FV tests (tox) on Caracal"
         commands:
-          - ../.semaphore/run-and-monitor tox.log make tox-caracal
+          - ../.semaphore/run-and-monitor tox.log make tox-caracal tox-fv-caracal
       - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
         commands:
           # Env vars needed for saving performance results.

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -16,7 +16,12 @@
     jobs:
       - name: "OpenStack: Unit and FV tests (tox) on Caracal"
         commands:
-          - ../.semaphore/run-and-monitor tox.log make tox-caracal tox-fv-caracal
+          # Run sequentially via `bash -c '... && ...'` rather than as
+          # multiple targets on a single make invocation: a make invoked
+          # with MAKEFLAGS=-j would otherwise schedule the two targets in
+          # parallel and have two concurrent tox runs contend over the
+          # shared .tox/ working tree.
+          - ../.semaphore/run-and-monitor tox.log bash -c 'make tox-caracal && make tox-fv-caracal'
       - name: "OpenStack: Mainline ST (DevStack + Tempest) on Caracal"
         commands:
           # Env vars needed for saving performance results.

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -17,6 +17,15 @@ tox: build-test-container
 tox-%: upper-constraints-%.txt
 	$(MAKE) tox PIP_CONSTRAINT=/code/upper-constraints-$*.txt
 
+# Functional-verification tests.  Separate target because they spawn a
+# real etcd subprocess and use eventlet's cooperative I/O, so they can't
+# run alongside the standard unit-test discovery (see tox.ini's [testenv:fv]).
+tox-fv: build-test-container
+	$(RUN_TEST_CONTAINER) tox -e fv
+
+tox-fv-%: upper-constraints-%.txt
+	$(MAKE) tox-fv PIP_CONSTRAINT=/code/upper-constraints-$*.txt
+
 upper-constraints-caracal.txt:
 	curl -fsSL --retry 5 https://raw.githubusercontent.com/openstack/requirements/refs/heads/$$(./infer-openstack-branch.sh caracal requirements)/upper-constraints.txt -o $@
 

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -15,13 +15,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-# It's advised always to do eventlet monkey-patching before anything else.
-# https://eventlet.readthedocs.io/en/latest/patching.html
-import eventlet
-
-eventlet.monkey_patch()
-
-import logging  # noqa: I100
+# eventlet.monkey_patch() must run before any module that captures references
+# to socket / threading / etc. is imported.  We do NOT call it here, because
+# importing this module from a unit-test process would then contaminate the
+# whole test process with eventlet -- which in turn causes subunit's runner
+# (used by tox / .testr.conf) to deadlock its own stdout writes through the
+# eventlet hub, hanging the test run.  Instead the production entry-point
+# wrapper (networking_calico.agent.dhcp_agent_main, registered in setup.py
+# as `calico-dhcp-agent`) does the monkey_patch *before* importing this
+# module, so all the imports below still happen under the patched socket /
+# threading machinery in production.
+import logging
 import os
 import re
 import socket
@@ -31,6 +35,7 @@ import time
 
 from etcd3gw.exceptions import Etcd3Exception
 
+import eventlet
 from eventlet.event import Event
 from eventlet.queue import Empty
 from eventlet.queue import LightQueue

--- a/networking-calico/networking_calico/agent/dhcp_agent_main.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent_main.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Production entry-point wrapper for the Calico DHCP agent.
+
+This module exists to keep ``eventlet.monkey_patch()`` out of the
+``dhcp_agent`` library module itself.  Calling ``monkey_patch()`` at
+module-import time -- the way the DHCP agent used to do it -- patches
+``socket`` / ``threading`` / etc. in any Python process that imports
+the module, including unit-test processes that just want to construct
+``CalicoDhcpAgent`` to assert on its methods.  Under that contamination,
+subunit's test runner (which writes binary subunit-protocol messages to
+stdout via ``os.fdopen(fileno, 'wb', 0)``) ends up parked in
+``epoll_wait()`` on an empty FD set, and the whole test run hangs.
+
+The fix is to do ``monkey_patch()`` here, *before* importing the
+``dhcp_agent`` module.  In production, ``setup.py`` registers this
+module's ``main`` as the ``calico-dhcp-agent`` console-script entry
+point -- so the daemon still runs under a fully monkey-patched
+interpreter, just like before.  In unit tests, ``dhcp_agent`` is
+imported directly and ``monkey_patch()`` does not run.
+
+Per the eventlet docs the patch must happen as early as possible:
+https://eventlet.readthedocs.io/en/latest/patching.html
+"""
+
+import eventlet
+
+eventlet.monkey_patch()
+
+from networking_calico.agent.dhcp_agent import main  # noqa: E402
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    main()

--- a/networking-calico/networking_calico/tests/test_dhcp_agent.py
+++ b/networking-calico/networking_calico/tests/test_dhcp_agent.py
@@ -69,6 +69,36 @@ class TestFakePlugin(base.BaseTestCase):
         self.plugin.release_dhcp_port("calico", "dhcp")
 
 
+class TestImportIsolation(base.BaseTestCase):
+    """Regression test: importing ``networking_calico.agent.dhcp_agent``
+    must not call ``eventlet.monkey_patch()``.
+
+    Module-level ``monkey_patch()`` was the cause of an indefinite hang
+    in ``tox -e py38`` -- subunit's runner ended up parked in
+    epoll_wait() on an empty FD set because every test process inherited
+    the patched interpreter via this module's import.  The patch is now
+    confined to the production wrapper at
+    ``networking_calico.agent.dhcp_agent_main``.  If anyone ever adds
+    ``monkey_patch()`` back to a unit-test-imported module this test
+    will fail immediately.
+
+    By the time this test runs, the test runner has already imported
+    test_dhcp_agent.py, which in turn imported the dhcp_agent module
+    (line 35-36), so the global socket-patched flag accurately reflects
+    what an import of that module does.
+    """
+
+    def test_dhcp_agent_import_does_not_monkey_patch_socket(self):
+        import eventlet.patcher
+
+        self.assertFalse(
+            eventlet.patcher.is_monkey_patched("socket"),
+            "Importing networking_calico.agent.dhcp_agent must not call"
+            " eventlet.monkey_patch(); see networking_calico/agent/"
+            "dhcp_agent_main.py for the production wrapper that does.",
+        )
+
+
 class TestDhcpAgent(base.BaseTestCase):
     def setUp(self):
         super(TestDhcpAgent, self).setUp()

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -33,7 +33,8 @@ from __future__ import print_function
 #
 # So this entire file is opt-in via the CALICO_RUN_FV_TESTS=1 environment
 # variable.  Without it, the module imports cleanly (no monkey_patch) and
-# the test class is skipped at setUpClass time.  See the eventlet docs:
+# the test class is marked skipped at class-decoration time by
+# @unittest.skipUnless -- no setUpClass needs to run.  See the eventlet docs:
 # https://eventlet.readthedocs.io/en/latest/patching.html
 import os
 

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -21,12 +21,28 @@ Tests for etcdutils with a real etcd server.
 
 from __future__ import print_function
 
-# It's advised always to do eventlet monkey-patching as early as possible; but
-# __future__ imports are required to be at the very top of the file, so we must come
-# after those.  https://eventlet.readthedocs.io/en/latest/patching.html
+# These are functional-verification tests: they need a real etcd binary on
+# disk and use eventlet's cooperative I/O.  Running them under the standard
+# tox / subunit unit-test discovery is problematic for two reasons:
+#
+#  - ``eventlet.monkey_patch()`` at module import time patches socket /
+#    threading globally for the test process, even if these tests are
+#    skipped, which interacts badly with subunit's runner and hangs the run.
+#  - Other unit tests in the same process suddenly find themselves under a
+#    monkey-patched interpreter, which can change their behaviour subtly.
+#
+# So this entire file is opt-in via the CALICO_RUN_FV_TESTS=1 environment
+# variable.  Without it, the module imports cleanly (no monkey_patch) and
+# the test class is skipped at setUpClass time.  See the eventlet docs:
+# https://eventlet.readthedocs.io/en/latest/patching.html
+import os
+
+_FV_ENABLED = os.environ.get("CALICO_RUN_FV_TESTS") == "1"
+
 import eventlet
 
-eventlet.monkey_patch()
+if _FV_ENABLED:
+    eventlet.monkey_patch()
 
 import logging  # noqa: I100
 import shutil
@@ -42,6 +58,7 @@ from networking_calico.common import config as calico_config
 _log = logging.getLogger(__name__)
 
 
+@unittest.skipUnless(_FV_ENABLED, "set CALICO_RUN_FV_TESTS=1 to run FV tests")
 class TestFVEtcdutils(unittest.TestCase):
     def setUp(self):
         super(TestFVEtcdutils, self).setUp()

--- a/networking-calico/setup.py
+++ b/networking-calico/setup.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# THIS FILE IS MANAGED BY THE GLOBAL REQUIREMENTS REPO - DO NOT EDIT
 from setuptools import find_packages
 from setuptools import setup
 

--- a/networking-calico/setup.py
+++ b/networking-calico/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     entry_points={
         "console_scripts": [
-            "calico-dhcp-agent = networking_calico.agent.dhcp_agent:main",
+            "calico-dhcp-agent = networking_calico.agent.dhcp_agent_main:main",
             "calico-resync = networking_calico.resync.cli:main",
         ],
         "neutron.ml2.mechanism_drivers": [

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -23,6 +23,20 @@ commands =
 [testenv:venv]
 commands = {posargs}
 
+[testenv:fv]
+# Functional-verification tests.  These spawn a real etcd subprocess and
+# need eventlet's cooperative I/O, so they opt in to monkey_patch via
+# CALICO_RUN_FV_TESTS=1 (see networking_calico/tests/test_fv_etcdutils.py).
+# Run them with `tox -e fv` (or the make wrappers below); the standard
+# `tox -e py38` run does NOT include them because module-level
+# eventlet.monkey_patch in the same Python process as the other unit
+# tests interacts badly with subunit's runner and hangs the test run.
+setenv =
+   {[testenv]setenv}
+   CALICO_RUN_FV_TESTS=1
+commands =
+   python -m unittest -v networking_calico.tests.test_fv_etcdutils
+
 [testenv:cover]
 commands = python setup.py test --coverage --coverage-package-name=networking_calico --testr-args='{posargs}'
     coverage report

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -27,7 +27,7 @@ commands = {posargs}
 # Functional-verification tests.  These spawn a real etcd subprocess and
 # need eventlet's cooperative I/O, so they opt in to monkey_patch via
 # CALICO_RUN_FV_TESTS=1 (see networking_calico/tests/test_fv_etcdutils.py).
-# Run them with `tox -e fv` (or the make wrappers below); the standard
+# Run them with `tox -e fv` (or via the Makefile wrappers); the standard
 # `tox -e py38` run does NOT include them because module-level
 # eventlet.monkey_patch in the same Python process as the other unit
 # tests interacts badly with subunit's runner and hangs the test run.


### PR DESCRIPTION
Two unit-test-discovery files were calling eventlet.monkey_patch() at module import time:

 - networking_calico/agent/dhcp_agent.py:22 (production code, but imported by test_dhcp_agent and test_subnet_watcher);
 - networking_calico/tests/test_fv_etcdutils.py:29 (the FV tests).

Either was enough on its own to contaminate the entire test process with eventlet.  Under that contamination, subunit's runner -- which writes binary subunit-protocol status messages to stdout via os.fdopen(fileno, 'wb', 0) -- ends up parked indefinitely in epoll_wait() on an empty FD set partway through `tox -e py38`.  Symptom: `make -C networking-calico tox-caracal` hangs forever after "_run_testr called".

A note on reproducibility: this hang started appearing reliably on my own laptop, _today_, despite the structural problem above having been latent in the repo for a long time.  I am confident I've not noticed a hang like this before today.  CI has continued to pass throughout; and rebooting my laptop (to eliminate any accumulated process / kernel / monitoring-agent state) did not change the behaviour -- the hang still reproduces from a clean boot.  We do not have a satisfying explanation for the timing trigger that made the latent pathology suddenly become a deterministic hang on one machine; venv contents, package versions, and freshly-checked-out upstream state were all investigated and none of them looked like an obvious cause.  The fix below addresses the root structural issue (module-level monkey_patch contaminating the test process), so we're unblocked regardless of what tipped the balance.

Untangling without breaking production:

 1. Move dhcp_agent's monkey_patch into a new wrapper module networking_calico/agent/dhcp_agent_main.py, and re-point the `calico-dhcp-agent` console_script in setup.py at it.  The wrapper does monkey_patch() before importing the dhcp_agent module, so every subsequent module-level import in dhcp_agent (etcd3gw, neutron, eventlet.event, eventlet.queue, ...) still happens under a fully patched interpreter in production -- identical effective behaviour to today.  Unit tests that just want to import CalicoDhcpAgent no longer trigger the patch.

 2. Gate test_fv_etcdutils' monkey_patch and the whole TestFVEtcdutils class behind CALICO_RUN_FV_TESTS=1.  These are FV tests that spawn a real etcd subprocess and require eventlet; they were never safe to autodiscover into the unit-test sweep.  Without the env var the module imports cleanly (no monkey_patch), and the class skips via @unittest.skipUnless.

 3. Provide a deterministic way to run the FV tests:
    - tox.ini grows a [testenv:fv] env that reuses the standard [testenv] config (deps, passenv), sets CALICO_RUN_FV_TESTS=1, and invokes the FV tests under unittest directly (not subunit / coverage).
    - Makefile grows `tox-fv` and `tox-fv-<release>` targets that mirror the existing `tox` / `tox-<release>` pattern, so e.g. `make tox-fv-caracal` runs the FV tests against caracal pins.
    - The Semaphore "OpenStack: Unit and FV tests (tox) on Caracal" job (which already named FV tests in its title but didn't run them) is extended to invoke both make targets sequentially: unit tests first (fast, gates the FV run on failure), then FV tests against the same .tox/py38 venv on the host.  Source in .semaphore/semaphore.yml.d/blocks/40-openstack.yml; .semaphore/semaphore.yml and .semaphore/semaphore-scheduled-builds.yml regenerated via `make gen-semaphore-yaml`.

After these changes:
 - `python -m subunit.run discover -t . networking_calico/tests` completes in seconds (was: indefinite hang).
 - `make tox-caracal` finishes cleanly.
 - `make tox-fv-caracal` runs the 4 FV tests in ~65s.
 - Production `calico-dhcp-agent` daemon behaviour is unchanged: the new wrapper monkey-patches before importing the agent module, so all module-level imports still happen under a patched interpreter.
