### PR TITLE
Patch tier finalizers instead of updating the whole object

### DIFF
--- a/kube-controllers/pkg/controllers/tier/tier_controller.go
+++ b/kube-controllers/pkg/controllers/tier/tier_controller.go
@@ -16,6 +16,7 @@ package tier
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"github.com/projectcalico/api/pkg/client/clientset_generated/clientset"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	uruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -231,8 +233,8 @@ func (c *TierController) reconcile(name string) error {
 		// Tier is not being deleted — ensure it has a finalizer.
 		if !hasFinalizer(tier) {
 			logCtx.Info("Adding finalizer to Tier")
-			tier.SetFinalizers(append(tier.Finalizers, v3.TierFinalizer))
-			if _, err := c.cli.ProjectcalicoV3().Tiers().Update(c.ctx, tier, metav1.UpdateOptions{}); err != nil {
+			finalizers := append(slices.Clone(tier.Finalizers), v3.TierFinalizer)
+			if err := c.patchFinalizers(tier.Name, finalizers); err != nil {
 				return fmt.Errorf("failed to add finalizer: %v", err)
 			}
 		}
@@ -258,11 +260,29 @@ func (c *TierController) reconcile(name string) error {
 
 	// No policies left — remove the finalizer to allow deletion.
 	logCtx.Info("No policies remain in tier, removing finalizer")
-	tier.Finalizers = slices.DeleteFunc(tier.Finalizers, func(s string) bool { return s == v3.TierFinalizer })
-	if _, err := c.cli.ProjectcalicoV3().Tiers().Update(c.ctx, tier, metav1.UpdateOptions{}); err != nil {
+	finalizers := slices.DeleteFunc(slices.Clone(tier.Finalizers), func(s string) bool { return s == v3.TierFinalizer })
+	if err := c.patchFinalizers(tier.Name, finalizers); err != nil {
 		return fmt.Errorf("failed to remove finalizer: %v", err)
 	}
 	return nil
+}
+
+// patchFinalizers updates only the tier's finalizers via a merge patch. We patch
+// rather than Update the whole object so that status is left out of the request
+// body. Status is owned by the status subresource, and TierStatus is a non-pointer
+// struct, so a full Update always serializes it and the API server logs a spurious
+// `unknown field "status"` warning.
+func (c *TierController) patchFinalizers(name string, finalizers []string) error {
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"finalizers": finalizers,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling finalizer patch: %v", err)
+	}
+	_, err = c.cli.ProjectcalicoV3().Tiers().Patch(c.ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }
 
 // policyCounts tracks the number of policies referencing a tier, broken down by kind.

--- a/kube-controllers/pkg/controllers/tier/tier_controller_test.go
+++ b/kube-controllers/pkg/controllers/tier/tier_controller_test.go
@@ -17,6 +17,7 @@ package tier
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -90,6 +91,48 @@ func TestReconcile_AddsFinalizer(t *testing.T) {
 	}
 }
 
+// TestReconcile_AddFinalizerPatchOmitsStatus verifies that the finalizer write is a
+// metadata-only patch that does not carry status. Sending status on the main resource
+// endpoint makes the API server log a spurious `unknown field "status"` warning.
+func TestReconcile_AddFinalizerPatchOmitsStatus(t *testing.T) {
+	tier := &v3.Tier{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-tier"},
+		Spec:       v3.TierSpec{},
+		Status: v3.TierStatus{
+			Conditions: []metav1.Condition{{
+				Type:   "Ready",
+				Status: metav1.ConditionTrue,
+				Reason: "Active",
+			}},
+		},
+	}
+	cli := fake.NewClientset(tier)
+	c := newTestController(cli, tier)
+
+	if err := c.reconcile("my-tier"); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	patched := false
+	for _, action := range cli.Actions() {
+		if action.GetVerb() != "patch" || action.GetResource().Resource != "tiers" {
+			continue
+		}
+		patched = true
+		pa := action.(k8stesting.PatchAction)
+		if strings.Contains(string(pa.GetPatch()), "status") {
+			t.Fatalf("finalizer patch should not include status, got: %s", pa.GetPatch())
+		}
+	}
+	if !patched {
+		t.Fatalf("expected a finalizer patch; actions: %s", actionSummary(cli.Actions()))
+	}
+
+	if !hasFinalizer(getUpdatedTier(t, cli, "my-tier")) {
+		t.Fatal("expected finalizer to be added")
+	}
+}
+
 func TestReconcile_SkipsFinalizerIfAlreadyPresent(t *testing.T) {
 	tier := &v3.Tier{
 		ObjectMeta: metav1.ObjectMeta{
@@ -106,8 +149,8 @@ func TestReconcile_SkipsFinalizerIfAlreadyPresent(t *testing.T) {
 	}
 
 	for _, action := range cli.Actions() {
-		if action.GetVerb() == "update" && action.GetResource().Resource == "tiers" {
-			t.Fatal("unexpected update action when finalizer already present")
+		if isTierWrite(action) {
+			t.Fatal("unexpected write action when finalizer already present")
 		}
 	}
 }
@@ -199,8 +242,8 @@ func TestReconcile_DeletingTierWithoutFinalizer(t *testing.T) {
 	}
 
 	for _, action := range cli.Actions() {
-		if action.GetVerb() == "update" {
-			t.Fatal("unexpected update for deleting tier without finalizer")
+		if isTierWrite(action) {
+			t.Fatal("unexpected write for deleting tier without finalizer")
 		}
 	}
 }
@@ -214,8 +257,8 @@ func TestReconcile_TierNotInCache(t *testing.T) {
 	}
 
 	for _, action := range cli.Actions() {
-		if action.GetVerb() == "update" {
-			t.Fatal("unexpected update for nonexistent tier")
+		if isTierWrite(action) {
+			t.Fatal("unexpected write for nonexistent tier")
 		}
 	}
 }
@@ -384,21 +427,24 @@ func (f *fakeRateLimitingQueue) AddRateLimited(item string)  { f.rateLimitedAdds
 func (f *fakeRateLimitingQueue) Forget(item string)          { f.forgets++ }
 func (f *fakeRateLimitingQueue) NumRequeues(item string) int { return f.requeues }
 
-// getUpdatedTier finds the tier from Update actions in the fake client.
+// getUpdatedTier reads the tier back from the fake client after reconcile, so it
+// reflects whatever write the controller made (Update or Patch).
 func getUpdatedTier(t *testing.T, cli *fake.Clientset, name string) *v3.Tier {
 	t.Helper()
-	for _, action := range cli.Actions() {
-		if action.GetVerb() == "update" && action.GetResource().Resource == "tiers" && action.GetSubresource() == "" {
-			ua := action.(k8stesting.UpdateAction)
-			obj := ua.GetObject()
-			tier, ok := obj.(*v3.Tier)
-			if ok && tier.Name == name {
-				return tier
-			}
-		}
+	tier, err := cli.ProjectcalicoV3().Tiers().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get tier %q: %v", name, err)
 	}
-	t.Fatalf("no Update action found for tier %q; actions: %s", name, actionSummary(cli.Actions()))
-	return nil
+	return tier
+}
+
+// isTierWrite reports whether the action mutates a tier (Update or Patch), so tests
+// can assert that no write happened regardless of which verb the controller uses.
+func isTierWrite(action k8stesting.Action) bool {
+	if action.GetResource().Resource != "tiers" {
+		return false
+	}
+	return action.GetVerb() == "update" || action.GetVerb() == "patch"
 }
 
 func actionSummary(actions []k8stesting.Action) string {


### PR DESCRIPTION
The tier controller adds and removes its finalizer with a full Update of the tier object. The tier's status field is a non-pointer struct, so it is always serialized in the request, and the API server logs `unknown field "status"` for status sent to the main resource endpoint (status belongs to the status subresource). This switches the finalizer writes to a metadata-only merge patch so status stays out of the request.

Related: #13079.

```release-note
Fixes spurious `unknown field "status"` warnings logged when kube-controllers manages tier finalizers.
```
