### PR TITLE
ci: only run branch CI monitor on real branch pushes

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -1989,6 +1989,14 @@ after_pipeline:
           # and posts to Slack itself when there is something worth reporting. A pass
           # is recorded too so the engine can recover open incidents for the branch.
           - |
+            # Only true pushes to master/release-*. On a pull-request pipeline
+            # SEMAPHORE_GIT_BRANCH is the PR's *target* branch (so a PR against
+            # master reads as "master"); gate on the ref type / PR number first
+            # so PR builds don't masquerade as branch builds.
+            if [ "$SEMAPHORE_GIT_REF_TYPE" != "branch" ] || [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then
+              echo "not a branch push (ref_type=${SEMAPHORE_GIT_REF_TYPE} pr=${SEMAPHORE_GIT_PR_NUMBER}) — not monitored"
+              exit 0
+            fi
             case "$SEMAPHORE_GIT_BRANCH" in
               master|release-*) ;;
               *) echo "branch $SEMAPHORE_GIT_BRANCH not monitored"; exit 0 ;;

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6478,6 +6478,14 @@ after_pipeline:
           # and posts to Slack itself when there is something worth reporting. A pass
           # is recorded too so the engine can recover open incidents for the branch.
           - |
+            # Only true pushes to master/release-*. On a pull-request pipeline
+            # SEMAPHORE_GIT_BRANCH is the PR's *target* branch (so a PR against
+            # master reads as "master"); gate on the ref type / PR number first
+            # so PR builds don't masquerade as branch builds.
+            if [ "$SEMAPHORE_GIT_REF_TYPE" != "branch" ] || [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then
+              echo "not a branch push (ref_type=${SEMAPHORE_GIT_REF_TYPE} pr=${SEMAPHORE_GIT_PR_NUMBER}) — not monitored"
+              exit 0
+            fi
             case "$SEMAPHORE_GIT_BRANCH" in
               master|release-*) ;;
               *) echo "branch $SEMAPHORE_GIT_BRANCH not monitored"; exit 0 ;;

--- a/.semaphore/semaphore.yml.d/99-after_pipeline.yml
+++ b/.semaphore/semaphore.yml.d/99-after_pipeline.yml
@@ -15,6 +15,14 @@ after_pipeline:
           # and posts to Slack itself when there is something worth reporting. A pass
           # is recorded too so the engine can recover open incidents for the branch.
           - |
+            # Only true pushes to master/release-*. On a pull-request pipeline
+            # SEMAPHORE_GIT_BRANCH is the PR's *target* branch (so a PR against
+            # master reads as "master"); gate on the ref type / PR number first
+            # so PR builds don't masquerade as branch builds.
+            if [ "$SEMAPHORE_GIT_REF_TYPE" != "branch" ] || [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then
+              echo "not a branch push (ref_type=${SEMAPHORE_GIT_REF_TYPE} pr=${SEMAPHORE_GIT_PR_NUMBER}) — not monitored"
+              exit 0
+            fi
             case "$SEMAPHORE_GIT_BRANCH" in
               master|release-*) ;;
               *) echo "branch $SEMAPHORE_GIT_BRANCH not monitored"; exit 0 ;;


### PR DESCRIPTION
## Description

The branch CI monitor added in #12945 (the `after_pipeline` "Branch CI monitor"
job) gated only on `SEMAPHORE_GIT_BRANCH` matching `master|release-*`. On a
Semaphore **pull-request** pipeline, `SEMAPHORE_GIT_BRANCH` holds the PR's
*target* branch — so a PR against `master` reads as `master`, matched the
filter, and fired the monitor. The result was a spurious
`:red_circle: calico/master — CI Failing` Slack alert for a failure that was
actually confined to a contributor's PR branch (the misconfigured-cache failure
on #13071).

This adds a ref-type guard before the branch-name check so only genuine branch
pushes are monitored:

```sh
if [ "$SEMAPHORE_GIT_REF_TYPE" != "branch" ] || [ -n "$SEMAPHORE_GIT_PR_NUMBER" ]; then
  echo "not a branch push (...) — not monitored"
  exit 0
fi
```

`SEMAPHORE_GIT_REF_TYPE != branch` rejects PR and tag pipelines (the actual
fix); the `SEMAPHORE_GIT_PR_NUMBER` check is a belt-and-braces on the same
failure mode. This mirrors how the rest of `semaphore.yml` already distinguishes
PR builds from branch builds (e.g. the checkout block uses
`SEMAPHORE_GIT_REF_TYPE = branch`, the cache-store block uses
`-z SEMAPHORE_GIT_PR_NUMBER`).

Edited `.semaphore/semaphore.yml.d/99-after_pipeline.yml` and regenerated
`.semaphore/semaphore.yml` and `.semaphore/semaphore-scheduled-builds.yml` with
`make gen-semaphore-yaml`. CI-config only; no in-repo test harness exercises the
`after_pipeline` job.

## Release Note

```release-note
NONE
```
