### PR TITLE
ci: pin VPP CI runs to latest stable release

### DIFF
--- a/.semaphore/end-to-end/pipelines/vpp.yml
+++ b/.semaphore/end-to-end/pipelines/vpp.yml
@@ -55,16 +55,16 @@ global_job_config:
     - name: PRIVATE_REGISTRY
       value: "quay.io/"
     - name: RELEASE_STREAM
-      value: "master"
+      value: "v3.32.0"
     - name: VPP_VERSION
-      value: "master"
+      value: "v3.32.0"
 
 blocks:
   - name: k8s-e2e ST
     dependencies: []
     task:
       jobs:
-        - name: v3.28 regression test
+        - name: v3.31 regression test
           commands:
             - ~/calico/.semaphore/end-to-end/scripts/body_standard.sh
           matrix:
@@ -75,9 +75,9 @@ blocks:
               values:
                 - "calico-vpp-nohuge.yaml"
             - env_var: RELEASE_STREAM
-              values: ["v3.28"]
+              values: ["v3.31"]
             - env_var: VPP_VERSION
-              values: ["v3.28.0"]
+              values: ["v3.31.0"]
 
         - name: VPP-kadm
           execution_time_limit:


### PR DESCRIPTION
Pin the Calico/VPP CI runs to latest stable release instead of master to prevent situations where a change in Calico master breaks the CI and necessitates a fix which addresses the Calico hosted CI but breaks the internal/local CIs run by the Calico/VPP team.

<!-- Describe your changes, including the type of change (bug fix, feature, etc.),
why it should be merged, testing done, and links to related issues. -->

<!-- For any user-visible change, replace TBD with a one-line description. -->
**Release note:**
```release-note
TBD
```
