### PR TITLE
fix(felix-fv): tolerate un-stamped service-flow duplicate in goldmane staged test

### DIFF
--- a/felix/fv/flow_logs_goldmane_staged_test.go
+++ b/felix/fv/flow_logs_goldmane_staged_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -737,8 +737,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ aggregation of flow log wit
 	BeforeEach(func() {
 		infra = getInfra()
 		opts = infrastructure.DefaultTopologyOptions()
-		opts.IPIPMode = api.IPIPModeNever
 		opts.FlowLogSource = infrastructure.FlowLogSourceLocalSocket
+		opts.IPIPMode = api.IPIPModeNever
 
 		opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "5"
 		opts.ExtraEnvVars["FELIX_FLOWLOGSCOLLECTORDEBUGTRACE"] = "true"
@@ -1406,8 +1406,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 	BeforeEach(func() {
 		infra = getInfra()
 		opts = infrastructure.DefaultTopologyOptions()
-		opts.IPIPMode = api.IPIPModeNever
 		opts.FlowLogSource = infrastructure.FlowLogSourceLocalSocket
+		opts.IPIPMode = api.IPIPModeNever
 
 		opts.ExtraEnvVars["FELIX_FLOWLOGSFLUSHINTERVAL"] = "3"
 		opts.ExtraEnvVars["FELIX_FLOWLOGSCOLLECTORDEBUGTRACE"] = "true"

--- a/felix/fv/flow_logs_goldmane_staged_test.go
+++ b/felix/fv/flow_logs_goldmane_staged_test.go
@@ -417,6 +417,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ goldmane flow log with stag
 			MatchEnforcedPolicies:  true,
 			MatchPendingPolicies:   true,
 			Includes:               []flowlogs.IncludeFilter{flowlogs.IncludeByDestPort(wepPort)},
+			// ep1-1 -> ep2-1 goes via the service cluster IP, so Felix can report an un-stamped
+			// duplicate of the service flow if a flush beats DNAT correlation. Require the
+			// service-stamped flow but tolerate the empty-DstService duplicate.
+			TolerateServiceCorrelationRace: true,
 		})
 
 		ep1_1_Meta := endpoint.Metadata{

--- a/felix/fv/flowlogs/flow_tester.go
+++ b/felix/fv/flowlogs/flow_tester.go
@@ -50,6 +50,7 @@ type FlowTester struct {
 	options FlowTesterOptions
 	flows   map[flowMeta]flowlog.FlowLog
 	errors  []string
+	checked []string
 }
 
 type FlowTesterOptions struct {
@@ -65,6 +66,20 @@ type FlowTesterOptions struct {
 
 	// Set of include filters used to only include certain flows. Set of filters is ORed.
 	Includes []IncludeFilter
+
+	// TolerateServiceCorrelationRace, when set, makes CheckFlow additionally absorb — without
+	// requiring — a flow that is identical to a checked service flow except that its DstService is
+	// empty. Felix stamps DstService only once it has correlated a connection's DNAT record (see
+	// the collector's reportMetrics, where the service lookup is gated on IsDNAT); a flush that
+	// happens before that correlation lands reports an un-stamped duplicate that differs only in
+	// DstService. The service-stamped flow is still required; this only stops the un-stamped
+	// duplicate being reported as an unchecked flow.
+	//
+	// The duplicate is matched with the same keying as CheckFlow (see flowMetaFromFlowLog), so it
+	// is only as discriminating as the Match* options below. Use this with policy matching enabled
+	// (MatchEnforcedPolicies / MatchPendingPolicies) so a stray empty-DstService flow that differs
+	// in its policy sets is not absorbed.
+	TolerateServiceCorrelationRace bool
 
 	// What values to check.
 	CheckPackets         bool // Checks packets in/out
@@ -231,7 +246,23 @@ func (t *FlowTester) CheckFlow(fl flowlog.FlowLog) {
 	}
 
 	if len(errs) != 0 {
-		t.errors = append(t.errors, fmt.Sprintf("Statistics incorrect: %#v\n- %s", fl, strings.Join(errs, "/n- ")))
+		t.errors = append(t.errors, fmt.Sprintf("Statistics incorrect: %#v\n- %s", fl, strings.Join(errs, "\n- ")))
+	}
+
+	t.checked = append(t.checked, fmt.Sprintf("Checked flow: %s", formatFlow(fl)))
+
+	// Absorb the un-stamped service-correlation-race duplicate, if present. See
+	// TolerateServiceCorrelationRace. The duplicate is identical except DstService is empty, so we
+	// rebuild the key with DstService zeroed and delete it; the delete is a no-op when absent, so
+	// the duplicate is tolerated but never required.
+	if t.options.TolerateServiceCorrelationRace && fl.DstService != flowlog.EmptyService {
+		noSvc := fl
+		noSvc.DstService = flowlog.EmptyService
+		dupMeta := t.flowMetaFromFlowLog(noSvc)
+		if _, dup := t.flows[dupMeta]; dup {
+			delete(t.flows, dupMeta)
+			t.checked = append(t.checked, fmt.Sprintf("Tolerated no-service duplicate of: %s", formatFlow(fl)))
+		}
 	}
 }
 
@@ -245,7 +276,10 @@ func (t *FlowTester) Finish() error {
 	if len(t.errors) == 0 {
 		return nil
 	}
-	return errors.New(strings.Join(t.errors, "\n==============\n"))
+	// Build a fresh slice rather than append(t.errors, ...), so we never write into t.errors'
+	// backing array — that keeps Finish() idempotent if it is called more than once without a reset.
+	combined := append(append([]string{}, t.errors...), t.checked...)
+	return errors.New(strings.Join(combined, "\n==============\n"))
 }
 
 // dumpReceivedFlows renders every flow currently held by the tester. Used in
@@ -311,6 +345,7 @@ func (t *FlowTester) flowMetaFromFlowLog(fl flowlog.FlowLog) flowMeta {
 func (t *FlowTester) reset() {
 	t.flows = make(map[flowMeta]flowlog.FlowLog)
 	t.errors = nil
+	t.checked = nil
 }
 
 func WaitForConntrackScan(bpfEnabled bool) {


### PR DESCRIPTION
OSS back-port of tigera/calico-private#12391.
Drops that PR's enterprise-only flow_logs_enterprise_test.go hunk; the
underlying race lives in the (shared) collector reportMetrics code path
and the OSS staged test exercises the identical ep1-1 -> ep2-1
service-cluster-IP flow, so the rest of the diff applies as-is.

The "goldmane flow log with staged policy tests / should get expected
flow logs" test in flow_logs_goldmane_staged_test.go intermittently
failed with an "Unchecked flow" for ep1-1 -> ep2-1 (src, allow, allow-all)
whose DstService was empty, despite the test also matching the same
flow with the service stamped.

ep1-1 -> ep2-1 traffic is sent via the service cluster IP and DNAT'd
to the backend.  The collector only stamps DstService once it has
correlated the connection's DNAT record (reportMetrics gates the
service lookup on data.IsDNAT, and PreDNAT info arrives from conntrack
asynchronously from the NFLOG-driven stats).  If a flush reports the
flow before that correlation lands, IsDNAT is still false, the service
lookup is never attempted, and an un-stamped duplicate is emitted that
differs from the expected flow only in DstService.  Waiting for the
service lookup cache to populate (already done in BeforeEach) does not
close this race, because it is per-flow DNAT correlation, not cache
population, that is missing.

Add an opt-in FlowTester option, TolerateServiceCorrelationRace, that
makes CheckFlow absorb an otherwise-identical flow whose DstService is
empty.  The service-stamped flow is still required (CheckFlow errors
if it is absent, so Eventually keeps retrying); only the un-stamped
duplicate is tolerated.  Enable it on the one tester in this suite
that asserts a service flow; no other FV test is affected.

Also improve FlowTester failure diagnostics: include the checked flows
alongside the errors in Finish() output so a failure shows what was
matched, not just the deltas; reset that accumulator in reset() so it
does not leak across the Eventually retries; and fix a "/n-" -> "\n-"
newline typo in the statistics-mismatch message.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
