### PR TITLE
test(e2e): make ginkgo suite timeout configurable, default 90m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ push-chart: bin/helm
 # using a local kind cluster.
 ###############################################################################
 E2E_PROCS ?= 4
+E2E_TIMEOUT ?= 90m
 E2E_TEST_CONFIG ?= e2e/config/kind.yaml
 E2E_OUTPUT_DIR ?= report
 E2E_JUNIT_REPORT ?= e2e_conformance.xml
@@ -277,7 +278,7 @@ e2e-test-clusternetworkpolicy:
 e2e-run:
 	@if [ -z "$(KUBECONFIG)" ]; then echo "e2e-run: KUBECONFIG must be set"; exit 1; fi
 	mkdir -p $(E2E_OUTPUT_DIR)
-	KUBECONFIG=$(KUBECONFIG) go run github.com/onsi/ginkgo/v2/ginkgo -procs=$(E2E_PROCS) --junit-report=$(E2E_JUNIT_REPORT) --output-dir=$(E2E_OUTPUT_DIR)/ ./e2e/bin/k8s/e2e.test -- --calico.test-config=$(abspath $(E2E_TEST_CONFIG))
+	KUBECONFIG=$(KUBECONFIG) go run github.com/onsi/ginkgo/v2/ginkgo -procs=$(E2E_PROCS) --timeout=$(E2E_TIMEOUT) --junit-report=$(E2E_JUNIT_REPORT) --output-dir=$(E2E_OUTPUT_DIR)/ ./e2e/bin/k8s/e2e.test -- --calico.test-config=$(abspath $(E2E_TEST_CONFIG))
 
 ## Run the ClusterNetworkPolicy specific e2e tests against the cluster at $KUBECONFIG.
 e2e-run-cnp:


### PR DESCRIPTION
## What

Make the ginkgo e2e suite timeout configurable via a new `E2E_TIMEOUT` make variable (default `90m`), passed to ginkgo with `--timeout` in the `e2e-run` target.

## Why

Ginkgo applies an **implicit 1h suite timeout** when `--timeout` is unset. As the e2e suite grows, a slow run (heavy datapath specs, a loaded CI agent, slow image pulls) can exceed that budget and get killed mid-suite — which surfaces as a suite **FAIL** that looks like a test failure but is really a budget cutoff, not a real assertion failure.

Profiling one lane showed the suite wall already sitting in the 50–62 min range across runs of the *same* spec set (environment-driven variance), with runs crossing the 60m default and being killed. Making the budget an explicit, overridable variable stops those false-fails and lets slow lanes opt into more headroom without editing the recipe.

No behavior change for lanes already finishing under 1h — this only raises the ceiling and makes it configurable.

## Test plan

- `make e2e-run E2E_TIMEOUT=...` overrides the budget; unset defaults to `90m`.
- No change to which tests run or how they're selected — only the suite-level `--timeout` flag passed to ginkgo.

**Release note:**
```release-note
Not required
```
